### PR TITLE
[cmdb] 优化订阅关联变化检测，降低 FalkorDB 图查询放大风险

### DIFF
--- a/server/apps/cmdb/services/instance.py
+++ b/server/apps/cmdb/services/instance.py
@@ -579,6 +579,68 @@ class InstanceManage(object):
         return src_edge + dst_edge
 
     @staticmethod
+    def instance_association_map(
+        model_id: str, inst_ids: list[int], related_model: str | None = None
+    ) -> dict[int, list[int]]:
+        """批量查询实例关联映射，避免按实例逐条查询关系。"""
+
+        normalized_ids: list[int] = []
+        seen_ids: set[int] = set()
+        for inst_id in inst_ids:
+            try:
+                normalized_id = int(inst_id)
+            except (TypeError, ValueError):
+                continue
+            if normalized_id in seen_ids:
+                continue
+            seen_ids.add(normalized_id)
+            normalized_ids.append(normalized_id)
+
+        if not normalized_ids:
+            return {}
+
+        relation_map: dict[int, set[int]] = {
+            inst_id: set() for inst_id in normalized_ids
+        }
+
+        with GraphClient() as ag:
+            src_query_data = [
+                {"field": "src_inst_id", "type": "int[]", "value": normalized_ids},
+                {"field": "src_model_id", "type": "str=", "value": model_id},
+            ]
+            if related_model:
+                src_query_data.append(
+                    {"field": "dst_model_id", "type": "str=", "value": related_model}
+                )
+            src_edges = ag.query_edge(INSTANCE_ASSOCIATION, src_query_data)
+
+            dst_query_data = [
+                {"field": "dst_inst_id", "type": "int[]", "value": normalized_ids},
+                {"field": "dst_model_id", "type": "str=", "value": model_id},
+            ]
+            if related_model:
+                dst_query_data.append(
+                    {"field": "src_model_id", "type": "str=", "value": related_model}
+                )
+            dst_edges = ag.query_edge(INSTANCE_ASSOCIATION, dst_query_data)
+
+        for edge in src_edges:
+            src_inst_id = edge.get("src_inst_id")
+            dst_inst_id = edge.get("dst_inst_id")
+            if src_inst_id in relation_map and dst_inst_id is not None:
+                relation_map[src_inst_id].add(int(dst_inst_id))
+
+        for edge in dst_edges:
+            dst_inst_id = edge.get("dst_inst_id")
+            src_inst_id = edge.get("src_inst_id")
+            if dst_inst_id in relation_map and src_inst_id is not None:
+                relation_map[dst_inst_id].add(int(src_inst_id))
+
+        return {
+            inst_id: sorted(related_ids) for inst_id, related_ids in relation_map.items()
+        }
+
+    @staticmethod
     def check_asso_mapping(data: dict):
         """校验关联关系的约束"""
         asso_info = ModelManage.model_association_info_search(data["model_asst_id"])

--- a/server/apps/cmdb/services/subscription_trigger.py
+++ b/server/apps/cmdb/services/subscription_trigger.py
@@ -230,23 +230,19 @@ class SubscriptionTriggerService:
             f"rule_id={self.rule.id}, related_model={related_model}, "
             f"instance_count={len(instance_ids)}"
         )
-        relation_map: dict[int, list[int]] = {}
-        for inst_id in instance_ids:
-            try:
-                rels = InstanceManage.instance_association(self.rule.model_id, inst_id)
-            except Exception as exc:
-                logger.error(
-                    f"[Subscription] query relation failed inst_id={inst_id}, error={exc}",
-                    exc_info=True,
-                )
-                continue
-            related_ids: list[int] = []
-            for rel in rels:
-                if rel.get("src_model_id") == related_model:
-                    related_ids.append(int(rel.get("src_inst_id")))
-                elif rel.get("dst_model_id") == related_model:
-                    related_ids.append(int(rel.get("dst_inst_id")))
-            relation_map[inst_id] = sorted(list(set(related_ids)))
+        try:
+            relation_map = InstanceManage.instance_association_map(
+                self.rule.model_id,
+                instance_ids,
+                related_model=related_model,
+            )
+        except Exception as exc:
+            logger.error(
+                "[Subscription] batch query relation failed "
+                f"rule_id={self.rule.id}, related_model={related_model}, error={exc}",
+                exc_info=True,
+            )
+            return {inst_id: [] for inst_id in instance_ids}
         logger.info(
             "[Subscription] 关联实例查询完成 "
             f"rule_id={self.rule.id}, relation_map_size={len(relation_map)}"

--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -129,6 +129,66 @@ def test_instance_association_instance_list_denies_user_without_object_permissio
     mock_association_list.assert_not_called()
 
 
+def test_instance_association_map_batches_graph_queries_by_direction():
+    from apps.cmdb.services.instance import InstanceManage
+
+    src_edges = [
+        {
+            "src_inst_id": 101,
+            "dst_inst_id": 201,
+            "src_model_id": "host",
+            "dst_model_id": "service",
+        },
+        {
+            "src_inst_id": 102,
+            "dst_inst_id": 202,
+            "src_model_id": "host",
+            "dst_model_id": "service",
+        },
+    ]
+    dst_edges = [
+        {
+            "src_inst_id": 301,
+            "dst_inst_id": 102,
+            "src_model_id": "service",
+            "dst_model_id": "host",
+        }
+    ]
+
+    graph_client = MagicMock()
+    graph_client.query_edge.side_effect = [src_edges, dst_edges]
+
+    graph_context = MagicMock()
+    graph_context.__enter__.return_value = graph_client
+    graph_context.__exit__.return_value = False
+
+    with patch(
+        "apps.cmdb.services.instance.GraphClient",
+        return_value=graph_context,
+    ):
+        relation_map = InstanceManage.instance_association_map(
+            model_id="host",
+            inst_ids=[101, 102],
+            related_model="service",
+        )
+
+    assert relation_map == {101: [201], 102: [202, 301]}
+    assert graph_client.query_edge.call_count == 2
+    src_call, dst_call = graph_client.query_edge.call_args_list
+    assert src_call.args[0] == "instance_association"
+    assert src_call.args[1] == [
+        {"field": "src_inst_id", "type": "int[]", "value": [101, 102]},
+        {"field": "src_model_id", "type": "str=", "value": "host"},
+        {"field": "dst_model_id", "type": "str=", "value": "service"},
+    ]
+    assert dst_call.args[0] == "instance_association"
+    assert dst_call.args[1] == [
+        {"field": "dst_inst_id", "type": "int[]", "value": [101, 102]},
+        {"field": "dst_model_id", "type": "str=", "value": "host"},
+        {"field": "src_model_id", "type": "str=", "value": "service"},
+    ]
+
+
 class CQLQueryTest:
     """
     用于测试和执行CQL查询的辅助类


### PR DESCRIPTION
## 问题本质
CMDB 订阅规则的关联变化检测会先拉出规则命中的实例集合，再对每个实例逐条查询双向关联关系，形成实例数线性放大的 FalkorDB 查询链路。

## 业务影响
当规则覆盖实例数较大或同时监听多个关联模型时，定时检测会把一次规则检查放大为大量串行图查询，拖慢订阅链路，并持续挤占 CMDB 图查询资源。

## 本次处理
- 为实例关联查询增加批量映射能力，按方向各执行一次图查询后回填实例到关联实例的映射
- 让订阅关联变化检测直接复用批量查询结果，移除按实例逐条查询关系的 N+1 模式
- 补充回归测试，约束双向批量查询的调用方式和映射结果

## 验证方式
- `PYTHONPATH="/tmp/bklite_pytest_stubs:$PYTHONPATH" INSTALL_APPS='system_mgmt,alerts,console_mgmt,job_mgmt,log,monitor,node_mgmt,operation_analysis,opspilot,cmdb' uv run --extra dev pytest apps/cmdb/tests.py -q -k instance_association_map_batches_graph_queries_by_direction -o addopts=''`
- `uv run python -m py_compile apps/cmdb/services/instance.py apps/cmdb/services/subscription_trigger.py apps/cmdb/tests.py`
