### PR TITLE
[instance] 收紧节点实例操作权限，修复跨组织绕过风险

### DIFF
--- a/server/apps/node_mgmt/tests/test_node_permission_guards.py
+++ b/server/apps/node_mgmt/tests/test_node_permission_guards.py
@@ -1,0 +1,151 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from apps.core.utils.web_utils import WebUtils
+from apps.node_mgmt.utils import permission as node_permission
+from apps.node_mgmt.views import collector_configuration, node as node_view
+
+
+class FakeOrganizations(list):
+    def all(self):
+        return self
+
+
+class FakeNode:
+    def __init__(self, node_id="node-1", organizations=None):
+        self.id = node_id
+        self.name = f"name-{node_id}"
+        self.ip = "127.0.0.1"
+        self.operating_system = "linux"
+        self.install_method = "manual"
+        self.nodeorganization_set = FakeOrganizations(
+            [SimpleNamespace(organization=org) for org in organizations or [2]]
+        )
+
+    def save(self):
+        self.saved = True
+
+
+class FakeNodeQuerySet(list):
+    def filter(self, **kwargs):
+        if "id__in" in kwargs:
+            ids = {str(value) for value in kwargs["id__in"]}
+            return FakeNodeQuerySet([node for node in self if str(node.id) in ids])
+        if "cloud_region_id" in kwargs:
+            return self
+        return self
+
+    def prefetch_related(self, *args):
+        return self
+
+    def distinct(self):
+        return self
+
+    def values_list(self, field, flat=False):
+        if field == "id" and flat:
+            return [node.id for node in self]
+        return []
+
+
+class FakeConfigQuerySet(list):
+    def select_related(self, *args):
+        return self
+
+    def prefetch_related(self, *args):
+        return self
+
+    def filter(self, **kwargs):
+        return self
+
+
+class FakeConfig:
+    id = "cfg-1"
+    name = "cfg"
+    config_template = "x"
+    collector_id = "collector-1"
+    cloud_region_id = 1
+    is_pre = False
+    collector = SimpleNamespace(node_operating_system="linux")
+
+    def __init__(self, nodes):
+        self.nodes = FakeOrganizations(nodes)
+
+
+def make_request(data=None):
+    return SimpleNamespace(
+        user=SimpleNamespace(username="alice", domain="default"),
+        data=data or {},
+        COOKIES={"current_team": "1", "include_children": "0"},
+    )
+
+
+def response_data(response):
+    return json.loads(response.content.decode())
+
+
+def test_authorize_node_ids_requires_operate_permission(monkeypatch):
+    node = FakeNode()
+    monkeypatch.setattr(node_permission.Node.objects, "filter", Mock(return_value=FakeNodeQuerySet([node])))
+    monkeypatch.setattr(
+        node_permission,
+        "get_permission_rules",
+        Mock(return_value={"instance": [{"id": node.id, "permission": ["View"]}], "team": []}),
+    )
+
+    nodes, response = node_permission.authorize_node_ids(make_request(), [node.id])
+
+    assert nodes is None
+    assert response.status_code == 403
+
+
+def test_authorize_target_organizations_rejects_out_of_scope_org(monkeypatch):
+    monkeypatch.setattr(
+        node_permission,
+        "get_permission_rules",
+        Mock(return_value={"team": [2], "instance": []}),
+    )
+
+    response = node_permission.authorize_target_organizations(make_request(), [3])
+
+    assert response.status_code == 403
+
+
+def test_batch_operate_node_collector_requires_node_permission(monkeypatch):
+    authorize = Mock(return_value=(None, WebUtils.response_403("denied")))
+    service = Mock()
+    monkeypatch.setattr(node_view, "authorize_node_ids", authorize)
+    monkeypatch.setattr(node_view.NodeService, "batch_operate_node_collector", service)
+
+    response = node_view.NodeViewSet().batch_operate_node_collector(
+        make_request({"node_ids": ["node-1"], "collector_id": "collector-1", "operation": "restart"})
+    )
+
+    assert response.status_code == 403
+    service.assert_not_called()
+
+
+def test_config_node_asso_hides_unauthorized_nodes(monkeypatch):
+    allowed = FakeNode("node-allowed")
+    denied = FakeNode("node-denied")
+    authorized_nodes = FakeNodeQuerySet([allowed])
+    config_qs = FakeConfigQuerySet([FakeConfig([allowed, denied])])
+
+    monkeypatch.setattr(collector_configuration, "get_authorized_node_queryset", Mock(return_value=authorized_nodes))
+    monkeypatch.setattr(
+        collector_configuration.CollectorConfiguration.objects,
+        "select_related",
+        Mock(return_value=config_qs),
+    )
+
+    response = collector_configuration.CollectorConfigurationViewSet().get_config_node_asso(make_request({}))
+
+    payload = response_data(response)
+    assert payload["data"][0]["nodes"] == [
+        {
+            "id": "node-allowed",
+            "name": "name-node-allowed",
+            "ip": "127.0.0.1",
+            "operating_system": "linux",
+        }
+    ]

--- a/server/apps/node_mgmt/utils/permission.py
+++ b/server/apps/node_mgmt/utils/permission.py
@@ -1,0 +1,108 @@
+from apps.core.utils.permission_utils import get_instance_permission_map, get_permission_rules, permission_filter
+from apps.core.utils.web_utils import WebUtils
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.models.sidecar import Node
+
+
+def normalize_ids(values):
+    if not values:
+        return []
+    if not isinstance(values, list):
+        values = [values]
+    return [str(value) for value in values if value is not None and str(value) != ""]
+
+
+def normalize_orgs(values):
+    if not values:
+        return set()
+    if not isinstance(values, list):
+        values = [values]
+    orgs = set()
+    for value in values:
+        try:
+            orgs.add(int(value))
+        except (TypeError, ValueError):
+            continue
+    return orgs
+
+
+def get_node_permission(request):
+    include_children = request.COOKIES.get("include_children", "0") == "1"
+    permission = get_permission_rules(
+        request.user,
+        request.COOKIES.get("current_team"),
+        "node_mgmt",
+        NodeConstants.MODULE,
+        include_children=include_children,
+    )
+    return permission if isinstance(permission, dict) else {}
+
+
+def get_authorized_node_queryset(request, permission=None):
+    permission = permission or get_node_permission(request)
+    return permission_filter(
+        Node,
+        permission,
+        team_key="nodeorganization__organization__in",
+        id_key="id__in",
+    )
+
+
+def get_node_organizations(node):
+    return {rel.organization for rel in node.nodeorganization_set.all()}
+
+
+def get_node_permissions(node, permission):
+    instance_permission_map = get_instance_permission_map(permission)
+    node_id = str(node.id)
+    if node_id in instance_permission_map:
+        return instance_permission_map[node_id]
+
+    permission_orgs = normalize_orgs(permission.get("team", []))
+    if get_node_organizations(node) & permission_orgs:
+        return NodeConstants.DEFAULT_PERMISSION
+
+    return []
+
+
+def add_node_permissions(permission, items):
+    node_permission_map = get_instance_permission_map(permission)
+    for node_info in items:
+        if node_info["id"] in node_permission_map:
+            node_info["permission"] = node_permission_map[node_info["id"]]
+        else:
+            node_info["permission"] = NodeConstants.DEFAULT_PERMISSION
+
+
+def authorize_node_ids(request, node_ids, required_permission="Operate"):
+    normalized_ids = normalize_ids(node_ids)
+    if not normalized_ids:
+        return None, WebUtils.response_error(error_message="node_ids is required")
+
+    nodes = list(
+        Node.objects.filter(id__in=normalized_ids)
+        .prefetch_related("nodeorganization_set")
+        .distinct()
+    )
+    node_map = {str(node.id): node for node in nodes}
+    if any(node_id not in node_map for node_id in normalized_ids):
+        return None, WebUtils.response_error(error_message="node does not exist")
+
+    permission = get_node_permission(request)
+    for node_id in normalized_ids:
+        if required_permission not in get_node_permissions(node_map[node_id], permission):
+            return None, WebUtils.response_403("User does not have permission to operate this node")
+
+    return [node_map[node_id] for node_id in normalized_ids], None
+
+
+def authorize_target_organizations(request, organizations):
+    target_orgs = normalize_orgs(organizations)
+    if not target_orgs:
+        return None
+
+    permission = get_node_permission(request)
+    allowed_orgs = normalize_orgs(permission.get("team", []))
+    if not target_orgs.issubset(allowed_orgs):
+        return WebUtils.response_403("User does not have permission to assign nodes to these organizations")
+    return None

--- a/server/apps/node_mgmt/views/collector_configuration.py
+++ b/server/apps/node_mgmt/views/collector_configuration.py
@@ -1,21 +1,19 @@
 from rest_framework.viewsets import ModelViewSet
 from rest_framework.decorators import action
 
-from apps.core.utils.permission_utils import get_permission_rules, permission_filter
 from apps.core.utils.web_utils import WebUtils
-from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models.sidecar import CollectorConfiguration, Node
 from apps.node_mgmt.serializers.collector_configuration import (
     CollectorConfigurationSerializer,
     CollectorConfigurationCreateSerializer,
     CollectorConfigurationUpdateSerializer,
     BulkDeleteConfigurationSerializer,
-    ApplyToNodeSerializer,
 )
 from apps.node_mgmt.filters.collector_configuration import CollectorConfigurationFilter
 from apps.node_mgmt.services.collector_configuration import (
     CollectorConfigurationService,
 )
+from apps.node_mgmt.utils.permission import authorize_node_ids, get_authorized_node_queryset
 
 
 class CollectorConfigurationViewSet(ModelViewSet):
@@ -34,24 +32,11 @@ class CollectorConfigurationViewSet(ModelViewSet):
 
     @action(detail=False, methods=["post"], url_path="config_node_asso")
     def get_config_node_asso(self, request):
-        # 获取用户节点权限列表
-        include_children = request.COOKIES.get("include_children", "0") == "1"
-        permission = get_permission_rules(
-            request.user,
-            request.COOKIES.get("current_team"),
-            "node_mgmt",
-            NodeConstants.MODULE,
-            include_children=include_children,
-        )
-        queryset = permission_filter(
-            Node,
-            permission,
-            team_key="nodeorganization__organization__in",
-            id_key="id__in",
-        )
-        node_ids = list(queryset.values_list("id", flat=True).distinct())
+        queryset = get_authorized_node_queryset(request)
+        node_ids = list(queryset.distinct().values_list("id", flat=True))
         if not node_ids:
             return WebUtils.response_success([])
+        authorized_node_ids = set(node_ids)
 
         qs = (
             CollectorConfiguration.objects.select_related("collector")
@@ -88,6 +73,7 @@ class CollectorConfigurationViewSet(ModelViewSet):
                         "operating_system": node.operating_system,
                     }
                     for node in obj.nodes.all()
+                    if node.id in authorized_node_ids
                 ],
             )
             for obj in qs
@@ -125,6 +111,9 @@ class CollectorConfigurationViewSet(ModelViewSet):
         for item in request.data:
             collector_configuration_id = item["collector_configuration_id"]
             node_id = item["node_id"]
+            _, error_response = authorize_node_ids(request, [node_id])
+            if error_response:
+                return error_response
             success, message = CollectorConfigurationService.apply_to_node(node_id, collector_configuration_id)
             result.append(
                 {
@@ -141,6 +130,9 @@ class CollectorConfigurationViewSet(ModelViewSet):
     def cancel_apply_to_node(self, request):
         config_id = request.data["collector_configuration_id"]
         node_id = request.data["node_id"]
+        _, error_response = authorize_node_ids(request, [node_id])
+        if error_response:
+            return error_response
         try:
             config = CollectorConfiguration.objects.get(id=config_id)
             node = Node.objects.get(id=node_id)

--- a/server/apps/node_mgmt/views/node.py
+++ b/server/apps/node_mgmt/views/node.py
@@ -5,7 +5,6 @@ from rest_framework.viewsets import GenericViewSet
 from django.db.models import Q
 
 from apps.core.utils.loader import LanguageLoader
-from apps.core.utils.permission_utils import get_permission_rules, permission_filter
 from apps.core.utils.web_utils import WebUtils
 from apps.node_mgmt.constants.cloudregion_service import CloudRegionServiceConstants
 from apps.node_mgmt.constants.collector import CollectorConstants
@@ -24,6 +23,13 @@ from apps.node_mgmt.services.node import NodeService
 from apps.node_mgmt.tasks.sidecar_config import sync_node_properties_to_sidecar
 from apps.node_mgmt.models.action import CollectorActionTaskNode, CollectorActionTask
 from apps.node_mgmt.utils.task_result_schema import normalize_task_result_for_read
+from apps.node_mgmt.utils.permission import (
+    add_node_permissions,
+    authorize_node_ids,
+    authorize_target_organizations,
+    get_authorized_node_queryset,
+    get_node_permission,
+)
 
 
 class NodeFilterHandler:
@@ -184,32 +190,13 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
     search_fields = ["id", "name", "ip", "cloud_region_id", "install_method"]
 
     def add_permission(self, permission, items):
-        node_permission_map = {i["id"]: i["permission"] for i in permission.get("instance", [])}
-        for node_info in items:
-            if node_info["id"] in node_permission_map:
-                node_info["permission"] = node_permission_map[node_info["id"]]
-            else:
-                node_info["permission"] = NodeConstants.DEFAULT_PERMISSION
+        add_node_permissions(permission, items)
 
     @action(methods=["post"], detail=False, url_path=r"search")
     def search(self, request, *args, **kwargs):
         # 获取权限规则
-        include_children = request.COOKIES.get("include_children", "0") == "1"
-        permission = get_permission_rules(
-            request.user,
-            request.COOKIES.get("current_team"),
-            "node_mgmt",
-            NodeConstants.MODULE,
-            include_children=include_children,
-        )
-
-        # 应用权限过滤
-        queryset = permission_filter(
-            Node,
-            permission,
-            team_key="nodeorganization__organization__in",
-            id_key="id__in",
-        )
+        permission = get_node_permission(request)
+        queryset = get_authorized_node_queryset(request, permission)
 
         # 应用自定义查询参数格式化（统一处理所有过滤条件）
         custom_filters = request.data.get("filters")
@@ -254,16 +241,25 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
         return WebUtils.response_success(processed_data)
 
     def destroy(self, request, *args, **kwargs):
-        instance = self.get_object()
+        nodes, error_response = authorize_node_ids(request, [kwargs.get("pk")])
+        if error_response:
+            return error_response
+        instance = nodes[0]
         self.perform_destroy(instance)
         return WebUtils.response_success()
 
     @action(methods=["patch"], detail=True, url_path="update")
     def update_node(self, request, pk=None):
-        node = self.get_object()
+        nodes, error_response = authorize_node_ids(request, [pk])
+        if error_response:
+            return error_response
+        node = nodes[0]
 
         name = request.data.get("name")
         organizations = request.data.get("organizations")
+        error_response = authorize_target_organizations(request, organizations)
+        if error_response:
+            return error_response
 
         if name is not None:
             node.name = name
@@ -327,6 +323,9 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
         serializer.is_valid(raise_exception=True)
         node_ids = serializer.validated_data["node_ids"]
         collector_configuration_id = serializer.validated_data["collector_configuration_id"]
+        _, error_response = authorize_node_ids(request, node_ids)
+        if error_response:
+            return error_response
         result, message = NodeService.batch_binding_node_configuration(node_ids, collector_configuration_id)
 
         if result:
@@ -341,6 +340,9 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
         node_ids = serializer.validated_data["node_ids"]
         collector_id = serializer.validated_data["collector_id"]
         operation = serializer.validated_data["operation"]
+        _, error_response = authorize_node_ids(request, node_ids)
+        if error_response:
+            return error_response
         task_id = NodeService.batch_operate_node_collector(
             node_ids,
             collector_id,
@@ -362,7 +364,12 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
         serializer.is_valid(raise_exception=True)
         validated_data = cast(dict[str, Any], serializer.validated_data)
 
-        queryset = CollectorActionTaskNode.objects.filter(task_id=task_id).select_related("node").prefetch_related("node__nodeorganization_set")
+        authorized_node_ids = list(get_authorized_node_queryset(request).distinct().values_list("id", flat=True))
+        queryset = (
+            CollectorActionTaskNode.objects.filter(task_id=task_id, node_id__in=authorized_node_ids)
+            .select_related("node")
+            .prefetch_related("node__nodeorganization_set")
+        )
         status_list = validated_data.get("status")
         if status_list:
             queryset = queryset.filter(status__in=status_list)
@@ -388,7 +395,7 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
             for obj in items
         ]
 
-        summary_queryset = CollectorActionTaskNode.objects.filter(task_id=task_id)
+        summary_queryset = CollectorActionTaskNode.objects.filter(task_id=task_id, node_id__in=authorized_node_ids)
         summary = {
             "total": summary_queryset.count(),
             "waiting": summary_queryset.filter(status="waiting").count(),
@@ -416,7 +423,11 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
 
     @action(detail=False, methods=["post"], url_path="node_config_asso")
     def get_node_config_asso(self, request):
-        nodes = Node.objects.prefetch_related("collectorconfiguration_set").filter(cloud_region_id=request.data["cloud_region_id"])
+        nodes = (
+            get_authorized_node_queryset(request)
+            .prefetch_related("collectorconfiguration_set")
+            .filter(cloud_region_id=request.data["cloud_region_id"])
+        )
         if request.data.get("ids"):
             nodes = nodes.filter(id__in=request.data["ids"])
 


### PR DESCRIPTION
## 问题本质

节点实例的搜索入口会按“所属组织 + 系统管理权限”裁剪资源范围，但节点更新、删除、批量绑定配置、批量控制采集器、任务节点结果查询、节点配置关联等入口仍可直接使用节点 ID 或任务 ID 访问/操作节点，导致同一类实例能力在列表与操作路径上的权限边界不一致。

## 业务影响

拥有部分节点权限的用户可能绕过列表入口，读取其他组织节点的配置关联或任务结果，并对无权限节点执行更新、删除、采集器启停和配置绑定等敏感操作。

## 本次处理方式

- 新增节点实例权限守卫，统一按节点所属组织与系统管理返回的实例/组织权限判定 View/Operate。
- 在节点更新、删除、批量绑定配置、批量控制采集器、任务节点结果、节点配置关联入口补齐权限裁剪。
- 在采集配置关联入口过滤无权限节点，并在应用/取消配置到节点前校验节点 Operate 权限。
- 补充回归测试覆盖只读权限禁止控制、组织范围收缩、批量控制前置拦截和配置关联节点泄露。

## 验证方式

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 DJANGO_SETTINGS_MODULE=settings INSTALL_APPS=node_mgmt,system_mgmt UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --extra dev --with pytest --with pytest-django pytest -p django -o addopts='' --confcutdir=apps/node_mgmt/tests apps/node_mgmt/tests/test_node_permission_guards.py`
- `UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with flake8 flake8 apps/node_mgmt/utils/permission.py apps/node_mgmt/views/node.py apps/node_mgmt/views/collector_configuration.py apps/node_mgmt/tests/test_node_permission_guards.py`
