### PR TITLE
[monitor] 修复无数据基准失效导致的误报和旧告警残留风险

### DIFF
--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -158,6 +158,174 @@ def test_scan_policy_task_persists_watermark_after_successful_scan(monkeypatch):
     assert result["success"] is True
 
 
+def _install_monitor_policy_view_dependencies(monkeypatch):
+    class ModelViewSet:
+        pass
+
+    def action(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    beat_models = _install_module(
+        monkeypatch,
+        "django_celery_beat.models",
+        PeriodicTask=object,
+        CrontabSchedule=object,
+    )
+    _install_module(monkeypatch, "django_celery_beat", models=beat_models)
+    rest_viewsets = _install_module(monkeypatch, "rest_framework.viewsets", ModelViewSet=ModelViewSet)
+    rest_decorators = _install_module(monkeypatch, "rest_framework.decorators", action=action)
+    _install_module(monkeypatch, "rest_framework", viewsets=rest_viewsets, decorators=rest_decorators)
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.permission_utils",
+        get_permission_rules=lambda *args, **kwargs: {},
+        permission_filter=lambda *args, **kwargs: [],
+    )
+    _install_module(monkeypatch, "apps.core.utils.web_utils", WebUtils=object)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(NO_DATA="no_data"),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_CREATE_BATCH_SIZE=100, BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.permission",
+        PermissionConstants=types.SimpleNamespace(POLICY_MODULE="policy", DEFAULT_PERMISSION=[]),
+    )
+    _install_module(monkeypatch, "apps.monitor.filters.monitor_policy", MonitorPolicyFilter=object)
+
+    class _ImportQuerySet:
+        def all(self):
+            return []
+
+    class _ImportMonitorPolicy:
+        objects = _ImportQuerySet()
+
+    _install_module(monkeypatch, "apps.monitor.models", PolicyOrganization=object, MonitorAlert=object)
+    _install_module(monkeypatch, "apps.monitor.models.monitor_policy", MonitorPolicy=_ImportMonitorPolicy)
+    _install_module(monkeypatch, "apps.monitor.serializers.monitor_policy", MonitorPolicySerializer=object)
+    _install_module(monkeypatch, "apps.monitor.services.alert_lifecycle_notify", AlertLifecycleNotifier=object)
+    _install_module(monkeypatch, "apps.monitor.services.policy", PolicyService=object)
+    _install_module(monkeypatch, "apps.monitor.services.policy_baseline", PolicyBaselineService=object)
+    _install_module(monkeypatch, "apps.monitor.utils.pagination", parse_page_params=lambda *args, **kwargs: (1, 10))
+    _install_module(monkeypatch, "config.drf.pagination", CustomPageNumberPagination=object)
+
+
+def test_monitor_policy_baseline_refreshes_when_grouping_contract_changes(monkeypatch):
+    _install_monitor_policy_view_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_policy_view_baseline_test_module",
+        Path(__file__).resolve().parents[1] / "views" / "monitor_policy.py",
+    )
+
+    view = module.MonitorPolicyViewSet()
+    old_policy = types.SimpleNamespace(
+        source={"type": "instance", "values": ["('host-1',)"]},
+        group_by=["instance_id", "mountpoint"],
+        query_condition={"metric_id": 10},
+        monitor_object_id=3,
+        collect_type="host",
+    )
+    updated_policy = types.SimpleNamespace(
+        source={"type": "instance", "values": ["('host-1',)"]},
+        group_by=["instance_id"],
+        query_condition={"metric_id": 10},
+        monitor_object_id=3,
+        collect_type="host",
+        enable_alerts=["threshold", "no_data"],
+    )
+
+    old_state = view.get_baseline_state(old_policy)
+
+    assert view.should_update_policy_baselines({"group_by": ["instance_id"]}, old_state, updated_policy) is True
+    assert view.baseline_state_changed(old_state, updated_policy) is True
+
+
+def test_monitor_policy_disabling_no_data_closes_active_no_data_alerts(monkeypatch):
+    _install_monitor_policy_view_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_policy_view_disable_no_data_test_module",
+        Path(__file__).resolve().parents[1] / "views" / "monitor_policy.py",
+    )
+
+    policy = types.SimpleNamespace(id=42)
+    alert = types.SimpleNamespace(
+        status="new",
+        end_event_time=None,
+        operator="",
+        operation_logs=[],
+    )
+    bulk_updates = []
+    lifecycle_calls = []
+    baseline_calls = []
+
+    class PolicyQuerySet:
+        def first(self):
+            return policy
+
+    class MonitorPolicy:
+        class objects:
+            @staticmethod
+            def filter(**kwargs):
+                return PolicyQuerySet()
+
+    class AlertQuerySet(list):
+        pass
+
+    class MonitorAlert:
+        class objects:
+            @staticmethod
+            def filter(**kwargs):
+                return AlertQuerySet([alert])
+
+            @staticmethod
+            def bulk_update(alerts, fields):
+                bulk_updates.append((alerts, fields))
+
+    class PolicyBaselineService:
+        def __init__(self, policy_obj):
+            self.policy_obj = policy_obj
+
+        def clear(self):
+            baseline_calls.append(("clear", self.policy_obj.id))
+
+    class AlertLifecycleNotifier:
+        def __init__(self, policy_obj):
+            self.policy_obj = policy_obj
+
+        def notify_alerts(self, alerts, action, operator="", reason=""):
+            lifecycle_calls.append((alerts, action, operator, reason))
+
+    module.MonitorPolicy = MonitorPolicy
+    module.MonitorAlert = MonitorAlert
+    module.PolicyBaselineService = PolicyBaselineService
+    module.AlertLifecycleNotifier = AlertLifecycleNotifier
+    module.datetime = _FrozenDateTime
+
+    module.MonitorPolicyViewSet().update_policy_baselines(
+        policy_id=policy.id,
+        enable_alerts=["threshold"],
+        operator="alice",
+    )
+
+    assert alert.status == "closed"
+    assert alert.end_event_time == _FrozenDateTime.fixed_now
+    assert alert.operator == "alice"
+    assert alert.operation_logs[-1]["reason"] == "no_data_disabled"
+    assert bulk_updates == [([alert], ["status", "end_event_time", "operator", "operation_logs"])]
+    assert lifecycle_calls == [([alert], "closed", "alice", "no_data_disabled")]
+    assert baseline_calls == [("clear", policy.id)]
+
+
 def _install_scanner_dependencies(monkeypatch):
     alert_constants = types.SimpleNamespace(THRESHOLD="threshold", NO_DATA="no_data")
 

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from datetime import datetime, timezone
 
@@ -27,6 +28,13 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
     serializer_class = MonitorPolicySerializer
     filterset_class = MonitorPolicyFilter
     pagination_class = CustomPageNumberPagination
+    BASELINE_AFFECTING_FIELDS = {
+        "source",
+        "group_by",
+        "query_condition",
+        "monitor_object",
+        "collect_type",
+    }
 
     def list(self, request, *args, **kwargs):
         monitor_object_id = request.query_params.get("monitor_object_id", None)
@@ -90,9 +98,10 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         request.data["updated_by"] = request.user.username
         policy_id = kwargs["pk"]
 
-        # 获取策略变更前的 enable 状态
+        # 获取策略变更前的 enable 状态和无数据基准语义
         policy = MonitorPolicy.objects.filter(id=policy_id).first()
         old_enable = policy.enable if policy else None
+        old_baseline_state = self.get_baseline_state(policy)
 
         response = super().update(request, *args, **kwargs)
         updated_policy = MonitorPolicy.objects.filter(id=policy_id).first()
@@ -103,8 +112,13 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         organizations = request.data.get("organizations", [])
         if organizations:
             self.update_policy_organizations(policy_id, organizations)
-        if "enable_alerts" in request.data:
-            self.update_policy_baselines(policy_id, request.data.get("enable_alerts", []))
+        if self.should_update_policy_baselines(request.data, old_baseline_state, updated_policy):
+            self.update_policy_baselines(
+                policy_id,
+                updated_policy.enable_alerts,
+                operator=request.user.username,
+                reset_active_no_data_alerts=self.baseline_state_changed(old_baseline_state, updated_policy),
+            )
 
         # 处理 enable 字段变更
         if "enable" in request.data and policy and updated_policy:
@@ -117,9 +131,10 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         request.data["updated_by"] = request.user.username
         policy_id = kwargs["pk"]
 
-        # 获取策略变更前的 enable 状态
+        # 获取策略变更前的 enable 状态和无数据基准语义
         policy = MonitorPolicy.objects.filter(id=policy_id).first()
         old_enable = policy.enable if policy else None
+        old_baseline_state = self.get_baseline_state(policy)
 
         response = super().partial_update(request, *args, **kwargs)
         updated_policy = MonitorPolicy.objects.filter(id=policy_id).first()
@@ -130,8 +145,13 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         organizations = request.data.get("organizations", [])
         if organizations:
             self.update_policy_organizations(policy_id, organizations)
-        if "enable_alerts" in request.data:
-            self.update_policy_baselines(policy_id, request.data.get("enable_alerts", []))
+        if self.should_update_policy_baselines(request.data, old_baseline_state, updated_policy):
+            self.update_policy_baselines(
+                policy_id,
+                updated_policy.enable_alerts,
+                operator=request.user.username,
+                reset_active_no_data_alerts=self.baseline_state_changed(old_baseline_state, updated_policy),
+            )
 
         # 处理 enable 字段变更
         if "enable" in request.data and policy and updated_policy:
@@ -173,16 +193,86 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         PolicyOrganization.objects.filter(policy_id=policy_id).delete()
         return super().destroy(request, *args, **kwargs)
 
-    def update_policy_baselines(self, policy_id, enable_alerts):
+    def get_baseline_state(self, policy):
+        if not policy:
+            return {}
+        return {
+            "source": copy.deepcopy(policy.source),
+            "group_by": copy.deepcopy(policy.group_by),
+            "query_condition": copy.deepcopy(policy.query_condition),
+            "monitor_object": policy.monitor_object_id,
+            "collect_type": policy.collect_type,
+        }
+
+    def baseline_state_changed(self, old_state, policy):
+        if not old_state or not policy:
+            return False
+        return old_state != self.get_baseline_state(policy)
+
+    def should_update_policy_baselines(self, request_data, old_state, policy):
+        if not policy:
+            return False
+        if "enable_alerts" in request_data:
+            return True
+        if AlertConstants.NO_DATA not in (policy.enable_alerts or []):
+            return False
+        if not any(field in request_data for field in self.BASELINE_AFFECTING_FIELDS):
+            return False
+        return self.baseline_state_changed(old_state, policy)
+
+    def update_policy_baselines(
+        self,
+        policy_id,
+        enable_alerts,
+        operator="system",
+        reset_active_no_data_alerts=False,
+    ):
         policy = MonitorPolicy.objects.filter(id=policy_id).first()
         if not policy:
             return
 
         baseline_service = PolicyBaselineService(policy)
         if AlertConstants.NO_DATA in enable_alerts:
+            if reset_active_no_data_alerts:
+                self.close_active_no_data_alerts(policy, operator, "policy_baseline_changed")
             baseline_service.refresh()
         else:
+            self.close_active_no_data_alerts(policy, operator, "no_data_disabled")
             baseline_service.clear()
+
+    def close_active_no_data_alerts(self, policy, operator, reason):
+        now = datetime.now(timezone.utc)
+        alerts_to_close = list(
+            MonitorAlert.objects.filter(
+                policy_id=policy.id,
+                alert_type="no_data",
+                status="new",
+            )
+        )
+        if not alerts_to_close:
+            return
+
+        operation_log = {
+            "action": "closed",
+            "reason": reason,
+            "operator": operator,
+            "time": now.isoformat(),
+        }
+        for alert in alerts_to_close:
+            alert.status = "closed"
+            alert.end_event_time = now
+            alert.operator = operator
+            alert.operation_logs = (alert.operation_logs or []) + [operation_log]
+        MonitorAlert.objects.bulk_update(
+            alerts_to_close,
+            fields=["status", "end_event_time", "operator", "operation_logs"],
+        )
+        AlertLifecycleNotifier(policy).notify_alerts(
+            alerts_to_close,
+            action="closed",
+            operator=operator,
+            reason=reason,
+        )
 
     def handle_policy_enable_change(self, policy_id, old_enable, new_enable):
         if old_enable == new_enable:


### PR DESCRIPTION
## 问题本质
无数据告警的基准表只在 `enable_alerts` 变化时刷新。策略的数据范围、分组字段、查询条件或监控对象变化后，扫描链路仍会复用旧的 `PolicyInstanceBaseline`，已生成的无数据告警也会继续保持 active。

## 业务影响
策略口径变化后，旧维度会被继续判定为无数据，导致无数据误报；旧无数据告警因新查询结果不再包含旧 `metric_instance_id`，可能长期无法自动恢复，影响告警准确性和状态可信度。

## 本次处理方式
- 将 source、group_by、query_condition、monitor_object、collect_type 纳入无数据基准语义判断。
- 当这些字段变化且无数据告警仍启用时，关闭旧 active 无数据告警并刷新基准。
- 当无数据告警被禁用时，关闭旧 active 无数据告警并清理基准。
- 补充策略更新与禁用无数据告警的回归测试。

## 验证方式
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev pytest -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_policy_scan_failure_handling.py`
- `uv run --extra dev python -m py_compile apps/monitor/views/monitor_policy.py apps/monitor/tests/test_policy_scan_failure_handling.py`
- `uvx flake8 --config=server/.flake8 server/apps/monitor/views/monitor_policy.py server/apps/monitor/tests/test_policy_scan_failure_handling.py`
- `uvx black --check --line-length 150 server/apps/monitor/views/monitor_policy.py server/apps/monitor/tests/test_policy_scan_failure_handling.py`
