### PR TITLE
[monitor] 修复告警中心恢复关联断裂导致的错恢复风险

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -314,7 +314,7 @@ class EventAlertManager:
             start_time = str(int(event.event_time.timestamp())) if event.event_time else None
             alert_events.append(
                 {
-                    "external_id": event.id,
+                    "external_id": str(event.alert_id),
                     "rule_id": str(event.policy_id),
                     "title": event.content,
                     "description": event.content,
@@ -329,6 +329,7 @@ class EventAlertManager:
                         "policy_name": self.policy.name,
                         "metric_instance_id": event.metric_instance_id,
                         "alert_id": event.alert_id,
+                        "event_id": event.id,
                     },
                 }
             )

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -475,9 +475,77 @@ def test_alert_center_notification_result_is_persisted(monkeypatch):
 
     assert len(send_calls) == 1
     assert send_calls[0][0] == 9
-    assert send_calls[0][2]["events"][0]["external_id"] == "evt-1"
+    assert send_calls[0][2]["events"][0]["external_id"] == "77"
+    assert send_calls[0][2]["events"][0]["labels"]["event_id"] == "evt-1"
     assert event.notice_result == [send_result]
     assert bulk_update_calls == [([event], ["notice_result"], 100)]
+
+
+def test_alert_center_created_event_uses_alert_id_for_recovery_correlation(monkeypatch):
+    send_calls = []
+
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=types.SimpleNamespace(objects=types.SimpleNamespace(bulk_update=lambda *args, **kwargs: None)),
+        MonitorEventRawData=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.dimension",
+        format_dimension_str=lambda dimensions: "",
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.utils.system_mgmt_api",
+        SystemMgmtUtils=types.SimpleNamespace(
+            send_msg_with_channel=lambda *args: send_calls.append(args) or {"result": True}
+        ),
+    )
+    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    module = _load_module(
+        "monitor_policy_event_alert_manager_alert_center_correlation_test_module",
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
+    )
+
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = types.SimpleNamespace(id=1010, name="alert-center-policy", notice_type_id=9)
+    manager.instances_map = {"host-1": "Host 1"}
+    manager._is_alert_center = True
+
+    event = types.SimpleNamespace(
+        id="evt-created-1",
+        level="critical",
+        policy_id=1010,
+        content="cpu critical",
+        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
+        value=95.0,
+        monitor_instance_id="host-1",
+        dimensions={"instance_id": "host-1"},
+        metric_instance_id="('host-1',)",
+        alert_id=8801,
+        notice_result=None,
+    )
+
+    manager.notify_events([event])
+
+    pushed_event = send_calls[0][2]["events"][0]
+    assert pushed_event["external_id"] == "8801"
+    assert pushed_event["labels"]["alert_id"] == 8801
+    assert pushed_event["labels"]["event_id"] == "evt-created-1"
 
 
 def test_alert_center_notification_reuses_same_batch_result_for_each_event(monkeypatch):


### PR DESCRIPTION
## 问题本质
监控告警推送到告警中心时，产生告警事件使用监控事件 ID 作为 `external_id`，但恢复/关闭通知使用告警 ID 作为 `external_id`。告警中心依赖相同 `external_id` 将恢复事件关联到已产生的告警，因此恢复闭环会断开。

## 业务影响
告警中心可能无法把恢复/关闭消息匹配到原始告警，导致已恢复的监控告警仍显示为持续异常，影响告警准确性和处置判断。

## 本次处理方式
- 将告警中心 created 事件的 `external_id` 改为监控告警 ID，与恢复/关闭通知保持一致。
- 保留原监控事件 ID 到 labels，避免丢失事件级审计线索。
- 增加回归测试覆盖 created/recovery 关联键一致性。

## 验证方式
- `uv run python -m py_compile apps/monitor/tasks/services/policy_scan/event_alert_manager.py apps/monitor/tests/test_policy_scan_failure_handling.py`
- `uv run pytest -p no:django --confcutdir=apps/monitor/tests -o addopts='' apps/monitor/tests/test_policy_scan_failure_handling.py -q`
