### PR TITLE
[node_mgmt] 修复安装回调按 IP 收敛导致的假成功风险

### DIFF
--- a/server/apps/node_mgmt/constants/installer.py
+++ b/server/apps/node_mgmt/constants/installer.py
@@ -15,6 +15,7 @@ class InstallerConstants:
 
     EXECUTION_PHASE_KEY = "execution_phase"
     EXECUTION_ATTEMPT_KEY = "execution_attempt"
+    INSTALL_NODE_ID_KEY = "install_node_id"
     EXECUTION_PHASE_BOOTSTRAP_RUNNING = "bootstrap_running"
     EXECUTION_PHASE_CONNECTIVITY_WAITING = "connectivity_waiting"
     EXECUTION_PHASE_FINISHED = "finished"

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -9,6 +9,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from apps.node_mgmt.constants.collector import CollectorConstants
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.database import DatabaseConstants
+from apps.node_mgmt.constants.installer import InstallerConstants
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.services.cloudregion import RegionService
 from apps.node_mgmt.utils.crypto_helper import EncryptedJsonResponse
@@ -157,13 +158,11 @@ class Sidecar:
             status="running",
         ).exists()
 
-        install_running_exists = False
-        if node_ip:
-            install_running_exists = ControllerTaskNode.objects.filter(
-                ip=node_ip,
-                status="running",
-                task__type="install",
-            ).exists()
+        install_running_exists = ControllerTaskNode.objects.filter(
+            **{f"result__{InstallerConstants.INSTALL_NODE_ID_KEY}": node_id},
+            status="running",
+            task__type="install",
+        ).exists()
 
         if not action_running_exists and not install_running_exists:
             return
@@ -716,7 +715,8 @@ class Sidecar:
                 # 如果已经存在关联的自定义配置则跳过，避免覆盖用户配置
                 if CollectorConfiguration.objects.filter(collector=collector_obj, nodes=node).exists():
                     logger.info(
-                        f"Node {node.id} already has a custom configuration for collector {collector_obj.name}, skipping default configuration creation."
+                        f"Node {node.id} already has a custom configuration for collector {collector_obj.name}, "
+                        "skipping default configuration creation."
                     )
                     continue
 

--- a/server/apps/node_mgmt/tasks/installer.py
+++ b/server/apps/node_mgmt/tasks/installer.py
@@ -5,7 +5,6 @@ import threading
 
 from celery import shared_task
 from django.db import transaction
-from django.db.models import Count, Q
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.crypto.aes_crypto import AESCryptor
@@ -20,9 +19,9 @@ from apps.node_mgmt.models import (
     PackageVersion,
     Node,
     NodeCollectorInstallStatus,
-    Collector,
 )
 from apps.node_mgmt.models import ControllerTaskNode
+from apps.node_mgmt.services.package import PackageService
 
 from apps.node_mgmt.utils.installer import (
     exec_command_to_remote,
@@ -554,10 +553,17 @@ def install_controller_on_nodes(task_obj, nodes, package_obj):
                 },
             )
 
+            install_node_id = uuid.uuid4().hex
+            node_obj.result = {
+                **(node_obj.result or {}),
+                InstallerConstants.INSTALL_NODE_ID_KEY: install_node_id,
+            }
+            node_obj.save(update_fields=["result"])
+
             install_command = InstallerService.get_install_command(
                 task_obj.created_by,
                 node_obj.ip,
-                uuid.uuid4().hex,
+                install_node_id,
                 resolved_package.os,
                 resolved_package.id,
                 task_obj.cloud_region_id,
@@ -710,7 +716,7 @@ def converge_controller_install_connectivity_for_node(node_id):
         return
 
     running_task_nodes = ControllerTaskNode.objects.filter(
-        ip=node.ip,
+        **{f"result__{InstallerConstants.INSTALL_NODE_ID_KEY}": node_id},
         status="running",
         task__type="install",
     ).select_related("task")
@@ -1057,11 +1063,16 @@ def install_collector(task_id):
                     next_steps=next_steps,
                 )
 
-            if resolved_package.os in NodeConstants.LINUX_OS:
+            if resolved_package.os == NodeConstants.LINUX_OS:
                 executable_path = f"{collector_install_dir}/{executable_name}"
+                set_executable_command = (
+                    f"if [ -d '{executable_path}' ]; then "
+                    f"find '{executable_path}' -type f -exec chmod +x {{}} \\; ; "
+                    f"else chmod +x '{executable_path}'; fi"
+                )
                 exec_command_to_local(
                     node_obj.node_id,
-                    f"if [ -d '{executable_path}' ]; then find '{executable_path}' -type f -exec chmod +x {{}} \\; ; else chmod +x '{executable_path}'; fi",
+                    set_executable_command,
                 )
                 _update_step_status(node_obj, "success", "Executable permissions updated")
 

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -1,17 +1,16 @@
 from queue import Queue
 from types import SimpleNamespace
 import json
-from io import BytesIO
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.base.models import User
-from apps.node_mgmt.constants.node import NodeConstants
-from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.crypto.aes_crypto import AESCryptor
+from apps.node_mgmt.constants.installer import InstallerConstants
+from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models import CloudRegion, Collector, CollectorConfiguration, Controller, Node, PackageVersion, SidecarEnv
 from apps.node_mgmt.models.installer import ControllerTask, ControllerTaskNode
 from apps.node_mgmt.services.installer import InstallerService
@@ -1520,7 +1519,8 @@ def test_backfill_package_storage_paths_dry_run_reports_legacy_copy(monkeypatch,
     output = capsys.readouterr().out
 
     assert (
-        f"[dry-run] {package_obj.id}: copy linux/Controller/1.0.1/fusion-collectors-linux-amd64.zip -> linux/x86_64/Controller/1.0.1/fusion-collectors-linux-amd64.zip"
+        f"[dry-run] {package_obj.id}: copy linux/Controller/1.0.1/fusion-collectors-linux-amd64.zip -> "
+        "linux/x86_64/Controller/1.0.1/fusion-collectors-linux-amd64.zip"
         in output
     )
 
@@ -2595,6 +2595,80 @@ def test_collector_retrieve_exposes_architecture_display(monkeypatch):
     assert response.data["cpu_architecture"] == NodeConstants.ARM64_ARCH
     assert response.data["architecture_display"] == "ARM64"
     assert response.data["display_name"] == "Vector（ARM64）"
+
+
+@pytest.mark.django_db
+def test_install_connectivity_converge_matches_generated_node_id_not_ip():
+    cloud_region = CloudRegion.objects.create(
+        name="connectivity-region",
+        introduction="test",
+        created_by="tester",
+        updated_by="tester",
+    )
+    stale_task = ControllerTask.objects.create(
+        cloud_region=cloud_region,
+        type="install",
+        status="running",
+        work_node="worker-1",
+        package_version_id=1,
+        created_by="tester",
+        updated_by="tester",
+    )
+    current_task = ControllerTask.objects.create(
+        cloud_region=cloud_region,
+        type="install",
+        status="running",
+        work_node="worker-1",
+        package_version_id=1,
+        created_by="tester",
+        updated_by="tester",
+    )
+    common_result = {
+        InstallerConstants.EXECUTION_PHASE_KEY: InstallerConstants.EXECUTION_PHASE_CONNECTIVITY_WAITING,
+        "steps": [{"action": "connectivity_check", "status": "running", "message": "Wait for node connection"}],
+    }
+    stale_task_node = ControllerTaskNode.objects.create(
+        task=stale_task,
+        ip="10.0.0.88",
+        node_name="stale-node",
+        os=NodeConstants.LINUX_OS,
+        organizations=[1],
+        port=22,
+        username="root",
+        password="",
+        status=InstallerConstants.STEP_STATUS_RUNNING,
+        result={**common_result, InstallerConstants.INSTALL_NODE_ID_KEY: "stale-install-node"},
+    )
+    current_task_node = ControllerTaskNode.objects.create(
+        task=current_task,
+        ip="10.0.0.88",
+        node_name="current-node",
+        os=NodeConstants.LINUX_OS,
+        organizations=[1],
+        port=22,
+        username="root",
+        password="",
+        status=InstallerConstants.STEP_STATUS_RUNNING,
+        result={**common_result, InstallerConstants.INSTALL_NODE_ID_KEY: "current-install-node"},
+    )
+    Node.objects.create(
+        id="current-install-node",
+        name="current-node",
+        ip="10.0.0.88",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/tmp/config",
+        cloud_region=cloud_region,
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    installer_tasks.converge_controller_install_connectivity_for_node("current-install-node")
+
+    stale_task_node.refresh_from_db()
+    current_task_node.refresh_from_db()
+    assert stale_task_node.status == InstallerConstants.STEP_STATUS_RUNNING
+    assert current_task_node.status == InstallerConstants.STEP_STATUS_SUCCESS
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题本质

节点管理自动安装会为本次安装生成新的节点 ID，但安装连通确认只按 IP 匹配运行中的安装节点。同 IP 并发安装、重试或跨区域场景下，任意一个 Sidecar 回调都可能把不属于本次安装的任务节点一起推进成功。

同时，采集器安装任务中解析架构包和采集器定义时调用了 `PackageService`，但任务模块没有导入该服务，采集器安装会在状态落库前直接中断。

## 业务影响

安装链路可能出现假成功：节点实际未完成本次安装，任务却显示成功，后续配置下发和运行状态排障会被错误状态误导。采集器安装链路也可能在批量安装时直接失败，导致探针包下发与安装结果无法闭环。

## 本次处理

- 自动安装生成命令前记录本次安装使用的节点 ID。
- Sidecar 回调触发与安装连通收敛改为按该安装节点 ID 匹配任务节点，不再按 IP 泛匹配。
- 修复采集器安装任务缺失的 `PackageService` 导入，并收敛 Linux 判断与命令拼接。
- 增加同 IP 多安装任务的回归测试，确保只推进匹配本次安装节点 ID 的任务。

## 验证方式

- `uvx flake8 --config=server/.flake8 server/apps/node_mgmt/constants/installer.py server/apps/node_mgmt/services/sidecar.py server/apps/node_mgmt/tasks/installer.py server/apps/node_mgmt/tests/test_architecture_support.py`
- `uv run --extra dev python -m py_compile apps/node_mgmt/constants/installer.py apps/node_mgmt/services/sidecar.py apps/node_mgmt/tasks/installer.py apps/node_mgmt/tests/test_architecture_support.py`
- `INSTALL_APPS='system_mgmt,alerts,console_mgmt,job_mgmt,log,monitor,node_mgmt,operation_analysis,opspilot,cmdb' uv run --extra dev pytest apps/node_mgmt/tests/test_installer_failure_enrichment.py -q --confcutdir=apps/node_mgmt/tests -o addopts=''`
