### PR TITLE
fix(cmdb): 修复腾讯云采集 encrypted_fields 中 secretSecret 拼写错误导致的鉴权失败

### DIFF
--- a/server/apps/cmdb/constants/constants.py
+++ b/server/apps/cmdb/constants/constants.py
@@ -468,7 +468,7 @@ COLLECT_OBJ_TREE = [
                 "type": CollectDriverTypes.PROTOCOL,
                 "tag": ["SDK"],
                 "desc": "采集腾讯云账户下CVM、VPC、云数据库等资产清单",
-                "encrypted_fields": ["accessKey", "secretSecret"],
+                "encrypted_fields": ["accessKey", "accessSecret"],
             },
         ],
     },


### PR DESCRIPTION
# 修复腾讯云采集 `encrypted_fields` 中 `secretSecret` 拼写错误导致的鉴权失败

## 问题现象与修复
用4月30日的最新版本，纯净vm安装，docker-compose 18罗汉。

在后台cmdb配置过程中，点区域更新，前端提示失败。导致添加任务也失败。
<img width="1164" height="630" alt="image" src="https://github.com/user-attachments/assets/f80942dc-4d91-409f-88bc-9c786935dfa2" />

经过多轮分析，AI分析给力，就改了一行代码跑通了。

```
diff --git a/server/apps/cmdb/constants/constants.py b/server/apps/cmdb/constants/constants.py
index f2c7225..905c9c3 100644
--- a/server/apps/cmdb/constants/constants.py
+++ b/server/apps/cmdb/constants/constants.py
@@ -468,7 +468,7 @@ COLLECT_OBJ_TREE = [
                 "type": CollectDriverTypes.PROTOCOL,
                 "tag": ["SDK"],
                 "desc": "采集腾讯云账户下CVM、VPC、云数据库等资产清单",
-                "encrypted_fields": ["accessKey", "secretSecret"],
+                "encrypted_fields": ["accessKey", "accessSecret"],
             },
         ],
     },

```
这反推说明server部分受aliyun污染前面没改全，外发前的测试未验全，回归测试的缺位。外网的image镜像应该还是错的，请继续跟进。

------

# 以下来自AI 分析 （附带上仅为参考）


在 BK-Lite 中创建腾讯云（qcloud）资源采集任务，填入正确的 SecretId / SecretKey 并执行后，stargazer 端 14 个采集器全部报：

```
[TencentCloudSDKException] code:AuthFailure.SecretIdNotFound
message:SecretId不存在，请输入正确的密钥。
```

任务最终展示"没有发现任何有效数据"，但日志里没有任何鉴权相关的报错暴露给用户，问题非常隐蔽。

## 根本原因

`server/apps/cmdb/constants/constants.py` 第 471 行，qcloud 采集对象元数据中：

```python
"encrypted_fields": ["accessKey", "secretSecret"],
```

其中 `secretSecret` 是 `accessSecret` 的拼写错误。从文件头注释 `@Time: 2025/11/13 14:29` 与同目录 `aliyun.py` 的 `@Time: 2025/11/13 14:24` 对比可以看出，qcloud 配置是 5 分钟后从 aliyun 复制过来的，复制过程中改字段名时手误。

`encrypted_fields` 这个列表常量被三处共用：

| 用途 | 位置 | typo 后的实际行为 |
|------|------|------|
| 入库前加密 | `models/collect_model.py:174-187` `save()` | `accessSecret` 不在列表 → **不加密 → DB 明文存储 SecretKey** |
| 运行时解密 | `models/collect_model.py:154-172` `decrypt_credentials` | 同上跳过 → 取出来还是明文（侥幸能用，但有副作用见下） |
| API 输出脱敏 | `serializers/collect_serializer.py:60-70` `to_representation` | 同上跳过 → **API 返回里 SecretKey 明文回到前端** |

### 失败链路

1. 用户首次创建任务，填入真实 SecretId / SecretKey
2. `save()` 加密时只加密 `accessKey`（typo `secretSecret` 在 DB 里不存在，无操作），**`accessSecret` 字段以明文落 DB**
3. 序列化返回时同样只把 `accessKey` 替换成 `******`，**`accessSecret` 真值随 GET 响应回到前端**（在浏览器开发者工具里直接可见）
4. 用户在前端编辑该任务（哪怕只改个名字）：表单里 `accessKey` 显示为 `******`，提交时这个 `******` 被当作真值回写
5. `save()` 把 `******` 当明文加密 → DB 里 `accessKey` 变成 `enc:加密后的******`
6. 下次执行采集时 `decrypt_credentials` 解密 `accessKey` 得到 `******`（6 个星号），传给 stargazer 当 SecretId
7. 腾讯云 SDK 返回 `AuthFailure.SecretIdNotFound`

## 修复

```diff
- "encrypted_fields": ["accessKey", "secretSecret"],
+ "encrypted_fields": ["accessKey", "accessSecret"],
```

仅 1 行改动。修复后：
- 加密路径正常，DB 中 `accessSecret` 加密存储为 `enc:xxx`
- 解密路径正常，`decrypt_credentials` 还原出明文 SK
- 序列化输出 `accessSecret` 也会被脱敏成 `******`，不再向前端泄露

## 验证

在测试环境（自部署 BK-Lite）端到端跑通：

| 检查点 | 修复前 | 修复后 |
|------|------|------|
| DB 中 `accessSecret` | 明文 | `enc:` 前缀加密 ✅ |
| API 返回 `accessSecret` | 真实 SK | `******` ✅ |
| `decrypt_credentials` 输出 | （依赖 DB 是否被污染过） | AK 36 字符 / SK 32 字符，长度正确 ✅ |
| Server 推给 telegraf 的 env_config | 编辑过的任务里是 `enc:xxx` 加密串 | 完整明文 AK/SK ✅ |
| stargazer SDK 调用 | 14/14 全 `AuthFailure.SecretIdNotFound` | 0 条 `AuthFailure`，仅有不支持区域的 warning ✅ |
| 采集结果 | `published 14/14 metrics`（全是 error metric，"没有发现任何有效数据"） | `published 73/73 metrics`，包含 CVM `collect_status=success`、`charge_type=POSTPAID_BY_HOUR` 等真实资源属性 ✅ |

## 已知遗留问题（不在本 PR 范围内）

发现但**未在本 PR 处理**的相关问题，建议另开 issue 跟进：

1. **存量数据需要清洗**：本 PR 之前创建过 qcloud 任务的环境，DB 里 `accessSecret` 仍是明文，且如果用户编辑过任务，`accessKey` 可能已经被二次加密损坏。建议提供一次性迁移脚本扫描修复，或在升级文档里说明需要重建 qcloud 任务。

2. **`save()` 不识别脱敏占位符**：`save()` 只通过 `enc:` 前缀判断"已加密"，没有识别 `******` 这种脱敏占位符。这个逻辑对所有云厂商都通用，建议在 `save()` 加密前判断 `value == "******"` 时跳过（或直接保留 DB 原值），避免任何编辑动作都损坏凭据。

3. **stargazer 静默吞掉 SDK 异常**：`agents/stargazer/plugins/inputs/qcloud/qcloud_info.py` 中 14 个采集器对 `TencentCloudSDKException` 全部 try/except 后只 WARNING 不抛出，导致鉴权失败也显示"采集成功，发现 0 条数据"，对用户极度误导。建议至少把 `AuthFailure` 类异常作为致命错误冒泡到任务状态。

4. **`node_configs/cloud/qcloud.py:30` 的 fallback 可清理**：

   ```python
   secret_value = self.credential.get("accessSecret") or self.credential.get("secretSecret", "")
   ```

   这行是为了 typo 临时兜底加的（`secretSecret` 字段在 DB 里从来不存在），typo 修复后可以简化为：

   ```python
   secret_value = self.credential.get("accessSecret", "")
   ```

   本 PR 暂不动，保持最小化。

## 影响范围

- 仅影响 qcloud 模块；aliyun 等其他云厂商的 `encrypted_fields` 已确认拼写正确
- 向后兼容：本 PR 仅改一个常量，没有数据库 schema 变更
- 升级路径：建议升级后**重建已有 qcloud 任务**，或运行清洗脚本（待补）

## Commit

```
fix(cmdb): typo 'secretSecret' -> 'accessSecret' in qcloud encrypted_fields
``