### PR TITLE
[instance] 修复日志实例写操作绕过组织与系统管理权限的风险

### DIFF
--- a/server/apps/log/tests/test_collect_instance_permission_guards.py
+++ b/server/apps/log/tests/test_collect_instance_permission_guards.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from apps.log.views.collect_config import CollectConfigViewSet, CollectInstanceViewSet
+
+
+class FakeQuerySet(list):
+    def select_related(self, *args):
+        return self
+
+    def prefetch_related(self, *args):
+        return self
+
+    def delete(self):
+        self.deleted = True
+
+
+class FakeOrganizations(list):
+    def all(self):
+        return self
+
+
+def make_request(data):
+    return SimpleNamespace(
+        user=SimpleNamespace(username="alice", domain="default"),
+        data=data,
+        COOKIES={"current_team": "1", "include_children": "0"},
+    )
+
+
+def make_instance(instance_id="inst-1", collect_type_id=7, organizations=None):
+    return SimpleNamespace(
+        id=instance_id,
+        collect_type_id=collect_type_id,
+        collectinstanceorganization_set=FakeOrganizations(
+            [SimpleNamespace(organization=org) for org in organizations or [2]]
+        ),
+    )
+
+
+def test_remove_collect_instance_requires_operate_permission(monkeypatch):
+    instance = make_instance()
+    from apps.log.views import collect_config
+
+    monkeypatch.setattr(
+        collect_config.CollectInstance.objects,
+        "filter",
+        Mock(return_value=FakeQuerySet([instance])),
+    )
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(return_value={"data": {}, "team": [1]}),
+    )
+    node_mgmt = Mock()
+    monkeypatch.setattr(collect_config, "NodeMgmt", node_mgmt)
+
+    response = CollectInstanceViewSet().remove_collect_instance(make_request({"instance_ids": [instance.id]}))
+
+    assert response.status_code == 403
+    node_mgmt.assert_not_called()
+
+
+def test_remove_collect_instance_allows_authorized_org_scope(monkeypatch):
+    instance = make_instance()
+    config_qs = FakeQuerySet([])
+    instance_delete_qs = FakeQuerySet([])
+    from apps.log.views import collect_config
+
+    monkeypatch.setattr(
+        collect_config.CollectInstance.objects,
+        "filter",
+        Mock(side_effect=[FakeQuerySet([instance]), instance_delete_qs]),
+    )
+    monkeypatch.setattr(collect_config.CollectConfig.objects, "filter", Mock(return_value=config_qs))
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(return_value={"data": {"all": {"team": [2]}}, "team": [1]}),
+    )
+
+    response = CollectInstanceViewSet().remove_collect_instance(make_request({"instance_ids": [instance.id]}))
+
+    assert response.status_code == 200
+    assert getattr(config_qs, "deleted", False)
+    assert getattr(instance_delete_qs, "deleted", False)
+
+
+def test_get_config_content_requires_view_permission(monkeypatch):
+    instance = make_instance()
+    config = SimpleNamespace(id="cfg-1", collect_instance_id=instance.id, collect_instance=instance)
+    from apps.log.views import collect_config
+
+    monkeypatch.setattr(
+        collect_config.CollectConfig.objects,
+        "filter",
+        Mock(return_value=FakeQuerySet([config])),
+    )
+    monkeypatch.setattr(
+        collect_config.CollectInstance.objects,
+        "filter",
+        Mock(return_value=FakeQuerySet([instance])),
+    )
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(return_value={"data": {}, "team": [1]}),
+    )
+    node_mgmt = Mock()
+    monkeypatch.setattr(collect_config, "NodeMgmt", node_mgmt)
+
+    response = CollectConfigViewSet().get_config_content(make_request({"ids": [config.id]}))
+
+    assert response.status_code == 403
+    node_mgmt.assert_not_called()
+
+
+def test_set_organizations_rejects_target_org_outside_authorized_scope(monkeypatch):
+    instance = make_instance()
+    from apps.log.views import collect_config
+
+    monkeypatch.setattr(
+        collect_config.CollectInstance.objects,
+        "filter",
+        Mock(return_value=FakeQuerySet([instance])),
+    )
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(return_value={"data": {"all": {"team": [2]}}, "team": [1]}),
+    )
+    set_orgs = Mock()
+    monkeypatch.setattr(collect_config.CollectTypeService, "set_instances_organizations", set_orgs)
+
+    response = CollectInstanceViewSet().set_organizations(
+        make_request({"instance_ids": [instance.id], "organizations": [3]})
+    )
+
+    assert response.status_code == 403
+    set_orgs.assert_not_called()

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -3,6 +3,7 @@ import yaml
 from rest_framework.decorators import action
 from rest_framework.viewsets import ModelViewSet, ViewSet
 
+from apps.core.constants import DEFAULT_PERMISSION
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.permission_utils import (
     get_permissions_rules,
@@ -175,6 +176,149 @@ class CollectTypeViewSet(ModelViewSet):
 
 
 class CollectInstanceViewSet(ViewSet):
+    OPERATE_PERMISSION = "Operate"
+
+    @staticmethod
+    def _normalize_ids(values):
+        if not values:
+            return []
+        if not isinstance(values, list):
+            values = [values]
+        return [str(value) for value in values if value is not None and str(value) != ""]
+
+    @staticmethod
+    def _normalize_orgs(values):
+        if not values:
+            return set()
+        if not isinstance(values, list):
+            values = [values]
+        orgs = set()
+        for value in values:
+            try:
+                orgs.add(int(value))
+            except (TypeError, ValueError):
+                continue
+        return orgs
+
+    @staticmethod
+    def _normalize_team_permissions(values):
+        team_ids = set()
+        if not isinstance(values, list):
+            return team_ids
+        for value in values:
+            if isinstance(value, dict):
+                value = value.get("id")
+            try:
+                team_ids.add(int(value))
+            except (TypeError, ValueError):
+                continue
+        return team_ids
+
+    @staticmethod
+    def _normalize_instance_permissions(values):
+        permission_map = {}
+        if not isinstance(values, list):
+            return permission_map
+        for value in values:
+            if not isinstance(value, dict) or "id" not in value:
+                continue
+            permission_map[str(value["id"])] = value.get("permission") or DEFAULT_PERMISSION
+        return permission_map
+
+    def _get_permission_context(self, request):
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        permission_result = get_permissions_rules(
+            request.user,
+            request.COOKIES.get("current_team"),
+            "log",
+            PermissionConstants.INSTANCE_MODULE,
+            include_children=include_children,
+        )
+        if not isinstance(permission_result, dict):
+            permission_result = {}
+        return permission_result.get("data", {}), self._normalize_orgs(permission_result.get("team", []))
+
+    @staticmethod
+    def _instance_orgs(instance):
+        return {rel.organization for rel in instance.collectinstanceorganization_set.all()}
+
+    def _permissions_for_instance(self, instance, permission_data, current_teams):
+        instance_orgs = self._instance_orgs(instance)
+
+        admin_teams = self._normalize_orgs(permission_data.get("all", {}).get("team", []))
+        if admin_teams and instance_orgs & admin_teams:
+            return DEFAULT_PERMISSION
+
+        type_permission = permission_data.get(str(instance.collect_type_id), {})
+        if not type_permission:
+            if current_teams & instance_orgs:
+                return DEFAULT_PERMISSION
+            return []
+
+        instance_permissions = self._normalize_instance_permissions(type_permission.get("instance", []))
+        if str(instance.id) in instance_permissions:
+            return instance_permissions[str(instance.id)]
+
+        team_permissions = self._normalize_team_permissions(type_permission.get("team", []))
+        if instance_orgs & team_permissions:
+            return DEFAULT_PERMISSION
+
+        return []
+
+    def _allowed_organization_scope(self, permission_data, current_teams, collect_type_id=None):
+        allowed = set(current_teams)
+        allowed |= self._normalize_orgs(permission_data.get("all", {}).get("team", []))
+
+        if collect_type_id is not None:
+            type_permission = permission_data.get(str(collect_type_id), {})
+            allowed |= self._normalize_team_permissions(type_permission.get("team", []))
+        else:
+            for key, type_permission in permission_data.items():
+                if key == "all" or not isinstance(type_permission, dict):
+                    continue
+                allowed |= self._normalize_team_permissions(type_permission.get("team", []))
+
+        return allowed
+
+    def _authorize_instances(self, request, instance_ids, required_permission=OPERATE_PERMISSION):
+        normalized_ids = self._normalize_ids(instance_ids)
+        if not normalized_ids:
+            return None, WebUtils.response_error(error_message="instance_ids is required")
+
+        instances = list(
+            CollectInstance.objects.filter(id__in=normalized_ids)
+            .select_related("collect_type")
+            .prefetch_related("collectinstanceorganization_set")
+        )
+        instance_map = {str(instance.id): instance for instance in instances}
+        missing_ids = [instance_id for instance_id in normalized_ids if instance_id not in instance_map]
+        if missing_ids:
+            return None, WebUtils.response_error(error_message="collect instance does not exist")
+
+        permission_data, current_teams = self._get_permission_context(request)
+        for instance_id in normalized_ids:
+            permissions = self._permissions_for_instance(instance_map[instance_id], permission_data, current_teams)
+            if required_permission not in permissions:
+                return None, WebUtils.response_403("User does not have permission to operate this instance")
+
+        return instances, None
+
+    def _authorize_target_organizations(self, request, organizations, collect_type_id=None):
+        target_orgs = self._normalize_orgs(organizations)
+        if not target_orgs:
+            return None
+        permission_data, current_teams = self._get_permission_context(request)
+        allowed_orgs = self._allowed_organization_scope(permission_data, current_teams, collect_type_id)
+        if not target_orgs.issubset(allowed_orgs):
+            return WebUtils.response_403("User does not have permission to assign instances to these organizations")
+        return None
+
+    def _extract_batch_instance_organizations(self, request_data):
+        organizations = set()
+        for instance in request_data.get("instances", []):
+            organizations |= self._normalize_orgs(instance.get("group_ids", []))
+        return list(organizations)
+
     @action(methods=["post"], detail=False, url_path="search")
     def search(self, request):
         """
@@ -229,7 +373,7 @@ class CollectInstanceViewSet(ViewSet):
             # 超管权限检查
             admin_cur_team = instance_res.get("all", {}).get("team")
             if admin_cur_team:
-                qs = CollectInstance.objects.filter(collectinstanceorganization__organization_in=admin_cur_team)
+                qs = CollectInstance.objects.filter(collectinstanceorganization__organization__in=admin_cur_team)
                 inst_permission_map = {}
             else:
                 objs = CollectInstance.objects.prefetch_related("collectinstanceorganization_set").all()
@@ -276,12 +420,22 @@ class CollectInstanceViewSet(ViewSet):
 
     @action(methods=["post"], detail=False, url_path="batch_create")
     def batch_create(self, request):
+        error_response = self._authorize_target_organizations(
+            request,
+            self._extract_batch_instance_organizations(request.data),
+            request.data.get("collect_type_id"),
+        )
+        if error_response:
+            return error_response
         CollectTypeService.batch_create_collect_configs(request.data)
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=False, url_path="remove_collect_instance")
     def remove_collect_instance(self, request):
         instance_ids = request.data.get("instance_ids", [])
+        _, error_response = self._authorize_instances(request, instance_ids)
+        if error_response:
+            return error_response
         config_objs = CollectConfig.objects.filter(collect_instance_id__in=instance_ids)
         child_configs, configs = [], []
         for config in config_objs:
@@ -302,8 +456,19 @@ class CollectInstanceViewSet(ViewSet):
 
     @action(methods=["post"], detail=False, url_path="instance_update")
     def instance_update(self, request):
+        instance_id = request.data.get("instance_id")
+        instances, error_response = self._authorize_instances(request, [instance_id])
+        if error_response:
+            return error_response
+        error_response = self._authorize_target_organizations(
+            request,
+            request.data.get("organizations", []),
+            instances[0].collect_type_id,
+        )
+        if error_response:
+            return error_response
         CollectTypeService.update_instance(
-            request.data.get("instance_id"),
+            instance_id,
             request.data.get("name"),
             request.data.get("organizations", []),
         )
@@ -314,16 +479,39 @@ class CollectInstanceViewSet(ViewSet):
         """设置监控对象实例组织"""
         instance_ids = request.data.get("instance_ids", [])
         organizations = request.data.get("organizations", [])
+        instances, error_response = self._authorize_instances(request, instance_ids)
+        if error_response:
+            return error_response
+        collect_type_ids = {instance.collect_type_id for instance in instances}
+        for collect_type_id in collect_type_ids:
+            error_response = self._authorize_target_organizations(request, organizations, collect_type_id)
+            if error_response:
+                return error_response
         CollectTypeService.set_instances_organizations(instance_ids, organizations)
         return WebUtils.response_success()
 
 
 class CollectConfigViewSet(ViewSet):
+    @staticmethod
+    def _extract_config_instance_ids(config_objs):
+        return list({config_obj.collect_instance_id for config_obj in config_objs})
+
+    def _authorize_config_instances(self, request, config_objs, required_permission="Operate"):
+        instance_ids = self._extract_config_instance_ids(config_objs)
+        helper = CollectInstanceViewSet()
+        _, error_response = helper._authorize_instances(request, instance_ids, required_permission)
+        return error_response
+
     @action(methods=["post"], detail=False, url_path="get_config_content")
     def get_config_content(self, request):
-        config_objs = CollectConfig.objects.filter(id__in=request.data["ids"])
+        config_objs = list(
+            CollectConfig.objects.filter(id__in=request.data["ids"]).select_related("collect_instance")
+        )
         if not config_objs:
             return WebUtils.response_error("配置不存在!")
+        error_response = self._authorize_config_instances(request, config_objs, required_permission="View")
+        if error_response:
+            return error_response
 
         result = {}
         for config_obj in config_objs:
@@ -350,11 +538,18 @@ class CollectConfigViewSet(ViewSet):
     def update_instance_collect_config(self, request):
         child = request.data.get("child")
         base = request.data.get("base")
+        instance_id = request.data.get("instance_id")
+        collect_type_id = request.data.get("collect_type_id")
 
         if isinstance(child, dict) and child.get("content") is None:
             return WebUtils.response_error("child.content is required")
         if isinstance(base, dict) and base.get("content") is None:
             return WebUtils.response_error("base.content is required")
+        instances, error_response = CollectInstanceViewSet()._authorize_instances(request, [instance_id])
+        if error_response:
+            return error_response
+        if str(instances[0].collect_type_id) != str(collect_type_id):
+            return WebUtils.response_error(error_message="collect_type does not match instance")
 
         CollectTypeService.update_instance_config_v2(
             child,


### PR DESCRIPTION
## 问题本质
@baiyf-git 日志采集实例的搜索路径会结合组织归属和系统管理实例权限做范围过滤，但实例删除、组织调整、实例配置读取/更新、批量创建等操作入口没有复用同一套实例权限边界，导致列表可见范围和实际可操作范围脱钩。

## 影响
拥有日志模块访问能力的用户可以通过实例 ID 直接触发敏感实例配置读取、配置更新、删除或组织归属变更；组织归属本应收缩实例范围，但写操作入口没有将系统管理权限与实例所属组织共同落到资源上，存在跨组织实例操作和权限模型失真风险。

## 本次处理
- 为日志采集实例操作入口增加统一的实例权限校验，写操作必须具备对应实例的 Operate 权限。
- 组织归属变更和批量创建时，限制目标组织必须落在用户可管理的组织范围内。
- 配置读取要求实例 View 权限，配置更新要求实例 Operate 权限，并校验实例与采集类型一致。
- 修复管理员实例搜索路径中的组织过滤字段拼写问题。

## 验证
- `python3 -m py_compile server/apps/log/views/collect_config.py server/apps/log/tests/test_collect_instance_permission_guards.py`
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DJANGO_SETTINGS_MODULE=settings INSTALL_APPS=log UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --extra dev --with pytest --with pytest-django pytest -p django -o addopts='' --confcutdir=apps/log/tests apps/log/tests/test_collect_instance_permission_guards.py`
- `UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with flake8 flake8 apps/log/views/collect_config.py apps/log/tests/test_collect_instance_permission_guards.py`
