### PR TITLE
[alert] 修复告警来源伪造与恢复错配风险

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -147,9 +147,23 @@ class AlertSourceAdapter(ABC):
         return bulk_events
 
     @staticmethod
-    def generate_external_id(item: str, resource_name: str, source_id) -> str:
-        components = f"{item or ''}|{resource_name or ''}|{source_id or ''}"
-        return hashlib.md5(components.encode("utf-8")).hexdigest()
+    def generate_external_id(
+        item: str,
+        resource_id: str,
+        resource_type: str,
+        resource_name: str,
+        source_id: str,
+    ) -> str:
+        fingerprint_data = {
+            "item": item or "",
+            "resource_id": resource_id or "",
+            "resource_type": resource_type or "",
+            "resource_name": resource_name or "",
+            "source_id": source_id or "",
+        }
+        return hashlib.md5(
+            json.dumps(fingerprint_data, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
 
     def add_base_fields(self, event: Event, alert: Dict[str, Any]):
         """添加基础字段"""
@@ -160,7 +174,13 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
 
         if not event.external_id or not str(event.external_id).strip():
-            event.external_id = self.generate_external_id(event.item, event.resource_name, self.alert_source.source_id)
+            event.external_id = self.generate_external_id(
+                event.item,
+                event.resource_id,
+                event.resource_type,
+                event.resource_name,
+                self.alert_source.source_id,
+            )
             logger.debug(f"Generated external_id for event: {event.event_id}")
 
     @staticmethod

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 
 import nats_client
 from apps.alerts.models.models import Alert, Event, Incident, Level
-from apps.alerts.constants.constants import AlertStatus, EventLevel, LevelType
+from apps.alerts.constants.constants import AlertStatus, EventLevel, LevelType, AlertsSourceTypes
 from apps.core.logger import alert_logger as logger
 from apps.alerts.models.alert_source import AlertSource
 from apps.alerts.common.source_adapter.base import AlertSourceAdapterFactory
@@ -249,7 +249,12 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 "message": "Missing pusher identifier.",
             }
 
-        event_source = AlertSource.objects.filter(source_id=source_id).first()
+        event_source = AlertSource.objects.filter(
+            source_id=source_id,
+            source_type=AlertsSourceTypes.NATS,
+            is_active=True,
+            is_effective=True,
+        ).first()
         if not event_source:
             logger.error(f"Invalid source_id: {source_id}, pusher: {pusher}")
             return {

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -11,6 +11,7 @@ from apps.alerts.aggregation.builder.synthetic_alert_builder import (
     SyntheticAlertBuilder,
 )
 from apps.alerts.aggregation.processor.aggregation_processor import AggregationProcessor
+from apps.alerts.nats.nats import receive_alert_events
 from apps.alerts.constants import (
     AlertStatus,
     AlarmStrategyType,
@@ -748,6 +749,129 @@ class AlertSourceIngressTestCase(TestCase):
         self.assertEqual(events[0].external_id, events[1].external_id)
         self.assertEqual(events[0].action, EventAction.CREATED)
         self.assertEqual(events[1].action, EventAction.RECOVERY)
+
+    def test_receiver_rejects_inactive_source(self):
+        source = AlertSource.objects.create(
+            name="RESTful Disabled",
+            source_id="rest-disabled",
+            source_type=AlertsSourceTypes.RESTFUL,
+            secret="rest-secret",
+            is_active=False,
+            config={
+                "event_fields_mapping": {
+                    "title": "title",
+                    "level": "level",
+                    "start_time": "start_time",
+                }
+            },
+        )
+
+        response = self.client.post(
+            f"/api/v1/alerts/api/source/{source.source_id}/webhook/",
+            data=json.dumps(
+                {
+                    "events": [
+                        {
+                            "title": "disabled-source-event",
+                            "level": "3",
+                            "start_time": str(int(timezone.now().timestamp())),
+                        }
+                    ]
+                }
+            ),
+            content_type="application/json",
+            HTTP_SECRET="rest-secret",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(Event.objects.count(), 0)
+
+    def test_default_external_id_distinguishes_resource_identity(self):
+        source = AlertSource.objects.create(
+            name="RESTful Source",
+            source_id="rest-source",
+            source_type=AlertsSourceTypes.RESTFUL,
+            secret="rest-secret",
+            config={
+                "event_fields_mapping": {
+                    "title": "title",
+                    "description": "description",
+                    "level": "level",
+                    "item": "item",
+                    "start_time": "start_time",
+                    "resource_id": "resource_id",
+                    "resource_name": "resource_name",
+                    "resource_type": "resource_type",
+                    "action": "action",
+                }
+            },
+        )
+
+        payload = {
+            "events": [
+                {
+                    "title": "cpu high",
+                    "description": "cpu > 90%",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "resource_id": "service-1",
+                    "resource_name": "shared-name",
+                    "resource_type": "service",
+                    "action": "created",
+                },
+                {
+                    "title": "cpu high",
+                    "description": "cpu > 90%",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "resource_id": "service-2",
+                    "resource_name": "shared-name",
+                    "resource_type": "service",
+                    "action": "created",
+                },
+            ]
+        }
+
+        response = self.client.post(
+            f"/api/v1/alerts/api/source/{source.source_id}/webhook/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_SECRET="rest-secret",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        events = list(Event.objects.filter(source=source).order_by("resource_id"))
+        self.assertEqual(len(events), 2)
+        self.assertNotEqual(events[0].external_id, events[1].external_id)
+
+    def test_nats_ingress_rejects_non_nats_source(self):
+        source = AlertSource.objects.create(
+            name="Prometheus Source",
+            source_id="prometheus-prod",
+            source_type=AlertsSourceTypes.PROMETHEUS,
+            secret="prom-secret",
+            config={},
+        )
+
+        result = receive_alert_events(
+            source_id=source.source_id,
+            pusher="lite-monitor",
+            events=[
+                {
+                    "title": "forged",
+                    "description": "forged",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "action": "created",
+                }
+            ],
+        )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(Event.objects.count(), 0)
 
     def test_integration_guide_returns_prometheus_template(self):
         source = AlertSource.objects.create(

--- a/server/apps/alerts/views/receiver.py
+++ b/server/apps/alerts/views/receiver.py
@@ -34,7 +34,11 @@ def _receive_events(request, path_source_id=None, expected_source_type=None):
         if not source_id:
             return JsonResponse({"status": "error", "message": "Missing source_id."}, status=400)
 
-        event_source = AlertSource.objects.filter(source_id=source_id).first()
+        event_source = AlertSource.objects.filter(
+            source_id=source_id,
+            is_active=True,
+            is_effective=True,
+        ).first()
         if not event_source:
             return JsonResponse({"status": "error", "message": "Invalid source_id or source_type."}, status=400)
 
@@ -108,4 +112,3 @@ def request_test(requests):
     """
     logger.info("Processing request test: request=%s", requests)
     return WebUtils.response_success([])
-


### PR DESCRIPTION
## 问题本质
- NATS 告警入口直接信任调用方传入的 `source_id`，会把非 NATS 告警源也当作合法来源处理。
- 缺省 `external_id` 只使用 `item + resource_name + source_id` 生成，资源同名时会把不同对象压成同一恢复键。
- HTTP 告警接收入口没有拦住停用或失效的告警源。

## 业务影响
- 具备 NATS 调用能力的内部调用方可以伪装成其他告警源写入事件，放大错源与事件伪造风险。
- 不同资源同名时，恢复/关闭事件可能错误关联到其他对象，导致 DB Event 恢复闭环串线、状态失真。
- 已停用的告警源仍可能继续入库，配置停用无法形成真实接入边界。

## 本次处理
- 将 NATS 接收入口限制为 `source_type=nats` 且 `is_active/is_effective=true` 的告警源。
- 将 HTTP 接收入口限制为仅接受启用且生效的告警源。
- 将缺省 `external_id` 扩展为 `item + resource_id + resource_type + resource_name + source_id` 共同生成。
- 补充对应回归测试。

## 验证
- `uv run --extra dev python -m py_compile apps/alerts/views/receiver.py apps/alerts/nats/nats.py apps/alerts/common/source_adapter/base.py apps/alerts/test/tests.py`
- `uv run --extra dev python - <<'PY' ... PY`
  - 验证不同资源标识会生成不同 `external_id`
  - 验证 NATS 入口只查询 NATS 且启用/生效的告警源
  - 验证 HTTP 入口只查询启用/生效的告警源
- 额外说明：仓库现有 `apps/alerts/test/tests.py` 在当前默认分支测试基线下仍受无关迁移问题影响，`pytest` 建库阶段会因 `NewSessionEventRelation` 迁移失败中断，本次未改动该链路。
