### PR TITLE
fix(web): skip electron binary download in docker build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 # 设置Node.js最大堆内存为4GB
 ENV NODE_OPTIONS="--max-old-space-size=8192"
 
+# 跳过 electron 二进制下载（react-devtools 的传递依赖，构建期不需要）
+ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
+
 # 如果提供了 NEXUS_NODEJS_REPOSITY，则切换 npm 源
 RUN if [ -n "$NEXUS_NODEJS_REPOSITY" ]; then \
   echo "Setting npm registry to: $NEXUS_NODEJS_REPOSITY"; \


### PR DESCRIPTION
## Summary
- web/Dockerfile 增加 \`ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1\`
- \`react-devtools\` 作为 devDependency 会通过传递依赖触发 electron 二进制下载(默认从 github releases 拉取 ~100MB+),在国内网络环境下极易超时
- \`next build\` 产物不需要 electron 二进制,直接跳过即可,加速 Docker 构建

## Test plan
- [ ] 在国内网络环境下执行 \`docker build ./web\`,确认不再下载 electron 二进制
- [ ] 验证构建产物正常,\`pnpm run start\` 启动无异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)