### PR TITLE
[incremental] 修复运营分析导入导出入口权限回退

### DIFF
--- a/server/apps/operation_analysis/tests.py
+++ b/server/apps/operation_analysis/tests.py
@@ -2,3 +2,40 @@
 # @File: tests.py
 # @Time: 2025/7/14 16:35
 # @Author: windyzhao
+import ast
+from pathlib import Path
+
+
+VIEW_FILE = Path(__file__).with_name("views") / "import_export_view.py"
+
+
+def _get_function_decorators(function_name):
+    module = ast.parse(VIEW_FILE.read_text(encoding="utf-8"))
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "ImportExportViewSet":
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == function_name:
+                    return item.decorator_list
+    raise AssertionError(f"未找到函数 {function_name}")
+
+
+def _assert_has_permission(function_name, expected_permission):
+    decorators = _get_function_decorators(function_name)
+    for decorator in decorators:
+        if isinstance(decorator, ast.Call) and getattr(decorator.func, "id", "") == "HasPermission":
+            literal_args = [arg.value for arg in decorator.args if isinstance(arg, ast.Constant)]
+            assert expected_permission in literal_args
+            return
+    raise AssertionError(f"{function_name} 缺少 HasPermission({expected_permission})")
+
+
+def test_import_export_export_requires_module_view_permission():
+    _assert_has_permission("export_objects", "operation_analysis-View")
+
+
+def test_import_export_precheck_requires_module_add_permission():
+    _assert_has_permission("import_precheck", "operation_analysis-Add")
+
+
+def test_import_export_submit_requires_module_add_permission():
+    _assert_has_permission("import_submit", "operation_analysis-Add")

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from apps.core.decorators.api_permission import HasPermission
 from apps.operation_analysis.constants.import_export import ConflictAction, ConflictReason, ImportExportErrorCode, ObjectType
 from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.serializers.import_export_serializers import (
@@ -27,6 +28,7 @@ class ImportExportViewSet(ViewSet):
     }
 
     @action(detail=False, methods=["post"], url_path="export")
+    @HasPermission("operation_analysis-View")
     def export_objects(self, request):
         serializer = ExportRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -51,6 +53,7 @@ class ImportExportViewSet(ViewSet):
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["post"], url_path="import/precheck")
+    @HasPermission("operation_analysis-Add")
     def import_precheck(self, request):
         serializer = ImportPrecheckRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -77,6 +80,7 @@ class ImportExportViewSet(ViewSet):
         return Response(result, status=status.HTTP_200_OK)
 
     @action(detail=False, methods=["post"], url_path="import/submit")
+    @HasPermission("operation_analysis-Add")
     def import_submit(self, request):
         serializer = ImportSubmitRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## 问题
- `server/apps/operation_analysis/views/import_export_view.py` 在最近的权限修补里误删了 `export`、`import/precheck`、`import/submit` 三个入口的 `HasPermission` 门禁。
- 结果是未持有 `operation_analysis-View` / `operation_analysis-Add` 的普通登录用户也能直接访问导入导出链路；其中 `namespace` 导出分支还不会按组织过滤，能够导出全局命名空间连接配置。

## 修复
- 恢复 `export_objects` 的 `@HasPermission("operation_analysis-View")`。
- 恢复 `import_precheck` / `import_submit` 的 `@HasPermission("operation_analysis-Add")`。
- 增加回归测试，锁定这三个入口必须挂载模块级权限装饰器。

## 验证
- `python3 -m py_compile apps/operation_analysis/views/import_export_view.py apps/operation_analysis/tests.py`
- `INSTALL_APPS='system_mgmt,operation_analysis' DB_ENGINE=sqlite DB_NAME=':memory:' SECRET_KEY=weops-lite DJANGO_SETTINGS_MODULE=settings PYTHONPATH=. uv run --extra dev pytest apps/operation_analysis/tests.py -q --confcutdir=apps/operation_analysis -o addopts=''`
- `git diff --check`
