### PR TITLE
[monitor] 修复无数据告警吞掉阈值告警导致漏报风险

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -94,14 +94,19 @@ class EventAlertManager:
         existing_alert_events = []
 
         active_alerts_map = {
-            self._get_alert_metric_instance_id(alert): alert
+            self._build_alert_key(
+                self._get_alert_metric_instance_id(alert), alert.alert_type
+            ): alert
             for alert in self.active_alerts
         }
 
         for event in events:
             metric_instance_id = event.get("metric_instance_id", "")
-            if metric_instance_id in active_alerts_map:
-                alert = active_alerts_map[metric_instance_id]
+            alert_key = self._build_alert_key(
+                metric_instance_id, self._get_event_alert_type(event)
+            )
+            if alert_key in active_alerts_map:
+                alert = active_alerts_map[alert_key]
                 event["alert_id"] = alert.id
                 event["_alert_obj"] = alert
                 existing_alert_events.append(event)
@@ -118,9 +123,17 @@ class EventAlertManager:
                     f"got {len(new_alerts)} for policy {self.policy.id}"
                 )
 
-            alert_map = {alert.metric_instance_id: alert for alert in new_alerts}
+            alert_map = {
+                self._build_alert_key(alert.metric_instance_id, alert.alert_type): alert
+                for alert in new_alerts
+            }
             for event in new_alert_events:
-                alert = alert_map.get(event.get("metric_instance_id", ""))
+                alert = alert_map.get(
+                    self._build_alert_key(
+                        event.get("metric_instance_id", ""),
+                        self._get_event_alert_type(event),
+                    )
+                )
                 if alert:
                     event["alert_id"] = alert.id
                     event["_alert_obj"] = alert
@@ -159,6 +172,12 @@ class EventAlertManager:
         if alert.metric_instance_id:
             return alert.metric_instance_id
         return str((alert.monitor_instance_id,))
+
+    def _get_event_alert_type(self, event) -> str:
+        return "no_data" if event.get("level") == "no_data" else "alert"
+
+    def _build_alert_key(self, metric_instance_id: str, alert_type: str) -> tuple:
+        return metric_instance_id, alert_type
 
     def _create_alerts_from_events(self, events):
         if not events:
@@ -287,13 +306,13 @@ class EventAlertManager:
                 logger.info(
                     f"send notice success for policy {self.policy.name}: {send_result}"
                 )
+            return [send_result]
         except Exception as e:
             logger.error(
                 f"send notice exception for policy {self.policy.name}: {e}",
                 exc_info=True,
             )
-
-        return []
+            return [{"result": False, "message": str(e)}]
 
     def notify_events(self, event_objs):
         events_to_notify = []

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -268,3 +268,149 @@ def test_no_data_events_can_notify_without_legacy_policy_field(monkeypatch):
 
     assert event.notice_result == [{"result": True}]
     assert bulk_update_calls == [([event], ["notice_result"], 100)]
+
+
+def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(
+            BULK_CREATE_BATCH_SIZE=100,
+            BULK_UPDATE_BATCH_SIZE=100,
+        ),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=object,
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=object,
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_key_test_module",
+        Path(__file__).resolve().parents[1]
+        / "tasks"
+        / "services"
+        / "policy_scan"
+        / "event_alert_manager.py",
+    )
+
+    metric_instance_id = "('host-1',)"
+    active_no_data_alert = types.SimpleNamespace(
+        id=101,
+        metric_instance_id=metric_instance_id,
+        monitor_instance_id="host-1",
+        alert_type="no_data",
+    )
+    created_alert = types.SimpleNamespace(
+        id=202,
+        metric_instance_id=metric_instance_id,
+        alert_type="alert",
+    )
+    created_from_events = []
+    persisted_events = []
+    existing_updates = []
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(id=1006, name="mixed-policy")
+    manager.active_alerts = [active_no_data_alert]
+    manager._create_alerts_from_events = lambda events: created_from_events.extend(
+        events
+    ) or [created_alert]
+    manager.create_events = lambda events: persisted_events.extend(events) or events
+    manager._update_existing_alerts_from_events = lambda events: existing_updates.extend(
+        events
+    )
+
+    threshold_event = {
+        "metric_instance_id": metric_instance_id,
+        "monitor_instance_id": "host-1",
+        "dimensions": {"instance_id": "host-1"},
+        "value": 95.0,
+        "level": "critical",
+        "content": "cpu critical",
+    }
+
+    event_objs, new_alerts = manager.create_events_and_alerts([threshold_event])
+
+    assert created_from_events == [threshold_event]
+    assert persisted_events == [threshold_event]
+    assert existing_updates == []
+    assert threshold_event["alert_id"] == created_alert.id
+    assert threshold_event["_alert_obj"] is created_alert
+    assert event_objs == [threshold_event]
+    assert new_alerts == [created_alert]
+
+
+def test_send_notice_returns_channel_result_for_event_audit(monkeypatch):
+    send_results = [{"result": True, "message": "sent"}]
+
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=object,
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=types.SimpleNamespace(
+            send_msg_with_channel=lambda *args: send_results[0]
+        ),
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_notice_test_module",
+        Path(__file__).resolve().parents[1]
+        / "tasks"
+        / "services"
+        / "policy_scan"
+        / "event_alert_manager.py",
+    )
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(
+        id=1007,
+        name="notice-policy",
+        notice_type_id=9,
+        notice_users=["admin"],
+    )
+    event = types.SimpleNamespace(content="cpu critical")
+
+    assert manager.send_notice(event) == send_results


### PR DESCRIPTION
@baiyf-git

## 问题本质
监控策略扫描在复用活动告警时只按 `metric_instance_id` 去重，没有区分 `alert` 与 `no_data`。当同一指标维度已有无数据告警时，后续阈值异常事件会被挂到这个无数据告警上，不会创建独立阈值告警。

## 主要影响
这会造成阈值告警漏建、通知内容和告警类型不一致，恢复/升级链路也会基于错误的告警类型推进。

## 本次处理
- 将活动告警匹配键调整为 `(metric_instance_id, alert_type)`。
- 新建告警回填事件 `alert_id` 时同样按告警类型匹配。
- 通知发送返回真实 channel 结果，避免事件通知审计一直为空。
- 补充策略扫描单元测试覆盖阈值告警与无数据告警同指标共存场景。

## 验证
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest pytest -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_policy_scan_failure_handling.py`
- `python3 -m py_compile server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py server/apps/monitor/tests/test_policy_scan_failure_handling.py`
- `git diff --check`

说明：标准 pytest 配置会加载根 `conftest.py` 与 Django settings，当前环境缺少 `django_extensions`，因此对该纯桩测试文件禁用了插件自动加载。