### PR TITLE
[ops-analysis] 修复同参组件重复查询导致的运行时数据放大风险

### DIFF
--- a/web/scripts/ops-analysis-request-dedup-test.ts
+++ b/web/scripts/ops-analysis-request-dedup-test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+
+import {
+  buildRequestDedupKey,
+  dedupeInFlightRequest,
+} from '../src/app/ops-analysis/api/requestDedup';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const keyA = buildRequestDedupKey(7, {
+    page: 1,
+    filters: {
+      keyword: 'cpu',
+      time_range: ['2026-05-07 00:00:00', '2026-05-07 01:00:00'],
+    },
+  });
+  const keyB = buildRequestDedupKey(7, {
+    filters: {
+      time_range: ['2026-05-07 00:00:00', '2026-05-07 01:00:00'],
+      keyword: 'cpu',
+    },
+    page: 1,
+  });
+  assert.equal(keyA, keyB, '相同参数不同键顺序必须命中同一个去重 key');
+
+  let requestCount = 0;
+  const factory = async () => {
+    requestCount += 1;
+    await sleep(20);
+    return { ok: true, requestCount };
+  };
+
+  const [resultA, resultB] = await Promise.all([
+    dedupeInFlightRequest(keyA, factory),
+    dedupeInFlightRequest(keyB, factory),
+  ]);
+  assert.equal(requestCount, 1, '并发相同请求只应下发一次');
+  assert.deepEqual(resultA, resultB, '并发去重后的结果必须一致');
+
+  await dedupeInFlightRequest(keyA, factory);
+  assert.equal(requestCount, 2, '请求完成后不应缓存结果，后续刷新应重新下发');
+}
+
+void main();

--- a/web/src/app/ops-analysis/api/dataSource.ts
+++ b/web/src/app/ops-analysis/api/dataSource.ts
@@ -1,4 +1,5 @@
 import useApiClient from '@/utils/request';
+import { buildRequestDedupKey, dedupeInFlightRequest } from './requestDedup';
 
 export const useDataSourceApi = () => {
   const { get, post, put, del } = useApiClient();
@@ -24,8 +25,11 @@ export const useDataSourceApi = () => {
   };
 
   const getSourceDataByApiId = async (id: number, params?: any) => {
-    return post(`/operation_analysis/api/data_source/get_source_data/${id}/`, params);
-  }
+    const dedupKey = buildRequestDedupKey(id, params);
+    return dedupeInFlightRequest(dedupKey, () =>
+      post(`/operation_analysis/api/data_source/get_source_data/${id}/`, params),
+    );
+  };
 
   return {
     getDataSourceList,

--- a/web/src/app/ops-analysis/api/requestDedup.ts
+++ b/web/src/app/ops-analysis/api/requestDedup.ts
@@ -1,0 +1,43 @@
+const inflightRequests = new Map<string, Promise<unknown>>();
+
+const sortValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortValue((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+
+  return value;
+};
+
+export const buildRequestDedupKey = (
+  dataSourceId: number,
+  params?: Record<string, unknown>,
+): string => {
+  const normalizedParams = params ? JSON.stringify(sortValue(params)) : '{}';
+  return `${dataSourceId}:${normalizedParams}`;
+};
+
+export const dedupeInFlightRequest = async <T>(
+  key: string,
+  requestFactory: () => Promise<T>,
+): Promise<T> => {
+  const existingRequest = inflightRequests.get(key);
+  if (existingRequest) {
+    return existingRequest as Promise<T>;
+  }
+
+  const request = requestFactory().finally(() => {
+    inflightRequests.delete(key);
+  });
+
+  inflightRequests.set(key, request);
+  return request;
+};


### PR DESCRIPTION
## 问题本质
运营分析仪表盘和拓扑图会把每个组件/节点都作为独立运行时查询入口。相同数据源、相同筛选条件的请求在同一次页面刷新中不会复用，导致前端并发重复打到 `get_source_data`，再继续放大到 Django 代理层和 NATS 下游服务。

## 业务影响
- 同一页面存在多个同参组件时，会重复触发相同的运行时查询
- 高频刷新、大屏场景和拓扑图批量刷新会把重复请求进一步放大
- 下游 Monitor / Log / Alert / CMDB 数据服务会承受不必要的重复压力，页面长尾也会被拉长

## 本次处理
- 在 `web/src/app/ops-analysis/api/requestDedup.ts` 新增仅针对并发中的同参请求去重逻辑
- `getSourceDataByApiId` 按 `dataSource + 规范化参数` 生成 key，共享同一批次中的 in-flight Promise
- 请求完成后立即清理，不缓存结果，避免把旧的运行时数据复用到后续刷新
- 新增脚本验证相同参数不同键顺序仍能命中同一个去重 key，且请求完成后可正常重新发起

## 验证方式
- `cd web && pnpm exec eslint src/app/ops-analysis/api/dataSource.ts src/app/ops-analysis/api/requestDedup.ts --ext .ts`
- `cd web && pnpm exec tsx scripts/ops-analysis-request-dedup-test.ts`

## 备注
- `pnpm run type-check` 当前失败于仓库现有前端依赖/配置问题（包括缺失 `tsconfig.lint.json` 和多处既有模块缺失），与本次改动无关，因此未作为阻塞项处理。
