### PR TITLE
[monitor] 修复告警中心恢复关联失效导致状态不同步风险

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -314,7 +314,7 @@ class EventAlertManager:
             start_time = str(int(event.event_time.timestamp())) if event.event_time else None
             alert_events.append(
                 {
-                    "external_id": event.id,
+                    "external_id": str(event.alert_id),
                     "rule_id": str(event.policy_id),
                     "title": event.content,
                     "description": event.content,

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -475,9 +475,77 @@ def test_alert_center_notification_result_is_persisted(monkeypatch):
 
     assert len(send_calls) == 1
     assert send_calls[0][0] == 9
-    assert send_calls[0][2]["events"][0]["external_id"] == "evt-1"
+    assert send_calls[0][2]["events"][0]["external_id"] == "77"
     assert event.notice_result == [send_result]
     assert bulk_update_calls == [([event], ["notice_result"], 100)]
+
+
+def test_alert_center_created_event_uses_alert_id_as_recovery_external_id(monkeypatch):
+    send_calls = []
+
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=types.SimpleNamespace(
+            objects=types.SimpleNamespace(bulk_update=lambda *args, **kwargs: None)
+        ),
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=types.SimpleNamespace(
+            send_msg_with_channel=lambda *args: send_calls.append(args)
+            or {"result": True}
+        ),
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_external_id_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
+    )
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(id=1010, name="alert-center-policy", notice_type_id=9)
+    manager.instances_map = {"host-1": "Host 1"}
+
+    event = types.SimpleNamespace(
+        id="evt-created-1",
+        level="critical",
+        policy_id=1010,
+        content="cpu critical",
+        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
+        value=95.0,
+        monitor_instance_id="host-1",
+        dimensions={"instance_id": "host-1"},
+        metric_instance_id="('host-1',)",
+        alert_id=88,
+        notice_result=None,
+    )
+
+    manager._push_to_alert_center([event])
+
+    payload_event = send_calls[0][2]["events"][0]
+    assert payload_event["external_id"] == "88"
+    assert payload_event["labels"]["alert_id"] == 88
 
 
 def test_alert_center_notification_reuses_same_batch_result_for_each_event(monkeypatch):


### PR DESCRIPTION
## 问题本质
监控告警推送到告警中心时，创建事件使用监控事件 ID 作为 external_id，但恢复/关闭生命周期事件使用告警 ID 作为 external_id。告警中心的恢复处理依赖 created 与 recovery/closed 事件 external_id 一致，因此恢复事件无法关联到原告警。

## 业务影响
监控侧告警已经恢复或关闭时，告警中心侧可能仍保留未恢复状态，造成告警生命周期断裂、恢复闭环失真，并增加值班排障成本。

## 本次处理
将告警中心创建事件的 external_id 调整为对应告警 ID，与恢复/关闭事件保持同一关联键；补充回归测试覆盖创建事件与生命周期事件的恢复关联身份一致性。

## 验证方式
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest pytest -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_policy_scan_failure_handling.py -q`
- `uv run python -m py_compile apps/monitor/tasks/services/policy_scan/event_alert_manager.py apps/monitor/services/alert_lifecycle_notify.py`
- `uvx flake8 --config=./server/.flake8 server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py server/apps/monitor/tests/test_policy_scan_failure_handling.py`