### PR TITLE
fix: support legacy controller package architectures

### DIFF
--- a/server/apps/node_mgmt/filters/package.py
+++ b/server/apps/node_mgmt/filters/package.py
@@ -1,4 +1,5 @@
 from django_filters import rest_framework as filters
+from django.db.models import Q
 
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models.package import PackageVersion
@@ -16,6 +17,10 @@ class PackageVersionFilter(filters.FilterSet):
     def filter_cpu_architecture(self, queryset, name, value):
         normalized_arch = normalize_cpu_architecture(value)
         if normalized_arch:
+            target_type = self.data.get("type")
+            target_object = self.data.get("object")
+            if normalized_arch == NodeConstants.X86_64_ARCH and target_type == "controller" and target_object == "Controller":
+                return queryset.filter(Q(cpu_architecture=normalized_arch) | Q(cpu_architecture=""))
             return queryset.filter(cpu_architecture=normalized_arch)
 
         target_os = self.data.get("os")

--- a/server/apps/node_mgmt/serializers/package.py
+++ b/server/apps/node_mgmt/serializers/package.py
@@ -6,16 +6,37 @@ from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
 
 
 class PackageVersionSerializer(serializers.ModelSerializer):
-    cpu_architecture = serializers.SerializerMethodField()
-
     class Meta:
         model = PackageVersion
-        fields = "__all__"
+        fields = [
+            "id",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "domain",
+            "updated_by_domain",
+            "type",
+            "os",
+            "cpu_architecture",
+            "object",
+            "version",
+            "name",
+            "description",
+        ]
 
-    def get_cpu_architecture(self, obj):
+    @staticmethod
+    def _normalized_cpu_architecture(obj):
         normalized_arch = normalize_cpu_architecture(getattr(obj, "cpu_architecture", ""))
         if normalized_arch:
             return normalized_arch
+        if getattr(obj, "type", "") == "controller" and getattr(obj, "object", "") == "Controller":
+            return NodeConstants.X86_64_ARCH
         if getattr(obj, "os", "") == NodeConstants.WINDOWS_OS and getattr(obj, "object", "") == "Controller":
             return NodeConstants.X86_64_ARCH
         return getattr(obj, "cpu_architecture", "")
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        data["cpu_architecture"] = self._normalized_cpu_architecture(instance)
+        return data

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -34,6 +34,7 @@ from apps.node_mgmt.management.services.node_init.collector_init import import_c
 from apps.node_mgmt.management.services.node_init.controller_init import controller_init
 from apps.node_mgmt.nats.node import NatsService
 from apps.node_mgmt.serializers.collector import CollectorSerializer
+from apps.node_mgmt.serializers.package import PackageVersionSerializer
 from apps.node_mgmt.views.collector import CollectorViewSet
 from apps.node_mgmt.views.installer import InstallerViewSet
 from apps.node_mgmt.views.sidecar import OpenSidecarViewSet
@@ -1125,6 +1126,79 @@ def test_package_list_filters_controller_versions_by_exact_architecture():
     ).qs
 
     assert list(filtered.values_list("id", flat=True)) == [arm_package.id]
+
+
+@pytest.mark.django_db
+def test_package_list_treats_legacy_empty_arch_controller_as_x86_64():
+    legacy_package = PackageVersion.objects.create(
+        type="controller",
+        os=NodeConstants.LINUX_OS,
+        cpu_architecture="",
+        object="Controller",
+        version="0.9.0",
+        name="controller-legacy.zip",
+        created_by="tester",
+        updated_by="tester",
+    )
+    x86_package = PackageVersion.objects.create(
+        type="controller",
+        os=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        object="Controller",
+        version="1.0.0",
+        name="controller-x86_64.tar.gz",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    queryset = PackageVersion.objects.filter(type="controller", object="Controller", os=NodeConstants.LINUX_OS)
+    filtered = PackageVersionFilter(
+        data={
+            "type": "controller",
+            "object": "Controller",
+            "os": NodeConstants.LINUX_OS,
+            "cpu_architecture": NodeConstants.X86_64_ARCH,
+        },
+        queryset=queryset,
+    ).qs
+
+    assert set(filtered.values_list("id", flat=True)) == {x86_package.id, legacy_package.id}
+
+
+@pytest.mark.django_db
+def test_package_version_serializer_exposes_normalized_cpu_architecture():
+    package = PackageVersion.objects.create(
+        type="controller",
+        os=NodeConstants.LINUX_OS,
+        cpu_architecture="amd64",
+        object="Controller",
+        version="1.0.1",
+        name="fusion-collectors-linux-amd64.zip",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    data = PackageVersionSerializer(package).data
+
+    assert data["cpu_architecture"] == NodeConstants.X86_64_ARCH
+
+
+@pytest.mark.django_db
+def test_package_version_serializer_treats_legacy_empty_arch_controller_as_x86_64():
+    package = PackageVersion.objects.create(
+        type="controller",
+        os=NodeConstants.LINUX_OS,
+        cpu_architecture="",
+        object="Controller",
+        version="1.0.1",
+        name="fusion-collectors-linux-legacy.zip",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    data = PackageVersionSerializer(package).data
+
+    assert data["cpu_architecture"] == NodeConstants.X86_64_ARCH
 
 
 @pytest.mark.django_db

--- a/web/src/app/node-manager/(pages)/cloudregion/node/controllerInstall/installConfig/index.tsx
+++ b/web/src/app/node-manager/(pages)/cloudregion/node/controllerInstall/installConfig/index.tsx
@@ -156,31 +156,27 @@ const InstallConfig: React.FC<InstallConfigProps> = ({ onNext, cancel }) => {
     return CPU_ARCHITECTURE_OPTIONS[os] || CPU_ARCHITECTURE_OPTIONS.linux;
   }, [os]);
 
-  // 根据选中的操作系统和 CPU 架构过滤版本列表
+  // 对当前查询结果做去重，接口已按操作系统和 CPU 架构精确过滤
   const filteredSidecarVersionList = useMemo(() => {
-    if (!os) return sidecarVersionList;
-    const filtered = sidecarVersionList.filter(
-      (item) => item.os === os && item.cpu_architecture === cpuArchitecture
-    );
     const deduped = new Map();
-    filtered.forEach((item) => {
+    sidecarVersionList.forEach((item) => {
       const key = `${item.os}-${item.cpu_architecture}-${item.version}`;
       if (!deduped.has(key)) {
         deduped.set(key, item);
       }
     });
     return Array.from(deduped.values());
-  }, [cpuArchitecture, os, sidecarVersionList]);
+  }, [sidecarVersionList]);
 
   const noVersionAvailable = useMemo(() => {
     return !versionLoading && filteredSidecarVersionList.length === 0;
   }, [filteredSidecarVersionList.length, versionLoading]);
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading && os && cpuArchitecture) {
       getSidecarList();
     }
-  }, [isLoading]);
+  }, [isLoading, os, cpuArchitecture]);
 
   useEffect(() => {
     if (os) {


### PR DESCRIPTION
Treat legacy controller packages without a recorded cpu architecture as x86_64 during package listing and serialization so the controller install page remains usable while old package records are being backfilled.