### PR TITLE
fix(monitor): add permission guards to manual_collect endpoints

### DIFF
--- a/server/apps/monitor/views/manual_collect.py
+++ b/server/apps/monitor/views/manual_collect.py
@@ -2,6 +2,11 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.services.manual_collect import ManualCollectService
+from apps.monitor.views.monitor_instance import (
+    _build_actor_context,
+    _ensure_operate_instances,
+    _ensure_target_organizations,
+)
 from apps.rpc.node_mgmt import NodeMgmt
 
 
@@ -15,17 +20,23 @@ class ManualCollect(viewsets.ViewSet):
     # 创建手动监控实例
     @action(methods=['post'], detail=False, url_path='create_manual_instance')
     def create_manual_instance(self, request):
+        actor_context = _build_actor_context(request)
+        _ensure_target_organizations(request.data.get("organizations", []), actor_context)
         data = ManualCollectService.create_manual_collect_instance(request.data)
         return WebUtils.response_success(data)
 
     # 生成安装命令
     @action(methods=['post'], detail=False, url_path='generate_install_command')
     def generate_install_command(self, request):
+        actor_context = _build_actor_context(request)
+        _ensure_operate_instances(request, [request.data["instance_id"]], actor_context)
         data = ManualCollectService.generate_install_command(request.data["instance_id"], request.data["cloud_region_id"])
         return WebUtils.response_success(data)
 
     # 检查手动采集状态
     @action(methods=['post'], detail=False, url_path='check_collect_status')
     def check_collect_status(self, request):
+        actor_context = _build_actor_context(request)
+        _ensure_operate_instances(request, [request.data["instance_id"]], actor_context)
         success = ManualCollectService.check_collect_status(request.data["monitor_object_id"], request.data["instance_id"])
         return WebUtils.response_success(dict(success=success))


### PR DESCRIPTION
manual_collect's create_manual_instance, generate_install_command, and check_collect_status were missing object-level and organization-level authorization checks, allowing low-privilege users to operate on arbitrary instances and cross-organization resources.

Now reuses _ensure_target_organizations() and _ensure_operate_instances() from monitor_instance.py, consistent with the rest of the module.