### PR TITLE
feat(monitor): replace event-level notification with alert lifecycle …

### DIFF
--- a/openspec/changes/monitor-alert-lifecycle-notify/design.md
+++ b/openspec/changes/monitor-alert-lifecycle-notify/design.md
@@ -1,0 +1,142 @@
+## 设计概述
+
+将通知触发点从 MonitorEvent 上移至 MonitorAlert 生命周期状态变化。告警创建时快照通知配置（渠道 + 接收人），后续生命周期内所有通知均使用快照配置。
+
+## 数据模型变更
+
+### MonitorAlert 新增字段
+
+```python
+notice_type_id = models.IntegerField(default=0, verbose_name="通知方式ID")
+notice_users = models.JSONField(default=list, verbose_name="通知人")
+```
+
+创建告警时从 `MonitorPolicy` 快照：
+- `alert.notice_type_id = policy.notice_type_id`
+- `alert.notice_users = policy.notice_users`
+
+### MonitorEvent.notice_result 字段
+
+保留但不再主动写入。历史数据兼容，新事件该字段为空 list。
+
+## 通知触发点
+
+| 动作 | 触发位置 | 条件 |
+|------|---------|------|
+| created | EventAlertManager._create_alerts_from_events 之后 | 新告警创建成功 |
+| upgraded | EventAlertManager._update_existing_alerts_from_events 中 | level 权重提升 |
+| closed | 现有逻辑不变 | 手动关闭/策略删除/策略禁用/no_data禁用 |
+| recovered | 现有逻辑不变 | info_event_count >= recovery_condition / no_data恢复 |
+
+## AlertLifecycleNotifier 重构
+
+### 核心变更：通知配置来源
+
+Before:
+```python
+class AlertLifecycleNotifier:
+    def __init__(self, policy):
+        self.policy = policy
+        # 从 policy 取 notice_type_id
+```
+
+After:
+```python
+class AlertLifecycleNotifier:
+    @staticmethod
+    def notify(alerts, action, operator="", reason=""):
+        # 从每个 alert 自身取 notice_type_id / notice_users
+        # 按 notice_type_id 分组批量发送
+```
+
+### 渠道分发逻辑
+
+```
+notify(alerts, action):
+    按 alert.notice_type_id 分组
+    对每组:
+        查询 Channel
+        if channel 不存在:
+            log warning, skip
+        elif channel 是 alert center (nats + receive_alert_events):
+            构建 alert center payload, 批量推送
+        else:
+            构建通用通知内容, 通过 SystemMgmtUtils.send_msg_with_channel 发送
+```
+
+### 通知内容模板
+
+普通渠道通知内容按动作区分：
+
+| 动作 | 标题模板 | 内容要素 |
+|------|---------|---------|
+| created | 告警产生：{policy_name} | 资源、级别、告警内容、时间 |
+| upgraded | 告警升级：{policy_name} | 资源、旧级别→新级别、告警内容、时间 |
+| closed | 告警关闭：{policy_name} | 资源、操作人、原因、时间 |
+| recovered | 告警恢复：{policy_name} | 资源、持续时长、时间 |
+
+告警中心 NATS payload 的 action 映射：
+
+| 内部动作 | alert center action |
+|---------|-------------------|
+| created | created |
+| upgraded | updated |
+| closed | closed |
+| recovered | recovery |
+
+## EventAlertManager 变更
+
+### 移除 notify_events
+
+`notify_events` 方法整体移除（或保留为空操作 + deprecation warning）。调用方不再调用此方法。
+
+### 创建告警时快照 + 通知
+
+```python
+def _create_alerts_from_events(self, events):
+    # ... 现有逻辑 ...
+    for event in events:
+        create_alerts.append(MonitorAlert(
+            ...
+            notice_type_id=self.policy.notice_type_id,  # 新增
+            notice_users=self.policy.notice_users,       # 新增
+        ))
+    new_alerts = MonitorAlert.objects.bulk_create(...)
+    
+    # 新增：触发 created 通知
+    AlertLifecycleNotifier.notify(new_alerts, action="created")
+    
+    return new_alerts
+```
+
+### 升级时通知
+
+```python
+def _update_existing_alerts_from_events(self, event_data_list):
+    # ... 现有升级逻辑 ...
+    if alert_level_updates:
+        MonitorAlert.objects.bulk_update(...)
+        # 新增：触发 upgraded 通知
+        AlertLifecycleNotifier.notify(alert_level_updates, action="upgraded")
+```
+
+## 兼容性
+
+### 存量活跃告警
+
+已存在的 MonitorAlert 没有 notice_type_id/notice_users 字段值（默认为 0/[]）。处理策略：
+
+- 迁移时不回填（避免大量数据更新）
+- AlertLifecycleNotifier 中判断：如果 alert.notice_type_id == 0，fallback 到 policy 取配置
+- 这样存量告警的关闭/恢复通知不受影响
+
+### MonitorEvent.notice_result
+
+字段保留，新事件不再写入。前端如果展示该字段，不受影响（空 list 表示无通知记录）。
+
+## 不做的事
+
+- 不提供"批量更新活跃告警通知方式"的 UI/API
+- 不 fallback 到策略当前渠道（渠道不存在就跳过）
+- 不改变 MonitorEvent 的创建逻辑（事件仍正常记录）
+- 不改变告警中心 receive_alert_events 的接收端逻辑

--- a/openspec/changes/monitor-alert-lifecycle-notify/proposal.md
+++ b/openspec/changes/monitor-alert-lifecycle-notify/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+监控模块当前通知机制以事件（MonitorEvent）为粒度触发：每次策略扫描产生告警事件时即发送通知。这导致同一告警在其生命周期内会产生大量重复通知，且"告警升级"等关键状态变化没有通知。需要将通知主体从事件切换为告警（MonitorAlert），仅在告警生命周期关键状态变化时触发通知。
+
+此外，当策略通知方式变更时，活跃告警的通知渠道归属不明确。需要在告警创建时快照通知配置，使告警成为自包含的生命周期实体。
+
+## What Changes
+
+- MonitorAlert 模型新增 `notice_type_id` 和 `notice_users` 字段，创建时从策略快照。
+- 移除 `EventAlertManager.notify_events()` 中的事件级通知逻辑（不再对每个事件发通知）。
+- 扩展 `AlertLifecycleNotifier`，支持四种生命周期动作的通知：created、upgraded、closed、recovered。
+- 告警创建时（`_create_alerts_from_events`）触发 created 通知。
+- 告警升级时（`_update_existing_alerts_from_events` 中 level 提升）触发 upgraded 通知。
+- `AlertLifecycleNotifier` 改为从 alert 自身的 `notice_type_id`/`notice_users` 取通知配置，不再依赖 policy 实时状态。
+- 渠道不存在时记录日志跳过，不 fallback 到策略当前渠道。
+- 普通通知渠道（邮件/企微/飞书等）也统一走告警通知模型，不再只限于告警中心 NATS。
+
+## Capabilities
+
+### New Capabilities
+- `monitor-alert-lifecycle-notify`: 基于告警生命周期状态变化的统一通知能力，覆盖 created/upgraded/closed/recovered 四种动作，支持所有通知渠道。
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `server/apps/monitor/models/monitor_policy.py`: MonitorAlert 新增 notice_type_id、notice_users 字段。
+- `server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py`: 移除 notify_events，创建告警时快照通知配置并触发 created 通知，升级时触发 upgraded 通知。
+- `server/apps/monitor/services/alert_lifecycle_notify.py`: 重构为从 alert 取通知配置，支持所有渠道和四种动作。
+- `server/apps/monitor/tasks/services/policy_scan/alert_detector.py`: recovered 通知保持不变（已走 lifecycle notifier）。
+- `server/apps/monitor/views/monitor_policy.py`: closed 通知保持不变（已走 lifecycle notifier）。
+- `server/apps/monitor/views/monitor_alert.py`: 手动关闭通知保持不变。
+- 需要新增数据库迁移文件。

--- a/openspec/changes/monitor-alert-lifecycle-notify/tasks.md
+++ b/openspec/changes/monitor-alert-lifecycle-notify/tasks.md
@@ -1,0 +1,36 @@
+## 1. 数据模型与迁移
+
+- [x] 1.1 MonitorAlert 模型新增 `notice_type_id`（IntegerField, default=0）和 `notice_users`（JSONField, default=list）字段
+- [x] 1.2 生成并应用数据库迁移文件（不回填存量数据）
+
+## 2. AlertLifecycleNotifier 重构
+
+- [x] 2.1 重构 `AlertLifecycleNotifier`，改为从 alert 自身取 notice_type_id/notice_users（alert.notice_type_id == 0 时 fallback 到 policy）
+- [x] 2.2 支持普通渠道通知（邮件/企微/飞书等），不再仅限 alert center NATS
+- [x] 2.3 按 notice_type_id 分组批量发送，渠道不存在时 log warning 跳过
+- [x] 2.4 支持四种动作的通知内容模板：created/upgraded/closed/recovered
+- [x] 2.5 告警中心 NATS payload 的 action 映射：created→created, upgraded→updated, closed→closed, recovered→recovery
+
+## 3. 告警创建时快照通知配置并触发通知
+
+- [x] 3.1 `EventAlertManager._create_alerts_from_events` 中创建告警时写入 notice_type_id/notice_users（从 policy 快照）
+- [x] 3.2 创建告警成功后调用 `AlertLifecycleNotifier.notify(new_alerts, action="created")`
+
+## 4. 告警升级时触发通知
+
+- [x] 4.1 `EventAlertManager._update_existing_alerts_from_events` 中 level 提升并 bulk_update 后调用 `AlertLifecycleNotifier.notify(alert_level_updates, action="upgraded")`
+
+## 5. 移除事件级通知
+
+- [x] 5.1 移除 `EventAlertManager.notify_events` 方法的实际通知逻辑（保留方法签名为空操作或直接删除）
+- [x] 5.2 移除 `EventAlertManager.send_notice` 方法
+- [x] 5.3 移除 `EventAlertManager._push_to_alert_center` 方法（created 推送已迁移到 lifecycle notifier）
+- [x] 5.4 移除 `EventAlertManager._check_alert_center_channel` 及相关初始化逻辑
+- [x] 5.5 清理 policy scan 主流程中对 `notify_events` 的调用
+
+## 6. 验证
+
+- [x] 6.1 确认现有 closed/recovered 通知路径不受破坏（AlertLifecycleNotifier 调用点在 alert_detector.py、monitor_policy.py、monitor_alert.py）
+- [x] 6.2 确认 MonitorEvent 创建逻辑不受影响（事件仍正常记录，notice_result 字段保留但不写入）
+- [ ] 6.3 执行 `cd server && make test` 确认测试通过（阻塞：当前环境无法连通 PostgreSQL；补充：`uv run pytest apps/monitor/tests/test_policy_scan_failure_handling.py -q` 中本次相关 monitor 用例已通过）
+- [ ] 6.4 检查 lsp_diagnostics 确认无类型错误（阻塞：本地未安装 basedpyright-langserver；补充：变更文件已通过 `python3 -m py_compile` 语法校验）

--- a/server/apps/monitor/migrations/0035_monitoralert_notice_type_id_monitoralert_notice_users.py
+++ b/server/apps/monitor/migrations/0035_monitoralert_notice_type_id_monitoralert_notice_users.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("monitor", "0034_monitorplugin_node_selector"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="monitoralert",
+            name="notice_type_id",
+            field=models.IntegerField(default=0, verbose_name="通知方式ID"),
+        ),
+        migrations.AddField(
+            model_name="monitoralert",
+            name="notice_users",
+            field=models.JSONField(default=list, verbose_name="通知人"),
+        ),
+    ]

--- a/server/apps/monitor/models/monitor_policy.py
+++ b/server/apps/monitor/models/monitor_policy.py
@@ -159,6 +159,8 @@ class MonitorAlert(TimeInfo):
     operator = models.CharField(blank=True, null=True, max_length=50, verbose_name="告警处理人")
     info_event_count = models.IntegerField(default=0, verbose_name="信息事件数量")
     operation_logs = models.JSONField(default=list, verbose_name="操作记录")
+    notice_type_id = models.IntegerField(default=0, verbose_name="通知方式ID")
+    notice_users = models.JSONField(default=list, verbose_name="通知人")
 
     class Meta:
         verbose_name = "监控告警"

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -1,53 +1,114 @@
+from collections import defaultdict
+
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
 from apps.system_mgmt.models import Channel
 
 
+ACTION_TO_ALERT_CENTER = {
+    "created": "created",
+    "upgraded": "updated",
+    "recovered": "recovery",
+    "closed": "closed",
+}
+
+LEVEL_TO_ALERT_CENTER = {
+    "critical": "0",
+    "error": "1",
+    "warning": "2",
+    "info": "3",
+    "no_data": "2",
+}
+
+
 class AlertLifecycleNotifier:
-    def __init__(self, policy):
+    def __init__(self, policy=None):
         self.policy = policy
-        self._is_alert_center = self._check_alert_center_channel()
 
     def notify_alerts(self, alerts, action, operator="", reason=""):
-        if not alerts or not self._should_notify() or not self._is_alert_center:
-            logger.warning(f"Lifecycle notify skipped for policy {self.policy.id}: should_notify={self._should_notify()}, is_alert_center={self._is_alert_center}")
+        """发送告警生命周期通知。从 alert 自身取通知配置，alert.notice_type_id == 0 时 fallback 到 policy。"""
+        if not alerts:
             return
 
-        try:
-            logger.info("Lifecycle alert notify")
-            self._push_to_alert_center(alerts, action, operator, reason)
-        except Exception as e:
-            logger.error(
-                f"Lifecycle notify exception for policy {self.policy.id}: action={action}, error={e}",
-                exc_info=True,
-            )
+        groups = defaultdict(list)
+        for alert in alerts:
+            channel_id = self._resolve_notice_type_id(alert)
+            notice_users = self._resolve_notice_users(alert)
+            if not channel_id:
+                logger.warning(f"Alert {alert.id} has no notice_type_id configured, skip notification")
+                continue
+            groups[(channel_id, tuple(notice_users) if notice_users else ())].append(alert)
 
-    def _should_notify(self):
-        return bool(self.policy.notice and self.policy.notice_type_id)
+        for (channel_id, notice_users_tuple), group_alerts in groups.items():
+            notice_users = list(notice_users_tuple)
+            try:
+                self._send_to_channel(channel_id, notice_users, group_alerts, action, operator, reason)
+            except Exception as e:
+                logger.error(
+                    f"Lifecycle notify exception: action={action}, channel_id={channel_id}, error={e}",
+                    exc_info=True,
+                )
 
-    def _check_alert_center_channel(self):
-        channel = Channel.objects.filter(id=self.policy.notice_type_id).first()
+    def _resolve_notice_type_id(self, alert):
+        if alert.notice_type_id:
+            return alert.notice_type_id
+        if self.policy and self.policy.notice and self.policy.notice_type_id:
+            return self.policy.notice_type_id
+        return 0
+
+    def _resolve_notice_users(self, alert):
+        if alert.notice_users:
+            return alert.notice_users
+        if self.policy and self.policy.notice_users:
+            return self.policy.notice_users
+        return []
+
+    def _send_to_channel(self, channel_id, notice_users, alerts, action, operator, reason):
+        channel = Channel.objects.filter(id=channel_id).first()
         if not channel:
-            return False
-        return channel.channel_type == "nats" and channel.config.get("method_name") == "receive_alert_events"
+            logger.warning(f"Channel {channel_id} not found, skip notification for {len(alerts)} alerts")
+            return
 
-    def _push_to_alert_center(self, alerts, action, operator, reason):
+        is_alert_center = channel.channel_type == "nats" and channel.config.get("method_name") == "receive_alert_events"
+
+        if is_alert_center:
+            self._push_to_alert_center(channel_id, alerts, action, operator, reason)
+        else:
+            self._send_normal_notice(channel_id, notice_users, alerts, action, operator, reason)
+
+    def _send_normal_notice(self, channel_id, notice_users, alerts, action, operator, reason):
+        for alert in alerts:
+            title = self._build_title(alert, action)
+            content = self._build_content(alert, action, operator, reason)
+            try:
+                send_result = SystemMgmtUtils.send_msg_with_channel(channel_id, title, content, notice_users)
+                if send_result.get("result") is False:
+                    logger.error(f"Normal notify failed: alert={alert.id}, action={action}, message={send_result.get('message', 'Unknown error')}")
+                else:
+                    logger.info(f"Normal notify success: alert={alert.id}, action={action}")
+            except Exception as e:
+                logger.error(f"Normal notify exception: alert={alert.id}, action={action}, error={e}", exc_info=True)
+
+    def _push_to_alert_center(self, channel_id, alerts, action, operator, reason):
         content = {
             "source_id": "nats",
             "pusher": "lite-monitor",
             "events": [self._build_alert_center_payload(alert, action, operator, reason) for alert in alerts],
         }
-        send_result = SystemMgmtUtils.send_msg_with_channel(self.policy.notice_type_id, "", content, [])
-        if send_result.get("result") is False:
-            logger.error(
-                f"Lifecycle push to alert center failed for policy {self.policy.id}: "
-                f"action={action}, message={send_result.get('message', 'Unknown error')}"
-            )
-        else:
-            logger.info(f"Lifecycle push to alert center success for policy {self.policy.id}: action={action}, count={len(alerts)}")
+        try:
+            send_result = SystemMgmtUtils.send_msg_with_channel(channel_id, "", content, [])
+            if send_result.get("result") is False:
+                logger.error(
+                    f"Lifecycle push to alert center failed: action={action}, "
+                    f"count={len(alerts)}, message={send_result.get('message', 'Unknown error')}"
+                )
+            else:
+                logger.info(f"Lifecycle push to alert center success: action={action}, count={len(alerts)}")
+        except Exception as e:
+            logger.error(f"Lifecycle push to alert center exception: action={action}, error={e}", exc_info=True)
 
     def _build_alert_center_payload(self, alert, action, operator, reason):
-        alert_center_action = self._map_action_to_alert_center(action)
+        alert_center_action = ACTION_TO_ALERT_CENTER.get(action, "created")
         start_time = str(int(alert.start_event_time.timestamp())) if alert.start_event_time else None
         end_time = str(int(alert.end_event_time.timestamp())) if alert.end_event_time else None
         return {
@@ -55,36 +116,54 @@ class AlertLifecycleNotifier:
             "rule_id": str(alert.policy_id),
             "title": alert.content,
             "description": alert.content,
-            "level": self._map_level_to_alert_center(alert.level),
+            "level": LEVEL_TO_ALERT_CENTER.get(alert.level, "3"),
             "value": float(alert.value) if alert.value is not None else None,
             "action": alert_center_action,
             "start_time": start_time,
             "end_time": end_time,
             "resource_id": alert.monitor_instance_id,
-            "resource_name": alert.monitor_instance_name,
-            "tags": alert.dimensions,
+            "resource_name": getattr(alert, "monitor_instance_name", ""),
+            "tags": getattr(alert, "dimensions", {}),
             "labels": {
-                "policy_name": self.policy.name,
-                "metric_instance_id": alert.metric_instance_id,
+                "policy_name": getattr(self.policy, "name", "") if self.policy else "",
+                "metric_instance_id": getattr(alert, "metric_instance_id", ""),
                 "operator": operator,
                 "reason": reason,
                 "status": alert.status,
             },
         }
 
-    def _map_level_to_alert_center(self, level):
-        level_map = {
-            "critical": "0",
-            "error": "1",
-            "warning": "2",
-            "info": "3",
-            "no_data": "2",
+    def _build_title(self, alert, action):
+        action_labels = {
+            "created": "告警产生",
+            "upgraded": "告警升级",
+            "closed": "告警关闭",
+            "recovered": "告警恢复",
         }
-        return level_map.get(level, "3")
+        label = action_labels.get(action, "告警通知")
+        policy_name = getattr(self.policy, "name", "") if self.policy else ""
+        return f"{label}：{policy_name}" if policy_name else label
 
-    def _map_action_to_alert_center(self, action):
-        action_map = {
-            "recovered": "recovery",
-            "closed": "closed",
-        }
-        return action_map.get(action, "created")
+    def _build_content(self, alert, action, operator, reason):
+        parts = [f"告警内容：{alert.content}"]
+
+        instance_name = getattr(alert, "monitor_instance_name", "") or alert.monitor_instance_id
+        if instance_name:
+            parts.append(f"资源：{instance_name}")
+
+        parts.append(f"级别：{alert.level}")
+
+        if action == "upgraded":
+            parts.append("状态：告警级别已升级")
+        elif action == "closed":
+            if operator:
+                parts.append(f"操作人：{operator}")
+            if reason:
+                parts.append(f"原因：{reason}")
+        elif action == "recovered":
+            parts.append("状态：已自动恢复")
+
+        if alert.start_event_time:
+            parts.append(f"开始时间：{alert.start_event_time.strftime('%Y-%m-%d %H:%M:%S')}")
+
+        return "\n".join(parts)

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -1,13 +1,10 @@
-"""事件告警管理服务 - 负责事件和告警的创建、通知"""
-
 import uuid
 
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import MonitorAlert, MonitorEvent, MonitorEventRawData
+from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 from apps.monitor.utils.dimension import format_dimension_str
-from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
-from apps.system_mgmt.models import Channel
 from apps.core.logger import celery_logger as logger
 
 
@@ -16,7 +13,6 @@ class EventAlertManager:
         self.policy = policy
         self.instances_map = instances_map
         self.active_alerts = active_alerts
-        self._is_alert_center = self._check_alert_center_channel()
 
     def create_events(self, events):
         if not events:
@@ -182,7 +178,6 @@ class EventAlertManager:
                     monitor_instance_id=monitor_instance_id,
                     metric_instance_id=metric_instance_id,
                     dimensions=dimensions,
-                    # monitor_instance_name=display_name,
                     monitor_instance_name=instance_name,
                     alert_type=alert_type,
                     level=level,
@@ -191,6 +186,8 @@ class EventAlertManager:
                     status="new",
                     start_event_time=self.policy.last_run_time,
                     operator="",
+                    notice_type_id=self.policy.notice_type_id,
+                    notice_users=self.policy.notice_users,
                 )
             )
 
@@ -208,6 +205,10 @@ class EventAlertManager:
             )
 
         logger.info(f"Created {len(new_alerts)} new alerts for policy {self.policy.id}")
+
+        if new_alerts and self.policy.notice:
+            AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created")
+
         return new_alerts
 
     def _format_dimension_str(self, dimensions: dict) -> str:
@@ -247,120 +248,5 @@ class EventAlertManager:
             )
             logger.info(f"Updated {len(alert_level_updates)} alerts with higher severity levels")
 
-    def send_notice(self, event_obj):
-        title = f"告警通知：{self.policy.name}"
-        content = f"告警内容：{event_obj.content}"
-
-        try:
-            send_result = SystemMgmtUtils.send_msg_with_channel(self.policy.notice_type_id, title, content, self.policy.notice_users)
-            if send_result.get("result") is False:
-                logger.error(f"send notice failed for policy {self.policy.name}: {send_result.get('message', 'Unknown error')}")
-            else:
-                logger.info(f"send notice success for policy {self.policy.name}: {send_result}")
-            return [send_result]
-        except Exception as e:
-            logger.error(
-                f"send notice exception for policy {self.policy.name}: {e}",
-                exc_info=True,
-            )
-            return [{"result": False, "message": str(e)}]
-
-    def notify_events(self, event_objs):
-        events_to_notify = []
-
-        for event in event_objs:
-            if event.level == "info":
-                continue
-            events_to_notify.append(event)
-
-        if not events_to_notify:
-            return
-
-        if self._is_alert_center:
-            notice_results = self._push_to_alert_center(events_to_notify)
-            # 告警中心走批量推送，当前渠道只返回整批发送结果，而不是逐事件回执。
-            # 因此这里将同一批次结果写回到每个事件，便于审计时保留真实下游返回值。
-            for event in events_to_notify:
-                event.notice_result = notice_results
-            MonitorEvent.objects.bulk_update(
-                events_to_notify,
-                ["notice_result"],
-                batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
-            )
-        else:
-            for event in events_to_notify:
-                notice_results = self.send_notice(event)
-                event.notice_result = notice_results
-
-            MonitorEvent.objects.bulk_update(
-                events_to_notify,
-                ["notice_result"],
-                batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
-            )
-
-    def _check_alert_center_channel(self) -> bool:
-        """检查通知渠道是否为告警中心（初始化时调用一次）"""
-        if not self.policy.notice_type_id:
-            return False
-        # todo 获取Channel详情的nats方法
-        channel = Channel.objects.filter(id=self.policy.notice_type_id).first()
-        if not channel:
-            return False
-        return channel.channel_type == "nats" and channel.config.get("method_name") == "receive_alert_events"
-
-    def _push_to_alert_center(self, events_to_notify):
-        alert_events = []
-        for event in events_to_notify:
-            start_time = str(int(event.event_time.timestamp())) if event.event_time else None
-            alert_events.append(
-                {
-                    # 告警中心依赖 external_id 将 created 与 recovery/closed 生命周期事件关联到同一告警。
-                    "external_id": str(event.alert_id),
-                    "rule_id": str(event.policy_id),
-                    "title": event.content,
-                    "description": event.content,
-                    "level": self._map_level_to_alert_center(event.level),
-                    "value": float(event.value) if event.value is not None else None,
-                    "action": "created",
-                    "start_time": start_time,
-                    "resource_id": event.monitor_instance_id,
-                    "resource_name": self.instances_map.get(event.monitor_instance_id, ""),
-                    "tags": event.dimensions,
-                    "labels": {
-                        "policy_name": self.policy.name,
-                        "metric_instance_id": event.metric_instance_id,
-                        "alert_id": event.alert_id,
-                        "event_id": event.id,
-                    },
-                }
-            )
-
-        content = {
-            "source_id": "nats",
-            "pusher": "lite-monitor",
-            "events": alert_events,
-        }
-        try:
-            send_result = SystemMgmtUtils.send_msg_with_channel(self.policy.notice_type_id, "", content, [])
-            if send_result.get("result") is False:
-                logger.error(f"Push to alert center failed for policy {self.policy.name}: {send_result.get('message', 'Unknown error')}")
-            else:
-                logger.info(f"Push to alert center success for policy {self.policy.name}: {len(alert_events)} events")
-            return [send_result]
-        except Exception as e:
-            logger.error(
-                f"Push to alert center exception for policy {self.policy.name}: {e}",
-                exc_info=True,
-            )
-            return [{"result": False, "message": str(e)}]
-
-    def _map_level_to_alert_center(self, level):
-        """映射告警级别到告警中心格式: 0-致命, 1-错误, 2-预警, 3-提醒"""
-        level_map = {
-            "critical": "0",
-            "error": "1",
-            "warning": "2",
-            "info": "3",
-            "no_data": "2",
-        }
-        return level_map.get(level, "3")
+            if self.policy.notice:
+                AlertLifecycleNotifier(self.policy).notify_alerts(alert_level_updates, action="upgraded")

--- a/server/apps/monitor/tasks/services/policy_scan/scanner.py
+++ b/server/apps/monitor/tasks/services/policy_scan/scanner.py
@@ -34,12 +34,8 @@ class MonitorPolicyScan:
             self.active_alerts,
             self.metric_query_service,
         )
-        self.event_alert_manager = EventAlertManager(
-            policy, self.instances_map, self.active_alerts
-        )
-        self.snapshot_recorder = SnapshotRecorder(
-            policy, self.instances_map, self.active_alerts, self.metric_query_service
-        )
+        self.event_alert_manager = EventAlertManager(policy, self.instances_map, self.active_alerts)
+        self.snapshot_recorder = SnapshotRecorder(policy, self.instances_map, self.active_alerts, self.metric_query_service)
 
     def _get_active_alerts(self):
         """获取策略的活动告警"""
@@ -134,14 +130,7 @@ class MonitorPolicyScan:
             return None, None
 
         event_objs, new_alerts = result
-        logger.info(
-            f"Created {len(event_objs)} events and {len(new_alerts)} new alerts"
-        )
-
-        if self.policy.notice and event_objs:
-            self._execute_step(
-                "Send notifications", self.event_alert_manager.notify_events, event_objs
-            )
+        logger.info(f"Created {len(event_objs)} events and {len(new_alerts)} new alerts")
 
         return event_objs, new_alerts
 
@@ -205,9 +194,7 @@ class MonitorPolicyScan:
     def _pre_check(self):
         """前置检查"""
         if self.policy.source and not self.instances_map:
-            logger.warning(
-                f"Policy {self.policy.id} has source but no instances, skipping scan"
-            )
+            logger.warning(f"Policy {self.policy.id} has source but no instances, skipping scan")
             return False
 
         self._execute_step(
@@ -230,9 +217,7 @@ class MonitorPolicyScan:
             )
             if success and result is not None:
                 alert_events, info_events = result
-                logger.info(
-                    f"Threshold alerts: {len(alert_events)} alerts, {len(info_events)} info events"
-                )
+                logger.info(f"Threshold alerts: {len(alert_events)} alerts, {len(info_events)} info events")
 
         if AlertConstants.NO_DATA in self.policy.enable_alerts:
             success, result = self._execute_step(

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -577,63 +577,6 @@ def test_snapshot_recorder_skips_fallback_raw_metric_query_for_no_data_alerts(mo
     assert snapshot_calls == [(3, {}, True)]
 
 
-def test_no_data_events_can_notify_without_legacy_policy_field(monkeypatch):
-    bulk_update_calls = []
-
-    class MonitorEvent:
-        class objects:
-            @staticmethod
-            def bulk_update(event_objs, fields, batch_size=None):
-                bulk_update_calls.append((event_objs, fields, batch_size))
-
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.alert_policy",
-        AlertConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.database",
-        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.models",
-        MonitorAlert=object,
-        MonitorEvent=MonitorEvent,
-        MonitorEventRawData=object,
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.dimension",
-        format_dimension_str=lambda dimensions: "",
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=object,
-    )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
-    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
-
-    module = _load_module(
-        "monitor_policy_event_alert_manager_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
-
-    manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(id=1005, name="no-data-policy")
-    manager._is_alert_center = False
-    manager.send_notice = lambda event: [{"result": True}]
-
-    event = types.SimpleNamespace(level="no_data", notice_result=None)
-
-    manager.notify_events([event])
-
-    assert event.notice_result == [{"result": True}]
-    assert bulk_update_calls == [([event], ["notice_result"], 100)]
-
-
 def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
     _install_module(
         monkeypatch,
@@ -662,10 +605,9 @@ def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
     )
     _install_module(
         monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=object,
+        "apps.monitor.services.alert_lifecycle_notify",
+        AlertLifecycleNotifier=lambda *args, **kwargs: types.SimpleNamespace(notify_alerts=lambda *a, **kw: None),
     )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
     _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
 
     module = _load_module(
@@ -716,200 +658,6 @@ def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
     assert new_alerts == [created_alert]
 
 
-def test_send_notice_returns_channel_result_for_event_audit(monkeypatch):
-    send_results = [{"result": True, "message": "sent"}]
-
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.alert_policy",
-        AlertConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.database",
-        DatabaseConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.models",
-        MonitorAlert=object,
-        MonitorEvent=object,
-        MonitorEventRawData=object,
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.dimension",
-        format_dimension_str=lambda dimensions: "",
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=types.SimpleNamespace(send_msg_with_channel=lambda *args: send_results[0]),
-    )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
-    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
-
-    module = _load_module(
-        "monitor_policy_event_alert_manager_notice_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
-
-    manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(
-        id=1007,
-        name="notice-policy",
-        notice_type_id=9,
-        notice_users=["admin"],
-    )
-    event = types.SimpleNamespace(content="cpu critical")
-
-    assert manager.send_notice(event) == send_results
-
-
-def test_alert_center_notification_result_is_persisted(monkeypatch):
-    bulk_update_calls = []
-    send_calls = []
-    send_result = {"result": False, "message": "channel unavailable"}
-
-    class MonitorEvent:
-        class objects:
-            @staticmethod
-            def bulk_update(event_objs, fields, batch_size=None):
-                bulk_update_calls.append((event_objs, fields, batch_size))
-
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.alert_policy",
-        AlertConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.database",
-        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.models",
-        MonitorAlert=object,
-        MonitorEvent=MonitorEvent,
-        MonitorEventRawData=object,
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.dimension",
-        format_dimension_str=lambda dimensions: "",
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=types.SimpleNamespace(send_msg_with_channel=lambda *args: send_calls.append(args) or send_result),
-    )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
-    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
-
-    module = _load_module(
-        "monitor_policy_event_alert_manager_alert_center_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
-
-    manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(
-        id=1008,
-        name="alert-center-policy",
-        notice_type_id=9,
-    )
-    manager.instances_map = {"host-1": "Host 1"}
-    manager._is_alert_center = True
-
-    event = types.SimpleNamespace(
-        id="evt-1",
-        level="critical",
-        policy_id=1008,
-        content="cpu critical",
-        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
-        value=95.0,
-        monitor_instance_id="host-1",
-        dimensions={"instance_id": "host-1"},
-        metric_instance_id="('host-1',)",
-        alert_id=77,
-        notice_result=None,
-    )
-
-    manager.notify_events([event])
-
-    assert len(send_calls) == 1
-    assert send_calls[0][0] == 9
-    assert send_calls[0][2]["events"][0]["external_id"] == "77"
-    assert send_calls[0][2]["events"][0]["labels"]["event_id"] == "evt-1"
-    assert event.notice_result == [send_result]
-    assert bulk_update_calls == [([event], ["notice_result"], 100)]
-
-
-def test_alert_center_created_event_uses_alert_id_as_external_id(monkeypatch):
-    send_calls = []
-
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.alert_policy",
-        AlertConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.database",
-        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.models",
-        MonitorAlert=object,
-        MonitorEvent=types.SimpleNamespace(objects=types.SimpleNamespace(bulk_update=lambda *args, **kwargs: None)),
-        MonitorEventRawData=object,
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.dimension",
-        format_dimension_str=lambda dimensions: "",
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=types.SimpleNamespace(send_msg_with_channel=lambda *args: send_calls.append(args) or {"result": True}),
-    )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
-    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
-
-    module = _load_module(
-        "monitor_policy_event_alert_manager_external_id_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
-
-    manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(id=1010, name="alert-center-policy", notice_type_id=9)
-    manager.instances_map = {"host-1": "Host 1"}
-
-    event = types.SimpleNamespace(
-        id="evt-created-1",
-        level="critical",
-        policy_id=1010,
-        content="cpu critical",
-        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
-        value=95.0,
-        monitor_instance_id="host-1",
-        dimensions={"instance_id": "host-1"},
-        metric_instance_id="('host-1',)",
-        alert_id=88,
-        notice_result=None,
-    )
-
-    manager._push_to_alert_center([event])
-
-    payload_event = send_calls[0][2]["events"][0]
-    assert payload_event["external_id"] == "88"
-    assert payload_event["external_id"] != event.id
-    assert payload_event["labels"]["alert_id"] == 88
-    assert payload_event["labels"]["event_id"] == "evt-created-1"
-
-
 def test_alert_center_created_and_recovery_events_share_same_external_id(monkeypatch):
     _install_module(
         monkeypatch,
@@ -941,31 +689,11 @@ def test_alert_center_created_and_recovery_events_share_same_external_id(monkeyp
     _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
     _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger(), monitor_logger=_Logger())
 
-    event_module = _load_module(
-        "monitor_policy_event_alert_manager_consistency_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
     lifecycle_module = _load_module(
         "monitor_alert_lifecycle_notify_consistency_test_module",
         Path(__file__).resolve().parents[1] / "services" / "alert_lifecycle_notify.py",
     )
 
-    event_manager = object.__new__(event_module.EventAlertManager)
-    event_manager.policy = types.SimpleNamespace(id=1011, name="alert-center-policy", notice_type_id=9)
-    event_manager.instances_map = {"host-1": "Host 1"}
-
-    created_event = types.SimpleNamespace(
-        id="evt-created-2",
-        level="critical",
-        policy_id=1011,
-        content="cpu critical",
-        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
-        value=95.0,
-        monitor_instance_id="host-1",
-        dimensions={"instance_id": "host-1"},
-        metric_instance_id="('host-1',)",
-        alert_id=99,
-    )
     alert = types.SimpleNamespace(
         id=99,
         policy_id=1011,
@@ -979,104 +707,19 @@ def test_alert_center_created_and_recovery_events_share_same_external_id(monkeyp
         dimensions={"instance_id": "host-1"},
         metric_instance_id="('host-1',)",
         status="recovered",
+        notice_type_id=9,
+        notice_users=[],
     )
-
-    created_payload = event_manager._push_to_alert_center([created_event])[0]
-    assert created_payload["result"] is True
 
     lifecycle_notifier = object.__new__(lifecycle_module.AlertLifecycleNotifier)
     lifecycle_notifier.policy = types.SimpleNamespace(id=1011, name="alert-center-policy", notice_type_id=9)
 
-    created_external_id = str(created_event.alert_id)
+    created_payload = lifecycle_notifier._build_alert_center_payload(alert, "created", operator="", reason="")
     recovery_payload = lifecycle_notifier._build_alert_center_payload(alert, "recovered", operator="tester", reason="auto")
 
-    assert recovery_payload["external_id"] == created_external_id
-    assert recovery_payload["external_id"] != created_event.id
-
-
-def test_alert_center_notification_reuses_same_batch_result_for_each_event(monkeypatch):
-    bulk_update_calls = []
-    send_result = {"result": True, "message": "accepted"}
-
-    class MonitorEvent:
-        class objects:
-            @staticmethod
-            def bulk_update(event_objs, fields, batch_size=None):
-                bulk_update_calls.append((event_objs, fields, batch_size))
-
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.alert_policy",
-        AlertConstants=types.SimpleNamespace(),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.constants.database",
-        DatabaseConstants=types.SimpleNamespace(BULK_UPDATE_BATCH_SIZE=100),
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.models",
-        MonitorAlert=object,
-        MonitorEvent=MonitorEvent,
-        MonitorEventRawData=object,
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.dimension",
-        format_dimension_str=lambda dimensions: "",
-    )
-    _install_module(
-        monkeypatch,
-        "apps.monitor.utils.system_mgmt_api",
-        SystemMgmtUtils=types.SimpleNamespace(send_msg_with_channel=lambda *args: send_result),
-    )
-    _install_module(monkeypatch, "apps.system_mgmt.models", Channel=object)
-    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
-
-    module = _load_module(
-        "monitor_policy_event_alert_manager_batch_notice_test_module",
-        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
-    )
-
-    manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(id=1009, name="alert-center-policy", notice_type_id=9)
-    manager.instances_map = {"host-1": "Host 1", "host-2": "Host 2"}
-    manager._is_alert_center = True
-
-    event_one = types.SimpleNamespace(
-        id="evt-1",
-        level="critical",
-        policy_id=1009,
-        content="cpu critical",
-        event_time=datetime(2026, 4, 21, 8, 0, tzinfo=timezone.utc),
-        value=95.0,
-        monitor_instance_id="host-1",
-        dimensions={"instance_id": "host-1"},
-        metric_instance_id="('host-1',)",
-        alert_id=77,
-        notice_result=None,
-    )
-    event_two = types.SimpleNamespace(
-        id="evt-2",
-        level="warning",
-        policy_id=1009,
-        content="memory warning",
-        event_time=datetime(2026, 4, 21, 8, 1, tzinfo=timezone.utc),
-        value=81.0,
-        monitor_instance_id="host-2",
-        dimensions={"instance_id": "host-2"},
-        metric_instance_id="('host-2',)",
-        alert_id=78,
-        notice_result=None,
-    )
-
-    manager.notify_events([event_one, event_two])
-
-    assert event_one.notice_result == [send_result]
-    assert event_two.notice_result == [send_result]
-    assert event_one.notice_result is event_two.notice_result
-    assert bulk_update_calls == [([event_one, event_two], ["notice_result"], 100)]
+    assert created_payload["external_id"] == str(alert.id)
+    assert recovery_payload["external_id"] == str(alert.id)
+    assert created_payload["external_id"] == recovery_payload["external_id"]
 
 
 def test_last_over_time_uses_policy_window_in_range_selector(monkeypatch):


### PR DESCRIPTION
…notification

Alerts now notify on lifecycle transitions (created/upgraded/closed/recovered) instead of per-event. MonitorAlert snapshots notice_type_id and notice_users from policy at creation time, making alerts self-contained notification entities.

- Add notice_type_id/notice_users fields to MonitorAlert model
- Rewrite AlertLifecycleNotifier to read config from alert (fallback to policy)
- Support normal channels (email/wecom/feishu) in addition to alert center NATS
- Trigger created/upgraded notifications in EventAlertManager
- Remove event-level notify_events/send_notice/_push_to_alert_center methods
- Remove notify_events call from scanner main flow
- Update tests to match new API