### PR TITLE
bugfix: [MLOPS]修复训练启动缺少并发互斥，可能导致重复训练与状态串线

### DIFF
--- a/server/apps/mlops/views/anomaly_detection.py
+++ b/server/apps/mlops/views/anomaly_detection.py
@@ -85,6 +85,8 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
         """
         启动训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -138,6 +140,10 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"查询 MLflow run 数量失败，降级 expected_run_count=0, TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
             # 启动前清理可能残留的旧训练容器
             try:
                 WebhookClient.stop(job_id)
@@ -158,10 +164,6 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
                 train_image=train_image,
             )
 
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
-
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
             poll_train_job_status.delay(train_job.id, self.MLFLOW_PREFIX, expected_run_count)
@@ -175,13 +177,21 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},

--- a/server/apps/mlops/views/base.py
+++ b/server/apps/mlops/views/base.py
@@ -1,6 +1,6 @@
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.mlops.constants import TrainJobStatus, MLflowRunStatus
-from apps.core.logger import mlops_logger as logger
+from django.db import transaction
 
 
 class TeamModelViewSet(AuthViewSet):
@@ -14,6 +14,31 @@ class TeamModelViewSet(AuthViewSet):
     MLFLOW_PREFIX = ""
 
     # ---- run delete eligibility helpers (shared across all TrainJob viewsets) ----
+
+    def claim_train_job_running(self, train_job):
+        """Atomically claim a TrainJob as running.
+
+        Returns the previous status when the claim succeeds, or ``None`` if the
+        TrainJob is already running.
+        """
+        with transaction.atomic():
+            locked_train_job = train_job.__class__.objects.select_for_update().get(pk=train_job.pk)
+            if locked_train_job.status == TrainJobStatus.RUNNING:
+                return None
+
+            previous_status = locked_train_job.status
+            locked_train_job.status = TrainJobStatus.RUNNING
+            locked_train_job.save(update_fields=["status"])
+
+        train_job.status = TrainJobStatus.RUNNING
+        return previous_status
+
+    @staticmethod
+    def restore_train_job_status(train_job, previous_status):
+        """Restore a TrainJob status after webhook launch failure."""
+        updated = train_job.__class__.objects.filter(pk=train_job.pk, status=TrainJobStatus.RUNNING).update(status=previous_status)
+        if updated:
+            train_job.status = previous_status
 
     @staticmethod
     def annotate_run_delete_eligibility(run_datas, train_job_status):

--- a/server/apps/mlops/views/classification.py
+++ b/server/apps/mlops/views/classification.py
@@ -778,6 +778,8 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
         """
         启动训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -809,13 +811,6 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
                 train_job_id=train_job.id,
             )
 
-            # 启动前清理可能残留的旧训练容器
-            try:
-                WebhookClient.stop(job_id)
-                logger.info(f"已清理残留的旧训练容器: job_id={job_id}")
-            except (WebhookError, WebhookConnectionError, WebhookTimeoutError):
-                pass  # 容器不存在是正常的
-
             # 调用 WebhookClient 启动训练
             # 动态获取训练镜像
             train_image = get_image_by_prefix(self.MLFLOW_PREFIX, train_job.algorithm)
@@ -839,6 +834,17 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"查询 MLflow run 数量失败，降级 expected_run_count=0, TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
+            # 启动前清理可能残留的旧训练容器
+            try:
+                WebhookClient.stop(job_id)
+                logger.info(f"已清理残留的旧训练容器: job_id={job_id}")
+            except (WebhookError, WebhookConnectionError, WebhookTimeoutError):
+                pass  # 容器不存在是正常的
+
             WebhookClient.train(
                 job_id=job_id,
                 bucket=config.bucket,
@@ -850,10 +856,6 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
                 minio_secret_key=config.minio_secret_key,
                 train_image=train_image,
             )
-
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
 
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
@@ -868,13 +870,21 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -320,6 +320,8 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
         """
         启动图片分类训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -379,6 +381,10 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"MLflow 查询失败，降级 expected_run_count=0: TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
             # 启动前清理可能残留的旧训练容器
             try:
                 WebhookClient.stop(job_id)
@@ -400,10 +406,6 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
                 device=device,
             )
 
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
-
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
             poll_train_job_status.delay(train_job.id, self.MLFLOW_PREFIX, expected_run_count)
@@ -418,13 +420,21 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},

--- a/server/apps/mlops/views/log_clustering.py
+++ b/server/apps/mlops/views/log_clustering.py
@@ -106,6 +106,8 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
         """
         启动训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -159,6 +161,10 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"查询 MLflow run 数量失败，降级 expected_run_count=0, TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
             # 启动前清理可能残留的旧训练容器
             try:
                 WebhookClient.stop(job_id)
@@ -179,10 +185,6 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
                 train_image=train_image,
             )
 
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
-
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
             poll_train_job_status.delay(train_job.id, self.MLFLOW_PREFIX, expected_run_count)
@@ -196,13 +198,21 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -302,6 +302,8 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
         """
         启动目标检测训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -361,6 +363,10 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"MLflow 查询失败，降级 expected_run_count=0: TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
             # 启动前清理可能残留的旧训练容器
             try:
                 WebhookClient.stop(job_id)
@@ -382,10 +388,6 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
                 device=device,
             )
 
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
-
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
             poll_train_job_status.delay(train_job.id, self.MLFLOW_PREFIX, expected_run_count)
@@ -400,13 +402,21 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},

--- a/server/apps/mlops/views/timeseries_predict.py
+++ b/server/apps/mlops/views/timeseries_predict.py
@@ -106,6 +106,8 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
         """
         启动训练任务
         """
+        train_job = None
+        previous_status = None
         try:
             train_job = self.get_object()
 
@@ -159,6 +161,10 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
             except Exception:
                 logger.warning(f"查询 MLflow run 数量失败，降级 expected_run_count=0, TrainJob ID={train_job.id}")
 
+            previous_status = self.claim_train_job_running(train_job)
+            if previous_status is None:
+                return Response({"error": "训练任务已在运行中"}, status=status.HTTP_400_BAD_REQUEST)
+
             # 启动前清理可能残留的旧训练容器
             try:
                 WebhookClient.stop(job_id)
@@ -179,10 +185,6 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
                 train_image=train_image,
             )
 
-            # 更新任务状态
-            train_job.status = TrainJobStatus.RUNNING
-            train_job.save(update_fields=["status"])
-
             # 启动异步轮询训练状态
             logger.info(f"触发轮询任务: TrainJob ID={train_job.id}, 预期 run 数量: {expected_run_count}")
             poll_train_job_status.delay(train_job.id, self.MLFLOW_PREFIX, expected_run_count)
@@ -196,13 +198,21 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
             )
 
         except WebhookTimeoutError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookConnectionError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except WebhookError as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {e}")
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         except Exception as e:
+            if train_job and previous_status is not None:
+                self.restore_train_job_status(train_job, previous_status)
             logger.error(f"启动训练任务失败: {str(e)}", exc_info=True)
             return Response(
                 {"error": f"启动训练任务失败: {str(e)}"},


### PR DESCRIPTION
Closes #2844;
- 改动范围：只改了后端 7 个文件：server/apps/mlops/views/base.py 和 6 个 train() 入口文件（anomaly_detection.py、classification.py、image_classification.py、log_clustering.py、object_detection.py、timeseries_predict.py）。
- 修复方式：在 base.py 加了共享的原子抢占 helper：先用 transaction.atomic() + select_for_update() 抢占并把状态写成 RUNNING，抢不到就返回原来的 400；所有 train 入口都改为 先 claim，再 WebhookClient.stop/train，并删除旧的“webhook 后再写 RUNNING”逻辑。失败回滚现在同时覆盖 WebhookTimeoutError、WebhookConnectionError、WebhookError 和通用 Exception，且回滚用了 status=RUNNING 的 CAS 条件，避免覆盖后续终态。