### PR TITLE
[alert] 修复 Alert 与 Incident 旁路查询未按资源范围裁剪导致的越权风险

### DIFF
--- a/server/apps/alerts/serializers/incident.py
+++ b/server/apps/alerts/serializers/incident.py
@@ -39,6 +39,12 @@ class IncidentModelSerializer(serializers.ModelSerializer):
             "alert": {"write_only": True},  # 多对多关系字段
         }
 
+    def __init__(self, instance=None, data=serializers.empty, **kwargs):
+        super().__init__(instance=instance, data=data, **kwargs)
+        allowed_alert_queryset = self.context.get("allowed_alert_queryset")
+        if allowed_alert_queryset is not None:
+            self.fields["alert"].queryset = allowed_alert_queryset
+
     def create(self, validated_data):
         """
         重写create方法来处理多对多关系

--- a/server/apps/alerts/test/test_alert_incident_permissions.py
+++ b/server/apps/alerts/test/test_alert_incident_permissions.py
@@ -1,0 +1,184 @@
+import json
+
+import pytest
+from django.contrib.auth.hashers import make_password
+from django.utils import timezone
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.alerts.constants.constants import AlertStatus, AlertsSourceTypes, EventAction, EventType, IncidentStatus
+from apps.alerts.models import Alert, AlertSource, Event, Incident
+from apps.alerts.views.alert import AlertModelViewSet
+from apps.alerts.views.incident import IncidentModelViewSet
+from apps.system_mgmt.models import User
+
+
+def _build_user(username, group_list, alarm_permissions):
+    user = User.objects.create(
+        username=username,
+        display_name=username,
+        email=f"{username}@example.com",
+        password=make_password("password123"),
+        domain="domain.com",
+        group_list=group_list,
+    )
+    user.permission = {"alarm": set(alarm_permissions)}
+    user.is_superuser = False
+    return user
+
+
+def _build_alert(team, operator, suffix):
+    source = AlertSource.objects.create(
+        name=f"source-{suffix}",
+        source_id=f"source-{suffix}",
+        source_type=AlertsSourceTypes.WEBHOOK,
+    )
+    event = Event.objects.create(
+        source=source,
+        push_source_id="default",
+        raw_data={},
+        title=f"event-{suffix}",
+        description="desc",
+        level="warning",
+        service="svc",
+        event_type=EventType.ALERT,
+        tags={},
+        location="gz",
+        external_id=f"external-{suffix}",
+        start_time=timezone.now(),
+        labels={},
+        action=EventAction.CREATED,
+        event_id=f"EVENT-{suffix}",
+        item="cpu",
+        resource_id=f"resource-{suffix}",
+        resource_type="host",
+        resource_name=f"host-{suffix}",
+        status="received",
+        assignee=[],
+    )
+    alert = Alert.objects.create(
+        alert_id=f"ALERT-{suffix}",
+        status=AlertStatus.UNASSIGNED,
+        level="warning",
+        title=f"alert-{suffix}",
+        content="content",
+        labels={},
+        first_event_time=timezone.now(),
+        last_event_time=timezone.now(),
+        item="cpu",
+        resource_id=f"resource-{suffix}",
+        resource_name=f"host-{suffix}",
+        resource_type="host",
+        operate=None,
+        operator=operator,
+        source_name=source.name,
+        fingerprint=f"fp-{suffix}",
+        group_by_field="service",
+        rule_id=f"rule-{suffix}",
+        team=team,
+    )
+    alert.events.add(event)
+    return alert
+
+
+@pytest.mark.django_db
+def test_alert_list_is_scoped_by_operator_and_authorized_team():
+    user = _build_user("alert-owner", [1], ["Alarms-View"])
+    team_alert = _build_alert([1], [], "team")
+    assigned_alert = _build_alert([2], ["alert-owner"], "assigned")
+    hidden_alert = _build_alert([2], ["someone-else"], "hidden")
+
+    factory = APIRequestFactory()
+    request = factory.get("/api/alert")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = AlertModelViewSet.as_view({"get": "list"})(request)
+    payload = json.loads(response.content)
+    returned_alert_ids = {item["alert_id"] for item in payload["data"]}
+
+    assert team_alert.alert_id in returned_alert_ids
+    assert assigned_alert.alert_id in returned_alert_ids
+    assert hidden_alert.alert_id not in returned_alert_ids
+
+
+@pytest.mark.django_db
+def test_incident_retrieve_rejects_cross_team_access():
+    user = _build_user("incident-reader", [1], ["Incidents-View"])
+    foreign_alert = _build_alert([2], ["someone-else"], "foreign")
+    incident = Incident.objects.create(
+        incident_id="INCIDENT-foreign",
+        status=IncidentStatus.PENDING,
+        level="warning",
+        title="foreign-incident",
+        content="content",
+        note="",
+        labels={},
+        operator=[],
+        fingerprint="incident-fp",
+        created_by="system",
+        updated_by="system",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+    incident.alert.add(foreign_alert)
+
+    factory = APIRequestFactory()
+    request = factory.get(f"/api/incident/{incident.pk}/")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = IncidentModelViewSet.as_view({"get": "retrieve"})(request, pk=incident.pk)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_incident_create_rejects_unscoped_alert_ids():
+    user = _build_user("incident-editor", [1], ["Alarms-Edit"])
+    hidden_alert = _build_alert([2], ["someone-else"], "hidden-create")
+
+    factory = APIRequestFactory()
+    request = factory.post(
+        "/api/incident",
+        {
+            "title": "new-incident",
+            "level": "warning",
+            "content": "content",
+            "note": "",
+            "labels": {},
+            "operator": [],
+            "alert": [hidden_alert.pk],
+        },
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = IncidentModelViewSet.as_view({"post": "create"})(request)
+
+    assert response.status_code == 400
+    assert Incident.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_alert_operator_rejects_unscoped_alert_ids():
+    user = _build_user("alert-editor", [1], ["Alarms-Edit"])
+    hidden_alert = _build_alert([2], ["someone-else"], "hidden-operator")
+
+    factory = APIRequestFactory()
+    request = factory.post(
+        "/api/alert/operator/assign/",
+        {"alert_id": [hidden_alert.alert_id], "assignee": ["alert-editor"]},
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = AlertModelViewSet.as_view({"post": "operator"})(request, operator_action="assign")
+    payload = json.loads(response.content)
+    hidden_alert.refresh_from_db()
+
+    assert response.status_code == 500
+    assert payload["result"] is False
+    assert payload["data"][hidden_alert.alert_id]["message"] == "您没有权限操作此告警"
+    assert hidden_alert.status == AlertStatus.UNASSIGNED

--- a/server/apps/alerts/test/test_alert_incident_permissions.py
+++ b/server/apps/alerts/test/test_alert_incident_permissions.py
@@ -5,11 +5,21 @@ from django.contrib.auth.hashers import make_password
 from django.utils import timezone
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from apps.alerts.constants.constants import AlertStatus, AlertsSourceTypes, EventAction, EventType, IncidentStatus
-from apps.alerts.models import Alert, AlertSource, Event, Incident
+from apps.alerts.constants.constants import (
+    AlertStatus,
+    AlertsSourceTypes,
+    EventAction,
+    EventType,
+    IncidentStatus,
+    LogAction,
+    LogTargetType,
+)
+from apps.alerts.models import Alert, AlertSource, Event, Incident, OperatorLog
 from apps.alerts.views.alert import AlertModelViewSet
 from apps.alerts.views.incident import IncidentModelViewSet
-from apps.system_mgmt.models import User
+from apps.alerts.views.event import EventModelViewSet
+from apps.alerts.views.operator_log import SystemLogModelViewSet
+from apps.system_mgmt.models import Group, User
 
 
 def _build_user(username, group_list, alarm_permissions):
@@ -23,7 +33,13 @@ def _build_user(username, group_list, alarm_permissions):
     )
     user.permission = {"alarm": set(alarm_permissions)}
     user.is_superuser = False
+    user.is_authenticated = True
     return user
+
+
+def _ensure_groups(*group_ids):
+    for group_id in group_ids:
+        Group.objects.get_or_create(id=group_id, defaults={"name": f"group-{group_id}", "parent_id": 0})
 
 
 def _build_alert(team, operator, suffix):
@@ -82,6 +98,7 @@ def _build_alert(team, operator, suffix):
 
 @pytest.mark.django_db
 def test_alert_list_is_scoped_by_operator_and_authorized_team():
+    _ensure_groups(1, 2)
     user = _build_user("alert-owner", [1], ["Alarms-View"])
     team_alert = _build_alert([1], [], "team")
     assigned_alert = _build_alert([2], ["alert-owner"], "assigned")
@@ -103,6 +120,7 @@ def test_alert_list_is_scoped_by_operator_and_authorized_team():
 
 @pytest.mark.django_db
 def test_incident_retrieve_rejects_cross_team_access():
+    _ensure_groups(1, 2)
     user = _build_user("incident-reader", [1], ["Incidents-View"])
     foreign_alert = _build_alert([2], ["someone-else"], "foreign")
     incident = Incident.objects.create(
@@ -134,6 +152,7 @@ def test_incident_retrieve_rejects_cross_team_access():
 
 @pytest.mark.django_db
 def test_incident_create_rejects_unscoped_alert_ids():
+    _ensure_groups(1, 2)
     user = _build_user("incident-editor", [1], ["Alarms-Edit"])
     hidden_alert = _build_alert([2], ["someone-else"], "hidden-create")
 
@@ -162,6 +181,7 @@ def test_incident_create_rejects_unscoped_alert_ids():
 
 @pytest.mark.django_db
 def test_alert_operator_rejects_unscoped_alert_ids():
+    _ensure_groups(1, 2)
     user = _build_user("alert-editor", [1], ["Alarms-Edit"])
     hidden_alert = _build_alert([2], ["someone-else"], "hidden-operator")
 
@@ -182,3 +202,57 @@ def test_alert_operator_rejects_unscoped_alert_ids():
     assert payload["result"] is False
     assert payload["data"][hidden_alert.alert_id]["message"] == "您没有权限操作此告警"
     assert hidden_alert.status == AlertStatus.UNASSIGNED
+
+
+@pytest.mark.django_db
+def test_event_retrieve_rejects_cross_team_access():
+    _ensure_groups(1, 2)
+    user = _build_user("event-reader", [1], ["Alarms-View"])
+    hidden_alert = _build_alert([2], ["someone-else"], "hidden-event")
+    hidden_event = hidden_alert.events.first()
+
+    factory = APIRequestFactory()
+    request = factory.get(f"/api/events/{hidden_event.pk}/")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = EventModelViewSet.as_view({"get": "retrieve"})(request, pk=hidden_event.pk)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_operator_log_list_hides_cross_team_alert_history():
+    _ensure_groups(1, 2)
+    user = _build_user("log-reader", [1], ["operation_log-View"])
+    visible_alert = _build_alert([1], [], "visible-log")
+    hidden_alert = _build_alert([2], ["someone-else"], "hidden-log")
+    OperatorLog.objects.create(
+        operator="system",
+        action=LogAction.MODIFY,
+        target_type=LogTargetType.ALERT,
+        operator_object="告警处理-关闭",
+        target_id=visible_alert.alert_id,
+        overview="visible log",
+    )
+    OperatorLog.objects.create(
+        operator="system",
+        action=LogAction.MODIFY,
+        target_type=LogTargetType.ALERT,
+        operator_object="告警处理-关闭",
+        target_id=hidden_alert.alert_id,
+        overview="hidden log",
+    )
+
+    factory = APIRequestFactory()
+    request = factory.get("/api/log/")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    response = SystemLogModelViewSet.as_view({"get": "list"})(request)
+    payload = response.data
+    rows = payload["data"] if isinstance(payload, dict) else payload
+    returned_overviews = {item["overview"] for item in rows}
+
+    assert "visible log" in returned_overviews
+    assert "hidden log" not in returned_overviews

--- a/server/apps/alerts/utils/permission_scope.py
+++ b/server/apps/alerts/utils/permission_scope.py
@@ -1,5 +1,8 @@
+from django.db import connection
 from django.db.models import Q
 
+from apps.alerts.constants.constants import LogTargetType
+from apps.alerts.models.models import Alert, Incident
 from apps.system_mgmt.nats_api import get_authorized_groups_scoped
 
 
@@ -38,6 +41,21 @@ def get_authorized_group_ids(request):
     return group_ids
 
 
+def _filter_json_membership_fallback(queryset, field_name, expected_values):
+    expected_set = {value for value in expected_values if value not in (None, "")}
+    if not expected_set:
+        return queryset.none()
+
+    matched_ids = []
+    for item in queryset.only("id", field_name):
+        current_values = getattr(item, field_name, []) or []
+        if isinstance(current_values, str):
+            current_values = [current_values]
+        if expected_set.intersection(set(current_values)):
+            matched_ids.append(item.pk)
+    return queryset.filter(pk__in=matched_ids)
+
+
 def filter_alert_queryset_for_request(queryset, request):
     user = getattr(request, "user", None)
     if not user:
@@ -46,16 +64,25 @@ def filter_alert_queryset_for_request(queryset, request):
         return queryset
 
     username = getattr(user, "username", "")
-    query = Q()
-    if username:
-        query |= Q(operator__contains=username)
+    group_ids = get_authorized_group_ids(request)
+    if connection.features.supports_json_field_contains:
+        query = Q()
+        if username:
+            query |= Q(operator__contains=username)
 
-    for group_id in get_authorized_group_ids(request):
-        query |= Q(team__contains=group_id)
+        for group_id in group_ids:
+            query |= Q(team__contains=group_id)
 
-    if not query.children:
+        if not query.children:
+            return queryset.none()
+        return queryset.filter(query).distinct()
+
+    scoped_by_operator = _filter_json_membership_fallback(queryset, "operator", [username]) if username else queryset.none()
+    scoped_by_team = _filter_json_membership_fallback(queryset, "team", group_ids) if group_ids else queryset.none()
+    allowed_ids = set(scoped_by_operator.values_list("pk", flat=True)) | set(scoped_by_team.values_list("pk", flat=True))
+    if not allowed_ids:
         return queryset.none()
-    return queryset.filter(query).distinct()
+    return queryset.filter(pk__in=allowed_ids).distinct()
 
 
 def filter_incident_queryset_for_request(queryset, request):
@@ -66,13 +93,70 @@ def filter_incident_queryset_for_request(queryset, request):
         return queryset.distinct()
 
     username = getattr(user, "username", "")
-    query = Q()
-    if username:
-        query |= Q(operator__contains=username) | Q(alert__operator__contains=username)
+    group_ids = get_authorized_group_ids(request)
+    if connection.features.supports_json_field_contains:
+        query = Q()
+        if username:
+            query |= Q(operator__contains=username) | Q(alert__operator__contains=username)
 
-    for group_id in get_authorized_group_ids(request):
-        query |= Q(alert__team__contains=group_id)
+        for group_id in group_ids:
+            query |= Q(alert__team__contains=group_id)
 
-    if not query.children:
+        if not query.children:
+            return queryset.none()
+        return queryset.filter(query).distinct()
+
+    matched_ids = []
+    for incident in queryset.prefetch_related("alert").only("id", "operator"):
+        incident_operators = incident.operator or []
+        if isinstance(incident_operators, str):
+            incident_operators = [incident_operators]
+
+        if username and username in incident_operators:
+            matched_ids.append(incident.pk)
+            continue
+
+        for alert in incident.alert.all():
+            alert_operators = alert.operator or []
+            if isinstance(alert_operators, str):
+                alert_operators = [alert_operators]
+            alert_teams = alert.team or []
+            if username and username in alert_operators:
+                matched_ids.append(incident.pk)
+                break
+            if set(group_ids).intersection(set(alert_teams)):
+                matched_ids.append(incident.pk)
+                break
+
+    if not matched_ids:
         return queryset.none()
+    return queryset.filter(pk__in=matched_ids).distinct()
+
+
+def filter_event_queryset_for_request(queryset, request):
+    request_scoped_alerts = filter_alert_queryset_for_request(Alert.objects.all(), request)
+    return queryset.filter(alert__in=request_scoped_alerts).distinct()
+
+
+def filter_operator_log_queryset_for_request(queryset, request):
+    user = getattr(request, "user", None)
+    if not user:
+        return queryset.none()
+    if getattr(user, "is_superuser", False):
+        return queryset
+
+    scoped_alert_ids = list(
+        filter_alert_queryset_for_request(Alert.objects.all(), request).values_list("alert_id", flat=True)
+    )
+    scoped_incident_ids = list(
+        filter_incident_queryset_for_request(Incident.objects.all(), request).values_list("incident_id", flat=True)
+    )
+    if not scoped_alert_ids and not scoped_incident_ids:
+        return queryset.none()
+
+    query = Q()
+    if scoped_alert_ids:
+        query |= Q(target_type=LogTargetType.ALERT, target_id__in=scoped_alert_ids)
+    if scoped_incident_ids:
+        query |= Q(target_type=LogTargetType.INCIDENT, target_id__in=scoped_incident_ids)
     return queryset.filter(query).distinct()

--- a/server/apps/alerts/utils/permission_scope.py
+++ b/server/apps/alerts/utils/permission_scope.py
@@ -1,0 +1,78 @@
+from django.db.models import Q
+
+from apps.system_mgmt.nats_api import get_authorized_groups_scoped
+
+
+def _get_actor_context(request):
+    user = getattr(request, "user", None)
+    return {
+        "username": getattr(user, "username", ""),
+        "domain": getattr(user, "domain", "domain.com"),
+        "current_team": request.COOKIES.get("current_team"),
+        "is_superuser": getattr(user, "is_superuser", False),
+    }
+
+
+def get_authorized_group_ids(request):
+    user = getattr(request, "user", None)
+    if not user:
+        return []
+    if getattr(user, "is_superuser", False):
+        current_team = request.COOKIES.get("current_team")
+        try:
+            return [int(current_team)] if current_team not in (None, "") else []
+        except (TypeError, ValueError):
+            return []
+
+    include_children = request.COOKIES.get("include_children", "0") == "1"
+    result = get_authorized_groups_scoped(_get_actor_context(request), include_children=include_children)
+    if not result.get("result"):
+        return []
+
+    group_ids = []
+    for group_id in result.get("data", []):
+        try:
+            group_ids.append(int(group_id))
+        except (TypeError, ValueError):
+            continue
+    return group_ids
+
+
+def filter_alert_queryset_for_request(queryset, request):
+    user = getattr(request, "user", None)
+    if not user:
+        return queryset.none()
+    if getattr(user, "is_superuser", False):
+        return queryset
+
+    username = getattr(user, "username", "")
+    query = Q()
+    if username:
+        query |= Q(operator__contains=username)
+
+    for group_id in get_authorized_group_ids(request):
+        query |= Q(team__contains=group_id)
+
+    if not query.children:
+        return queryset.none()
+    return queryset.filter(query).distinct()
+
+
+def filter_incident_queryset_for_request(queryset, request):
+    user = getattr(request, "user", None)
+    if not user:
+        return queryset.none()
+    if getattr(user, "is_superuser", False):
+        return queryset.distinct()
+
+    username = getattr(user, "username", "")
+    query = Q()
+    if username:
+        query |= Q(operator__contains=username) | Q(alert__operator__contains=username)
+
+    for group_id in get_authorized_group_ids(request):
+        query |= Q(alert__team__contains=group_id)
+
+    if not query.children:
+        return queryset.none()
+    return queryset.filter(query).distinct()

--- a/server/apps/alerts/views/alert.py
+++ b/server/apps/alerts/views/alert.py
@@ -8,6 +8,7 @@ from apps.alerts.filters import AlertModelFilter
 from apps.alerts.models.models import Alert
 from apps.alerts.serializers import AlertModelSerializer
 from apps.alerts.service.alter_operator import AlertOperator
+from apps.alerts.utils.permission_scope import filter_alert_queryset_for_request
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.web_utils import WebUtils
 from apps.system_mgmt.models.user import User
@@ -25,7 +26,7 @@ class AlertModelViewSet(ModelViewSet):
     pagination_class = CustomPageNumberPagination
 
     def get_queryset(self):
-        queryset = Alert.objects.annotate(
+        queryset = Alert.objects.exclude(session_status__in=SessionStatus.NO_CONFIRMED).annotate(
             event_count_annotated=Count("events"),
         ).prefetch_related("events__source", "incident_set")
 
@@ -33,14 +34,17 @@ class AlertModelViewSet(ModelViewSet):
         if connection.vendor == "postgresql":
             from django.contrib.postgres.aggregates import StringAgg
 
-            queryset = Alert.objects.annotate(
+            queryset = Alert.objects.exclude(session_status__in=SessionStatus.NO_CONFIRMED).annotate(
                 event_count_annotated=Count("events"),
                 # 通过事件获取告警源名称（去重）
                 source_names_annotated=StringAgg("events__source__name", delimiter=", ", distinct=True),
                 incident_title_annotated=StringAgg("incident__title", delimiter=", ", distinct=True),
             ).prefetch_related("events__source")
 
-        return queryset
+        request = getattr(self, "request", None)
+        if request is None:
+            return queryset
+        return filter_alert_queryset_for_request(queryset, request)
 
     @staticmethod
     def _build_operator_user_map(page):
@@ -78,9 +82,21 @@ class AlertModelViewSet(ModelViewSet):
         )
         return WebUtils.response_success(serializer.data)
 
+    @HasPermission("Alarms-View")
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+    @HasPermission("Alarms-Edit")
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
     @HasPermission("Alarms-Edit")
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
+
+    @HasPermission("Alarms-Edit")
+    def partial_update(self, request, *args, **kwargs):
+        return super().partial_update(request, *args, **kwargs)
 
     @HasPermission("Alarms-Delete")
     def destroy(self, request, *args, **kwargs):
@@ -99,10 +115,18 @@ class AlertModelViewSet(ModelViewSet):
         Custom operator method to handle alert operations.
         """
         alert_id_list = request.data["alert_id"]
+        allowed_alert_ids = set(
+            self.filter_queryset(self.get_queryset()).filter(alert_id__in=alert_id_list).values_list("alert_id", flat=True)
+        )
         operator = AlertOperator(user=self.request.user.username)
         result_list = {}
         status_list = []
         for alert_id in alert_id_list:
+            if alert_id not in allowed_alert_ids:
+                result = {"result": False, "message": "您没有权限操作此告警", "data": {}}
+                result_list[alert_id] = result
+                status_list.append(False)
+                continue
             result = operator.operate(action=operator_action, alert_id=alert_id, data=request.data)
             result_list[alert_id] = result
             status_list.append(result["result"])

--- a/server/apps/alerts/views/event.py
+++ b/server/apps/alerts/views/event.py
@@ -2,6 +2,7 @@
 from apps.alerts.filters import EventModelFilter
 from apps.alerts.models.models import Event
 from apps.alerts.serializers import EventModelSerializer
+from apps.alerts.utils.permission_scope import filter_event_queryset_for_request
 from apps.core.decorators.api_permission import HasPermission
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
@@ -18,6 +19,16 @@ class EventModelViewSet(ModelViewSet):
     filterset_class = EventModelFilter
     pagination_class = CustomPageNumberPagination
 
+    def get_queryset(self):
+        request = getattr(self, "request", None)
+        if request is None:
+            return Event.objects.all()
+        return filter_event_queryset_for_request(Event.objects.all(), request)
+
     @HasPermission("Integration-View,Alarms-View")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    @HasPermission("Integration-View,Alarms-View")
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)

--- a/server/apps/alerts/views/incident.py
+++ b/server/apps/alerts/views/incident.py
@@ -52,6 +52,14 @@ class IncidentModelViewSet(ModelViewSet):
             context["allowed_alert_queryset"] = filter_alert_queryset_for_request(Alert.objects.all(), request)
         return context
 
+    def _get_allowed_alert_ids(self):
+        request = getattr(self, "request", None)
+        if request is None:
+            return set()
+        return set(
+            filter_alert_queryset_for_request(Alert.objects.all(), request).values_list("id", flat=True)
+        )
+
     @HasPermission("Incidents-View")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
@@ -66,30 +74,39 @@ class IncidentModelViewSet(ModelViewSet):
         data = request.data
         incident_id = f"INCIDENT-{uuid.uuid4().hex}"
         data["incident_id"] = incident_id
-        if not data["alert"]:
+        alert_ids = list(data.get("alert", []))
+        if not alert_ids:
             return Response(
                 {"detail": "must provide at least one alert to create an incident."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        else:
-            has_incident_alert_ids = list(
-                Alert.objects.filter(
-                    id__in=data["alert"], incident__isnull=False
-                ).values_list("id", flat=True)
+
+        allowed_alert_ids = self._get_allowed_alert_ids()
+        unauthorized_alert_ids = set(alert_ids) - allowed_alert_ids
+        if unauthorized_alert_ids:
+            return Response(
+                {"detail": "Some alerts are out of your authorized scope."},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-            not_incident_alert_ids = set(data["alert"]) - set(has_incident_alert_ids)
-            data["alert"] = list(not_incident_alert_ids)
-            if not not_incident_alert_ids:
-                logger.warning(
-                    f"Some alerts {has_incident_alert_ids} are already associated with an incident. "
-                    "They will not be included in the new incident."
-                )
-                return Response(
-                    {
-                        "detail": "Some alerts are already associated with an incident and will not be included."
-                    },
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
+
+        has_incident_alert_ids = list(
+            Alert.objects.filter(
+                id__in=alert_ids, incident__isnull=False
+            ).values_list("id", flat=True)
+        )
+        not_incident_alert_ids = set(alert_ids) - set(has_incident_alert_ids)
+        data["alert"] = list(not_incident_alert_ids)
+        if not not_incident_alert_ids:
+            logger.warning(
+                f"Some alerts {has_incident_alert_ids} are already associated with an incident. "
+                "They will not be included in the new incident."
+            )
+            return Response(
+                {
+                    "detail": "Some alerts are already associated with an incident and will not be included."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         if not data["operator"]:
             data["operator"] = self.request.user.username
 
@@ -117,6 +134,14 @@ class IncidentModelViewSet(ModelViewSet):
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
         instance = self.get_object()
+        if "alert" in request.data:
+            requested_alert_ids = set(request.data.get("alert", []))
+            unauthorized_alert_ids = requested_alert_ids - self._get_allowed_alert_ids()
+            if unauthorized_alert_ids:
+                return Response(
+                    {"detail": "Some alerts are out of your authorized scope."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)

--- a/server/apps/alerts/views/incident.py
+++ b/server/apps/alerts/views/incident.py
@@ -13,6 +13,10 @@ from apps.alerts.models.models import Alert, Incident
 from apps.alerts.models.operator_log import OperatorLog
 from apps.alerts.serializers import IncidentModelSerializer
 from apps.alerts.service.incident_operator import IncidentOperator
+from apps.alerts.utils.permission_scope import (
+    filter_alert_queryset_for_request,
+    filter_incident_queryset_for_request,
+)
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.logger import alert_logger as logger
 from apps.core.utils.web_utils import WebUtils
@@ -36,11 +40,25 @@ class IncidentModelViewSet(ModelViewSet):
         queryset = Incident.objects.annotate(
             alert_count=Count("alert")
         ).prefetch_related("alert")
-        return queryset
+        request = getattr(self, "request", None)
+        if request is None:
+            return queryset
+        return filter_incident_queryset_for_request(queryset, request)
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        request = context.get("request")
+        if request is not None:
+            context["allowed_alert_queryset"] = filter_alert_queryset_for_request(Alert.objects.all(), request)
+        return context
 
     @HasPermission("Incidents-View")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    @HasPermission("Incidents-View")
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
 
     @HasPermission("Alarms-Edit")
     @transaction.atomic
@@ -120,6 +138,11 @@ class IncidentModelViewSet(ModelViewSet):
 
         return Response(serializer.data)
 
+    @HasPermission("Incidents-Edit")
+    @transaction.atomic
+    def partial_update(self, request, *args, **kwargs):
+        return self.update(request, *args, partial=True, **kwargs)
+
     @HasPermission("Incidents-Delete")
     @transaction.atomic
     def destroy(self, request, *args, **kwargs):
@@ -156,8 +179,16 @@ class IncidentModelViewSet(ModelViewSet):
         operator = IncidentOperator(user=self.request.user.username)
         result_list = {}
         status_list = []
+        allowed_incident_ids = set(
+            self.filter_queryset(self.get_queryset()).filter(incident_id__in=incident_id_list).values_list("incident_id", flat=True)
+        )
 
         for incident_id in incident_id_list:
+            if incident_id not in allowed_incident_ids:
+                result = {"result": False, "message": "您没有权限操作此事故", "data": {}}
+                result_list[incident_id] = result
+                status_list.append(False)
+                continue
             result = operator.operate(
                 action=operator_action, incident_id=incident_id, data=request.data
             )

--- a/server/apps/alerts/views/operator_log.py
+++ b/server/apps/alerts/views/operator_log.py
@@ -2,6 +2,7 @@
 from apps.alerts.filters import OperatorLogModelFilter
 from apps.alerts.models.operator_log import OperatorLog
 from apps.alerts.serializers import OperatorLogModelSerializer
+from apps.alerts.utils.permission_scope import filter_operator_log_queryset_for_request
 from apps.core.decorators.api_permission import HasPermission
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
@@ -18,6 +19,16 @@ class SystemLogModelViewSet(ModelViewSet):
     ordering = ["-created_at"]
     pagination_class = CustomPageNumberPagination
 
+    def get_queryset(self):
+        request = getattr(self, "request", None)
+        if request is None:
+            return OperatorLog.objects.all()
+        return filter_operator_log_queryset_for_request(OperatorLog.objects.all(), request)
+
     @HasPermission("operation_log-View")
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    @HasPermission("operation_log-View")
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)


### PR DESCRIPTION
## 问题本质
Alert / Incident 的权限只停留在功能权限层，没有把处理人和组织范围持续下推到详情、事故创建、原始事件、处置记录等旁路查询，导致范围外资源仍可被读取或关联。

## 业务影响
拥有告警模块权限但不属于目标处理人或组织的用户，仍可能通过详情、关联 Incident、Event、OperatorLog 等接口看到跨组织告警内容和处置痕迹。

## 本次处理
- 统一收敛 Alert / Incident 的资源范围计算，按处理人或授权组织裁剪 queryset
- 为 Alert / Incident 的 retrieve、operator、Incident create/update 增加范围校验
- 为 Event / OperatorLog 旁路读取补齐同一套范围过滤
- 补充回归测试覆盖列表、详情、Incident 关联、事件旁路、处置记录旁路

## 验证方式
- `python3 -m py_compile server/apps/alerts/utils/permission_scope.py server/apps/alerts/views/incident.py server/apps/alerts/views/event.py server/apps/alerts/views/operator_log.py server/apps/alerts/test/test_alert_incident_permissions.py`
- `INSTALL_APPS="system_mgmt,alerts" ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=":memory:" SECRET_KEY=weops-lite DJANGO_SETTINGS_MODULE=settings PYTHONPATH=. uv run --extra dev pytest apps/alerts/test/test_alert_incident_permissions.py -q --nomigrations --confcutdir=apps/alerts/test -o addopts=""`
