### PR TITLE
[log] 收敛日志查询放大路径，降低列表和搜索响应时延风险

### DIFF
--- a/server/apps/log/constants/victoriametrics.py
+++ b/server/apps/log/constants/victoriametrics.py
@@ -15,3 +15,8 @@ class VictoriaLogsConstants:
     # SSE连接配置
     MAX_CONNECTION_TIME = int(os.getenv("SSE_MAX_CONNECTION_TIME", "1800"))  # 默认30分钟
     KEEPALIVE_INTERVAL = int(os.getenv("SSE_KEEPALIVE_INTERVAL", "45"))     # 默认45秒
+
+    # 查询保护：避免单次日志检索返回过大结果集，拖慢 VMLogs 和 Web 响应。
+    QUERY_LIMIT_MAX = int(os.getenv("VICTORIALOGS_QUERY_LIMIT_MAX", "1000"))
+    FIELD_VALUES_LIMIT_MAX = int(os.getenv("VICTORIALOGS_FIELD_VALUES_LIMIT_MAX", "1000"))
+    HITS_FIELDS_LIMIT_MAX = int(os.getenv("VICTORIALOGS_HITS_FIELDS_LIMIT_MAX", "100"))

--- a/server/apps/log/nats/log.py
+++ b/server/apps/log/nats/log.py
@@ -7,8 +7,23 @@ from apps.core.utils.permission_utils import (
     check_instance_permission,
 )
 from apps.log.constants.permission import PermissionConstants
+from apps.log.constants.victoriametrics import VictoriaLogsConstants
 from apps.log.models.policy import Alert, Policy
 from apps.log.utils.query_log import VictoriaMetricsAPI
+
+
+def _normalize_bounded_int(value, field_name: str, default, max_value: int):
+    if value in (None, ""):
+        return default
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} 必须是整数")
+    if normalized < 1:
+        raise ValueError(f"{field_name} 必须大于等于 1")
+    if normalized > max_value:
+        raise ValueError(f"{field_name} 不能大于 {max_value}")
+    return normalized
 
 
 @nats_client.register
@@ -17,6 +32,10 @@ def log_search(query, time_range, limit=10, *args, **kwargs):
     start_time, end_time = time_range
     start_time = format_time_iso(start_time)
     end_time = format_time_iso(end_time)
+    try:
+        limit = _normalize_bounded_int(limit, "limit", 10, VictoriaLogsConstants.QUERY_LIMIT_MAX)
+    except ValueError as exc:
+        return {"result": False, "data": [], "message": str(exc)}
     vm_api = VictoriaMetricsAPI()
     data = vm_api.query(query, start_time, end_time, limit)
     return {"result": True, "data": data, "message": ""}
@@ -28,6 +47,10 @@ def log_hits(query, time_range, field, fields_limit=5, step="5m", *args, **kwarg
     start_time, end_time = time_range
     start_time = format_time_iso(start_time)
     end_time = format_time_iso(end_time)
+    try:
+        fields_limit = _normalize_bounded_int(fields_limit, "fields_limit", 5, VictoriaLogsConstants.HITS_FIELDS_LIMIT_MAX)
+    except ValueError as exc:
+        return {"result": False, "data": [], "message": str(exc)}
     vm_api = VictoriaMetricsAPI()
     resp = vm_api.hits(query, start_time, end_time, field, fields_limit, step)
     data = []

--- a/server/apps/log/serializers/search.py
+++ b/server/apps/log/serializers/search.py
@@ -1,5 +1,62 @@
 from rest_framework import serializers
 
+from apps.log.constants.victoriametrics import VictoriaLogsConstants
+
+
+class LogFieldValuesSerializer(serializers.Serializer):
+    filed = serializers.RegexField(
+        regex=r"^[A-Za-z_][A-Za-z0-9_.]*$",
+        max_length=200,
+        error_messages={"invalid": "filed 参数格式非法"},
+    )
+    start_time = serializers.CharField(required=False, allow_blank=True, default="")
+    end_time = serializers.CharField(required=False, allow_blank=True, default="")
+    limit = serializers.IntegerField(
+        min_value=1,
+        max_value=VictoriaLogsConstants.FIELD_VALUES_LIMIT_MAX,
+        default=100,
+    )
+
+
+class LogSearchSerializer(serializers.Serializer):
+    query = serializers.CharField(required=True, allow_blank=False)
+    start_time = serializers.CharField(required=False, allow_blank=True, default="")
+    end_time = serializers.CharField(required=False, allow_blank=True, default="")
+    limit = serializers.IntegerField(
+        min_value=1,
+        max_value=VictoriaLogsConstants.QUERY_LIMIT_MAX,
+        default=10,
+    )
+    log_groups = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+        default=list,
+    )
+
+
+class LogHitsSerializer(serializers.Serializer):
+    query = serializers.CharField(required=True, allow_blank=False)
+    start_time = serializers.CharField(required=False, allow_blank=True, default="")
+    end_time = serializers.CharField(required=False, allow_blank=True, default="")
+    field = serializers.RegexField(
+        regex=r"^[A-Za-z_][A-Za-z0-9_.]*$",
+        max_length=200,
+        error_messages={"invalid": "field 参数格式非法"},
+    )
+    fields_limit = serializers.IntegerField(
+        min_value=1,
+        max_value=VictoriaLogsConstants.HITS_FIELDS_LIMIT_MAX,
+        default=5,
+    )
+    step = serializers.CharField(required=False, allow_blank=True, default="5m")
+    log_groups = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        allow_empty=True,
+        default=list,
+    )
+
 
 class LogTopStatsSerializer(serializers.Serializer):
     query = serializers.CharField(required=False, allow_blank=True, default="*")

--- a/server/apps/log/services/collect_type.py
+++ b/server/apps/log/services/collect_type.py
@@ -330,9 +330,10 @@ class CollectTypeService:
         for instance_id, config_id in conf_objs:
             conf_map[instance_id].append(config_id)
 
-        # 获取节点信息(只补充节点名称，可以不用鉴权)
-        nodes = NodeMgmt().node_list(dict(page_size=-1))
-        node_map = {node["id"]: node["name"] for node in nodes["nodes"]}
+        # 只补充当前页实例关联的节点名称，避免每次实例列表查询都拉取全量节点。
+        page_node_ids = [instance.node_id for instance in page_data if instance.node_id]
+        nodes = NodeMgmt().get_node_names_by_ids(page_node_ids) if page_node_ids else []
+        node_map = {node["id"]: node["name"] for node in nodes}
 
         # 构建结果（与监控模块格式保持一致，使用 results 字段）
         items = []

--- a/server/apps/log/tests/test_collect_instance_search.py
+++ b/server/apps/log/tests/test_collect_instance_search.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+
+from apps.log.services.collect_type import CollectTypeService
+
+
+class FakeQuerySet:
+    def __init__(self, instances):
+        self.instances = instances
+
+    def filter(self, **kwargs):
+        collect_type_id = kwargs.get("collect_type_id")
+        if collect_type_id:
+            return FakeQuerySet([item for item in self.instances if item.collect_type_id == collect_type_id])
+
+        name = kwargs.get("name__icontains")
+        if name:
+            return FakeQuerySet([item for item in self.instances if name in item.name])
+
+        return self
+
+    def distinct(self):
+        return self
+
+    def select_related(self, *args):
+        return self
+
+    def count(self):
+        return len(self.instances)
+
+    def __getitem__(self, value):
+        return self.instances[value]
+
+
+class FakeValuesListManager:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def filter(self, **kwargs):
+        ids = set(kwargs.get("collect_instance_id__in", []))
+        return FakeValuesListQuery([row for row in self.rows if row[0] in ids])
+
+
+class FakeValuesListQuery:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def values_list(self, *args):
+        return self.rows
+
+
+def test_search_instance_uses_current_page_node_lookup(monkeypatch):
+    instances = [
+        SimpleNamespace(
+            id=f"inst-{idx}",
+            name=f"instance-{idx}",
+            node_id=f"node-{idx}",
+            collect_type_id="ctype",
+            collect_type=SimpleNamespace(name="file", collector="Vector"),
+        )
+        for idx in range(1, 6)
+    ]
+    requested_node_ids = []
+
+    class FakeNodeMgmt:
+        def get_node_names_by_ids(self, node_ids):
+            requested_node_ids.extend(node_ids)
+            return [{"id": node_id, "name": f"name-{node_id}"} for node_id in node_ids]
+
+    monkeypatch.setattr(
+        "apps.log.services.collect_type.CollectInstanceOrganization",
+        SimpleNamespace(objects=FakeValuesListManager([("inst-3", 1), ("inst-4", 2)])),
+    )
+    monkeypatch.setattr(
+        "apps.log.services.collect_type.CollectConfig",
+        SimpleNamespace(objects=FakeValuesListManager([("inst-3", "conf-3"), ("inst-4", "conf-4")])),
+    )
+    monkeypatch.setattr("apps.log.services.collect_type.NodeMgmt", FakeNodeMgmt)
+
+    result = CollectTypeService.search_instance_with_permission(
+        collect_type_id=None,
+        name=None,
+        page=2,
+        page_size=2,
+        queryset=FakeQuerySet(instances),
+    )
+
+    assert requested_node_ids == ["node-3", "node-4"]
+    assert result["count"] == 5
+    assert [item["node_name"] for item in result["items"]] == ["name-node-3", "name-node-4"]

--- a/server/apps/log/tests/test_search_query_limits.py
+++ b/server/apps/log/tests/test_search_query_limits.py
@@ -1,0 +1,56 @@
+from apps.log.constants.victoriametrics import VictoriaLogsConstants
+from apps.log.nats.log import _normalize_bounded_int, log_search
+from apps.log.serializers.search import LogFieldValuesSerializer, LogHitsSerializer, LogSearchSerializer
+
+
+def test_log_search_serializer_rejects_oversized_limit():
+    serializer = LogSearchSerializer(data={"query": "*", "limit": VictoriaLogsConstants.QUERY_LIMIT_MAX + 1})
+
+    assert not serializer.is_valid()
+    assert "limit" in serializer.errors
+
+
+def test_log_hits_serializer_rejects_oversized_fields_limit():
+    serializer = LogHitsSerializer(
+        data={
+            "query": "*",
+            "field": "_stream",
+            "fields_limit": VictoriaLogsConstants.HITS_FIELDS_LIMIT_MAX + 1,
+        }
+    )
+
+    assert not serializer.is_valid()
+    assert "fields_limit" in serializer.errors
+
+
+def test_log_field_values_serializer_rejects_oversized_limit():
+    serializer = LogFieldValuesSerializer(
+        data={
+            "filed": "_stream",
+            "limit": VictoriaLogsConstants.FIELD_VALUES_LIMIT_MAX + 1,
+        }
+    )
+
+    assert not serializer.is_valid()
+    assert "limit" in serializer.errors
+
+
+def test_log_nats_search_rejects_oversized_limit_without_vm_query(monkeypatch):
+    class FakeVictoriaMetricsAPI:
+        def query(self, *args, **kwargs):
+            raise AssertionError("VMLogs query should not be called")
+
+    monkeypatch.setattr("apps.log.nats.log.VictoriaMetricsAPI", FakeVictoriaMetricsAPI)
+
+    result = log_search(
+        "*",
+        ("2026-04-22 00:00:00", "2026-04-22 00:01:00"),
+        limit=VictoriaLogsConstants.QUERY_LIMIT_MAX + 1,
+    )
+
+    assert result["result"] is False
+    assert "limit" in result["message"]
+
+
+def test_normalize_bounded_int_accepts_default():
+    assert _normalize_bounded_int("", "limit", 10, 1000) == 10

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -229,7 +229,7 @@ class CollectInstanceViewSet(ViewSet):
             # 超管权限检查
             admin_cur_team = instance_res.get("all", {}).get("team")
             if admin_cur_team:
-                qs = CollectInstance.objects.filter(collectinstanceorganization__organization_in=admin_cur_team)
+                qs = CollectInstance.objects.filter(collectinstanceorganization__organization__in=admin_cur_team)
                 inst_permission_map = {}
             else:
                 objs = CollectInstance.objects.prefetch_related("collectinstanceorganization_set").all()

--- a/server/apps/log/views/search.py
+++ b/server/apps/log/views/search.py
@@ -6,21 +6,22 @@ from apps.log.services.search import SearchService
 from apps.log.utils.log_group import LogGroupQueryBuilder
 from apps.log.models.log_group import SearchCondition
 from apps.log.serializers.log_group import SearchConditionSerializer
-from apps.log.serializers.search import LogTopStatsSerializer
+from apps.log.serializers.search import LogFieldValuesSerializer, LogHitsSerializer, LogSearchSerializer, LogTopStatsSerializer
 from apps.log.filters.log_group import SearchConditionFilter
 
 
 class LogSearchViewSet(ViewSet):
     def _field_values_response(self, request):
-        field = request.query_params.get("filed", "")
-        start_time = request.query_params.get("start_time", "")
-        end_time = request.query_params.get("end_time", "")
-        limit = int(request.query_params.get("limit", 100))
+        serializer = LogFieldValuesSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
 
-        if not field:
-            return WebUtils.response_error("Field parameter is required.")
-
-        data = SearchService.field_values(start_time, end_time, field, limit)
+        data = SearchService.field_values(
+            validated_data.get("start_time", ""),
+            validated_data.get("end_time", ""),
+            validated_data["filed"],
+            validated_data.get("limit", 100),
+        )
         return WebUtils.response_success(data)
 
     @action(methods=["get"], detail=False, url_path="field_names")
@@ -40,21 +41,23 @@ class LogSearchViewSet(ViewSet):
         """
         Search logs based on the provided query parameters.
         """
-        query = request.data.get("query", "")
-        start_time = request.data.get("start_time", "")
-        end_time = request.data.get("end_time", "")
-        limit = request.data.get("limit", 10)
-        log_groups = request.data.get("log_groups", [])
-
-        if not query:
-            return WebUtils.response_error("Query parameter is required.")
+        serializer = LogSearchSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+        log_groups = validated_data.get("log_groups", [])
 
         # 验证日志分组
         is_valid, error_msg, _ = LogGroupQueryBuilder.validate_log_groups(log_groups)
         if not is_valid:
             return WebUtils.response_error(error_msg)
 
-        data = SearchService.search_logs(query, start_time, end_time, limit, log_groups)
+        data = SearchService.search_logs(
+            validated_data["query"],
+            validated_data.get("start_time", ""),
+            validated_data.get("end_time", ""),
+            validated_data.get("limit", 10),
+            log_groups,
+        )
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="hits")
@@ -62,23 +65,25 @@ class LogSearchViewSet(ViewSet):
         """
         Search hits based on the provided query parameters.
         """
-        query = request.data.get("query", "")
-        start_time = request.data.get("start_time", "")
-        end_time = request.data.get("end_time", "")
-        field = request.data.get("field", "")
-        fields_limit = request.data.get("fields_limit", 5)
-        step = request.data.get("step", "5m")
-        log_groups = request.data.get("log_groups", [])
-
-        if not query or not field:
-            return WebUtils.response_error("Query and field parameters are required.")
+        serializer = LogHitsSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+        log_groups = validated_data.get("log_groups", [])
 
         # 验证日志分组
         is_valid, error_msg, _ = LogGroupQueryBuilder.validate_log_groups(log_groups)
         if not is_valid:
             return WebUtils.response_error(error_msg)
 
-        data = SearchService.search_hits(query, start_time, end_time, field, fields_limit, step, log_groups)
+        data = SearchService.search_hits(
+            validated_data["query"],
+            validated_data.get("start_time", ""),
+            validated_data.get("end_time", ""),
+            validated_data["field"],
+            validated_data.get("fields_limit", 5),
+            validated_data.get("step", "5m"),
+            log_groups,
+        )
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="top_stats")

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -368,6 +368,12 @@ def node_list(query_data: dict):
 
 
 @nats_client.register
+def get_node_names_by_ids(node_ids: list):
+    """按节点ID批量获取节点名称。"""
+    return NodeService.get_node_names_by_ids(node_ids)
+
+
+@nats_client.register
 def collector_list(query_data: dict):
     return []
 

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -420,3 +420,11 @@ class NodeService:
             }
             for node in nodes
         ]
+
+    @staticmethod
+    def get_node_names_by_ids(node_ids):
+        normalized_node_ids = list({str(node_id) for node_id in node_ids if node_id not in (None, "")})
+        if not normalized_node_ids:
+            return []
+
+        return list(Node.objects.filter(id__in=normalized_node_ids).values("id", "name"))

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -52,6 +52,13 @@ class NodeMgmt(object):
         return_data = self.client.run("node_list", query_data)
         return return_data
 
+    def get_node_names_by_ids(self, node_ids):
+        """
+        :param node_ids: 节点ID列表
+        :return: [{"id": "node_id", "name": "node_name"}]
+        """
+        return self.client.run("get_node_names_by_ids", node_ids)
+
     def batch_create_configs_and_child_configs(self, configs: list, child_configs: list):
         """
         批量创建配置和子配置

--- a/web/src/app/log/(pages)/search/page.tsx
+++ b/web/src/app/log/(pages)/search/page.tsx
@@ -539,7 +539,7 @@ const SearchView: React.FC = () => {
                 placeholder={t('common.inputMsg')}
                 value={limit}
                 min={1}
-                max={1000000}
+                max={1000}
                 precision={0}
                 controls={false}
                 onChange={(val) => setLimit(val || 1)}


### PR DESCRIPTION
## 问题本质

本次审查聚焦代码与业务逻辑层的日志查询性能，修复两条会放大查询成本的路径：

1. 日志实例列表在完成分页后，仍通过节点服务拉取全量节点再补充当前页节点名称。节点规模增长后，普通列表/筛选请求会被放大成全量节点查询，拖慢实例列表响应。
2. 原始日志搜索接口缺少服务端查询上限，前端也允许一次请求 1000000 条原始日志，参数会直接传给 VMLogs。用户误操作或高频刷新时会显著放大 VMLogs 检索、网络传输和 Web 响应成本。

## 处理方式

- 实例列表只按当前页实例关联的节点 ID 批量获取节点名称，不再每次拉取全量节点。
- 修正全量类型实例查询中的组织过滤字段，避免超管组织过滤走错查询条件。
- 为原始日志 search / hits / field_values 增加服务端参数校验和上限，NATS 查询入口同步拦截超大 limit。
- 将前端原始日志列表条数上限收敛到 1000，与后端默认保护一致。

## 验证

- 新增日志实例分页节点补全测试，确认只查询当前页节点。
- 新增 VMLogs 查询上限测试，确认超大 limit / fields_limit 会在进入 VMLogs 前被拦截。
- 目标日志模块单测结果：9 passed。

@baiyf-git 请关注这次代码层查询放大风险收敛，重点看实例列表节点补全和 VMLogs 返回条数上限是否符合当前产品预期。
