### PR TITLE
[incremental] 修复监控权限收敛导致 API 密钥团队失效

### DIFF
--- a/server/apps/monitor/tests/test_node_mgmt_actor_context.py
+++ b/server/apps/monitor/tests/test_node_mgmt_actor_context.py
@@ -1,0 +1,75 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_module(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_node_mgmt_view(monkeypatch):
+    class ViewSet:
+        pass
+
+    def action(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    _install_module(monkeypatch, "rest_framework.viewsets", ViewSet=ViewSet)
+    _install_module(monkeypatch, "rest_framework.decorators", action=action)
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(monkeypatch, "apps.core.utils.web_utils", WebUtils=types.SimpleNamespace(response_success=lambda data=None: data))
+    _install_module(monkeypatch, "apps.monitor.services.node_mgmt", InstanceConfigService=object)
+    _install_module(monkeypatch, "apps.rpc.node_mgmt", NodeMgmt=object)
+    _install_module(monkeypatch, "apps.core.logger", monitor_logger=types.SimpleNamespace(debug=lambda *args, **kwargs: None))
+    _install_module(monkeypatch, "apps.monitor.utils.pagination", parse_page_params=lambda *args, **kwargs: (1, 10))
+
+    return _load_module(
+        "monitor_node_mgmt_view_test_module",
+        Path(__file__).resolve().parents[1] / "views" / "node_mgmt.py",
+    )
+
+
+def test_build_actor_context_accepts_api_secret_integer_group_list(monkeypatch):
+    module = _load_node_mgmt_view(monkeypatch)
+    request = types.SimpleNamespace(
+        COOKIES={"current_team": "7", "include_children": "1"},
+        user=types.SimpleNamespace(
+            username="api-user",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[7],
+        ),
+    )
+
+    assert module._build_actor_context(request)["group_list"] == [7]
+
+
+def test_build_actor_context_keeps_token_group_dicts(monkeypatch):
+    module = _load_node_mgmt_view(monkeypatch)
+    request = types.SimpleNamespace(
+        COOKIES={"current_team": "8"},
+        user=types.SimpleNamespace(
+            username="token-user",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[{"id": "8", "name": "team-a"}],
+        ),
+    )
+
+    assert module._build_actor_context(request)["group_list"] == [8]

--- a/server/apps/monitor/views/node_mgmt.py
+++ b/server/apps/monitor/views/node_mgmt.py
@@ -19,13 +19,24 @@ def _build_actor_context(request):
     except (TypeError, ValueError):
         raise BaseAppException("current_team 参数非法")
 
+    group_list = []
+    for group in getattr(request.user, "group_list", []):
+        if isinstance(group, dict) and "id" in group:
+            group_id = group["id"]
+        else:
+            group_id = group
+        try:
+            group_list.append(int(group_id))
+        except (TypeError, ValueError):
+            continue
+
     return {
         "username": request.user.username,
         "domain": request.user.domain,
         "current_team": current_team,
         "include_children": request.COOKIES.get("include_children", "0") == "1",
         "is_superuser": request.user.is_superuser,
-        "group_list": [int(group["id"]) for group in getattr(request.user, "group_list", []) if isinstance(group, dict) and "id" in group],
+        "group_list": group_list,
     }
 
 


### PR DESCRIPTION
## 涉及范围
- 增量提交：723152f5d578569fa2717d4c87deaa877826fa0d（监控接入权限边界修复）
- 关键文件：server/apps/monitor/views/node_mgmt.py、server/apps/core/backends.py、server/apps/monitor/services/node_mgmt.py

## 具体问题
最近提交在监控采集配置接口新增 actor_context 权限校验时，只从 `request.user.group_list` 的字典结构中提取组织 ID。仓库中 `APISecretAuthBackend` 明确会把 API 密钥用户的 `group_list` 设置为整型列表 `[team]`，因此这类调用会被解析成空组织范围。

## 全局影响
这是局部解析逻辑影响全局权限链路：API 密钥用户即使绑定了合法团队，也会在监控实例接入、采集配置查看、采集配置更新链路中被当作无组织权限处理，导致自动化/API 接入监控配置失败。

## 证据
- `server/apps/core/backends.py` 中 `APISecretAuthBackend` 设置 `user.group_list = [user_secret.team]`
- `server/apps/monitor/views/node_mgmt.py` 的新增 actor_context 原逻辑只接受 `{"id": ...}` 结构
- `server/apps/monitor/services/node_mgmt.py` 会用 actor_context.group_list 计算非超管的组织授权范围，空列表会触发无权限结果

## 最小修复
- 兼容 `group_list` 的字典和整型/字符串两种结构，统一归一化为组织 ID 列表
- 补充轻量单测覆盖 API 密钥整型列表和普通 token 字典列表两种路径

## 验证
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -q -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_node_mgmt_actor_context.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run python -m py_compile apps/monitor/views/node_mgmt.py`
