### PR TITLE
[node_mgmt] 修复探针配置与指令缓存未失效导致的下发失真风险

### DIFF
--- a/server/apps/node_mgmt/apps.py
+++ b/server/apps/node_mgmt/apps.py
@@ -7,4 +7,5 @@ class NodeMgmtConfig(AppConfig):
 
     def ready(self):
         import apps.node_mgmt.nats.node  # noqa
-        import apps.node_mgmt.nats.permission   #noqa
+        import apps.node_mgmt.nats.permission  # noqa
+        import apps.node_mgmt.signals  # noqa

--- a/server/apps/node_mgmt/services/sidecar_cache.py
+++ b/server/apps/node_mgmt/services/sidecar_cache.py
@@ -1,0 +1,77 @@
+from collections.abc import Iterable
+
+from django.core.cache import cache
+
+
+NODE_ETAG_CACHE_PREFIX = "node_etag_"
+CONFIGURATION_ETAG_CACHE_PREFIX = "configuration_etag_"
+ASSIGNMENT_ETAG_INVALIDATION_ACTIONS = {"post_add", "post_remove", "pre_clear"}
+
+
+def _normalize_ids(ids: Iterable | None) -> list[str]:
+    if not ids:
+        return []
+
+    normalized = []
+    seen = set()
+    for item in ids:
+        if item is None:
+            continue
+        value = str(item)
+        if value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def invalidate_node_etags(node_ids: Iterable | None):
+    keys = [f"{NODE_ETAG_CACHE_PREFIX}{node_id}" for node_id in _normalize_ids(node_ids)]
+    if keys:
+        cache.delete_many(keys)
+
+
+def invalidate_configuration_etag(configuration_id):
+    if configuration_id is not None:
+        cache.delete(f"{CONFIGURATION_ETAG_CACHE_PREFIX}{configuration_id}")
+
+
+def _node_ids_from_assignment_clear(instance):
+    nodes_manager = getattr(instance, "nodes", None)
+    if not nodes_manager:
+        return []
+    return list(nodes_manager.values_list("id", flat=True))
+
+
+def invalidate_assignment_node_etags(action, reverse, instance, pk_set):
+    if action not in ASSIGNMENT_ETAG_INVALIDATION_ACTIONS:
+        return
+
+    if reverse:
+        invalidate_node_etags([getattr(instance, "pk", None)])
+        return
+
+    node_ids = pk_set if pk_set is not None else _node_ids_from_assignment_clear(instance)
+    invalidate_node_etags(node_ids)
+
+
+def invalidate_action_node_etag(instance):
+    node_id = getattr(instance, "node_id", None)
+    if node_id is None and getattr(instance, "node", None) is not None:
+        node_id = getattr(instance.node, "pk", None)
+    invalidate_node_etags([node_id])
+
+
+def invalidate_child_config_etag(instance):
+    configuration_id = getattr(instance, "collector_config_id", None)
+    if configuration_id is None and getattr(instance, "collector_config", None) is not None:
+        configuration_id = getattr(instance.collector_config, "pk", None)
+    invalidate_configuration_etag(configuration_id)
+
+
+def invalidate_collector_configuration_etag(instance):
+    invalidate_configuration_etag(getattr(instance, "pk", None))
+
+
+def invalidate_collector_configuration_node_etags(instance):
+    invalidate_node_etags(_node_ids_from_assignment_clear(instance))

--- a/server/apps/node_mgmt/signals.py
+++ b/server/apps/node_mgmt/signals.py
@@ -1,0 +1,40 @@
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete
+from django.dispatch import receiver
+
+from apps.node_mgmt.models.sidecar import (
+    Action,
+    ChildConfig,
+    CollectorConfiguration,
+)
+from apps.node_mgmt.services.sidecar_cache import (
+    invalidate_action_node_etag,
+    invalidate_assignment_node_etags,
+    invalidate_child_config_etag,
+    invalidate_collector_configuration_etag,
+    invalidate_collector_configuration_node_etags,
+)
+
+
+@receiver(m2m_changed, sender=CollectorConfiguration.nodes.through)
+def invalidate_node_assignment_etags(sender, instance, action, reverse, pk_set, **kwargs):
+    invalidate_assignment_node_etags(action, reverse, instance, pk_set)
+
+
+@receiver([post_save, post_delete], sender=Action)
+def invalidate_action_etag(sender, instance, **kwargs):
+    invalidate_action_node_etag(instance)
+
+
+@receiver([post_save, post_delete], sender=ChildConfig)
+def invalidate_child_config_render_etag(sender, instance, **kwargs):
+    invalidate_child_config_etag(instance)
+
+
+@receiver([post_save, post_delete], sender=CollectorConfiguration)
+def invalidate_configuration_render_etag(sender, instance, **kwargs):
+    invalidate_collector_configuration_etag(instance)
+
+
+@receiver(pre_delete, sender=CollectorConfiguration)
+def invalidate_deleted_configuration_node_etags(sender, instance, **kwargs):
+    invalidate_collector_configuration_node_etags(instance)

--- a/server/apps/node_mgmt/tests/test_sidecar_cache_invalidation.py
+++ b/server/apps/node_mgmt/tests/test_sidecar_cache_invalidation.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+from apps.node_mgmt.services import sidecar_cache
+
+
+def test_node_assignment_add_invalidates_affected_node_etags(monkeypatch):
+    deleted_keys = []
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete_many=lambda keys: deleted_keys.extend(keys)))
+
+    sidecar_cache.invalidate_assignment_node_etags(
+        action="post_add",
+        reverse=False,
+        instance=SimpleNamespace(pk="config-a"),
+        pk_set={"node-a", "node-b"},
+    )
+
+    assert sorted(deleted_keys) == ["node_etag_node-a", "node_etag_node-b"]
+
+
+def test_node_assignment_reverse_change_invalidates_node_etag(monkeypatch):
+    deleted_keys = []
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete_many=lambda keys: deleted_keys.extend(keys)))
+
+    sidecar_cache.invalidate_assignment_node_etags(
+        action="post_remove",
+        reverse=True,
+        instance=SimpleNamespace(pk="node-a"),
+        pk_set={"config-a"},
+    )
+
+    assert deleted_keys == ["node_etag_node-a"]
+
+
+def test_node_assignment_clear_invalidates_previously_bound_nodes(monkeypatch):
+    deleted_keys = []
+    manager = SimpleNamespace(values_list=lambda *args, **kwargs: ["node-a", "node-b"])
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete_many=lambda keys: deleted_keys.extend(keys)))
+
+    sidecar_cache.invalidate_assignment_node_etags(
+        action="pre_clear",
+        reverse=False,
+        instance=SimpleNamespace(pk="config-a", nodes=manager),
+        pk_set=None,
+    )
+
+    assert sorted(deleted_keys) == ["node_etag_node-a", "node_etag_node-b"]
+
+
+def test_child_and_parent_config_changes_invalidate_render_etag(monkeypatch):
+    deleted_keys = []
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete=lambda key: deleted_keys.append(key)))
+
+    sidecar_cache.invalidate_child_config_etag(SimpleNamespace(collector_config_id="config-a"))
+    sidecar_cache.invalidate_collector_configuration_etag(SimpleNamespace(pk="config-b"))
+
+    assert deleted_keys == ["configuration_etag_config-a", "configuration_etag_config-b"]
+
+
+def test_action_changes_invalidate_node_poll_etag(monkeypatch):
+    deleted_keys = []
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete_many=lambda keys: deleted_keys.extend(keys)))
+
+    sidecar_cache.invalidate_action_node_etag(SimpleNamespace(node_id="node-a"))
+
+    assert deleted_keys == ["node_etag_node-a"]
+
+
+def test_deleted_configuration_invalidates_bound_node_poll_etags(monkeypatch):
+    deleted_keys = []
+    manager = SimpleNamespace(values_list=lambda *args, **kwargs: ["node-a", "node-b"])
+    monkeypatch.setattr(sidecar_cache, "cache", SimpleNamespace(delete_many=lambda keys: deleted_keys.extend(keys)))
+
+    sidecar_cache.invalidate_collector_configuration_node_etags(SimpleNamespace(nodes=manager))
+
+    assert sorted(deleted_keys) == ["node_etag_node-a", "node_etag_node-b"]


### PR DESCRIPTION
负责人：白宇飞

## 问题本质
sidecar 通过 ETag 轮询节点 assignments、待执行 actions 和渲染后的采集器配置，但配置绑定、配置删除、子配置变更、Action 写入等入口没有统一失效对应缓存。配置或指令已经在服务端变更时，探针仍可能拿到 304，导致下发链路在缓存周期内不闭环。

## 主要风险
这是代码与业务逻辑层的状态一致性问题：探针配置更新、配置取消绑定、配置删除或操作指令下发后，实际 sidecar 可能暂时不感知，表现为配置未生效、旧配置继续运行或操作指令延迟执行，排障时服务端状态与探针行为不一致。

## 本次处理
- 收敛 node/configuration ETag 失效 helper。
- 在 node_mgmt 启动时注册模型信号，覆盖配置绑定/解绑/清空、配置删除、配置内容变更、子配置变更、Action 写入/删除等写入路径。
- 补充缓存失效单元测试，覆盖配置下发和指令轮询关键入口。

## 验证
- `python3 -m py_compile apps/node_mgmt/services/sidecar_cache.py apps/node_mgmt/signals.py apps/node_mgmt/tests/test_sidecar_cache_invalidation.py apps/node_mgmt/apps.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -o addopts='' --confcutdir=apps/node_mgmt/tests apps/node_mgmt/tests/test_sidecar_cache_invalidation.py`
- `HTTPS_PROXY=http://127.0.0.1:7897 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with flake8 flake8 apps/node_mgmt/services/sidecar_cache.py apps/node_mgmt/signals.py apps/node_mgmt/tests/test_sidecar_cache_invalidation.py apps/node_mgmt/apps.py`
