### PR TITLE
fix(opspilot): highlight selected kubernetes instance with blue border

### DIFF
--- a/web/src/app/opspilot/components/skill/kubernetesToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/kubernetesToolEditor.tsx
@@ -85,8 +85,8 @@ const KubernetesToolEditor: React.FC<KubernetesToolEditorProps> = ({
                 <button
                   key={instance.id}
                   type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
+                  className={`w-full rounded p-3 text-left transition ${
+                    isActive ? 'border-2 border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border border-[var(--color-border)] bg-[var(--color-bg-1)]'
                   }`}
                   onClick={() => onSelect(instance.id)}
                 >


### PR DESCRIPTION
Active instance gets border-2 with primary color, inactive gets thin gray border for clear visual distinction.