### PR TITLE
feat: split resource collector from metric collector

### DIFF
--- a/agents/webhookd/bk-lite-log-collector.yaml
+++ b/agents/webhookd/bk-lite-log-collector.yaml
@@ -1,0 +1,228 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bk-lite-collector
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector-daemonset
+  namespace: bk-lite-collector    
+spec:
+  selector:
+    matchLabels:
+      app: vector-daemonset
+  template:
+    metadata:
+      labels:
+        app: vector-daemonset
+    spec:
+      serviceAccount: vector-daemonset
+      containers:
+        - name: vector
+          image: bk-lite.tencentcloudcr.com/bklite/vector:0.39.0-debian
+          volumeMounts:
+            - name: vector-config-volume
+              mountPath: /etc/vector/vector.yaml
+              subPath: vector.yaml
+            - name: var-log
+              mountPath: /var/log
+              readOnly: true
+            - name: var-lib-docker-containers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: nats-ca-cert
+              mountPath: /etc/nats_ca.crt
+              subPath: ca.crt
+              readOnly: true
+          env:
+            - name: VECTOR_CONFIG
+              value: /etc/vector/vector.yaml
+            - name: VECTOR_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          envFrom:
+            - secretRef:
+                name: bk-lite-monitor-config-secret
+          ports:
+            - containerPort: 8686
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
+      volumes:
+        - name: vector-config-volume
+          configMap:
+            name: vector-daemonset-config
+        - name: var-log
+          hostPath:
+            path: /var/log
+        - name: var-lib-docker-containers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: nats-ca-cert
+          secret:
+            secretName: bk-lite-monitor-config-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector-daemonset
+  namespace: bk-lite-collector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector-daemonset
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces", "nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector-daemonset
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector-daemonset
+subjects:
+  - kind: ServiceAccount
+    name: vector-daemonset
+    namespace: bk-lite-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: vector-daemonset
+  namespace: bk-lite-collector
+  labels:
+    app: vector-daemonset
+spec:
+  type: ClusterIP
+  ports:
+    - name: api
+      port: 8686
+      targetPort: 8686
+      protocol: TCP
+  selector:
+    app: vector-daemonset
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector-daemonset-config
+  namespace: bk-lite-collector  
+data:
+  vector.yaml: |
+    api:
+      enabled: true
+      address: "0.0.0.0:8686"
+
+    sources:
+      kubernetes_logs:
+        type: kubernetes_logs
+        self_node_name: "${VECTOR_NODE_NAME}"
+        pod_annotation_fields:
+          container_image: "container_image"
+          container_name: "container_name" 
+          pod_name: "pod_name"
+          pod_namespace: "pod_namespace"
+          pod_node_name: "pod_node_name"
+        namespace_annotation_fields:
+          namespace_labels: "namespace_labels"
+        node_annotation_fields:
+          node_labels: "node_labels"
+        extra_field_selector: ""
+        extra_label_selector: ""
+        max_read_bytes: 2048
+        max_line_bytes: 32768
+        fingerprint_lines: 1
+        glob_minimum_cooldown_ms: 60000
+        timezone: "UTC"
+
+    transforms:
+      # 多行日志合并 - 支持主流开发语言日志格式
+      multiline_merge:
+        type: reduce
+        inputs:
+          - kubernetes_logs
+        group_by:
+          - kubernetes.pod_name
+          - kubernetes.container_name
+          - kubernetes.pod_namespace
+        merge_strategies:
+          message: concat_newline
+        # 匹配常见的日志开始模式：支持 Log4j、uWSGI、Traefik 等
+        starts_when: match(string!(.message), r'(?i)^(\d{4}-\d{2}-\d{2}[\sT]\d{2}:\d{2}:\d{2}|\d{2}/\w{3}/\d{4}\s+\d{2}:\d{2}:\d{2}|\w{3}\s+\d{1,2},\s+\d{4}|\[[^\]]*\d{2}:\d{2}:\d{2}[^\]]*\]|time="[^"]*").*?(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)|^(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)[\s\[\(:>-]|^\[pid:\s*\d+\||^\*{3}\s+\w+|^spawned\s+uWSGI')
+        flush_period_ms: 1000
+
+      parse_and_enrich:
+        type: remap
+        inputs:
+          - multiline_merge
+        source: |
+          # 添加采集相关的元数据
+          .collect_type = "kubernetes"
+          .instance_id = "lite"
+          .streams = ["default", "${CLUSTER_NAME}"]
+          .node_name = get_env_var!("VECTOR_NODE_NAME")
+          
+          # 处理时间戳 - kubernetes_logs 源已经提供了正确的时间戳
+          if !exists(.timestamp) {
+            .timestamp = now()
+          }
+          
+          # 提取重要的Kubernetes元数据
+          .k8s_pod_name = .kubernetes.pod_name
+          .k8s_namespace = .kubernetes.pod_namespace
+          .k8s_container_name = .kubernetes.container_name
+          .k8s_node_name = .kubernetes.pod_node_name
+          
+          # 保持原始消息
+          .log_message = .message
+
+    sinks:
+      nats_sink:
+        type: nats
+        inputs:
+          - parse_and_enrich
+        connection_name: vector-daemonset
+        subject: vector
+        # 从环境变量NATS_URL读取
+        url: ${NATS_URL}
+        tls:
+          enabled: true
+          ca_file: /etc/nats_ca.crt
+        auth:
+          strategy: user_password
+          user_password:
+            user: ${NATS_USERNAME}
+            password: ${NATS_PASSWORD}
+        encoding:
+          codec: json
+        healthcheck:
+          enabled: true

--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -1,0 +1,439 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bk-lite-collector
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: bk-lite-collector
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  selector:
+    matchLabels:
+      name: cadvisor
+  template:
+    metadata:
+      labels:
+        name: cadvisor
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8080'
+        prometheus.io/path: '/metrics'
+    spec:
+      serviceAccountName: cadvisor
+      containers:
+      - name: cadvisor
+        image: bk-lite.tencentcloudcr.com/bklite/cadvisor:0.56.2
+        resources:
+          requests:
+            memory: 400Mi
+            cpu: 400m
+          limits:
+            memory: 2000Mi
+            cpu: 800m
+        args:
+          - --housekeeping_interval=10s
+          - --docker_only
+          - --store_container_labels=false
+          - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace
+        volumeMounts:
+          - name: rootfs
+            mountPath: /rootfs
+            readOnly: true
+          - name: var-run
+            mountPath: /var/run
+            readOnly: true
+          - name: sys
+            mountPath: /sys
+            readOnly: true
+          - name: docker
+            mountPath: /var/lib/docker
+            readOnly: true
+          - name: disk
+            mountPath: /dev/disk
+            readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: telegraf-daemonset
+  namespace: bk-lite-collector
+spec:
+  selector:
+    matchLabels:
+      app: telegraf-daemonset
+  template:
+    metadata:
+      labels:
+        app: telegraf-daemonset
+    spec:
+      containers:
+        - name: telegraf
+          image: bk-lite.tencentcloudcr.com/bklite/telegraf:1.29.5
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          envFrom:
+            - secretRef:
+                name: bk-lite-monitor-config-secret
+          env:
+            - name: HOST_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: telegraf-config-volume
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+            - name: nats-ca-cert
+              mountPath: /etc/nats_ca.crt
+              subPath: ca.crt
+      volumes:
+        - name: telegraf-config-volume
+          configMap:
+            name: telegraf-daemonset-config
+        - name: nats-ca-cert
+          secret:
+            secretName: bk-lite-monitor-config-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf-deployment
+  namespace: bk-lite-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telegraf
+  template:
+    metadata:
+      labels:
+        app: telegraf
+    spec:
+      containers:
+        - name: telegraf
+          image: bk-lite.tencentcloudcr.com/bklite/telegraf:1.29.5
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          envFrom:
+            - secretRef:
+                name: bk-lite-monitor-config-secret
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: telegraf-config-volume
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+            - name: nats-ca-cert
+              mountPath: /etc/nats_ca.crt
+              subPath: ca.crt
+      volumes:
+        - name: telegraf-config-volume
+          configMap:
+            name: telegraf-config
+        - name: nats-ca-cert
+          secret:
+            secretName: bk-lite-monitor-config-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vmagent
+  namespace: bk-lite-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vmagent
+  template:
+    metadata:
+      labels:
+        app: vmagent
+    spec:
+      serviceAccountName: vmagent
+      containers:
+        - name: vmagent
+          image: bk-lite.tencentcloudcr.com/bklite/vmagent
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          args:
+            - "--promscrape.config=/etc/prometheus/prometheus.yml"
+            - "--remoteWrite.url=http://telegraf:9090/receive"
+          envFrom:
+            - secretRef:
+                name: bk-lite-monitor-config-secret
+          volumeMounts:
+            - name: vmagent-config-volume
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+      volumes:
+        - name: vmagent-config-volume
+          configMap:
+            name: vmagent-config
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vmagent
+  namespace: bk-lite-collector
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vmagent-role
+  namespace: bk-lite-collector
+rules:
+- apiGroups: [""]
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  - namespaces
+  verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vmagent-role-binding
+  namespace: bk-lite-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vmagent-role
+subjects:
+- kind: ServiceAccount
+  name: vmagent
+  namespace: bk-lite-collector
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cadvisor
+  namespace: bk-lite-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: telegraf
+  namespace: bk-lite-collector
+spec:
+  selector:
+    app: telegraf
+  ports:
+    - protocol: TCP
+      port: 9090
+      targetPort: 9090
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cadvisor
+  namespace: bk-lite-collector
+spec:
+  selector:
+    name: cadvisor
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-config
+  namespace: bk-lite-collector
+data:
+  telegraf.conf: |
+    [global_tags]
+
+    [agent]
+      interval = "10s"
+      round_interval = true
+      metric_buffer_limit = 100000
+      flush_buffer_when_full = true
+      collection_jitter = "0s"
+      flush_interval = "5s"
+      flush_jitter = "0s"
+      debug = false
+      quiet = false
+      hostname = "${CLUSTER_NAME:-k8s-bklite-cluster}"
+
+    [[inputs.http_listener_v2]]
+      service_address = ":9090"
+      paths = ["/receive"]
+      data_format = "prometheusremotewrite"
+
+    [[outputs.nats]]
+      servers = ["${NATS_URL:-nats://nats:4222}"]
+      username = "${NATS_USERNAME:-username}"
+      password = "${NATS_PASSWORD:-password}"
+      subject = "metrics.cloud"
+      data_format = "influx"
+      secure = true
+      insecure_skip_verify = false
+      tls_ca = "/etc/nats_ca.crt"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vmagent-config
+  namespace: bk-lite-collector
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 60s
+    scrape_configs:
+      - job_name: 'kubernetes-cadvisor'
+        kubernetes_sd_configs:
+        - role: pod
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_name]
+          action: keep
+          regex: cadvisor
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+          action: keep
+          regex: true
+        - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+          action: replace
+          target_label: __metrics_path__
+          regex: (.+)
+        - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+          action: replace
+          target_label: __address__
+          regex: ([^:]+)(?::\d+)?;(\\d+)
+          replacement: $1:$2
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          target_label: node
+        - target_label: instance_id
+          replacement: "%{CLUSTER_NAME}"
+        - target_label: instance_type
+          replacement: k8s
+        - target_label: instance_name
+          replacement: "%{CLUSTER_NAME}"
+        - source_labels: [container_label_io_kubernetes_pod_name]
+          target_label: pod
+          action: replace
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-daemonset-config
+  namespace: bk-lite-collector
+data:
+  telegraf.conf: |
+    [global_tags]
+      agent_id="$HOST_NODE_NAME"
+      instance_id="$HOST_NODE_NAME"
+
+    [agent]
+      interval = "10s"
+      round_interval = true
+      metric_batch_size = 1000
+      metric_buffer_limit = 10000
+      collection_jitter = "0s"
+      flush_interval = "30s"
+      flush_jitter = "0s"
+      precision = "0s"
+      hostname = "$HOST_NODE_NAME"
+      omit_hostname = false
+
+
+    [[outputs.http]]
+    url = "http://telegraf:9090/receive"
+    method = "POST"
+    data_format = "prometheusremotewrite"
+    [outputs.http.headers]
+      Content-Type  = "application/x-protobuf"
+      Content-Encoding = "snappy"
+      X-Prometheus-Remote-Write-Version = "0.1.0"
+
+    [[inputs.cpu]]
+      percpu = true
+      totalcpu = true
+      collect_cpu_time = false
+      report_active = false
+      core_tags = false
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.disk]]
+      ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.diskio]]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.mem]]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.net]]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.processes]]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }
+
+    [[inputs.system]]
+      tags = { "instance_name"="$HOST_NODE_NAME","node"="$HOST_NODE_NAME","instance_type"="k8s","instance_id"="${CLUSTER_NAME:-k8s-lite-cluster}"  }

--- a/agents/webhookd/bk-lite-resource-collector.yaml
+++ b/agents/webhookd/bk-lite-resource-collector.yaml
@@ -1,0 +1,340 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bk-lite-collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.13.0
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.13.0
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '8080'
+        prometheus.io/path: '/metrics'
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - name: kube-state-metrics
+        image: bk-lite.tencentcloudcr.com/bklite/kube-state-metrics:2.13.0
+        resources:
+          requests:
+            memory: 64Mi
+            cpu: 50m
+          limits:
+            memory: 256Mi
+            cpu: 200m
+        args:
+          - '--metric-labels-allowlist=*=[*]'
+          - '--metric-annotations-allowlist=*=[*]'
+          - '--metric-labels-allowlist=namespaces=[*]'
+        livenessProbe:
+          httpGet:
+            path: /livez
+            port: http-metrics
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: telemetry
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.13.0
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.13.0
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - serviceaccounts
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  - ingressclasses
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.13.0
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: bk-lite-collector
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.13.0
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: telegraf-resource
+  namespace: bk-lite-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: telegraf-resource
+  template:
+    metadata:
+      labels:
+        app: telegraf-resource
+    spec:
+      containers:
+        - name: telegraf
+          image: bk-lite.tencentcloudcr.com/bklite/telegraf:1.29.5
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          envFrom:
+            - secretRef:
+                name: bk-lite-monitor-config-secret
+          volumeMounts:
+            - name: telegraf-config-volume
+              mountPath: /etc/telegraf/telegraf.conf
+              subPath: telegraf.conf
+            - name: nats-ca-cert
+              mountPath: /etc/nats_ca.crt
+              subPath: ca.crt
+      volumes:
+        - name: telegraf-config-volume
+          configMap:
+            name: telegraf-resource-config
+        - name: nats-ca-cert
+          secret:
+            secretName: bk-lite-monitor-config-secret
+            items:
+              - key: ca.crt
+                path: ca.crt
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: telegraf-resource-config
+  namespace: bk-lite-collector
+data:
+  telegraf.conf: |
+    [global_tags]
+
+    [agent]
+      interval = "60s"
+      round_interval = true
+      metric_buffer_limit = 100000
+      flush_buffer_when_full = true
+      collection_jitter = "0s"
+      flush_interval = "10s"
+      flush_jitter = "0s"
+      debug = false
+      quiet = false
+      hostname = "${CLUSTER_NAME:-k8s-bklite-cluster}"
+
+    [[inputs.prometheus]]
+      urls = ["http://kube-state-metrics:8080/metrics"]
+      metric_version = 2
+      [inputs.prometheus.tags]
+        instance_id = "${CLUSTER_NAME:-k8s-bklite-cluster}"
+        instance_type = "k8s"
+        instance_name = "${CLUSTER_NAME:-k8s-bklite-cluster}"
+
+    [[outputs.nats]]
+      servers = ["${NATS_URL:-nats://nats:4222}"]
+      username = "${NATS_USERNAME:-username}"
+      password = "${NATS_PASSWORD:-password}"
+      subject = "metrics.cloud"
+      data_format = "influx"
+      secure = true
+      insecure_skip_verify = false
+      tls_ca = "/etc/nats_ca.crt"

--- a/agents/webhookd/infra/API.md
+++ b/agents/webhookd/infra/API.md
@@ -36,7 +36,7 @@ Content-Type: application/json
 | 参数 | 类型 | 必填 | 说明 |
 |------|------|------|------|
 | cluster_name | string | 是 | 集群名称，用于标识。只允许字母、数字、下划线和连字符 |
-| type | string | 是 | 采集器类型，枚举值：`metric`（指标采集）或 `log`（日志采集） |
+| type | string | 是 | 采集器类型，枚举值：`metric`（指标采集）、`log`（日志采集）或 `resource`（K8s 资源信息采集） |
 | nats_url | string | 是 | NATS 服务器地址，格式：`nats://host:port` |
 | nats_username | string | 是 | NATS 用户名 |
 | nats_password | string | 是 | NATS 密码 |
@@ -97,6 +97,22 @@ curl -X POST \
   http://localhost:8080/infra/render
 ```
 
+### 渲染资源采集器配置
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{
+    "cluster_name": "prod-cluster",
+    "type": "resource",
+    "nats_url": "nats://192.168.1.100:4222",
+    "nats_username": "admin",
+    "nats_password": "secret123",
+    "nats_ca": "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAJC1...\n-----END CERTIFICATE-----"
+  }' \
+  http://localhost:8080/infra/render
+```
+
 ### 提取 YAML 内容并保存到文件
 
 ```bash
@@ -119,7 +135,7 @@ curl -s -X POST \
 
 返回的 `yaml` 字段包含完整的 K8s 配置，由两部分组成：
 
-1. **Collector 配置**：根据 `type` 选择 metric 或 log 采集器模板
+1. **Collector 配置**：根据 `type` 选择 metric、log 或 resource 采集器模板
 2. **Secret 配置**：包含 NATS 连接信息（已 Base64 编码）
 
 可直接用于 `kubectl apply -f` 部署。
@@ -136,7 +152,7 @@ curl -s -X POST \
 ## 注意事项
 
 1. **cluster_name 命名规则**: 只允许字母、数字、下划线和连字符
-2. **type 取值**: 必须是 `metric` 或 `log`
+2. **type 取值**: 必须是 `metric`、`log` 或 `resource`
 3. **nats_ca 格式**: 需要完整的 PEM 格式证书
 4. **Content-Type**: 请求必须设置 `Content-Type: application/json`
 

--- a/agents/webhookd/infra/kubernetes.sh
+++ b/agents/webhookd/infra/kubernetes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # webhookd infra render script
-# 接收 JSON: {"cluster_name": "xxx", "type": "metric|log", "nats_url": "nats://x.x.x.x:4222", "nats_username": "user", "nats_password": "pass", "nats_ca": "..."}
+# 接收 JSON: {"cluster_name": "xxx", "type": "metric|log|resource", "nats_url": "nats://x.x.x.x:4222", "nats_username": "user", "nats_password": "pass", "nats_ca": "..."}
 # 渲染出 K8s 配置 YAML
 set -euo pipefail
 
@@ -9,6 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WEBHOOKD_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LOGS_TEMPLATE=$(cat "$WEBHOOKD_DIR/bk-lite-log-collector.yaml")
 METRIC_TEMPLATE=$(cat "$WEBHOOKD_DIR/bk-lite-metric-collector.yaml")
+RESOURCE_TEMPLATE=$(cat "$WEBHOOKD_DIR/bk-lite-resource-collector.yaml")
 SECRET_TEMPLATE=$(cat <<'EOF'
 apiVersion: v1
 kind: Secret
@@ -84,7 +85,7 @@ validate_cluster_name() {
 }
 
 validate_type() {
-    [[ "$1" == "metric" || "$1" == "log" ]]
+    [[ "$1" == "metric" || "$1" == "log" || "$1" == "resource" ]]
 }
 
 require_field() {
@@ -98,7 +99,7 @@ require_field() {
 require_field "cluster_name" "$CLUSTER_NAME"
 validate_cluster_name "$CLUSTER_NAME" || { json_error "$CLUSTER_NAME" "Invalid cluster_name format (only alphanumeric, underscore and hyphen allowed)"; exit 1; }
 require_field "type" "$TYPE"
-validate_type "$TYPE" || { json_error "$CLUSTER_NAME" "Invalid type: must be 'metric' or 'log'"; exit 1; }
+validate_type "$TYPE" || { json_error "$CLUSTER_NAME" "Invalid type: must be 'metric', 'log' or 'resource'"; exit 1; }
 require_field "nats_url" "$NATS_URL"
 require_field "nats_username" "$NATS_USERNAME"
 require_field "nats_password" "$NATS_PASSWORD"
@@ -117,6 +118,8 @@ render_k8s_config() {
     local template
     if [ "$type" == "log" ]; then
         template="$LOGS_TEMPLATE"
+    elif [ "$type" == "resource" ]; then
+        template="$RESOURCE_TEMPLATE"
     else
         template="$METRIC_TEMPLATE"
     fi

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-03

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/design.md
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/design.md
@@ -1,0 +1,55 @@
+## Context
+
+当前 webhookd 通过 `infra/kubernetes.sh` 提供 K8s 采集器 YAML 渲染服务。模板文件 `bk-lite-metric-collector.yaml` 包含了指标采集（cadvisor + telegraf + vmagent）和资源信息采集（kube-state-metrics）两类功能，二者耦合在一起。
+
+数据通路现状：
+```
+cadvisor ──┐
+           ├──▶ vmagent (scrape) ──▶ telegraf-deployment ──▶ NATS
+ksm ───────┘
+```
+
+拆分后：
+```
+metric 模板:
+  cadvisor ──▶ vmagent (scrape) ──▶ telegraf-deployment ──▶ NATS
+
+resource 模板:
+  kube-state-metrics ──▶ telegraf-resource (inputs.prometheus) ──▶ NATS
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- metric 和 resource 模板完全独立，可单独部署，互不依赖
+- 两份模板部署到同一集群时不产生资源名称冲突
+- webhookd 支持 `type=resource` 渲染新模板
+
+**Non-Goals:**
+- 不修改 server 端代码（Django views/services）
+- 不修改前端代码
+- 不改变 NATS subject 或数据格式
+- 不改变现有 metric/log 的行为
+
+## Decisions
+
+### 1. resource 数据通路：telegraf 直接 scrape，不经 vmagent
+
+**选择**: resource 模板用 telegraf `inputs.prometheus` 直接抓取 kube-state-metrics
+
+**替代方案**: 像 metric 模板一样用 vmagent 做中转
+
+**理由**: kube-state-metrics 是单点 Deployment，只需抓一个固定 endpoint（kube-state-metrics:8080/metrics）。不需要 vmagent 的 kubernetes_sd_configs 服务发现能力。少一层组件更简洁、资源消耗更少。
+
+### 2. 命名约定：resource 侧组件加 `-resource` 后缀
+
+metric 模板保持原有名称（cadvisor、vmagent、telegraf-deployment 等），resource 模板中的同类组件加 `-resource` 后缀（telegraf-resource、telegraf-resource-config），避免同一 namespace 下的冲突。kube-state-metrics 本身名称不变，因为它只存在于 resource 模板。
+
+### 3. Namespace 和 Secret 两边都声明
+
+两份模板都包含 `Namespace: bk-lite-collector` 的声明。Secret 由 kubernetes.sh 渲染时统一追加。`kubectl apply` 是幂等的，不会冲突。
+
+## Risks / Trade-offs
+
+- **[已部署集群升级]** 用户如果已经部署了旧的 metric-collector（包含 ksm），升级后新的 metric-collector 不再包含 ksm，但旧的 ksm 资源不会被自动清理 → 在文档/发布说明中提示用户需要手动清理旧的 ksm 资源，或先 `kubectl delete` 再重新 apply
+- **[两套 telegraf 资源开销]** resource 模板独立一套 telegraf → ksm 数据量不大，telegraf-resource 资源需求很低（128Mi/100m 足够）

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/proposal.md
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+当前 `bk-lite-metric-collector.yaml` 把指标采集（cadvisor、telegraf、vmagent）和 Kubernetes 资源信息采集（kube-state-metrics）混在一起。用户无法单独部署 kube-state-metrics 来采集集群资源状态，也无法在不部署 kube-state-metrics 的情况下只采集节点指标。拆分后两份模板各自独立，可以按需组合部署。
+
+## What Changes
+
+- 从 `bk-lite-metric-collector.yaml` 中移除所有 kube-state-metrics 相关资源（Deployment、Service、RBAC），以及 vmagent-config 中对 kube-state-metrics 的 scrape job
+- 新建 `bk-lite-resource-collector.yaml`，包含 kube-state-metrics 和独立的 telegraf-resource 数据通路（用 telegraf inputs.prometheus 直接 scrape ksm，不经过 vmagent）
+- webhookd `kubernetes.sh` 的 type 枚举从 `metric|log` 扩展为 `metric|log|resource`，加载并渲染新模板
+- 更新 webhookd `infra/API.md` 文档
+
+## Capabilities
+
+### New Capabilities
+- `resource-collector-template`: 独立的 kube-state-metrics 采集模板，包含 ksm Deployment、telegraf-resource（直接 scrape ksm 并输出到 NATS）、以及相关 RBAC/Service/ConfigMap
+- `webhookd-resource-type`: webhookd kubernetes.sh 支持 type=resource，渲染 resource-collector 模板
+
+### Modified Capabilities
+
+## Impact
+
+- `agents/webhookd/bk-lite-metric-collector.yaml` — 移除 kube-state-metrics 相关资源
+- `agents/webhookd/bk-lite-resource-collector.yaml` — 新文件
+- `agents/webhookd/infra/kubernetes.sh` — type 校验和模板分支扩展
+- `agents/webhookd/infra/API.md` — 文档更新
+- 不涉及 server 端代码变更，不涉及前端变更

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/specs/resource-collector-template/spec.md
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/specs/resource-collector-template/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Resource collector template contains kube-state-metrics
+`bk-lite-resource-collector.yaml` SHALL contain a kube-state-metrics Deployment (v2.13.0) with associated ClusterRole, ClusterRoleBinding, ServiceAccount, and headless Service.
+
+#### Scenario: kube-state-metrics resources present
+- **WHEN** the resource collector template is rendered
+- **THEN** the output YAML contains Deployment `kube-state-metrics`, Service `kube-state-metrics`, ClusterRole `kube-state-metrics`, ClusterRoleBinding `kube-state-metrics`, ServiceAccount `kube-state-metrics` in namespace `bk-lite-collector`
+
+### Requirement: Resource collector template contains independent telegraf-resource data path
+`bk-lite-resource-collector.yaml` SHALL contain a Deployment `telegraf-resource` that uses `inputs.prometheus` to scrape `kube-state-metrics:8080/metrics`, and `outputs.nats` to send data to NATS (subject `metrics.cloud`).
+
+#### Scenario: telegraf-resource scrapes kube-state-metrics directly
+- **WHEN** the resource collector is deployed
+- **THEN** `telegraf-resource` scrapes kube-state-metrics endpoint via `inputs.prometheus` at `http://kube-state-metrics:8080/metrics`
+- **THEN** scraped data is sent to NATS via `outputs.nats` on subject `metrics.cloud`
+
+#### Scenario: telegraf-resource uses dedicated ConfigMap
+- **WHEN** the resource collector template is rendered
+- **THEN** the output contains ConfigMap `telegraf-resource-config` with telegraf configuration for prometheus input and nats output
+
+### Requirement: Resource collector template includes instance tags
+`telegraf-resource` SHALL tag all metrics with `instance_id`, `instance_type=k8s`, and `instance_name` using the `CLUSTER_NAME` environment variable from the Secret, consistent with the metric collector's tagging convention.
+
+#### Scenario: Metrics have correct instance tags
+- **WHEN** telegraf-resource sends data to NATS
+- **THEN** each metric includes tags `instance_id=<CLUSTER_NAME>`, `instance_type=k8s`, `instance_name=<CLUSTER_NAME>`
+
+### Requirement: Resource collector template declares shared namespace
+`bk-lite-resource-collector.yaml` SHALL declare `Namespace: bk-lite-collector` so it can be deployed independently without requiring the metric collector.
+
+#### Scenario: Independent deployment
+- **WHEN** only the resource collector template is applied to a cluster (without metric collector)
+- **THEN** the namespace `bk-lite-collector` is created and all resources deploy successfully
+
+### Requirement: No naming conflicts with metric collector
+All resource-specific components (telegraf, ConfigMap) SHALL use `-resource` suffix to avoid name collisions with the metric collector template when both are deployed to the same cluster.
+
+#### Scenario: Both templates deployed to same cluster
+- **WHEN** both metric collector and resource collector are applied to the same cluster
+- **THEN** no resource name conflicts occur — metric has `telegraf-deployment`/`telegraf-config`, resource has `telegraf-resource`/`telegraf-resource-config`
+
+### Requirement: Metric collector no longer contains kube-state-metrics
+After the split, `bk-lite-metric-collector.yaml` SHALL NOT contain kube-state-metrics Deployment, Service, RBAC, or ServiceAccount. The vmagent ConfigMap SHALL NOT contain the `kubernetes-kube-state-metrics` scrape job.
+
+#### Scenario: kube-state-metrics removed from metric template
+- **WHEN** the metric collector template is rendered
+- **THEN** the output YAML does not contain any resources named `kube-state-metrics`
+- **THEN** the vmagent-config ConfigMap only contains the `kubernetes-cadvisor` scrape job

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/specs/webhookd-resource-type/spec.md
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/specs/webhookd-resource-type/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: webhookd accepts type=resource
+`kubernetes.sh` SHALL accept `type=resource` in addition to existing `metric` and `log` values.
+
+#### Scenario: Valid resource type
+- **WHEN** a request is sent with `"type": "resource"`
+- **THEN** kubernetes.sh validates successfully and proceeds to render
+
+#### Scenario: Invalid type rejected
+- **WHEN** a request is sent with `"type": "invalid"`
+- **THEN** kubernetes.sh returns an error: "Invalid type: must be 'metric', 'log' or 'resource'"
+
+### Requirement: webhookd renders resource-collector template
+When `type=resource`, kubernetes.sh SHALL load `bk-lite-resource-collector.yaml` as the template, render it with the Secret, and return the combined YAML.
+
+#### Scenario: Resource template rendered with Secret
+- **WHEN** a request is sent with `"type": "resource"` and valid NATS credentials
+- **THEN** the response `yaml` field contains the resource collector template concatenated with the rendered Secret
+
+### Requirement: API documentation updated
+`infra/API.md` SHALL document `resource` as a valid value for the `type` parameter.
+
+#### Scenario: API docs reflect new type
+- **WHEN** a developer reads `infra/API.md`
+- **THEN** the type parameter description lists `metric`, `log`, and `resource` as valid values

--- a/openspec/changes/archive/2026-04-03-split-resource-collector/tasks.md
+++ b/openspec/changes/archive/2026-04-03-split-resource-collector/tasks.md
@@ -1,0 +1,21 @@
+## 1. 新建 resource-collector 模板
+
+- [x] 1.1 创建 `agents/webhookd/bk-lite-resource-collector.yaml`，包含: Namespace、kube-state-metrics Deployment、ClusterRole、ClusterRoleBinding、ServiceAccount、headless Service（从现有 metric-collector 中提取，保持配置不变）
+- [x] 1.2 在 resource-collector 模板中添加 Deployment `telegraf-resource`，使用 `inputs.prometheus` 直接 scrape `http://kube-state-metrics:8080/metrics`，`outputs.nats` 输出到 `metrics.cloud`
+- [x] 1.3 在 resource-collector 模板中添加 ConfigMap `telegraf-resource-config`，配置 prometheus input（urls = kube-state-metrics:8080/metrics）和 nats output，添加 instance_id/instance_type/instance_name tags
+
+## 2. 精简 metric-collector 模板
+
+- [x] 2.1 从 `agents/webhookd/bk-lite-metric-collector.yaml` 中移除 kube-state-metrics Deployment、Service、ClusterRole、ClusterRoleBinding、ServiceAccount
+- [x] 2.2 修改 vmagent-config ConfigMap，移除 `kubernetes-kube-state-metrics` scrape job，只保留 `kubernetes-cadvisor`
+
+## 3. 更新 webhookd kubernetes.sh
+
+- [x] 3.1 在 `kubernetes.sh` 顶部加载新模板: `RESOURCE_TEMPLATE=$(cat "$WEBHOOKD_DIR/bk-lite-resource-collector.yaml")`
+- [x] 3.2 修改 `validate_type()` 函数，接受 `metric|log|resource`
+- [x] 3.3 修改 `render_k8s_config()` 函数中的模板选择逻辑，增加 `resource` 分支
+- [x] 3.4 更新错误提示信息，将 "must be 'metric' or 'log'" 改为 "must be 'metric', 'log' or 'resource'"
+
+## 4. 更新文档
+
+- [x] 4.1 更新 `agents/webhookd/infra/API.md`，type 参数说明加入 `resource`，添加渲染 resource collector 的 curl 示例

--- a/openspec/specs/resource-collector-template/spec.md
+++ b/openspec/specs/resource-collector-template/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Resource collector template contains kube-state-metrics
+`bk-lite-resource-collector.yaml` SHALL contain a kube-state-metrics Deployment (v2.13.0) with associated ClusterRole, ClusterRoleBinding, ServiceAccount, and headless Service.
+
+#### Scenario: kube-state-metrics resources present
+- **WHEN** the resource collector template is rendered
+- **THEN** the output YAML contains Deployment `kube-state-metrics`, Service `kube-state-metrics`, ClusterRole `kube-state-metrics`, ClusterRoleBinding `kube-state-metrics`, ServiceAccount `kube-state-metrics` in namespace `bk-lite-collector`
+
+### Requirement: Resource collector template contains independent telegraf-resource data path
+`bk-lite-resource-collector.yaml` SHALL contain a Deployment `telegraf-resource` that uses `inputs.prometheus` to scrape `kube-state-metrics:8080/metrics`, and `outputs.nats` to send data to NATS (subject `metrics.cloud`).
+
+#### Scenario: telegraf-resource scrapes kube-state-metrics directly
+- **WHEN** the resource collector is deployed
+- **THEN** `telegraf-resource` scrapes kube-state-metrics endpoint via `inputs.prometheus` at `http://kube-state-metrics:8080/metrics`
+- **THEN** scraped data is sent to NATS via `outputs.nats` on subject `metrics.cloud`
+
+#### Scenario: telegraf-resource uses dedicated ConfigMap
+- **WHEN** the resource collector template is rendered
+- **THEN** the output contains ConfigMap `telegraf-resource-config` with telegraf configuration for prometheus input and nats output
+
+### Requirement: Resource collector template includes instance tags
+`telegraf-resource` SHALL tag all metrics with `instance_id`, `instance_type=k8s`, and `instance_name` using the `CLUSTER_NAME` environment variable from the Secret, consistent with the metric collector's tagging convention.
+
+#### Scenario: Metrics have correct instance tags
+- **WHEN** telegraf-resource sends data to NATS
+- **THEN** each metric includes tags `instance_id=<CLUSTER_NAME>`, `instance_type=k8s`, `instance_name=<CLUSTER_NAME>`
+
+### Requirement: Resource collector template declares shared namespace
+`bk-lite-resource-collector.yaml` SHALL declare `Namespace: bk-lite-collector` so it can be deployed independently without requiring the metric collector.
+
+#### Scenario: Independent deployment
+- **WHEN** only the resource collector template is applied to a cluster (without metric collector)
+- **THEN** the namespace `bk-lite-collector` is created and all resources deploy successfully
+
+### Requirement: No naming conflicts with metric collector
+All resource-specific components (telegraf, ConfigMap) SHALL use `-resource` suffix to avoid name collisions with the metric collector template when both are deployed to the same cluster.
+
+#### Scenario: Both templates deployed to same cluster
+- **WHEN** both metric collector and resource collector are applied to the same cluster
+- **THEN** no resource name conflicts occur — metric has `telegraf-deployment`/`telegraf-config`, resource has `telegraf-resource`/`telegraf-resource-config`
+
+### Requirement: Metric collector no longer contains kube-state-metrics
+After the split, `bk-lite-metric-collector.yaml` SHALL NOT contain kube-state-metrics Deployment, Service, RBAC, or ServiceAccount. The vmagent ConfigMap SHALL NOT contain the `kubernetes-kube-state-metrics` scrape job.
+
+#### Scenario: kube-state-metrics removed from metric template
+- **WHEN** the metric collector template is rendered
+- **THEN** the output YAML does not contain any resources named `kube-state-metrics`
+- **THEN** the vmagent-config ConfigMap only contains the `kubernetes-cadvisor` scrape job

--- a/openspec/specs/webhookd-resource-type/spec.md
+++ b/openspec/specs/webhookd-resource-type/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: webhookd accepts type=resource
+`kubernetes.sh` SHALL accept `type=resource` in addition to existing `metric` and `log` values.
+
+#### Scenario: Valid resource type
+- **WHEN** a request is sent with `"type": "resource"`
+- **THEN** kubernetes.sh validates successfully and proceeds to render
+
+#### Scenario: Invalid type rejected
+- **WHEN** a request is sent with `"type": "invalid"`
+- **THEN** kubernetes.sh returns an error: "Invalid type: must be 'metric', 'log' or 'resource'"
+
+### Requirement: webhookd renders resource-collector template
+When `type=resource`, kubernetes.sh SHALL load `bk-lite-resource-collector.yaml` as the template, render it with the Secret, and return the combined YAML.
+
+#### Scenario: Resource template rendered with Secret
+- **WHEN** a request is sent with `"type": "resource"` and valid NATS credentials
+- **THEN** the response `yaml` field contains the resource collector template concatenated with the rendered Secret
+
+### Requirement: API documentation updated
+`infra/API.md` SHALL document `resource` as a valid value for the `type` parameter.
+
+#### Scenario: API docs reflect new type
+- **WHEN** a developer reads `infra/API.md`
+- **THEN** the type parameter description lists `metric`, `log`, and `resource` as valid values


### PR DESCRIPTION
- Created a new resource collector template `bk-lite-resource-collector.yaml` to independently deploy kube-state-metrics and telegraf-resource.
- Removed kube-state-metrics resources from the existing `bk-lite-metric-collector.yaml`.
- Updated webhookd to support rendering the new resource collector template with type=resource.
- Added necessary RBAC roles and bindings for kube-state-metrics and telegraf-resource.
- Ensured no naming conflicts between metric and resource collectors by appending `-resource` to resource-specific components.
- Updated API documentation to reflect the new resource type and its usage.