### PR TITLE
[log] 下推日志实例权限过滤，降低全量查询放大风险

### DIFF
--- a/server/apps/log/nats/log.py
+++ b/server/apps/log/nats/log.py
@@ -103,6 +103,19 @@ def _paginate_items(items: list, page, page_size):
     }
 
 
+def _build_paginated_alert_segments(queryset, page, page_size):
+    total_count = queryset.count()
+    start = (page - 1) * page_size
+    end = start + page_size
+    paged_alerts = queryset.order_by("-start_event_time", "-created_at")[start:end]
+    return {
+        "count": total_count,
+        "page": page,
+        "page_size": page_size,
+        "items": [_build_log_alert_segment(alert) for alert in paged_alerts],
+    }
+
+
 def _build_log_alert_segment(alert: Alert) -> dict:
     start_event_time = getattr(alert, "start_event_time", None)
     created_at = getattr(alert, "created_at", None)
@@ -216,9 +229,8 @@ def query_log_alert_segments(query_data: dict, *args, **kwargs):
     if level_values:
         queryset = queryset.filter(level__in=level_values)
 
-    items = [_build_log_alert_segment(alert) for alert in queryset.order_by("-start_event_time", "-created_at")]
     return {
         "result": True,
-        "data": _paginate_items(items, page, page_size),
+        "data": _build_paginated_alert_segments(queryset, page, page_size),
         "message": "",
     }

--- a/server/apps/log/services/collect_type.py
+++ b/server/apps/log/services/collect_type.py
@@ -310,7 +310,7 @@ class CollectTypeService:
         end = start + page_size
 
         # 获取当前页的数据
-        page_data = queryset[start:end]
+        page_data = list(queryset[start:end])
 
         # 获取实例ID列表用于补充额外信息
         instance_ids = [instance.id for instance in page_data]

--- a/server/apps/log/tests/test_collect_instance_permission_guards.py
+++ b/server/apps/log/tests/test_collect_instance_permission_guards.py
@@ -6,6 +6,9 @@ from apps.log.views.collect_config import CollectConfigViewSet, CollectInstanceV
 
 
 class FakeQuerySet(list):
+    def distinct(self):
+        return self
+
     def select_related(self, *args):
         return self
 
@@ -301,9 +304,59 @@ def test_search_all_collect_types_respects_admin_scope_from_permission_data(monk
     response = CollectInstanceViewSet().search(make_request({"page": 1, "page_size": 10}))
 
     assert response.status_code == 200
-    collect_instance_filter.assert_called_once_with(collectinstanceorganization__organization__in=[2])
+    collect_instance_filter.assert_called_once_with(collectinstanceorganization__organization__in={2})
     payload = json.loads(response.content)
     assert payload["data"]["items"][0]["permission"] == ["View", "Operate"]
+
+
+def test_search_all_collect_types_uses_database_scope_before_pagination(monkeypatch):
+    instance = make_instance(organizations=[2])
+    from apps.log.views import collect_config
+
+    search_result = {
+        "count": 1,
+        "items": [
+            {
+                "id": instance.id,
+                "collect_type_id": instance.collect_type_id,
+                "organization": [2],
+            }
+        ],
+    }
+    collect_instance_filter = Mock(return_value=FakeQuerySet([instance]))
+    service_search = Mock(return_value=search_result)
+
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(
+            return_value={
+                "data": {
+                    str(instance.collect_type_id): {
+                        "team": [2],
+                        "instance": [{"id": instance.id, "permission": ["View"]}],
+                    }
+                },
+                "team": [1],
+            }
+        ),
+    )
+    monkeypatch.setattr(collect_config.CollectInstance.objects, "filter", collect_instance_filter)
+    monkeypatch.setattr(collect_config.CollectTypeService, "search_instance_with_permission", service_search)
+
+    response = CollectInstanceViewSet().search(make_request({"page": 1, "page_size": 10}))
+
+    assert response.status_code == 200
+    collect_instance_filter.assert_called_once()
+    service_search.assert_called_once()
+    payload = json.loads(response.content)
+    assert payload["data"]["items"][0]["permission"] == ["View"]
+
+
+def test_search_rejects_unbounded_page_size():
+    response = CollectInstanceViewSet().search(make_request({"page": 1, "page_size": 100000}))
+
+    assert response.status_code == 400
 
 
 def test_search_single_collect_type_merges_duplicate_instance_permissions(monkeypatch):

--- a/server/apps/log/tests/test_log_alert_segments_pagination.py
+++ b/server/apps/log/tests/test_log_alert_segments_pagination.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from apps.log.nats.log import _build_paginated_alert_segments
+
+
+class FakeAlertQuerySet:
+    def __init__(self, alerts):
+        self.alerts = alerts
+        self.sliced = None
+
+    def count(self):
+        return len(self.alerts)
+
+    def order_by(self, *fields):
+        return self
+
+    def __getitem__(self, value):
+        self.sliced = value
+        return self.alerts[value]
+
+
+def make_alert(alert_id):
+    event_time = datetime(2026, 5, 6, 1, alert_id, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=alert_id,
+        policy_id="policy-1",
+        collect_type_id="ctype-1",
+        source_id=f"source-{alert_id}",
+        level="warning",
+        value="1",
+        content="content",
+        status="active",
+        start_event_time=event_time,
+        end_event_time=event_time,
+        created_at=event_time,
+        updated_at=event_time,
+    )
+
+
+def test_alert_segments_are_sliced_before_building_response_items():
+    queryset = FakeAlertQuerySet([make_alert(idx) for idx in range(1, 6)])
+
+    result = _build_paginated_alert_segments(queryset, page=2, page_size=2)
+
+    assert queryset.sliced == slice(2, 4, None)
+    assert result["count"] == 5
+    assert [item["id"] for item in result["items"]] == [3, 4]

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -2,6 +2,7 @@ import toml
 import yaml
 from rest_framework.decorators import action
 from rest_framework.viewsets import ModelViewSet, ViewSet
+from django.db.models import Q
 
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.permission_utils import (
@@ -179,6 +180,7 @@ class CollectTypeViewSet(ModelViewSet):
 
 class CollectInstanceViewSet(ViewSet):
     OPERATE_PERMISSION = "Operate"
+    PAGE_SIZE_MAX = 500
 
     @staticmethod
     def _normalize_ids(values):
@@ -201,6 +203,20 @@ class CollectInstanceViewSet(ViewSet):
             except (TypeError, ValueError):
                 continue
         return orgs
+
+    @classmethod
+    def _normalize_page_params(cls, request_data):
+        try:
+            page = int(request_data.get("page", 1))
+            page_size = int(request_data.get("page_size", 10))
+        except (TypeError, ValueError):
+            raise ValueError("page and page_size must be integers")
+
+        if page < 1:
+            raise ValueError("page must be greater than or equal to 1")
+        if page_size < 1 or page_size > cls.PAGE_SIZE_MAX:
+            raise ValueError(f"page_size must be between 1 and {cls.PAGE_SIZE_MAX}")
+        return page, page_size
 
     def _get_permission_context(self, request):
         include_children = request.COOKIES.get("include_children", "0") == "1"
@@ -280,6 +296,39 @@ class CollectInstanceViewSet(ViewSet):
             organizations |= self._normalize_orgs(instance.get("group_ids", []))
         return list(organizations)
 
+    def _build_all_collect_type_scope(self, permission_data, current_teams):
+        admin_cur_team = self._normalize_orgs(permission_data.get("all", {}).get("team", []))
+        if admin_cur_team:
+            return (
+                CollectInstance.objects.filter(collectinstanceorganization__organization__in=admin_cur_team).distinct(),
+                {},
+            )
+
+        current_team_ids = self._normalize_orgs(current_teams)
+        instance_ids = []
+        scope_query = Q(collectinstanceorganization__organization__in=current_team_ids)
+
+        for collect_type_id, type_permission in permission_data.items():
+            if collect_type_id == "all" or not isinstance(type_permission, dict):
+                continue
+
+            team_ids = self._normalize_orgs(type_permission.get("team", []))
+            if team_ids:
+                scope_query |= Q(
+                    collect_type_id=collect_type_id,
+                    collectinstanceorganization__organization__in=team_ids,
+                )
+
+            for instance_permission in type_permission.get("instance", []):
+                if isinstance(instance_permission, dict) and instance_permission.get("id") is not None:
+                    instance_ids.append(instance_permission["id"])
+
+        if instance_ids:
+            scope_query |= Q(id__in=instance_ids)
+
+        queryset = CollectInstance.objects.filter(scope_query).distinct()
+        return queryset, {}
+
     @action(methods=["post"], detail=False, url_path="search")
     def search(self, request):
         """
@@ -289,8 +338,10 @@ class CollectInstanceViewSet(ViewSet):
         """
         collect_type_id = request.data.get("collect_type_id")
         name = request.data.get("name")
-        page = int(request.data.get("page", 1))
-        page_size = int(request.data.get("page_size", 10))
+        try:
+            page, page_size = self._normalize_page_params(request.data)
+        except ValueError as exc:
+            return WebUtils.response_error(error_message=str(exc))
 
         # 获取当前用户选择的组织（必填）
         current_team = request.COOKIES.get("current_team")
@@ -333,33 +384,7 @@ class CollectInstanceViewSet(ViewSet):
             )
             permission_data = instance_res.get("data", {}) if isinstance(instance_res, dict) else {}
             current_teams = instance_res.get("team", []) if isinstance(instance_res, dict) else []
-            # 超管权限检查
-            admin_cur_team = permission_data.get("all", {}).get("team")
-            if admin_cur_team:
-                qs = CollectInstance.objects.filter(collectinstanceorganization__organization__in=admin_cur_team)
-                inst_permission_map = {}
-            else:
-                objs = CollectInstance.objects.prefetch_related("collectinstanceorganization_set").all()
-                result = []
-                for instance in objs:
-                    organizations = {org.organization for org in instance.collectinstanceorganization_set.all()}
-                    result.append(
-                        {
-                            "instance_id": instance.id,
-                            "organizations": organizations,
-                            "collect_type_id": instance.collect_type_id,
-                        }
-                    )
-
-                # 使用新的优雅权限过滤方法
-                inst_permission_map = filter_instances_with_permissions(result, permission_data, current_teams)
-                # 获取有权限的实例ID列表
-                authorized_instance_ids = list(inst_permission_map.keys())
-                if not authorized_instance_ids:
-                    # 如果没有任何权限，返回空结果
-                    return WebUtils.response_success({"count": 0, "items": []})
-                # 重新查询数据库，获取有权限的实例完整信息
-                qs = CollectInstance.objects.filter(id__in=authorized_instance_ids)
+            qs, inst_permission_map = self._build_all_collect_type_scope(permission_data, current_teams)
             # 使用统一的服务层方法
             data = CollectTypeService.search_instance_with_permission(
                 collect_type_id=None,
@@ -368,6 +393,16 @@ class CollectInstanceViewSet(ViewSet):
                 page_size=page_size,
                 queryset=qs,
             )
+            if inst_permission_map == {}:
+                scoped_items = [
+                    {
+                        "instance_id": item["id"],
+                        "organizations": item.get("organization", []),
+                        "collect_type_id": item.get("collect_type_id"),
+                    }
+                    for item in data["items"]
+                ]
+                inst_permission_map = filter_instances_with_permissions(scoped_items, permission_data, current_teams)
 
         for instance_info in data["items"]:
             if instance_info["id"] in inst_permission_map:


### PR DESCRIPTION
## 问题本质
日志实例“全部类型”查询先把全量采集实例和组织关系拉到应用层做权限过滤，再二次回查分页；日志告警片段查询也先构造完整结果列表再做分页。

## 业务影响
实例列表、筛选和告警片段接口的查询成本会随实例量或时间窗口内告警量线性放大，容易造成响应变慢、接口超时和高频查询卡顿。

## 本次处理
- 将全部类型实例权限范围下推到 DB 查询，分页后只对当前页补权限。
- 限制实例查询 `page_size` 上限，避免单次请求拉取过大页面。
- 将告警片段查询改为 DB count + 当前页切片，再构造返回项。

## 验证方式
- `python3 -m py_compile server/apps/log/views/collect_config.py server/apps/log/services/collect_type.py server/apps/log/nats/log.py server/apps/log/tests/test_collect_instance_permission_guards.py server/apps/log/tests/test_log_alert_segments_pagination.py`
- `PYTHONPATH=/tmp/bklite-log-perf-review/server DJANGO_SETTINGS_MODULE=settings INSTALL_APPS=log VICTORIALOGS_HOST=http://victorialogs.invalid uv run --extra dev pytest -q apps/log/tests/test_collect_instance_search.py apps/log/tests/test_collect_instance_permission_guards.py apps/log/tests/test_log_alert_segments_pagination.py -o addopts='' --confcutdir=apps/log/tests`
- `uv run --with flake8 flake8 apps/log/views/collect_config.py apps/log/services/collect_type.py apps/log/nats/log.py apps/log/tests/test_collect_instance_permission_guards.py apps/log/tests/test_log_alert_segments_pagination.py`
- `git diff --check`

@baiyf-git 请关注该日志查询性能风险修复。
