### PR TITLE
[ansible-executor] 修复回调拒收假闭环，收紧 Playbook ZIP 输入边界

### DIFF
--- a/agents/ansible-executor/service/ansible_runner.py
+++ b/agents/ansible-executor/service/ansible_runner.py
@@ -734,7 +734,7 @@ async def prepare_playbook_execution(
                 with zipfile.ZipFile(local_path, "r") as zf:
                     namelist = zf.namelist()
                     logger.info("[prepare_playbook] ZIP 内容 (%d 个文件): %s", len(namelist), namelist)
-                    zf.extractall(workspace)
+                    _safe_extract_zip(zf, workspace)
                 logger.info("[prepare_playbook] ZIP 已解压到: %s", workspace)
                 # 列出解压后的 workspace 内容
                 all_files = [str(p.relative_to(workspace)) for p in workspace.rglob("*") if p.is_file()]

--- a/agents/ansible-executor/service/nats_service.py
+++ b/agents/ansible-executor/service/nats_service.py
@@ -304,8 +304,28 @@ class AnsibleNATSService:
         timeout = int(callback.get("timeout", self.config.callback_timeout))
         request_payload = json.dumps({"args": [payload], "kwargs": {}}, ensure_ascii=False).encode("utf-8")
 
-        await self.nc.request(subject, request_payload, timeout=timeout)
+        response = await self.nc.request(subject, request_payload, timeout=timeout)
+        self._ensure_callback_accepted(response.data)
         logger.info("callback sent: subject=%s task_id=%s", subject, payload.get("task_id"))
+
+    @staticmethod
+    def _ensure_callback_accepted(response_data: bytes):
+        try:
+            response = json.loads(response_data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("callback returned invalid JSON response") from exc
+
+        if not isinstance(response, dict):
+            raise ValueError("callback returned non-object response")
+
+        if response.get("success") is not True:
+            message = response.get("message") or response.get("error") or response.get("result") or "callback request rejected"
+            raise RuntimeError(str(message))
+
+        result = response.get("result")
+        if isinstance(result, dict) and result.get("success") is False:
+            message = result.get("message") or result.get("error") or "callback handler rejected result"
+            raise RuntimeError(str(message))
 
     async def _enqueue_callback_retry(self, callback: dict[str, Any], payload: dict[str, Any], reason: str):
         retry_payload = {

--- a/agents/ansible-executor/tests/test_ansible_runner.py
+++ b/agents/ansible-executor/tests/test_ansible_runner.py
@@ -1,9 +1,11 @@
 import zipfile
-from pathlib import Path
 
 import pytest
 
+from core.config import ServiceConfig
+from service import ansible_runner
 from service.ansible_runner import _safe_extract_zip, _safe_workspace_path
+from service.ansible_runner import PlaybookRequest, prepare_playbook_execution
 
 
 def test_safe_workspace_path_rejects_parent_escape(tmp_path):
@@ -35,3 +37,27 @@ def test_safe_extract_zip_allows_regular_files(tmp_path):
         _safe_extract_zip(archive, workspace)
 
     assert (workspace / "nested" / "file.txt").read_text(encoding="utf-8") == "hello"
+
+
+@pytest.mark.asyncio
+async def test_prepare_playbook_execution_rejects_unsafe_zip_member(tmp_path, monkeypatch):
+    archive_path = tmp_path / "payload.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("../outside.yml", "- hosts: all\n")
+        archive.writestr("playbook.yml", "- hosts: all\n")
+
+    async def fake_download(config, workspace, bucket_name, file_item):
+        return str(archive_path)
+
+    monkeypatch.setattr(ansible_runner, "BASE_TASK_DIR", tmp_path / "work")
+    monkeypatch.setattr(ansible_runner, "download_object_to_workspace", fake_download)
+
+    config = ServiceConfig(nats_servers=["nats://127.0.0.1:4222"], nats_instance_id="default")
+    request = PlaybookRequest(
+        playbook_path="playbook.yml",
+        inventory_content="[all]\n127.0.0.1 ansible_connection=local\n",
+        files=[{"name": "payload.zip", "file_key": "payload.zip", "bucket_name": "bucket"}],
+    )
+
+    with pytest.raises(ValueError, match="zip member"):
+        await prepare_playbook_execution(config, request)

--- a/agents/ansible-executor/tests/test_nats_service.py
+++ b/agents/ansible-executor/tests/test_nats_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import pytest
 
@@ -12,6 +13,19 @@ class DummyMessage:
 
     async def in_progress(self):
         self.in_progress_calls += 1
+
+
+class DummyNATSResponse:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode("utf-8")
+
+
+class DummyNATSClient:
+    def __init__(self, payload):
+        self.payload = payload
+
+    async def request(self, subject, request_payload, timeout):
+        return DummyNATSResponse(self.payload)
 
 
 @pytest.mark.asyncio
@@ -95,3 +109,39 @@ async def test_run_task_with_ack_progress_cancels_keepalive(tmp_path, monkeypatc
 
     assert calls["run"] == 1
     assert result == {"task_id": "task-2", "owner_id": "owner-b"}
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_rejects_handler_failure(tmp_path):
+    service = AnsibleNATSService(
+        ServiceConfig(
+            nats_servers=["nats://127.0.0.1:4222"],
+            nats_instance_id="default",
+            js_stream="BK_ANS_EXEC_TASKS",
+            js_subject_prefix="bk.ans_exec.tasks",
+            js_durable="ansible-executor",
+            state_db_path=str(tmp_path / "task.db"),
+        )
+    )
+    service.nc = DummyNATSClient({"success": True, "result": {"success": False, "message": "invalid result"}})
+
+    with pytest.raises(RuntimeError, match="invalid result"):
+        await service._invoke_callback({"subject": "job.ansible_task_callback"}, {"task_id": "task-3"})
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_rejects_transport_failure(tmp_path):
+    service = AnsibleNATSService(
+        ServiceConfig(
+            nats_servers=["nats://127.0.0.1:4222"],
+            nats_instance_id="default",
+            js_stream="BK_ANS_EXEC_TASKS",
+            js_subject_prefix="bk.ans_exec.tasks",
+            js_durable="ansible-executor",
+            state_db_path=str(tmp_path / "task.db"),
+        )
+    )
+    service.nc = DummyNATSClient({"success": False, "message": "callback exception"})
+
+    with pytest.raises(RuntimeError, match="callback exception"):
+        await service._invoke_callback({"subject": "job.ansible_task_callback"}, {"task_id": "task-4"})


### PR DESCRIPTION
## 问题本质

ansible-executor 在执行完成后只要 NATS callback 请求返回就标记回调已送达，没有校验服务端是否真正接收结果；同时 Playbook ZIP 的普通执行路径没有复用已有安全解压逻辑。

## 业务影响

当服务端回调因结果格式、任务不存在或处理异常明确拒收时，执行器仍可能把本地任务标记为 callback sent，导致作业侧状态停留在运行中或与执行器本地状态不一致，排障时形成假闭环。Playbook ZIP 输入边界不一致也会让执行工作区可信度依赖调用方，增加执行入口被异常压缩包污染的风险。

## 本次处理方式

- 校验 callback 的 NATS 响应：外层请求失败或回调处理器返回 `success: false` 时抛错，沿用现有 callback retry / callback_failed 流程。
- Playbook ZIP 普通执行路径统一使用 `_safe_extract_zip`，拒绝越界成员与符号链接成员。
- 增加回调拒收与不安全 ZIP 成员的回归测试。

## 验证方式

- `PYTHONPATH=. uv run --with ruff ruff check .`
- `PYTHONPATH=. uv run --with pytest --with pytest-asyncio pytest`

负责人：白宇飞
