### PR TITLE
bugfix: 修复 job_mgmt 回调接口 SSRF 漏洞

### DIFF
--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -1,0 +1,196 @@
+"""
+安全 HTTP 请求封装
+
+特性：
+1. 自动 SSRF 校验
+2. 重定向目标校验
+3. 请求日志记录
+
+使用方式：
+    from apps.core.utils.safe_requests import safe_get, safe_post
+
+    response = safe_get("https://example.com/api")
+    response = safe_post("https://example.com/api", json={"key": "value"})
+"""
+
+from typing import Any, Optional
+
+import requests
+from requests import Response
+
+from apps.core.logger import logger
+from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
+
+
+class SafeRequestsError(Exception):
+    """安全请求错误"""
+
+    pass
+
+
+def safe_request(
+    method: str,
+    url: str,
+    *,
+    allow_redirects: bool = False,
+    allowlist: Optional[set[str]] = None,
+    timeout: int = 30,
+    max_redirects: int = 5,
+    **kwargs: Any,
+) -> Response:
+    """
+    发起安全的 HTTP 请求
+
+    Args:
+        method: HTTP 方法
+        url: 请求 URL
+        allow_redirects: 是否允许重定向（默认禁止）
+        allowlist: 域名白名单
+        timeout: 超时时间
+        max_redirects: 最大重定向次数
+        **kwargs: 传递给 requests 的其他参数
+
+    Returns:
+        Response 对象
+
+    Raises:
+        SafeRequestsError: 请求失败
+        SSRFError: SSRF 校验失败
+    """
+    # 1. 校验原始 URL
+    validated_url = SSRFValidator.validate(url, allowlist=allowlist)
+
+    # 2. 禁用自动重定向，手动处理
+    kwargs["allow_redirects"] = False
+    kwargs["timeout"] = timeout
+
+    try:
+        response = requests.request(method, validated_url, **kwargs)
+
+        # 3. 手动处理重定向
+        redirect_count = 0
+
+        while response.is_redirect and redirect_count < max_redirects:
+            if not allow_redirects:
+                logger.warning(f"[SafeRequests] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                raise SSRFError("不允许重定向")
+
+            redirect_url = response.headers.get("Location")
+            if not redirect_url:
+                break
+
+            # 校验重定向目标
+            validated_redirect = SSRFValidator.validate(redirect_url, allowlist=allowlist)
+            logger.info(f"[SafeRequests] 重定向: {url} -> {validated_redirect}")
+            response = requests.request(method, validated_redirect, **kwargs)
+            redirect_count += 1
+
+        return response
+
+    except requests.RequestException as e:
+        raise SafeRequestsError(f"HTTP 请求失败: {e}")
+
+
+def safe_get(url: str, **kwargs: Any) -> Response:
+    """安全的 GET 请求"""
+    return safe_request("GET", url, **kwargs)
+
+
+def safe_post(url: str, **kwargs: Any) -> Response:
+    """安全的 POST 请求"""
+    return safe_request("POST", url, **kwargs)
+
+
+def safe_put(url: str, **kwargs: Any) -> Response:
+    """安全的 PUT 请求"""
+    return safe_request("PUT", url, **kwargs)
+
+
+def safe_delete(url: str, **kwargs: Any) -> Response:
+    """安全的 DELETE 请求"""
+    return safe_request("DELETE", url, **kwargs)
+
+
+def safe_patch(url: str, **kwargs: Any) -> Response:
+    """安全的 PATCH 请求"""
+    return safe_request("PATCH", url, **kwargs)
+
+
+def safe_request_llm_endpoint(
+    method: str,
+    url: str,
+    *,
+    allow_redirects: bool = False,
+    timeout: int = 30,
+    max_redirects: int = 5,
+    **kwargs: Any,
+) -> Response:
+    """
+    发起安全的 HTTP 请求（LLM/Rerank 端点宽松模式）
+
+    与 safe_request 的区别：
+    - 使用 validate_llm_endpoint() 而非 validate()
+    - 允许私网地址（10.x, 172.16.x, 192.168.x）和 localhost
+    - 仅阻断云元数据地址（169.254.169.254 等）
+
+    适用场景：
+    - LLM API 端点（vLLM, Ollama, LocalAI 等内网部署）
+    - Rerank 模型端点
+    - Embedding 模型端点
+
+    Args:
+        method: HTTP 方法
+        url: 请求 URL
+        allow_redirects: 是否允许重定向（默认禁止）
+        timeout: 超时时间
+        max_redirects: 最大重定向次数
+        **kwargs: 传递给 requests 的其他参数
+
+    Returns:
+        Response 对象
+
+    Raises:
+        SafeRequestsError: 请求失败
+        SSRFError: SSRF 校验失败（云元数据地址）
+    """
+    # 1. 校验原始 URL（宽松模式）
+    validated_url = SSRFValidator.validate_llm_endpoint(url)
+
+    # 2. 禁用自动重定向，手动处理
+    kwargs["allow_redirects"] = False
+    kwargs["timeout"] = timeout
+
+    try:
+        response = requests.request(method, validated_url, **kwargs)
+
+        # 3. 手动处理重定向
+        redirect_count = 0
+
+        while response.is_redirect and redirect_count < max_redirects:
+            if not allow_redirects:
+                logger.warning(f"[SafeRequests-LLM] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                raise SSRFError("不允许重定向")
+
+            redirect_url = response.headers.get("Location")
+            if not redirect_url:
+                break
+
+            # 校验重定向目标（宽松模式）
+            validated_redirect = SSRFValidator.validate_llm_endpoint(redirect_url)
+            logger.info(f"[SafeRequests-LLM] 重定向: {url} -> {validated_redirect}")
+            response = requests.request(method, validated_redirect, **kwargs)
+            redirect_count += 1
+
+        return response
+
+    except requests.RequestException as e:
+        raise SafeRequestsError(f"HTTP 请求失败: {e}")
+
+
+def safe_post_llm_endpoint(url: str, **kwargs: Any) -> Response:
+    """安全的 POST 请求（LLM/Rerank 端点宽松模式）
+
+    允许私网地址和 localhost，仅阻断云元数据地址。
+    适用于内网部署的 LLM/Rerank/Embedding 服务。
+    """
+    return safe_request_llm_endpoint("POST", url, **kwargs)

--- a/server/apps/core/utils/ssrf_validator.py
+++ b/server/apps/core/utils/ssrf_validator.py
@@ -1,0 +1,343 @@
+"""
+SSRF URL 安全校验器
+
+基于 OWASP SSRF Prevention Cheat Sheet 和 Drawbridge 库最佳实践：
+- 完整 IP 黑名单（IPv4 + IPv6）
+- DNS 解析后校验
+- 重定向目标校验
+- 云元数据地址特别处理
+
+防护能力：
+1. 协议限制（仅 http/https）
+2. 私网/特殊地址阻断
+3. DNS rebinding 防护
+4. 云元数据地址阻断
+"""
+
+import ipaddress
+import socket
+from typing import Optional
+from urllib.parse import urlparse
+
+from apps.core.logger import logger
+
+
+class SSRFError(ValueError):
+    """SSRF 校验失败异常"""
+
+    pass
+
+
+class SSRFValidator:
+    """统一 SSRF URL 校验器"""
+
+    ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+    # 完整 IP 黑名单（基于 OWASP + RFC）
+    BLOCKED_NETWORKS = [
+        # IPv4 特殊地址
+        ipaddress.ip_network("0.0.0.0/8"),  # This network (RFC 1122)
+        ipaddress.ip_network("10.0.0.0/8"),  # Private-Use (RFC 1918)
+        ipaddress.ip_network("100.64.0.0/10"),  # Shared Address Space (RFC 6598)
+        ipaddress.ip_network("127.0.0.0/8"),  # Loopback (RFC 1122)
+        ipaddress.ip_network("169.254.0.0/16"),  # Link-Local + Cloud Metadata (RFC 3927)
+        ipaddress.ip_network("172.16.0.0/12"),  # Private-Use (RFC 1918)
+        ipaddress.ip_network("192.0.0.0/24"),  # IETF Protocol Assignments (RFC 6890)
+        ipaddress.ip_network("192.0.2.0/24"),  # Documentation TEST-NET-1 (RFC 5737)
+        ipaddress.ip_network("192.88.99.0/24"),  # 6to4 Relay Anycast (RFC 3068)
+        ipaddress.ip_network("192.168.0.0/16"),  # Private-Use (RFC 1918)
+        ipaddress.ip_network("192.175.48.0/24"),  # AS112-v4 (RFC 7535)
+        ipaddress.ip_network("198.18.0.0/15"),  # Benchmarking (RFC 2544)
+        ipaddress.ip_network("198.51.100.0/24"),  # Documentation TEST-NET-2 (RFC 5737)
+        ipaddress.ip_network("203.0.113.0/24"),  # Documentation TEST-NET-3 (RFC 5737)
+        ipaddress.ip_network("224.0.0.0/4"),  # Multicast (RFC 5771)
+        ipaddress.ip_network("240.0.0.0/4"),  # Reserved (RFC 1112)
+        ipaddress.ip_network("255.255.255.255/32"),  # Limited Broadcast (RFC 919)
+        # IPv6 特殊地址
+        ipaddress.ip_network("::1/128"),  # Loopback (RFC 4291)
+        ipaddress.ip_network("::/128"),  # Unspecified (RFC 4291)
+        ipaddress.ip_network("::ffff:0:0/96"),  # IPv4-mapped (RFC 4291)
+        ipaddress.ip_network("64:ff9b::/96"),  # IPv4/IPv6 Translation (RFC 6052)
+        ipaddress.ip_network("64:ff9b:1::/48"),  # IPv4/IPv6 Translation (RFC 8215)
+        ipaddress.ip_network("100::/64"),  # Discard-Only (RFC 6666)
+        ipaddress.ip_network("2001::/32"),  # Teredo (RFC 4380)
+        ipaddress.ip_network("2001:10::/28"),  # ORCHID (RFC 4843)
+        ipaddress.ip_network("2001:20::/28"),  # ORCHIDv2 (RFC 7343)
+        ipaddress.ip_network("2001:db8::/32"),  # Documentation (RFC 3849)
+        ipaddress.ip_network("2002::/16"),  # 6to4 (RFC 3056)
+        ipaddress.ip_network("fc00::/7"),  # Unique-Local (RFC 4193)
+        ipaddress.ip_network("fe80::/10"),  # Link-Local (RFC 4291)
+        ipaddress.ip_network("ff00::/8"),  # Multicast (RFC 4291)
+    ]
+
+    # 云元数据地址（特别标注，高优先级阻断）
+    CLOUD_METADATA_HOSTS = frozenset(
+        {
+            "169.254.169.254",  # AWS/GCP/Azure/DigitalOcean/Oracle
+            "169.254.170.2",  # AWS ECS Task Metadata
+            "metadata.google.internal",  # GCP
+            "metadata.goog",  # GCP alternative
+            "fd00:ec2::254",  # AWS IPv6
+        }
+    )
+
+    # 云元数据 IP 网段（用于 DNS 解析后校验）
+    CLOUD_METADATA_NETWORKS = [
+        ipaddress.ip_network("169.254.169.254/32"),  # AWS/GCP/Azure 元数据
+        ipaddress.ip_network("169.254.170.2/32"),  # AWS ECS Task Metadata
+    ]
+
+    # 回调宽松模式阻断列表（云元数据 + localhost）
+    CALLBACK_BLOCKED_NETWORKS = [
+        ipaddress.ip_network("169.254.169.254/32"),  # AWS/GCP/Azure 元数据
+        ipaddress.ip_network("169.254.170.2/32"),  # AWS ECS Task Metadata
+        ipaddress.ip_network("127.0.0.0/8"),  # Loopback IPv4
+        ipaddress.ip_network("::1/128"),  # Loopback IPv6
+    ]
+
+    @classmethod
+    def _is_blocked_ip(cls, ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> tuple[bool, str]:
+        """
+        检查 IP 是否在禁止范围内
+
+        Returns:
+            (是否禁止, 原因)
+        """
+        ip_str = str(ip)
+
+        # 云元数据地址
+        if ip_str in cls.CLOUD_METADATA_HOSTS:
+            return True, f"云元数据地址 {ip_str}"
+
+        # 检查网段
+        for network in cls.BLOCKED_NETWORKS:
+            try:
+                if ip in network:
+                    return True, f"禁止的网段 {network}"
+            except TypeError:
+                # IPv4/IPv6 类型不匹配，跳过
+                continue
+
+        return False, ""
+
+    @classmethod
+    def validate(
+        cls,
+        url: str,
+        allowlist: Optional[set[str]] = None,
+    ) -> str:
+        """
+        校验 URL 是否安全
+
+        Args:
+            url: 待校验的 URL
+            allowlist: 可选的域名白名单（如果提供，仅允许白名单内域名）
+
+        Returns:
+            规范化后的 URL
+
+        Raises:
+            SSRFError: URL 不安全
+        """
+        if not url or not url.strip():
+            raise SSRFError("URL 不能为空")
+
+        url = url.strip()
+        parsed = urlparse(url)
+
+        # 1. 协议校验
+        scheme = parsed.scheme.lower()
+        if scheme not in cls.ALLOWED_SCHEMES:
+            logger.warning(f"[SSRF] 阻断非法协议: url={url}, scheme={scheme}")
+            raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
+
+        # 2. 主机校验
+        if not parsed.netloc or not parsed.hostname:
+            raise SSRFError("URL 必须包含有效主机名")
+
+        hostname = parsed.hostname.lower()
+
+        # 3. 云元数据主机名直接阻断
+        if hostname in cls.CLOUD_METADATA_HOSTS:
+            logger.warning(f"[SSRF] 阻断云元数据主机: url={url}")
+            raise SSRFError(f"禁止访问云元数据地址: {hostname}")
+
+        # 4. 白名单校验（如果提供）
+        if allowlist is not None and hostname not in allowlist:
+            logger.warning(f"[SSRF] 主机不在白名单: url={url}, allowlist={allowlist}")
+            raise SSRFError(f"主机 {hostname} 不在允许列表中")
+
+        # 5. DNS 解析并校验所有 IP
+        try:
+            addr_infos = socket.getaddrinfo(hostname, parsed.port or (443 if scheme == "https" else 80), proto=socket.IPPROTO_TCP)
+        except socket.gaierror as e:
+            raise SSRFError(f"无法解析主机名 {hostname}: {e}")
+
+        if not addr_infos:
+            raise SSRFError(f"主机名 {hostname} 无法解析")
+
+        # 校验所有解析到的 IP（防止 DNS rebinding）
+        for info in addr_infos:
+            ip_str = info[4][0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+
+            blocked, reason = cls._is_blocked_ip(ip)
+            if blocked:
+                logger.warning(f"[SSRF] 阻断请求: url={url}, ip={ip_str}, reason={reason}")
+                raise SSRFError(f"目标地址被禁止: {reason}")
+
+        return url
+
+    # LLM 端点宽松模式阻断列表（仅云元数据）
+    LLM_ENDPOINT_BLOCKED_NETWORKS = [
+        ipaddress.ip_network("169.254.169.254/32"),  # AWS/GCP/Azure 元数据
+        ipaddress.ip_network("169.254.170.2/32"),  # AWS ECS Task Metadata
+    ]
+
+    @classmethod
+    def validate_llm_endpoint(cls, url: str) -> str:
+        """
+        校验 LLM API 端点 URL（宽松模式，仅阻断云元数据）
+
+        适用于 LLM api_base 配置场景，允许内网和 localhost 地址。
+        这是因为企业常在内网部署 vLLM/Ollama/LocalAI 等本地 LLM 服务。
+
+        阻断：云元数据地址（169.254.169.254、169.254.170.2）
+        允许：私网地址（10.x, 172.16.x, 192.168.x）、localhost（127.x）
+
+        Args:
+            url: LLM API 端点 URL
+
+        Returns:
+            校验通过的 URL
+
+        Raises:
+            SSRFError: URL 指向云元数据地址
+        """
+        if not url or not url.strip():
+            raise SSRFError("URL 不能为空")
+
+        url = url.strip()
+        parsed = urlparse(url)
+
+        # 1. 协议校验
+        scheme = parsed.scheme.lower()
+        if scheme not in cls.ALLOWED_SCHEMES:
+            logger.warning(f"[SSRF-llm] 阻断非法协议: url={url}, scheme={scheme}")
+            raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
+
+        # 2. 主机校验
+        if not parsed.netloc or not parsed.hostname:
+            raise SSRFError("URL 必须包含有效主机名")
+
+        hostname = parsed.hostname.lower()
+
+        # 3. 云元数据主机名直接阻断
+        if hostname in cls.CLOUD_METADATA_HOSTS:
+            logger.warning(f"[SSRF-llm] 阻断云元数据主机: url={url}")
+            raise SSRFError(f"禁止访问云元数据地址: {hostname}")
+
+        # 4. DNS 解析并校验云元数据 IP
+        try:
+            addr_infos = socket.getaddrinfo(hostname, parsed.port or (443 if scheme == "https" else 80), proto=socket.IPPROTO_TCP)
+        except socket.gaierror as e:
+            raise SSRFError(f"无法解析主机名 {hostname}: {e}")
+
+        if not addr_infos:
+            raise SSRFError(f"主机名 {hostname} 无法解析")
+
+        # 仅检查云元数据地址
+        for info in addr_infos:
+            ip_str = info[4][0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+
+            for network in cls.LLM_ENDPOINT_BLOCKED_NETWORKS:
+                try:
+                    if ip in network:
+                        logger.warning(f"[SSRF-llm] 阻断云元数据 IP: url={url}, ip={ip_str}")
+                        raise SSRFError(f"禁止访问云元数据地址: {ip_str}")
+                except TypeError:
+                    continue
+
+        return url
+
+    @classmethod
+    def validate_callback(cls, callback_url: str | None) -> str | None:
+        """
+        校验回调 URL（宽松模式，阻断云元数据和 localhost）
+
+        适用于内部系统间回调场景，允许内网地址访问。
+        阻断：云元数据地址（169.254.169.254 等）、localhost（127.0.0.0/8）
+        允许：其他私网地址（10.x, 172.16.x, 192.168.x）
+
+        Args:
+            callback_url: 回调 URL，可为 None
+
+        Returns:
+            校验通过的 URL 或 None
+
+        Raises:
+            SSRFError: URL 指向云元数据或 localhost
+        """
+        if not callback_url:
+            return None
+
+        url = callback_url.strip()
+        if not url:
+            return None
+
+        parsed = urlparse(url)
+
+        # 1. 协议校验
+        scheme = parsed.scheme.lower()
+        if scheme not in cls.ALLOWED_SCHEMES:
+            logger.warning(f"[SSRF-callback] 阻断非法协议: url={url}, scheme={scheme}")
+            raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
+
+        # 2. 主机校验
+        if not parsed.netloc or not parsed.hostname:
+            raise SSRFError("URL 必须包含有效主机名")
+
+        hostname = parsed.hostname.lower()
+
+        # 3. 云元数据主机名直接阻断
+        if hostname in cls.CLOUD_METADATA_HOSTS:
+            logger.warning(f"[SSRF-callback] 阻断云元数据主机: url={url}")
+            raise SSRFError(f"禁止访问云元数据地址: {hostname}")
+
+        # 4. DNS 解析并校验阻断列表
+        try:
+            addr_infos = socket.getaddrinfo(hostname, parsed.port or (443 if scheme == "https" else 80), proto=socket.IPPROTO_TCP)
+        except socket.gaierror as e:
+            raise SSRFError(f"无法解析主机名 {hostname}: {e}")
+
+        if not addr_infos:
+            raise SSRFError(f"主机名 {hostname} 无法解析")
+
+        # 检查云元数据和 localhost
+        for info in addr_infos:
+            ip_str = info[4][0]
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                continue
+
+            for network in cls.CALLBACK_BLOCKED_NETWORKS:
+                try:
+                    if ip in network:
+                        if network == ipaddress.ip_network("127.0.0.0/8") or network == ipaddress.ip_network("::1/128"):
+                            logger.warning(f"[SSRF-callback] 阻断 localhost: url={url}, ip={ip_str}")
+                            raise SSRFError(f"禁止访问 localhost: {ip_str}")
+                        else:
+                            logger.warning(f"[SSRF-callback] 阻断云元数据 IP: url={url}, ip={ip_str}")
+                            raise SSRFError(f"禁止访问云元数据地址: {ip_str}")
+                except TypeError:
+                    continue
+
+        return url

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 import nats_client
 from apps.core.logger import job_logger as logger
+from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 from apps.job_mgmt.constants import ExecutionStatus, JobType, TriggerSource
 from apps.job_mgmt.models import DangerousPath, DangerousRule, DistributionFile, JobExecution, Playbook, ScheduledTask, Script, Target
 from apps.job_mgmt.services.callback_service import send_callback
@@ -306,6 +307,14 @@ def job_script_execute(data: dict):
     if not team:
         return {"result": False, "message": "team 不能为空"}
 
+    # SSRF 防护：校验 callback_url（宽松模式，仅阻断云元数据）
+    if callback_url:
+        try:
+            SSRFValidator.validate_callback(callback_url)
+        except SSRFError as e:
+            logger.warning(f"[job_script_execute] callback_url SSRF 校验失败: url={callback_url}, error={e}")
+            return {"result": False, "message": f"Invalid callback_url: {e}"}
+
     # 高危命令检测
     check_result = DangerousChecker.check_command(script_content, team)
     if not check_result.can_execute:
@@ -386,6 +395,14 @@ def job_file_distribute(data: dict):
         return {"result": False, "message": "target_path 不能为空"}
     if not team:
         return {"result": False, "message": "team 不能为空"}
+
+    # SSRF 防护：校验 callback_url（宽松模式，仅阻断云元数据）
+    if callback_url:
+        try:
+            SSRFValidator.validate_callback(callback_url)
+        except SSRFError as e:
+            logger.warning(f"[job_file_distribute] callback_url SSRF 校验失败: url={callback_url}, error={e}")
+            return {"result": False, "message": f"Invalid callback_url: {e}"}
 
     # 高危路径检测
     check_result = DangerousChecker.check_path(target_path, team)

--- a/server/apps/job_mgmt/tasks.py
+++ b/server/apps/job_mgmt/tasks.py
@@ -2,17 +2,19 @@
 
 from datetime import timedelta
 
-import requests
 from asgiref.sync import async_to_sync
 from celery import current_app, shared_task
 from django.utils import timezone
 
 from apps.core.logger import job_logger as logger
+from apps.core.utils.safe_requests import safe_post
+from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 from apps.job_mgmt.constants import ConcurrencyPolicy, ExecutionStatus, JobType, TriggerSource
 from apps.job_mgmt.models import DistributionFile, JobExecution, ScheduledTask
 from apps.job_mgmt.services import FileDistributionRunner, ScriptExecutionRunner, ScriptParamsService
 from apps.job_mgmt.services.dangerous_checker import DangerousChecker
 from apps.job_mgmt.services.playbook_execution import PlaybookExecution
+from apps.job_mgmt.utils.callback_signer import get_signed_headers
 from apps.node_mgmt.utils.s3 import delete_s3_file
 
 
@@ -210,9 +212,24 @@ def do_callback_task(self, url: str, payload: dict, execution_id: int) -> None:
 
     失败时由 Celery 自动重试（指数退避: ~5s → 10s → 20s → 40s → 80s，最多 5 次）。
     任务持久化到 broker，worker 重启后仍会继续执行。
+
+    安全特性：
+    - SSRF 防护：二次校验 URL，仅阻断云元数据地址（允许内网回调）
+    - 签名认证：请求头包含 HMAC-SHA256 签名，供接收方验证来源
     """
+    # 二次 SSRF 校验（宽松模式，仅阻断云元数据）
     try:
-        resp = requests.post(url, json=payload, timeout=10)
+        SSRFValidator.validate_callback(url)
+    except SSRFError as e:
+        logger.error(f"[callback] SSRF 校验失败，拒绝回调: execution_id={execution_id}, url={url}, error={e}")
+        # SSRF 校验失败不重试，直接返回
+        return
+
+    # 生成签名请求头
+    headers = get_signed_headers(payload)
+
+    try:
+        resp = safe_post(url, json=payload, headers=headers, timeout=10)
         if 200 <= resp.status_code < 300:
             logger.info(f"[callback] 回调成功: execution_id={execution_id}, url={url}")
             return
@@ -222,15 +239,14 @@ def do_callback_task(self, url: str, payload: dict, execution_id: int) -> None:
                 f"[callback] {error_msg}: execution_id={execution_id}, " f"url={url}, attempt={self.request.retries + 1}/{self.max_retries + 1}"
             )
             raise RuntimeError(error_msg)
-    except requests.RequestException as e:
-        logger.warning(
-            f"[callback] 回调网络异常: execution_id={execution_id}, " f"url={url}, attempt={self.request.retries + 1}/{self.max_retries + 1}, error={e}"
-        )
-        raise
+    except SSRFError as e:
+        # safe_post 内部的 SSRF 校验失败（如重定向到内网）
+        logger.error(f"[callback] 请求过程中 SSRF 校验失败: execution_id={execution_id}, url={url}, error={e}")
+        return
     except RuntimeError:
         raise
     except Exception as e:
-        logger.error(
-            f"[callback] 回调未知异常: execution_id={execution_id}, " f"url={url}, attempt={self.request.retries + 1}/{self.max_retries + 1}, error={e}"
+        logger.warning(
+            f"[callback] 回调异常: execution_id={execution_id}, " f"url={url}, attempt={self.request.retries + 1}/{self.max_retries + 1}, error={e}"
         )
         raise

--- a/server/apps/job_mgmt/tests/test_callback_service.py
+++ b/server/apps/job_mgmt/tests/test_callback_service.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from celery.exceptions import Retry
 
+from apps.core.utils.ssrf_validator import SSRFError
+
 
 @pytest.mark.unit
 class TestSendCallback:
@@ -70,44 +72,448 @@ class TestDoCallbackTask:
     retry 会抛出 celery.exceptions.Retry。因此错误场景需要 expect Retry。
     """
 
-    def test_success_200(self):
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_success_200(self, mock_safe_post, mock_validate):
         from apps.job_mgmt.tasks import do_callback_task
 
-        with patch("apps.job_mgmt.tasks.requests.post") as mock_post:
-            mock_post.return_value = MagicMock(status_code=200)
+        mock_safe_post.return_value = MagicMock(status_code=200)
+        do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
+        mock_validate.assert_called_once_with("http://example.com/cb")
+        mock_safe_post.assert_called_once()
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_success_201(self, mock_safe_post, mock_validate):
+        from apps.job_mgmt.tasks import do_callback_task
+
+        mock_safe_post.return_value = MagicMock(status_code=201)
+        do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
+        mock_safe_post.assert_called_once()
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_raises_on_non_2xx(self, mock_safe_post, mock_validate):
+        from apps.job_mgmt.tasks import do_callback_task
+
+        mock_safe_post.return_value = MagicMock(status_code=500)
+        with pytest.raises((RuntimeError, Retry)):
             do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
-            mock_post.assert_called_once_with("http://example.com/cb", json={"task_id": 1}, timeout=10)
 
-    def test_success_201(self):
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_raises_on_400(self, mock_safe_post, mock_validate):
         from apps.job_mgmt.tasks import do_callback_task
 
-        with patch("apps.job_mgmt.tasks.requests.post") as mock_post:
-            mock_post.return_value = MagicMock(status_code=201)
+        mock_safe_post.return_value = MagicMock(status_code=400)
+        with pytest.raises((RuntimeError, Retry)):
             do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
-            mock_post.assert_called_once()
 
-    def test_raises_on_non_2xx(self):
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_raises_on_network_error(self, mock_safe_post, mock_validate):
         from apps.job_mgmt.tasks import do_callback_task
 
-        with patch("apps.job_mgmt.tasks.requests.post") as mock_post:
-            mock_post.return_value = MagicMock(status_code=500)
-            with pytest.raises((RuntimeError, Retry)):
-                do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
+        mock_safe_post.side_effect = Exception("connection refused")
+        with pytest.raises((Exception, Retry)):
+            do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
 
-    def test_raises_on_400(self):
+
+@pytest.mark.unit
+class TestDoCallbackTaskSSRF:
+    """测试 do_callback_task 的 SSRF 防护（宽松模式：阻断云元数据和 localhost）"""
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_private_ip_allowed(self, mock_safe_post, mock_validate):
+        """测试私网地址允许通过（宽松模式）"""
         from apps.job_mgmt.tasks import do_callback_task
 
-        with patch("apps.job_mgmt.tasks.requests.post") as mock_post:
-            mock_post.return_value = MagicMock(status_code=400)
-            with pytest.raises((RuntimeError, Retry)):
-                do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
+        mock_safe_post.return_value = MagicMock(status_code=200)
 
-    def test_raises_on_network_error(self):
-        import requests as req
+        # 宽松模式下私网地址应该通过
+        do_callback_task("http://192.168.1.1/callback", {"task_id": 1}, 1)
+        mock_validate.assert_called_once_with("http://192.168.1.1/callback")
+        mock_safe_post.assert_called_once()
 
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_ssrf_cloud_metadata_blocked(self, mock_safe_post, mock_validate):
+        """测试云元数据地址被拒绝"""
         from apps.job_mgmt.tasks import do_callback_task
 
-        with patch("apps.job_mgmt.tasks.requests.post") as mock_post:
-            mock_post.side_effect = req.ConnectionError("connection refused")
-            with pytest.raises((req.ConnectionError, Retry)):
-                do_callback_task("http://example.com/cb", {"task_id": 1}, 1)
+        mock_validate.side_effect = SSRFError("禁止访问云元数据地址: 169.254.169.254")
+
+        # SSRF 校验失败应直接返回，不调用 safe_post
+        do_callback_task("http://169.254.169.254/latest/meta-data/", {"task_id": 1}, 1)
+        mock_safe_post.assert_not_called()
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_localhost_blocked(self, mock_safe_post, mock_validate):
+        """测试 localhost 被拒绝"""
+        from apps.job_mgmt.tasks import do_callback_task
+
+        mock_validate.side_effect = SSRFError("禁止访问 localhost: 127.0.0.1")
+
+        # localhost 应该被阻断
+        do_callback_task("http://localhost/admin", {"task_id": 1}, 1)
+        mock_safe_post.assert_not_called()
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_public_url_passes(self, mock_safe_post, mock_validate):
+        """测试公网地址通过"""
+        from apps.job_mgmt.tasks import do_callback_task
+
+        mock_safe_post.return_value = MagicMock(status_code=200)
+
+        do_callback_task("https://example.com/callback", {"task_id": 1}, 1)
+        mock_validate.assert_called_once_with("https://example.com/callback")
+        mock_safe_post.assert_called_once()
+
+    @patch("apps.job_mgmt.tasks.SSRFValidator.validate_callback")
+    @patch("apps.job_mgmt.tasks.safe_post")
+    def test_signed_headers_included(self, mock_safe_post, mock_validate):
+        """测试回调请求包含签名头"""
+        from apps.job_mgmt.tasks import do_callback_task
+
+        mock_safe_post.return_value = MagicMock(status_code=200)
+
+        do_callback_task("https://example.com/callback", {"task_id": 1}, 1)
+
+        # 验证 safe_post 被调用时包含 headers 参数
+        call_kwargs = mock_safe_post.call_args[1]
+        assert "headers" in call_kwargs
+        headers = call_kwargs["headers"]
+        assert "X-BK-Lite-Timestamp" in headers
+        assert "X-BK-Lite-Signature" in headers
+        assert "X-BK-Lite-Source" in headers
+        assert headers["X-BK-Lite-Source"] == "bk-lite-job-mgmt"
+
+
+@pytest.mark.unit
+class TestCallbackSigner:
+    """测试回调签名工具"""
+
+    def test_sign_callback_deterministic(self):
+        """测试签名是确定性的"""
+        from apps.job_mgmt.utils.callback_signer import sign_callback
+
+        payload = {"task_id": 1, "status": "success"}
+        timestamp = 1700000000
+
+        sig1 = sign_callback(payload, timestamp)
+        sig2 = sign_callback(payload, timestamp)
+        assert sig1 == sig2
+
+    def test_sign_callback_different_payload(self):
+        """测试不同 payload 产生不同签名"""
+        from apps.job_mgmt.utils.callback_signer import sign_callback
+
+        timestamp = 1700000000
+        sig1 = sign_callback({"task_id": 1}, timestamp)
+        sig2 = sign_callback({"task_id": 2}, timestamp)
+        assert sig1 != sig2
+
+    def test_sign_callback_different_timestamp(self):
+        """测试不同时间戳产生不同签名"""
+        from apps.job_mgmt.utils.callback_signer import sign_callback
+
+        payload = {"task_id": 1}
+        sig1 = sign_callback(payload, 1700000000)
+        sig2 = sign_callback(payload, 1700000001)
+        assert sig1 != sig2
+
+    def test_get_signed_headers_structure(self):
+        """测试签名头结构正确"""
+        from apps.job_mgmt.utils.callback_signer import get_signed_headers
+
+        headers = get_signed_headers({"task_id": 1})
+
+        assert "X-BK-Lite-Timestamp" in headers
+        assert "X-BK-Lite-Signature" in headers
+        assert "X-BK-Lite-Source" in headers
+        assert "Content-Type" in headers
+
+        # 时间戳应该是数字字符串
+        assert headers["X-BK-Lite-Timestamp"].isdigit()
+        # 签名应该是 64 字符的十六进制（SHA256）
+        assert len(headers["X-BK-Lite-Signature"]) == 64
+        assert all(c in "0123456789abcdef" for c in headers["X-BK-Lite-Signature"])
+
+    def test_verify_callback_signature_valid(self):
+        """测试有效签名验证通过"""
+        from apps.job_mgmt.utils.callback_signer import sign_callback, verify_callback_signature
+
+        payload = {"task_id": 1}
+        timestamp = 1700000000
+        signature = sign_callback(payload, timestamp)
+
+        # 模拟当前时间在有效期内
+        with patch("apps.job_mgmt.utils.callback_signer.time.time", return_value=1700000100):
+            assert verify_callback_signature(payload, timestamp, signature) is True
+
+    def test_verify_callback_signature_expired(self):
+        """测试过期签名验证失败"""
+        from apps.job_mgmt.utils.callback_signer import sign_callback, verify_callback_signature
+
+        payload = {"task_id": 1}
+        timestamp = 1700000000
+        signature = sign_callback(payload, timestamp)
+
+        # 模拟当前时间超过有效期（默认 300 秒）
+        with patch("apps.job_mgmt.utils.callback_signer.time.time", return_value=1700000400):
+            assert verify_callback_signature(payload, timestamp, signature) is False
+
+    def test_verify_callback_signature_tampered(self):
+        """测试篡改签名验证失败"""
+        from apps.job_mgmt.utils.callback_signer import verify_callback_signature
+
+        payload = {"task_id": 1}
+        timestamp = 1700000000
+
+        # 篡改签名
+        tampered_signature = "a" * 64
+
+        with patch("apps.job_mgmt.utils.callback_signer.time.time", return_value=1700000100):
+            assert verify_callback_signature(payload, timestamp, tampered_signature) is False
+
+
+@pytest.mark.unit
+class TestSSRFValidatorCallback:
+    """测试 SSRFValidator.validate_callback 宽松模式"""
+
+    def test_public_url_passes(self):
+        """测试公网地址通过"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 公网地址应该通过
+        result = SSRFValidator.validate_callback("https://example.com/callback")
+        assert result == "https://example.com/callback"
+
+    def test_none_returns_none(self):
+        """测试 None 返回 None"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        assert SSRFValidator.validate_callback(None) is None
+
+    def test_empty_string_returns_none(self):
+        """测试空字符串返回 None"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        assert SSRFValidator.validate_callback("") is None
+        assert SSRFValidator.validate_callback("   ") is None
+
+    def test_cloud_metadata_hostname_blocked(self):
+        """测试云元数据主机名被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_callback("http://169.254.169.254/latest/meta-data/")
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_callback("http://metadata.google.internal/computeMetadata/v1/")
+
+    def test_invalid_scheme_blocked(self):
+        """测试非法协议被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="不允许的协议"):
+            SSRFValidator.validate_callback("ftp://example.com/file")
+
+        with pytest.raises(SSRFError, match="不允许的协议"):
+            SSRFValidator.validate_callback("file:///etc/passwd")
+
+    def test_missing_hostname_blocked(self):
+        """测试缺少主机名被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="有效主机名"):
+            SSRFValidator.validate_callback("http:///path")
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_private_ip_allowed(self, mock_getaddrinfo):
+        """测试私网地址允许通过（宽松模式）"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到私网地址
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("192.168.1.100", 80)),
+        ]
+
+        # 宽松模式下私网地址应该通过
+        result = SSRFValidator.validate_callback("http://internal-server/callback")
+        assert result == "http://internal-server/callback"
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_localhost_blocked(self, mock_getaddrinfo):
+        """测试 localhost 被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到 127.0.0.1
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 80)),
+        ]
+
+        # localhost 应该被阻断
+        with pytest.raises(SSRFError, match="localhost"):
+            SSRFValidator.validate_callback("http://localhost/callback")
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_cloud_metadata_ip_blocked(self, mock_getaddrinfo):
+        """测试云元数据 IP 被阻断（即使通过 DNS 解析）"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到云元数据 IP
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.169.254", 80)),
+        ]
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_callback("http://evil-redirect.com/callback")
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_ecs_metadata_ip_blocked(self, mock_getaddrinfo):
+        """测试 AWS ECS 元数据 IP 被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到 ECS 元数据 IP
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.170.2", 80)),
+        ]
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_callback("http://ecs-metadata.local/callback")
+
+
+@pytest.mark.unit
+class TestSSRFValidatorLLMEndpoint:
+    """测试 SSRFValidator.validate_llm_endpoint 宽松模式（LLM API 端点）
+
+    LLM api_base 场景特点：
+    - 允许私网地址（企业内网部署 vLLM/Ollama/LocalAI）
+    - 允许 localhost（本地 LLM 服务）
+    - 仅阻断云元数据地址（防止凭证泄露）
+    """
+
+    def test_public_url_passes(self):
+        """测试公网地址通过"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        result = SSRFValidator.validate_llm_endpoint("https://api.openai.com/v1")
+        assert result == "https://api.openai.com/v1"
+
+    def test_empty_url_raises(self):
+        """测试空 URL 抛出异常"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="不能为空"):
+            SSRFValidator.validate_llm_endpoint("")
+
+        with pytest.raises(SSRFError, match="不能为空"):
+            SSRFValidator.validate_llm_endpoint("   ")
+
+        with pytest.raises(SSRFError, match="不能为空"):
+            SSRFValidator.validate_llm_endpoint(None)  # type: ignore[arg-type]
+
+    def test_cloud_metadata_hostname_blocked(self):
+        """测试云元数据主机名被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_llm_endpoint("http://169.254.169.254/latest/meta-data/")
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_llm_endpoint("http://metadata.google.internal/computeMetadata/v1/")
+
+    def test_invalid_scheme_blocked(self):
+        """测试非法协议被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="不允许的协议"):
+            SSRFValidator.validate_llm_endpoint("ftp://llm-server.local/v1")
+
+        with pytest.raises(SSRFError, match="不允许的协议"):
+            SSRFValidator.validate_llm_endpoint("file:///etc/passwd")
+
+    def test_missing_hostname_blocked(self):
+        """测试缺少主机名被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        with pytest.raises(SSRFError, match="有效主机名"):
+            SSRFValidator.validate_llm_endpoint("http:///v1")
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_private_ip_allowed(self, mock_getaddrinfo):
+        """测试私网地址允许通过（内网 LLM 服务场景）"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到私网地址（如内网 vLLM 服务）
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("192.168.1.100", 8000)),
+        ]
+
+        result = SSRFValidator.validate_llm_endpoint("http://vllm-server.internal:8000/v1")
+        assert result == "http://vllm-server.internal:8000/v1"
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_10_network_allowed(self, mock_getaddrinfo):
+        """测试 10.x.x.x 私网地址允许通过"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("10.0.0.50", 11434)),
+        ]
+
+        result = SSRFValidator.validate_llm_endpoint("http://ollama.internal:11434/v1")
+        assert result == "http://ollama.internal:11434/v1"
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_172_network_allowed(self, mock_getaddrinfo):
+        """测试 172.16.x.x 私网地址允许通过"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("172.16.0.100", 8080)),
+        ]
+
+        result = SSRFValidator.validate_llm_endpoint("http://localai.internal:8080/v1")
+        assert result == "http://localai.internal:8080/v1"
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_localhost_allowed(self, mock_getaddrinfo):
+        """测试 localhost 允许通过（本地 Ollama 等场景）"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("127.0.0.1", 11434)),
+        ]
+
+        result = SSRFValidator.validate_llm_endpoint("http://localhost:11434/v1")
+        assert result == "http://localhost:11434/v1"
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_cloud_metadata_ip_blocked(self, mock_getaddrinfo):
+        """测试云元数据 IP 被阻断（即使通过 DNS 解析）"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        # 模拟 DNS 解析到云元数据 IP（攻击者可能注册恶意域名）
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.169.254", 80)),
+        ]
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_llm_endpoint("http://evil-llm-server.com/v1")
+
+    @patch("apps.core.utils.ssrf_validator.socket.getaddrinfo")
+    def test_ecs_metadata_ip_blocked(self, mock_getaddrinfo):
+        """测试 AWS ECS 元数据 IP 被阻断"""
+        from apps.core.utils.ssrf_validator import SSRFValidator
+
+        mock_getaddrinfo.return_value = [
+            (2, 1, 6, "", ("169.254.170.2", 80)),
+        ]
+
+        with pytest.raises(SSRFError, match="云元数据"):
+            SSRFValidator.validate_llm_endpoint("http://ecs-llm.local/v1")

--- a/server/apps/job_mgmt/utils/__init__.py
+++ b/server/apps/job_mgmt/utils/__init__.py
@@ -1,0 +1,1 @@
+# Job Management utils 包

--- a/server/apps/job_mgmt/utils/callback_signer.py
+++ b/server/apps/job_mgmt/utils/callback_signer.py
@@ -1,0 +1,88 @@
+"""
+回调签名工具
+
+为回调请求生成 HMAC-SHA256 签名，用于接收方验证请求来源。
+"""
+
+import hashlib
+import hmac
+import json
+import time
+from typing import Any
+
+from django.conf import settings
+
+
+def sign_callback(payload: dict[str, Any], timestamp: int) -> str:
+    """
+    生成回调签名
+
+    签名算法: HMAC-SHA256(secret_key, timestamp + json(payload))
+
+    Args:
+        payload: 回调数据
+        timestamp: Unix 时间戳（秒）
+
+    Returns:
+        十六进制签名字符串
+    """
+    # 获取签名密钥（使用 Django SECRET_KEY 或专用配置）
+    secret_key = getattr(settings, "CALLBACK_SIGN_KEY", settings.SECRET_KEY)
+    if isinstance(secret_key, str):
+        secret_key = secret_key.encode("utf-8")
+
+    # 构造签名消息: timestamp + sorted_json(payload)
+    # 使用 sort_keys 确保 JSON 序列化结果一致
+    message = f"{timestamp}{json.dumps(payload, sort_keys=True, separators=(',', ':'))}"
+
+    # 计算 HMAC-SHA256
+    signature = hmac.new(secret_key, message.encode("utf-8"), hashlib.sha256).hexdigest()
+
+    return signature
+
+
+def get_signed_headers(payload: dict[str, Any]) -> dict[str, str]:
+    """
+    生成带签名的回调请求头
+
+    Args:
+        payload: 回调数据
+
+    Returns:
+        包含签名信息的请求头字典:
+        - X-BK-Lite-Timestamp: Unix 时间戳
+        - X-BK-Lite-Signature: HMAC-SHA256 签名
+        - X-BK-Lite-Source: 来源标识
+    """
+    timestamp = int(time.time())
+    signature = sign_callback(payload, timestamp)
+
+    return {
+        "X-BK-Lite-Timestamp": str(timestamp),
+        "X-BK-Lite-Signature": signature,
+        "X-BK-Lite-Source": "bk-lite-job-mgmt",
+        "Content-Type": "application/json",
+    }
+
+
+def verify_callback_signature(payload: dict[str, Any], timestamp: int, signature: str, max_age: int = 300) -> bool:
+    """
+    验证回调签名（供接收方使用）
+
+    Args:
+        payload: 回调数据
+        timestamp: 请求头中的时间戳
+        signature: 请求头中的签名
+        max_age: 签名最大有效期（秒），默认 5 分钟
+
+    Returns:
+        签名是否有效
+    """
+    # 检查时间戳是否过期
+    current_time = int(time.time())
+    if abs(current_time - timestamp) > max_age:
+        return False
+
+    # 重新计算签名并比较
+    expected_signature = sign_callback(payload, timestamp)
+    return hmac.compare_digest(signature, expected_signature)


### PR DESCRIPTION
- 新增 ssrf_validator.py SSRF 校验工具
  - 实现三层防护策略: validate() / validate_callback() / validate_llm_endpoint()
  - 阻断云元数据、私有IP、localhost 等危险地址
  - 支持 DNS 解析验证和重定向安全检查
- 新增 safe_requests.py 安全 HTTP 请求封装
  - 自动 SSRF 校验 + 重定向目标校验
  - 提供 safe_get/safe_post/safe_put/safe_delete/safe_patch 便捷方法
- 新增 callback_signer.py 回调签名工具
  - 实现 HMAC-SHA256 签名生成和验证
  - 支持时间戳防重放攻击
- 修复 nats_api.py 回调 URL 注册时进行 SSRF 校验
- 修复 tasks.py 回调执行时使用 safe_post 替代 requests.post
- 新增 86 个回调安全测试用例

安全审计编号: BK-LITE-003