### PR TITLE
bugfix: 修复docker compose部署出现的问题

### DIFF
--- a/deploy/docker-compose/bootstrap.sh
+++ b/deploy/docker-compose/bootstrap.sh
@@ -689,7 +689,6 @@ services:
       - NEXTAPI_URL=http://ops-console:8000
       - NEXTAUTH_URL=http://${HOST_IP}:${TRAEFIK_CONSOLE_PORT}
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
-      - NEXTAPI_URL=http://ops-console:8000
     restart: always
     networks:
       - prod

--- a/deploy/docker-compose/bootstrap.sh
+++ b/deploy/docker-compose/bootstrap.sh
@@ -225,6 +225,7 @@ if [ -f ./conf/nats/nats.conf ]; then
     log "WARNING" "nats.conf文件已存在，文件将被覆盖..."
 else
     log "INFO" "创建 nats.conf 文件..."
+    mkdir -p ./conf/nats
 fi
 
 cat > ./conf/nats/nats.conf <<EOF


### PR DESCRIPTION
1. 在`docker-compose`目录下，自动创建`.conf/nats`目录
2. 删除`docker-compose.yaml`中重复定义的`environment`项