### PR TITLE
[alert] 修复无效匹配规则退化为全量告警的风险

### DIFF
--- a/server/apps/alerts/aggregation/strategy/matcher.py
+++ b/server/apps/alerts/aggregation/strategy/matcher.py
@@ -82,6 +82,9 @@ class StrategyMatcher:
 
         try:
             q_filter = StrategyMatcher._build_q_filter(match_rules)
+            if q_filter is None:
+                logger.warning("match_rules 非空但没有有效条件，返回空结果集")
+                return events_queryset.none()
 
             logger.debug(f"match_rules过滤: {len(match_rules)}组条件, 首组示例: {match_rules[0][:2] if match_rules and match_rules[0] else 'empty'}")
 
@@ -94,7 +97,7 @@ class StrategyMatcher:
             return events_queryset.none()
 
     @staticmethod
-    def _build_q_filter(match_rules: List[List[Dict]]) -> Q:
+    def _build_q_filter(match_rules: List[List[Dict]]) -> Optional[Q]:
         """
         构建Django Q对象
 
@@ -102,7 +105,7 @@ class StrategyMatcher:
         内层列表: AND 关系
 
         Returns:
-            Q对象，如果所有条件都无效则返回空Q()（匹配所有）
+            Q对象；如果规则非空但所有条件都无效，则返回None
         """
         or_conditions = []
 
@@ -126,10 +129,11 @@ class StrategyMatcher:
                     combined_and &= q
                 or_conditions.append(combined_and)
 
-        # 如果没有任何有效的OR条件组，返回空Q()（匹配所有记录）
+        # 如果没有任何有效的OR条件组，说明规则非空但全部无效。
+        # 这类配置不能退化成“匹配全部”，否则会把局部策略放大成全局策略。
         if not or_conditions:
-            logger.warning("所有match_rules条件都无效，返回空过滤器")
-            return Q()
+            logger.warning("所有match_rules条件都无效")
+            return None
 
         # 将多个OR条件组合并
         final_q = or_conditions[0]

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -11,6 +11,7 @@ from apps.alerts.aggregation.builder.synthetic_alert_builder import (
     SyntheticAlertBuilder,
 )
 from apps.alerts.aggregation.processor.aggregation_processor import AggregationProcessor
+from apps.alerts.aggregation.strategy.matcher import StrategyMatcher
 from apps.alerts.constants import (
     AlertStatus,
     AlarmStrategyType,
@@ -429,6 +430,40 @@ class MissingDetectionProcessorTestCase(TestCase):
             strategy.params["last_heartbeat_time"],
             Event.objects.get(event_id="EVENT-RECOVERY").received_at.isoformat(),
         )
+
+
+class StrategyMatcherTestCase(TestCase):
+    def setUp(self):
+        self.source = AlertSource.objects.create(
+            name="matcher-source",
+            source_id="matcher-source",
+            source_type=AlertsSourceTypes.WEBHOOK,
+        )
+        Event.objects.create(
+            source=self.source,
+            raw_data={},
+            title="cpu high",
+            description="cpu high",
+            level="1",
+            start_time=timezone.now(),
+            event_id="EVENT-strategy-matcher",
+        )
+
+    def test_invalid_in_rule_does_not_match_all_events(self):
+        matched = StrategyMatcher.match_events_to_strategy(
+            Event.objects.all(),
+            [[{"key": "title", "operator": "in", "value": "cpu high"}]],
+        )
+
+        self.assertFalse(matched.exists())
+
+    def test_invalid_regex_rule_does_not_match_all_events(self):
+        matched = StrategyMatcher.match_events_to_strategy(
+            Event.objects.all(),
+            [[{"key": "title", "operator": "regex", "value": "["}]],
+        )
+
+        self.assertFalse(matched.exists())
 
 
 class AlertSourceIngressTestCase(TestCase):


### PR DESCRIPTION
## 问题本质
告警聚合/缺失检测共用的策略匹配器在 `match_rules` 非空但条件全部无效时，会退化成空 `Q()`，最终把本应局部生效的策略放大成匹配全部事件。

## 业务影响
一旦策略里混入坏正则、错误的 `in/not_in` 参数或其他无效条件，策略扫描就可能误命中全量事件，造成误告警、重复告警，甚至把缺失检测放大成全局心跳告警。

## 本次处理
- 将“非空但全无效规则”改为返回空结果集，不再退化成全量匹配。
- 补充回归测试，覆盖坏正则和错误 `in` 参数类型两类失效规则。

## 验证方式
- `python3 -m py_compile server/apps/alerts/aggregation/strategy/matcher.py server/apps/alerts/test/tests.py`
- `uv run python` 最小脚本验证：空规则保持不过滤；坏正则和错误 `in` 参数都会返回空结果，而不是匹配全部。
