### PR TITLE
feat(web): support multi-select notification channels in strategy UI

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/notificationForm.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/notificationForm.tsx
@@ -23,7 +23,6 @@ const getChannelIcon = (channelType: string): string => {
   return iconMap[channelType] || 'jiqiren3';
 };
 
-// 根据 channel_type 返回对应的翻译键
 const getChannelTypeKey = (channelType: string): string => {
   const keyMap: Record<string, string> = {
     email: 'monitor.events.channelTypeEmail',
@@ -50,12 +49,17 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
   const { t } = useTranslation();
   const form = Form.useFormInstance<StrategyFields>();
 
-  // 通知渠道变更时清空通知者
-  const handleChannelChange = () => {
-    form.setFieldValue('notice_users', []);
+  const handleChannelChange = (newIds: (string | number)[]) => {
+    form.setFieldValue('notice_type_ids', newIds);
+    const selectedTypes = channelList
+      .filter((ch) => newIds.includes(ch.id))
+      .map((ch) => ch.channel_type);
+    const allNats = selectedTypes.length > 0 && selectedTypes.every((t) => t === 'nats');
+    if (allNats) {
+      form.setFieldValue('notice_users', []);
+    }
   };
 
-  // 将 channelList 转换为 SelectCard 需要的数据格式
   const channelCardData: CardItem[] = useMemo(() => {
     return channelList.map((item) => {
       const tagKey = getChannelTypeKey(item.channel_type);
@@ -100,7 +104,7 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
                     {t('monitor.events.notificationChannel')}
                   </span>
                 }
-                name="notice_type_id"
+                name="notice_type_ids"
                 rules={[
                   {
                     required: true,
@@ -111,10 +115,7 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
                 {channelList.length ? (
                   <SelectCard
                     data={channelCardData}
-                    onChange={(val) => {
-                      form.setFieldValue('notice_type_id', val);
-                      handleChannelChange();
-                    }}
+                    onChange={handleChannelChange}
                   />
                 ) : (
                   <span>
@@ -133,21 +134,21 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
               <Form.Item
                 noStyle
                 shouldUpdate={(prevValues, currentValues) =>
-                  prevValues.notice_type_id !== currentValues.notice_type_id
+                  prevValues.notice_type_ids !== currentValues.notice_type_ids
                 }
               >
                 {({ getFieldValue }) => {
-                  const selectedChannel = channelList.find(
-                    (item) => item.id === getFieldValue('notice_type_id')
-                  );
-                  const channelType = selectedChannel?.channel_type;
+                  const selectedIds: number[] = getFieldValue('notice_type_ids') || [];
+                  const selectedChannels = channelList.filter((item) => selectedIds.includes(item.id));
+                  const channelTypes = selectedChannels.map((ch) => ch.channel_type);
 
-                  // NATS 渠道不需要通知者
-                  if (channelType === 'nats') {
+                  if (!selectedChannels.length || channelTypes.every((t) => t === 'nats')) {
                     return null;
                   }
 
-                  if (channelType === 'email') {
+                  const hasEmail = channelTypes.includes('email');
+
+                  if (hasEmail) {
                     return (
                       <Form.Item<StrategyFields>
                         label={
@@ -164,9 +165,7 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
                         ]}
                       >
                         <Select
-                          style={{
-                            width: '100%'
-                          }}
+                          style={{ width: '100%' }}
                           showSearch
                           allowClear
                           mode="multiple"
@@ -215,9 +214,7 @@ const NotificationForm: React.FC<NotificationFormProps> = ({
                       ]}
                     >
                       <Select
-                        style={{
-                          width: '100%'
-                        }}
+                        style={{ width: '100%' }}
                         mode="tags"
                         placeholder={t(
                           'monitor.events.notifierTagsPlaceholder'

--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -156,7 +156,7 @@ const StrategyOperation = () => {
       const channelItem = channelList[0];
       const initForm: TableDataItem = {
         organizations: groupId,
-        notice_type_id: channelItem?.id,
+        notice_type_ids: channelItem ? [channelItem.id] : [],
         notice_type: channelItem?.channel_type,
         notice: false,
         period: 5,
@@ -641,10 +641,9 @@ const StrategyOperation = () => {
           : {};
         params.no_data_period = params.no_data_recovery_period = periodValue;
       }
-      if (params.notice_type_id) {
-        params.notice_type =
-          channelList.find((item) => item.id === params.notice_type_id)
-            ?.channel_type || '';
+      if (params.notice_type_ids?.length) {
+        const firstChannel = channelList.find((item) => item.id === params.notice_type_ids![0]);
+        params.notice_type = firstChannel?.channel_type || '';
       }
       params.enable_alerts = _enableAlerts;
       params.recovery_condition = params.recovery_condition || 0;

--- a/web/src/app/monitor/(pages)/event/strategy/detail/selectCard.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/selectCard.tsx
@@ -3,19 +3,23 @@ import { Tag } from 'antd';
 import Icon from '@/components/icon';
 import { CardItem, SelectCardProps } from '@/app/monitor/types/event';
 
-// 根据 CSS 变量生成带透明度的颜色
 const getColorWithOpacity = (cssVar: string, opacity: number): string => {
   return `color-mix(in srgb, var(${cssVar}) ${opacity * 100}%, transparent)`;
 };
 
 const SelectCard: React.FC<SelectCardProps> = ({
   data = [],
-  value,
+  value = [],
   onChange,
   cardWidth
 }) => {
   const handleCardClick = (item: CardItem) => {
-    onChange?.(item.value);
+    const currentValue = value || [];
+    const exists = currentValue.includes(item.value);
+    const newValue = exists
+      ? currentValue.filter((v) => v !== item.value)
+      : [...currentValue, item.value];
+    onChange?.(newValue);
   };
 
   return (
@@ -29,7 +33,7 @@ const SelectCard: React.FC<SelectCardProps> = ({
       }}
     >
       {data.map((item, index) => {
-        const isSelected = value === item.value;
+        const isSelected = (value || []).includes(item.value);
         return (
           <div
             key={index}
@@ -47,14 +51,12 @@ const SelectCard: React.FC<SelectCardProps> = ({
             } shadow-md transition-all duration-300 ease-in-out rounded-lg p-3 cursor-pointer group hover:shadow-lg`}
           >
             <div className="flex gap-3 h-full">
-              {/* 左侧图标 */}
               {item.icon && (
                 <Icon
                   type={item.icon}
                   className="text-2xl flex-shrink-0 mt-1"
                 />
               )}
-              {/* 右侧内容 */}
               <div className="flex-1 min-w-0 flex flex-col">
                 <h2
                   className="text-[14px] font-bold m-0 truncate"

--- a/web/src/app/monitor/types/event.ts
+++ b/web/src/app/monitor/types/event.ts
@@ -10,8 +10,8 @@ export interface CardItem {
 
 export interface SelectCardProps {
   data: CardItem[];
-  value?: string | number;
-  onChange?: (value: string | number) => void;
+  value?: (string | number)[];
+  onChange?: (value: (string | number)[]) => void;
   cardWidth?: number;
 }
 
@@ -59,7 +59,7 @@ export interface StrategyFields {
   no_data_level?: string;
   notice?: boolean;
   notice_type?: string;
-  notice_type_id?: number;
+  notice_type_ids?: number[];
   notice_users?: string[];
   monitor_object?: number;
   id?: number;


### PR DESCRIPTION
Convert SelectCard from single-select to multi-select (toggle). Update monitor and log strategy forms to use notice_type_ids (array) instead of notice_type_id (single value). Notice users are shown when any non-NATS channel is selected.