### PR TITLE
[incremental] 修复作业开放接口同步执行任务阻塞风险

### DIFF
--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -10,7 +10,7 @@ from apps.job_mgmt.models import DangerousPath, DangerousRule, DistributionFile,
 from apps.job_mgmt.services.callback_service import send_callback
 from apps.job_mgmt.services.dangerous_checker import DangerousChecker
 from apps.job_mgmt.services.script_params_service import ScriptParamsService
-from apps.job_mgmt.tasks import distribute_files_task, execute_script_task
+from apps.job_mgmt.tasks import _dispatch_execution_job
 from apps.node_mgmt.utils.s3 import delete_s3_file
 
 
@@ -299,7 +299,7 @@ def job_script_execute(data: dict):
     )
 
     # 触发异步执行
-    execute_script_task(execution.id)
+    _dispatch_execution_job(JobType.SCRIPT, execution.id)
 
     return {"result": True, "data": {"task_id": execution.id}}
 
@@ -384,7 +384,7 @@ def job_file_distribute(data: dict):
     )
 
     # 触发异步执行
-    distribute_files_task(execution.id)
+    _dispatch_execution_job(JobType.FILE_DISTRIBUTION, execution.id)
 
     return {"result": True, "data": {"task_id": execution.id}}
 

--- a/server/apps/job_mgmt/tests/test_nats_open_api.py
+++ b/server/apps/job_mgmt/tests/test_nats_open_api.py
@@ -22,8 +22,8 @@ class TestJobScriptExecute:
         }
 
         with patch("apps.job_mgmt.services.dangerous_checker.DangerousChecker.check_command") as mock_check, patch(
-            "apps.job_mgmt.tasks.ScriptExecutionRunner"
-        ):
+            "apps.job_mgmt.tasks.current_app.send_task"
+        ) as mock_send_task:
             mock_result = MagicMock()
             mock_result.can_execute = True
             mock_result.forbidden = []
@@ -33,6 +33,10 @@ class TestJobScriptExecute:
 
         assert result["result"] is True
         assert "task_id" in result["data"]
+        mock_send_task.assert_called_once_with(
+            "apps.job_mgmt.tasks.execute_script_task",
+            args=[result["data"]["task_id"]],
+        )
 
     def test_empty_target_list(self):
         from apps.job_mgmt.nats_api import job_script_execute
@@ -82,6 +86,40 @@ class TestJobScriptExecute:
 @pytest.mark.unit
 @pytest.mark.django_db
 class TestJobFileDistribute:
+    def test_success_dispatches_async_task(self):
+        from apps.job_mgmt.models import DistributionFile
+        from apps.job_mgmt.nats_api import job_file_distribute
+
+        distribution_file = DistributionFile.objects.create(
+            original_name="patch.rpm",
+            file_key="job-files/2026/05/07/patch.rpm",
+        )
+        data = {
+            "name": "test",
+            "file_keys": [distribution_file.file_key],
+            "target_source": "node_mgmt",
+            "target_list": [{"node_id": "n1", "name": "h1", "ip": "1.1.1.1", "os": "linux", "cloud_region_id": "r1"}],
+            "target_path": "/tmp/",
+            "team": [1],
+        }
+
+        with patch("apps.job_mgmt.services.dangerous_checker.DangerousChecker.check_path") as mock_check, patch(
+            "apps.job_mgmt.tasks.current_app.send_task"
+        ) as mock_send_task:
+            mock_result = MagicMock()
+            mock_result.can_execute = True
+            mock_result.forbidden = []
+            mock_check.return_value = mock_result
+
+            result = job_file_distribute(data)
+
+        assert result["result"] is True
+        assert "task_id" in result["data"]
+        mock_send_task.assert_called_once_with(
+            "apps.job_mgmt.tasks.distribute_files_task",
+            args=[result["data"]["task_id"]],
+        )
+
     def test_empty_file_ids(self):
         from apps.job_mgmt.nats_api import job_file_distribute
 
@@ -186,7 +224,7 @@ class TestJobTargetList:
         from apps.job_mgmt.nats_api import job_target_list
 
         for i in range(5):
-            Target.objects.create(name=f"node-{i}", ip=f"10.0.0.{i+1}", os_type="linux", team=[1])
+            Target.objects.create(name=f"node-{i}", ip=f"10.0.0.{i + 1}", os_type="linux", team=[1])
 
         result = job_target_list({"page": 1, "page_size": 2})
         assert result["data"]["count"] == 5


### PR DESCRIPTION
## 涉及范围
- 增量提交：8b9cfc837d09578de557572eea9b8e7cdc000017（新增作业管理开放接口）
- 关键文件：`server/apps/job_mgmt/nats_api.py`、`server/apps/job_mgmt/tests/test_nats_open_api.py`

## 问题
新增的脚本执行与文件分发 NATS 开放接口在创建 `JobExecution` 后直接调用 Celery task 对象：`execute_script_task(execution.id)` / `distribute_files_task(execution.id)`。

## 根因
Celery task 对象被直接调用时会在当前 NATS 请求链路内同步执行 `Runner.run()`，没有进入队列；这与接口注释和现有调度链路中的异步派发语义不一致。

## 全局影响
局部新增的开放接口会影响作业执行链路：第三方调用脚本执行或文件分发时，请求线程可能被目标执行、NATS RPC、文件分发等耗时逻辑阻塞；执行异常也会直接冒泡到开放接口调用方，导致任务记录已创建但接口失败或调用超时。

## 修复
- 改为复用作业模块统一的 `_dispatch_execution_job` 派发入口。
- 覆盖脚本执行与文件分发两个新增开放入口，避免同一根因在兄弟路径继续触发。
- 补充测试断言开放接口只创建任务并派发 Celery，不同步执行 Runner。

## 验证
- `python3 -m py_compile apps/job_mgmt/nats_api.py apps/job_mgmt/tests/test_nats_open_api.py`
- `INSTALL_APPS=job_mgmt,node_mgmt,system_mgmt ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite uv run --extra dev pytest apps/job_mgmt/tests/test_nats_open_api.py -q`
- `uv run --with 'flake8>=4.0.1' flake8 --config=./.flake8 apps/job_mgmt/nats_api.py apps/job_mgmt/tests/test_nats_open_api.py`
- `git diff --check`
