### PR TITLE
[incremental] 修复运维分析图表时间维度和多序列归零风险

### DIFF
--- a/web/src/app/ops-analysis/utils/chartDataTransform.ts
+++ b/web/src/app/ops-analysis/utils/chartDataTransform.ts
@@ -24,6 +24,21 @@ export class ChartDataTransformer {
     return String(value);
   }
 
+  private static isUnixTimestampLike(value: any): boolean {
+    if (typeof value === 'string' && !/^\d+(\.\d+)?$/.test(value.trim())) {
+      return false;
+    }
+
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+      return false;
+    }
+
+    const secondsValue = numericValue > 9999999999 ? numericValue / 1000 : numericValue;
+
+    return secondsValue >= 946684800 && secondsValue <= 4102444800;
+  }
+
   static shouldFormatAsTimeDimension(values: any[]): boolean {
     const normalizedValues = values.filter(
       (value) => value !== undefined && value !== null && value !== ''
@@ -34,9 +49,17 @@ export class ChartDataTransformer {
     }
 
     const validCount = normalizedValues.filter((value) => {
+      if (typeof value === 'number') {
+        return this.isUnixTimestampLike(value);
+      }
+
       if (typeof value === 'string') {
         const trimmed = value.trim();
         if (!trimmed) return false;
+
+        if (this.isUnixTimestampLike(trimmed)) {
+          return true;
+        }
 
         const hasExplicitDateMarkers = /[-/:T\s]/.test(trimmed);
         if (!hasExplicitDateMarkers) return false;
@@ -63,16 +86,19 @@ export class ChartDataTransformer {
     return false;
   }
 
-  private static dataToMap(data: any[]): { [key: string]: number } {
+  private static dataToMap(
+    data: any[],
+    shouldFormatAsTime: boolean
+  ): { [key: string]: number } {
     const map: { [key: string]: number } = {};
     if (data.length === 0) return map;
     if (typeof data[0] === 'object' && !Array.isArray(data[0]) && 'name' in data[0] && 'value' in data[0]) {
       data.forEach((item: any) => {
-        map[this.formatTimeValue(item.name)] = parseFloat(item.value) || 0;
+        map[this.formatDimensionValue(item.name, shouldFormatAsTime)] = parseFloat(item.value) || 0;
       });
     } else if (Array.isArray(data[0]) && data[0].length >= 2) {
       data.forEach((item: any[]) => {
-        map[this.formatTimeValue(item[0])] = item[1];
+        map[this.formatDimensionValue(item[0], shouldFormatAsTime)] = parseFloat(item[1]) || 0;
       });
     }
     return map;
@@ -80,8 +106,21 @@ export class ChartDataTransformer {
 
   static formatTimeValue(value: any): string {
     if (typeof value === 'number') {
-      return dayjs(value * 1000).format('MM-DD HH:mm:ss');
+      const timestamp = value > 9999999999 ? value : value * 1000;
+      return dayjs(timestamp).format('MM-DD HH:mm:ss');
     } else if (typeof value === 'string') {
+      if (this.isUnixTimestampLike(value)) {
+        const numericValue = Number(value);
+        const timestamp = numericValue > 9999999999 ? numericValue : numericValue * 1000;
+        return dayjs(timestamp).format('MM-DD HH:mm:ss');
+      }
+
+      const trimmed = value.trim();
+      const hasExplicitDateMarkers = /[-/:T\s]/.test(trimmed);
+      if (!hasExplicitDateMarkers) {
+        return value;
+      }
+
       const dateValue = dayjs(value);
       if (dateValue.isValid()) {
         return dateValue.format('MM-DD HH:mm:ss');
@@ -171,31 +210,7 @@ export class ChartDataTransformer {
         });
         const categories = Array.from(allCategoriesSet).sort();
         const series = keys.map((k) => {
-          const dataMap = this.dataToMap(
-            rawData[k].map((item: any) => {
-              if (Array.isArray(item) && item.length >= 2) {
-                return [
-                  this.formatDimensionValue(item[0], shouldFormatAsTime),
-                  item[1],
-                ];
-              }
-
-              if (
-                item &&
-                typeof item === 'object' &&
-                !Array.isArray(item) &&
-                'name' in item &&
-                'value' in item
-              ) {
-                return {
-                  ...item,
-                  name: this.formatDimensionValue(item.name, shouldFormatAsTime),
-                };
-              }
-
-              return item;
-            })
-          );
+          const dataMap = this.dataToMap(rawData[k], shouldFormatAsTime);
           return {
             name: k,
             data: categories.map((cat) => dataMap[cat] || 0),


### PR DESCRIPTION
@baiyf-git

1) 涉及范围
- 增量提交：`921d53a88294a37637ae388552439e0e307b2011`（运维分析图表数据处理优化）
- 关键文件：`web/src/app/ops-analysis/utils/chartDataTransform.ts`
- 关联下游：`server/apps/monitor/nats/monitor.py::mm_query_range` 返回 `[{ name: <timestamp>, value: ... }]` 供折线/柱状图消费

2) 具体问题
最近的图表维度识别变更只把带日期分隔符的字符串视为时间，导致监控查询返回的 Unix 时间戳不再格式化为时间维度；同时多序列数据会先格式化维度再进入 `dataToMap`，`dataToMap` 又按时间再次解析 key，普通分类值（如 `2024`）会和 categories 不一致，最终序列值被映射成 0。

3) 根因
时间维度判断与数据映射 key 的格式化规则不一致：categories 使用 `formatDimensionValue`，series map 仍使用 `formatTimeValue`，并且 numeric timestamp 被排除在时间维度识别之外。

4) 全局影响
这是局部工具函数改动影响全局图表消费链路：仪表盘和拓扑图的 line/bar 组件共用 `ChartDataTransformer`，监控范围查询、日志命中统计等 NATS 数据源都会经过该转换层。

5) 闭环修复
- 增加 Unix 秒/毫秒时间戳识别，恢复监控时间序列的时间维度展示。
- 让多序列 categories 与 series data map 使用同一套 `formatDimensionValue` 规则，避免分类维度被二次解析后归零。
- 保留普通数字/字符串分类值，不再把 `2024` 这类分类误解析为日期。

6) 证据
- `mm_query_range` 将 VictoriaMetrics `values` 的第 0 位 timestamp 放入 `name` 字段。
- 增量 diff 中 `shouldFormatAsTimeDimension` 仅接受字符串日期，直接改变该下游契约。
- 多序列路径里 categories 和 `dataToMap` 的 key 格式化逻辑不一致，可从代码路径直接证明数据丢失。

7) 验证
- `git diff --check`
- `pnpm exec eslint src/app/ops-analysis/utils/chartDataTransform.ts --ext .ts`
- Node 回归脚本验证：Unix timestamp 仍格式化为时间；普通分类多序列 `2024/2025` 保持分类且 values 不归零。
