### PR TITLE
解决job作业列表为空，预期不为空问题。修改 execution.py

### DIFF
--- a/server/apps/job_mgmt/views/execution.py
+++ b/server/apps/job_mgmt/views/execution.py
@@ -82,7 +82,7 @@ class JobExecutionViewSet(AuthViewSet):
         username = request.user.username if request.user else ""
         name = data["name"]
         timeout = data.get("timeout", 600)
-        team = data.get("team", [])
+        team = data.get("team") or [int(request.COOKIES.get("current_team", 1))]
         params = data.get("params", [])
 
         # 处理新格式参数：解析 is_modified=False 的参数


### PR DESCRIPTION
/job/execution/job-record  空的记录 ,不管选多少天跨度。
/job/execution/job-record?id=1 有具体作业记录

Bug链清晰:

1. 第85 行:team = data.get("team",[])-如果前端 quick_execute payload没传 team,默认空数组
2. 第112行:team=team-记录就这么存进DB,值为[] 
3. List查询时按team__contains=current_team 过滤,空数组永远匹配不上看不到最干净的修复(server侧):没传team时,默认填当前team。
4. 第85行改成: 

`team = data.get("team") or [request.COOKIES.get("current_team", 1)] `

或者serializer 层面给team字段加default,从request拿current_team。（ 但这是个upstream bug,既影响 quick_execute,playbook_callback/scheduled_task等其它创建入口也可能有同样毛病.）