### PR TITLE
feat：运营分析新增「监控中心」内置仪表盘

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -9,7 +9,12 @@ from django.db.models import Count, Q
 from apps.core.utils.time_util import format_timestamp
 from apps.core.utils.loader import LanguageLoader
 
-from apps.monitor.models import MonitorAlert, MonitorInstance, MonitorObject, MonitorObjectType, Metric, MetricGroup, MonitorPlugin
+from apps.monitor.models import (
+    MonitorAlert, MonitorInstance, MonitorObject, MonitorObjectType,
+    Metric, MetricGroup, MonitorPlugin, MonitorPolicy, MonitorEvent,
+    MonitorAlertMetricSnapshot, PolicyInstanceBaseline, CollectConfig,
+    MonitorInstanceOrganization, PolicyOrganization,
+)
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
 from apps.monitor.serializers.monitor_object import MonitorObjectSerializer, MonitorObjectTypeSerializer
 from apps.monitor.serializers.plugin import MonitorPluginSerializer
@@ -1022,3 +1027,121 @@ def mm_query(query: str, step="5m", *args, **kwargs):
     else:
         data = []
     return {"result": True, "data": data, "message": ""}
+
+
+@nats_client.register
+def get_monitor_statistics(user_info=None, **kwargs):
+    """监控中心总览统计
+
+    返回资源/能力/告警三大维度全部计数指标，供 operation_analysis
+    内置仪表盘以 single 值卡片渲染（按 selectedFields 取字段）。
+
+    Args:
+        user_info: { team: int, is_superuser: bool, ... } 由 operation_analysis 注入
+
+    Returns:
+        { "result": True, "data": { 各项计数 ... }, "message": "" }
+    """
+    user_info = user_info or {}
+    team = user_info.get("team")
+    is_superuser = bool(user_info.get("is_superuser"))
+
+    def _scope_instance(qs):
+        if is_superuser or not team:
+            return qs
+        return qs.filter(monitorinstanceorganization__organization=team).distinct()
+
+    def _scope_policy(qs):
+        if is_superuser or not team:
+            return qs
+        return qs.filter(policyorganization__organization=team).distinct()
+
+    # ============ 资源概览 ============
+    monitor_object_total = MonitorObject.objects.count()
+    monitor_object_visible = MonitorObject.objects.filter(is_visible=True).count()
+    monitor_object_category = MonitorObjectType.objects.count()
+
+    instance_qs = _scope_instance(MonitorInstance.objects.filter(is_deleted=False))
+    monitor_instance_total = instance_qs.count()
+    monitor_instance_active = instance_qs.filter(is_active=True).count()
+    monitor_instance_inactive = instance_qs.filter(is_active=False).count()
+
+    # ============ 能力概览 ============
+    plugin_total = MonitorPlugin.objects.count()
+    plugin_builtin = MonitorPlugin.objects.filter(is_pre=True).count()
+    plugin_custom = MonitorPlugin.objects.filter(is_pre=False).count()
+    metric_total = Metric.objects.count()
+    metric_group_total = MetricGroup.objects.count()
+    collect_config_total = CollectConfig.objects.filter(
+        monitor_instance_id__in=instance_qs.values_list("id", flat=True)
+    ).count() if not (is_superuser or not team) else CollectConfig.objects.count()
+
+    # ============ 告警概览 ============
+    policy_qs = _scope_policy(MonitorPolicy.objects.all())
+    policy_total = policy_qs.count()
+    policy_enabled = policy_qs.filter(enable=True).count()
+    policy_disabled = policy_qs.filter(enable=False).count()
+    # 阈值策略：有 threshold 配置 / 无数据策略：no_data_level 非空
+    policy_threshold = policy_qs.exclude(threshold=[]).count()
+    policy_no_data = policy_qs.exclude(no_data_level="").count()
+
+    alert_qs = MonitorAlert.objects.filter(
+        policy_id__in=policy_qs.values_list("id", flat=True)
+    ) if not is_superuser else MonitorAlert.objects.all()
+    alert_history = alert_qs.count()
+    alert_current = alert_qs.filter(status="new").count()
+    alert_recovered = alert_qs.filter(status="recovered").count()
+    alert_closed = alert_qs.filter(status="closed").count()
+
+    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    alert_today = alert_qs.filter(created_at__gte=today_start).count()
+
+    event_qs = MonitorEvent.objects.filter(
+        policy_id__in=policy_qs.values_list("id", flat=True)
+    ) if not is_superuser else MonitorEvent.objects.all()
+    event_total = event_qs.count()
+    event_today = event_qs.filter(created_at__gte=today_start).count()
+
+    alert_snapshot_total = MonitorAlertMetricSnapshot.objects.filter(
+        policy_id__in=policy_qs.values_list("id", flat=True)
+    ).count() if not is_superuser else MonitorAlertMetricSnapshot.objects.count()
+
+    no_data_baseline_total = PolicyInstanceBaseline.objects.filter(
+        policy_id__in=policy_qs.values_list("id", flat=True)
+    ).count() if not is_superuser else PolicyInstanceBaseline.objects.count()
+
+    return {
+        "result": True,
+        "data": {
+            # 资源
+            "monitor_object_total": monitor_object_total,
+            "monitor_object_visible": monitor_object_visible,
+            "monitor_object_category": monitor_object_category,
+            "monitor_instance_total": monitor_instance_total,
+            "monitor_instance_active": monitor_instance_active,
+            "monitor_instance_inactive": monitor_instance_inactive,
+            # 能力
+            "plugin_total": plugin_total,
+            "plugin_builtin": plugin_builtin,
+            "plugin_custom": plugin_custom,
+            "metric_total": metric_total,
+            "metric_group_total": metric_group_total,
+            "collect_config_total": collect_config_total,
+            # 告警
+            "policy_total": policy_total,
+            "policy_enabled": policy_enabled,
+            "policy_disabled": policy_disabled,
+            "alert_current": alert_current,
+            "alert_history": alert_history,
+            "alert_today": alert_today,
+            "alert_recovered": alert_recovered,
+            "alert_closed": alert_closed,
+            "policy_threshold": policy_threshold,
+            "policy_no_data": policy_no_data,
+            "event_total": event_total,
+            "event_today": event_today,
+            "alert_snapshot_total": alert_snapshot_total,
+            "no_data_baseline_total": no_data_baseline_total,
+        },
+        "message": "",
+    }

--- a/server/apps/operation_analysis/support-files/builtin_canvases.yaml
+++ b/server/apps/operation_analysis/support-files/builtin_canvases.yaml
@@ -1068,6 +1068,100 @@ dashboards:
       end: '2026-05-18T09:16:29.990Z'
       start: '2026-04-18T09:16:29.990Z'
       selectValue: 43200
+- key: dashboard::监控中心仪表盘_内置
+  name: 监控中心仪表盘_内置
+  desc: 监控中心资源/能力/告警总览
+  other:
+    timeSelector:
+      selectValue: 10080
+      rangePickerVaule: null
+  view_sets:
+  # ===== 资源概览 =====
+  - {h: 3, w: 2, x: 0,  y: 0, i: mon-stat-r01, name: 监控对象总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_object_total],
+       thresholdColors: [{color: '#366ce4', value: '70'}, {color: '#366ce4', value: '30'}, {color: '#366ce4', value: '0'}]}}
+  - {h: 3, w: 2, x: 2,  y: 0, i: mon-stat-r02, name: 可见监控对象数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_object_visible],
+       thresholdColors: [{color: '#366ce4', value: '70'}, {color: '#366ce4', value: '30'}, {color: '#366ce4', value: '0'}]}}
+  - {h: 3, w: 2, x: 4,  y: 0, i: mon-stat-r03, name: 监控对象分类数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_object_category],
+       thresholdColors: [{color: '#366ce4', value: '70'}, {color: '#366ce4', value: '30'}, {color: '#366ce4', value: '0'}]}}
+  - {h: 3, w: 2, x: 6,  y: 0, i: mon-stat-r04, name: 监控实例总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_instance_total],
+       thresholdColors: [{color: '#366ce4', value: '70'}, {color: '#366ce4', value: '30'}, {color: '#366ce4', value: '0'}]}}
+  - {h: 3, w: 2, x: 8,  y: 0, i: mon-stat-r05, name: 活跃实例数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_instance_active],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 10, y: 0, i: mon-stat-r06, name: 停用实例数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [monitor_instance_inactive],
+       thresholdColors: [{color: '#EAB839', value: '70'}, {color: '#EAB839', value: '30'}, {color: '#EAB839', value: '0'}]}}
+  # ===== 能力概览 =====
+  - {h: 3, w: 2, x: 0,  y: 3, i: mon-stat-c01, name: 监控插件总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [plugin_total],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 2,  y: 3, i: mon-stat-c02, name: 内置插件数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [plugin_builtin],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 4,  y: 3, i: mon-stat-c03, name: 自定义插件数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [plugin_custom],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 6,  y: 3, i: mon-stat-c04, name: 指标定义总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [metric_total],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 8,  y: 3, i: mon-stat-c05, name: 指标分组总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [metric_group_total],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 10, y: 3, i: mon-stat-c06, name: 采集配置总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [collect_config_total],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  # ===== 告警概览 =====
+  - {h: 3, w: 2, x: 0,  y: 6, i: mon-stat-a01, name: 告警策略总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [policy_total],
+       thresholdColors: [{color: '#fd9c40', value: '70'}, {color: '#fd9c40', value: '30'}, {color: '#fd9c40', value: '0'}]}}
+  - {h: 3, w: 2, x: 2,  y: 6, i: mon-stat-a02, name: 启用策略数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [policy_enabled],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 4,  y: 6, i: mon-stat-a03, name: 禁用策略数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [policy_disabled],
+       thresholdColors: [{color: '#EAB839', value: '70'}, {color: '#EAB839', value: '30'}, {color: '#EAB839', value: '0'}]}}
+  - {h: 3, w: 2, x: 6,  y: 6, i: mon-stat-a04, name: 当前告警总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_current],
+       thresholdColors: [{color: '#fd666d', value: '70'}, {color: '#fd666d', value: '30'}, {color: '#fd666d', value: '0'}]}}
+  - {h: 3, w: 2, x: 8,  y: 6, i: mon-stat-a05, name: 历史告警总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_history],
+       thresholdColors: [{color: '#fd9c40', value: '70'}, {color: '#fd9c40', value: '30'}, {color: '#fd9c40', value: '0'}]}}
+  - {h: 3, w: 2, x: 10, y: 6, i: mon-stat-a06, name: 今日新增告警数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_today],
+       thresholdColors: [{color: '#fd666d', value: '70'}, {color: '#fd666d', value: '30'}, {color: '#fd666d', value: '0'}]}}
+  - {h: 3, w: 2, x: 0,  y: 9, i: mon-stat-a07, name: 已恢复告警数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_recovered],
+       thresholdColors: [{color: '#67a567', value: '70'}, {color: '#67a567', value: '30'}, {color: '#67a567', value: '0'}]}}
+  - {h: 3, w: 2, x: 2,  y: 9, i: mon-stat-a08, name: 已关闭告警数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_closed],
+       thresholdColors: [{color: '#bfbfbf', value: '70'}, {color: '#bfbfbf', value: '30'}, {color: '#bfbfbf', value: '0'}]}}
+  - {h: 3, w: 2, x: 4,  y: 9, i: mon-stat-a09, name: 阈值策略数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [policy_threshold],
+       thresholdColors: [{color: '#fd9c40', value: '70'}, {color: '#fd9c40', value: '30'}, {color: '#fd9c40', value: '0'}]}}
+  - {h: 3, w: 2, x: 6,  y: 9, i: mon-stat-a10, name: 无数据策略数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [policy_no_data],
+       thresholdColors: [{color: '#EAB839', value: '70'}, {color: '#EAB839', value: '30'}, {color: '#EAB839', value: '0'}]}}
+  - {h: 3, w: 2, x: 8,  y: 9, i: mon-stat-a11, name: 监控事件总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [event_total],
+       thresholdColors: [{color: '#9254de', value: '70'}, {color: '#9254de', value: '30'}, {color: '#9254de', value: '0'}]}}
+  - {h: 3, w: 2, x: 10, y: 9, i: mon-stat-a12, name: 今日新增事件数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [event_today],
+       thresholdColors: [{color: '#9254de', value: '70'}, {color: '#9254de', value: '30'}, {color: '#9254de', value: '0'}]}}
+  - {h: 3, w: 2, x: 0,  y: 12, i: mon-stat-a13, name: 告警快照总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [alert_snapshot_total],
+       thresholdColors: [{color: '#36cfc9', value: '70'}, {color: '#36cfc9', value: '30'}, {color: '#36cfc9', value: '0'}]}}
+  - {h: 3, w: 2, x: 2,  y: 12, i: mon-stat-a14, name: 无数据基准总数, moved: false, static: false, description: '',
+     valueConfig: {chartType: single, dataSource: '监控中心总览统计::monitor/get_monitor_statistics', selectedFields: [no_data_baseline_total],
+       thresholdColors: [{color: '#36cfc9', value: '70'}, {color: '#36cfc9', value: '30'}, {color: '#36cfc9', value: '0'}]}}
+  refs:
+    datasource_keys:
+    - 监控中心总览统计::monitor/get_monitor_statistics
+    namespace_keys: []
+  filters: []
 topologies: []
 architectures: []
 datasources:
@@ -1513,6 +1607,45 @@ datasources:
     title: 通知失败率
     value_type: number
     description: 发送失败的通知在全部通知中的占比，单位为 %
+  namespace_keys:
+  - 默认命名空间
+- key: 监控中心总览统计::monitor/get_monitor_statistics
+  name: 监控中心总览统计
+  rest_api: monitor/get_monitor_statistics
+  desc: 监控中心资源/能力/告警总览统计数据
+  is_active: true
+  params: []
+  tags:
+  - monitor
+  chart_type:
+  - single
+  field_schema:
+  - {key: monitor_object_total, title: 监控对象总数, value_type: number, description: 监控对象定义总数}
+  - {key: monitor_object_visible, title: 可见监控对象数, value_type: number, description: 可见的监控对象数}
+  - {key: monitor_object_category, title: 监控对象分类数, value_type: number, description: 监控对象分类总数}
+  - {key: monitor_instance_total, title: 监控实例总数, value_type: number, description: 未删除的监控实例总数}
+  - {key: monitor_instance_active, title: 活跃实例数, value_type: number, description: 处于启用状态的监控实例数}
+  - {key: monitor_instance_inactive, title: 停用实例数, value_type: number, description: 处于停用状态的监控实例数}
+  - {key: plugin_total, title: 监控插件总数, value_type: number, description: 监控插件总数}
+  - {key: plugin_builtin, title: 内置插件数, value_type: number, description: 系统内置的监控插件数}
+  - {key: plugin_custom, title: 自定义插件数, value_type: number, description: 用户自定义的监控插件数}
+  - {key: metric_total, title: 指标定义总数, value_type: number, description: 指标定义条目总数}
+  - {key: metric_group_total, title: 指标分组总数, value_type: number, description: 指标分组总数}
+  - {key: collect_config_total, title: 采集配置总数, value_type: number, description: 采集配置总数}
+  - {key: policy_total, title: 告警策略总数, value_type: number, description: 告警策略总数}
+  - {key: policy_enabled, title: 启用策略数, value_type: number, description: 启用的告警策略数}
+  - {key: policy_disabled, title: 禁用策略数, value_type: number, description: 禁用的告警策略数}
+  - {key: alert_current, title: 当前告警总数, value_type: number, description: 当前未处理的告警总数}
+  - {key: alert_history, title: 历史告警总数, value_type: number, description: 历史告警总数}
+  - {key: alert_today, title: 今日新增告警数, value_type: number, description: 今日新增的告警数}
+  - {key: alert_recovered, title: 已恢复告警数, value_type: number, description: 已恢复状态的告警数}
+  - {key: alert_closed, title: 已关闭告警数, value_type: number, description: 已关闭状态的告警数}
+  - {key: policy_threshold, title: 阈值策略数, value_type: number, description: 配置了阈值的策略数}
+  - {key: policy_no_data, title: 无数据策略数, value_type: number, description: 配置了无数据检测的策略数}
+  - {key: event_total, title: 监控事件总数, value_type: number, description: 监控事件总数}
+  - {key: event_today, title: 今日新增事件数, value_type: number, description: 今日新增的监控事件数}
+  - {key: alert_snapshot_total, title: 告警快照总数, value_type: number, description: 告警指标快照总数}
+  - {key: no_data_baseline_total, title: 无数据基准总数, value_type: number, description: 策略实例基准总数}
   namespace_keys:
   - 默认命名空间
 namespaces:

--- a/server/apps/operation_analysis/support-files/source_api.json
+++ b/server/apps/operation_analysis/support-files/source_api.json
@@ -297,5 +297,45 @@
             "filterType": "params"
         }
     ]
+},
+{
+    "name": "监控中心总览统计",
+    "desc": "监控中心资源/能力/告警总览统计数据",
+    "rest_api": "monitor/get_monitor_statistics",
+    "tag": [
+        "monitor"
+    ],
+    "chart_type": [
+        "single"
+    ],
+    "params": [],
+    "field_schema": [
+        {"key": "monitor_object_total", "title": "监控对象总数", "value_type": "number", "description": "监控对象定义总数"},
+        {"key": "monitor_object_visible", "title": "可见监控对象数", "value_type": "number", "description": "可见的监控对象数"},
+        {"key": "monitor_object_category", "title": "监控对象分类数", "value_type": "number", "description": "监控对象分类总数"},
+        {"key": "monitor_instance_total", "title": "监控实例总数", "value_type": "number", "description": "未删除的监控实例总数"},
+        {"key": "monitor_instance_active", "title": "活跃实例数", "value_type": "number", "description": "处于启用状态的监控实例数"},
+        {"key": "monitor_instance_inactive", "title": "停用实例数", "value_type": "number", "description": "处于停用状态的监控实例数"},
+        {"key": "plugin_total", "title": "监控插件总数", "value_type": "number", "description": "监控插件总数"},
+        {"key": "plugin_builtin", "title": "内置插件数", "value_type": "number", "description": "系统内置的监控插件数"},
+        {"key": "plugin_custom", "title": "自定义插件数", "value_type": "number", "description": "用户自定义的监控插件数"},
+        {"key": "metric_total", "title": "指标定义总数", "value_type": "number", "description": "指标定义条目总数"},
+        {"key": "metric_group_total", "title": "指标分组总数", "value_type": "number", "description": "指标分组总数"},
+        {"key": "collect_config_total", "title": "采集配置总数", "value_type": "number", "description": "采集配置总数"},
+        {"key": "policy_total", "title": "告警策略总数", "value_type": "number", "description": "告警策略总数"},
+        {"key": "policy_enabled", "title": "启用策略数", "value_type": "number", "description": "启用的告警策略数"},
+        {"key": "policy_disabled", "title": "禁用策略数", "value_type": "number", "description": "禁用的告警策略数"},
+        {"key": "alert_current", "title": "当前告警总数", "value_type": "number", "description": "当前未处理的告警总数"},
+        {"key": "alert_history", "title": "历史告警总数", "value_type": "number", "description": "历史告警总数"},
+        {"key": "alert_today", "title": "今日新增告警数", "value_type": "number", "description": "今日新增的告警数"},
+        {"key": "alert_recovered", "title": "已恢复告警数", "value_type": "number", "description": "已恢复状态的告警数"},
+        {"key": "alert_closed", "title": "已关闭告警数", "value_type": "number", "description": "已关闭状态的告警数"},
+        {"key": "policy_threshold", "title": "阈值策略数", "value_type": "number", "description": "配置了阈值的策略数"},
+        {"key": "policy_no_data", "title": "无数据策略数", "value_type": "number", "description": "配置了无数据检测的策略数"},
+        {"key": "event_total", "title": "监控事件总数", "value_type": "number", "description": "监控事件总数"},
+        {"key": "event_today", "title": "今日新增事件数", "value_type": "number", "description": "今日新增的监控事件数"},
+        {"key": "alert_snapshot_total", "title": "告警快照总数", "value_type": "number", "description": "告警指标快照总数"},
+        {"key": "no_data_baseline_total", "title": "无数据基准总数", "value_type": "number", "description": "策略实例基准总数"}
+    ]
 }
 ]

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,10 @@
     "@ant-design/icons": "^5.6.1",
     "@ant-design/nextjs-registry": "^1.3.0",
     "@antv/g6": "^5.0.50",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^9.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@isoflow/isopacks": "^0.0.10",
     "@types/react-resizable": "^3.0.8",
     "@xyflow/react": "^12.8.4",
     "antd": "^5.29.3",
@@ -46,7 +50,8 @@
     "remark": "^15.0.1",
     "remark-gfm": "^4.0.0",
     "remark-html": "^16.0.1",
-    "uuid": "^11.0.3"
+    "uuid": "^11.0.3",
+    "x-isoflow-react-19": "^1.1.1-patch-6"
   },
   "devDependencies": {
     "@ant-design/v5-patch-for-react-19": "^1.0.3",


### PR DESCRIPTION
- 新增 monitor NATS 处理器 get_monitor_statistics，聚合返回资源/能力/告警 26 项计数指标，并按当前组织做权限过滤
- 在 operation_analysis 内置数据源中注册「监控中心总览统计」，含完整 field_schema
- 在 builtin_canvases.yaml 新增「监控中心仪表盘_内置」，含 26 个 single 值卡片分三栏布局
- 补齐 web/package.json 中缺失的 x-isoflow-react-19 / @isoflow/isopacks 依赖声明（架构图页面运行时依赖）