### PR TITLE
fix(console_mgmt): prevent cross-account tampering in init_user_set

### DIFF
--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -81,10 +81,27 @@ def init_user_set(request):
     except Exception:
         return JsonResponse({"result": False, "message": loader.get("error.parse_request_failed", "Failed to parse request body")})
 
+    # 校验当前用户是否处于首次登录状态（仅属于默认组 OpsPilotGuest）
+    group_list = getattr(request.user, "group_list", [])
+    if not group_list or len(group_list) != 1:
+        return JsonResponse({"result": False, "message": loader.get("error.not_first_login", "User has already been initialized")})
+
+    first_group = group_list[0]
+    group_name = first_group.get("name") if isinstance(first_group, dict) else str(first_group)
+    if group_name != "OpsPilotGuest":
+        return JsonResponse({"result": False, "message": loader.get("error.not_first_login", "User has already been initialized")})
+
+    # 使用当前登录用户的身份，不信任前端传入的 user_id
+    try:
+        user = User.objects.get(username=request.user.username, domain=request.user.domain)
+    except User.DoesNotExist:
+        return JsonResponse({"result": False, "message": loader.get("error.user_not_found", "User not found")})
+
     client = SystemMgmt()
-    res = client.init_user_default_attributes(kwargs["user_id"], kwargs["group_name"], request.user.group_list[0]["id"])
+    res = client.init_user_default_attributes(user.id, kwargs["group_name"], group_list[0]["id"])
     if not res["result"]:
         return JsonResponse(res)
+    log_operation(request, "create", "console_mgmt", f"初始化用户设置: {request.user.username}")
     return JsonResponse(res)
 
 

--- a/web/src/app/ops-console/(pages)/home/page.tsx
+++ b/web/src/app/ops-console/(pages)/home/page.tsx
@@ -19,7 +19,7 @@ const ControlPage = () => {
   const { t } = useTranslation();
   const { post } = useApiClient();
   const { clientData, appConfigList, loading, appConfigLoading, refreshAppConfig } = useClientData();
-  const { loading: userLoading, isFirstLogin, userId } = useUserInfoContext();
+  const { loading: userLoading, isFirstLogin } = useUserInfoContext();
   const [isPopoverVisible, setIsPopoverVisible] = useState<boolean>(false);
   const [confirmLoading, setConfirmLoading] = useState<boolean>(false);
   const [form] = Form.useForm();
@@ -124,7 +124,6 @@ const ControlPage = () => {
       const values = await form.validateFields();
       await post('/console_mgmt/init_user_set/', {
         group_name: values.group_name,
-        user_id: userId,
       });
       message.success(t('common.saveSuccess'));
       window.location.reload();


### PR DESCRIPTION
- Use request.user identity instead of trusting client-supplied user_id
- Add server-side first-login validation (only OpsPilotGuest group)
- Add operation log for user initialization
- Remove unused user_id from frontend request payload

Closes #2852