### PR TITLE
[cmdb] 收紧采集任务旁路查询权限，降低跨组织访问风险

### DIFF
--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -129,6 +129,87 @@ def test_instance_association_instance_list_denies_user_without_object_permissio
     mock_association_list.assert_not_called()
 
 
+def test_collect_model_viewset_scopes_detail_queryset_by_permission():
+    from apps.cmdb.views.collect import CollectModelViewSet
+
+    request = _make_cmdb_request()
+    view = CollectModelViewSet()
+    view.request = request
+    view.action = "info"
+
+    filtered_queryset = MagicMock(name="filtered_queryset")
+
+    with patch.object(
+        CollectModelViewSet,
+        "get_queryset_by_permission",
+        return_value=filtered_queryset,
+    ) as mock_get_queryset_by_permission:
+        result = view.get_queryset()
+
+    assert result is filtered_queryset
+    mock_get_queryset_by_permission.assert_called_once_with(request, view.queryset.all())
+
+
+def test_collect_model_instances_uses_permission_filtered_queryset():
+    from apps.cmdb.views.collect import CollectModelViewSet
+
+    request = _make_cmdb_request()
+    request.GET = SimpleNamespace(dict=lambda: {"task_type": "host"})
+    view = CollectModelViewSet()
+
+    authorized_queryset = MagicMock(name="authorized_queryset")
+    filtered_queryset = MagicMock(name="filtered_queryset")
+    authorized_queryset.filter.return_value = filtered_queryset
+    filtered_queryset.values_list.return_value = [
+        [{"_id": 1001, "inst_name": "host-a"}],
+    ]
+
+    with patch.object(
+        CollectModelViewSet,
+        "get_queryset_by_permission",
+        return_value=authorized_queryset,
+    ) as mock_get_queryset_by_permission:
+        response = view.model_instances(request)
+
+    payload = json.loads(response.content)
+    assert payload["result"] is True
+    assert payload["data"] == [{"id": 1001, "inst_name": "host-a"}]
+    mock_get_queryset_by_permission.assert_called_once_with(request, view.queryset.all())
+    authorized_queryset.filter.assert_called_once()
+
+
+def test_build_region_query_credential_uses_authorized_task_lookup():
+    from apps.cmdb.views.collect import CollectModelViewSet
+
+    request = _make_cmdb_request()
+    task = SimpleNamespace(
+        decrypt_credentials={"secret_key": "value"},
+        driver_type="qcloud",
+    )
+    params_cls = MagicMock()
+    params_cls.build_region_credential.return_value = {"region_secret": "ok"}
+    view = CollectModelViewSet()
+
+    with patch.object(
+        CollectModelViewSet,
+        "_get_authorized_task",
+        return_value=task,
+    ) as mock_get_authorized_task, patch(
+        "apps.cmdb.views.collect.NodeParamsFactory.get_params_class",
+        return_value=params_cls,
+    ) as mock_get_params_class:
+        credential = view._build_region_query_credential(
+            request,
+            {"model_id": "qcloud_account", "driver_type": "ignored"},
+            task_id=42,
+        )
+
+    assert credential["model_id"] == "qcloud"
+    assert credential["region_secret"] == "ok"
+    mock_get_authorized_task.assert_called_once_with(request, 42)
+    mock_get_params_class.assert_called_once_with("qcloud", "qcloud")
+
+
 class CQLQueryTest:
     """
     用于测试和执行CQL查询的辅助类

--- a/server/apps/cmdb/views/collect.py
+++ b/server/apps/cmdb/views/collect.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 from django.conf import settings
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
 from rest_framework import status
 from rest_framework.decorators import action
@@ -39,6 +40,14 @@ class CollectModelViewSet(AuthViewSet):
     pagination_class = CustomPageNumberPagination
     permission_classes = [InstanceTaskPermission]
     permission_key = PERMISSION_TASK
+    permission_scoped_actions = {
+        "retrieve",
+        "update",
+        "partial_update",
+        "destroy",
+        "info",
+        "exec_task",
+    }
 
     @staticmethod
     def _parse_positive_int(value, field_name, default):
@@ -52,14 +61,26 @@ class CollectModelViewSet(AuthViewSet):
             raise ValueError(f"{field_name} 必须大于等于 1")
         return parsed
 
-    def _build_region_query_credential(self, params, task_id=None):
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        request = getattr(self, "request", None)
+        action = getattr(self, "action", None)
+        if request is not None and action in self.permission_scoped_actions:
+            return self.get_queryset_by_permission(request, queryset)
+        return queryset
+
+    def _get_authorized_task(self, request, task_id):
+        queryset = self.get_queryset_by_permission(request, self.queryset.all())
+        return get_object_or_404(queryset, id=task_id)
+
+    def _build_region_query_credential(self, request, params, task_id=None):
         credential = dict(params)
         model_id = (credential.get("model_id") or "").split("_account", 1)[0]
         credential["model_id"] = model_id
 
         driver_type = credential.get("driver_type")
         if task_id:
-            instance = self.queryset.get(id=task_id)
+            instance = self._get_authorized_task(request, task_id)
             raw_credential = instance.decrypt_credentials or {}
             driver_type = instance.driver_type
         else:
@@ -237,9 +258,13 @@ class CollectModelViewSet(AuthViewSet):
         """
         params = requests.GET.dict()
         task_type = params["task_type"]
+        queryset = self.get_queryset_by_permission(requests, self.queryset.all())
         # 云对象可以重复选择不做过滤
-        instances = CollectModels.objects.filter(~Q(instances=[]), ~Q(task_type=CollectPluginTypes.CLOUD),
-                                                 task_type=task_type).values_list("instances", flat=True)
+        instances = queryset.filter(
+            ~Q(instances=[]),
+            ~Q(task_type=CollectPluginTypes.CLOUD),
+            task_type=task_type,
+        ).values_list("instances", flat=True)
         result = []
         for instance in instances:
             if not isinstance(instance, list) or not instance:
@@ -270,7 +295,7 @@ class CollectModelViewSet(AuthViewSet):
         if not cloud_name:
             return WebUtils.response_error(error_message="cloud_id 不存在", status_code=400)
         task_id = params.pop("task_id", None)
-        credential = self._build_region_query_credential(params, task_id=task_id)
+        credential = self._build_region_query_credential(requests, params, task_id=task_id)
         result = CollectModelService.list_regions(credential, cloud_name=cloud_name)
         if result.get("success"):
             return WebUtils.response_success(result.get("result", []))


### PR DESCRIPTION
## 问题本质
采集任务权限只在列表链路做了组织与实例范围裁剪，但详情类动作和按 `task_id` 的辅助查询没有统一复用同一套权限过滤，导致部分接口可以直接绕过主权限边界。

## 业务影响
用户拿到任务 ID 或调用旁路接口时，可能读取到权限范围外的采集任务详情、历史实例快照或区域查询结果，形成跨组织信息暴露与越权辅助操作风险。

## 本次处理
- 让采集任务详情类动作统一走 `get_queryset_by_permission` 后的查询集
- 为按 `task_id` 取凭据的区域查询增加权限内任务查找
- 为 `model_instances` 复用同一套任务权限裁剪，避免返回范围外实例
- 补充回归测试，覆盖详情查询、实例枚举和区域查询的权限收口

## 验证
- `uv run python -m py_compile apps/cmdb/views/collect.py apps/cmdb/tests.py`
- `uv run pytest server/apps/cmdb/tests.py -q` 受仓库当前 Django 启动配置影响失败：`django_celery_beat.models.SolarSchedule ... isn't in an application in INSTALLED_APPS`
