### PR TITLE
[cmdb] 修复多云配置采集主机关联失真风险

### DIFF
--- a/server/apps/cmdb/collection/collect_plugin/middleware.py
+++ b/server/apps/cmdb/collection/collect_plugin/middleware.py
@@ -116,8 +116,63 @@ class MiddlewareCollectMetrics(CollectBase):
             return router_id
         return self.get_inst_name(data)
 
+    @staticmethod
+    def _get_default_instance_snapshot(instances):
+        if isinstance(instances, list) and instances:
+            first_instance = instances[0]
+            if isinstance(first_instance, dict):
+                return first_instance
+        return {}
+
+    def _get_matched_instance_snapshot(self, raw_ip=""):
+        task = self.get_collect_inst()
+        instances = task.instances if isinstance(task.instances, list) else []
+
+        if raw_ip:
+            for instance_item in instances:
+                if not isinstance(instance_item, dict):
+                    continue
+                instance_ip = str(instance_item.get("ip_addr") or instance_item.get("host") or "").strip()
+                if instance_ip == raw_ip:
+                    return instance_item
+
+        return self._get_default_instance_snapshot(instances)
+
+    def _get_cloud_label(self, raw_ip=""):
+        task = self.get_collect_inst()
+        params = task.params if isinstance(task.params, dict) else {}
+        instances = task.instances if isinstance(task.instances, list) else []
+
+        matched_instance = self._get_matched_instance_snapshot(raw_ip=raw_ip)
+
+        for source in (matched_instance, params, self._get_default_instance_snapshot(instances)):
+            if not isinstance(source, dict):
+                continue
+            cloud_name = str(source.get("cloud_name") or "").strip()
+            if cloud_name:
+                return cloud_name
+
+        for source in (matched_instance, params, self._get_default_instance_snapshot(instances)):
+            if not isinstance(source, dict):
+                continue
+            cloud = str(source.get("cloud") or source.get("cloud_id") or "").strip()
+            if cloud:
+                return cloud
+
+        return ""
+
+    def _get_host_association_inst_name(self, data):
+        raw_ip = self.get_ip_addr(data)
+        if not raw_ip:
+            return ""
+
+        cloud_label = self._get_cloud_label(raw_ip=raw_ip)
+        if cloud_label:
+            return f"{raw_ip}[{cloud_label}]"
+        return raw_ip
+
     def get__host_assos(self, data):
-        host_inst_name = self.get_ip_addr(data)
+        host_inst_name = self._get_host_association_inst_name(data)
         if not host_inst_name:
             logger.warning(
                 "实例未解析到主机标识，跳过run关联创建 instance_id=%s node_name=%s",

--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -129,6 +129,60 @@ def test_instance_association_instance_list_denies_user_without_object_permissio
     mock_association_list.assert_not_called()
 
 
+def test_middleware_host_association_uses_cloud_aware_host_name():
+    from apps.cmdb.collection.collect_plugin.middleware import MiddlewareCollectMetrics
+
+    class _TestMiddlewareCollectMetrics(MiddlewareCollectMetrics):
+        @property
+        def _metrics(self):
+            return ["middleware_info_gauge"]
+
+    task_snapshot = SimpleNamespace(
+        instances=[{"ip_addr": "10.0.0.1", "cloud_name": "prod-region", "inst_name": "10.0.0.1[prod-region]"}],
+        params={"cloud_name": "fallback-region"},
+    )
+
+    with patch.object(_TestMiddlewareCollectMetrics, "get_collect_inst", return_value=task_snapshot):
+        plugin = _TestMiddlewareCollectMetrics(inst_name="middleware-a", inst_id="1", task_id="task-1")
+        assos = plugin.get__host_assos({"ip_addr": "10.0.0.1"})
+
+    assert assos == [
+        {
+            "model_id": "host",
+            "inst_name": "10.0.0.1[prod-region]",
+            "asst_id": "run",
+            "model_asst_id": "rabbitmq_run_host",
+        }
+    ]
+
+
+def test_middleware_host_association_falls_back_to_raw_ip_without_cloud_label():
+    from apps.cmdb.collection.collect_plugin.middleware import MiddlewareCollectMetrics
+
+    class _TestMiddlewareCollectMetrics(MiddlewareCollectMetrics):
+        @property
+        def _metrics(self):
+            return ["middleware_info_gauge"]
+
+    task_snapshot = SimpleNamespace(
+        instances=[{"ip_addr": "10.0.0.2", "inst_name": "10.0.0.2"}],
+        params={},
+    )
+
+    with patch.object(_TestMiddlewareCollectMetrics, "get_collect_inst", return_value=task_snapshot):
+        plugin = _TestMiddlewareCollectMetrics(inst_name="middleware-b", inst_id="2", task_id="task-2")
+        assos = plugin.get__host_assos({"ip_addr": "10.0.0.2"})
+
+    assert assos == [
+        {
+            "model_id": "host",
+            "inst_name": "10.0.0.2",
+            "asst_id": "run",
+            "model_asst_id": "rabbitmq_run_host",
+        }
+    ]
+
+
 class CQLQueryTest:
     """
     用于测试和执行CQL查询的辅助类


### PR DESCRIPTION
## 问题本质
中间件配置采集在创建 `run -> host` 关系时使用了裸 IP 作为目标主机名，而 host 采集链路会把多云主机统一写成 `IP[云区域]` 形式。

## 业务影响
多云场景下，同一台主机上的中间件实例会找不到真实 host 实例，导致运行关系缺失，进一步影响 CMDB 关系查询、拓扑分析和后续影响面判断。

## 本次处理
- 让中间件采集链路在生成 host 关联时复用 host 实例的云标签语义
- 补充回归测试，覆盖带云标签和不带云标签两种主机关联场景

## 验证方式
- `cd server && uv run python -m py_compile apps/cmdb/collection/collect_plugin/middleware.py apps/cmdb/tests.py`
- `cd server && INSTALL_APPS='cmdb,system_mgmt' uv run --extra dev python -m pytest apps/cmdb/tests.py -q --confcutdir=apps/cmdb -o addopts='' -k 'middleware_host_association'`
