### PR TITLE
fix(stargazer): 使用 rindex 切分 Prometheus 解析器的 labels 与 value

### DIFF
--- a/agents/stargazer/tasks/utils/nats_helper.py
+++ b/agents/stargazer/tasks/utils/nats_helper.py
@@ -235,7 +235,7 @@ def convert_prometheus_to_influx(prometheus_data: str, params: Dict[str, Any]) -
                 metric_name = line[: line.index("{")]
                 rest = line[line.index("{") + 1 :]
                 labels_part = rest[: rest.rindex("}")]
-                value_part = rest[rest.index("}") + 1 :].strip()
+                value_part = rest[rest.rindex("}") + 1 :].strip()
             else:
                 # 无 labels
                 parts = line.split()


### PR DESCRIPTION
## 这是什么

一行 fix：把 Prometheus 解析器里切分 value 的 `index('}')` 改成 `rindex('}')`。


vmware 采集信息落 cmdb不足秤（被吃了大半）
指挥AI查出bug 了， 晚点我再提pr
tasks/utils/nats_helper.py  看到了灾难性 bug，236-241 行：
```
231             # 解析 Prometheus 格式
232             # 格式: metric_name{labels} value timestamp
233             if "{" in line:
234                 # 有 labels
235                 metric_name = line[: line.index("{")]
236                 rest = line[line.index("{") + 1 :]
237                 labels_part = rest[: rest.rindex("}")]
238                 value_part = rest[rest.index("}") + 1 :].strip()      # 这里是rindex
```

本地修复后验证是它造成的，因为
**telegraf 端 0 个 parse error**（之前那种 `Invalid timestamp: Linux/Windows/...` 全消失了）



## 为什么

当一行 Prometheus 数据的 label 值里出现字面 `}` 字符时（例如 VM/实例名是 `cluster}prod`），`str.index('}')` 会匹配到 label value 内部的**第一个** `}`，而不是 labels block 的闭合大括号。

上面一行的 `labels_part` 已经用了 `rindex('}')`，两边切割点不一致 → 切出来的 metric 是错的：`value_part` 里混入了 label 残片，下游 NATS publisher 解析 timestamp 时直接抛 `Invalid timestamp` 然后**默默丢掉这一行**。

## 生产环境实际影响

在一个 CMDB vmware 采集任务里，`vmware_vm_info_gauge` 的 series 数从 **60 → 23** 静默丢失，原因就是有些 VM 显示名里带 `}`。改完这一行后，解析器恢复 publish 60 行，NATS helper 0 条 `Invalid timestamp` 警告。
