### PR TITLE
[incremental] 修复 K8s 告警源渲染模板缺失导致安装失败

### DIFF
--- a/server/apps/alerts/support-files/kubernetes-event-exporter/secret.yaml.template
+++ b/server/apps/alerts/support-files/kubernetes-event-exporter/secret.yaml.template
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bk-lite-k8s-event-exporter-secret
+  namespace: bk-lite-alerts
+type: Opaque
+stringData:
+  CLUSTER_NAME: "your-k8s-cluster"
+  BK_LITE_RECEIVER_URL: "http://bk-lite-server:8001/api/v1/alerts/api/receiver_data/"
+  BK_LITE_SOURCE_ID: "k8s"
+  BK_LITE_PUSH_SOURCE_ID: k8s
+  BK_LITE_SECRET: "your-alert-source-secret"

--- a/server/apps/alerts/test/test_k8s_render.py
+++ b/server/apps/alerts/test/test_k8s_render.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+def test_k8s_render_support_templates_are_packaged_together():
+    support_dir = Path(__file__).resolve().parents[1] / "support-files" / "kubernetes-event-exporter"
+    secret_template = support_dir / "secret.yaml.template"
+    exporter_template = support_dir / "bk-lite-k8s-event-exporter.yaml"
+
+    assert secret_template.is_file()
+    assert exporter_template.is_file()
+
+    secret_content = secret_template.read_text(encoding="utf-8")
+    exporter_content = exporter_template.read_text(encoding="utf-8")
+
+    assert "kind: Secret" in secret_content
+    assert "your-k8s-cluster" in secret_content
+    assert "http://bk-lite-server:8001/api/v1/alerts/api/receiver_data/" in secret_content
+    assert "your-alert-source-secret" in secret_content
+    assert "BK_LITE_PUSH_SOURCE_ID: k8s" in secret_content
+    assert "kind: Deployment" in exporter_content
+    assert "name: kubernetes-event-exporter" in exporter_content


### PR DESCRIPTION
## 涉及范围
- 增量提交：46d3d0f85 `fix:告警中心新增k8s通道`
- 关键文件：`server/apps/alerts/views/alert_source.py`、`server/apps/alerts/views/open_api_k8s.py`、`server/apps/alerts/support-files/kubernetes-event-exporter/*`

## 具体问题
新增 K8s 告警源后，渲染部署 YAML 的共享 helper 会读取 `secret.yaml.template`，但增量提交只加入了 exporter YAML 和 README，没有提交 Secret 模板文件。

## 根因与影响
根因是共享渲染资源缺失。该 helper 同时被登录态下载、安装命令生成后的开放渲染接口、以及部署 YAML 下载路径复用，所以不是单个按钮问题；用户一旦进入 K8s 通道安装/下载流程，会在服务端读取模板时失败，导致 K8s 告警接入链路不可用。

## 修复
- 补齐 `secret.yaml.template`，包含 exporter 部署所需的 Secret 字段和原渲染逻辑使用的占位值。
- 增加轻量回归测试，确认 K8s 渲染链路依赖的 Secret 模板和 exporter 模板被同时提交，并保留 helper 替换所需占位内容。

## 闭环说明
本次修复落在共享资源层，覆盖所有调用 `_build_k8s_deploy_yaml` 的入口；相邻路径不会再因为同一个缺失模板文件触发 500。

## 验证
- `git diff --check`
- `python3 -m py_compile server/apps/alerts/views/alert_source.py server/apps/alerts/service/k8s_install.py server/apps/alerts/views/open_api_k8s.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -o addopts='' --confcutdir=apps/alerts/test apps/alerts/test/test_k8s_render.py`
