### PR TITLE
fix: normalize monitor team scopes

### DIFF
--- a/server/apps/core/utils/group_query_mixin.py
+++ b/server/apps/core/utils/group_query_mixin.py
@@ -2,7 +2,9 @@
 组织级联查询混合类
 提供统一的组织权限过滤方法，确保查询集合与"选择组织 + 用户权限"一致
 """
+
 from apps.core.logger import logger
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
@@ -81,7 +83,7 @@ class GroupQueryMixin:
 
         # 普通用户，从user.group_list获取
         if hasattr(request.user, "group_list"):
-            return [i["id"] for i in request.user.group_list] or []
+            return normalize_user_group_ids(request.user.group_list)
 
         logger.warning(f"无法获取用户 {request.user.username} 的组织列表")
         return []

--- a/server/apps/core/utils/user_group.py
+++ b/server/apps/core/utils/user_group.py
@@ -4,6 +4,18 @@ from apps.rpc.system_mgmt import SystemMgmt
 logger = logging.getLogger(__name__)
 
 
+def normalize_user_group_ids(group_list):
+    """兼容 dict/int/str 结构并统一提取组织 ID 列表。"""
+    normalized_group_ids = []
+    for group in group_list or []:
+        group_id = group.get("id") if isinstance(group, dict) else group
+        try:
+            normalized_group_ids.append(int(group_id))
+        except (TypeError, ValueError):
+            continue
+    return normalized_group_ids
+
+
 class SubGroup:
     def __init__(self, group_id, group_list):
         self.group_id = group_id
@@ -104,6 +116,10 @@ class Group:
         """获取用户组织ID与子组ID的列表"""
         if user_group_list is None:
             user_group_list = []
+
+        normalized_group_ids = normalize_user_group_ids(user_group_list)
+        if normalized_group_ids and len(normalized_group_ids) == len(user_group_list):
+            return list(set(normalized_group_ids))
 
         all_groups = self.get_group_list()
         if not all_groups:

--- a/server/apps/core/utils/viewset_utils.py
+++ b/server/apps/core/utils/viewset_utils.py
@@ -6,6 +6,7 @@ from rest_framework import viewsets
 from rest_framework.response import Response
 
 from apps.core.utils.loader import LanguageLoader
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.permission_utils import delete_instance_rules, get_permission_rules
 
 logger = logging.getLogger(__name__)
@@ -31,7 +32,7 @@ class GenericViewSetFun(object):
 
     def get_has_permission(self, user, instance, current_team, is_list=False, is_check=False, include_children=False):
         """获取规则实例ID"""
-        user_groups = [int(i["id"]) for i in user.group_list]
+        user_groups = normalize_user_group_ids(getattr(user, "group_list", []))
         if include_children:
             group_tree = getattr(user, "group_tree", [])
             child_groups = self.extract_child_group_ids(group_tree, current_team)

--- a/server/apps/monitor/tests/test_node_mgmt_actor_context.py
+++ b/server/apps/monitor/tests/test_node_mgmt_actor_context.py
@@ -34,6 +34,15 @@ def _load_node_mgmt_view(monkeypatch):
     _install_module(monkeypatch, "rest_framework.decorators", action=action)
     _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
     _install_module(monkeypatch, "apps.core.utils.web_utils", WebUtils=types.SimpleNamespace(response_success=lambda data=None: data))
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.user_group",
+        normalize_user_group_ids=lambda groups: [
+            int(group.get("id") if isinstance(group, dict) else group)
+            for group in groups
+            if (group.get("id") if isinstance(group, dict) else group) is not None
+        ],
+    )
     _install_module(monkeypatch, "apps.monitor.services.node_mgmt", InstanceConfigService=object)
     _install_module(monkeypatch, "apps.rpc.node_mgmt", NodeMgmt=object)
     _install_module(monkeypatch, "apps.core.logger", monitor_logger=types.SimpleNamespace(debug=lambda *args, **kwargs: None))
@@ -73,3 +82,61 @@ def test_build_actor_context_keeps_token_group_dicts(monkeypatch):
     )
 
     assert module._build_actor_context(request)["group_list"] == [8]
+
+
+def test_get_nodes_accepts_api_secret_integer_group_list(monkeypatch):
+    captured = {}
+
+    class NodeMgmt:
+        def node_list(self, payload):
+            captured["payload"] = payload
+            return payload
+
+    module = _load_node_mgmt_view(monkeypatch)
+    module.NodeMgmt = NodeMgmt
+
+    request = types.SimpleNamespace(
+        COOKIES={"current_team": "7"},
+        data={},
+        user=types.SimpleNamespace(
+            username="api-user",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[7],
+        ),
+    )
+
+    module.NodeMgmtView().get_nodes(request)
+
+    assert captured["payload"]["organization_ids"] == [7]
+    assert captured["payload"]["permission_data"]["current_team"] == 7
+
+
+def test_get_nodes_keeps_opspilot_guest_group_ids(monkeypatch):
+    captured = {}
+
+    class NodeMgmt:
+        def node_list(self, payload):
+            captured["payload"] = payload
+            return payload
+
+    module = _load_node_mgmt_view(monkeypatch)
+    module.NodeMgmt = NodeMgmt
+
+    request = types.SimpleNamespace(
+        COOKIES={"current_team": "8"},
+        data={},
+        user=types.SimpleNamespace(
+            username="token-user",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[
+                {"id": "8", "name": "team-a"},
+                {"id": "10", "name": "OpsPilotGuest"},
+            ],
+        ),
+    )
+
+    module.NodeMgmtView().get_nodes(request)
+
+    assert set(captured["payload"]["organization_ids"]) == {8, 10}

--- a/server/apps/monitor/views/node_mgmt.py
+++ b/server/apps/monitor/views/node_mgmt.py
@@ -2,6 +2,7 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.services.node_mgmt import InstanceConfigService
 from apps.rpc.node_mgmt import NodeMgmt
@@ -19,32 +20,26 @@ def _build_actor_context(request):
     except (TypeError, ValueError):
         raise BaseAppException("current_team 参数非法")
 
-    group_list = []
-    for group in getattr(request.user, "group_list", []):
-        if isinstance(group, dict) and "id" in group:
-            group_id = group["id"]
-        else:
-            group_id = group
-        try:
-            group_list.append(int(group_id))
-        except (TypeError, ValueError):
-            continue
-
     return {
         "username": request.user.username,
         "domain": request.user.domain,
         "current_team": current_team,
         "include_children": request.COOKIES.get("include_children", "0") == "1",
         "is_superuser": request.user.is_superuser,
-        "group_list": group_list,
+        "group_list": normalize_user_group_ids(getattr(request.user, "group_list", [])),
     }
 
 
 class NodeMgmtView(ViewSet):
     @action(methods=["post"], detail=False, url_path="nodes")
     def get_nodes(self, request):
-        orgs = {i["id"] for i in request.user.group_list if i["name"] == "OpsPilotGuest"}
-        orgs.add(request.COOKIES.get("current_team"))
+        actor_context = _build_actor_context(request)
+        orgs = {
+            int(group["id"])
+            for group in getattr(request.user, "group_list", [])
+            if isinstance(group, dict) and group.get("name") == "OpsPilotGuest" and group.get("id") is not None
+        }
+        orgs.add(actor_context["current_team"])
 
         page, page_size = parse_page_params(request.data, default_page=1, default_page_size=10, allow_page_size_all=True)
 
@@ -64,7 +59,7 @@ class NodeMgmtView(ViewSet):
                 permission_data={
                     "username": request.user.username,
                     "domain": request.user.domain,
-                    "current_team": request.COOKIES.get("current_team"),
+                    "current_team": actor_context["current_team"],
                 },
             )
         )


### PR DESCRIPTION
Normalize mixed group_list payloads across monitor and shared permission helpers so API secret users regain team-scoped access without changing existing token behavior.