### PR TITLE
[monitor] 修复策略扫描假成功导致的告警漏报风险

### DIFF
--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -11,6 +11,13 @@ from apps.monitor.tasks.utils.policy_methods import period_to_seconds
 from apps.monitor.constants.alert_policy import AlertConstants
 
 
+def _run_scan_and_record_success(policy_obj, scan_time):
+    """Run one policy scan window and advance the watermark only after success."""
+    policy_obj.last_run_time = scan_time
+    MonitorPolicyScan(policy_obj).run()
+    MonitorPolicy.objects.filter(id=policy_obj.id).update(last_run_time=scan_time)
+
+
 @shared_task(base=Singleton, raise_on_duplicate=False)
 def scan_policy_task(policy_id):
     """扫描监控策略
@@ -43,14 +50,8 @@ def scan_policy_task(policy_id):
         current_time = datetime.now(timezone.utc)
 
         if not policy_obj.last_run_time:
-            policy_obj.last_run_time = current_time
-            MonitorPolicy.objects.filter(id=policy_id).update(
-                last_run_time=current_time
-            )
-            logger.info(
-                f"监控策略 [{policy_id}] 首次执行，设置 last_run_time: {current_time}"
-            )
-            MonitorPolicyScan(policy_obj).run()
+            logger.info(f"监控策略 [{policy_id}] 首次执行，扫描时间点: {current_time}")
+            _run_scan_and_record_success(policy_obj, current_time)
         else:
             period_seconds = period_to_seconds(policy_obj.period)
             gap_seconds = (current_time - policy_obj.last_run_time).total_seconds()
@@ -60,23 +61,16 @@ def scan_policy_task(policy_id):
             backfill_count = int(gap_seconds // period_seconds)
 
             if backfill_count <= 1:
-                policy_obj.last_run_time = current_time
-                MonitorPolicy.objects.filter(id=policy_id).update(
-                    last_run_time=current_time
-                )
-                MonitorPolicyScan(policy_obj).run()
+                _run_scan_and_record_success(policy_obj, current_time)
             else:
                 backfill_count = min(backfill_count, AlertConstants.MAX_BACKFILL_COUNT)
                 logger.info(f"监控策略 [{policy_id}] 需要补偿 {backfill_count} 个周期")
 
                 for i in range(backfill_count):
-                    policy_obj.last_run_time = policy_obj.last_run_time + timedelta(
+                    scan_time = policy_obj.last_run_time + timedelta(
                         seconds=period_seconds
                     )
-                    MonitorPolicyScan(policy_obj).run()
-                    MonitorPolicy.objects.filter(id=policy_id).update(
-                        last_run_time=policy_obj.last_run_time
-                    )
+                    _run_scan_and_record_success(policy_obj, scan_time)
                     logger.debug(
                         f"监控策略 [{policy_id}] 完成第 {i + 1}/{backfill_count} 次补偿"
                     )

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -301,8 +301,6 @@ class EventAlertManager:
         for event in event_objs:
             if event.level == "info":
                 continue
-            if event.level == "no_data" and self.policy.no_data_alert <= 0:
-                continue
             events_to_notify.append(event)
 
         if not events_to_notify:

--- a/server/apps/monitor/tasks/services/policy_scan/scanner.py
+++ b/server/apps/monitor/tasks/services/policy_scan/scanner.py
@@ -210,14 +210,11 @@ class MonitorPolicyScan:
             )
             return False
 
-        try:
-            self._execute_step(
-                "Set monitor instance key",
-                self.metric_query_service.set_monitor_obj_instance_key,
-                critical=True,
-            )
-        except Exception:
-            return False
+        self._execute_step(
+            "Set monitor instance key",
+            self.metric_query_service.set_monitor_obj_instance_key,
+            critical=True,
+        )
 
         return True
 
@@ -227,7 +224,9 @@ class MonitorPolicyScan:
 
         if AlertConstants.THRESHOLD in self.policy.enable_alerts:
             success, result = self._execute_step(
-                "Process threshold alerts", self._process_threshold_alerts
+                "Process threshold alerts",
+                self._process_threshold_alerts,
+                critical=True,
             )
             if success and result is not None:
                 alert_events, info_events = result
@@ -237,7 +236,9 @@ class MonitorPolicyScan:
 
         if AlertConstants.NO_DATA in self.policy.enable_alerts:
             success, result = self._execute_step(
-                "Process no-data alerts", self._process_no_data_alerts
+                "Process no-data alerts",
+                self._process_no_data_alerts,
+                critical=True,
             )
             if success and result is not None:
                 no_data_events = result

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -1,0 +1,270 @@
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+class _Logger:
+    def info(self, *args, **kwargs):
+        return None
+
+    def debug(self, *args, **kwargs):
+        return None
+
+    def warning(self, *args, **kwargs):
+        return None
+
+    def error(self, *args, **kwargs):
+        return None
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_module(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _PolicyQuerySet:
+    def __init__(self, manager):
+        self.manager = manager
+
+    def select_related(self, *args):
+        return self
+
+    def first(self):
+        return self.manager.policy
+
+    def update(self, **kwargs):
+        self.manager.updates.append(kwargs)
+        for key, value in kwargs.items():
+            setattr(self.manager.policy, key, value)
+        return 1
+
+
+class _PolicyManager:
+    def __init__(self, policy):
+        self.policy = policy
+        self.updates = []
+
+    def filter(self, **kwargs):
+        return _PolicyQuerySet(self)
+
+
+class _PolicyModel:
+    objects = None
+
+
+class _FrozenDateTime(datetime):
+    fixed_now = datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz=None):
+        if tz is None:
+            return cls.fixed_now.replace(tzinfo=None)
+        return cls.fixed_now.astimezone(tz)
+
+
+def _install_monitor_policy_dependencies(monkeypatch, policy, scan_cls):
+    def shared_task(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    _PolicyModel.objects = _PolicyManager(policy)
+
+    _install_module(monkeypatch, "celery", shared_task=shared_task)
+    _install_module(monkeypatch, "celery_singleton", Singleton=object)
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(monkeypatch, "apps.monitor.models", MonitorPolicy=_PolicyModel)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+    _install_module(monkeypatch, "apps.monitor.tasks.services.policy_scan", MonitorPolicyScan=scan_cls)
+    _install_module(monkeypatch, "apps.monitor.tasks.utils.policy_methods", period_to_seconds=lambda period: 60)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(MAX_BACKFILL_SECONDS=3600, MAX_BACKFILL_COUNT=10),
+    )
+
+
+def test_scan_policy_task_does_not_persist_watermark_when_scan_fails(monkeypatch):
+    policy = types.SimpleNamespace(
+        id=1001,
+        enable=True,
+        last_run_time=datetime(2026, 4, 21, 7, 59, tzinfo=timezone.utc),
+        period={"type": "min", "value": 1},
+    )
+
+    class FailingScan:
+        def __init__(self, policy_obj):
+            self.policy_obj = policy_obj
+
+        def run(self):
+            raise RuntimeError("victoriametrics unavailable")
+
+    _install_monitor_policy_dependencies(monkeypatch, policy, FailingScan)
+    module = _load_module(
+        "monitor_policy_failure_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "monitor_policy.py",
+    )
+    module.datetime = _FrozenDateTime
+
+    with pytest.raises(RuntimeError, match="victoriametrics unavailable"):
+        module.scan_policy_task(policy.id)
+
+    assert _PolicyModel.objects.updates == []
+
+
+def test_scan_policy_task_persists_watermark_after_successful_scan(monkeypatch):
+    policy = types.SimpleNamespace(
+        id=1002,
+        enable=True,
+        last_run_time=datetime(2026, 4, 21, 7, 59, tzinfo=timezone.utc),
+        period={"type": "min", "value": 1},
+    )
+    scanned_at = []
+
+    class SuccessfulScan:
+        def __init__(self, policy_obj):
+            self.policy_obj = policy_obj
+
+        def run(self):
+            scanned_at.append(self.policy_obj.last_run_time)
+
+    _install_monitor_policy_dependencies(monkeypatch, policy, SuccessfulScan)
+    module = _load_module(
+        "monitor_policy_success_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "monitor_policy.py",
+    )
+    module.datetime = _FrozenDateTime
+
+    result = module.scan_policy_task(policy.id)
+
+    assert scanned_at == [_FrozenDateTime.fixed_now]
+    assert _PolicyModel.objects.updates == [{"last_run_time": _FrozenDateTime.fixed_now}]
+    assert result["success"] is True
+
+
+def _install_scanner_dependencies(monkeypatch):
+    alert_constants = types.SimpleNamespace(THRESHOLD="threshold", NO_DATA="no_data")
+
+    _install_module(monkeypatch, "apps.monitor.constants.alert_policy", AlertConstants=alert_constants)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorInstanceOrganization=object,
+        MonitorAlert=object,
+        MonitorInstance=object,
+        PolicyInstanceBaseline=object,
+    )
+    _install_module(monkeypatch, "apps.monitor.services.policy_baseline", PolicyBaselineService=object)
+    _install_module(monkeypatch, "apps.monitor.tasks.services.policy_scan.metric_query", MetricQueryService=object)
+    _install_module(monkeypatch, "apps.monitor.tasks.services.policy_scan.alert_detector", AlertDetector=object)
+    _install_module(monkeypatch, "apps.monitor.tasks.services.policy_scan.event_alert_manager", EventAlertManager=object)
+    _install_module(monkeypatch, "apps.monitor.tasks.services.policy_scan.snapshot_recorder", SnapshotRecorder=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+    return alert_constants
+
+
+def test_policy_scan_collect_events_propagates_threshold_failures(monkeypatch):
+    alert_constants = _install_scanner_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_policy_scanner_failure_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "scanner.py",
+    )
+
+    scanner = object.__new__(module.MonitorPolicyScan)
+    scanner.policy = types.SimpleNamespace(id=1003, enable_alerts=[alert_constants.THRESHOLD])
+
+    def fail_threshold():
+        raise RuntimeError("metric query failed")
+
+    scanner._process_threshold_alerts = fail_threshold
+
+    with pytest.raises(RuntimeError, match="metric query failed"):
+        scanner._collect_events()
+
+
+def test_policy_scan_pre_check_propagates_metric_setup_failures(monkeypatch):
+    _install_scanner_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_policy_scanner_precheck_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "scanner.py",
+    )
+
+    scanner = object.__new__(module.MonitorPolicyScan)
+    scanner.policy = types.SimpleNamespace(id=1004, source={})
+    scanner.metric_query_service = types.SimpleNamespace(set_monitor_obj_instance_key=lambda: (_ for _ in ()).throw(RuntimeError("metric missing")))
+
+    with pytest.raises(RuntimeError, match="metric missing"):
+        scanner._pre_check()
+
+
+def test_no_data_events_can_notify_without_legacy_policy_field(monkeypatch):
+    bulk_update_calls = []
+
+    class MonitorEvent:
+        class objects:
+            @staticmethod
+            def bulk_update(event_objs, fields, batch_size=None):
+                bulk_update_calls.append((event_objs, fields, batch_size))
+
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=MonitorEvent,
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=object,
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
+    )
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(id=1005, name="no-data-policy")
+    manager._is_alert_center = False
+    manager.send_notice = lambda event: [{"result": True}]
+
+    event = types.SimpleNamespace(level="no_data", notice_result=None)
+
+    manager.notify_events([event])
+
+    assert event.notice_result == [{"result": True}]
+    assert bulk_update_calls == [([event], ["notice_result"], 100)]


### PR DESCRIPTION
@白宇飞

## 问题
监控策略扫描在窗口扫描完成前就写入 last_run_time，且阈值/无数据检测失败会被吞掉，可能出现任务成功但本轮告警没有真实扫描。

## 影响
VictoriaMetrics 查询、指标配置或检测逻辑短暂失败时，扫描水位仍会前进，后续补偿不会覆盖这个时间窗，存在告警漏报和排障误判风险；无数据告警通知还引用了不存在的历史字段，可能导致告警已生成但通知未发出。

## 本次处理
- 将策略扫描水位更新移动到扫描成功之后。
- 让策略前置检查、阈值检测、无数据检测失败向任务层抛出，避免假成功。
- 移除无数据通知对不存在字段 `no_data_alert` 的依赖。
- 补充聚焦单元测试覆盖失败不推进水位、成功后推进水位、检测失败抛出、无数据通知不依赖历史字段。

## 验证
`INSTALL_APPS='system_mgmt,alerts,console_mgmt,job_mgmt,log,monitor,node_mgmt,operation_analysis,opspilot,cmdb' uv run --extra dev pytest apps/monitor/tests/test_alert_name_template.py apps/monitor/tests/test_policy_scan_failure_handling.py -q --confcutdir=apps/monitor/tests -o addopts=''`

结果：7 passed。