### PR TITLE
[monitor] 修复告警窗口查询与通知回写缺陷，降低误报漏报和漏发失察风险

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -40,7 +40,7 @@ class EventAlertManager:
                     value=event["value"],
                     level=event["level"],
                     content=event["content"],
-                    notice_result=True,
+                    notice_result=[],
                     event_time=self.policy.last_run_time,
                 )
             )
@@ -193,10 +193,6 @@ class EventAlertManager:
             instance_name = self.instances_map.get(
                 monitor_instance_id, monitor_instance_id
             )
-            dimension_str = self._format_dimension_str(dimensions)
-            # display_name = (
-            #     f"{instance_name} - {dimension_str}" if dimension_str else instance_name
-            # )
 
             if event["level"] != "no_data":
                 alert_type = "alert"
@@ -326,7 +322,14 @@ class EventAlertManager:
             return
 
         if self._is_alert_center:
-            self._push_to_alert_center(events_to_notify)
+            notice_results = self._push_to_alert_center(events_to_notify)
+            for event in events_to_notify:
+                event.notice_result = notice_results
+            MonitorEvent.objects.bulk_update(
+                events_to_notify,
+                ["notice_result"],
+                batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
+            )
         else:
             for event in events_to_notify:
                 notice_results = self.send_notice(event)
@@ -399,11 +402,13 @@ class EventAlertManager:
                     f"Push to alert center success for policy {self.policy.name}: "
                     f"{len(alert_events)} events"
                 )
+            return [send_result]
         except Exception as e:
             logger.error(
                 f"Push to alert center exception for policy {self.policy.name}: {e}",
                 exc_info=True,
             )
+            return [{"result": False, "message": str(e)}]
 
     def _map_level_to_alert_center(self, level):
         """映射告警级别到告警中心格式: 0-致命, 1-错误, 2-预警, 3-提醒"""

--- a/server/apps/monitor/tasks/utils/policy_methods.py
+++ b/server/apps/monitor/tasks/utils/policy_methods.py
@@ -53,8 +53,8 @@ def _count(metric_query, start, end, step, group_by):
 
 
 def last_over_time(metric_query, start, end, step, group_by):
-    query = f"any(last_over_time({metric_query})) by ({group_by})"
-    metrics = VictoriaMetricsAPI().query(query, step, end)
+    query = f"any(last_over_time({metric_query}[{step}])) by ({group_by})"
+    metrics = VictoriaMetricsAPI().query(query, None, end)
     for data in metrics.get("data", {}).get("result", []):
         data["values"] = [data["value"]]
     return metrics

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -414,3 +414,129 @@ def test_send_notice_returns_channel_result_for_event_audit(monkeypatch):
     event = types.SimpleNamespace(content="cpu critical")
 
     assert manager.send_notice(event) == send_results
+
+
+def test_alert_center_notification_result_is_persisted(monkeypatch):
+    bulk_update_calls = []
+    send_calls = []
+    send_result = {"result": False, "message": "channel unavailable"}
+
+    class MonitorEvent:
+        class objects:
+            @staticmethod
+            def bulk_update(event_objs, fields, batch_size=None):
+                bulk_update_calls.append((event_objs, fields, batch_size))
+
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=MonitorEvent,
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=types.SimpleNamespace(
+            send_msg_with_channel=lambda *args: send_calls.append(args) or send_result
+        ),
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_alert_center_test_module",
+        Path(__file__).resolve().parents[1]
+        / "tasks"
+        / "services"
+        / "policy_scan"
+        / "event_alert_manager.py",
+    )
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(
+        id=1008,
+        name="alert-center-policy",
+        notice_type_id=9,
+    )
+    manager.instances_map = {"host-1": "Host 1"}
+    manager._is_alert_center = True
+
+    event = types.SimpleNamespace(
+        id="evt-1",
+        level="critical",
+        policy_id=1008,
+        content="cpu critical",
+        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
+        value=95.0,
+        monitor_instance_id="host-1",
+        dimensions={"instance_id": "host-1"},
+        metric_instance_id="('host-1',)",
+        alert_id=77,
+        notice_result=None,
+    )
+
+    manager.notify_events([event])
+
+    assert len(send_calls) == 1
+    assert send_calls[0][0] == 9
+    assert send_calls[0][2]["events"][0]["external_id"] == "evt-1"
+    assert event.notice_result == [send_result]
+    assert bulk_update_calls == [([event], ["notice_result"], 100)]
+
+
+def test_last_over_time_uses_policy_window_in_range_selector(monkeypatch):
+    query_calls = []
+
+    class VictoriaMetricsAPI:
+        def query(self, query, step="5m", time=None):
+            query_calls.append((query, step, time))
+            return {"data": {"result": [{"value": [200, "7"]}]}}
+
+    _install_module(
+        monkeypatch,
+        "apps.core.exceptions.base_app_exception",
+        BaseAppException=Exception,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.victoriametrics_api",
+        VictoriaMetricsAPI=VictoriaMetricsAPI,
+    )
+
+    module = _load_module(
+        "monitor_policy_methods_last_over_time_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "utils" / "policy_methods.py",
+    )
+
+    result = module.last_over_time(
+        "ping_percent_packet_loss{instance_type='ping'}",
+        start=100,
+        end=200,
+        step="5m",
+        group_by="instance_id",
+    )
+
+    assert query_calls == [
+        (
+            "any(last_over_time(ping_percent_packet_loss{instance_type='ping'}[5m])) by (instance_id)",
+            None,
+            200,
+        )
+    ]
+    assert result["data"]["result"][0]["values"] == [[200, "7"]]


### PR DESCRIPTION
## 问题本质

本次审查发现两处代码与业务逻辑层的告警链路缺陷，需要 @baiyf-git 重点关注：

1. `last_over_time` 聚合没有把策略检测周期写入查询窗口，内置策略中大量使用该算法时，窗口语义会失真，可能导致本应按周期判断的告警变成错误查询或错误取值。
2. 推送到告警中心的通知结果没有回写到 `MonitorEvent.notice_result`，且事件创建时默认写成成功态，通道失败时会留下“看起来已通知”的错误审计结果。

## 影响

- 告警触发准确性：依赖 `last_over_time` 的策略可能出现误报、漏报或判断失真。
- 通知链路可靠性：告警中心通知失败后事件状态仍可能显示成功，排障时无法准确识别漏发风险，也不利于后续补偿治理。

## 本次处理

- 修正 `last_over_time` 查询，按策略周期构造 range selector，并继续把 instant query 结果转换为事件计算所需的 `values` 结构。
- 事件创建时不再预设通知成功；告警中心发送后统一把真实发送结果写回事件。
- 清理触及文件中会导致门禁失败的未使用变量。
- 补充回归测试覆盖窗口查询构造和告警中心通知结果回写。

## 验证

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_policy_scan_failure_handling.py`
- `HTTPS_PROXY=http://127.0.0.1:7897 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with flake8 flake8 apps/monitor/tasks/utils/policy_methods.py apps/monitor/tasks/services/policy_scan/event_alert_manager.py apps/monitor/tests/test_policy_scan_failure_handling.py`
- `git diff --check`
- `python3 -m py_compile server/apps/monitor/tasks/utils/policy_methods.py server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py server/apps/monitor/tests/test_policy_scan_failure_handling.py`
