### PR TITLE
[incremental] 修复 monitor NATS 创建接口无法透传用户上下文

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -135,11 +135,21 @@ def _normalize_nats_create_payload(data: dict) -> dict:
     return dict(data)
 
 
-def _ensure_maintainer_fields(data: dict, operator: str = "api") -> dict:
+def _resolve_nats_actor(user_info: Optional[dict]) -> tuple[str, str]:
+    if not isinstance(user_info, dict):
+        return "api", "domain.com"
+
+    user = _normalize_permission_user(user_info.get("user"))
+    operator = getattr(user, "username", None) or "api"
+    domain = user_info.get("domain") or getattr(user, "domain", None) or "domain.com"
+    return operator, domain
+
+
+def _ensure_maintainer_fields(data: dict, operator: str = "api", domain: str = "domain.com") -> dict:
     data.setdefault("created_by", operator)
     data.setdefault("updated_by", operator)
-    data.setdefault("domain", "domain.com")
-    data.setdefault("updated_by_domain", "domain.com")
+    data.setdefault("domain", domain)
+    data.setdefault("updated_by_domain", domain)
     return data
 
 
@@ -165,16 +175,16 @@ def _build_validation_message(exc: Exception) -> str:
     return "; ".join(dict.fromkeys(messages)) if messages else str(exc)
 
 
-def _create_with_serializer(serializer_class, data: dict, operator: str = "api"):
-    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator)
+def _create_with_serializer(serializer_class, data: dict, operator: str = "api", domain: str = "domain.com"):
+    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator, domain=domain)
     serializer = serializer_class(data=payload)
     serializer.is_valid(raise_exception=True)
     instance = serializer.save()
     return instance, serializer.data
 
 
-def _create_monitor_object_payload(data: dict, operator: str = "api"):
-    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator)
+def _create_monitor_object_payload(data: dict, operator: str = "api", domain: str = "domain.com"):
+    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator, domain=domain)
     children = payload.pop("children", [])
 
     if not payload.get("instance_id_keys"):
@@ -213,8 +223,8 @@ def _create_monitor_object_payload(data: dict, operator: str = "api"):
     return parent_obj, serializer.data
 
 
-def _create_metric_group_payload(data: dict, operator: str = "api"):
-    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator)
+def _create_metric_group_payload(data: dict, operator: str = "api", domain: str = "domain.com"):
+    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator, domain=domain)
     payload.setdefault("monitor_plugin", None)
     serializer = MetricGroupSerializer(data=payload)
     serializer.is_valid(raise_exception=True)
@@ -222,8 +232,8 @@ def _create_metric_group_payload(data: dict, operator: str = "api"):
     return instance, serializer.data
 
 
-def _create_metric_payload(data: dict, operator: str = "api"):
-    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator)
+def _create_metric_payload(data: dict, operator: str = "api", domain: str = "domain.com"):
+    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator, domain=domain)
     payload.setdefault("monitor_plugin", None)
     serializer = MetricSerializer(data=payload)
     serializer.is_valid(raise_exception=True)
@@ -237,8 +247,8 @@ def _get_monitor_policy_viewset():
     return MonitorPolicyViewSet()
 
 
-def _create_monitor_policy_payload(data: dict, operator: str = "api"):
-    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator)
+def _create_monitor_policy_payload(data: dict, operator: str = "api", domain: str = "domain.com"):
+    payload = _ensure_maintainer_fields(_normalize_nats_create_payload(data), operator=operator, domain=domain)
     if not payload.get("schedule"):
         raise ValueError("schedule 不能为空")
 
@@ -255,9 +265,10 @@ def _create_monitor_policy_payload(data: dict, operator: str = "api"):
     return policy, MonitorPolicySerializer(policy).data
 
 
-def _execute_nats_create(create_func, data: dict):
+def _execute_nats_create(create_func, data: dict, user_info: Optional[dict] = None):
     try:
-        _, result_data = create_func(data)
+        operator, domain = _resolve_nats_actor(user_info)
+        _, result_data = create_func(data, operator=operator, domain=domain)
         return {"result": True, "data": result_data, "message": ""}
     except (serializers.ValidationError, ValueError) as exc:
         return {"result": False, "data": [], "message": _build_validation_message(exc)}
@@ -430,33 +441,51 @@ def _get_instance_permission_map(permission) -> dict:
 
 
 @nats_client.register
-def create_monitor_object_type(data: dict):
-    return _execute_nats_create(lambda payload: _create_with_serializer(MonitorObjectTypeSerializer, payload), data)
+def create_monitor_object_type(data: dict, *args, **kwargs):
+    return _execute_nats_create(
+        lambda payload, operator="api", domain="domain.com": _create_with_serializer(
+            MonitorObjectTypeSerializer,
+            payload,
+            operator=operator,
+            domain=domain,
+        ),
+        data,
+        user_info=kwargs.get("user_info"),
+    )
 
 
 @nats_client.register
-def create_monitor_object(data: dict):
-    return _execute_nats_create(_create_monitor_object_payload, data)
+def create_monitor_object(data: dict, *args, **kwargs):
+    return _execute_nats_create(_create_monitor_object_payload, data, user_info=kwargs.get("user_info"))
 
 
 @nats_client.register
-def create_monitor_plugin(data: dict):
-    return _execute_nats_create(lambda payload: _create_with_serializer(MonitorPluginSerializer, payload), data)
+def create_monitor_plugin(data: dict, *args, **kwargs):
+    return _execute_nats_create(
+        lambda payload, operator="api", domain="domain.com": _create_with_serializer(
+            MonitorPluginSerializer,
+            payload,
+            operator=operator,
+            domain=domain,
+        ),
+        data,
+        user_info=kwargs.get("user_info"),
+    )
 
 
 @nats_client.register
-def create_metric_group(data: dict):
-    return _execute_nats_create(_create_metric_group_payload, data)
+def create_metric_group(data: dict, *args, **kwargs):
+    return _execute_nats_create(_create_metric_group_payload, data, user_info=kwargs.get("user_info"))
 
 
 @nats_client.register
-def create_metric(data: dict):
-    return _execute_nats_create(_create_metric_payload, data)
+def create_metric(data: dict, *args, **kwargs):
+    return _execute_nats_create(_create_metric_payload, data, user_info=kwargs.get("user_info"))
 
 
 @nats_client.register
-def create_monitor_policy(data: dict):
-    return _execute_nats_create(_create_monitor_policy_payload, data)
+def create_monitor_policy(data: dict, *args, **kwargs):
+    return _execute_nats_create(_create_monitor_policy_payload, data, user_info=kwargs.get("user_info"))
 
 
 @nats_client.register

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -1,0 +1,149 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_module(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_monitor_nats_dependencies(monkeypatch):
+    def register(func):
+        return func
+
+    class ValidationError(Exception):
+        def __init__(self, detail):
+            super().__init__(str(detail))
+            self.detail = detail
+
+    class _Logger:
+        def exception(self, *args, **kwargs):
+            return None
+
+        def info(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+    class _StubModel:
+        objects = types.SimpleNamespace()
+
+    _install_module(monkeypatch, "nats_client", register=register)
+    rest_serializers = _install_module(monkeypatch, "rest_framework.serializers", ValidationError=ValidationError)
+    _install_module(monkeypatch, "rest_framework", serializers=rest_serializers)
+    _install_module(monkeypatch, "django.db.models", Count=lambda *args, **kwargs: None, Q=lambda *args, **kwargs: None)
+    _install_module(monkeypatch, "django.db", models=sys.modules["django.db.models"])
+    _install_module(monkeypatch, "apps.core.utils.time_util", format_timestamp=lambda value: value)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=_StubModel,
+        MonitorInstance=_StubModel,
+        MonitorObject=_StubModel,
+        MonitorObjectType=_StubModel,
+        Metric=_StubModel,
+        MetricGroup=_StubModel,
+        MonitorPlugin=_StubModel,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.serializers.monitor_metrics",
+        MetricGroupSerializer=object,
+        MetricSerializer=object,
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.serializers.monitor_object",
+        MonitorObjectSerializer=object,
+        MonitorObjectTypeSerializer=object,
+    )
+    _install_module(monkeypatch, "apps.monitor.serializers.plugin", MonitorPluginSerializer=object)
+    _install_module(monkeypatch, "apps.monitor.serializers.monitor_policy", MonitorPolicySerializer=object)
+    _install_module(monkeypatch, "apps.monitor.services.metrics", Metrics=types.SimpleNamespace(parse_step_to_seconds=lambda step: 300))
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.permission_utils",
+        check_instance_permission=lambda *args, **kwargs: True,
+        get_permission_rules=lambda *args, **kwargs: {},
+        get_permissions_rules=lambda *args, **kwargs: {},
+        permission_filter=lambda *args, **kwargs: [],
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.permission",
+        PermissionConstants=types.SimpleNamespace(INSTANCE_MODULE="instance"),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.victoriametrics_api", VictoriaMetricsAPI=object)
+    _install_module(monkeypatch, "apps.core.logger", nats_logger=_Logger())
+
+
+def test_create_monitor_object_type_accepts_user_info_and_uses_actor_context(monkeypatch):
+    _install_monitor_nats_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_nats_create_handlers_test_module",
+        Path(__file__).resolve().parents[1] / "nats" / "monitor.py",
+    )
+
+    captured = {}
+
+    def fake_create_with_serializer(serializer_class, data, operator="api", domain="domain.com"):
+        captured["serializer_class"] = serializer_class
+        captured["data"] = data
+        captured["operator"] = operator
+        captured["domain"] = domain
+        return object(), {"id": "host"}
+
+    monkeypatch.setattr(module, "_create_with_serializer", fake_create_with_serializer)
+
+    result = module.create_monitor_object_type(
+        {"id": "host", "name": "Host"},
+        user_info={"user": types.SimpleNamespace(username="alice", domain="tenant-a.com"), "domain": "tenant-a.com"},
+    )
+
+    assert result == {"result": True, "data": {"id": "host"}, "message": ""}
+    assert captured["data"] == {"id": "host", "name": "Host"}
+    assert captured["operator"] == "alice"
+    assert captured["domain"] == "tenant-a.com"
+
+
+def test_execute_nats_create_uses_domain_from_user_info_for_string_users(monkeypatch):
+    _install_monitor_nats_dependencies(monkeypatch)
+    module = _load_module(
+        "monitor_nats_create_handlers_string_user_test_module",
+        Path(__file__).resolve().parents[1] / "nats" / "monitor.py",
+    )
+
+    captured = {}
+
+    def fake_create(payload, operator="api", domain="domain.com"):
+        captured["payload"] = payload
+        captured["operator"] = operator
+        captured["domain"] = domain
+        return object(), {"id": "metric"}
+
+    result = module._execute_nats_create(
+        fake_create,
+        {"name": "cpu_usage"},
+        user_info={"user": "alice", "domain": "tenant-b.com"},
+    )
+
+    assert result == {"result": True, "data": {"id": "metric"}, "message": ""}
+    assert captured == {
+        "payload": {"name": "cpu_usage"},
+        "operator": "alice",
+        "domain": "tenant-b.com",
+    }


### PR DESCRIPTION
## Summary
- 修复 monitor 新增 NATS create 接口未接收 `user_info`，导致经 `MonitorOperationAnaRpc` 调用时直接参数不匹配失败
- 将创建入口统一接回 actor context，复用真实 `username/domain` 写入 maintainer 字段
- 新增纯单元测试，覆盖 `user_info` 透传与字符串用户 + 显式域名场景

## Root Cause
`f9d771171` 新增的 `create_monitor_object_type/create_monitor_object/create_monitor_plugin/create_metric_group/create_metric/create_monitor_policy` handler 只接收 `data` 参数，但调用方 `MonitorOperationAnaRpc` 会和其他 monitor RPC 一样透传 `user_info`。因此按设计调用这些接口时会先在 Python 调用层报 `unexpected keyword argument 'user_info'`，自监控创建链路整体不可用。

## Validation
- `python3 -m py_compile apps/monitor/nats/monitor.py apps/monitor/tests/test_nats_create_handlers.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 UV_CACHE_DIR=/tmp/uv-cache-bklite uv run --with pytest pytest -o addopts='' --confcutdir=apps/monitor/tests apps/monitor/tests/test_nats_create_handlers.py -q`
- `git diff --check`
