### PR TITLE
[ops-analysis] 修复数据代理权限失守与下游失败假成功风险

### DIFF
--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -38,10 +38,16 @@ class GetNatsData:
         :return:
         """
         username = self.request.user.username
-        team = int(self.request.COOKIES.get("current_team"))
+        try:
+            team = int(self.request.COOKIES.get("current_team"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("缺少合法的 current_team 上下文") from exc
+
+        include_children = self.request.COOKIES.get("include_children", "0") == "1"
         self.params[self.user_param_key] = {
             "team": team,
-            "user": username
+            "user": username,
+            "include_children": include_children,
         }
 
     def set_namespace_servers(self):
@@ -119,4 +125,4 @@ class GetNatsData:
             import traceback
 
             logger.error("==获取NATS数据源数据失败==: namespace={} error={}".format(namespace.name, traceback.format_exc()))
-            return []
+            raise RuntimeError(f"获取数据源数据失败: {namespace.name}") from e

--- a/server/apps/operation_analysis/tests.py
+++ b/server/apps/operation_analysis/tests.py
@@ -2,3 +2,83 @@
 # @File: tests.py
 # @Time: 2025/7/14 16:35
 # @Author: windyzhao
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from apps.operation_analysis.common.get_nats_source_data import GetNatsData
+from apps.operation_analysis.views.datasource_view import DataSourceAPIModelViewSet
+
+
+def _make_request(data=None, current_team="1", include_children="0"):
+    return SimpleNamespace(
+        user=SimpleNamespace(
+            username="alice",
+            domain="default",
+            is_superuser=False,
+            permission={"ops-analysis": {"data_source-View"}},
+        ),
+        data=data or {},
+        COOKIES={"current_team": current_team, "include_children": include_children},
+    )
+
+
+def _make_instance():
+    return SimpleNamespace(
+        id=1,
+        groups=[1],
+        rest_api="monitor/query_monitor_alert_segments",
+        namespaces=SimpleNamespace(all=lambda: [SimpleNamespace(id=11, name="ns-1", namespace="bklite", enable_tls=False, account="u", decrypt_password="p", domain="nats.local:4222")]),
+    )
+
+
+def test_get_source_data_requires_instance_permission(monkeypatch):
+    view = DataSourceAPIModelViewSet()
+    view.loader = None
+    instance = _make_instance()
+    request = _make_request()
+
+    monkeypatch.setattr(view, "get_object", Mock(return_value=instance))
+    monkeypatch.setattr(view, "get_has_permission", Mock(return_value=False))
+    get_data_mock = Mock()
+    monkeypatch.setattr("apps.operation_analysis.views.datasource_view.GetNatsData", Mock(return_value=SimpleNamespace(get_data=get_data_mock)))
+
+    response = view.get_source_data(request, pk="1")
+
+    assert response.status_code == 403
+    get_data_mock.assert_not_called()
+
+
+def test_get_source_data_returns_bad_gateway_on_nats_failure(monkeypatch):
+    view = DataSourceAPIModelViewSet()
+    view.loader = None
+    instance = _make_instance()
+    request = _make_request()
+
+    monkeypatch.setattr(view, "get_object", Mock(return_value=instance))
+    monkeypatch.setattr(view, "get_has_permission", Mock(return_value=True))
+    monkeypatch.setattr(
+        "apps.operation_analysis.views.datasource_view.GetNatsData",
+        Mock(return_value=SimpleNamespace(get_data=Mock(side_effect=RuntimeError("timeout")))),
+    )
+
+    response = view.get_source_data(request, pk="1")
+
+    assert response.status_code == 502
+    assert response.data["detail"] == "获取数据源数据失败，请稍后重试"
+
+
+def test_get_nats_data_forwards_include_children_flag():
+    request = _make_request(include_children="1")
+    client = GetNatsData(
+        namespace="monitor",
+        path="query_monitor_alert_segments",
+        params={},
+        namespace_list=[],
+        request=request,
+    )
+
+    assert client.params["user_info"] == {
+        "team": 1,
+        "user": "alice",
+        "include_children": True,
+    }

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -4,6 +4,7 @@
 # @Author: windyzhao
 from rest_framework.decorators import action
 from rest_framework.response import Response
+from rest_framework import status
 
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.viewset_utils import AuthViewSet
@@ -75,9 +76,28 @@ class DataSourceAPIModelViewSet(AuthViewSet):
     permission_key = "datasource"
     ORGANIZATION_FIELD = "groups"  # 使用 groups 字段作为组织字段
 
+    def _ensure_view_permission(self, request, instance):
+        user = getattr(request, "user", None)
+        if getattr(user, "is_superuser", False):
+            return None
+
+        current_team = request.COOKIES.get("current_team", "0")
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        has_permission = self.get_has_permission(user, instance, current_team, is_check=True, include_children=include_children)
+        if has_permission:
+            return None
+
+        message = self.loader.get("error.no_permission_view") if self.loader else "User does not have permission to view this instance"
+        return self.value_error(message)
+
+    @HasPermission("data_source-View")
     @action(detail=False, methods=["post"], url_path=r"get_source_data/(?P<pk>[^/.]+)")
     def get_source_data(self, request, *args, **kwargs):
         instance = self.get_object()
+        permission_response = self._ensure_view_permission(request, instance)
+        if permission_response is not None:
+            return permission_response
+
         params = dict(request.data)
         namespace_list = instance.namespaces.all()
         if "/" not in instance.rest_api:
@@ -88,9 +108,12 @@ class DataSourceAPIModelViewSet(AuthViewSet):
         client = GetNatsData(namespace=namespace, path=path, params=params, namespace_list=namespace_list, request=request)
         try:
             result = client.get_data()
+        except ValueError as e:
+            logger.error("获取数据源数据参数非法: {}".format(e))
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             logger.error("获取数据源数据失败: {}".format(e))
-            result = []
+            return Response({"detail": "获取数据源数据失败，请稍后重试"}, status=status.HTTP_502_BAD_GATEWAY)
 
         return Response(result)
 


### PR DESCRIPTION
## 问题本质
- 运营分析真实取数入口 `get_source_data` 未执行数据源实例级权限校验，知道数据源 ID 即可越过组织范围直接触发下游查询。
- 数据代理未透传 `include_children`，且下游 NATS/业务服务异常会被吞成空数组，前端会把失败误判成无数据。

## 业务影响
- 可能造成跨组织数据源被直接调用，扩大运营分析查询权限边界。
- 可能把下游超时或报错展示成正常空图表，同时丢失子组织范围数据，导致分析结果失真且难排障。

## 本次处理
- 为 `get_source_data` 补上对象级查看权限校验。
- 将 `include_children` 纳入下游 `user_info` 权限上下文。
- 将 NATS/代理失败从空数据降级改为明确错误响应，避免假成功。
- 增加对应回归测试用例。

## 验证方式
- `python3 -m py_compile server/apps/operation_analysis/common/get_nats_source_data.py server/apps/operation_analysis/views/datasource_view.py server/apps/operation_analysis/tests.py`
- `git diff --check`
- `uv run --extra dev --extra mlops python -m pytest -c /dev/null apps/operation_analysis/tests.py -q` 由于仓库现有 Django 测试基线装载 `django_celery_beat` 时失败，未能完成
