### PR TITLE
fix(server): 修正 k8s 日志采集状态检查的时间格式以兼容 VictoriaLogs

### DIFF
--- a/server/apps/log/services/k8s_collect.py
+++ b/server/apps/log/services/k8s_collect.py
@@ -263,8 +263,8 @@ class K8sLogCollectService:
         query = f'collect_type:"kubernetes" AND instance_id:"{instance.id}"'
         data = SearchService.search_logs(
             query,
-            start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            end_time.strftime("%Y-%m-%d %H:%M:%S"),
+            start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
             1,
         )
         return bool(data)


### PR DESCRIPTION
## 问题

VictoriaLogs 仅接受 RFC3339 时间戳（如 `2026-05-13T05:31:50Z`），但 `K8sLogCollectService.check_collect_status` 调用 `SearchService.search_logs` 时传入了空格分隔的 `2026-05-13 05:31:50` 格式，导致 VL 解析失败，Web UI 上「日志接入 → 验证接入状态」按钮报 `System error`。

## 错误日志

\`\`\`
victoria-logs-1 | cannot parse start=2026-05-13 05:31:50: parsing time "2026-05-13 05:31:50" as "2006-01-02T15:04:05": cannot parse " 05:31:50" as "T"
\`\`\`

## 修复

最小两行，对齐同模块 `apps/log/utils/time_util.py::TimeHelper.get_time_range` 已经使用的 RFC3339 风格：

\`\`\`diff
-            start_time.strftime("%Y-%m-%d %H:%M:%S"),
-            end_time.strftime("%Y-%m-%d %H:%M:%S"),
+            start_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            end_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
\`\`\`

`USE_TZ=True` 下 `timezone.now()` 是 UTC aware，直接拼 `Z` 语义正确。

## 验证

修复后 UI「验证」按钮恢复正常返回数据，server 日志不再出现 VL 解析错误。