### PR TITLE
[ansible-executor] 修复任务重复执行与执行边界缺陷，降低节点失控风险

### DIFF
--- a/agents/ansible-executor/service/ansible_runner.py
+++ b/agents/ansible-executor/service/ansible_runner.py
@@ -1,10 +1,12 @@
 import asyncio
+import contextlib
 import importlib
 import json
 import os
 import re
 import shlex
 import shutil
+import signal
 import ssl
 import stat
 import uuid
@@ -224,6 +226,7 @@ async def download_object_to_workspace(config: ServiceConfig, workspace: Path, b
         raise ValueError("file_key is required")
     if not file_name:
         raise ValueError("file name is required")
+    destination = _safe_workspace_path(workspace, file_name, "file name")
 
     nats_client_module = importlib.import_module("nats.aio.client")
     nc = nats_client_module.Client()
@@ -254,13 +257,35 @@ async def download_object_to_workspace(config: ServiceConfig, workspace: Path, b
     try:
         js = nc.jetstream(timeout=120)
         object_store = await js.object_store(bucket_name)
-        destination = workspace / file_name
         destination.parent.mkdir(parents=True, exist_ok=True)
         with destination.open("wb") as target_file:
             await object_store.get(file_key, writeinto=target_file)
         return str(destination)
     finally:
         await nc.close()
+
+
+def _safe_workspace_path(workspace: Path, relative_path: str, field_name: str) -> Path:
+    raw_path = str(relative_path).strip()
+    if not raw_path:
+        raise ValueError(f"{field_name} is required")
+    candidate = Path(raw_path)
+    if candidate.is_absolute() or any(part in {"..", ""} for part in candidate.parts):
+        raise ValueError(f"{field_name} must be a relative path inside workspace")
+
+    base = workspace.resolve()
+    target = (base / candidate).resolve(strict=False)
+    try:
+        target.relative_to(base)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must stay inside workspace") from exc
+    return target
+
+
+def _safe_extract_zip(zip_file: zipfile.ZipFile, workspace: Path) -> None:
+    for member in zip_file.infolist():
+        _safe_workspace_path(workspace, member.filename, "zip member")
+    zip_file.extractall(workspace)
 
 
 def _normalize_windows_target_path(target_path: str) -> str:
@@ -556,7 +581,7 @@ async def prepare_playbook_execution(
             local_path = await download_object_to_workspace(config, workspace, bucket_name, file_item)
             if local_path.endswith(".zip"):
                 with zipfile.ZipFile(local_path, "r") as zf:
-                    zf.extractall(workspace)
+                    _safe_extract_zip(zf, workspace)
                 # 在解压后的内容中查找 playbook.yml 入口文件
                 playbook_entry = payload.playbook_path or "playbook.yml"
                 # 支持 ZIP 内有顶层目录的情况（如 playbook-template/playbook.yml）
@@ -703,16 +728,28 @@ def build_playbook_winrm_preflight_command(payload: PlaybookRequest) -> list[str
 
 
 async def run_command(cmd: list[str], timeout: int) -> tuple[int, str]:
+    process_kwargs: dict[str, Any] = {}
+    if os.name == "posix":
+        process_kwargs["start_new_session"] = True
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
+        **process_kwargs,
     )
     try:
         stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
     except asyncio.TimeoutError:
-        proc.kill()
-        await proc.wait()
+        if os.name == "posix":
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
         logger.error("command timed out: %s", " ".join(shlex.quote(part) for part in cmd))
         return 124, "command timed out"
     output, decode_strategy = decode_command_output(stdout)

--- a/agents/ansible-executor/service/nats_service.py
+++ b/agents/ansible-executor/service/nats_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import importlib
 import json
 import ssl
@@ -276,6 +277,33 @@ class AnsibleNATSService:
             json.dumps(retry_payload, ensure_ascii=False).encode("utf-8"),
         )
 
+    @staticmethod
+    def _callback_retry_final_status(payload: dict[str, Any]) -> str:
+        if str(payload.get("status", "")).strip() in {"success", "failed"}:
+            return str(payload["status"]).strip()
+        return "success" if payload.get("success") else "failed"
+
+    async def _keep_message_in_progress(self, msg, task: asyncio.Task) -> None:
+        interval = max(1.0, min(30.0, float(self.config.js_ack_wait) / 2))
+        while not task.done():
+            await asyncio.sleep(interval)
+            if task.done():
+                break
+            try:
+                await msg.in_progress()
+            except Exception as err:
+                logger.warning("failed to extend task ack wait: %s", err)
+
+    async def _run_task_with_ack_progress(self, msg, task: "QueuedTask") -> dict[str, Any]:
+        running_task = asyncio.create_task(self._run_task(task))
+        keepalive_task = asyncio.create_task(self._keep_message_in_progress(msg, running_task))
+        try:
+            return await running_task
+        finally:
+            keepalive_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await keepalive_task
+
     async def _run_task(self, task: "QueuedTask") -> dict[str, Any]:
         workspace = None
         code = -1
@@ -356,7 +384,7 @@ class AnsibleNATSService:
                     await msg.ack()
                     continue
 
-                await self._run_task(task)
+                await self._run_task_with_ack_progress(msg, task)
                 await msg.ack()
             except Exception as err:
                 logger.exception("worker task failed worker=%s error=%s", worker_id, err)
@@ -396,7 +424,7 @@ class AnsibleNATSService:
                 await self._invoke_callback(callback, payload)
                 self.task_store.update_status(
                     task_id,
-                    "success",
+                    self._callback_retry_final_status(payload),
                     payload,
                     self._now_iso(),
                 )

--- a/agents/ansible-executor/tests/conftest.py
+++ b/agents/ansible-executor/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/agents/ansible-executor/tests/test_ansible_runner_safety.py
+++ b/agents/ansible-executor/tests/test_ansible_runner_safety.py
@@ -1,0 +1,41 @@
+import asyncio
+import sys
+import zipfile
+
+import pytest
+
+from service.ansible_runner import _safe_extract_zip, _safe_workspace_path, run_command
+
+
+def test_safe_workspace_path_rejects_path_traversal(tmp_path):
+    with pytest.raises(ValueError):
+        _safe_workspace_path(tmp_path, "../outside.yml", "file name")
+
+    with pytest.raises(ValueError):
+        _safe_workspace_path(tmp_path, "/tmp/outside.yml", "file name")
+
+
+def test_safe_extract_zip_rejects_path_traversal(tmp_path):
+    archive_path = tmp_path / "payload.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../outside.yml", "bad")
+
+    with zipfile.ZipFile(archive_path) as archive:
+        with pytest.raises(ValueError):
+            _safe_extract_zip(archive, tmp_path / "workspace")
+
+
+def test_run_command_timeout_returns_124():
+    code, output = asyncio.run(
+        run_command(
+            [
+                sys.executable,
+                "-c",
+                "import time; time.sleep(10)",
+            ],
+            timeout=1,
+        )
+    )
+
+    assert code == 124
+    assert output == "command timed out"

--- a/agents/ansible-executor/tests/test_nats_service_lifecycle.py
+++ b/agents/ansible-executor/tests/test_nats_service_lifecycle.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from core.config import ServiceConfig
+from service.nats_service import AnsibleNATSService
+
+
+class FakeMsg:
+    def __init__(self):
+        self.in_progress_calls = 0
+
+    async def in_progress(self):
+        self.in_progress_calls += 1
+
+
+def test_callback_retry_preserves_failed_task_status(tmp_path):
+    service = AnsibleNATSService(
+        ServiceConfig(
+            nats_servers=["nats://127.0.0.1:4222"],
+            nats_instance_id="default",
+            state_db_path=str(tmp_path / "state.db"),
+        )
+    )
+
+    assert service._callback_retry_final_status({"status": "failed", "success": False}) == "failed"
+    assert service._callback_retry_final_status({"status": "success", "success": True}) == "success"
+    assert service._callback_retry_final_status({"success": False}) == "failed"
+
+
+def test_ack_wait_is_extended_while_task_runs(tmp_path):
+    async def run_case():
+        service = AnsibleNATSService(
+            ServiceConfig(
+                nats_servers=["nats://127.0.0.1:4222"],
+                nats_instance_id="default",
+                js_ack_wait=2,
+                state_db_path=str(tmp_path / "state.db"),
+            )
+        )
+        msg = FakeMsg()
+        running_task = asyncio.create_task(asyncio.sleep(1.2))
+        await service._keep_message_in_progress(msg, running_task)
+        await running_task
+        return msg.in_progress_calls
+
+    assert asyncio.run(run_case()) >= 1


### PR DESCRIPTION
## 问题

本次审查聚焦 ansible-executor 的代码与业务逻辑层，确认到执行生命周期和文件落点边界存在会影响节点受控稳定性的风险：

- 长时间 playbook 执行期间，worker 持有 JetStream 消息但不续租 ack；当执行时间超过 `ack_wait` 后，同一任务会被重新投递，其他 worker 可能再次执行同一个远程操作，导致安装、回滚或配置任务重复执行，状态回写互相覆盖。
- 命令超时时只终止 helper 父进程，Ansible/SSH/WinRM 子进程可能继续存活并继续修改远端主机，造成“系统已判失败但远端仍在执行”的受控失真。
- 对象存储下载文件名与 ZIP 成员缺少工作目录边界校验，任务载荷可让文件写出任务 workspace，扩大执行器本地文件落点风险。
- callback 重试成功后无条件把本地任务状态写为 success，会把原本失败的执行结果改写成成功，影响后续查询和排障判断。

## 修复

- 长任务执行期间定期发送 JetStream `in_progress`，避免超过 `ack_wait` 被重复投递和重复执行。
- 超时清理改为按进程组终止，减少 Ansible 子进程、SSH/WinRM 子进程残留。
- 下载文件与 ZIP 解压统一限制在任务 workspace 内，拒绝绝对路径和 `..` 路径穿越。
- callback 重试回写时保留原始执行成功/失败状态，避免失败任务被改写成成功。
- 增加针对任务续租、状态回写、路径穿越、超时返回的回归测试。

负责人：白宇飞

## 验证

- `PYTHONPATH=. uv run --project . --with pytest pytest tests -q`
- `PYTHONPATH=. uv run --project . --with ruff ruff check service/ansible_runner.py service/nats_service.py tests`
- `python3 -m py_compile service/ansible_runner.py service/nats_service.py tests/conftest.py tests/test_ansible_runner_safety.py tests/test_nats_service_lifecycle.py`
- `git diff --check`
