### PR TITLE
fix(console_mgmt): move validate_pwd from GET query string to POST body

### DIFF
--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -132,7 +132,8 @@ def update_user_base_info(request):
 
 
 def validate_pwd(request):
-    password = request.GET.get("password")
+    body = json.loads(request.body)
+    password = body.get("password")
     username = request.user.username
     domain = request.user.domain
 

--- a/web/src/components/user-info/userInformation.tsx
+++ b/web/src/components/user-info/userInformation.tsx
@@ -147,7 +147,7 @@ const UserInformation: React.FC<UserInformationProps> = ({ visible, onClose }) =
   const handleVerifyPassword = async (values: any) => {
     try {
       setVerifyPasswordLoading(true);
-      await get(`/console_mgmt/validate_pwd/?password=${values.password}`);
+      await post('/console_mgmt/validate_pwd/', { password: values.password });
       setVerifyIdentityModalVisible(false);
       verifyForm.resetFields();
 


### PR DESCRIPTION
Password was being passed as a URL query parameter, exposing it in browser history, proxy logs, APM traces and access logs. Changed to POST with password in request body.

Closes #2954