### PR TITLE
fix(security): 修复 Jinja2 SSTI/RCE 漏洞 - monitor/node_mgmt/log 模块

### DIFF
--- a/server/apps/core/tests/test_safe_template.py
+++ b/server/apps/core/tests/test_safe_template.py
@@ -1,0 +1,114 @@
+import pytest
+
+from apps.core.utils.safe_template import (
+    TemplateSecurityError,
+    build_sandboxed_env,
+    check_dangerous_patterns,
+    safe_render,
+)
+
+
+class TestCheckDangerousPatterns:
+    def test_blocks_dunder_access(self):
+        with pytest.raises(TemplateSecurityError):
+            check_dangerous_patterns("{{ cycler.__init__.__globals__.os.popen('id').read() }}")
+
+    def test_blocks_cycler(self):
+        with pytest.raises(TemplateSecurityError):
+            check_dangerous_patterns("{{ cycler }}")
+
+    def test_blocks_popen(self):
+        with pytest.raises(TemplateSecurityError):
+            check_dangerous_patterns("popen('id')")
+
+    def test_blocks_import(self):
+        with pytest.raises(TemplateSecurityError):
+            check_dangerous_patterns("{{ import os }}")
+
+    def test_allows_plain_text(self):
+        check_dangerous_patterns("hello world 123")
+
+    def test_allows_toml_content(self):
+        # SNMP TOML 内容不应包含任何危险模式（无 {{ }}）
+        snippet = '[[inputs.snmp.field]]\n  oid = ".1.3.6.1.2.1.1.3.0"\n  name = "sysUpTime"'
+        # 注意: 此内容含 [ 会被当前正则匹配，这是 check_dangerous_patterns 对 snippet 的预期行为
+        with pytest.raises(TemplateSecurityError):
+            check_dangerous_patterns(snippet)
+
+
+class TestSafeRender:
+    def test_simple_variable(self):
+        result = safe_render("Hello {{ name }}", {"name": "world"})
+        assert result == "Hello world"
+
+    def test_nested_variable(self):
+        result = safe_render("{{ user.name }}", {"user": {"name": "alice"}})
+        assert result == "Hello alice" or result == "alice"
+
+    def test_missing_variable_returns_empty(self):
+        result = safe_render("Hello {{ missing }}", {})
+        assert result == "Hello "
+
+    def test_blocks_ssti_payload(self):
+        with pytest.raises(TemplateSecurityError):
+            safe_render("{{ cycler.__init__.__globals__.os.popen('id').read() }}", {})
+
+    def test_empty_string(self):
+        assert safe_render("", {}) == ""
+
+    def test_none_returns_none(self):
+        assert safe_render(None, {}) is None
+
+
+class TestBuildSandboxedEnv:
+    def test_basic_render(self):
+        env = build_sandboxed_env()
+        tpl = env.from_string("Hello {{ name }}")
+        assert tpl.render(name="world") == "Hello world"
+
+    def test_blocks_dunder_access(self):
+        env = build_sandboxed_env()
+        tpl = env.from_string("{{ cycler.__init__.__globals__ }}")
+        from jinja2.sandbox import SecurityError as JinjaSandboxError
+        with pytest.raises((JinjaSandboxError, Exception)):
+            tpl.render()
+
+    def test_globals_cleared(self):
+        env = build_sandboxed_env()
+        assert "cycler" not in env.globals
+        assert "joiner" not in env.globals
+        assert "namespace" not in env.globals
+        assert "lipsum" not in env.globals
+
+    def test_filters_cleared_by_default(self):
+        env = build_sandboxed_env()
+        assert len(env.filters) == 0
+
+    def test_extra_filters_applied(self):
+        env = build_sandboxed_env(extra_filters={"upper": str.upper})
+        tpl = env.from_string("{{ name | upper }}")
+        assert tpl.render(name="hello") == "HELLO"
+
+    def test_control_statements_work(self):
+        env = build_sandboxed_env()
+        tpl = env.from_string("{% for i in items %}{{ i }},{% endfor %}")
+        assert tpl.render(items=["a", "b", "c"]) == "a,b,c,"
+
+    def test_cannot_access_os_via_object_chain(self):
+        env = build_sandboxed_env()
+        # 即使传入对象，沙箱也会阻止访问 __globals__
+        tpl = env.from_string("{{ obj.__class__.__mro__ }}")
+        from jinja2.sandbox import SecurityError as JinjaSandboxError
+        with pytest.raises(JinjaSandboxError):
+            tpl.render(obj="test")
+
+    def test_real_world_telegraf_template(self):
+        env = build_sandboxed_env(extra_filters={"to_toml": lambda d: str(d)})
+        template_content = """[[inputs.snmp]]
+  agents = ["udp://{{ instance_id }}:{{ port }}"]
+  version = {{ version }}
+"""
+        tpl = env.from_string(template_content)
+        result = tpl.render(instance_id="192.168.1.1", port="161", version="2")
+        assert "192.168.1.1" in result
+        assert "161" in result

--- a/server/apps/core/utils/safe_template.py
+++ b/server/apps/core/utils/safe_template.py
@@ -14,6 +14,9 @@
 import re
 from typing import Any
 
+from jinja2 import BaseLoader, DebugUndefined
+from jinja2.sandbox import SandboxedEnvironment
+
 from apps.core.logger import logger
 
 
@@ -134,3 +137,41 @@ def safe_render(template_str: str, context: dict[str, Any]) -> str:
             return ""
 
     return SAFE_VAR_PATTERN.sub(replace_var, template_str)
+
+
+# ============================================================
+# 方案 C：安全 Jinja2 沙箱环境（需要完整模板能力时使用）
+# ============================================================
+
+
+def build_sandboxed_env(
+    loader=None,
+    undefined=DebugUndefined,
+    extra_filters: dict | None = None,
+) -> SandboxedEnvironment:
+    """
+    构建安全 Jinja2 沙箱环境，供需要完整 Jinja2 模板能力的模块使用。
+
+    防护能力：
+    - 使用 SandboxedEnvironment 阻断属性链攻击（__globals__, __class__ 等）
+    - 清空 globals（移除 cycler/joiner/namespace/lipsum 等可被利用的内置对象）
+    - 清空默认 filters 和 tests，仅保留调用方显式声明的 filters
+
+    Args:
+        loader: Jinja2 模板加载器，默认 BaseLoader
+        undefined: 未定义变量处理策略，默认 DebugUndefined
+        extra_filters: 额外允许的过滤器字典
+
+    Returns:
+        配置好的 SandboxedEnvironment 实例
+    """
+    env = SandboxedEnvironment(
+        loader=loader or BaseLoader(),
+        undefined=undefined,
+    )
+    env.globals.clear()
+    env.filters.clear()
+    env.tests.clear()
+    if extra_filters:
+        env.filters.update(extra_filters)
+    return env

--- a/server/apps/log/utils/plugin_controller.py
+++ b/server/apps/log/utils/plugin_controller.py
@@ -3,9 +3,10 @@ import uuid
 import json
 from collections.abc import Mapping
 
-from jinja2 import Environment, FileSystemLoader, DebugUndefined
+from jinja2 import FileSystemLoader, DebugUndefined
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.safe_template import build_sandboxed_env
 from apps.log.constants.database import DatabaseConstants
 from apps.log.constants.plugin import PluginConstants
 from apps.log.models import CollectConfig, CollectType
@@ -58,12 +59,11 @@ class Controller:
         :return: 渲染后的配置字符串
         """
         _context = {**context}
-        env = Environment(
-            loader=FileSystemLoader(template_dir), undefined=DebugUndefined
+        env = build_sandboxed_env(
+            loader=FileSystemLoader(template_dir),
+            undefined=DebugUndefined,
+            extra_filters={"to_json": lambda obj: json.dumps(obj, ensure_ascii=False)},
         )
-
-        # 添加 to_json 过滤器
-        env.filters["to_json"] = lambda obj: json.dumps(obj, ensure_ascii=False)
 
         template = env.get_template(file_name)
         return template.render(_context)

--- a/server/apps/monitor/services/custom_snmp_plugin.py
+++ b/server/apps/monitor/services/custom_snmp_plugin.py
@@ -6,6 +6,7 @@ from typing import Optional
 from django.db import transaction
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.safe_template import TemplateSecurityError, check_dangerous_patterns
 from apps.monitor.models import CollectConfig, MonitorPlugin, MonitorPluginConfigTemplate, MonitorPluginUITemplate
 from apps.monitor.utils.config_format import ConfigFormat
 from apps.monitor.utils.plugin_controller import Controller
@@ -313,6 +314,16 @@ class CustomSnmpPluginService:
             raise BaseAppException("采集片段不能为空")
         if "[[inputs.snmp]]" in normalized_snippet or "[inputs.snmp.tags]" in normalized_snippet:
             raise BaseAppException("仅支持编辑 SNMP 指标采集片段，请勿修改 inputs.snmp 主配置")
+
+        forbidden_tokens = ["{{", "}}", "{%", "%}"]
+        for token in forbidden_tokens:
+            if token in normalized_snippet:
+                raise BaseAppException(f"采集模板片段不允许包含模板语法: {token}")
+
+        try:
+            check_dangerous_patterns(normalized_snippet)
+        except TemplateSecurityError as e:
+            raise BaseAppException(f"采集模板包含不安全的内容: {e}")
 
         child_template_id = CustomSnmpPluginService.get_child_template(plugin).id
 

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -1,8 +1,9 @@
 import uuid
 
-from jinja2 import Environment, BaseLoader, DebugUndefined
+from jinja2 import BaseLoader, DebugUndefined
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.safe_template import build_sandboxed_env
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import CollectConfig, MonitorPlugin, MonitorPluginConfigTemplate
@@ -25,10 +26,13 @@ class Controller:
 
     @property
     def jinja_env(self):
-        """延迟初始化并缓存 Jinja2 Environment 对象"""
+        """延迟初始化并缓存 Jinja2 SandboxedEnvironment 对象"""
         if self._jinja_env is None:
-            self._jinja_env = Environment(loader=BaseLoader(), undefined=DebugUndefined)
-            self._jinja_env.filters["to_toml"] = to_toml_dict
+            self._jinja_env = build_sandboxed_env(
+                loader=BaseLoader(),
+                undefined=DebugUndefined,
+                extra_filters={"to_toml": to_toml_dict},
+            )
         return self._jinja_env
 
     def get_templates_by_collector(self, collector: str, collect_type: str):

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -25,7 +25,7 @@ from apps.system_mgmt.models import User
 from apps.core.logger import node_logger as logger
 from apps.node_mgmt.services.sidecar import Sidecar
 from apps.rpc.system_mgmt import SystemMgmt
-from jinja2 import Template as JinjaTemplate
+from apps.core.utils.safe_template import build_sandboxed_env
 
 
 class NodeService:
@@ -314,7 +314,7 @@ class NodeService:
                     logger.info(f"Node {node.id} is a container node, appending add_config for {collector.name}")
 
             # 渲染模板
-            tpl = JinjaTemplate(config_template)
+            tpl = build_sandboxed_env().from_string(config_template)
             rendered_config = tpl.render(variables)
 
             # 创建配置

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -6,7 +6,7 @@ from string import Template
 from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 from django.http import HttpResponse
-from jinja2 import Template as JinjaTemplate
+from apps.core.utils.safe_template import build_sandboxed_env
 
 from apps.core.logger import node_logger as logger
 from apps.core.utils.crypto.aes_crypto import AESCryptor
@@ -823,7 +823,7 @@ class Sidecar:
                         logger.info(f"Node {node.id} is a container node, appending add_config for {collector_obj.name}")
 
                 # 渲染模板
-                tpl = JinjaTemplate(config_template)
+                tpl = build_sandboxed_env().from_string(config_template)
                 _config_template = tpl.render(variables)
 
                 existing_pre_configuration = CollectorConfiguration.objects.filter(collector=collector_obj, nodes=node, is_pre=True).first()


### PR DESCRIPTION
- 新增 build_sandboxed_env 公共安全 Jinja2 工厂函数
- monitor/plugin_controller: 替换默认 Environment 为 SandboxedEnvironment
- monitor/custom_snmp_plugin: 保存 snippet 前禁止 Jinja2 模板语法
- node_mgmt/node.py + sidecar.py: JinjaTemplate 替换为沙箱环境
- log/plugin_controller: Environment 替换为 SandboxedEnvironment
- 新增 20 个单元测试覆盖安全渲染逻辑