### PR TITLE
fix: lowercase Docker image tag to fix buildx error

### DIFF
--- a/.github/workflows/build-server-base.yml
+++ b/.github/workflows/build-server-base.yml
@@ -19,6 +19,9 @@ jobs:
       packages: write
 
     steps:
+      - name: Set image name to lowercase
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -39,7 +42,7 @@ jobs:
           file: ./server/support-files/release/Dockerfile.base
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
github.repository preserves original casing (TencentBlueKing/bk-lite), but Docker tags must be all lowercase. Added a step to lowercase the image name before using it in tags.