### PR TITLE
[monitor] 收紧监控实例纳管写入口权限，降低跨组织误操作风险

### DIFF
--- a/server/apps/monitor/tests/test_monitor_instance_permission_guards.py
+++ b/server/apps/monitor/tests/test_monitor_instance_permission_guards.py
@@ -1,0 +1,174 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_module(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class _Q:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def __or__(self, other):
+        return self
+
+
+class _QuerySet:
+    def __init__(self, rows, allowed_ids=None):
+        self.rows = rows
+        self.allowed_ids = allowed_ids
+
+    def filter(self, *args, **kwargs):
+        rows = self.rows
+        if "monitor_object_id" in kwargs:
+            rows = [row for row in rows if row["monitor_object_id"] == kwargs["monitor_object_id"]]
+        if self.allowed_ids is not None:
+            rows = [row for row in rows if row["id"] in self.allowed_ids]
+        return _QuerySet(rows, self.allowed_ids)
+
+    def values(self, *fields):
+        return [{field: row[field] for field in fields} for row in self.rows]
+
+    def values_list(self, field, flat=False):
+        return [row[field] for row in self.rows]
+
+    def distinct(self):
+        return self
+
+
+class _MonitorInstance:
+    rows = []
+    allowed_ids = set()
+
+    class objects:
+        @staticmethod
+        def filter(**kwargs):
+            rows = _MonitorInstance.rows
+            if "id__in" in kwargs:
+                ids = set(kwargs["id__in"])
+                rows = [row for row in rows if row["id"] in ids]
+            if "monitor_object_id" in kwargs:
+                rows = [row for row in rows if row["monitor_object_id"] == kwargs["monitor_object_id"]]
+            return _QuerySet(rows, _MonitorInstance.allowed_ids)
+
+
+def _load_monitor_instance_view(monkeypatch, permission):
+    class ViewSet:
+        pass
+
+    def action(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    class UnauthorizedException(Exception):
+        pass
+
+    _install_module(monkeypatch, "rest_framework.viewsets", ViewSet=ViewSet)
+    _install_module(monkeypatch, "rest_framework.decorators", action=action)
+    _install_module(monkeypatch, "django.db.models", Q=_Q)
+    _install_module(
+        monkeypatch,
+        "apps.core.exceptions.base_app_exception",
+        BaseAppException=Exception,
+        UnauthorizedException=UnauthorizedException,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.user_group",
+        normalize_user_group_ids=lambda groups: [int(item.get("id") if isinstance(item, dict) else item) for item in groups],
+    )
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.permission_utils",
+        get_permission_rules=lambda *args, **kwargs: permission,
+        permission_filter=lambda *args, **kwargs: None,
+    )
+    _install_module(monkeypatch, "apps.core.utils.web_utils", WebUtils=types.SimpleNamespace(response_success=lambda data=None: data))
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.permission",
+        PermissionConstants=types.SimpleNamespace(INSTANCE_MODULE="instance", DEFAULT_PERMISSION=["View", "Operate"]),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorInstance=_MonitorInstance,
+        MonitorObject=object,
+        CollectConfig=object,
+        MonitorObjectOrganizationRule=object,
+    )
+    _install_module(monkeypatch, "apps.monitor.services.monitor_instance", InstanceSearch=object)
+    _install_module(monkeypatch, "apps.monitor.services.monitor_object", MonitorObjectService=object)
+    _install_module(monkeypatch, "apps.monitor.services.policy_source_cleanup", cleanup_policy_sources=lambda *args: None)
+    _install_module(monkeypatch, "apps.monitor.services.metrics", Metrics=object)
+    _install_module(monkeypatch, "apps.monitor.utils.pagination", parse_page_params=lambda *args, **kwargs: (1, 10))
+    _install_module(monkeypatch, "apps.rpc.node_mgmt", NodeMgmt=object)
+    _install_module(
+        monkeypatch,
+        "apps.system_mgmt.utils.group_utils",
+        GroupUtils=types.SimpleNamespace(get_user_authorized_child_groups=lambda group_list, current_team, include_children=False: [current_team]),
+    )
+
+    return _load_module(
+        "monitor_instance_view_test_module",
+        Path(__file__).resolve().parents[1] / "views" / "monitor_instance.py",
+    )
+
+
+def _request():
+    return types.SimpleNamespace(
+        COOKIES={"current_team": "7"},
+        user=types.SimpleNamespace(
+            username="operator",
+            domain="domain.com",
+            is_superuser=False,
+            group_list=[7],
+        ),
+    )
+
+
+def test_operate_guard_rejects_view_only_instance_permission(monkeypatch):
+    module = _load_monitor_instance_view(
+        monkeypatch,
+        {"team": [], "instance": [{"id": "inst-a", "permission": ["View"]}]},
+    )
+    _MonitorInstance.rows = [{"id": "inst-a", "monitor_object_id": 1}]
+    _MonitorInstance.allowed_ids = set()
+
+    with pytest.raises(module.UnauthorizedException):
+        module._ensure_operate_instances(_request(), ["inst-a"])
+
+
+def test_operate_guard_accepts_team_scoped_instance(monkeypatch):
+    module = _load_monitor_instance_view(monkeypatch, {"team": [7], "instance": []})
+    _MonitorInstance.rows = [{"id": "inst-a", "monitor_object_id": 1}]
+    _MonitorInstance.allowed_ids = {"inst-a"}
+
+    assert module._ensure_operate_instances(_request(), ["inst-a"]) == ["inst-a"]
+
+
+def test_target_organization_guard_rejects_out_of_scope_org(monkeypatch):
+    module = _load_monitor_instance_view(monkeypatch, {"team": [7], "instance": []})
+    actor_context = module._build_actor_context(_request())
+
+    with pytest.raises(module.UnauthorizedException):
+        module._ensure_target_organizations([9], actor_context)

--- a/server/apps/monitor/views/monitor_instance.py
+++ b/server/apps/monitor/views/monitor_instance.py
@@ -1,8 +1,9 @@
 from rest_framework import viewsets
 from rest_framework.decorators import action
+from django.db.models import Q
 
-from apps.core.exceptions.base_app_exception import BaseAppException
-from apps.core.logger import monitor_logger as logger
+from apps.core.exceptions.base_app_exception import BaseAppException, UnauthorizedException
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.permission_utils import get_permission_rules, permission_filter
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.permission import PermissionConstants
@@ -18,6 +19,103 @@ from apps.monitor.services.policy_source_cleanup import cleanup_policy_sources
 from apps.monitor.services.metrics import Metrics as MetricsService
 from apps.monitor.utils.pagination import parse_page_params
 from apps.rpc.node_mgmt import NodeMgmt
+from apps.system_mgmt.utils.group_utils import GroupUtils
+
+
+def _build_actor_context(request):
+    current_team = request.COOKIES.get("current_team")
+    if current_team in (None, ""):
+        raise BaseAppException("缺少 current_team 参数")
+
+    try:
+        current_team = int(current_team)
+    except (TypeError, ValueError):
+        raise BaseAppException("current_team 参数非法")
+
+    return {
+        "current_team": current_team,
+        "include_children": request.COOKIES.get("include_children", "0") == "1",
+        "is_superuser": request.user.is_superuser,
+        "group_list": normalize_user_group_ids(getattr(request.user, "group_list", [])),
+    }
+
+
+def _normalize_id_list(values):
+    return [str(value) for value in values if value not in (None, "")]
+
+
+def _get_authorized_scope_groups(actor_context):
+    if actor_context["is_superuser"]:
+        return None
+
+    groups = GroupUtils.get_user_authorized_child_groups(
+        actor_context["group_list"],
+        actor_context["current_team"],
+        include_children=actor_context["include_children"],
+    )
+    if not groups:
+        raise UnauthorizedException("当前组织无可用权限范围")
+    return set(groups)
+
+
+def _ensure_target_organizations(organizations, actor_context):
+    try:
+        normalized_orgs = {int(org) for org in organizations if org not in (None, "")}
+    except (TypeError, ValueError):
+        raise BaseAppException("组织参数非法")
+    if not normalized_orgs or actor_context["is_superuser"]:
+        return
+
+    allowed_groups = _get_authorized_scope_groups(actor_context)
+    unauthorized_orgs = normalized_orgs - allowed_groups
+    if unauthorized_orgs:
+        raise UnauthorizedException("无权限关联指定组织")
+
+
+def _ensure_operate_instances(request, instance_ids):
+    normalized_ids = _normalize_id_list(instance_ids)
+    if not normalized_ids:
+        return []
+
+    actor_context = _build_actor_context(request)
+    instances = list(
+        MonitorInstance.objects.filter(id__in=normalized_ids).values(
+            "id",
+            "monitor_object_id",
+        )
+    )
+    found_ids = {instance["id"] for instance in instances}
+    if found_ids != set(normalized_ids):
+        raise BaseAppException("监控实例不存在")
+
+    if actor_context["is_superuser"]:
+        return normalized_ids
+
+    for monitor_object_id in {instance["monitor_object_id"] for instance in instances}:
+        permission = get_permission_rules(
+            request.user,
+            actor_context["current_team"],
+            "monitor",
+            f"{PermissionConstants.INSTANCE_MODULE}.{monitor_object_id}",
+            include_children=actor_context["include_children"],
+        )
+        team_ids = permission.get("team", [])
+        operate_instance_ids = [
+            item["id"]
+            for item in permission.get("instance", [])
+            if isinstance(item, dict) and "id" in item and "Operate" in item.get("permission", [])
+        ]
+        allowed_ids = set(
+            MonitorInstance.objects.filter(id__in=normalized_ids, monitor_object_id=monitor_object_id)
+            .filter(Q(monitorinstanceorganization__organization__in=team_ids) | Q(id__in=operate_instance_ids))
+            .distinct()
+            .values_list("id", flat=True)
+        )
+        requested_ids = {instance["id"] for instance in instances if instance["monitor_object_id"] == monitor_object_id}
+        if requested_ids - allowed_ids:
+            raise UnauthorizedException("无权限操作指定监控实例")
+
+    return normalized_ids
 
 
 class MonitorInstanceViewSet(viewsets.ViewSet):
@@ -221,7 +319,7 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
 
     @action(methods=["post"], detail=False, url_path="remove_monitor_instance")
     def remove_monitor_instance(self, request):
-        instance_ids = request.data.get("instance_ids", [])
+        instance_ids = _ensure_operate_instances(request, request.data.get("instance_ids", []))
         MonitorInstance.objects.filter(id__in=instance_ids).update(is_deleted=True)
         if request.data.get("clean_child_config"):
             config_objs = CollectConfig.objects.filter(
@@ -250,6 +348,9 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
 
     @action(methods=["post"], detail=False, url_path="update_monitor_instance")
     def update_monitor_instance(self, request):
+        actor_context = _build_actor_context(request)
+        _ensure_operate_instances(request, [request.data.get("instance_id")])
+        _ensure_target_organizations(request.data.get("organizations", []), actor_context)
         MonitorObjectService.update_instance(
             request.data.get("instance_id"),
             request.data.get("name"),
@@ -260,23 +361,29 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
     @action(methods=["post"], detail=False, url_path="instances_remove_organizations")
     def instances_remove_organizations(self, request):
         """删除监控对象实例组织"""
-        instance_ids = request.data.get("instance_ids", [])
+        actor_context = _build_actor_context(request)
+        instance_ids = _ensure_operate_instances(request, request.data.get("instance_ids", []))
         organizations = request.data.get("organizations", [])
+        _ensure_target_organizations(organizations, actor_context)
         MonitorObjectService.remove_instances_organizations(instance_ids, organizations)
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=False, url_path="instances_add_organizations")
     def instances_add_organizations(self, request):
         """添加监控对象实例组织"""
-        instance_ids = request.data.get("instance_ids", [])
+        actor_context = _build_actor_context(request)
+        instance_ids = _ensure_operate_instances(request, request.data.get("instance_ids", []))
         organizations = request.data.get("organizations", [])
+        _ensure_target_organizations(organizations, actor_context)
         MonitorObjectService.add_instances_organizations(instance_ids, organizations)
         return WebUtils.response_success()
 
     @action(methods=["post"], detail=False, url_path="set_instances_organizations")
     def set_instances_organizations(self, request):
         """设置监控对象实例组织"""
-        instance_ids = request.data.get("instance_ids", [])
+        actor_context = _build_actor_context(request)
+        instance_ids = _ensure_operate_instances(request, request.data.get("instance_ids", []))
         organizations = request.data.get("organizations", [])
+        _ensure_target_organizations(organizations, actor_context)
         MonitorObjectService.set_instances_organizations(instance_ids, organizations)
         return WebUtils.response_success()


### PR DESCRIPTION
## 问题本质
监控实例删除、配置清理、组织关联变更等纳管写入口直接信任请求里的实例 ID 和组织 ID，未在写入前校验调用者是否具备该实例的 `Operate` 权限，也未限制目标组织范围。

## 业务影响
用户只要拿到实例 ID，就可能删除其他组织的监控实例、清理节点侧采集配置，或把实例组织关系改到自己无权管理的组织，导致监控对象漏纳管、关系失真和跨组织越权操作。

## 本次处理方式
- 为监控实例写入口增加统一 `Operate` 权限校验。
- 对组织新增、删除、重设、实例更新时的目标组织做当前组织及子组织范围收敛。
- 补充轻量回归测试，覆盖只读权限拒绝、团队范围授权通过、越界组织拒绝。

## 验证方式
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -q -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_monitor_instance_permission_guards.py apps/monitor/tests/test_node_mgmt_actor_context.py`
- `python3 -m py_compile server/apps/monitor/views/monitor_instance.py server/apps/monitor/tests/test_monitor_instance_permission_guards.py && git diff --check`
- `UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with flake8 flake8 apps/monitor/views/monitor_instance.py apps/monitor/tests/test_monitor_instance_permission_guards.py --config .flake8`
