### PR TITLE
fix:优化采集端vc逻辑，修复snmp采集依赖报错。优化服务端采集任务状态概览

### DIFF
--- a/agents/stargazer/plugins/mysql_info.py
+++ b/agents/stargazer/plugins/mysql_info.py
@@ -220,10 +220,10 @@ class MysqlInfo:
                 inst_data = {"result": json.dumps(model_data), "success": execute_result}
 
             else:
+                logger.error(f"mysql_info collect error! {message}")
                 inst_data = {"result": message, "success": execute_result}
 
             result = convert_to_prometheus_format({"mysql": [inst_data]})
-
             return result
         except Exception as err:  # noqa
             import traceback

--- a/agents/stargazer/pyproject.toml
+++ b/agents/stargazer/pyproject.toml
@@ -118,7 +118,7 @@ qingyun = [
 ]
 
 snmp = [
-    "pysnmp==4.4.12",
+    "pysnmp==5.1.0",
     "pyasn1==0.4.8",
     "pyasn1-modules==0.2.8",
 ]

--- a/server/apps/cmdb/collect_tasks/bash.py
+++ b/server/apps/cmdb/collect_tasks/bash.py
@@ -53,8 +53,12 @@ class BaseCollect(object):
     def format_collect_data(self, result):
         # 强加了一个原始数据，如果原始数据存在则删除，保留原有逻辑
         raw_data = []
+        # 强加一个总数，这个总数是发现正常数据的总数，不是原始数据的总数
+        all_count = []
         if result.get("__raw_data__", False) or result.get("__raw_data__", False) == []:
             raw_data = result.pop("__raw_data__")
+        if result.get("all", False) or result.get("all", False) == 0:
+            all_count = result.pop("all")
         format_data = {"add": [], "update": [],
                        "delete": [], "association": []}
         for value in result.values():
@@ -80,6 +84,8 @@ class BaseCollect(object):
                         format_data[operator].append(_data)
         if raw_data:
             format_data["__raw_data__"] = raw_data
+        if raw_data:
+            format_data["all"] = all_count
         return format_data
 
     @staticmethod

--- a/server/apps/cmdb/collection/collect_plugin/network.py
+++ b/server/apps/cmdb/collection/collect_plugin/network.py
@@ -49,7 +49,7 @@ class CollectNetworkMetrics(CollectBase):
 
     @staticmethod
     def get_oid_map():
-        result = OidMapping.objects.all().values()
+        result = OidMapping.objects.all().values("model","oid","brand","device_type","built_in")
         return {i["oid"]: i for i in result}
 
     @staticmethod

--- a/server/apps/cmdb/collection/metrics_cannula.py
+++ b/server/apps/cmdb/collection/metrics_cannula.py
@@ -54,6 +54,7 @@ class MetricsCannula:
 
     def collect_controller(self) -> dict:
         result = {}
+        all_count = 0
         for model_id, metrics in self.collection_metrics.items():
             params = [
                 {"field": "model_id", "type": "str=", "value": model_id},
@@ -74,6 +75,7 @@ class MetricsCannula:
                     self.task_id,
                     collect_plugin=self.collect_plugin
                 )
+                all_count = all_count + len(metrics)
                 if self.manual:
                     self.add_list.extend(management.add_list)
                     self.delete_list.extend(management.delete_list)
@@ -83,5 +85,6 @@ class MetricsCannula:
                     collect_result = management.controller()
                 result[model_id] = collect_result
         result['__raw_data__'] = self.raw_data
+        result['all'] = all_count
         return result
 

--- a/server/apps/cmdb/serializers/collect_serializer.py
+++ b/server/apps/cmdb/serializers/collect_serializer.py
@@ -21,6 +21,10 @@ class CollectModelSerializer(serializers.ModelSerializer):
             # "task_type": {"required": True},
         }
 
+class CollectModelIdStatusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = CollectModels
+        fields = ("model_id", "exec_status")
 
 class CollectModelLIstSerializer(UsernameSerializer):
     message = serializers.SerializerMethodField()

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -24,7 +24,7 @@ def sync_collect_task(instance_id):
         return
     if instance.exec_status == CollectRunStatusType.NOT_START:
         CollectModels.objects.filter(id=instance_id).update(exec_status=CollectRunStatusType.RUNNING)
-
+    exec_error_message = ''
     try:
         if instance.is_job:
             # 脚本采集
@@ -34,29 +34,49 @@ def sync_collect_task(instance_id):
             # 协议采集
             collect = ProtocolCollect(task=instance)
             result, format_data = collect.main()
-
-        instance.exec_status = CollectRunStatusType.EXAMINE if instance.input_method else CollectRunStatusType.SUCCESS
+        task_exec_status = CollectRunStatusType.EXAMINE if instance.input_method else CollectRunStatusType.SUCCESS
+        instance.exec_status = task_exec_status
 
     except Exception as err:
         import traceback
-        logger.error("==采集失败== task_id={}, error={}".format(instance_id, traceback.format_exc()))
+        logger.error("==同步数据失败== task_id={}, error={}".format(instance_id, traceback.format_exc()))
+        exec_error_message = "==同步数据失败==, error={}".format(err)
         result = {}
         format_data = {}
         instance.exec_status = CollectRunStatusType.ERROR
+        task_exec_status = CollectRunStatusType.ERROR
 
     try:
         instance.collect_data = result
         instance.format_data = format_data
-        instance.collect_digest = {
+        collect_digest = {
             "add": len(format_data.get("add", [])),
+            "add_error": len([i for i in format_data.get('add',[]) if i.get('_status') != "success"]),
             "update": len(format_data.get("update", [])),
+            "update_error": len([i for i in format_data.get('update', []) if i.get('_status') != "success"]),
             "delete": len(format_data.get("delete", [])),
+            "delete_error": len([i for i in format_data.get('delete', []) if i.get('_status') != "success"]),
             "association": len(format_data.get("association", [])),
+            "association_error": len([i for i in format_data.get('association', []) if i.get('_status') != "success"]),
+            "all": format_data.get('all', 0) # 总数是发现的正常数据总数，例如：扫描了10个ip，其中6个是真的ip，4个ip不存在，总数为6
         }
+        # add是需要新增的数据，add_success是实际新增成功的数据（实际到cmdb的数据），add_error是新增失败的数据，其他以此类推
+        collect_digest['add_success'] = collect_digest['add'] - collect_digest['add_error']
+        collect_digest['update_success'] = collect_digest['update'] - collect_digest['update_error']
+        collect_digest['delete_success'] = collect_digest['delete'] - collect_digest['delete_error']
+        collect_digest['association_success'] = collect_digest['association'] - collect_digest['association_error']
+        # 如果任务执行失败，添加错误信息提示
+        if task_exec_status == CollectRunStatusType.ERROR:
+            collect_digest['message'] = exec_error_message
+        instance.collect_digest = collect_digest
         instance.save()
     except Exception as err:
-        logger.error("==保存采集结果失败== task_id={}, error={}".format(instance_id, err))
-        CollectModels.objects.filter(id=instance_id).update(exec_status=CollectRunStatusType.ERROR)
+        import traceback
+        logger.error("==保存采集结果失败== task_id={}, error={}".format(instance_id, traceback.format_exc()))
+        CollectModels.objects.filter(id=instance_id).update(
+            exec_status=CollectRunStatusType.ERROR,
+            collect_digest={"message": "保存采集结果失败: {}".format(err)}
+        )
 
     logger.info("==采集任务执行结束== task_id={}".format(instance_id))
 


### PR DESCRIPTION
fix:stargazer调整内容：1，vm的数据采集逻辑分层，让connect独立出来，能够上报connect异常的数据（todo，当前有问题，连接timeout时间大于telegraf超时时间，数据无法上报）  2，优化snmp采集逻辑，上报连接异常的信息   3，调整pysnmp的版本为5.1.0，因为原本4.x版本不支持python 3.12的环境，会报错   服务端调整内容：1，新增透传all的统计数据，all是采集上来的总数（不是原始数据，而是原始数据中正常的数据，它大于等于add、update、delete的总数，因为可能cmdb数据相同，不用修改）  2，任务概览新增add_error等统计数据，新增message字段，如果任务异常（下发配置、同步数据异常），则任务概览需要显示message。   3，新增配置采集任务task_status接口，以插件角度获取任务状态的统计数据