### PR TITLE
[ops-analysis] 收紧取数与导出对象校验，阻断跨组织访问风险

### DIFF
--- a/server/apps/operation_analysis/services/access_control.py
+++ b/server/apps/operation_analysis/services/access_control.py
@@ -1,0 +1,94 @@
+from django.db.models import Q
+from rest_framework.exceptions import PermissionDenied
+
+from apps.core.utils.permission_utils import get_permission_rules
+from apps.core.utils.user_group import normalize_user_group_ids
+
+
+def _extract_child_group_ids(group_tree, current_team_id):
+    group_ids = []
+
+    def extract_ids(groups, target_id):
+        for group in groups:
+            if group.get("id") == target_id:
+                group_ids.append(target_id)
+                if group.get("subGroups"):
+                    extract_subgroups(group["subGroups"])
+                return True
+            if group.get("subGroups") and extract_ids(group["subGroups"], target_id):
+                return True
+        return False
+
+    def extract_subgroups(subgroups):
+        for subgroup in subgroups:
+            group_ids.append(subgroup.get("id"))
+            if subgroup.get("subGroups"):
+                extract_subgroups(subgroup["subGroups"])
+
+    extract_ids(group_tree or [], current_team_id)
+    return [group_id for group_id in group_ids if group_id is not None]
+
+
+def get_scoped_group_ids(user, current_team, include_children=False):
+    user_groups = normalize_user_group_ids(getattr(user, "group_list", []))
+    if include_children:
+        child_groups = _extract_child_group_ids(getattr(user, "group_tree", []), current_team)
+        if child_groups:
+            user_groups = child_groups
+    return user_groups
+
+
+def build_authorized_queryset(queryset, user, current_team, permission_key, include_children=False, org_field="groups"):
+    fields = [field.name for field in queryset.model._meta.fields]
+    query = Q()
+    scoped_group_ids = get_scoped_group_ids(user, current_team, include_children)
+
+    if "created_by" in fields:
+        creator_query = Q(created_by=user.username, domain=user.domain)
+        if include_children and scoped_group_ids:
+            org_query = Q()
+            for group_id in scoped_group_ids:
+                org_query |= Q(**{f"{org_field}__contains": int(group_id)})
+            query = org_query | creator_query
+        else:
+            query = Q(**{f"{org_field}__contains": current_team}) | creator_query
+    elif org_field in fields:
+        query = Q(**{f"{org_field}__contains": current_team})
+
+    permission_data = get_permission_rules(user, current_team, "operation_analysis", permission_key, include_children)
+    instance_ids = [item["id"] for item in permission_data.get("instance", [])]
+    team_ids = permission_data.get("team", [])
+
+    if not instance_ids and not team_ids:
+        return queryset.none()
+
+    if instance_ids:
+        query |= Q(id__in=instance_ids)
+    for team_id in team_ids:
+        query |= Q(**{f"{org_field}__contains": int(team_id)})
+
+    return queryset.filter(query).distinct()
+
+
+def ensure_instance_view_permission(instance, user, current_team, permission_key, include_children=False, org_field="groups"):
+    groups = getattr(instance, org_field, [])
+    if not isinstance(groups, list):
+        groups = []
+
+    scoped_group_ids = set(get_scoped_group_ids(user, current_team, include_children))
+    if groups and not set(groups).intersection(scoped_group_ids):
+        raise PermissionDenied("当前用户无权查看该对象")
+
+    permission_data = get_permission_rules(user, current_team, "operation_analysis", permission_key, include_children)
+    if int(current_team) in permission_data.get("team", []):
+        return
+
+    if include_children:
+        allowed_teams = {int(team_id) for team_id in permission_data.get("team", [])}
+        allowed_teams.add(int(current_team))
+        if scoped_group_ids & allowed_teams:
+            return
+
+    instance_ids = {int(item["id"]) for item in permission_data.get("instance", []) if "View" in item.get("permission", [])}
+    if instance.id not in instance_ids:
+        raise PermissionDenied("当前用户无权查看该对象")

--- a/server/apps/operation_analysis/tests/test_permission_guards.py
+++ b/server/apps/operation_analysis/tests/test_permission_guards.py
@@ -1,0 +1,186 @@
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.models import User
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+from apps.operation_analysis.models.models import Dashboard
+from apps.operation_analysis.views.datasource_view import DataSourceAPIModelViewSet, NameSpaceModelViewSet
+from apps.operation_analysis.views.import_export_view import ImportExportViewSet
+from apps.operation_analysis.views.openapi_import_export_view import OpenImportExportViewSet
+from apps.operation_analysis.views.view import DirectoryModelViewSet
+
+
+pytestmark = pytest.mark.django_db
+
+
+def _set_permissions(user, *permissions):
+    user.permission = {"ops-analysis": set(permissions)}
+    return user
+
+
+def _create_user(username, group_list):
+    return User.objects.create_user(
+        username=username,
+        password="testpass123",
+        domain="domain.com",
+        locale="en",
+        group_list=group_list,
+        roles=[],
+    )
+
+
+def test_get_source_data_rejects_datasource_outside_authorized_scope():
+    factory = APIRequestFactory()
+    user = _set_permissions(
+        _create_user("viewer", [{"id": 1, "name": "Team 1"}]),
+        "data_source-View",
+    )
+    namespace = NameSpace.objects.create(name="ns-1", namespace="bk", account="user", password="secret", domain="nats.example.com")
+    datasource = DataSourceAPIModel.objects.create(
+        name="ds-1",
+        rest_api="ops/query",
+        groups=[2],
+        created_by="other",
+        updated_by="other",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+    datasource.namespaces.add(namespace)
+
+    request = factory.post(f"/api/v1/operation_analysis/api/data_source/get_source_data/{datasource.id}/", {}, format="json")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    view = DataSourceAPIModelViewSet.as_view({"post": "get_source_data"})
+    with patch("apps.operation_analysis.services.access_control.get_permission_rules", return_value={"team": [], "instance": []}), patch(
+        "apps.operation_analysis.views.datasource_view.GetNatsData.get_data"
+    ) as mocked_get_data:
+        response = view(request, pk=str(datasource.id))
+
+    assert response.status_code == 403
+    mocked_get_data.assert_not_called()
+
+
+def test_namespace_list_only_returns_namespaces_bound_to_authorized_datasources():
+    factory = APIRequestFactory()
+    user = _set_permissions(
+        _create_user("viewer-list", [{"id": 1, "name": "Team 1"}]),
+        "namespace-View",
+    )
+    visible_ns = NameSpace.objects.create(name="visible-ns", namespace="bk", account="user", password="secret", domain="nats-visible.example.com")
+    hidden_ns = NameSpace.objects.create(name="hidden-ns", namespace="bk", account="user", password="secret", domain="nats-hidden.example.com")
+    visible_ds = DataSourceAPIModel.objects.create(
+        name="visible-ds",
+        rest_api="ops/visible",
+        groups=[1],
+        created_by="other",
+        updated_by="other",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+    hidden_ds = DataSourceAPIModel.objects.create(
+        name="hidden-ds",
+        rest_api="ops/hidden",
+        groups=[2],
+        created_by="other",
+        updated_by="other",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+    visible_ds.namespaces.add(visible_ns)
+    hidden_ds.namespaces.add(hidden_ns)
+
+    request = factory.get("/api/v1/operation_analysis/api/namespace/")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    view = NameSpaceModelViewSet.as_view({"get": "list"})
+    with patch(
+        "apps.operation_analysis.views.datasource_view.build_authorized_queryset",
+        return_value=DataSourceAPIModel.objects.filter(id=visible_ds.id),
+    ):
+        response = view(request)
+
+    assert response.status_code == 200
+    assert [item["name"] for item in response.data] == ["visible-ns"]
+
+
+def test_export_rejects_dashboard_ids_outside_authorized_scope():
+    factory = APIRequestFactory()
+    user = _set_permissions(
+        _create_user("viewer-export", [{"id": 1, "name": "Team 1"}]),
+        "operation_analysis-View",
+    )
+    dashboard = Dashboard.objects.create(
+        name="cross-team-dashboard",
+        groups=[2],
+        created_by="other",
+        updated_by="other",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+
+    request = factory.post(
+        "/api/v1/operation_analysis/api/import_export/export/",
+        {"object_type": "dashboard", "object_ids": [dashboard.id]},
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    view = ImportExportViewSet.as_view({"post": "export_objects"})
+    with patch("apps.operation_analysis.services.access_control.get_permission_rules", return_value={"team": [], "instance": []}), patch(
+        "apps.operation_analysis.views.import_export_view.ExportService.export_objects"
+    ) as mocked_export:
+        response = view(request)
+
+    assert response.status_code == 403
+    mocked_export.assert_not_called()
+
+
+def test_openapi_export_rejects_dashboard_ids_outside_token_team_scope():
+    factory = APIRequestFactory()
+    user = _create_user("api-user", [1])
+    dashboard = Dashboard.objects.create(
+        name="cross-team-openapi-dashboard",
+        groups=[2],
+        created_by="other",
+        updated_by="other",
+        domain="domain.com",
+        updated_by_domain="domain.com",
+    )
+
+    request = factory.post(
+        "/api/v1/operation_analysis/open_api/import_export/export",
+        {"object_type": "dashboard", "object_ids": [dashboard.id]},
+        format="json",
+    )
+    request.api_pass = True
+    force_authenticate(request, user=user)
+
+    view = OpenImportExportViewSet.as_view({"post": "export_objects"})
+    with patch("apps.operation_analysis.services.access_control.get_permission_rules", return_value={"team": [], "instance": []}), patch(
+        "apps.operation_analysis.views.openapi_import_export_view.ExportService.export_objects"
+    ) as mocked_export:
+        response = view(request)
+
+    assert response.status_code == 400
+    mocked_export.assert_not_called()
+
+
+def test_directory_tree_requires_view_permission():
+    factory = APIRequestFactory()
+    user = _set_permissions(_create_user("tree-user", [{"id": 1, "name": "Team 1"}]))
+
+    request = factory.get("/api/v1/operation_analysis/api/directory/tree/")
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=user)
+
+    view = DirectoryModelViewSet.as_view({"get": "tree"})
+    with patch("apps.operation_analysis.views.view.DictDirectoryService.get_dict_trees") as mocked_get_tree:
+        response = view(request)
+
+    assert response.status_code == 403
+    mocked_get_tree.assert_not_called()

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -15,6 +15,7 @@ from apps.operation_analysis.serializers.datasource_serializers import DataSourc
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace, DataSourceTag
+from apps.operation_analysis.services.access_control import build_authorized_queryset, ensure_instance_view_permission
 from apps.core.logger import operation_analysis_logger as logger
 
 
@@ -40,6 +41,31 @@ class NameSpaceModelViewSet(ModelViewSet):
     ordering = ["id"]
     filterset_class = NameSpaceModelFilter
     pagination_class = CustomPageNumberPagination
+
+    def get_queryset(self):
+        request = getattr(self, "request", None)
+        user = getattr(request, "user", None)
+        if not request or not user or getattr(user, "is_superuser", False):
+            return super().get_queryset()
+
+        current_team = request.COOKIES.get("current_team")
+        if not current_team:
+            return NameSpace.objects.none()
+
+        try:
+            current_team = int(current_team)
+        except (TypeError, ValueError):
+            return NameSpace.objects.none()
+
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        authorized_datasources = build_authorized_queryset(
+            DataSourceAPIModel.objects.all(),
+            user,
+            current_team,
+            "datasource",
+            include_children=include_children,
+        )
+        return super().get_queryset().filter(data_sources__in=authorized_datasources).distinct()
 
     @HasPermission("namespace-View")
     def retrieve(self, request, *args, **kwargs):
@@ -75,9 +101,27 @@ class DataSourceAPIModelViewSet(AuthViewSet):
     permission_key = "datasource"
     ORGANIZATION_FIELD = "groups"  # 使用 groups 字段作为组织字段
 
+    def _get_authorized_datasource(self, request):
+        instance = self.get_object()
+        if getattr(request.user, "is_superuser", False):
+            return instance
+
+        current_team = int(request.COOKIES.get("current_team", "0"))
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        ensure_instance_view_permission(
+            instance,
+            request.user,
+            current_team,
+            self.permission_key,
+            include_children=include_children,
+            org_field=self.ORGANIZATION_FIELD,
+        )
+        return instance
+
+    @HasPermission("data_source-View")
     @action(detail=False, methods=["post"], url_path=r"get_source_data/(?P<pk>[^/.]+)")
     def get_source_data(self, request, *args, **kwargs):
-        instance = self.get_object()
+        instance = self._get_authorized_datasource(request)
         params = dict(request.data)
         namespace_list = instance.namespaces.all()
         if "/" not in instance.rest_api:

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -21,6 +21,7 @@ from apps.operation_analysis.serializers.import_export_serializers import (
 from apps.operation_analysis.services.import_export.export_service import ExportService
 from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 from apps.operation_analysis.services.import_export.import_service import ImportService
+from apps.operation_analysis.services.access_control import build_authorized_queryset
 from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 
 
@@ -31,6 +32,13 @@ class ImportExportViewSet(ViewSet):
         ObjectType.ARCHITECTURE: {"create": "view-AddChart", "overwrite": "view-EditChart"},
         ObjectType.DATASOURCE: {"create": "data_source-Add", "overwrite": "data_source-Edit"},
         ObjectType.NAMESPACE: {"create": "namespace-Add", "overwrite": "namespace-Edit"},
+    }
+
+    EXPORT_PERMISSION_KEY_MAP = {
+        ObjectType.DASHBOARD.value: "directory.dashboard",
+        ObjectType.TOPOLOGY.value: "directory.topology",
+        ObjectType.ARCHITECTURE.value: "directory.architecture",
+        ObjectType.DATASOURCE.value: "datasource",
     }
 
     @action(detail=False, methods=["post"], url_path="export")
@@ -46,7 +54,7 @@ class ImportExportViewSet(ViewSet):
 
         organization_id = getattr(request, "organization_id", 0)
 
-        object_keys = self._convert_ids_to_keys(object_type, object_ids)
+        object_keys = self._convert_ids_to_keys(request, object_type, object_ids)
 
         result = ExportService.export_objects(
             scope_type=scope,
@@ -153,26 +161,51 @@ class ImportExportViewSet(ViewSet):
 
         return Response(result, status=status.HTTP_200_OK)
 
-    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int]) -> list[str]:
+    def _get_authorized_queryset(self, request, object_type: str):
         from apps.operation_analysis.models.models import Dashboard, Topology, Architecture
         from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+
+        current_team = self._get_current_team(request)
+        if current_team is None:
+            raise PermissionDenied("缺少有效的组织上下文")
+
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        if object_type == ObjectType.NAMESPACE.value:
+            datasource_queryset = build_authorized_queryset(
+                DataSourceAPIModel.objects.all(),
+                request.user,
+                current_team,
+                "datasource",
+                include_children=include_children,
+            )
+            return NameSpace.objects.filter(data_sources__in=datasource_queryset).distinct()
+
+        model_map = {
+            ObjectType.DASHBOARD.value: Dashboard,
+            ObjectType.TOPOLOGY.value: Topology,
+            ObjectType.ARCHITECTURE.value: Architecture,
+            ObjectType.DATASOURCE.value: DataSourceAPIModel,
+        }
+        model = model_map[object_type]
+        permission_key = self.EXPORT_PERMISSION_KEY_MAP[object_type]
+        return build_authorized_queryset(model.objects.all(), request.user, current_team, permission_key, include_children=include_children)
+
+    def _convert_ids_to_keys(self, request, object_type: str, object_ids: list[int]) -> list[str]:
         from apps.operation_analysis.constants.import_export import BUSINESS_KEY_SEPARATOR
 
+        authorized_queryset = self._get_authorized_queryset(request, object_type).filter(id__in=object_ids)
+        if authorized_queryset.count() != len(set(object_ids)):
+            raise PermissionDenied("包含无权访问的导出对象")
+
         keys = []
-        if object_type == ObjectType.DASHBOARD.value:
-            for obj in Dashboard.objects.filter(id__in=object_ids):
-                keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
-        elif object_type == ObjectType.TOPOLOGY.value:
-            for obj in Topology.objects.filter(id__in=object_ids):
-                keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
-        elif object_type == ObjectType.ARCHITECTURE.value:
-            for obj in Architecture.objects.filter(id__in=object_ids):
+        if object_type in {ObjectType.DASHBOARD.value, ObjectType.TOPOLOGY.value, ObjectType.ARCHITECTURE.value}:
+            for obj in authorized_queryset:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.DATASOURCE.value:
-            for obj in DataSourceAPIModel.objects.filter(id__in=object_ids):
+            for obj in authorized_queryset:
                 keys.append(f"{obj.name}{BUSINESS_KEY_SEPARATOR}{obj.rest_api}")
         elif object_type == ObjectType.NAMESPACE.value:
-            for obj in NameSpace.objects.filter(id__in=object_ids):
+            for obj in authorized_queryset:
                 keys.append(obj.name)
         return keys
 

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -32,6 +32,7 @@ from apps.operation_analysis.serializers.import_export_serializers import (
 from apps.operation_analysis.services.import_export.export_service import ExportService
 from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 from apps.operation_analysis.services.import_export.import_service import ImportService
+from apps.operation_analysis.services.access_control import build_authorized_queryset
 from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 
 
@@ -48,6 +49,13 @@ class OpenImportExportViewSet(OpenAPIViewSet):
         请求头需包含有效的 API Token（由 APISecretMiddleware 验证）
         Header: Api-Authorization: <api_token>
     """
+
+    EXPORT_PERMISSION_KEY_MAP = {
+        ObjectType.DASHBOARD.value: "directory.dashboard",
+        ObjectType.TOPOLOGY.value: "directory.topology",
+        ObjectType.ARCHITECTURE.value: "directory.architecture",
+        ObjectType.DATASOURCE.value: "datasource",
+    }
 
     def _check_api_auth(self, request):
         if not getattr(request, "api_pass", False):
@@ -89,27 +97,43 @@ class OpenImportExportViewSet(OpenAPIViewSet):
             return request.user.username
         return "api_user"
 
-    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int]) -> list[str]:
+    def _get_authorized_queryset(self, request, object_type: str):
         """将对象 ID 转换为业务键"""
         from apps.operation_analysis.models.models import Dashboard, Topology, Architecture
         from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+        groups = self._require_groups(request)
+        current_team = groups[0]
+
+        if object_type == ObjectType.NAMESPACE.value:
+            datasource_queryset = build_authorized_queryset(DataSourceAPIModel.objects.all(), request.user, current_team, "datasource")
+            return NameSpace.objects.filter(data_sources__in=datasource_queryset).distinct()
+
+        model_map = {
+            ObjectType.DASHBOARD.value: Dashboard,
+            ObjectType.TOPOLOGY.value: Topology,
+            ObjectType.ARCHITECTURE.value: Architecture,
+            ObjectType.DATASOURCE.value: DataSourceAPIModel,
+        }
+        model = model_map[object_type]
+        permission_key = self.EXPORT_PERMISSION_KEY_MAP[object_type]
+        return build_authorized_queryset(model.objects.all(), request.user, current_team, permission_key)
+
+    def _convert_ids_to_keys(self, request, object_type: str, object_ids: list[int]) -> list[str]:
         from apps.operation_analysis.constants.import_export import BUSINESS_KEY_SEPARATOR
 
+        authorized_queryset = self._get_authorized_queryset(request, object_type).filter(id__in=object_ids)
+        if authorized_queryset.count() != len(set(object_ids)):
+            raise ValidationError("包含无权访问的导出对象")
+
         keys = []
-        if object_type == ObjectType.DASHBOARD.value:
-            for obj in Dashboard.objects.filter(id__in=object_ids):
-                keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
-        elif object_type == ObjectType.TOPOLOGY.value:
-            for obj in Topology.objects.filter(id__in=object_ids):
-                keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
-        elif object_type == ObjectType.ARCHITECTURE.value:
-            for obj in Architecture.objects.filter(id__in=object_ids):
+        if object_type in {ObjectType.DASHBOARD.value, ObjectType.TOPOLOGY.value, ObjectType.ARCHITECTURE.value}:
+            for obj in authorized_queryset:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.DATASOURCE.value:
-            for obj in DataSourceAPIModel.objects.filter(id__in=object_ids):
+            for obj in authorized_queryset:
                 keys.append(f"{obj.name}{BUSINESS_KEY_SEPARATOR}{obj.rest_api}")
         elif object_type == ObjectType.NAMESPACE.value:
-            for obj in NameSpace.objects.filter(id__in=object_ids):
+            for obj in authorized_queryset:
                 keys.append(obj.name)
         return keys
 
@@ -186,7 +210,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
         groups = self._require_groups(request)
         organization_id = groups[0]
 
-        object_keys = self._convert_ids_to_keys(object_type, object_ids)
+        object_keys = self._convert_ids_to_keys(request, object_type, object_ids)
 
         logger.info(
             "Open API export request: object_type=%s, object_ids=%s, organization_id=%s",

--- a/server/apps/operation_analysis/views/view.py
+++ b/server/apps/operation_analysis/views/view.py
@@ -104,7 +104,7 @@ class DirectoryModelViewSet(BuiltinVisibleMixin, AuthViewSet):
         _raise_if_builtin(instance, "删除")
         return super(DirectoryModelViewSet, self).destroy(request, *args, **kwargs)
 
-    # @HasPermission("view-View")
+    @HasPermission("view-View")
     @action(detail=False, methods=["get"], url_path="tree")
     def tree(self, request, *args, **kwargs):
         result = DictDirectoryService.get_dict_trees(request)


### PR DESCRIPTION
## 问题本质
运营分析里有多条读链路没有复用主对象权限裁剪：数据源取数动作会直接按主键取对象，目录树接口没有模块角色校验，导出接口会直接按传入 ID 解析对象键。结果是组织范围和对象权限没有同时生效。

## 业务影响
具备基础登录态或导出能力的用户，能够绕过正常列表/详情裁剪，直接触发跨组织取数、读取不应可见的目录树，或导出其他组织的看板/数据源配置。

## 本次处理
- 为运营分析补充统一对象授权 helper，复用组织范围 + 实例权限判定。
- 收紧 `get_source_data`、目录树 `tree`、普通导出与 OpenAPI 导出，拒绝无权对象 ID。
- 将 `NameSpace` 查询收口到当前组织可见的数据源关联范围，避免全局命名空间直接暴露。
- 增加 5 条回归测试覆盖上述越权路径。

## 验证方式
- `INSTALL_APPS='system_mgmt,operation_analysis' DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite DJANGO_SETTINGS_MODULE=settings PYTHONPATH=. uv run --extra dev pytest apps/operation_analysis/tests/test_permission_guards.py -q --confcutdir=apps/operation_analysis/tests -o addopts=''`
- `python3 -m py_compile server/apps/operation_analysis/services/access_control.py server/apps/operation_analysis/views/datasource_view.py server/apps/operation_analysis/views/import_export_view.py server/apps/operation_analysis/views/openapi_import_export_view.py server/apps/operation_analysis/views/view.py server/apps/operation_analysis/tests/test_permission_guards.py`
