### PR TITLE
脚本优化

### DIFF
--- a/agents/stargazer/plugins/shell/redis_default_discover.sh
+++ b/agents/stargazer/plugins/shell/redis_default_discover.sh
@@ -45,12 +45,22 @@ discover_redis() {
     # 获取主机内网 IP 地址
     bk_host_innerip=$(hostname -I | awk '{print $1}')  # 获取第一个内网 IP 地址
 
+    # 用于记录已处理的端口，实现去重
+    declare -A processed_ports
+
     for proc in "${procs[@]}"; do
         local pid=$(echo $proc | cut -d: -f1)
         local ip=$(echo $proc | cut -d: -f2)
         local port=$(echo $proc | cut -d: -f3)
         local redis_cli=$(echo $proc | cut -d: -f4)
         local install_path=$(echo $proc | cut -d: -f5)
+
+        # 根据端口去重，如果该端口已处理过则跳过
+        if [[ -n "${processed_ports[$port]}" ]]; then
+            continue
+        fi
+        processed_ports[$port]=1
+
         # 替换为绝对路径
         install_path=$(readlink -f "$install_path")
 

--- a/agents/stargazer/plugins/shell/zookeeper_default_discover.sh
+++ b/agents/stargazer/plugins/shell/zookeeper_default_discover.sh
@@ -53,7 +53,7 @@ GetZookeeperVersion(){
         else
             lib_path="$2/../lib"
         fi
-        version=$(ls $lib_path | grep zookeeper | grep "\.jar" | awk -F '-' '{print $NF}' | awk -F '.jar' '{print $1}')
+        version=$(ls $lib_path | grep zookeeper | grep "\.jar" | awk -F '-' '{print $NF}' | awk -F '.jar' '{print $1}' | head -n 1)
         install_path=$2
     fi
 }
@@ -64,7 +64,7 @@ Get_Zookeeper_Config(){
     tick_time=$(grep -oPm1 "(?<=tickTime=)[^ ]+" $cfg_path)
     init_limit=$(grep -oPm1 "(?<=initLimit=)[^ ]+" $cfg_path)
     sync_limit=$(grep -oPm1 "(?<=syncLimit=)[^ ]+" $cfg_path)
-    cluster_servers=$(grep -oPm1 "(?<=server.[0-9]+=[^ ]+)" $cfg_path | tr '\n' ',')
+    cluster_servers=$(grep -E "^server\.[0-9]+=" $cfg_path | cut -d'=' -f2 | tr '\n' ',' | sed 's/,$//')
 }
 
 # 新增函数：解析 Zookeeper 配置文件中的 dataDir


### PR DESCRIPTION
1、优化redis采集脚本重复输出同一端口进程问题。
2、优化zookeeper采集脚本版本号重复输出额grep错误
3、优化nginx采集脚本变量未定义引起的grep错误