### PR TITLE
[alert] 修复告警来源校验缺失与恢复错配风险

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -147,9 +147,23 @@ class AlertSourceAdapter(ABC):
         return bulk_events
 
     @staticmethod
-    def generate_external_id(item: str, resource_name: str, source_id) -> str:
-        components = f"{item or ''}|{resource_name or ''}|{source_id or ''}"
-        return hashlib.md5(components.encode("utf-8")).hexdigest()
+    def generate_external_id(
+        item: str,
+        resource_id: str,
+        resource_type: str,
+        resource_name: str,
+        source_id: str,
+    ) -> str:
+        fingerprint_data = {
+            "item": item or "",
+            "resource_id": resource_id or "",
+            "resource_type": resource_type or "",
+            "resource_name": resource_name or "",
+            "source_id": source_id or "",
+        }
+        return hashlib.md5(
+            json.dumps(fingerprint_data, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        ).hexdigest()
 
     def add_base_fields(self, event: Event, alert: Dict[str, Any]):
         """添加基础字段"""
@@ -160,7 +174,13 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
 
         if not event.external_id or not str(event.external_id).strip():
-            event.external_id = self.generate_external_id(event.item, event.resource_name, self.alert_source.source_id)
+            event.external_id = self.generate_external_id(
+                event.item,
+                event.resource_id,
+                event.resource_type,
+                event.resource_name,
+                self.alert_source.source_id,
+            )
             logger.debug(f"Generated external_id for event: {event.event_id}")
 
     @staticmethod

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -20,7 +20,7 @@ from django.utils import timezone
 
 import nats_client
 from apps.alerts.models.models import Alert, Event, Incident, Level
-from apps.alerts.constants.constants import AlertStatus, EventLevel, LevelType
+from apps.alerts.constants.constants import AlertStatus, EventLevel, LevelType, AlertsSourceTypes
 from apps.core.logger import alert_logger as logger
 from apps.alerts.models.alert_source import AlertSource
 from apps.alerts.common.source_adapter.base import AlertSourceAdapterFactory
@@ -249,7 +249,12 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 "message": "Missing pusher identifier.",
             }
 
-        event_source = AlertSource.objects.filter(source_id=source_id).first()
+        event_source = AlertSource.objects.filter(
+            source_id=source_id,
+            source_type=AlertsSourceTypes.NATS,
+            is_active=True,
+            is_effective=True,
+        ).first()
         if not event_source:
             logger.error(f"Invalid source_id: {source_id}, pusher: {pusher}")
             return {

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -11,6 +11,7 @@ from apps.alerts.aggregation.builder.synthetic_alert_builder import (
     SyntheticAlertBuilder,
 )
 from apps.alerts.aggregation.processor.aggregation_processor import AggregationProcessor
+from apps.alerts.nats.nats import receive_alert_events
 from apps.alerts.constants import (
     AlertStatus,
     AlarmStrategyType,
@@ -748,6 +749,129 @@ class AlertSourceIngressTestCase(TestCase):
         self.assertEqual(events[0].external_id, events[1].external_id)
         self.assertEqual(events[0].action, EventAction.CREATED)
         self.assertEqual(events[1].action, EventAction.RECOVERY)
+
+    def test_receiver_rejects_inactive_source(self):
+        source = AlertSource.objects.create(
+            name="RESTful Disabled",
+            source_id="rest-disabled",
+            source_type=AlertsSourceTypes.RESTFUL,
+            secret="rest-secret",
+            is_active=False,
+            config={
+                "event_fields_mapping": {
+                    "title": "title",
+                    "level": "level",
+                    "start_time": "start_time",
+                }
+            },
+        )
+
+        response = self.client.post(
+            f"/api/v1/alerts/api/source/{source.source_id}/webhook/",
+            data=json.dumps(
+                {
+                    "events": [
+                        {
+                            "title": "disabled-source-event",
+                            "level": "3",
+                            "start_time": str(int(timezone.now().timestamp())),
+                        }
+                    ]
+                }
+            ),
+            content_type="application/json",
+            HTTP_SECRET="rest-secret",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(Event.objects.count(), 0)
+
+    def test_default_external_id_distinguishes_resource_identity(self):
+        source = AlertSource.objects.create(
+            name="RESTful Source",
+            source_id="rest-source",
+            source_type=AlertsSourceTypes.RESTFUL,
+            secret="rest-secret",
+            config={
+                "event_fields_mapping": {
+                    "title": "title",
+                    "description": "description",
+                    "level": "level",
+                    "item": "item",
+                    "start_time": "start_time",
+                    "resource_id": "resource_id",
+                    "resource_name": "resource_name",
+                    "resource_type": "resource_type",
+                    "action": "action",
+                }
+            },
+        )
+
+        payload = {
+            "events": [
+                {
+                    "title": "cpu high",
+                    "description": "cpu > 90%",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "resource_id": "service-1",
+                    "resource_name": "shared-name",
+                    "resource_type": "service",
+                    "action": "created",
+                },
+                {
+                    "title": "cpu high",
+                    "description": "cpu > 90%",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "resource_id": "service-2",
+                    "resource_name": "shared-name",
+                    "resource_type": "service",
+                    "action": "created",
+                },
+            ]
+        }
+
+        response = self.client.post(
+            f"/api/v1/alerts/api/source/{source.source_id}/webhook/",
+            data=json.dumps(payload),
+            content_type="application/json",
+            HTTP_SECRET="rest-secret",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        events = list(Event.objects.filter(source=source).order_by("resource_id"))
+        self.assertEqual(len(events), 2)
+        self.assertNotEqual(events[0].external_id, events[1].external_id)
+
+    def test_nats_ingress_rejects_non_nats_source(self):
+        source = AlertSource.objects.create(
+            name="Prometheus Source",
+            source_id="prometheus-prod",
+            source_type=AlertsSourceTypes.PROMETHEUS,
+            secret="prom-secret",
+            config={},
+        )
+
+        result = receive_alert_events(
+            source_id=source.source_id,
+            pusher="lite-monitor",
+            events=[
+                {
+                    "title": "forged",
+                    "description": "forged",
+                    "level": "3",
+                    "item": "cpu_usage",
+                    "start_time": str(int(timezone.now().timestamp())),
+                    "action": "created",
+                }
+            ],
+        )
+
+        self.assertFalse(result["result"])
+        self.assertEqual(Event.objects.count(), 0)
 
     def test_integration_guide_returns_prometheus_template(self):
         source = AlertSource.objects.create(

--- a/server/apps/alerts/views/receiver.py
+++ b/server/apps/alerts/views/receiver.py
@@ -34,7 +34,11 @@ def _receive_events(request, path_source_id=None, expected_source_type=None):
         if not source_id:
             return JsonResponse({"status": "error", "message": "Missing source_id."}, status=400)
 
-        event_source = AlertSource.objects.filter(source_id=source_id).first()
+        event_source = AlertSource.objects.filter(
+            source_id=source_id,
+            is_active=True,
+            is_effective=True,
+        ).first()
         if not event_source:
             return JsonResponse({"status": "error", "message": "Invalid source_id or source_type."}, status=400)
 
@@ -108,4 +112,3 @@ def request_test(requests):
     """
     logger.info("Processing request test: request=%s", requests)
     return WebUtils.response_success([])
-


### PR DESCRIPTION
## 问题本质
- HTTP 告警接收入口只按 `source_id` 查源，停用或失效的告警源仍然可以继续写入事件。
- NATS 告警入口允许调用方传入任意 `source_id`，内部消息可以伪装成非 NATS 告警源进入事件链路。
- 通用 `external_id` 回退只使用 `item/resource_name/source_id`，当不同资源同名或缺少显式 `external_id` 时，恢复/关闭事件可能串到错误对象。

## 业务影响
- 停用接入源后仍可能继续入库，导致停用开关失效，错误或伪造事件继续污染告警中心。
- 内部 NATS 消息一旦选错或伪造来源，会绕过不同告警入口的语义边界，造成错源入库和后续聚合失真。
- 恢复闭环使用碰撞后的 `external_id` 关联时，会把不同资源的告警错误恢复，直接影响展示、通知和审计。

## 本次处理
- HTTP 接收入口仅接受 `is_active=True` 且 `is_effective=True` 的告警源。
- NATS 接收入口仅接受启用且生效的 NATS 类型告警源，阻断通过 NATS 伪装成其他接入类型的写入。
- 默认 `external_id` 生成改为纳入 `resource_id/resource_type/resource_name`，保证无显式外部 ID 时仍按资源语义区分恢复链路。
- 补充回归测试覆盖停用源拒收、NATS 错源拒收和默认 `external_id` 资源区分。

## 验证方式
- `python3 -m py_compile apps/alerts/views/receiver.py apps/alerts/common/source_adapter/base.py apps/alerts/nats/nats.py apps/alerts/test/tests.py`
- 最小回归脚本：直接创建本次涉及模型表，验证停用源拒收、默认 `external_id` 区分资源对象、NATS 不能伪装成非 NATS 源。
- `INSTALL_APPS=alerts,system_mgmt DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite ENABLE_CELERY=True uv run --extra dev python manage.py test apps.alerts.test.tests.AlertSourceIngressTestCase --verbosity 2` 在建库阶段被仓库既有 `alerts.0009` 迁移问题阻塞，未能作为本次变更回归结论。
