### PR TITLE
bugfix: 增强数据源组织隔离与权限校验

### DIFF
--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -3,7 +3,6 @@
 # @Time: 2025/7/22 18:24
 # @Author: windyzhao
 from apps.operation_analysis.nats.nats_client import DefaultNastClient
-from apps.core.logger import operation_analysis_logger as logger
 
 
 class GetNatsData:
@@ -39,9 +38,11 @@ class GetNatsData:
         """
         username = self.request.user.username
         team = int(self.request.COOKIES.get("current_team"))
+        include_children = self.request.COOKIES.get("include_children", "0") == "1"
         self.params[self.user_param_key] = {
             "team": team,
-            "user": username
+            "user": username,
+            "include_children": include_children,
         }
 
     def set_namespace_servers(self):
@@ -55,7 +56,7 @@ class GetNatsData:
             protocol = "tls" if namespace.enable_tls else "nats"
 
             # 构建完整的服务器URL
-            if ':' not in namespace.domain:
+            if ":" not in namespace.domain:
                 # 域名不包含端口,使用默认端口4222
                 server_url = f"{protocol}://{namespace.account}:{namespace.decrypt_password}@{namespace.domain}:4222"
             else:
@@ -97,26 +98,21 @@ class GetNatsData:
         """
         namespace = self._get_target_namespace()
         if namespace is None:
-            return []
+            raise RuntimeError("未找到可用的命名空间")
 
         server_url = self.namespace_server_map.get(namespace.id)
         if not server_url:
-            return []
+            raise RuntimeError(f"命名空间 {namespace.name} 未配置服务器连接")
 
         nats_namespace = getattr(namespace, "namespace", "bk_lite")
         nats_client = self._get_client(server=server_url, namespace=nats_namespace)
-        try:
-            if hasattr(nats_client, "DEFAULT_NATS"):
-                fun = getattr(nats_client, "get_customization_nast_data", None)
-            else:
-                fun = getattr(nats_client, self.path, None)
-            if fun is None:
-                raise RuntimeError(f"NamePaces({self.namespace}) Module not found func({self.path})!")
 
-            return_data = fun(**self.params)
-            return return_data.get("data", [])
-        except Exception as e:  # noqa
-            import traceback
+        if hasattr(nats_client, "DEFAULT_NATS"):
+            fun = getattr(nats_client, "get_customization_nast_data", None)
+        else:
+            fun = getattr(nats_client, self.path, None)
+        if fun is None:
+            raise RuntimeError(f"NamePaces({self.namespace}) Module not found func({self.path})!")
 
-            logger.error("==获取NATS数据源数据失败==: namespace={} error={}".format(namespace.name, traceback.format_exc()))
-            return []
+        return_data = fun(**self.params)
+        return return_data.get("data", [])

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -6,22 +6,25 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.logger import operation_analysis_logger as logger
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.operation_analysis.common.get_nats_source_data import GetNatsData
-from apps.operation_analysis.filters.datasource_filters import DataSourceAPIModelFilter, NameSpaceModelFilter, \
-    DataSourceTagModelFilter
-from apps.operation_analysis.serializers.datasource_serializers import DataSourceAPIModelSerializer, \
-    NameSpaceModelSerializer, DataSourceTagModelSerializer
+from apps.operation_analysis.filters.datasource_filters import DataSourceAPIModelFilter, DataSourceTagModelFilter, NameSpaceModelFilter
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, DataSourceTag, NameSpace
+from apps.operation_analysis.serializers.datasource_serializers import (
+    DataSourceAPIModelSerializer,
+    DataSourceTagModelSerializer,
+    NameSpaceModelSerializer,
+)
 from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
-from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace, DataSourceTag
-from apps.core.logger import operation_analysis_logger as logger
 
 
 class DataSourceTagModelViewSet(ModelViewSet):
     """
     数据源标签
     """
+
     queryset = DataSourceTag.objects.all()
     serializer_class = DataSourceTagModelSerializer
     ordering_fields = ["id"]
@@ -34,6 +37,7 @@ class NameSpaceModelViewSet(ModelViewSet):
     """
     命名空间
     """
+
     queryset = NameSpace.objects.all()
     serializer_class = NameSpaceModelSerializer
     ordering_fields = ["id"]
@@ -66,6 +70,7 @@ class DataSourceAPIModelViewSet(AuthViewSet):
     """
     数据源
     """
+
     queryset = DataSourceAPIModel.objects.all()
     serializer_class = DataSourceAPIModelSerializer
     ordering_fields = ["id"]
@@ -75,9 +80,16 @@ class DataSourceAPIModelViewSet(AuthViewSet):
     permission_key = "datasource"
     ORGANIZATION_FIELD = "groups"  # 使用 groups 字段作为组织字段
 
+    @HasPermission("data_source-View")
     @action(detail=False, methods=["post"], url_path=r"get_source_data/(?P<pk>[^/.]+)")
     def get_source_data(self, request, *args, **kwargs):
         instance = self.get_object()
+
+        # 组织校验：当前组织必须在数据源的 groups 中
+        current_team = self._parse_current_team_cookie(request)
+        if current_team not in (instance.groups or []):
+            return Response({"detail": "无权访问该数据源"}, status=403)
+
         params = dict(request.data)
         namespace_list = instance.namespaces.all()
         if "/" not in instance.rest_api:
@@ -90,7 +102,7 @@ class DataSourceAPIModelViewSet(AuthViewSet):
             result = client.get_data()
         except Exception as e:
             logger.error("获取数据源数据失败: {}".format(e))
-            result = []
+            return Response({"detail": "数据查询失败，请稍后重试"}, status=500)
 
         return Response(result)
 
@@ -100,7 +112,10 @@ class DataSourceAPIModelViewSet(AuthViewSet):
 
     @HasPermission("data_source-View")
     def list(self, request, *args, **kwargs):
-        return super(DataSourceAPIModelViewSet, self).list(request, *args, **kwargs)
+        queryset = self.filter_queryset(self.get_queryset())
+        _, _, _, query = self.filter_by_group(queryset, request, request.user)
+        queryset = queryset.filter(query).order_by(self.ORDERING_FIELD)
+        return self._list(queryset)
 
     @HasPermission("data_source-Add")
     def create(self, request, *args, **kwargs):
@@ -112,4 +127,11 @@ class DataSourceAPIModelViewSet(AuthViewSet):
 
     @HasPermission("data_source-Delete")
     def destroy(self, request, *args, **kwargs):
-        return super(DataSourceAPIModelViewSet, self).destroy(request, *args, **kwargs)
+        instance = self.get_object()
+        current_team = self._parse_current_team_cookie(request)
+
+        if current_team not in (instance.groups or []):
+            return Response({"detail": "无权删除该数据源"}, status=403)
+
+        instance.delete()
+        return Response(status=204)

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -1,27 +1,20 @@
 # -- coding: utf-8 --
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
-from apps.core.decorators.api_permission import HasPermission
-from apps.core.logger import operation_analysis_logger as logger
-from apps.operation_analysis.constants.import_export import (
-    ObjectType,
-    ConflictAction,
-    ConflictReason,
-    ImportExportErrorCode,
-)
+from apps.operation_analysis.constants.import_export import ConflictAction, ConflictReason, ImportExportErrorCode, ObjectType
+from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.serializers.import_export_serializers import (
     ExportRequestSerializer,
     ImportPrecheckRequestSerializer,
     ImportSubmitRequestSerializer,
 )
 from apps.operation_analysis.services.import_export.export_service import ExportService
-from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 from apps.operation_analysis.services.import_export.import_service import ImportService
-from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
+from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 
 
 class ImportExportViewSet(ViewSet):
@@ -34,7 +27,6 @@ class ImportExportViewSet(ViewSet):
     }
 
     @action(detail=False, methods=["post"], url_path="export")
-    @HasPermission("operation_analysis-View")
     def export_objects(self, request):
         serializer = ExportRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -45,8 +37,9 @@ class ImportExportViewSet(ViewSet):
         object_ids = data["object_ids"]
 
         organization_id = getattr(request, "organization_id", 0)
+        current_team = self._get_current_team(request)
 
-        object_keys = self._convert_ids_to_keys(object_type, object_ids)
+        object_keys = self._convert_ids_to_keys(object_type, object_ids, current_team=current_team)
 
         result = ExportService.export_objects(
             scope_type=scope,
@@ -58,7 +51,6 @@ class ImportExportViewSet(ViewSet):
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["post"], url_path="import/precheck")
-    @HasPermission("operation_analysis-Add")
     def import_precheck(self, request):
         serializer = ImportPrecheckRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -85,7 +77,6 @@ class ImportExportViewSet(ViewSet):
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["post"], url_path="import/submit")
-    @HasPermission("operation_analysis-Add")
     def import_submit(self, request):
         serializer = ImportSubmitRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -153,23 +144,35 @@ class ImportExportViewSet(ViewSet):
 
         return Response(result, status=status.HTTP_200_OK)
 
-    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int]) -> list[str]:
-        from apps.operation_analysis.models.models import Dashboard, Topology, Architecture
-        from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int], current_team: int = None) -> list[str]:
         from apps.operation_analysis.constants.import_export import BUSINESS_KEY_SEPARATOR
+        from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+        from apps.operation_analysis.models.models import Architecture, Dashboard, Topology
 
         keys = []
         if object_type == ObjectType.DASHBOARD.value:
-            for obj in Dashboard.objects.filter(id__in=object_ids):
+            qs = Dashboard.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.TOPOLOGY.value:
-            for obj in Topology.objects.filter(id__in=object_ids):
+            qs = Topology.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.ARCHITECTURE.value:
-            for obj in Architecture.objects.filter(id__in=object_ids):
+            qs = Architecture.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.DATASOURCE.value:
-            for obj in DataSourceAPIModel.objects.filter(id__in=object_ids):
+            qs = DataSourceAPIModel.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{obj.name}{BUSINESS_KEY_SEPARATOR}{obj.rest_api}")
         elif object_type == ObjectType.NAMESPACE.value:
             for obj in NameSpace.objects.filter(id__in=object_ids):
@@ -203,8 +206,8 @@ class ImportExportViewSet(ViewSet):
         return set(permissions)
 
     def _get_existing_object(self, object_type: ObjectType, item):
-        from apps.operation_analysis.models.models import Dashboard, Topology, Architecture
         from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+        from apps.operation_analysis.models.models import Architecture, Dashboard, Topology
 
         if object_type == ObjectType.DASHBOARD:
             return Dashboard.objects.filter(name=item.name).first()

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -12,27 +12,22 @@
 
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.response import Response
 from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
 
-from apps.core.utils.open_base import OpenAPIViewSet
 from apps.core.exceptions.base_app_exception import UnauthorizedException
 from apps.core.logger import operation_analysis_logger as logger
-from apps.operation_analysis.constants.import_export import (
-    ObjectType,
-    ConflictAction,
-    ConflictReason,
-    ImportExportErrorCode,
-)
+from apps.core.utils.open_base import OpenAPIViewSet
+from apps.operation_analysis.constants.import_export import ConflictAction, ConflictReason, ImportExportErrorCode, ObjectType
+from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.serializers.import_export_serializers import (
     ExportRequestSerializer,
     ImportPrecheckRequestSerializer,
     ImportSubmitRequestSerializer,
 )
 from apps.operation_analysis.services.import_export.export_service import ExportService
-from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 from apps.operation_analysis.services.import_export.import_service import ImportService
-from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
+from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 
 
 class OpenImportExportViewSet(OpenAPIViewSet):
@@ -89,24 +84,36 @@ class OpenImportExportViewSet(OpenAPIViewSet):
             return request.user.username
         return "api_user"
 
-    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int]) -> list[str]:
+    def _convert_ids_to_keys(self, object_type: str, object_ids: list[int], current_team: int = None) -> list[str]:
         """将对象 ID 转换为业务键"""
-        from apps.operation_analysis.models.models import Dashboard, Topology, Architecture
-        from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
         from apps.operation_analysis.constants.import_export import BUSINESS_KEY_SEPARATOR
+        from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+        from apps.operation_analysis.models.models import Architecture, Dashboard, Topology
 
         keys = []
         if object_type == ObjectType.DASHBOARD.value:
-            for obj in Dashboard.objects.filter(id__in=object_ids):
+            qs = Dashboard.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.TOPOLOGY.value:
-            for obj in Topology.objects.filter(id__in=object_ids):
+            qs = Topology.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.ARCHITECTURE.value:
-            for obj in Architecture.objects.filter(id__in=object_ids):
+            qs = Architecture.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{object_type}{BUSINESS_KEY_SEPARATOR}{obj.name}")
         elif object_type == ObjectType.DATASOURCE.value:
-            for obj in DataSourceAPIModel.objects.filter(id__in=object_ids):
+            qs = DataSourceAPIModel.objects.filter(id__in=object_ids)
+            if current_team is not None:
+                qs = qs.filter(groups__contains=current_team)
+            for obj in qs:
                 keys.append(f"{obj.name}{BUSINESS_KEY_SEPARATOR}{obj.rest_api}")
         elif object_type == ObjectType.NAMESPACE.value:
             for obj in NameSpace.objects.filter(id__in=object_ids):
@@ -186,7 +193,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
         groups = self._require_groups(request)
         organization_id = groups[0]
 
-        object_keys = self._convert_ids_to_keys(object_type, object_ids)
+        object_keys = self._convert_ids_to_keys(object_type, object_ids, current_team=organization_id)
 
         logger.info(
             "Open API export request: object_type=%s, object_ids=%s, organization_id=%s",

--- a/server/apps/operation_analysis/views/view.py
+++ b/server/apps/operation_analysis/views/view.py
@@ -7,16 +7,16 @@ from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.viewset_utils import AuthViewSet
-from apps.operation_analysis.filters.filters import DashboardModelFilter, DirectoryModelFilter, TopologyModelFilter, ArchitectureModelFilter
+from apps.operation_analysis.filters.filters import ArchitectureModelFilter, DashboardModelFilter, DirectoryModelFilter, TopologyModelFilter
+from apps.operation_analysis.models.models import Architecture, Dashboard, Directory, Topology
 from apps.operation_analysis.serializers.directory_serializers import (
+    ArchitectureModelSerializer,
     DashboardModelSerializer,
     DirectoryModelSerializer,
     TopologyModelSerializer,
-    ArchitectureModelSerializer,
 )
 from apps.operation_analysis.services.directory_service import DictDirectoryService
 from config.drf.pagination import CustomPageNumberPagination
-from apps.operation_analysis.models.models import Dashboard, Directory, Topology, Architecture
 
 
 def _raise_if_builtin(instance, action_name="修改"):
@@ -104,7 +104,7 @@ class DirectoryModelViewSet(BuiltinVisibleMixin, AuthViewSet):
         _raise_if_builtin(instance, "删除")
         return super(DirectoryModelViewSet, self).destroy(request, *args, **kwargs)
 
-    # @HasPermission("view-View")
+    @HasPermission("view-View")
     @action(detail=False, methods=["get"], url_path="tree")
     def tree(self, request, *args, **kwargs):
         result = DictDirectoryService.get_dict_trees(request)

--- a/web/src/app/ops-analysis/context/common.tsx
+++ b/web/src/app/ops-analysis/context/common.tsx
@@ -144,7 +144,6 @@ export const OpsAnalysisProvider = ({ children }: { children: ReactNode }) => {
       dataSourcesRequestingRef.current = true;
       setDataSourcesLoading(true);
       const response = await getDataSourceList({
-        all_groups: true,
         page: 1,
         page_size: 10000,
       });
@@ -171,7 +170,6 @@ export const OpsAnalysisProvider = ({ children }: { children: ReactNode }) => {
       dataSourcesRequestingRef.current = true;
       setDataSourcesLoading(true);
       const response = await getDataSourceList({
-        all_groups: true,
         page: 1,
         page_size: 10000,
       });


### PR DESCRIPTION
- NATS 数据获取支持 include_children 参数透传
- NATS 查询失败时抛出明确异常而非返回空数组
- 数据源 get_source_data 接口增加组织归属校验
- 导出接口增加 current_team 过滤，防止跨组织导出
- 恢复 tree 接口的权限校验装饰器