### PR TITLE
fix: enforce monitor auth boundaries

### DIFF
--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -1,9 +1,12 @@
 from django.db import transaction
 from django.db import models
+from django.db.models import Q
 
-from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException
+from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.database import DatabaseConstants
+from apps.monitor.constants.permission import PermissionConstants
 from apps.monitor.models import (
     MonitorInstance,
     MonitorInstanceOrganization,
@@ -16,6 +19,8 @@ from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.config_format import ConfigFormat
 from apps.monitor.utils.plugin_controller import Controller
 from apps.rpc.node_mgmt import NodeMgmt
+from apps.system_mgmt.models import User
+from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
 class InstanceConfigService:
@@ -23,6 +28,167 @@ class InstanceConfigService:
         "Pod": "pod_status_phase",
         "Node": "node_status_condition",
     }
+
+    @staticmethod
+    def _build_permission_data(actor_context):
+        return {
+            "username": actor_context["username"],
+            "domain": actor_context["domain"],
+            "current_team": actor_context["current_team"],
+            "include_children": actor_context.get("include_children", False),
+        }
+
+    @staticmethod
+    def _build_actor_user(actor_context):
+        return User(username=actor_context["username"], domain=actor_context["domain"])
+
+    @staticmethod
+    def _get_actor_scope_groups(actor_context):
+        if actor_context.get("is_superuser"):
+            return None
+        return GroupUtils.get_user_authorized_child_groups(
+            actor_context.get("group_list", []),
+            actor_context["current_team"],
+            include_children=actor_context.get("include_children", False),
+        )
+
+    @classmethod
+    def _get_authorized_monitor_instances(cls, actor_context, monitor_object_id, require_operate=False):
+        if actor_context.get("is_superuser"):
+            return MonitorInstance.objects.filter(monitor_object_id=monitor_object_id)
+
+        permission = get_permission_rules(
+            cls._build_actor_user(actor_context),
+            actor_context["current_team"],
+            "monitor",
+            f"{PermissionConstants.INSTANCE_MODULE}.{monitor_object_id}",
+            include_children=actor_context.get("include_children", False),
+        )
+        team_ids = permission.get("team", [])
+        instance_permissions = permission.get("instance", [])
+        allowed_instance_ids = [
+            item["id"]
+            for item in instance_permissions
+            if isinstance(item, dict) and "id" in item and (not require_operate or "Operate" in item.get("permission", []))
+        ]
+
+        queryset = MonitorInstance.objects.filter(monitor_object_id=monitor_object_id)
+        if team_ids and allowed_instance_ids:
+            return queryset.filter(Q(monitorinstanceorganization__organization__in=team_ids) | Q(id__in=allowed_instance_ids)).distinct()
+        if team_ids:
+            return queryset.filter(monitorinstanceorganization__organization__in=team_ids).distinct()
+        if allowed_instance_ids:
+            return queryset.filter(id__in=allowed_instance_ids)
+        return queryset.none()
+
+    @classmethod
+    def _get_authorized_collect_configs(cls, ids, actor_context=None, require_operate=False):
+        config_ids = list({str(config_id) for config_id in ids if config_id not in (None, "")})
+        if not config_ids:
+            return []
+
+        config_objs = list(CollectConfig.objects.filter(id__in=config_ids).select_related("monitor_instance__monitor_object"))
+        if not config_objs:
+            return []
+
+        if actor_context is None:
+            return config_objs
+
+        if actor_context.get("is_superuser"):
+            return config_objs
+
+        configs_by_object = {}
+        for config_obj in config_objs:
+            configs_by_object.setdefault(config_obj.monitor_instance.monitor_object_id, []).append(config_obj)
+
+        authorized_ids = set()
+        for monitor_object_id, object_configs in configs_by_object.items():
+            instance_ids = {
+                instance_id
+                for instance_id in cls._get_authorized_monitor_instances(
+                    actor_context,
+                    monitor_object_id,
+                    require_operate=require_operate,
+                ).values_list("id", flat=True)
+            }
+            for config_obj in object_configs:
+                if config_obj.monitor_instance_id in instance_ids:
+                    authorized_ids.add(config_obj.id)
+
+        if len(authorized_ids) != len(config_ids):
+            raise UnauthorizedException("无权限访问指定采集配置")
+
+        return [config_obj for config_obj in config_objs if config_obj.id in authorized_ids]
+
+    @classmethod
+    def _ensure_instance_access(cls, collect_instance_id, actor_context=None, require_operate=False):
+        instance = MonitorInstance.objects.select_related("monitor_object").filter(id=collect_instance_id).first()
+        if not instance:
+            raise BaseAppException("监控实例不存在")
+        if actor_context is None:
+            return instance
+        if actor_context.get("is_superuser"):
+            return instance
+        authorized = (
+            cls._get_authorized_monitor_instances(
+                actor_context,
+                instance.monitor_object_id,
+                require_operate=require_operate,
+            )
+            .filter(id=collect_instance_id)
+            .exists()
+        )
+        if not authorized:
+            raise UnauthorizedException("无权限访问指定监控实例")
+        return instance
+
+    @classmethod
+    def _sanitize_instances_for_onboarding(cls, instances, actor_context):
+        if actor_context.get("is_superuser"):
+            authorized_scope_groups = None
+        else:
+            authorized_scope_groups = set(cls._get_actor_scope_groups(actor_context) or [])
+            if not authorized_scope_groups:
+                raise UnauthorizedException("当前组织无可用权限范围")
+
+        requested_node_ids = set()
+        for instance in instances:
+            node_ids = instance.get("node_ids", [])
+            if not node_ids:
+                raise BaseAppException(f"实例 {instance.get('instance_name', instance.get('instance_id', 'unknown'))} 缺少 node_ids")
+            requested_node_ids.update(str(node_id) for node_id in node_ids if node_id not in (None, ""))
+
+        authorized_nodes = NodeMgmt().get_authorized_nodes_by_ids(
+            list(requested_node_ids),
+            cls._build_permission_data(actor_context),
+        )
+        authorized_node_map = {str(node["id"]): node for node in authorized_nodes}
+        unauthorized_node_ids = sorted(requested_node_ids - set(authorized_node_map))
+        if unauthorized_node_ids:
+            raise UnauthorizedException(f"存在无权限节点: {', '.join(unauthorized_node_ids)}")
+
+        sanitized_instances = []
+        for instance in instances:
+            node_ids = []
+            group_ids = set()
+            for raw_node_id in instance.get("node_ids", []):
+                node_id = str(raw_node_id)
+                node_info = authorized_node_map.get(node_id)
+                if not node_info:
+                    raise UnauthorizedException(f"节点 {node_id} 无权限访问")
+                node_ids.append(node_id)
+                node_groups = set(node_info.get("organization_ids", []))
+                if authorized_scope_groups is not None:
+                    node_groups &= authorized_scope_groups
+                if not node_groups:
+                    raise UnauthorizedException(f"节点 {node_id} 不在当前组织授权范围内")
+                group_ids.update(node_groups)
+
+            sanitized_instance = {**instance}
+            sanitized_instance["node_ids"] = node_ids
+            sanitized_instance["group_ids"] = sorted(group_ids)
+            sanitized_instances.append(sanitized_instance)
+        return sanitized_instances
 
     @classmethod
     def _get_default_group_metric(cls, child_obj):
@@ -64,9 +230,13 @@ class InstanceConfigService:
         return len(instances_to_update)
 
     @staticmethod
-    def get_config_content(ids):
+    def get_config_content(ids, actor_context=None):
         result = {}
-        config_objs = CollectConfig.objects.filter(id__in=ids)
+        config_objs = InstanceConfigService._get_authorized_collect_configs(
+            ids,
+            actor_context,
+            require_operate=False,
+        )
         if not config_objs:
             return result
 
@@ -90,8 +260,14 @@ class InstanceConfigService:
         return result
 
     @staticmethod
-    def get_instance_configs(collect_instance_id):
+    def get_instance_configs(collect_instance_id, actor_context=None):
         """获取实例配置"""
+
+        InstanceConfigService._ensure_instance_access(
+            collect_instance_id,
+            actor_context,
+            require_operate=False,
+        )
 
         config_objs = CollectConfig.objects.filter(monitor_instance_id=collect_instance_id)
 
@@ -129,7 +305,7 @@ class InstanceConfigService:
 
         items = list(result.values())
         for item in items:
-            config_content = InstanceConfigService.get_config_content(item["config_ids"])
+            config_content = InstanceConfigService.get_config_content(item["config_ids"], actor_context)
             item.update(config_content=config_content)
 
         return items
@@ -398,7 +574,7 @@ class InstanceConfigService:
         return instance_objs, association_objs, instance_ids
 
     @staticmethod
-    def create_monitor_instance_by_node_mgmt(data):
+    def create_monitor_instance_by_node_mgmt(data, actor_context=None):
         """创建监控对象实例（支持同一实例ID多种采集方式）"""
         instances = data.get("instances", [])
         monitor_object_id = data["monitor_object_id"]
@@ -411,10 +587,14 @@ class InstanceConfigService:
             logger.info("没有需要创建的实例")
             return
 
+        sanitized_instances = instances
+        if actor_context is not None:
+            sanitized_instances = InstanceConfigService._sanitize_instances_for_onboarding(instances, actor_context)
+
         # ============ 阶段1: 参数预校验与数据准备 ============
         try:
             new_instances, existing_instances, deleted_ids = InstanceConfigService._prepare_instances_for_creation(
-                instances,
+                sanitized_instances,
                 monitor_object_id,
                 collect_type,
                 collector,
@@ -448,9 +628,10 @@ class InstanceConfigService:
 
                 # 阶段3：调用 Controller 创建采集配置（使用外层事务）
                 # 注意：所有实例（新建+已存在）都需要创建采集配置
-                data["instances"] = new_instances + existing_instances
-                data["monitor_plugin_id"] = monitor_plugin_id
-                Controller(data).controller()
+                sanitized_data = {**data}
+                sanitized_data["instances"] = new_instances + existing_instances
+                sanitized_data["monitor_plugin_id"] = monitor_plugin_id
+                Controller(sanitized_data).controller()
                 logger.info("采集配置创建成功")
 
                 # ✅ 所有操作成功，事务自动提交
@@ -467,16 +648,35 @@ class InstanceConfigService:
         logger.info(f"创建监控实例成功,共 {len(created_instance_ids)} 个新实例,{len(existing_instances)} 个复用实例")
 
     @staticmethod
-    def update_instance_config(child_info, base_info):
+    def update_instance_config(child_info, base_info, actor_context=None):
+        config_ids = []
+        if base_info and base_info.get("id"):
+            config_ids.append(base_info["id"])
+        if child_info and child_info.get("id"):
+            config_ids.append(child_info["id"])
+
+        config_objs = InstanceConfigService._get_authorized_collect_configs(
+            config_ids,
+            actor_context,
+            require_operate=True,
+        )
+        config_map = {config.id: config for config in config_objs}
+
+        if base_info and child_info:
+            base_config = config_map.get(base_info["id"])
+            child_config = config_map.get(child_info["id"])
+            if base_config and child_config and base_config.monitor_instance_id != child_config.monitor_instance_id:
+                raise BaseAppException("基础配置与子配置不属于同一监控实例")
+
         if base_info:
-            config_obj = CollectConfig.objects.filter(id=base_info["id"]).first()
+            config_obj = config_map.get(base_info["id"])
             if config_obj:
                 content = ConfigFormat.json_to_yaml(base_info["content"])
                 env_config = base_info.get("env_config")
                 NodeMgmt().update_config_content(base_info["id"], content, env_config)
 
         if child_info:
-            config_obj = CollectConfig.objects.filter(id=child_info["id"]).first()
+            config_obj = config_map.get(child_info["id"])
             if not config_obj:
                 return
             env_config = child_info.get("env_config")

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -2,6 +2,7 @@ import uuid
 
 from jinja2 import Environment, BaseLoader, DebugUndefined
 
+from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import CollectConfig, MonitorPluginConfigTemplate
@@ -166,23 +167,23 @@ class Controller:
 
         if not templates_by_type:
             logger.warning(f"未找到任何模板：collector={collector}, collect_type={collect_type}")
-            return
+            raise BaseAppException(f"未找到采集模板：collector={collector}, collect_type={collect_type}")
 
         if not configs:
             logger.debug(f"没有需要创建的配置：collector={collector}, collect_type={collect_type}")
-            return
+            raise BaseAppException(f"没有可创建的采集配置：collector={collector}, collect_type={collect_type}")
 
         for config_info in configs:
             type_name = config_info.get("type")
             if not type_name:
-                logger.warning(f"配置缺少 type 字段，跳过: {config_info}")
-                continue
+                logger.warning(f"配置缺少 type 字段: {config_info}")
+                raise BaseAppException("采集配置缺少 type 字段")
 
             templates = templates_by_type.get(type_name)
 
             if not templates:
                 logger.warning(f"未找到模板：collector={collector}, collect_type={collect_type}, type={type_name}")
-                continue
+                raise BaseAppException(f"未找到采集模板：collector={collector}, collect_type={collect_type}, type={type_name}")
 
             env_config = {k[4:]: v for k, v in config_info.items() if k.startswith("ENV_")}
 
@@ -203,7 +204,7 @@ class Controller:
                     )
                 except (ValueError, Exception) as e:
                     logger.error(f"渲染模板失败：type={type_name}, config_id={config_id}, instance_id={config_info.get('instance_id')}, 错误: {e}")
-                    continue
+                    raise BaseAppException(f"渲染采集模板失败：type={type_name}, instance_id={config_info.get('instance_id')}") from e
 
                 if is_child:
                     child_env_config = {f"{k.upper()}__{config_id.upper()}": v for k, v in env_config.items()}
@@ -245,7 +246,7 @@ class Controller:
 
         if not collect_configs:
             logger.warning(f"没有生成任何配置：collector={collector}, collect_type={collect_type}")
-            return
+            raise BaseAppException(f"没有生成任何采集配置：collector={collector}, collect_type={collect_type}")
 
         # 步骤2：批量创建 CollectConfig（使用外层事务，不新建事务）
         try:

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -3,25 +3,24 @@ from apps.rpc.system_mgmt import SystemMgmt
 
 class SystemMgmtUtils:
     @staticmethod
-    def get_user_all(group=None, include_children=False):
-        result = SystemMgmt().get_group_users(
-            group=group, include_children=include_children
-        )
+    def get_user_all(actor_context, group=None, include_children=False):
+        result = SystemMgmt().get_group_users_scoped(actor_context, group=group, include_children=include_children)
         return result["data"]
 
     @staticmethod
-    def search_channel_list(channel_type="", teams=None, include_children=False):
+    def search_channel_list(actor_context, channel_type="", teams=None, include_children=False):
         """email、enterprise_wechat"""
-        result = SystemMgmt().search_channel_list(
-            channel_type, teams=teams, include_children=include_children
+        result = SystemMgmt().search_channel_list_scoped(
+            actor_context,
+            channel_type=channel_type,
+            teams=teams,
+            include_children=include_children,
         )
         return result["data"]
 
     @staticmethod
     def send_msg_with_channel(channel_id, title, content, receivers):
-        result = SystemMgmt().send_msg_with_channel(
-            channel_id, title, content, receivers
-        )
+        result = SystemMgmt().send_msg_with_channel(channel_id, title, content, receivers)
         return result
 
     @staticmethod
@@ -47,11 +46,7 @@ class SystemMgmtUtils:
             # 去重权限
             instance_permission_map[instance_id] = list(set(permissions))
 
-        if (
-            "0" in instance_permission_map
-            or "-1" in instance_permission_map
-            or not instance_permission_map
-        ):
+        if "0" in instance_permission_map or "-1" in instance_permission_map or not instance_permission_map:
             return None
         return instance_permission_map
 

--- a/server/apps/monitor/views/node_mgmt.py
+++ b/server/apps/monitor/views/node_mgmt.py
@@ -1,6 +1,7 @@
 from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 
+from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.services.node_mgmt import InstanceConfigService
 from apps.rpc.node_mgmt import NodeMgmt
@@ -8,17 +9,33 @@ from apps.core.logger import monitor_logger as logger
 from apps.monitor.utils.pagination import parse_page_params
 
 
+def _build_actor_context(request):
+    current_team = request.COOKIES.get("current_team")
+    if current_team in (None, ""):
+        raise BaseAppException("缺少 current_team 参数")
+
+    try:
+        current_team = int(current_team)
+    except (TypeError, ValueError):
+        raise BaseAppException("current_team 参数非法")
+
+    return {
+        "username": request.user.username,
+        "domain": request.user.domain,
+        "current_team": current_team,
+        "include_children": request.COOKIES.get("include_children", "0") == "1",
+        "is_superuser": request.user.is_superuser,
+        "group_list": [int(group["id"]) for group in getattr(request.user, "group_list", []) if isinstance(group, dict) and "id" in group],
+    }
+
+
 class NodeMgmtView(ViewSet):
     @action(methods=["post"], detail=False, url_path="nodes")
     def get_nodes(self, request):
-        orgs = {
-            i["id"] for i in request.user.group_list if i["name"] == "OpsPilotGuest"
-        }
+        orgs = {i["id"] for i in request.user.group_list if i["name"] == "OpsPilotGuest"}
         orgs.add(request.COOKIES.get("current_team"))
 
-        page, page_size = parse_page_params(
-            request.data, default_page=1, default_page_size=10, allow_page_size_all=True
-        )
+        page, page_size = parse_page_params(request.data, default_page=1, default_page_size=10, allow_page_size_all=True)
 
         organization_ids = [] if request.user.is_superuser else list(orgs)
         data = NodeMgmt().node_list(
@@ -44,27 +61,29 @@ class NodeMgmtView(ViewSet):
 
     @action(methods=["post"], detail=False, url_path="batch_setting_node_child_config")
     def batch_setting_node_child_config(self, request):
+        actor_context = _build_actor_context(request)
         logger.debug(
             "batch_setting_node_child_config called by user=%s, current_team=%s",
             request.user.username,
             request.COOKIES.get("current_team"),
         )
-        InstanceConfigService.create_monitor_instance_by_node_mgmt(request.data)
+        InstanceConfigService.create_monitor_instance_by_node_mgmt(request.data, actor_context)
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=False, url_path="get_instance_asso_config")
     def get_instance_child_config(self, request):
-        data = InstanceConfigService.get_instance_configs(request.data["instance_id"])
+        actor_context = _build_actor_context(request)
+        data = InstanceConfigService.get_instance_configs(request.data["instance_id"], actor_context)
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="get_config_content")
     def get_config_content(self, request):
-        result = InstanceConfigService.get_config_content(request.data["ids"])
+        actor_context = _build_actor_context(request)
+        result = InstanceConfigService.get_config_content(request.data["ids"], actor_context)
         return WebUtils.response_success(result)
 
     @action(methods=["post"], detail=False, url_path="update_instance_collect_config")
     def update_instance_collect_config(self, request):
-        InstanceConfigService.update_instance_config(
-            request.data.get("child"), request.data.get("base")
-        )
+        actor_context = _build_actor_context(request)
+        InstanceConfigService.update_instance_config(request.data.get("child"), request.data.get("base"), actor_context)
         return WebUtils.response_success()

--- a/server/apps/monitor/views/system_mgmt.py
+++ b/server/apps/monitor/views/system_mgmt.py
@@ -1,21 +1,49 @@
 from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 
+from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
+
+
+def _build_actor_context(request):
+    current_team = request.COOKIES.get("current_team")
+    if current_team in (None, ""):
+        raise BaseAppException("缺少 current_team 参数")
+
+    try:
+        current_team = int(current_team)
+    except (TypeError, ValueError):
+        raise BaseAppException("current_team 参数非法")
+
+    return {
+        "username": request.user.username,
+        "domain": request.user.domain,
+        "current_team": current_team,
+        "include_children": request.COOKIES.get("include_children", "0") == "1",
+        "is_superuser": request.user.is_superuser,
+    }
 
 
 class SystemMgmtView(ViewSet):
     @action(methods=["get"], detail=False, url_path="user_all")
     def get_user_all(self, request):
-        current_team = request.COOKIES.get("current_team")
+        actor_context = _build_actor_context(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
-        data = SystemMgmtUtils.get_user_all(group=int(current_team), include_children=include_children)
+        data = SystemMgmtUtils.get_user_all(
+            actor_context,
+            group=actor_context["current_team"],
+            include_children=include_children,
+        )
         return WebUtils.response_success(data)
 
     @action(methods=["get"], detail=False, url_path="search_channel_list")
     def search_channel_list(self, request):
-        current_team = request.COOKIES.get("current_team")
+        actor_context = _build_actor_context(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
-        data = SystemMgmtUtils.search_channel_list(teams=[int(current_team)], include_children=include_children)
+        data = SystemMgmtUtils.search_channel_list(
+            actor_context,
+            teams=[actor_context["current_team"]],
+            include_children=include_children,
+        )
         return WebUtils.response_success(data)

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -39,9 +39,7 @@ class NatsService:
         return encrypted_config
 
     @staticmethod
-    def _merge_and_encrypt_env_config(
-        old_env_config: dict, new_env_config: dict
-    ) -> dict:
+    def _merge_and_encrypt_env_config(old_env_config: dict, new_env_config: dict) -> dict:
         """
         合并并智能加密环境变量配置
         只对变化的密码字段进行加密，未变化的保持原值
@@ -59,10 +57,7 @@ class NatsService:
 
         for key, value in new_env_config.items():
             # 如果不是密码字段，直接使用新值
-            if (
-                EnvVariableConstants.SENSITIVE_FIELD_KEYWORD not in key.lower()
-                or not value
-            ):
+            if EnvVariableConstants.SENSITIVE_FIELD_KEYWORD not in key.lower() or not value:
                 merged_config[key] = value
                 continue
 
@@ -79,9 +74,7 @@ class NatsService:
         return merged_config
 
     @transaction.atomic
-    def batch_create_configs_and_child_configs(
-        self, configs: list, child_configs: list
-    ):
+    def batch_create_configs_and_child_configs(self, configs: list, child_configs: list):
         """
         批量创建配置及其子配置（带事务保护）
         :param configs: 配置列表
@@ -102,20 +95,11 @@ class NatsService:
             - env_config: 环境变量配置（可选）
         """
 
-        cloud_regions = Node.objects.filter(
-            id__in=[i["node_id"] for i in configs]
-        ).values("id", "cloud_region_id", "operating_system")
-        cloud_region_map = {
-            i["id"]: (i["cloud_region_id"], i["operating_system"])
-            for i in cloud_regions
-        }
+        cloud_regions = Node.objects.filter(id__in=[i["node_id"] for i in configs]).values("id", "cloud_region_id", "operating_system")
+        cloud_region_map = {i["id"]: (i["cloud_region_id"], i["operating_system"]) for i in cloud_regions}
 
-        collectors = Collector.objects.filter(
-            name__in=[i["collector_name"] for i in configs]
-        ).values("name", "node_operating_system", "id")
-        collector_map = {
-            (i["name"], i["node_operating_system"]): i["id"] for i in collectors
-        }
+        collectors = Collector.objects.filter(name__in=[i["collector_name"] for i in configs]).values("name", "node_operating_system", "id")
+        collector_map = {(i["name"], i["node_operating_system"]): i["id"] for i in collectors}
 
         conf_objs, node_config_assos = [], []
         for config in configs:
@@ -123,9 +107,7 @@ class NatsService:
             collector_id = collector_map[(config["collector_name"], operating_system)]
 
             # 加密包含password的环境变量
-            encrypted_env_config = self._encrypt_password_fields(
-                config.get("env_config", {})
-            )
+            encrypted_env_config = self._encrypt_password_fields(config.get("env_config", {}))
 
             conf_objs.append(
                 CollectorConfiguration(
@@ -137,16 +119,10 @@ class NatsService:
                     env_config=encrypted_env_config,
                 )
             )
-            node_config_assos.append(
-                NodeCollectorConfiguration(
-                    node_id=config["node_id"], collector_config_id=config["id"]
-                )
-            )
+            node_config_assos.append(NodeCollectorConfiguration(node_id=config["node_id"], collector_config_id=config["id"]))
 
         if conf_objs:
-            CollectorConfiguration.objects.bulk_create(
-                conf_objs, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
-            )
+            CollectorConfiguration.objects.bulk_create(conf_objs, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
         if node_config_assos:
             NodeCollectorConfiguration.objects.bulk_create(
                 node_config_assos,
@@ -185,16 +161,12 @@ class NatsService:
             .distinct()
         )
 
-        base_config_map = {
-            (i["nodes__id"], i["collector__name"]): i["id"] for i in base_configs
-        }
+        base_config_map = {(i["nodes__id"], i["collector__name"]): i["id"] for i in base_configs}
 
         node_objs = []
         for config in configs:
             # 加密包含password的环境变量
-            encrypted_env_config = self._encrypt_password_fields(
-                config.get("env_config", {})
-            )
+            encrypted_env_config = self._encrypt_password_fields(config.get("env_config", {}))
 
             node_objs.append(
                 ChildConfig(
@@ -202,9 +174,7 @@ class NatsService:
                     collect_type=config["collect_type"],
                     config_type=config["type"],
                     content=config["content"],
-                    collector_config_id=base_config_map[
-                        (config["node_id"], config["collector_name"])
-                    ],
+                    collector_config_id=base_config_map[(config["node_id"], config["collector_name"])],
                     env_config=encrypted_env_config,
                     sort_order=config.get("sort_order", 0),
                     config_section=config.get("config_section", ""),
@@ -212,9 +182,7 @@ class NatsService:
             )
 
         if node_objs:
-            ChildConfig.objects.bulk_create(
-                node_objs, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
-            )
+            ChildConfig.objects.bulk_create(node_objs, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
 
     @transaction.atomic
     def batch_create_child_configs(self, configs: list):
@@ -269,9 +237,7 @@ class NatsService:
 
         if env_config:
             # 智能合并并加密：只对变化的密码字段加密
-            merged_env_config = self._merge_and_encrypt_env_config(
-                child_config.env_config, env_config
-            )
+            merged_env_config = self._merge_and_encrypt_env_config(child_config.env_config, env_config)
             child_config.env_config = merged_env_config
 
         child_config.save()
@@ -293,9 +259,7 @@ class NatsService:
 
         if env_config:
             # 智能合并并加密：只对变化的密码字段加密
-            merged_env_config = self._merge_and_encrypt_env_config(
-                config.env_config, env_config
-            )
+            merged_env_config = self._merge_and_encrypt_env_config(config.env_config, env_config)
             config.env_config = merged_env_config
 
         config.save()
@@ -445,6 +409,12 @@ def get_child_configs_by_ids(ids: list):
 def get_configs_by_ids(ids: list):
     """根据ID获取配置"""
     return NatsService().get_configs_by_ids(ids)
+
+
+@nats_client.register
+def get_authorized_nodes_by_ids(node_ids: list, permission_data: dict = None):
+    """根据节点ID列表获取当前调用方有权限的节点"""
+    return NodeService.get_authorized_nodes_by_ids(node_ids, permission_data)
 
 
 @nats_client.register

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -380,3 +380,43 @@ class NodeService:
         serializer = NodeSerializer(nodes, many=True)
         node_data = serializer.data
         return dict(count=count, nodes=node_data)
+
+    @staticmethod
+    def get_authorized_nodes_by_ids(node_ids, permission_data=None):
+        if not node_ids:
+            return []
+
+        permission_data = permission_data or {}
+        normalized_node_ids = list({str(node_id) for node_id in node_ids if node_id not in (None, "")})
+        if not normalized_node_ids:
+            return []
+
+        if permission_data:
+            user_obj = User(username=permission_data["username"], domain=permission_data["domain"])
+            from apps.core.utils.permission_utils import permission_filter
+
+            include_children = permission_data.get("include_children", False)
+            permission = get_permission_rules(
+                user_obj,
+                permission_data["current_team"],
+                "node_mgmt",
+                NodeConstants.MODULE,
+                include_children=include_children,
+            )
+            qs = permission_filter(
+                Node,
+                permission,
+                team_key="nodeorganization__organization__in",
+                id_key="id__in",
+            )
+        else:
+            qs = Node.objects.all()
+
+        nodes = qs.filter(id__in=normalized_node_ids).distinct().prefetch_related("nodeorganization_set")
+        return [
+            {
+                "id": node.id,
+                "organization_ids": [rel.organization for rel in node.nodeorganization_set.all()],
+            }
+            for node in nodes
+        ]

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -7,12 +7,8 @@ class NodeMgmt(object):
     def __init__(self, is_local_client=False):
         is_local_client = os.getenv("IS_LOCAL_RPC", "0") == "1" or is_local_client
 
-        self.permission_client = (
-            AppClient("apps.node_mgmt.nats.node.permission") if is_local_client else RpcClient()
-        )
-        self.client = (
-            AppClient("apps.node_mgmt.nats.node") if is_local_client else RpcClient()
-        )
+        self.permission_client = AppClient("apps.node_mgmt.nats.node.permission") if is_local_client else RpcClient()
+        self.client = AppClient("apps.node_mgmt.nats.node") if is_local_client else RpcClient()
 
     def get_module_data(self, **kwargs):
         """
@@ -56,17 +52,13 @@ class NodeMgmt(object):
         return_data = self.client.run("node_list", query_data)
         return return_data
 
-    def batch_create_configs_and_child_configs(
-        self, configs: list, child_configs: list
-    ):
+    def batch_create_configs_and_child_configs(self, configs: list, child_configs: list):
         """
         批量创建配置和子配置
         :param configs: 配置列表
         :param child_configs: 子配置列表
         """
-        return_data = self.client.run(
-            "batch_create_configs_and_child_configs", configs, child_configs
-        )
+        return_data = self.client.run("batch_create_configs_and_child_configs", configs, child_configs)
         return return_data
 
     def batch_add_node_child_config(self, configs: list):
@@ -111,6 +103,14 @@ class NodeMgmt(object):
         :param ids: 配置ID列表
         """
         return_data = self.client.run("get_configs_by_ids", ids)
+        return return_data
+
+    def get_authorized_nodes_by_ids(self, node_ids, permission_data=None):
+        return_data = self.client.run(
+            "get_authorized_nodes_by_ids",
+            node_ids,
+            permission_data or {},
+        )
         return return_data
 
     def update_child_config_content(self, id, content, env_config=None):

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -86,6 +86,15 @@ class SystemMgmt(object):
         return_data = self.client.run("get_group_users", group=group, include_children=include_children)
         return return_data
 
+    def get_group_users_scoped(self, actor_context, group=None, include_children=False):
+        return_data = self.client.run(
+            "get_group_users_scoped",
+            actor_context=actor_context,
+            group=group,
+            include_children=include_children,
+        )
+        return return_data
+
     def get_all_users(self):
         return_data = self.client.run("get_all_users")
         return return_data
@@ -115,6 +124,16 @@ class SystemMgmt(object):
         :param include_children: bool , True、False
         """
         return_data = self.client.run("search_channel_list", channel_type=channel_type, teams=teams, include_children=include_children)
+        return return_data
+
+    def search_channel_list_scoped(self, actor_context, channel_type="", teams=None, include_children=False):
+        return_data = self.client.run(
+            "search_channel_list_scoped",
+            actor_context=actor_context,
+            channel_type=channel_type,
+            teams=teams,
+            include_children=include_children,
+        )
         return return_data
 
     def send_msg_with_channel(self, channel_id, title, content, receivers, attachments=None):

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -296,6 +296,82 @@ def get_group_users(group=None, include_children=False):
     return {"result": True, "data": list(users)}
 
 
+def _get_actor_user_scope(actor_context, include_children=False):
+    """
+    根据调用方上下文解析允许访问的组织范围。
+
+    :param actor_context: 调用方上下文，包含 username、domain、current_team、is_superuser 等字段
+    :param include_children: 是否包含当前组织下的已授权子组织
+    :return: (user_obj, authorized_groups)
+        - user_obj: 当前调用用户对象，不存在时返回 None
+        - authorized_groups: 当前调用方允许访问的组织 ID 列表
+    """
+    username = (actor_context or {}).get("username")
+    domain = (actor_context or {}).get("domain", "domain.com")
+    current_team = (actor_context or {}).get("current_team")
+    is_superuser = (actor_context or {}).get("is_superuser", False)
+
+    if not username or current_team in (None, ""):
+        return None, []
+
+    user_obj = User.objects.filter(username=username, domain=domain).first()
+    if not user_obj:
+        return None, []
+
+    try:
+        current_team = int(current_team)
+    except (TypeError, ValueError):
+        return user_obj, []
+
+    if is_superuser:
+        if include_children:
+            return user_obj, GroupUtils.get_group_with_descendants(current_team)
+        return user_obj, [current_team]
+
+    authorized_groups = GroupUtils.get_user_authorized_child_groups(
+        user_obj.group_list,
+        current_team,
+        include_children=include_children,
+    )
+    return user_obj, authorized_groups
+
+
+@nats_client.register
+def get_group_users_scoped(actor_context, group=None, include_children=False):
+    """
+    在调用方授权范围内查询组织用户列表。
+
+    :param actor_context: 调用方上下文，包含 username、domain、current_team、is_superuser 等字段
+    :param group: 可选，指定查询的组织 ID；若不传则使用调用方当前授权范围
+    :param include_children: 是否包含目标组织下的已授权子组织用户
+    :return: 标准 NATS 返回结构，data 为用户列表
+    """
+    user_obj, authorized_groups = _get_actor_user_scope(actor_context, include_children=include_children)
+    if not user_obj or not authorized_groups:
+        return {"result": True, "data": []}
+
+    if group is not None:
+        try:
+            group = int(group)
+        except (TypeError, ValueError):
+            return {"result": True, "data": []}
+        if group not in authorized_groups:
+            return {"result": True, "data": []}
+        query_groups = GroupUtils.get_user_authorized_child_groups(
+            user_obj.group_list,
+            group,
+            include_children=include_children,
+        )
+    else:
+        query_groups = authorized_groups
+
+    if not query_groups:
+        return {"result": True, "data": []}
+
+    users = User.objects.filter(group_list__overlap=query_groups).values("id", "username", "display_name")
+    return {"result": True, "data": list(users)}
+
+
 @nats_client.register
 def get_all_users():
     data = User.objects.all().values(*User.display_fields())
@@ -484,6 +560,39 @@ def search_channel_list(channel_type="", teams=None, include_children=False):
         "result": True,
         "data": [i for i in channels.values("id", "name", "channel_type", "description")],
     }
+
+
+@nats_client.register
+def search_channel_list_scoped(actor_context, channel_type="", teams=None, include_children=False):
+    """
+    在调用方授权范围内查询通知通道列表。
+
+    :param actor_context: 调用方上下文，包含 username、domain、current_team、is_superuser 等字段
+    :param channel_type: 可选，通道类型过滤条件
+    :param teams: 可选，待查询的组织 ID 列表；最终会与调用方授权范围取交集
+    :param include_children: 是否包含当前组织下的已授权子组织
+    :return: 标准 NATS 返回结构，data 为通知通道列表
+    """
+    user_obj, authorized_groups = _get_actor_user_scope(actor_context, include_children=include_children)
+    if not user_obj or not authorized_groups:
+        return {"result": True, "data": []}
+
+    if teams:
+        normalized_teams = []
+        for team in teams:
+            try:
+                normalized_teams.append(int(team))
+            except (TypeError, ValueError):
+                continue
+        teams = [team for team in normalized_teams if team in authorized_groups]
+    else:
+        teams = authorized_groups
+
+    return search_channel_list(
+        channel_type=channel_type,
+        teams=teams,
+        include_children=False,
+    )
 
 
 @nats_client.register


### PR DESCRIPTION
Re-validate node, config, and team-scoped access on sensitive monitor flows so client-supplied ids and teams cannot bypass server-side authorization.