### PR TITLE
fix(sidecar-installer): 允许 collector binaries 子目录可执行文件

### DIFF
--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -760,6 +760,7 @@ collector_configuration_directory: "%s\\generated"
 tags: ["zone:%s", "group:%s", "cpu_architecture:%s"]
 collector_binaries_accesslist:
   - "%s\\bin\\*"
+  - "%s\\bin\\*\\*"
 `,
 		cfg.ServerURL,
 		cfg.APIToken,
@@ -767,7 +768,7 @@ collector_binaries_accesslist:
 		cfg.NodeName,
 		installDir, installDir, installDir,
 		cfg.ZoneID, cfg.GroupID, cfg.Package.CPUArchitecture,
-		installDir,
+		installDir, installDir,
 	)
 
 	return os.WriteFile(filepath.Join(cfg.InstallDir, "sidecar.yml"), []byte(content), 0644)


### PR DESCRIPTION
## Summary
- 在 `setup-worker.go` 的 `collector_binaries_accesslist` 中追加 `"%s\\bin\\*\\*"`，使位于 `bin` 子目录下的采集器可执行文件也能通过白名单校验。
- 同步补一个 `installDir` 实参以匹配新增的 `%s` 占位符。

## Why
此前白名单仅包含 `bin\*`，仅匹配 `bin` 一级子项；当采集器以子目录形式部署（如 `bin/<name>/xxx.exe`）时，collector-sidecar 会以 "binary path not in allowed list" 拒绝执行。

## Test plan
- [x] Windows 节点重新生成 `sidecar.yml`，确认 `collector_binaries_accesslist` 同时包含 `bin\*` 与 `bin\*\*`。
- [x] 验证 `bin/<subdir>/collector.exe` 形式的采集器可正常被 sidecar 拉起。

🤖 Generated with [Claude Code](https://claude.com/claude-code)