### PR TITLE
[alert] 修复事件/事故查询放大并记录 DuckDB 聚合输入放大风险

### DIFF
--- a/docs/reviews/alert-query-performance-review-2026-05-08.md
+++ b/docs/reviews/alert-query-performance-review-2026-05-08.md
@@ -1,0 +1,35 @@
+# 告警查询性能 Review（2026-05-08）
+
+## 结论
+
+DuckDB 聚合链路存在一处链路级严重技术债务：聚合任务会按“每个活跃策略”重复从 PostgreSQL 拉取窗口内事件、在 Python 中整批序列化、再整批装载进 DuckDB 内存表，但当前策略配置对 `window_size` 没有代码级上限约束，也没有任何输入行数上限或共享输入复用。
+
+## 仓库证据
+
+- `server/apps/alerts/aggregation/processor/aggregation_processor.py`
+  - `process_aggregation()` 会遍历全部 `is_active=True` 的策略并逐个调用 `_process_strategy(...)`。
+  - `get_events_for_strategy()` 直接使用 `params["window_size"]` 计算 `received_at__gte=cutoff_time`，没有最大窗口保护。
+  - `_aggregate_for_dimensions()` 每个策略都会调用 `self.db_conn.load_events_to_memory(events)`，随后执行一次 DuckDB SQL。
+- `server/apps/alerts/aggregation/engine/connection.py`
+  - `load_events_to_memory()` 会把 QuerySet 直接 `values(...) -> list(...)` 全量拉到 Python。
+  - 之后逐条 `json.dumps(...)`，再构造成 `pandas.DataFrame`，最后 `DROP TABLE/CREATE TABLE` 重建整张 `events_table`。
+- `server/apps/alerts/aggregation/window/factory.py`
+  - `create_from_strategy()` 直接信任 `params["window_size"]`，没有上限、没有非正数保护。
+- `server/apps/alerts/serializers/strategy.py`
+  - 仅对 `missing_detection` 做参数校验；普通聚合策略的 `params.window_size`、`group_by`、`time_out` 没有任何规模约束。
+
+## 影响范围
+
+- 活跃策略一多，且窗口有重叠时，会重复执行“PG 扫窗口事件 -> Python 序列化 -> DataFrame 构造 -> DuckDB 重装表”的整套链路。
+- 单个策略只要把 `window_size` 配得过大，就会同步放大 PostgreSQL 读取量、Python 内存占用和 DuckDB 装载成本。
+- 这不是局部慢查询，而是策略数量与窗口大小共同驱动的乘法型放大，直接影响聚合时延、Worker 稳定性和排障成本。
+
+## 本次不直接修复的原因
+
+这条债务已经是聚合执行模型问题，不是单点 if/else 能安全补掉的缺陷。直接在本轮硬加窗口上限或粗暴裁剪输入，会改变现有策略语义和告警覆盖范围；而要做真正闭环修复，需要同时重构策略参数契约、任务切片方式与输入复用策略。
+
+## 建议后续处理
+
+1. 给普通聚合策略建立明确的 `window_size` 合法区间与最大输入预算。
+2. 把“按策略重复装载事件”改成“按时间窗/来源共享候选集，再做策略内过滤”。
+3. 在聚合执行链路记录每次策略的输入行数、装载耗时、DuckDB 执行耗时，便于后续治理和告警。

--- a/server/apps/alerts/serializers/incident.py
+++ b/server/apps/alerts/serializers/incident.py
@@ -118,8 +118,7 @@ class IncidentModelSerializer(serializers.ModelSerializer):
         # fallback: 直接计数
         return obj.alert.count() if obj.alert else 0
 
-    @staticmethod
-    def get_operator_users(obj):
+    def get_operator_users(self, obj):
         """
         获取操作员用户列表，从 JSONField 转换为字符串
         """
@@ -132,6 +131,9 @@ class IncidentModelSerializer(serializers.ModelSerializer):
 
         # 如果 operator 是列表，转换为逗号分隔的字符串
         if isinstance(obj.operator, list):
+            operator_user_map = self.context.get("operator_user_map")
+            if operator_user_map is not None:
+                return ", ".join(operator_user_map.get(user, user) for user in obj.operator)
             user_name_list = User.objects.filter(username__in=obj.operator).values_list("display_name", flat=True)
             return ", ".join(list(user_name_list))
 

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -3,8 +3,11 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.db import connection
+from django.db.models import Count
 from django.test import Client
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from apps.alerts.aggregation.builder.synthetic_alert_builder import (
@@ -22,9 +25,12 @@ from apps.alerts.constants import (
     HeartbeatStatus,
     LevelType,
 )
-from apps.alerts.models import Alert, AlertSource, AlarmStrategy, Event, Level
+from apps.alerts.models import Alert, AlertSource, AlarmStrategy, Event, Level, Incident
 from apps.alerts.serializers.alert_source import AlertSourceModelSerializer
+from apps.alerts.serializers.event import EventModelSerializer
+from apps.alerts.serializers.incident import IncidentModelSerializer
 from apps.alerts.serializers.strategy import AlarmStrategySerializer
+from apps.system_mgmt.models.user import User
 
 
 class AlarmStrategySerializerTestCase(TestCase):
@@ -782,3 +788,124 @@ class AlertSourceIngressTestCase(TestCase):
         self.assertEqual(payload["source_type"], AlertsSourceTypes.ZABBIX)
         self.assertIn(f"/api/v1/alerts/api/source/{source.source_id}/webhook/", payload["webhook_url"])
         self.assertIn("script_template", payload)
+
+
+class AlertQueryPerformanceTestCase(TestCase):
+    def setUp(self):
+        self.source = AlertSource.objects.create(
+            name="perf-source",
+            source_id="perf-source",
+            source_type=AlertsSourceTypes.WEBHOOK,
+        )
+        self.user = User.objects.create(
+            username="perf-user",
+            display_name="性能用户",
+            email="perf@example.com",
+            password="test-pass",
+            domain="domain.com",
+        )
+
+    def create_event(self, suffix, **overrides):
+        return Event.objects.create(
+            source=self.source,
+            raw_data={},
+            title=overrides.pop("title", f"event-{suffix}"),
+            description=overrides.pop("description", "desc"),
+            level=overrides.pop("level", "1"),
+            service=overrides.pop("service", "svc"),
+            event_type=overrides.pop("event_type", EventType.ALERT),
+            tags=overrides.pop("tags", {}),
+            location=overrides.pop("location", "gz"),
+            external_id=overrides.pop("external_id", f"ext-{suffix}"),
+            start_time=overrides.pop("start_time", timezone.now()),
+            end_time=overrides.pop("end_time", None),
+            labels=overrides.pop("labels", {}),
+            action=overrides.pop("action", EventAction.CREATED),
+            rule_id=overrides.pop("rule_id", None),
+            event_id=overrides.pop("event_id", f"EVENT-PERF-{suffix}"),
+            item=overrides.pop("item", "cpu"),
+            resource_id=overrides.pop("resource_id", f"res-{suffix}"),
+            resource_type=overrides.pop("resource_type", "host"),
+            resource_name=overrides.pop("resource_name", f"host-{suffix}"),
+            status=overrides.pop("status", "received"),
+            assignee=overrides.pop("assignee", []),
+            value=overrides.pop("value", None),
+        )
+
+    def test_event_queryset_avoids_source_n_plus_one_in_serializer(self):
+        self.create_event("1")
+        self.create_event("2")
+
+        events = list(Event.objects.select_related("source").order_by("id"))
+        with CaptureQueriesContext(connection) as ctx:
+            data = EventModelSerializer(events, many=True).data
+
+        self.assertEqual(len(ctx), 0)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["source_name"], "perf-source")
+
+    def test_incident_queryset_prefetches_alert_event_sources_for_serializer(self):
+        event_1 = self.create_event("incident-1")
+        event_2 = self.create_event("incident-2")
+
+        alert_1 = Alert.objects.create(
+            alert_id="ALERT-PERF-1",
+            status=AlertStatus.UNASSIGNED,
+            level="1",
+            title="alert-1",
+            content="content-1",
+            fingerprint="fp-1",
+            operator=[self.user.username],
+        )
+        alert_1.events.add(event_1)
+
+        alert_2 = Alert.objects.create(
+            alert_id="ALERT-PERF-2",
+            status=AlertStatus.UNASSIGNED,
+            level="1",
+            title="alert-2",
+            content="content-2",
+            fingerprint="fp-2",
+            operator=[self.user.username],
+        )
+        alert_2.events.add(event_2)
+
+        incident = Incident.objects.create(
+            incident_id="INCIDENT-PERF-1",
+            status="pending",
+            level="1",
+            title="incident-1",
+            content="incident-content",
+            operator=[self.user.username],
+        )
+        incident.alert.add(alert_1, alert_2)
+
+        incidents = list(
+            Incident.objects.annotate(alert_count=Count("alert", distinct=True))
+            .prefetch_related("alert__events__source")
+            .order_by("id")
+        )
+        operator_user_map = {self.user.username: self.user.display_name}
+        with CaptureQueriesContext(connection) as ctx:
+            data = IncidentModelSerializer(
+                incidents,
+                many=True,
+                context={"operator_user_map": operator_user_map},
+            ).data
+
+        self.assertEqual(len(ctx), 0)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["sources"], "perf-source")
+        self.assertEqual(data[0]["operator_users"], "性能用户")
+
+    def test_alert_queryset_uses_distinct_event_count_annotation(self):
+        annotation = Alert.objects.annotate(
+            event_count_annotated=Count("events", distinct=True)
+        ).query.annotations["event_count_annotated"]
+        self.assertTrue(annotation.distinct)
+
+    def test_incident_queryset_uses_distinct_alert_count_annotation(self):
+        annotation = Incident.objects.annotate(
+            alert_count=Count("alert", distinct=True)
+        ).query.annotations["alert_count"]
+        self.assertTrue(annotation.distinct)

--- a/server/apps/alerts/views/alert.py
+++ b/server/apps/alerts/views/alert.py
@@ -26,7 +26,7 @@ class AlertModelViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = Alert.objects.annotate(
-            event_count_annotated=Count("events"),
+            event_count_annotated=Count("events", distinct=True),
         ).prefetch_related("events__source", "incident_set")
 
         # StringAgg 是 PostgreSQL 专属函数，其他数据库通过 serializer fallback 处理
@@ -34,7 +34,7 @@ class AlertModelViewSet(ModelViewSet):
             from django.contrib.postgres.aggregates import StringAgg
 
             queryset = Alert.objects.annotate(
-                event_count_annotated=Count("events"),
+                event_count_annotated=Count("events", distinct=True),
                 # 通过事件获取告警源名称（去重）
                 source_names_annotated=StringAgg("events__source__name", delimiter=", ", distinct=True),
                 incident_title_annotated=StringAgg("incident__title", delimiter=", ", distinct=True),

--- a/server/apps/alerts/views/event.py
+++ b/server/apps/alerts/views/event.py
@@ -11,12 +11,15 @@ class EventModelViewSet(ModelViewSet):
     """
     事件视图集
     """
-    queryset = Event.objects.all()
+    queryset = Event.objects.select_related("source")
     serializer_class = EventModelSerializer
     ordering_fields = ["received_at"]
     ordering = ["-received_at"]
     filterset_class = EventModelFilter
     pagination_class = CustomPageNumberPagination
+
+    def get_queryset(self):
+        return Event.objects.select_related("source")
 
     @HasPermission("Integration-View,Alarms-View")
     def list(self, request, *args, **kwargs):

--- a/server/apps/alerts/views/incident.py
+++ b/server/apps/alerts/views/incident.py
@@ -2,6 +2,7 @@
 import uuid
 
 from django.db.models import Count
+from apps.system_mgmt.models.user import User
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -34,13 +35,59 @@ class IncidentModelViewSet(ModelViewSet):
 
     def get_queryset(self):
         queryset = Incident.objects.annotate(
-            alert_count=Count("alert")
-        ).prefetch_related("alert")
+            alert_count=Count("alert", distinct=True)
+        ).prefetch_related("alert__events__source")
         return queryset
+
+    @staticmethod
+    def _build_operator_user_map(incidents):
+        operator_usernames = set()
+        for incident in incidents:
+            if isinstance(incident.operator, list):
+                operator_usernames.update(incident.operator)
+        if not operator_usernames:
+            return {}
+        return dict(User.objects.filter(username__in=operator_usernames).values_list("username", "display_name"))
 
     @HasPermission("Incidents-View")
     def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            operator_user_map = self._build_operator_user_map(page)
+            serializer = self.get_serializer(
+                page,
+                many=True,
+                context={
+                    **self.get_serializer_context(),
+                    "operator_user_map": operator_user_map,
+                },
+            )
+            return self.get_paginated_response(serializer.data)
+
+        operator_user_map = self._build_operator_user_map(queryset)
+        serializer = self.get_serializer(
+            queryset,
+            many=True,
+            context={
+                **self.get_serializer_context(),
+                "operator_user_map": operator_user_map,
+            },
+        )
+        return WebUtils.response_success(serializer.data)
+
+    @HasPermission("Incidents-View")
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        operator_user_map = self._build_operator_user_map([instance])
+        serializer = self.get_serializer(
+            instance,
+            context={
+                **self.get_serializer_context(),
+                "operator_user_map": operator_user_map,
+            },
+        )
+        return Response(serializer.data)
 
     @HasPermission("Alarms-Edit")
     @transaction.atomic


### PR DESCRIPTION
## 问题本质
- Event 列表序列化逐条读取 `source`，请求量一大就稳定退化成 N+1 查询。
- Incident 列表/详情在 serializer 层逐条补 `operator` 和 `alert -> events -> source`，导致事故查询随结果量线性放大。
- Alert 列表把 `Count(events)` 与多表聚合放在同一查询里但未去重，存在事件数失真风险。
- DuckDB 聚合链路当前按“每个活跃策略”重复拉取窗口事件、重复装载内存表，且普通聚合策略没有 `window_size` 上限约束，这属于结构性放大问题，先以 review 文档落证据。

## 业务影响
- 事件列表、事故列表和事故详情在结果量上来后会明显变慢，且事故查询会被序列化补查进一步放大。
- 告警列表中的事件数在多表聚合场景下可能被放大，导致展示结果失真。
- 聚合策略一多或窗口过大时，DuckDB 链路会把 PG 读取、Python 序列化和内存装载成本成倍放大。

## 本次处理
- Event 查询改为 `select_related("source")`，消除事件列表的 `source` N+1。
- Incident 查询补齐 `alert__events__source` 预取，并批量映射 `operator` 显示名，消除事故列表/详情的多级补查。
- Alert/Incident 计数注解改为 `distinct=True`，避免多表聚合下的计数失真。
- 新增 `docs/reviews/alert-query-performance-review-2026-05-08.md`，记录 DuckDB 聚合输入重复装载与无窗口上限的结构性风险。

## 验证
- `python3 -m py_compile` 校验已修改 Python 文件通过。
- 自定义 schema-level 验证脚本通过：覆盖 Event/Incident 序列化零额外查询与 `distinct` 注解断言。
- `manage.py test apps.alerts.test.tests.AlertQueryPerformanceTestCase` 在 sqlite 环境仍被仓库既有迁移问题阻断：`alerts.0009_remove_correlationrules_aggregation_rules_and_more` 对 `NewSessionEventRelation.event` 的历史迁移错误会导致建库失败。
