### PR TITLE
[incremental] 修复配置文件采集绝对路径被重复拼接

### DIFF
--- a/agents/stargazer/plugins/inputs/config_file/config_file_info.py
+++ b/agents/stargazer/plugins/inputs/config_file/config_file_info.py
@@ -73,9 +73,7 @@ class ConfigFileInfo(SSHPlugin):
         if not file_name or not file_path:
             raise ValueError("config_file_name and config_file_path are required")
 
-        _file_path = Path(file_path)
-        config_file_path = _file_path / file_name
-        return config_file_path.as_posix()
+        return Path(file_path).as_posix()
 
     def _build_callback_payload(self, payload: dict) -> dict:
         status = str(payload.get("status") or "error").lower()

--- a/agents/stargazer/tests/test_config_file_info.py
+++ b/agents/stargazer/tests/test_config_file_info.py
@@ -1,0 +1,34 @@
+import sys
+import types
+from importlib import import_module
+
+
+class _DummySSHPlugin:
+    def __init__(self, params):
+        self.params = params
+
+
+class _DummyLogger:
+    def error(self, *_args, **_kwargs):
+        return None
+
+
+sys.modules.setdefault("sanic", types.ModuleType("sanic"))
+sanic_log_stub = types.ModuleType("sanic.log")
+sanic_log_stub.logger = _DummyLogger()
+script_executor_stub = types.ModuleType("plugins.script_executor")
+script_executor_stub.SSHPlugin = _DummySSHPlugin
+
+
+def test_config_file_path_uses_absolute_file_path_without_appending_name():
+    sys.modules.setdefault("sanic.log", sanic_log_stub)
+    sys.modules.setdefault("plugins.script_executor", script_executor_stub)
+    config_file_module = import_module("plugins.inputs.config_file.config_file_info")
+    plugin = config_file_module.ConfigFileInfo(
+        {
+            "config_file_path": "/etc/nginx/nginx.conf",
+            "config_file_name": "nginx.conf",
+        }
+    )
+
+    assert plugin._get_config_file_path() == "/etc/nginx/nginx.conf"


### PR DESCRIPTION
## 涉及范围
- 增量提交/PR：PR #2642 / commit 5ab2a90ef 的 CMDB 配置文件采集功能
- 关键文件：`agents/stargazer/plugins/inputs/config_file/config_file_info.py`、`server/apps/cmdb/serializers/collect_serializer.py`、`web/src/app/cmdb/(pages)/assetManage/autoDiscovery/collection/profess/components/configFileTask.tsx`

## 问题与根因
页面提示和后端校验都把 `config_file_path` 作为“配置文件绝对路径”，例如 `/etc/nginx/nginx.conf`；但 Stargazer 插件执行前又把 `config_file_name` 拼到该路径后面，实际采集路径变成 `/etc/nginx/nginx.conf/nginx.conf`。

根因是新增配置文件采集链路中，上游表单、后端序列化、节点参数和插件执行端对 `config_file_path` 的数据契约不一致。

## 全局影响
这是局部插件路径解析错误，但影响整条配置文件采集链路：任务创建可以成功，参数可以下发，Stargazer 执行时会访问错误路径，最终所有按页面示例输入的配置文件采集都会回传 file_not_found，资产详情页也无法看到真实版本内容。

## 修复说明
- 让 Stargazer 插件直接使用 `config_file_path` 作为绝对文件路径，不再追加 `config_file_name`。
- 增加回归测试覆盖 `/etc/nginx/nginx.conf` + `nginx.conf` 不应被拼成重复路径。

## 闭环性
同一根因的主要路径已检查：页面传参、后端校验、节点参数下发、Stargazer 插件执行和回调落库均以 `config_file_path` 表示完整文件路径；修复落在唯一执行路径解析点，不改变回调字段和展示字段语义。

## 验证
- `git diff --check`
- `python3 -m py_compile agents/stargazer/plugins/inputs/config_file/config_file_info.py agents/stargazer/tests/test_config_file_info.py`
- 使用最小导入脚本验证 `_get_config_file_path()` 返回 `/etc/nginx/nginx.conf`

备注：`uv run --with pytest pytest -q tests/test_config_file_info.py` 因本机缺少 `pg_config` 无法构建 `psycopg2==2.9.11`，未完成完整 pytest 启动。