### PR TITLE
[node_mgmt] 修复节点列表组织范围伪造导致的越权查看风险

### DIFF
--- a/server/apps/job_mgmt/tests/test_target_query_nodes_permission.py
+++ b/server/apps/job_mgmt/tests/test_target_query_nodes_permission.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from apps.job_mgmt.views import target
+
+
+class _NodeMgmtStub:
+    captured_query = None
+
+    def node_list(self, query_data):
+        self.__class__.captured_query = query_data
+        return {
+            "count": 0,
+            "nodes": [],
+        }
+
+
+class _CloudRegionQuerySetStub:
+    def values(self, *args):
+        return []
+
+
+class _CloudRegionManagerStub:
+    def all(self):
+        return _CloudRegionQuerySetStub()
+
+
+class _CloudRegionStub:
+    objects = _CloudRegionManagerStub()
+
+
+def _make_request(current_team="2"):
+    return SimpleNamespace(
+        query_params={"page": "1", "page_size": "20"},
+        COOKIES={"current_team": current_team, "include_children": "1"},
+        user=SimpleNamespace(
+            username="job_user",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[1],
+        ),
+    )
+
+
+def test_query_nodes_passes_node_permission_scope(monkeypatch):
+    monkeypatch.setattr(target, "NodeMgmt", _NodeMgmtStub)
+    monkeypatch.setattr(target, "CloudRegion", _CloudRegionStub)
+
+    view = target.TargetViewSet()
+    response = view.query_nodes.__wrapped__(view, _make_request())
+
+    assert response.data["result"] is True
+    assert _NodeMgmtStub.captured_query["organization_ids"] == []
+    assert _NodeMgmtStub.captured_query["permission_data"] == {
+        "username": "job_user",
+        "domain": "domain.com",
+        "current_team": 2,
+        "include_children": True,
+    }

--- a/server/apps/job_mgmt/views/target.py
+++ b/server/apps/job_mgmt/views/target.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.logger import job_logger as logger
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.job_mgmt.constants import OSType, SSHCredentialType
 from apps.job_mgmt.filters.target import TargetFilter
@@ -148,10 +149,22 @@ class TargetViewSet(AuthViewSet):
         if os_type:
             query_data["os"] = os_type
 
-        # 组织权限过滤
+        # 组织与节点实例权限过滤
         current_team = int(request.COOKIES.get("current_team") or "0")
-        if current_team:
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        user_group_ids = normalize_user_group_ids(getattr(request.user, "group_list", []))
+        if current_team and (request.user.is_superuser or current_team in user_group_ids):
             query_data["organization_ids"] = [current_team]
+        elif not request.user.is_superuser:
+            query_data["organization_ids"] = []
+
+        if not request.user.is_superuser:
+            query_data["permission_data"] = {
+                "username": request.user.username,
+                "domain": request.user.domain,
+                "current_team": current_team,
+                "include_children": include_children,
+            }
 
         try:
             node_mgmt = NodeMgmt()

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -693,13 +693,20 @@ def _prepare_user_rules_query(group_id, username, domain, app, include_children=
     all_role_ids = get_user_all_roles(user_obj)
     is_admin = bool(set(all_role_ids).intersection(admin_list))
 
+    target_group_id = int(group_id)
+
+    # 普通用户的 current_team 来自前端 Cookie，必须先确认它属于用户可用组织；
+    # 否则下游会把伪造组织当作 team 权限返回，放大实例列表范围。
+    if not is_admin and target_group_id not in user_obj.group_list:
+        return user_obj, [], [], False, is_admin
+
     # 获取查询的组ID列表（包含子组）
     query_group_ids = []
     if include_children:
         # 使用优化后的单次查询方法替代 N+1 的 get_all_child_groups
-        query_group_ids = GroupUtils.get_group_with_descendants_filtered(int(group_id), group_list=user_obj.group_list)
+        query_group_ids = GroupUtils.get_group_with_descendants_filtered(target_group_id, group_list=user_obj.group_list)
 
-    query_group_ids.append(int(group_id))
+    query_group_ids.append(target_group_id)
     query_group_ids = list(set(query_group_ids))
     # 设置管理员团队
     admin_teams = query_group_ids[:]

--- a/server/apps/system_mgmt/tests/test_permission_scope.py
+++ b/server/apps/system_mgmt/tests/test_permission_scope.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+from apps.system_mgmt import nats_api
+
+
+class _QuerySetStub:
+    def __init__(self, values=None, first_value=None):
+        self._values = values or []
+        self._first_value = first_value
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def values_list(self, *args, **kwargs):
+        return self._values
+
+    def first(self):
+        return self._first_value
+
+
+class _UserManagerStub:
+    def __init__(self, user):
+        self._user = user
+
+    def filter(self, *args, **kwargs):
+        return _QuerySetStub(first_value=self._user)
+
+
+class _RoleManagerStub:
+    def filter(self, *args, **kwargs):
+        return _QuerySetStub(values=[])
+
+
+class _GroupManagerStub:
+    def filter(self, *args, **kwargs):
+        return _QuerySetStub(first_value=None)
+
+
+def _patch_permission_models(monkeypatch, group_list):
+    user = SimpleNamespace(username="node_viewer", domain="domain.com", group_list=group_list)
+    monkeypatch.setattr(nats_api.User, "objects", _UserManagerStub(user))
+    monkeypatch.setattr(nats_api.Role, "objects", _RoleManagerStub())
+    monkeypatch.setattr(nats_api.Group, "objects", _GroupManagerStub())
+    monkeypatch.setattr(nats_api, "get_user_all_roles", lambda user_obj: [])
+    return user
+
+
+def test_prepare_user_rules_query_rejects_forged_current_team(monkeypatch):
+    user = _patch_permission_models(monkeypatch, group_list=[1])
+
+    result = nats_api._prepare_user_rules_query(2, "node_viewer", "domain.com", "node", False)
+
+    assert result == (user, [], [], False, False)
+
+
+def test_prepare_user_rules_query_keeps_valid_current_team_scope(monkeypatch):
+    user = _patch_permission_models(monkeypatch, group_list=[1])
+
+    result = nats_api._prepare_user_rules_query(1, "node_viewer", "domain.com", "node", False)
+
+    assert result == (user, [1], [1], False, False)


### PR DESCRIPTION
负责人：白宇飞

## 问题本质
节点列表权限链路把前端 Cookie 中的 current_team 直接带入系统管理权限规则查询。普通用户伪造不属于自己的组织 ID 时，系统管理权限会把该组织当作 team 范围返回；同时作业模块的节点查询只按 current_team 过滤，没有把 node_mgmt 实例权限传给节点列表服务。

## 影响
这会导致节点列表、节点搜索和作业目标选择等业务入口出现组织范围失真，存在跨组织查看节点基础信息的风险。

## 本次处理
- 系统管理权限规则入口先校验普通用户的 current_team 是否属于用户可用组织，非法组织直接返回空权限范围。
- 作业模块查询节点时传递 node_mgmt 权限上下文，并在组织筛选前校验 current_team 归属，避免绕过节点实例权限。
- 补充回归测试覆盖伪造 current_team 与作业节点查询权限上下文。

## 验证
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DJANGO_SETTINGS_MODULE=settings INSTALL_APPS='system_mgmt,job_mgmt,node_mgmt' ENABLE_CELERY=True UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --extra dev --with pytest --with pytest-django pytest -p django -q -o addopts='' --confcutdir=apps/system_mgmt/tests apps/system_mgmt/tests/test_permission_scope.py apps/job_mgmt/tests/test_target_query_nodes_permission.py`
- `git diff --check`
- `python3 -m py_compile server/apps/system_mgmt/nats_api.py server/apps/job_mgmt/views/target.py server/apps/system_mgmt/tests/test_permission_scope.py server/apps/job_mgmt/tests/test_target_query_nodes_permission.py`
