### PR TITLE
[incremental] 修复 legacy 控制器包被列出后无法安装

### DIFF
--- a/server/apps/node_mgmt/services/installer.py
+++ b/server/apps/node_mgmt/services/installer.py
@@ -5,13 +5,8 @@ from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.node_mgmt.constants.database import DatabaseConstants
 from apps.node_mgmt.constants.installer import InstallerConstants
 from apps.node_mgmt.constants.node import NodeConstants
-from apps.node_mgmt.models import SidecarEnv, Node, PackageVersion
-from apps.node_mgmt.models.installer import (
-    ControllerTask,
-    ControllerTaskNode,
-    CollectorTaskNode,
-    CollectorTask,
-)
+from apps.node_mgmt.models import Node, PackageVersion, SidecarEnv
+from apps.node_mgmt.models.installer import CollectorTask, CollectorTaskNode, ControllerTask, ControllerTaskNode
 from apps.node_mgmt.services.install_token import InstallTokenService
 from apps.node_mgmt.services.installer_session import InstallerSessionService
 from apps.node_mgmt.services.package import PackageService
@@ -41,7 +36,13 @@ class InstallerService:
         if not package_obj:
             raise BaseAppException("Package version not found")
         normalized_arch = normalize_cpu_architecture(cpu_architecture)
-        if package_obj.cpu_architecture == normalized_arch or not normalized_arch:
+        is_legacy_x86_controller = (
+            not package_obj.cpu_architecture
+            and normalized_arch == NodeConstants.X86_64_ARCH
+            and package_obj.type == "controller"
+            and package_obj.object == "Controller"
+        )
+        if package_obj.cpu_architecture == normalized_arch or not normalized_arch or is_legacy_x86_controller:
             return package_obj
         raise BaseAppException(
             f"No package found for os={package_obj.os}, object={package_obj.object}, version={package_obj.version}, arch={normalized_arch}"

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -1,40 +1,38 @@
+import json
 from queue import Queue
 from types import SimpleNamespace
-import json
-from io import BytesIO
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.base.models import User
-from apps.node_mgmt.constants.node import NodeConstants
-from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.crypto.aes_crypto import AESCryptor
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.filters.package import PackageVersionFilter
+from apps.node_mgmt.management.commands.backfill_node_cpu_architecture import Command as BackfillNodeCpuArchitectureCommand
+from apps.node_mgmt.management.commands.backfill_package_storage_paths import Command as BackfillPackageStoragePathsCommand
+from apps.node_mgmt.management.commands.collector_package_init import Command as CollectorPackageInitCommand
+from apps.node_mgmt.management.commands.controller_package_init import Command as ControllerPackageInitCommand
+from apps.node_mgmt.management.commands.installer_init import Command as InstallerInitCommand
+from apps.node_mgmt.management.commands.verify_architecture_rollout import Command as VerifyArchitectureRolloutCommand
+from apps.node_mgmt.management.services.node_init.collector_init import import_collector
+from apps.node_mgmt.management.services.node_init.controller_init import controller_init
+from apps.node_mgmt.management.services.node_init.definition_loader import load_definition_records
 from apps.node_mgmt.models import CloudRegion, Collector, CollectorConfiguration, Controller, Node, PackageVersion, SidecarEnv
 from apps.node_mgmt.models.installer import ControllerTask, ControllerTaskNode
+from apps.node_mgmt.nats.node import NatsService
+from apps.node_mgmt.serializers.collector import CollectorSerializer
+from apps.node_mgmt.serializers.package import PackageVersionSerializer
 from apps.node_mgmt.services.installer import InstallerService
 from apps.node_mgmt.services.installer_session import InstallerSessionService
-from apps.node_mgmt.services.sidecar import Sidecar
 from apps.node_mgmt.services.package import PackageService
-from apps.node_mgmt.filters.package import PackageVersionFilter
+from apps.node_mgmt.services.sidecar import Sidecar
 from apps.node_mgmt.services.version_upgrade import VersionUpgradeService
 from apps.node_mgmt.tasks import installer as installer_tasks
 from apps.node_mgmt.tasks.version_discovery import _calculate_upgrade_info
 from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
-from apps.node_mgmt.management.commands.collector_package_init import Command as CollectorPackageInitCommand
-from apps.node_mgmt.management.commands.backfill_node_cpu_architecture import Command as BackfillNodeCpuArchitectureCommand
-from apps.node_mgmt.management.commands.backfill_package_storage_paths import Command as BackfillPackageStoragePathsCommand
-from apps.node_mgmt.management.commands.controller_package_init import Command as ControllerPackageInitCommand
-from apps.node_mgmt.management.commands.installer_init import Command as InstallerInitCommand
-from apps.node_mgmt.management.commands.verify_architecture_rollout import Command as VerifyArchitectureRolloutCommand
-from apps.node_mgmt.management.services.node_init.definition_loader import load_definition_records
-from apps.node_mgmt.management.services.node_init.collector_init import import_collector
-from apps.node_mgmt.management.services.node_init.controller_init import controller_init
-from apps.node_mgmt.nats.node import NatsService
-from apps.node_mgmt.serializers.collector import CollectorSerializer
-from apps.node_mgmt.serializers.package import PackageVersionSerializer
 from apps.node_mgmt.views.collector import CollectorViewSet
 from apps.node_mgmt.views.installer import InstallerViewSet
 from apps.node_mgmt.views.sidecar import OpenSidecarViewSet
@@ -128,6 +126,41 @@ def test_installer_service_raises_when_arch_specific_package_missing():
         object="Controller",
         version="3.0.0",
         name="fusion-collectors-x86_64.tar.gz",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    with pytest.raises(BaseAppException):
+        InstallerService.resolve_package_by_architecture(seed.id, "arm64")
+
+
+@pytest.mark.django_db
+def test_installer_service_accepts_legacy_empty_arch_controller_as_x86_64():
+    seed = PackageVersion.objects.create(
+        type="controller",
+        os="linux",
+        cpu_architecture="",
+        object="Controller",
+        version="3.1.0",
+        name="fusion-collectors-legacy.tar.gz",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    resolved = InstallerService.resolve_package_by_architecture(seed.id, "x86_64")
+
+    assert resolved.id == seed.id
+
+
+@pytest.mark.django_db
+def test_installer_service_rejects_legacy_empty_arch_controller_for_arm64():
+    seed = PackageVersion.objects.create(
+        type="controller",
+        os="linux",
+        cpu_architecture="",
+        object="Controller",
+        version="3.1.1",
+        name="fusion-collectors-legacy.tar.gz",
         created_by="tester",
         updated_by="tester",
     )
@@ -1519,10 +1552,11 @@ def test_backfill_package_storage_paths_dry_run_reports_legacy_copy(monkeypatch,
     )
     output = capsys.readouterr().out
 
-    assert (
-        f"[dry-run] {package_obj.id}: copy linux/Controller/1.0.1/fusion-collectors-linux-amd64.zip -> linux/x86_64/Controller/1.0.1/fusion-collectors-linux-amd64.zip"
-        in output
+    expected_output = (
+        f"[dry-run] {package_obj.id}: copy linux/Controller/1.0.1/fusion-collectors-linux-amd64.zip "
+        "-> linux/x86_64/Controller/1.0.1/fusion-collectors-linux-amd64.zip"
     )
+    assert expected_output in output
 
 
 @pytest.mark.django_db
@@ -2441,9 +2475,10 @@ def test_nats_client_request_includes_error_message_from_nats_response(monkeypat
 
 @pytest.mark.django_db
 def test_nats_client_request_falls_back_to_pickled_base_app_exception_message(monkeypatch):
+    import jsonpickle
+
     from nats_client.clients import request
     from nats_client.exceptions import NatsClientException
-    import jsonpickle
 
     class _FakeResponse:
         data = json.dumps(


### PR DESCRIPTION
## 涉及范围
- 增量提交：cdf89a7d6d35f957be36e67c5b3c62d5c2b628c3、88f9bf82809dc05c0abd597ed9f970b301111e1d
- 关键文件：server/apps/node_mgmt/filters/package.py、server/apps/node_mgmt/serializers/package.py、web/src/app/node-manager/(pages)/cloudregion/node/controllerInstall/installConfig/index.tsx、server/apps/node_mgmt/services/installer.py

## 问题
最近增量把空 `cpu_architecture` 的 legacy 控制器包在列表和序列化层视为 `x86_64`，安装页会把这类包作为可选版本展示；但远程安装任务进入 `InstallerService.resolve_package_by_architecture()` 后仍按真实空值校验，选择这类包会在任务执行阶段报 `No package found ... arch=x86_64`。

## 根因
列表层和安装执行层对 legacy 空架构控制器包的语义不一致：上游已经把它暴露为 x86_64 可安装包，下游解析器仍只接受真实 `cpu_architecture == x86_64`。

## 全局影响
这是局部列表/序列化语义变化影响安装执行链路的问题。受影响链路为：包列表查询 -> 安装页版本选择 -> 控制器安装任务 -> 安装包架构解析。用户能选中旧包，但任务会失败，导致旧环境中只有 legacy 控制器包时无法安装控制器。

## 修复
- 在安装执行层补齐同一语义：仅当目标架构为 `x86_64` 且包是 legacy 空架构 `controller/Controller` 时允许使用该包。
- 保持 `arm64` 不走 legacy 空架构包，避免把旧 x86 包误用于 ARM 节点。
- 增加回归测试覆盖 x86 可安装和 arm64 仍拒绝两条路径。
- 顺手修正同一测试文件已有的 flake8 import/长行问题，避免触发门禁失败。

## 验证
- `INSTALL_APPS=node_mgmt,system_mgmt DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite uv run --extra dev pytest apps/node_mgmt/tests/test_architecture_support.py -q`：69 passed
- `uv run --with 'flake8>=4.0.1' flake8 --config=./.flake8 apps/node_mgmt/services/installer.py apps/node_mgmt/tests/test_architecture_support.py`：0
