### PR TITLE
[incremental] 修复测试空行变更导致的 flake8 门禁失败

### DIFF
--- a/server/apps/system_mgmt/tests/nats_api_test.py
+++ b/server/apps/system_mgmt/tests/nats_api_test.py
@@ -15,6 +15,7 @@ from apps.system_mgmt.nats_api import get_all_users
 
 logger = logging.getLogger(__name__)
 
+
 def create_test_users():
     """创建测试用户数据"""
     test_users = [


### PR DESCRIPTION
## 涉及范围
- Commit: 4d11a80069e89ea7c64d974d34ba480866fe3ced
- 文件: `server/apps/system_mgmt/tests/nats_api_test.py`

## 具体问题
最近合入的增量变更删除了 `logger = logging.getLogger(__name__)` 与顶层函数 `create_test_users()` 之间的一行空行，使顶层函数前只剩 1 个空行。

## 全局影响
该文件属于 server 测试代码，仓库 pre-commit 配置会通过 flake8 检查 Python 文件。顶层函数前空行不足会触发 pycodestyle/flake8 的 E305 风格错误，从而影响 server 侧提交/门禁流程。

## 证据
- `server/.pre-commit-config.yaml` 启用了 flake8，并使用 `server/.flake8`。
- `server/.flake8` 没有忽略 E305。
- 增量 diff 直接删除了顶层函数前的空行。

## 最小修复
恢复顶层函数前的第二个空行，不改动业务逻辑和测试语义。

## 验证
- `git diff --check`
- `python3 -m py_compile server/apps/system_mgmt/tests/nats_api_test.py`

说明：完整 `uv run flake8 ...` 曾因依赖解析需要外网/DNS 访问而未完成。