### PR TITLE
[cmdb] 修复实例关联列表绕过对象权限导致的关系泄露风险

### DIFF
--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -17,6 +17,8 @@ CMDB CQL查询测试类
 
 import os
 import sys
+import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 # 检查是否在Django环境中
@@ -34,6 +36,23 @@ if __name__ == "__main__":
 
 from apps.cmdb.graph.drivers.graph_client import GraphClient
 from apps.core.logger import cmdb_logger as logger
+
+
+def _make_cmdb_request(username="alice", groups=None):
+    groups = groups or [{"id": 1}]
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            username=username,
+            group_list=groups,
+            group_tree=[],
+            roles=[],
+            permission={"asset_info-View"},
+            is_superuser=False,
+            locale="zh-Hans",
+        ),
+        COOKIES={"current_team": str(groups[0]["id"]), "include_children": "0"},
+        api_pass=False,
+    )
 
 
 def test_import_model_config_applies_shared_post_import_extras():
@@ -74,6 +93,40 @@ def test_model_init_reuses_shared_post_import_extras():
         mock_migrator_cls.assert_called_once_with()
         mock_migrator.main.assert_called_once_with()
         mock_apply_extras.assert_called_once_with(mock_migrator.model_config)
+
+
+def test_instance_association_instance_list_denies_user_without_object_permission():
+    from apps.cmdb.views.instance import InstanceViewSet
+
+    request = _make_cmdb_request(username="alice")
+    instance = {
+        "_id": 1001,
+        "model_id": "host",
+        "inst_name": "host-a",
+        "organization": [1],
+        "_creator": "bob",
+    }
+
+    with patch(
+        "apps.cmdb.views.instance.InstanceManage.query_entity_by_id",
+        return_value=instance,
+    ), patch.object(
+        InstanceViewSet,
+        "check_instance_permission",
+        return_value=False,
+    ) as mock_check_permission, patch(
+        "apps.cmdb.views.instance.InstanceManage.instance_association_instance_list"
+    ) as mock_association_list:
+        response = InstanceViewSet().instance_association_instance_list(
+            request,
+            "host",
+            1001,
+        )
+
+    assert response.status_code == 403
+    assert json.loads(response.content)["result"] is False
+    mock_check_permission.assert_called_once()
+    mock_association_list.assert_not_called()
 
 
 class CQLQueryTest:

--- a/server/apps/cmdb/views/instance.py
+++ b/server/apps/cmdb/views/instance.py
@@ -568,22 +568,13 @@ class InstanceViewSet(CmdbPermissionMixin, viewsets.ViewSet):
                 "实例不存在", status_code=status.HTTP_404_NOT_FOUND
             )
 
-        if self.check_creator_and_organizations(request, instance):
-            # 如果是自己创建的实例，直接返回关联实例列表
-            organizations = self.organizations(request, instance)
-            # 再次确认用户所在的组织
-            if not organizations:
-                return WebUtils.response_error(
-                    "抱歉！您没有此实例的权限", status_code=status.HTTP_403_FORBIDDEN
-                )
-
-            has_permission = self.check_instance_permission(
-                request, instance, operator=VIEW
-            )
-            if not has_permission:
-                return WebUtils.response_error(
-                    "抱歉！您没有此实例的权限", status_code=status.HTTP_403_FORBIDDEN
-                )
+        permission_error = self.require_instance_permission(
+            request,
+            instance,
+            operator=VIEW,
+        )
+        if permission_error:
+            return permission_error
 
         asso_insts = InstanceManage.instance_association_instance_list(
             model_id, int(inst_id)


### PR DESCRIPTION
## 问题本质

CMDB 实例关联列表入口在读取目标实例后，没有对非创建人执行实例对象级查看权限校验，导致关系查询旁路了列表/详情链路的权限裁剪。

## 业务影响

用户只要具备入口级查看权限并知道实例 ID，就可能查询到无对象权限实例的关联关系，造成实例关系范围失真。

## 本次处理方式

复用统一的实例权限校验入口，在返回关联实例列表前校验当前用户对目标实例的 VIEW 权限；无权限时直接返回 403，避免继续进入 service 与 graph 查询。

## 验证方式

- `uv run --all-extras pytest apps/cmdb/tests.py::test_instance_association_instance_list_denies_user_without_object_permission -q`
- `uv run --all-extras python -m py_compile apps/cmdb/views/instance.py apps/cmdb/tests.py`

说明：完整 `apps/cmdb/tests.py` 当前存在既有用例 `test_import_model_config_applies_shared_post_import_extras` 失败，失败原因是用例 patch 的符号路径与当前实现中的函数内导入不一致；本次改动的新增回归用例已单独通过。
