### PR TITLE
[ops-analysis] 收紧数据源运行时校验，降低越权查询与假成功风险

### DIFF
--- a/docs/reviews/ops-analysis-namespace-governance-review-2026-05-07.md
+++ b/docs/reviews/ops-analysis-namespace-governance-review-2026-05-07.md
@@ -1,0 +1,29 @@
+# 运营分析 NameSpace 全局化治理债务
+
+## 问题本质
+
+当前运营分析的 `NameSpace` 已经退化成“全局共享的 NATS 凭据与路由对象”，不再带组织边界。任何拥有 `namespace-*` 菜单权限的用户，看到和修改的都是同一张全局表；导入导出链路也按全局名称解析依赖，而不是按组织范围解析。这意味着数据源虽然有 `groups` 字段，但其下游实际使用的 NATS 连接并不受组织约束。
+
+## 仓库证据
+
+- [`server/apps/operation_analysis/migrations/0010_remove_namespace_groups.py`](/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server/apps/operation_analysis/migrations/0010_remove_namespace_groups.py) 直接删除了 `NameSpace.groups`。
+- [`server/apps/operation_analysis/models/datasource_models.py`](/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server/apps/operation_analysis/models/datasource_models.py) 中 `NameSpace` 只剩 `name/account/password/domain/namespace` 等连接字段，没有任何组织字段。
+- [`server/apps/operation_analysis/views/datasource_view.py`](/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server/apps/operation_analysis/views/datasource_view.py) 的 `NameSpaceModelViewSet` 直接基于 `NameSpace.objects.all()` 暴露列表、详情、增删改，没有走 `AuthViewSet` 的实例/组织过滤。
+- [`server/apps/operation_analysis/services/import_export/precheck_service.py`](/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server/apps/operation_analysis/services/import_export/precheck_service.py) 中 `_check_group_permission()` 对没有 `groups` 字段的对象直接返回 `True`，导致命名空间冲突和覆盖天然按“全局可见”处理。
+- [`server/apps/operation_analysis/services/import_export/export_service.py`](/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server/apps/operation_analysis/services/import_export/export_service.py) 导出命名空间时直接 `NameSpace.objects.get/filter(...)`，并把 `account/password/domain` 打包进 YAML；一旦某组织导出的数据源依赖了共享命名空间，就会把全局连接配置一并带出。
+
+## 影响范围
+
+- 不同组织的数据源会复用同一批 `NameSpace` 记录，绑定关系无法表达“这个 NATS 连接只允许被哪个组织使用”。
+- 命名空间重名冲突、导入覆盖和 YAML 依赖解析都是全局语义，容易把一个组织的数据源误绑定到另一个组织维护的连接配置。
+- 导出数据源时会连带导出其引用的 `NameSpace` 凭据配置，扩大跨组织泄露风险。
+
+## 为什么暂不直接修复
+
+这不是单点补丁问题。要真正收敛风险，至少需要同时恢复 `NameSpace.groups`、补历史数据迁移、把 `NameSpace` 视图切到组织权限模型、重写导入导出冲突判定与依赖解析规则，并补上现有全局数据的归属修复策略。单轮内直接回滚这套模型，风险会高于本次 runtime 口子的最小修复。
+
+## 建议后续处理
+
+1. 恢复 `NameSpace.groups`，并把 `NameSpace` 全量切回组织作用域对象。
+2. 导入导出链路改为“同组织内按业务键解析”，不再用全局 `name` 直接命中。
+3. 为已有全局 `NameSpace` 制定一次性归属迁移方案，再开放后续编辑与覆盖。

--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -4,6 +4,7 @@
 # @Author: windyzhao
 from apps.operation_analysis.nats.nats_client import DefaultNastClient
 from apps.core.logger import operation_analysis_logger as logger
+from rest_framework.exceptions import ValidationError
 
 
 class GetNatsData:
@@ -81,12 +82,13 @@ class GetNatsData:
             try:
                 namespace_id = int(namespace_id)
             except (TypeError, ValueError):
-                namespace_id = None
+                raise ValidationError("namespace_id 非法")
 
         if namespace_id is not None:
             for ns in self.namespace_list:
                 if ns.id == namespace_id:
                     return ns
+            raise ValidationError("所选命名空间未绑定到当前数据源")
 
         # 未指定或未匹配到，返回第一个
         return self.namespace_list[0] if self.namespace_list else None
@@ -97,11 +99,11 @@ class GetNatsData:
         """
         namespace = self._get_target_namespace()
         if namespace is None:
-            return []
+            raise ValidationError("当前数据源没有可用命名空间")
 
         server_url = self.namespace_server_map.get(namespace.id)
         if not server_url:
-            return []
+            raise ValidationError("命名空间连接配置不完整")
 
         nats_namespace = getattr(namespace, "namespace", "bk_lite")
         nats_client = self._get_client(server=server_url, namespace=nats_namespace)
@@ -119,4 +121,4 @@ class GetNatsData:
             import traceback
 
             logger.error("==获取NATS数据源数据失败==: namespace={} error={}".format(namespace.name, traceback.format_exc()))
-            return []
+            raise RuntimeError("获取NATS数据源数据失败") from e

--- a/server/apps/operation_analysis/common/runtime_params.py
+++ b/server/apps/operation_analysis/common/runtime_params.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from rest_framework.exceptions import ValidationError
+
+
+RUNTIME_EXTRA_PARAM_NAMES = {"namespace_id", "page", "page_size", "query_list"}
+
+
+def _format_datetime(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise ValidationError("时间参数格式不合法")
+
+
+def _normalize_time_range(value: Any) -> list[str]:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        end_time = datetime.now()
+        start_time = end_time - timedelta(minutes=int(value))
+        return [_format_datetime(start_time), _format_datetime(end_time)]
+
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return [_format_datetime(value[0]), _format_datetime(value[1])]
+
+    if isinstance(value, dict):
+        select_value = value.get("selectValue")
+        if isinstance(select_value, (int, float)) and not isinstance(select_value, bool) and select_value > 0:
+            end_time = datetime.now()
+            start_time = end_time - timedelta(minutes=int(select_value))
+            return [_format_datetime(start_time), _format_datetime(end_time)]
+        start = value.get("start")
+        end = value.get("end")
+        if start and end:
+            return [_format_datetime(start), _format_datetime(end)]
+
+    raise ValidationError("timeRange 参数格式不合法")
+
+
+def _normalize_query_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        raise ValidationError("query_list 必须为数组")
+
+    normalized = []
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValidationError(f"query_list[{index}] 必须为对象")
+        field = item.get("field")
+        query_type = item.get("type")
+        if not isinstance(field, str) or not field.strip():
+            raise ValidationError(f"query_list[{index}].field 不能为空")
+        if not isinstance(query_type, str) or not query_type.strip():
+            raise ValidationError(f"query_list[{index}].type 不能为空")
+        normalized_item = {"field": field.strip(), "type": query_type.strip()}
+        if "value" in item:
+            if not isinstance(item["value"], str):
+                raise ValidationError(f"query_list[{index}].value 必须为字符串")
+            normalized_item["value"] = item["value"].strip()
+        if "start" in item:
+            normalized_item["start"] = _format_datetime(item["start"])
+        if "end" in item:
+            normalized_item["end"] = _format_datetime(item["end"])
+        normalized.append(normalized_item)
+    return normalized
+
+
+def _normalize_positive_int(name: str, value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValidationError(f"{name} 必须为正整数")
+    if parsed <= 0:
+        raise ValidationError(f"{name} 必须为正整数")
+    return parsed
+
+
+def _normalize_param_value(param_type: str, value: Any) -> Any:
+    if param_type == "string":
+        if isinstance(value, str):
+            return value
+        raise ValidationError("string 参数必须为字符串")
+
+    if param_type == "number":
+        if isinstance(value, bool):
+            raise ValidationError("number 参数必须为数字")
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(value, str):
+            try:
+                number = Decimal(value)
+            except InvalidOperation:
+                raise ValidationError("number 参数必须为数字")
+            return float(number) if "." in value else int(number)
+        raise ValidationError("number 参数必须为数字")
+
+    if param_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        raise ValidationError("boolean 参数必须为布尔值")
+
+    if param_type == "date":
+        return _format_datetime(value)
+
+    if param_type == "timeRange":
+        return _normalize_time_range(value)
+
+    return value
+
+
+def build_runtime_params(param_schema: Any, raw_params: Any) -> dict[str, Any]:
+    schema_items = param_schema if isinstance(param_schema, list) else []
+    request_params = dict(raw_params or {})
+
+    allowed_param_names = {
+        item.get("name")
+        for item in schema_items
+        if isinstance(item, dict) and isinstance(item.get("name"), str) and item.get("name").strip()
+    }
+    unknown_keys = set(request_params) - allowed_param_names - RUNTIME_EXTRA_PARAM_NAMES
+    if unknown_keys:
+        keys = ", ".join(sorted(str(key) for key in unknown_keys))
+        raise ValidationError(f"存在未声明的数据源参数: {keys}")
+
+    normalized: dict[str, Any] = {}
+    for item in schema_items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        name = name.strip()
+        param_type = item.get("type") or "string"
+        filter_type = item.get("filterType") or "fixed"
+        default_value = item.get("value")
+        has_input = name in request_params
+
+        if filter_type == "fixed":
+            if has_input and request_params[name] != default_value:
+                raise ValidationError(f"固定参数 {name} 不允许被覆盖")
+            if default_value not in (None, ""):
+                normalized[name] = _normalize_param_value(param_type, default_value)
+            continue
+
+        if has_input:
+            normalized[name] = _normalize_param_value(param_type, request_params[name])
+            continue
+
+        if default_value not in (None, ""):
+            normalized[name] = _normalize_param_value(param_type, default_value)
+
+    if "namespace_id" in request_params:
+        normalized["namespace_id"] = _normalize_positive_int("namespace_id", request_params["namespace_id"])
+    if "page" in request_params:
+        normalized["page"] = _normalize_positive_int("page", request_params["page"])
+    if "page_size" in request_params:
+        normalized["page_size"] = _normalize_positive_int("page_size", request_params["page_size"])
+    if "query_list" in request_params:
+        normalized["query_list"] = _normalize_query_list(request_params["query_list"])
+
+    return normalized

--- a/server/apps/operation_analysis/tests/test_datasource_runtime.py
+++ b/server/apps/operation_analysis/tests/test_datasource_runtime.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.exceptions import PermissionDenied, ValidationError
+
+from apps.operation_analysis.common.runtime_params import build_runtime_params
+from apps.operation_analysis.views.datasource_view import DataSourceAPIModelViewSet
+
+
+def test_build_runtime_params_rejects_unknown_keys():
+    with pytest.raises(ValidationError):
+        build_runtime_params(
+            [{"name": "query", "type": "string", "filterType": "params", "value": ""}],
+            {"query": "cpu", "unexpected": "boom"},
+        )
+
+
+def test_build_runtime_params_uses_fixed_defaults_and_runtime_extras():
+    params = build_runtime_params(
+        [
+            {"name": "query", "type": "string", "filterType": "params", "value": ""},
+            {"name": "time_range", "type": "timeRange", "filterType": "fixed", "value": 15},
+            {"name": "step", "type": "string", "filterType": "fixed", "value": "5m"},
+        ],
+        {
+            "query": "avg(cpu_usage)",
+            "page": 2,
+            "page_size": 20,
+            "query_list": [{"field": "host", "type": "str*", "value": "db"}],
+        },
+    )
+
+    assert params["query"] == "avg(cpu_usage)"
+    assert params["step"] == "5m"
+    assert params["page"] == 2
+    assert params["page_size"] == 20
+    assert params["query_list"] == [{"field": "host", "type": "str*", "value": "db"}]
+    assert len(params["time_range"]) == 2
+
+
+def test_get_source_data_rejects_unauthorized_instance_access():
+    view = DataSourceAPIModelViewSet()
+    request = SimpleNamespace(
+        user=SimpleNamespace(is_superuser=False),
+        COOKIES={"current_team": "2", "include_children": "0"},
+    )
+    view.request = request
+    view.get_object = lambda: SimpleNamespace(id=3)
+    view.get_has_permission = lambda user, instance, current_team, is_check=False, include_children=False: False
+
+    with pytest.raises(PermissionDenied):
+        view._ensure_source_access(request, view.get_object())

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -3,11 +3,13 @@
 # @Time: 2025/11/3 15:48
 # @Author: windyzhao
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.operation_analysis.common.get_nats_source_data import GetNatsData
+from apps.operation_analysis.common.runtime_params import build_runtime_params
 from apps.operation_analysis.filters.datasource_filters import DataSourceAPIModelFilter, NameSpaceModelFilter, \
     DataSourceTagModelFilter
 from apps.operation_analysis.serializers.datasource_serializers import DataSourceAPIModelSerializer, \
@@ -15,7 +17,6 @@ from apps.operation_analysis.serializers.datasource_serializers import DataSourc
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace, DataSourceTag
-from apps.core.logger import operation_analysis_logger as logger
 
 
 class DataSourceTagModelViewSet(ModelViewSet):
@@ -75,23 +76,36 @@ class DataSourceAPIModelViewSet(AuthViewSet):
     permission_key = "datasource"
     ORGANIZATION_FIELD = "groups"  # 使用 groups 字段作为组织字段
 
+    def _ensure_source_access(self, request, instance):
+        user = getattr(request, "user", None)
+        if getattr(user, "is_superuser", False):
+            return
+        current_team = request.COOKIES.get("current_team", "0")
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        has_permission = self.get_has_permission(user, instance, current_team, is_check=True, include_children=include_children)
+        if not has_permission:
+            raise PermissionDenied("User does not have permission to view this data source")
+
     @action(detail=False, methods=["post"], url_path=r"get_source_data/(?P<pk>[^/.]+)")
+    @HasPermission("data_source-View")
     def get_source_data(self, request, *args, **kwargs):
         instance = self.get_object()
-        params = dict(request.data)
-        namespace_list = instance.namespaces.all()
+        self._ensure_source_access(request, instance)
+        if not instance.is_active:
+            raise ValidationError("当前数据源已停用")
+
+        params = build_runtime_params(instance.params, request.data)
+        namespace_list = list(instance.namespaces.filter(is_active=True))
+        if not namespace_list:
+            raise ValidationError("当前数据源未绑定启用中的命名空间")
+
         if "/" not in instance.rest_api:
             namespace = "default"
             path = instance.rest_api
         else:
             namespace, path = instance.rest_api.split("/", 1)
         client = GetNatsData(namespace=namespace, path=path, params=params, namespace_list=namespace_list, request=request)
-        try:
-            result = client.get_data()
-        except Exception as e:
-            logger.error("获取数据源数据失败: {}".format(e))
-            result = []
-
+        result = client.get_data()
         return Response(result)
 
     @HasPermission("data_source-View")


### PR DESCRIPTION
## 问题本质
- 运营分析数据源运行时查询接口没有补实例级权限校验，拿到数据源 ID 即可直接触发查询。
- 后端没有按 `DataSourceAPI.params` 对运行时参数做白名单和类型校验，前端提交的未声明参数会直接进入 NATS 请求。
- 运行时链路对无效命名空间、停用配置和下游失败会吞错回空，前端容易看到“成功但没数据”的假成功。

## 业务影响
- 会放大跨组织误查、越权触发数据源查询和参数污染风险。
- 配置停用、命名空间解绑或下游异常时，排障信号会被空数组掩盖。

## 本次处理
- 为 `get_source_data` 增加数据源实例级权限校验和启用态校验。
- 新增后端运行时参数构建器，只允许已声明参数和必要分页/命名空间查询参数进入 NATS 请求。
- 取消 `namespace_id` 无效时回退到默认命名空间、取消下游异常吞没，改为显式失败。
- 追加 review 文档，记录 `NameSpace` 全局化导致的跨组织治理债务，作为后续模型治理入口。

## 验证方式
- `python3 -m py_compile server/apps/operation_analysis/common/runtime_params.py server/apps/operation_analysis/common/get_nats_source_data.py server/apps/operation_analysis/views/datasource_view.py server/apps/operation_analysis/tests/test_datasource_runtime.py`
- `INSTALL_APPS=operation_analysis,system_mgmt DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite PYTHONPATH=/Users/umaru/.codex/worktrees/bklite-15-ops-analysis-review/server DJANGO_SETTINGS_MODULE=settings uv run python -m pytest apps/operation_analysis/tests/test_datasource_runtime.py -o addopts=''`
