### PR TITLE
fix(web): pin @antv/xflow to 2.2.4 to avoid .less files breaking Turb…

### DIFF
--- a/web/src/app/cmdb/package.json
+++ b/web/src/app/cmdb/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@ant-design/icons": "^5.5.1",
     "@antv/x6": "^2.18.1",
-    "@antv/xflow": "^2.2.4",
+    "@antv/xflow": "2.2.4",
     "@dnd-kit/core": "^6.2.0",
     "@dnd-kit/modifiers": "^8.0.0",
     "@dnd-kit/sortable": "^9.0.0",


### PR DESCRIPTION
…opack

v2.3.x introduced .less files in dist which Turbopack cannot handle. Remove ^ prefix to prevent auto-upgrade in Docker builds where pnpm-workspace.yaml is regenerated and lockfile may be re-resolved.