### PR TITLE
[log] 修复采集配置越权改写导致的日志链路污染风险

### DIFF
--- a/server/apps/log/services/collect_type.py
+++ b/server/apps/log/services/collect_type.py
@@ -27,6 +27,22 @@ class CollectTypeService:
         return content
 
     @staticmethod
+    def _get_instance_config(config_info: dict, config_type: str, instance_id: str, is_child: bool):
+        config_id = config_info.get("id") if isinstance(config_info, dict) else None
+        if not config_id:
+            raise BaseAppException(f"{config_type}.id is required")
+
+        config_obj = CollectConfig.objects.filter(
+            id=config_id,
+            collect_instance_id=instance_id,
+            is_child=is_child,
+        ).first()
+        if not config_obj:
+            raise BaseAppException(f"{config_type} config does not belong to instance")
+
+        return config_obj
+
+    @staticmethod
     def get_collect_type(collect_type: str) -> str:
         """
         Get the collect type based on the provided string.
@@ -231,21 +247,28 @@ class CollectTypeService:
             )
 
         if base_info:
-            config_obj = CollectConfig.objects.filter(id=base_info["id"]).first()
-            if config_obj:
-                base_content = CollectTypeService._extract_update_payload(
-                    base_info, "base"
-                )
-                content = build_content(config_obj, "base", base_content)
-                env_config = base_info.get("env_config")
-                if env_config:
-                    child_env = {k: v for k, v in env_config.items()}
-                NodeMgmt().update_config_content(base_info["id"], content, env_config)
+            config_obj = CollectTypeService._get_instance_config(
+                base_info,
+                "base",
+                instance_id,
+                is_child=False,
+            )
+            base_content = CollectTypeService._extract_update_payload(
+                base_info, "base"
+            )
+            content = build_content(config_obj, "base", base_content)
+            env_config = base_info.get("env_config")
+            if env_config:
+                child_env = {k: v for k, v in env_config.items()}
+            NodeMgmt().update_config_content(base_info["id"], content, env_config)
 
         if child_info or child_env:
-            config_obj = CollectConfig.objects.filter(id=child_info["id"]).first()
-            if not config_obj:
-                return
+            config_obj = CollectTypeService._get_instance_config(
+                child_info,
+                "child",
+                instance_id,
+                is_child=True,
+            )
             child_content = CollectTypeService._extract_update_payload(
                 child_info, "child"
             )

--- a/server/apps/log/tests/test_collect_instance_permission_guards.py
+++ b/server/apps/log/tests/test_collect_instance_permission_guards.py
@@ -2,6 +2,10 @@ import json
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.log.services.collect_type import CollectTypeService
 from apps.log.views.collect_config import CollectConfigViewSet, CollectInstanceViewSet
 
 
@@ -21,6 +25,14 @@ class FakeOrganizations(list):
         return self
 
 
+class FakeFirstResult:
+    def __init__(self, value):
+        self.value = value
+
+    def first(self):
+        return self.value
+
+
 def make_request(data):
     return SimpleNamespace(
         user=SimpleNamespace(username="alice", domain="default"),
@@ -33,6 +45,7 @@ def make_instance(instance_id="inst-1", collect_type_id=7, organizations=None):
     return SimpleNamespace(
         id=instance_id,
         collect_type_id=collect_type_id,
+        node_id="node-1",
         collectinstanceorganization_set=FakeOrganizations([SimpleNamespace(organization=org) for org in organizations or [2]]),
     )
 
@@ -464,3 +477,65 @@ def test_update_instance_collect_config_allows_authorized_instance(monkeypatch):
 
     assert response.status_code == 200
     update_config.assert_called_once_with(None, {"content": "key: value"}, instance.id, instance.collect_type_id)
+
+
+def test_update_instance_config_rejects_config_from_other_instance(monkeypatch):
+    from apps.log.services import collect_type
+
+    instance = make_instance()
+    collect_type_obj = SimpleNamespace(collector="Vector", name="file")
+    node_mgmt = Mock()
+
+    monkeypatch.setattr(collect_type.CollectType.objects, "filter", Mock(return_value=FakeFirstResult(collect_type_obj)))
+    monkeypatch.setattr(collect_type.CollectInstance.objects, "filter", Mock(return_value=FakeFirstResult(instance)))
+    monkeypatch.setattr(collect_type.CollectConfig.objects, "filter", Mock(return_value=FakeFirstResult(None)))
+    monkeypatch.setattr(collect_type.Controller, "has_template_for_config_type", Mock(return_value=False))
+    monkeypatch.setattr(collect_type, "NodeMgmt", node_mgmt)
+
+    with pytest.raises(BaseAppException, match="base config does not belong to instance"):
+        CollectTypeService.update_instance_config_v2(
+            child_info=None,
+            base_info={"id": "foreign-cfg", "content": {"sinks": {}}},
+            instance_id=instance.id,
+            collect_type_id=instance.collect_type_id,
+        )
+
+    collect_type.CollectConfig.objects.filter.assert_called_once_with(
+        id="foreign-cfg",
+        collect_instance_id=instance.id,
+        is_child=False,
+    )
+    node_mgmt.assert_not_called()
+
+
+def test_update_instance_config_updates_only_owned_config(monkeypatch):
+    from apps.log.services import collect_type
+
+    instance = make_instance()
+    collect_type_obj = SimpleNamespace(collector="Vector", name="file")
+    config = SimpleNamespace(id="base-cfg", collect_instance_id=instance.id, file_type="yaml", is_child=False)
+    node_mgmt = Mock()
+
+    monkeypatch.setattr(collect_type.CollectType.objects, "filter", Mock(return_value=FakeFirstResult(collect_type_obj)))
+    monkeypatch.setattr(collect_type.CollectInstance.objects, "filter", Mock(return_value=FakeFirstResult(instance)))
+    monkeypatch.setattr(collect_type.CollectConfig.objects, "filter", Mock(return_value=FakeFirstResult(config)))
+    monkeypatch.setattr(collect_type.Controller, "has_template_for_config_type", Mock(return_value=False))
+    monkeypatch.setattr(collect_type, "NodeMgmt", node_mgmt)
+
+    CollectTypeService.update_instance_config_v2(
+        child_info=None,
+        base_info={"id": config.id, "content": {"sinks": {"nats": {"subject": "vector"}}}},
+        instance_id=instance.id,
+        collect_type_id=instance.collect_type_id,
+    )
+
+    collect_type.CollectConfig.objects.filter.assert_called_once_with(
+        id=config.id,
+        collect_instance_id=instance.id,
+        is_child=False,
+    )
+    node_mgmt.return_value.update_config_content.assert_called_once()
+    update_id, content, env_config = node_mgmt.return_value.update_config_content.call_args.args
+    assert update_id == config.id
+    assert "subject: vector" in content
+    assert env_config is None


### PR DESCRIPTION
## 问题本质
日志采集配置更新只校验调用方是否具备目标实例的操作权限，但服务层按请求里的配置 ID 直接更新 NodeMgmt 中的 base/child 配置，未确认该配置属于当前实例。

## 业务影响
有实例操作权限的用户只要传入其他实例的配置 ID，就可能改写不属于自己的 Vector/Beat 采集配置，造成日志错路由、字段污染、误过滤或丢数，进而影响查询、告警和审计结果。

## 本次处理
- 更新采集配置前强制校验配置 ID、实例 ID 与 base/child 类型一致。
- 配置不存在或不属于当前实例时直接拒绝更新，避免跨实例污染日志链路配置。
- 增加回归测试覆盖跨实例配置 ID 被拒绝和合法配置可更新两条路径。

## 验证方式
- `python3 -m py_compile server/apps/log/services/collect_type.py server/apps/log/tests/test_collect_instance_permission_guards.py`
- `DJANGO_SETTINGS_MODULE=settings INSTALL_APPS=log VICTORIALOGS_HOST=http://victorialogs.invalid uv run --extra dev pytest apps/log/tests/test_collect_instance_permission_guards.py -o addopts='' --confcutdir=apps/log/tests`
- `uv run --with flake8 flake8 apps/log/services/collect_type.py apps/log/tests/test_collect_instance_permission_guards.py`
- `git diff --check`
