### PR TITLE
[alert] 优化 Incident 关联查询并修复 Alert 事件数失真风险

### DIFF
--- a/server/apps/alerts/serializers/incident.py
+++ b/server/apps/alerts/serializers/incident.py
@@ -118,8 +118,7 @@ class IncidentModelSerializer(serializers.ModelSerializer):
         # fallback: 直接计数
         return obj.alert.count() if obj.alert else 0
 
-    @staticmethod
-    def get_operator_users(obj):
+    def get_operator_users(self, obj):
         """
         获取操作员用户列表，从 JSONField 转换为字符串
         """
@@ -132,6 +131,9 @@ class IncidentModelSerializer(serializers.ModelSerializer):
 
         # 如果 operator 是列表，转换为逗号分隔的字符串
         if isinstance(obj.operator, list):
+            operator_user_map = self.context.get("operator_user_map")
+            if operator_user_map is not None:
+                return ", ".join(operator_user_map.get(u, u) for u in obj.operator)
             user_name_list = User.objects.filter(username__in=obj.operator).values_list("display_name", flat=True)
             return ", ".join(list(user_name_list))
 

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -23,8 +23,11 @@ from apps.alerts.constants import (
     LevelType,
 )
 from apps.alerts.models import Alert, AlertSource, AlarmStrategy, Event, Level
+from apps.alerts.models.models import Incident
+from apps.alerts.serializers.incident import IncidentModelSerializer
 from apps.alerts.serializers.alert_source import AlertSourceModelSerializer
 from apps.alerts.serializers.strategy import AlarmStrategySerializer
+from apps.alerts.views.incident import IncidentModelViewSet
 
 
 class AlarmStrategySerializerTestCase(TestCase):
@@ -517,6 +520,97 @@ class AlertSourceIngressTestCase(TestCase):
         self.assertEqual(response.json()["status"], "success")
         self.assertEqual(Event.objects.count(), 1)
         self.assertEqual(Event.objects.first().source.source_id, source.source_id)
+
+
+class IncidentQueryPathTestCase(TestCase):
+    def setUp(self):
+        self.source = AlertSource.objects.create(
+            name="test-source",
+            source_id="source-incident",
+            source_type=AlertsSourceTypes.WEBHOOK,
+        )
+        self.user = get_user_model().objects.create(
+            username="incident-operator",
+            display_name="事故处理人",
+            email="incident@example.com",
+            password="pwd",
+        )
+
+    def create_event(self, event_id: str, title: str):
+        now = timezone.now()
+        return Event.objects.create(
+            source=self.source,
+            raw_data={},
+            title=title,
+            description=f"{title} description",
+            level="1",
+            service="svc",
+            event_type=EventType.ALERT,
+            tags={},
+            location="gz",
+            external_id=event_id,
+            start_time=now,
+            labels={},
+            action=EventAction.CREATED,
+            event_id=event_id,
+            item="cpu",
+            resource_id=f"res-{event_id}",
+            resource_type="host",
+            resource_name=f"host-{event_id}",
+            status="received",
+            assignee=[],
+        )
+
+    def create_alert(self, alert_id: str, events):
+        alert = Alert.objects.create(
+            alert_id=alert_id,
+            status=AlertStatus.UNASSIGNED,
+            level="1",
+            title=f"title-{alert_id}",
+            content=f"content-{alert_id}",
+            labels={},
+            first_event_time=timezone.now(),
+            last_event_time=timezone.now(),
+            fingerprint=f"fp-{alert_id}",
+            operator=[self.user.username],
+        )
+        alert.events.add(*events)
+        return alert
+
+    def test_incident_serializer_uses_prefetched_alert_sources_and_operator_map(self):
+        event_a = self.create_event("EVENT-A", "event-a")
+        event_b = self.create_event("EVENT-B", "event-b")
+        alert_1 = self.create_alert("ALERT-A", [event_a])
+        alert_2 = self.create_alert("ALERT-B", [event_b])
+
+        incident = Incident.objects.create(
+            incident_id="INCIDENT-A",
+            title="incident-a",
+            content="content",
+            labels={},
+            operator=[self.user.username],
+            level="1",
+        )
+        incident.alert.add(alert_1, alert_2)
+
+        viewset = IncidentModelViewSet()
+        queryset = list(viewset.get_queryset().filter(pk=incident.pk))
+        serializer = IncidentModelSerializer(
+            queryset,
+            many=True,
+            context={
+                "operator_user_map": {
+                    self.user.username: self.user.display_name,
+                }
+            },
+        )
+
+        with self.assertNumQueries(0):
+            data = serializer.data
+
+        self.assertEqual(data[0]["alert_count"], 2)
+        self.assertEqual(data[0]["sources"], "test-source")
+        self.assertEqual(data[0]["operator_users"], "事故处理人")
 
     def test_zabbix_webhook_normalizes_single_event_payload(self):
         source = AlertSource.objects.create(

--- a/server/apps/alerts/views/alert.py
+++ b/server/apps/alerts/views/alert.py
@@ -26,7 +26,7 @@ class AlertModelViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = Alert.objects.annotate(
-            event_count_annotated=Count("events"),
+            event_count_annotated=Count("events", distinct=True),
         ).prefetch_related("events__source", "incident_set")
 
         # StringAgg 是 PostgreSQL 专属函数，其他数据库通过 serializer fallback 处理
@@ -34,7 +34,7 @@ class AlertModelViewSet(ModelViewSet):
             from django.contrib.postgres.aggregates import StringAgg
 
             queryset = Alert.objects.annotate(
-                event_count_annotated=Count("events"),
+                event_count_annotated=Count("events", distinct=True),
                 # 通过事件获取告警源名称（去重）
                 source_names_annotated=StringAgg("events__source__name", delimiter=", ", distinct=True),
                 incident_title_annotated=StringAgg("incident__title", delimiter=", ", distinct=True),

--- a/server/apps/alerts/views/incident.py
+++ b/server/apps/alerts/views/incident.py
@@ -2,6 +2,7 @@
 import uuid
 
 from django.db.models import Count
+from django.db.models import Prefetch
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -16,6 +17,7 @@ from apps.alerts.service.incident_operator import IncidentOperator
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.logger import alert_logger as logger
 from apps.core.utils.web_utils import WebUtils
+from apps.system_mgmt.models.user import User
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
 
@@ -33,14 +35,63 @@ class IncidentModelViewSet(ModelViewSet):
     pagination_class = CustomPageNumberPagination
 
     def get_queryset(self):
+        alert_prefetch = Prefetch(
+            "alert",
+            queryset=Alert.objects.prefetch_related("events__source"),
+        )
         queryset = Incident.objects.annotate(
-            alert_count=Count("alert")
-        ).prefetch_related("alert")
+            alert_count=Count("alert", distinct=True)
+        ).prefetch_related(alert_prefetch)
         return queryset
+
+    @staticmethod
+    def _build_operator_user_map(objects):
+        operator_usernames = set()
+        for incident in objects:
+            if incident.operator:
+                operator_usernames.update(incident.operator)
+        if not operator_usernames:
+            return {}
+        return dict(User.objects.filter(username__in=operator_usernames).values_list("username", "display_name"))
 
     @HasPermission("Incidents-View")
     def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            operator_user_map = self._build_operator_user_map(page)
+            serializer = self.get_serializer(
+                page,
+                many=True,
+                context={
+                    **self.get_serializer_context(),
+                    "operator_user_map": operator_user_map,
+                },
+            )
+            return self.get_paginated_response(serializer.data)
+
+        operator_user_map = self._build_operator_user_map(queryset)
+        serializer = self.get_serializer(
+            queryset,
+            many=True,
+            context={
+                **self.get_serializer_context(),
+                "operator_user_map": operator_user_map,
+            },
+        )
+        return WebUtils.response_success(serializer.data)
+
+    @HasPermission("Incidents-View")
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        serializer = self.get_serializer(
+            instance,
+            context={
+                **self.get_serializer_context(),
+                "operator_user_map": self._build_operator_user_map([instance]),
+            },
+        )
+        return Response(serializer.data)
 
     @HasPermission("Alarms-Edit")
     @transaction.atomic


### PR DESCRIPTION
## 问题本质
- Incident 列表/详情在 serializer 中逐层访问 `alert -> events -> source`，但 queryset 只预取到 `alert`，会在事故数和关联告警数放大时触发级联补查。
- Alert 列表在 PostgreSQL 分支同时联结 `events` 和 `incident` 做聚合时，`Count("events")` 没有去重，会把同一告警的事件数重复计算。

## 业务影响
- Incident 列表、详情和关联事故页在多告警场景下会出现明显的 N+1 查询放大，查询时延会随事故和告警数量恶化。
- Alert 列表的事件数会被算重，进一步影响告警展示和依赖该字段的后续判断。

## 本次处理
- 为 Incident 查询补齐 `alert__events__source` 预取，并把操作人展示改为批量映射，避免序列化阶段逐条查库。
- 为 Alert 和 Incident 的聚合计数字段增加 `distinct=True`，消除多表联结下的重复计数。
- 补充 Incident 序列化回归用例，约束预取后的序列化不再额外打库。

## 验证方式
- `python3 -m py_compile server/apps/alerts/views/alert.py server/apps/alerts/views/incident.py server/apps/alerts/serializers/incident.py server/apps/alerts/test/tests.py`
- `ENABLE_CELERY=true DB_ENGINE=sqlite DB_NAME=bklite-test.sqlite3 INSTALL_APPS='system_mgmt,alerts,console_mgmt,job_mgmt,log,monitor,node_mgmt,operation_analysis,opspilot,cmdb' uv run --extra dev python manage.py test apps.alerts.test.tests.IncidentQueryPathTestCase apps.alerts.test.tests.MissingDetectionProcessorTestCase --verbosity 2`
  - 运行被仓库既有 `alerts.0009_remove_correlationrules_aggregation_rules_and_more` 迁移问题阻断，报错为 `FieldDoesNotExist: NewSessionEventRelation has no field named 'event'`，与本次改动无关。
