### PR TITLE
[alert] 修复恢复事件只关联不转态导致告警长期不关闭风险

### DIFF
--- a/server/apps/alerts/aggregation/recovery/recovery_handler.py
+++ b/server/apps/alerts/aggregation/recovery/recovery_handler.py
@@ -2,6 +2,7 @@
 from typing import List
 from collections import defaultdict
 
+from apps.alerts.aggregation.recovery.recovery_checker import AlertRecoveryChecker
 from apps.alerts.models.models import Alert, Event
 from apps.alerts.constants.constants import AlertStatus, EventAction
 from apps.core.logger import alert_logger as logger
@@ -88,6 +89,7 @@ class RecoveryHandler:
         # 4. 批量处理恢复事件关联
         total_added = 0
         total_skipped = 0
+        touched_alerts = {}
         
         for recovery_event in recovery_events:
             external_id = recovery_event.external_id
@@ -109,18 +111,26 @@ class RecoveryHandler:
                 # 检查是否已关联（使用预加载的数据，无额外查询）
                 if recovery_event.event_id not in alert_existing_events[alert.pk]:
                     alert.events.add(recovery_event)
+                    alert_existing_events[alert.pk].add(recovery_event.event_id)
                     total_added += 1
+                    touched_alerts[alert.pk] = alert
                     logger.debug(
                         f"恢复事件 {recovery_event.event_id} "
                         f"已关联到 Alert {alert.alert_id}"
                     )
                 else:
                     total_skipped += 1
-        
+
+        recovered_count = 0
+        for alert in touched_alerts.values():
+            if AlertRecoveryChecker.check_and_recover_alert(alert):
+                recovered_count += 1
+
         # 5. 汇总日志
         logger.info(
             f"恢复事件批量处理完成: "
             f"处理 {len(recovery_events)} 个恢复事件, "
             f"新增关联 {total_added} 个, "
-            f"跳过重复 {total_skipped} 个"
+            f"跳过重复 {total_skipped} 个, "
+            f"推进恢复 {recovered_count} 个"
         )

--- a/server/apps/alerts/test/tests.py
+++ b/server/apps/alerts/test/tests.py
@@ -11,6 +11,7 @@ from apps.alerts.aggregation.builder.synthetic_alert_builder import (
     SyntheticAlertBuilder,
 )
 from apps.alerts.aggregation.processor.aggregation_processor import AggregationProcessor
+from apps.alerts.aggregation.recovery.recovery_handler import RecoveryHandler
 from apps.alerts.constants import (
     AlertStatus,
     AlarmStrategyType,
@@ -429,6 +430,91 @@ class MissingDetectionProcessorTestCase(TestCase):
             strategy.params["last_heartbeat_time"],
             Event.objects.get(event_id="EVENT-RECOVERY").received_at.isoformat(),
         )
+
+
+class RecoveryHandlerTestCase(TestCase):
+    def setUp(self):
+        self.source = AlertSource.objects.create(
+            name="test-source",
+            source_id="source-1",
+            source_type=AlertsSourceTypes.WEBHOOK,
+        )
+
+    def test_recovery_event_immediately_recovers_active_alert(self):
+        created_at = timezone.now() - timedelta(minutes=5)
+        created_event = Event.objects.create(
+            source=self.source,
+            push_source_id="default",
+            raw_data={},
+            title="cpu high",
+            description="cpu > 90%",
+            level="1",
+            service="svc",
+            event_type=EventType.ALERT,
+            tags={},
+            location="gz",
+            external_id="ext-1",
+            start_time=created_at,
+            labels={},
+            action=EventAction.CREATED,
+            event_id="EVENT-CREATED-1",
+            item="cpu",
+            resource_id="node-1",
+            resource_type="host",
+            resource_name="node-1",
+            status="received",
+            assignee=[],
+        )
+        Event.objects.filter(pk=created_event.pk).update(received_at=created_at)
+        created_event.refresh_from_db()
+
+        alert = Alert.objects.create(
+            alert_id="ALERT-1",
+            status=AlertStatus.UNASSIGNED,
+            level="1",
+            title="cpu high",
+            content="cpu > 90%",
+            labels={},
+            first_event_time=created_at,
+            last_event_time=created_at,
+            item="cpu",
+            resource_id="node-1",
+            resource_name="node-1",
+            resource_type="host",
+            source_name="test-source",
+            fingerprint="fp-1",
+        )
+        alert.events.add(created_event)
+
+        recovery_event = Event.objects.create(
+            source=self.source,
+            push_source_id="default",
+            raw_data={},
+            title="cpu high",
+            description="cpu recovered",
+            level="1",
+            service="svc",
+            event_type=EventType.ALERT,
+            tags={},
+            location="gz",
+            external_id="ext-1",
+            start_time=timezone.now(),
+            labels={},
+            action=EventAction.RECOVERY,
+            event_id="EVENT-RECOVERY-1",
+            item="cpu",
+            resource_id="node-1",
+            resource_type="host",
+            resource_name="node-1",
+            status="received",
+            assignee=[],
+        )
+
+        RecoveryHandler.handle_recovery_events([recovery_event])
+
+        alert.refresh_from_db()
+        self.assertEqual(alert.status, AlertStatus.AUTO_RECOVERY)
+        self.assertTrue(alert.events.filter(event_id="EVENT-RECOVERY-1").exists())
 
 
 class AlertSourceIngressTestCase(TestCase):


### PR DESCRIPTION
## 问题本质
恢复事件进入 `alerts` 链路后，当前共享处理器只把事件挂回原告警，不会继续推进告警状态。

## 业务影响
当恢复事件到达时，如果后续没有新的 created/closed 事件再次触发聚合检查，原告警会继续保持活跃，造成告警长期不恢复、提醒持续发送、处置状态失真。

## 本次处理
- 在共享恢复处理器中，恢复事件关联到活跃告警后，立刻触发恢复状态检查。
- 补充回归测试，覆盖“恢复事件已到达并关联，但告警仍未恢复”的场景。

## 验证方式
- `python3 -m py_compile server/apps/alerts/aggregation/recovery/recovery_handler.py server/apps/alerts/test/tests.py`
- `git diff --check`
- `uv run python` 最小 mock 验证：确认恢复事件关联后会立即触发恢复检查
- `python manage.py test apps.alerts.test.tests.RecoveryHandlerTestCase -v 2`
  - 当前被仓库既有 `alerts` 历史迁移问题阻断：`NewSessionEventRelation has no field named 'event'`
