### PR TITLE
fix(security): 修复 SSTI/SSRF/存储型XSS/越权 等安全漏洞

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -30,6 +30,7 @@
     "antd-mobile-icons": "^0.3.0",
     "axios": "^1.7.7",
     "intl-messageformat": "^10.7.18",
+    "isomorphic-dompurify": "^3.15.0",
     "markdown-it": "^14.1.0",
     "next": "15.5.9",
     "next-auth": "^4.24.12",

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       intl-messageformat:
         specifier: ^10.7.18
         version: 10.7.18
+      isomorphic-dompurify:
+        specifier: ^3.15.0
+        version: 3.15.0
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
@@ -161,6 +164,21 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -168,6 +186,46 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.1':
+    resolution: {integrity: sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4':
+    resolution: {integrity: sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -205,6 +263,15 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
@@ -290,89 +357,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -443,24 +526,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -633,24 +720,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.14':
     resolution: {integrity: sha512-ISZjT44s59O8xKsPEIesiIydMG/sCXoMBCqsphDm/WcbnuWLxxb+GcvSIIA5NjUw6F8Tex7s5/LM2yDy8RqYBQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.14':
     resolution: {integrity: sha512-02c6JhLPJj10L2caH4U0zF8Hji4dOeahmuMl23stk0MU1wfd1OraE7rOloidSF8W5JTHkFdVo/O7uRUJJnUAJg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.14':
     resolution: {integrity: sha512-TNGeLiN1XS66kQhxHG/7wMeQDOoL0S33x9BgmydbrWAb9Qw0KYdd8o1ifx4HOGDWhVmJ+Ul+JQ7lyknQFilO3Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.14':
     resolution: {integrity: sha512-uZYAsaW/jS/IYkd6EWPJKW/NlPNSkWkBlaeVBi/WsFQNP05/bzkebUL8FH1pdsqx4f2fH/bWFcUABOM9nfiJkQ==}
@@ -709,30 +800,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.8.4':
     resolution: {integrity: sha512-zumFeaU1Ws5Ay872FTyIm7z8kfzEHu8NcIn8M6TxbJs0a7GRV21KBdpW1zNj2qy7HynnpQCqjAYXTUUmm9JAOw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.8.4':
     resolution: {integrity: sha512-qiqbB3Zz6IyO201f+1ojxLj65WYj8mixL5cOMo63nlg8CIzsP23cPYUrx1YaDPsCLszKZo7tVs14pc7BWf+/aQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.8.4':
     resolution: {integrity: sha512-TaqaDd9Oy6k45Hotx3pOf+pkbsxLaApv4rGd9mLuRM1k6YS/aw81YrsMryYPThrxrScEIUcmNIHaHsLiU4GMkw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.8.4':
     resolution: {integrity: sha512-ot9STAwyezN8w+bBHZ+bqSQIJ0qPZFlz/AyscpGqB/JnJQVDFQcRDmUPFEaAtt2UUHSWzN3GoTJ5ypqLBp2WQA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.8.4':
     resolution: {integrity: sha512-+2aJ/g90dhLiOLFSD1PbElXX3SoMdpO7HFPAZB+xot3CWlAZD1tReUFy7xe0L5GAR16ZmrxpIDM9v9gn5xRy/w==}
@@ -796,6 +892,9 @@ packages:
 
   '@types/react@18.3.26':
     resolution: {integrity: sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@8.46.1':
     resolution: {integrity: sha512-rUsLh8PXmBjdiPY+Emjz9NX2yHvhS11v0SR6xNJkm5GM1MO9ea/1GoDKlHHZGrOJclL/cZ2i/vRUYVtjRhrHVQ==}
@@ -898,41 +997,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -1078,6 +1185,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1153,11 +1263,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1225,6 +1343,9 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dompurify@3.4.7:
+    resolution: {integrity: sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1239,6 +1360,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -1558,6 +1683,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1674,6 +1803,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1716,6 +1848,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isomorphic-dompurify@3.15.0:
+    resolution: {integrity: sha512-9ZtkbQ8+SgNf6LuDAdu9bq23dVXMIGNM8ZYnyl2MufyZiSD5dqAUJcyjtYZz7B80HuPpEn/f0NCS6zKvavHtfA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
@@ -1737,6 +1873,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1801,24 +1946,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -1853,6 +2002,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1867,6 +2020,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -2030,6 +2186,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2393,6 +2552,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
@@ -2438,6 +2601,10 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2576,6 +2743,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.1.14:
     resolution: {integrity: sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==}
 
@@ -2598,12 +2768,27 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.1:
+    resolution: {integrity: sha512-sc2nGvGbixlJRHwTh/qQdPXTxJU1UDJboGPQm4d/01YUJ9r/u6aeIulQvEaxUlvKDN7hb1qCLjax+jhVAPLa/g==}
+
+  tldts@7.4.0:
+    resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2656,6 +2841,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici@7.26.0:
+    resolution: {integrity: sha512-3O9Tf67pGhgOv9jM35AbhkXAKi13f3oy3aE4CSgr+TckGeY+/iu97ZXN+J7DpHPzLbVApFd1IFhcnBjREYXYcg==}
+    engines: {node: '>=20.18.1'}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -2670,6 +2859,22 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2698,6 +2903,13 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -2793,9 +3005,57 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/runtime@7.28.4': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.4(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -2853,6 +3113,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.3':
     dependencies:
@@ -3388,6 +3650,9 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.1.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.46.1(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -3767,6 +4032,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3840,9 +4109,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3902,6 +4183,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.4.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3916,6 +4201,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@4.5.0: {}
+
+  entities@8.0.0: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -4397,6 +4684,12 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -4516,6 +4809,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4559,6 +4854,14 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isomorphic-dompurify@3.15.0:
+    dependencies:
+      dompurify: 3.4.7
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4579,6 +4882,32 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.26.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -4677,6 +5006,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.5.1: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -4695,6 +5026,8 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -4863,6 +5196,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   path-exists@4.0.0: {}
 
@@ -5320,6 +5657,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
@@ -5368,6 +5707,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5557,6 +5900,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.1.14: {}
 
   tapable@2.3.0: {}
@@ -5578,11 +5923,25 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@7.4.1: {}
+
+  tldts@7.4.0:
+    dependencies:
+      tldts-core: 7.4.1
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toggle-selection@1.0.6: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.0
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -5649,6 +6008,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici@7.26.0: {}
+
   unrs-resolver@1.11.1:
     dependencies:
       napi-postinstall: 0.3.4
@@ -5682,6 +6043,22 @@ snapshots:
       react: 18.3.1
 
   uuid@8.3.2: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -5731,6 +6108,10 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@4.0.0: {}
 

--- a/mobile/src/app/conversation/page.tsx
+++ b/mobile/src/app/conversation/page.tsx
@@ -12,6 +12,7 @@ import { conversationStyles, parseHistoryEvents } from './utils';
 import { useTranslation } from '@/utils/i18n';
 import { getApplication, getSessionMessages, getWelcomeMessage } from '@/api/bot';
 import { getAvatar } from '@/utils/avatar';
+import { sanitizeHtml } from '@/utils/sanitize';
 import { MessageContentItem } from '@/types/conversation';
 import { useSessionsCache } from './hooks';
 import { ExclamationTriangleOutline } from 'antd-mobile-icons';
@@ -101,19 +102,19 @@ export default function ConversationDetail() {
     sessionId: currentSessionId,
   });
 
-  // 初始化 markdown-it
+  // 初始化 markdown-it（html: false 不渲染原始 HTML，输出再统一净化）
   const md = useMemo(() => {
     return new MarkdownIt({
-      html: true,
+      html: false,
       linkify: true,
       typographer: true,
       breaks: true,
     });
   }, []);
 
-  // Markdown 渲染函数
+  // Markdown 渲染函数：渲染后用公共净化工具防御存储型 XSS
   const renderMarkdown = (text: string) => {
-    const html = md.render(text);
+    const html = sanitizeHtml(md.render(text));
     return <div dangerouslySetInnerHTML={{ __html: html }} className="markdown-body" />;
   };
 

--- a/mobile/src/utils/sanitize.ts
+++ b/mobile/src/utils/sanitize.ts
@@ -1,0 +1,104 @@
+import DOMPurify from 'isomorphic-dompurify';
+
+/**
+ * 公共 HTML 净化工具，统一防御存储型 / 反射型 XSS。
+ *
+ * 移动端使用 isomorphic-dompurify 以兼容 SSR（服务端无 window 时回退到 jsdom）。
+ * 用于所有需要把字符串当 HTML 注入 DOM 的场景（dangerouslySetInnerHTML 等），
+ * 尤其是 Markdown 渲染、会话消息、搜索高亮等包含用户可控内容的位置。
+ *
+ * 统一禁用：
+ *  - 事件处理属性（onerror / onload / onclick ... 任意 on* 属性）
+ *  - javascript: / data: 等危险 URL 协议
+ *  - <script> / <iframe> / <object> / <embed> / <svg> / <math> 等危险标签
+ */
+
+const FORBID_EVENT_ATTR: string[] = [
+  'onerror',
+  'onload',
+  'onclick',
+  'ondblclick',
+  'onmouseover',
+  'onmouseout',
+  'onmousemove',
+  'onmousedown',
+  'onmouseup',
+  'onfocus',
+  'onblur',
+  'onchange',
+  'oninput',
+  'onsubmit',
+  'onreset',
+  'onkeydown',
+  'onkeyup',
+  'onkeypress',
+  'onwheel',
+  'onscroll',
+  'oncontextmenu',
+  'onanimationstart',
+  'onanimationend',
+  'ontransitionend',
+  'onpointerdown',
+  'onpointerup',
+  'onpointermove',
+  'ontouchstart',
+  'ontouchend',
+  'ontouchmove',
+];
+
+const FORBID_DANGEROUS_TAGS: string[] = [
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'base',
+  'form',
+  'meta',
+  'link',
+  'svg',
+  'math',
+];
+
+export interface SanitizeOptions {
+  allowTags?: string[];
+  allowAttrs?: string[];
+  allowDataAttr?: boolean;
+}
+
+/**
+ * 默认净化：基于 DOMPurify 的 html 档案，禁用所有 on* 事件属性、
+ * javascript:/data: 协议、script/iframe/svg/math 等危险标签。
+ */
+export const sanitizeHtml = (
+  dirty: string | null | undefined,
+  options: SanitizeOptions = {}
+): string => {
+  if (!dirty) return '';
+
+  return DOMPurify.sanitize(dirty, {
+    USE_PROFILES: { html: true },
+    ADD_TAGS: options.allowTags,
+    ADD_ATTR: options.allowAttrs,
+    FORBID_ATTR: FORBID_EVENT_ATTR,
+    FORBID_TAGS: FORBID_DANGEROUS_TAGS,
+    ALLOW_DATA_ATTR: options.allowDataAttr ?? false,
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|ftp):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+  });
+};
+
+/**
+ * 转义字符串中的 HTML 特殊字符，使其作为纯文本安全展示。
+ * 用于在受信任的 HTML 模板里插值用户输入（如搜索高亮）。
+ */
+export const escapeHtml = (value: string | null | undefined): string => {
+  if (!value) return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+export default sanitizeHtml;

--- a/server/apps/core/tests/test_safe_jinja.py
+++ b/server/apps/core/tests/test_safe_jinja.py
@@ -1,0 +1,168 @@
+"""Jinja2 SSTI / 模板注入 安全回归测试。
+
+对应 2026-05 安全审计报告中确认的多处「用户可控内容进入默认 Jinja2 渲染」
+导致 SSTI/RCE 的漏洞点。这些用例确保：
+
+1. 统一安全渲染入口 :func:`render_secure_template` 会拦截全部已知 PoC，
+   不执行系统命令、不泄露 Python 运行时对象。
+2. 正常的 ``{{ variable }}`` 变量替换不被误伤。
+3. 各业务 sink（ChatFlow 变量管理器、监控插件控制器、SNMP 采集片段校验）
+   均不再可被 PoC 触发命令执行。
+
+新增/调整 Jinja2 渲染逻辑时，请保持本文件用例通过。
+"""
+
+import pytest
+from jinja2.exceptions import SecurityError, TemplateError, UndefinedError
+
+from apps.core.utils.safe_jinja import (
+    contains_template_syntax,
+    create_secure_jinja_environment,
+    render_secure_template,
+)
+
+pytestmark = pytest.mark.unit
+
+# 安全审计报告「六、建议回归用例」中列出的全部 PoC payload。
+SSTI_POCS = [
+    "{{ cycler.__init__.__globals__.os.popen('id').read() }}",
+    "{{ joiner.__init__.__globals__.os.popen('id').read() }}",
+    "{{ namespace.__init__.__globals__.os.popen('id').read() }}",
+    "{{ self.__init__.__globals__ }}",
+    "{{ ''.__class__.__mro__ }}",
+    "{{ ''.__class__.__mro__[1].__subclasses__() }}",
+    "{{ config.__class__.__mro__ }}",
+    "{{ request.__class__.__mro__ }}",
+    "{{ lipsum.__globals__.os.popen('id').read() }}",
+]
+
+# 命令执行 / 对象泄露的特征串，渲染结果中绝不应出现。
+LEAK_MARKERS = ("uid=", "gid=", "groups=", "<class", "object at 0x", "__main__")
+
+
+def _assert_no_leak(rendered: str):
+    lowered = rendered.lower()
+    for marker in LEAK_MARKERS:
+        assert marker.lower() not in lowered, f"渲染结果疑似逃逸/命令执行: {rendered!r}"
+
+
+class TestRenderSecureTemplate:
+    @pytest.mark.parametrize("payload", SSTI_POCS)
+    def test_ssti_poc_is_blocked(self, payload):
+        """每条 PoC 要么抛出安全异常，要么渲染为无害空串，绝不执行命令。"""
+        try:
+            rendered = render_secure_template(payload, {})
+        except (SecurityError, UndefinedError, TemplateError):
+            return  # 被沙箱拦截，符合预期
+        # 未抛异常时（如未定义变量被渲染为空），必须确认没有任何逃逸痕迹
+        _assert_no_leak(rendered)
+
+    def test_plain_variable_substitution(self):
+        out = render_secure_template(
+            "instance={{ instance_id }} ip={{ ip }}",
+            {"instance_id": "i-001", "ip": "10.0.0.1"},
+        )
+        assert out == "instance=i-001 ip=10.0.0.1"
+
+    def test_filters_still_available_when_kept(self):
+        out = render_secure_template("{{ name | upper }}", {"name": "abc"}, clear_globals=False)
+        assert out == "ABC"
+
+    def test_none_returns_none(self):
+        assert render_secure_template(None, {}) is None
+
+    def test_strict_undefined_raises(self):
+        with pytest.raises(UndefinedError):
+            render_secure_template("{{ missing }}", {}, strict_undefined=True)
+
+    def test_attribute_access_blocked(self):
+        with pytest.raises(SecurityError):
+            render_secure_template("{{ s.__class__ }}", {"s": "x"})
+
+
+class TestCreateSecureEnvironment:
+    def test_globals_cleared_by_default(self):
+        env = create_secure_jinja_environment()
+        assert "cycler" not in env.globals
+        assert "lipsum" not in env.globals
+
+    def test_globals_kept_when_requested(self):
+        env = create_secure_jinja_environment(clear_globals=False)
+        assert "range" in env.globals
+
+
+class TestContainsTemplateSyntax:
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("plain toml line", False),
+            ("no template here", False),
+            ("", False),
+            (None, False),
+            ("# {{ cycler }}", True),
+            ("{% for x in y %}", True),
+            ("value = {{ ip }}", True),
+        ],
+    )
+    def test_detection(self, text, expected):
+        assert contains_template_syntax(text) is expected
+
+
+class TestVariableManagerSink:
+    """ChatFlow 变量管理器：SSTI 不应执行，正常变量正常解析。"""
+
+    def _vm(self):
+        from apps.opspilot.utils.chat_flow_utils.engine.core.variable_manager import VariableManager
+
+        return VariableManager()
+
+    @pytest.mark.parametrize("payload", SSTI_POCS)
+    def test_resolve_template_blocks_ssti(self, payload):
+        vm = self._vm()
+        # resolve_template 在渲染失败时返回原始模板字符串（不执行）
+        result = vm.resolve_template(payload)
+        _assert_no_leak(result)
+
+    def test_resolve_template_normal(self):
+        vm = self._vm()
+        vm.set_variable("ip", "10.0.0.1")
+        assert vm.resolve_template("ip={{ ip }}") == "ip=10.0.0.1"
+
+
+class TestMonitorPluginControllerSink:
+    """监控插件控制器：用户可控采集模板内容中的 SSTI 不应执行。"""
+
+    def _controller(self):
+        from apps.monitor.utils.plugin_controller import Controller
+
+        return Controller({})
+
+    @pytest.mark.parametrize("payload", SSTI_POCS)
+    def test_render_template_blocks_ssti(self, payload):
+        controller = self._controller()
+        try:
+            rendered = controller.render_template(payload, {})
+        except (SecurityError, UndefinedError, TemplateError):
+            return
+        _assert_no_leak(rendered)
+
+    def test_render_template_normal(self):
+        controller = self._controller()
+        assert controller.render_template("name={{ svc }}", {"svc": "abc"}) == "name=abc"
+
+
+class TestSnmpCollectSnippetValidation:
+    """SNMP 采集片段保存前的安全护栏：拒绝模板表达式 / 双下划线。
+
+    与 ``CustomSnmpPluginService.update_collect_template`` 中的护栏逻辑保持一致：
+    ``contains_template_syntax(snippet) or "__" in snippet`` 命中即拒绝。
+    """
+
+    @pytest.mark.parametrize("payload", SSTI_POCS)
+    def test_malicious_snippet_is_caught_by_guard(self, payload):
+        snippet = f"# {payload}\n[[inputs.snmp.field]]\n  oid = \".1.3.6.1.2.1.1.3.0\""
+        assert contains_template_syntax(snippet) or "__" in snippet
+
+    def test_clean_snippet_passes_guard(self):
+        snippet = "[[inputs.snmp.field]]\n  oid = \".1.3.6.1.2.1.1.3.0\"\n  name = \"sysUpTime\""
+        assert not (contains_template_syntax(snippet) or "__" in snippet)

--- a/server/apps/core/tests/test_ssrf.py
+++ b/server/apps/core/tests/test_ssrf.py
@@ -1,0 +1,108 @@
+"""SSRF 防护回归测试。
+
+覆盖 apps.core.utils.ssrf.validate_url 对内网/回环/云元数据/保留地址及
+非 http(s) 协议的拦截，以及对正常公网地址的放行。
+
+这些用例只依赖标准库与 ssrf 模块（不依赖 DB / Django ORM），
+公网域名的 DNS 解析通过 mock 打桩，保证离线可跑。
+"""
+
+from unittest import mock
+
+import pytest
+
+from apps.core.utils.ssrf import SSRFValidationError, validate_url
+
+# 直接以 IP 字面量给出的目标会走「字面量直判」分支，无需 DNS 解析
+BLOCKED_LITERAL_URLS = [
+    "http://169.254.169.254/latest/meta-data/",  # 云元数据接口
+    "http://127.0.0.1/",  # 回环
+    "http://10.0.0.1/",  # 私网 A
+    "http://192.168.1.1/",  # 私网 C
+    "http://172.16.0.1/",  # 私网 B
+    "http://100.64.1.1/",  # CGNAT 共享地址段
+    "http://0.0.0.0/",  # 未指定地址
+    "http://[::1]/",  # IPv6 回环
+    "http://[::ffff:127.0.0.1]/",  # IPv4-mapped IPv6 回环
+]
+
+# 非 http/https 协议应被直接拒绝
+BLOCKED_SCHEME_URLS = [
+    "file:///etc/passwd",
+    "ftp://example.com/",
+    "gopher://127.0.0.1:6379/_INFO",
+]
+
+
+@pytest.mark.parametrize("url", BLOCKED_LITERAL_URLS)
+def test_validate_url_blocks_internal_ip_literals(url):
+    """内网/回环/保留/云元数据等 IP 字面量必须被拦截。"""
+    with pytest.raises(SSRFValidationError):
+        validate_url(url)
+
+
+@pytest.mark.parametrize("url", BLOCKED_SCHEME_URLS)
+def test_validate_url_blocks_dangerous_schemes(url):
+    """非 http/https 协议必须被拦截。"""
+    with pytest.raises(SSRFValidationError):
+        validate_url(url)
+
+
+def test_validate_url_blocks_localhost_hostname():
+    """localhost 经解析后指向回环地址，必须被拦截。"""
+    with mock.patch(
+        "apps.core.utils.ssrf.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("127.0.0.1", 0))],
+    ):
+        with pytest.raises(SSRFValidationError):
+            validate_url("http://localhost/")
+
+
+def test_validate_url_blocks_dns_rebinding_to_private():
+    """域名解析到私网地址（DNS rebinding）必须被拦截。"""
+    with mock.patch(
+        "apps.core.utils.ssrf.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("10.1.2.3", 0))],
+    ):
+        with pytest.raises(SSRFValidationError):
+            validate_url("http://evil.example.com/")
+
+
+def test_validate_url_blocks_when_any_resolved_ip_is_private():
+    """只要解析出的任一 IP 命中内网即拦截（多 A 记录绕过防护）。"""
+    with mock.patch(
+        "apps.core.utils.ssrf.socket.getaddrinfo",
+        return_value=[
+            (None, None, None, None, ("93.184.216.34", 0)),  # 公网
+            (None, None, None, None, ("127.0.0.1", 0)),  # 回环
+        ],
+    ):
+        with pytest.raises(SSRFValidationError):
+            validate_url("http://mixed.example.com/")
+
+
+def test_validate_url_empty_is_rejected():
+    """空 URL 必须被拒绝。"""
+    with pytest.raises(SSRFValidationError):
+        validate_url("")
+    with pytest.raises(SSRFValidationError):
+        validate_url(None)
+
+
+def test_validate_url_allows_public_https():
+    """正常公网 https 地址应放行并原样返回。"""
+    with mock.patch(
+        "apps.core.utils.ssrf.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("93.184.216.34", 0))],
+    ):
+        assert validate_url("https://example.com") == "https://example.com"
+        assert validate_url("http://example.com/path?x=1") == "http://example.com/path?x=1"
+
+
+def test_validate_url_can_skip_resolution():
+    """resolve=False 时只做协议/主机名校验，不做 DNS 解析。"""
+    # 公网域名在不解析时也应通过（不触发网络）
+    assert validate_url("https://example.com", resolve=False) == "https://example.com"
+    # 但协议非法仍应拦截
+    with pytest.raises(SSRFValidationError):
+        validate_url("file:///etc/passwd", resolve=False)

--- a/server/apps/core/utils/safe_jinja.py
+++ b/server/apps/core/utils/safe_jinja.py
@@ -1,0 +1,108 @@
+"""统一的 Jinja2 安全渲染工具。
+
+历史上多个业务模块直接使用 ``jinja2.Template`` 或 ``Environment.from_string``
+渲染用户可控内容（监控插件采集模板、OpsPilot ChatFlow 节点配置等），导致
+SSTI / 模板注入 / 远程代码执行（详见 2026-05 安全审计报告）。
+
+本模块提供统一的安全渲染入口，业务代码不应再直接调用默认 Jinja2 渲染用户
+可控内容。
+
+核心防护：
+
+1. 使用 :class:`ImmutableSandboxedEnvironment`：拦截一切下划线属性访问
+   （``__class__`` / ``__init__`` / ``__globals__`` / ``__mro__`` /
+   ``__subclasses__`` 等），从根本上切断 ``{{ cycler.__init__.__globals__... }}``
+   这类反射逃逸链；同时禁止对内置可变对象的修改操作。
+2. 可选清空 ``globals``：移除 ``cycler`` / ``joiner`` / ``namespace`` /
+   ``lipsum`` / ``range`` 等可作为逃逸入口的全局对象（纯变量替换场景默认开启）。
+3. 渲染上下文应只包含简单数据（字符串、数字、dict、list），调用方需避免
+   注入 ``request`` / ``settings`` / 模块 / 工具类等复杂对象。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from jinja2 import StrictUndefined, Undefined
+from jinja2.sandbox import ImmutableSandboxedEnvironment
+
+
+def create_secure_jinja_environment(
+    *,
+    strict_undefined: bool = False,
+    clear_globals: bool = True,
+    clear_filters: bool = False,
+) -> ImmutableSandboxedEnvironment:
+    """创建经过加固的 Jinja2 沙箱环境。
+
+    Args:
+        strict_undefined: 为 True 时未定义变量会抛出异常（默认行为保持宽松，
+            未定义变量渲染为空字符串，与历史 ``jinja2.Template`` 行为一致）。
+        clear_globals: 为 True 时清空全局对象（``cycler`` / ``joiner`` /
+            ``namespace`` / ``lipsum`` / ``range`` 等）。纯变量替换场景建议开启。
+        clear_filters: 为 True 时清空内置过滤器与测试函数。若业务模板需要
+            ``default`` / ``tojson`` 等过滤器，请保持 False。
+
+    Returns:
+        加固后的 :class:`ImmutableSandboxedEnvironment` 实例。
+    """
+    env = ImmutableSandboxedEnvironment(
+        autoescape=False,
+        undefined=StrictUndefined if strict_undefined else Undefined,
+    )
+    if clear_globals:
+        env.globals.clear()
+    if clear_filters:
+        env.filters.clear()
+        env.tests.clear()
+    return env
+
+
+def render_secure_template(
+    template_content: Optional[str],
+    context: Optional[Mapping[str, Any]] = None,
+    *,
+    strict_undefined: bool = False,
+    clear_globals: bool = True,
+    clear_filters: bool = False,
+) -> Optional[str]:
+    """使用安全沙箱环境渲染模板字符串。
+
+    用于替换业务代码中直接的 ``jinja2.Template(content).render(**ctx)`` 调用。
+    对于 SSTI payload（如 ``{{ cycler.__init__.__globals__.os.popen('id').read() }}``）
+    会抛出 :class:`jinja2.exceptions.SecurityError`，而不会执行系统命令。
+
+    Args:
+        template_content: 模板内容；为 None 时原样返回 None。
+        context: 渲染上下文（仅应包含简单数据）。
+        strict_undefined: 见 :func:`create_secure_jinja_environment`。
+        clear_globals: 见 :func:`create_secure_jinja_environment`。
+        clear_filters: 见 :func:`create_secure_jinja_environment`。
+
+    Returns:
+        渲染后的字符串。
+
+    Raises:
+        jinja2.exceptions.SecurityError: 模板尝试访问受限属性 / 危险操作。
+        jinja2.exceptions.TemplateError: 模板语法错误或（strict 模式下）变量未定义。
+    """
+    if template_content is None:
+        return None
+    env = create_secure_jinja_environment(
+        strict_undefined=strict_undefined,
+        clear_globals=clear_globals,
+        clear_filters=clear_filters,
+    )
+    template = env.from_string(str(template_content))
+    return template.render(**dict(context or {}))
+
+
+def contains_template_syntax(text: Optional[str]) -> bool:
+    """判断文本中是否包含 Jinja2 模板语法标记（``{{ }}`` 或 ``{% %}``）。
+
+    用于"只允许纯文本 / 结构化内容、不应包含模板表达式"的场景
+    （如监控插件 SNMP 采集片段）做前置拒绝。
+    """
+    if not text:
+        return False
+    return ("{{" in text and "}}" in text) or ("{%" in text and "%}" in text)

--- a/server/apps/core/utils/ssrf.py
+++ b/server/apps/core/utils/ssrf.py
@@ -1,0 +1,150 @@
+"""统一 SSRF 防护工具。
+
+历史上多处「服务端按用户可控 URL 发起请求」的场景（OpsPilot ChatFlow HTTP
+Action / Fetch 工具、Job NATS 回调等）未对目标地址做校验，可被用于探测/访问
+内网服务、云元数据接口（169.254.169.254）等，构成 SSRF（详见 2026-05 安全审计）。
+
+本模块提供统一入口：
+
+- :func:`validate_url`：校验单个 URL（仅允许 http/https，解析 DNS 后阻断
+  loopback / link-local / 私网 / 保留 / 组播 / 未指定 等危险地址，含 IPv6 与
+  IPv4-mapped IPv6）。
+- :func:`safe_request`：在 :mod:`requests` 之上做「先校验、禁用自动跳转、逐跳
+  重新校验」的安全请求，防止重定向绕过。
+
+业务代码不应再直接对用户可控 URL 调用 ``requests.*`` / ``urlopen``。
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import Iterable, Optional
+from urllib.parse import urljoin, urlparse
+
+DEFAULT_ALLOWED_SCHEMES = ("http", "https")
+
+
+class SSRFValidationError(ValueError):
+    """目标 URL 未通过 SSRF 安全校验。"""
+
+
+def _ip_is_blocked(ip: ipaddress._BaseAddress) -> bool:
+    """判断解析得到的 IP 是否属于应拦截的危险网段。"""
+    # IPv4-mapped / 兼容 IPv6（如 ::ffff:127.0.0.1）需还原为 IPv4 再判断
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        ip = mapped
+
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    ):
+        return True
+
+    # CGNAT 共享地址段 100.64.0.0/10（ipaddress 不归类为 private，但属内网范畴）
+    if ip.version == 4 and ip in ipaddress.ip_network("100.64.0.0/10"):
+        return True
+
+    # IPv6 唯一本地地址 fc00::/7（部分版本 is_private 已覆盖，这里兜底）
+    if ip.version == 6 and ip in ipaddress.ip_network("fc00::/7"):
+        return True
+
+    return False
+
+
+def _resolve_host_ips(host: str) -> list[str]:
+    """解析主机名为全部 IP（含 A/AAAA）。host 本身是 IP 字面量时直接返回。"""
+    try:
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise SSRFValidationError(f"无法解析目标主机: {host}") from exc
+    return list({info[4][0] for info in infos})
+
+
+def validate_url(
+    url: Optional[str],
+    *,
+    allowed_schemes: Iterable[str] = DEFAULT_ALLOWED_SCHEMES,
+    resolve: bool = True,
+) -> str:
+    """校验用户可控 URL，阻断指向内网/保留地址的 SSRF。
+
+    Args:
+        url: 待校验的目标 URL。
+        allowed_schemes: 允许的协议（默认仅 http/https）。
+        resolve: 是否做 DNS 解析并校验解析出的所有 IP（默认开启）。
+
+    Returns:
+        原样返回校验通过的 URL（便于链式使用）。
+
+    Raises:
+        SSRFValidationError: 协议不允许、缺少主机、解析失败或命中危险地址。
+    """
+    if not url or not isinstance(url, str):
+        raise SSRFValidationError("目标 URL 不能为空")
+
+    parsed = urlparse(url.strip())
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in {s.lower() for s in allowed_schemes}:
+        raise SSRFValidationError(f"不允许的 URL 协议: {scheme or '(空)'}，仅支持 {', '.join(allowed_schemes)}")
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFValidationError("目标 URL 缺少主机名")
+
+    if resolve:
+        for ip_str in _resolve_host_ips(host):
+            try:
+                ip = ipaddress.ip_address(ip_str)
+            except ValueError:
+                raise SSRFValidationError(f"目标主机解析出非法地址: {ip_str}")
+            if _ip_is_blocked(ip):
+                raise SSRFValidationError(f"目标地址指向受限网段（内网/回环/保留地址），已拒绝: {host} -> {ip}")
+
+    return url
+
+
+def safe_request(
+    method: str,
+    url: str,
+    *,
+    allowed_schemes: Iterable[str] = DEFAULT_ALLOWED_SCHEMES,
+    max_redirects: int = 3,
+    **kwargs,
+):
+    """在 SSRF 校验保护下发起 HTTP 请求。
+
+    - 请求前校验目标 URL；
+    - 禁用 :mod:`requests` 的自动重定向，手动逐跳重新校验 ``Location``，
+      防止「先返回合法地址再 302 到内网」的绕过；
+    - 其余参数透传给 :func:`requests.request`。
+
+    Raises:
+        SSRFValidationError: 任一跳目标未通过校验，或超过最大重定向次数。
+    """
+    import requests
+
+    kwargs.pop("allow_redirects", None)
+    current = validate_url(url, allowed_schemes=allowed_schemes)
+
+    for _ in range(max_redirects + 1):
+        response = requests.request(method, current, allow_redirects=False, **kwargs)
+        if response.is_redirect or response.is_permanent_redirect:
+            location = response.headers.get("Location")
+            if not location:
+                return response
+            current = validate_url(urljoin(current, location), allowed_schemes=allowed_schemes)
+            continue
+        return response
+
+    raise SSRFValidationError("重定向次数过多，疑似 SSRF 跳转链，已拒绝")

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -393,8 +393,11 @@ def job_file_distribute(data: dict):
         forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
         return {"result": False, "message": f"目标路径为高危路径，禁止分发: {', '.join(forbidden_rules)}"}
 
-    # 验证文件存在
-    distribution_files = DistributionFile.objects.filter(file_key__in=file_keys)
+    # 验证文件存在。
+    # 越权防护：只允许复用归属于当前调用方团队(team 列表)的文件，
+    # 防止跨团队凭 file_key 复用他人文件。team 为该 App 持有的团队ID列表。
+    team_ids = [int(t) for t in team]
+    distribution_files = DistributionFile.objects.filter(file_key__in=file_keys, team__in=team_ids)
     found_keys = set(distribution_files.values_list("file_key", flat=True))
     missing_keys = [k for k in file_keys if k not in found_keys]
     if missing_keys:

--- a/server/apps/job_mgmt/tasks.py
+++ b/server/apps/job_mgmt/tasks.py
@@ -8,6 +8,7 @@ from celery import current_app, shared_task
 from django.utils import timezone
 
 from apps.core.logger import job_logger as logger
+from apps.core.utils.ssrf import SSRFValidationError, safe_request, validate_url
 from apps.job_mgmt.constants import ConcurrencyPolicy, ExecutionStatus, JobType, TriggerSource
 from apps.job_mgmt.models import DistributionFile, JobExecution, ScheduledTask
 from apps.job_mgmt.services import FileDistributionRunner, ScriptExecutionRunner, ScriptParamsService
@@ -211,8 +212,15 @@ def do_callback_task(self, url: str, payload: dict, execution_id: int) -> None:
     失败时由 Celery 自动重试（指数退避: ~5s → 10s → 20s → 40s → 80s，最多 5 次）。
     任务持久化到 broker，worker 重启后仍会继续执行。
     """
+    # SSRF 防护：callback_url 来自外部 NATS 调用方（不可信），回调前统一校验，
+    # 阻断指向内网/回环/云元数据（169.254.169.254）等地址；校验失败不重试。
     try:
-        resp = requests.post(url, json=payload, timeout=10)
+        validate_url(url)
+    except SSRFValidationError as e:
+        logger.warning(f"[callback] 回调地址未通过 SSRF 校验，已拒绝: execution_id={execution_id}, url={url}, error={e}")
+        return
+    try:
+        resp = safe_request("POST", url, json=payload, timeout=10)
         if 200 <= resp.status_code < 300:
             logger.info(f"[callback] 回调成功: execution_id={execution_id}, url={url}")
             return

--- a/server/apps/job_mgmt/views/distribution_file.py
+++ b/server/apps/job_mgmt/views/distribution_file.py
@@ -10,6 +10,7 @@ from rest_framework.parsers import MultiPartParser
 from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.job_mgmt.models import DistributionFile
 from apps.job_mgmt.serializers.distribution_file import DistributionFileSerializer, DistributionFileUploadSerializer
@@ -62,10 +63,26 @@ class DistributionFileViewSet(AuthViewSet):
         # 上传到 JetStream Object Store
         async_to_sync(upload_file_to_s3)(file, file_key)
 
+        # 记录文件归属团队，供删除/复用时的越权校验。
+        # 优先使用 current_team cookie（用户当前所选团队，需属于该用户），否则回退首个所属组。
+        user_group_ids = normalize_user_group_ids(getattr(request.user, "group_list", []) or [])
+        team_id = None
+        current_team_str = request.COOKIES.get("current_team")
+        if current_team_str:
+            try:
+                current_team = int(current_team_str)
+            except (TypeError, ValueError):
+                current_team = None
+            if current_team is not None and (getattr(request.user, "is_superuser", False) or current_team in user_group_ids):
+                team_id = current_team
+        if team_id is None and user_group_ids:
+            team_id = user_group_ids[0]
+
         # 创建数据库记录
         distribution_file = DistributionFile.objects.create(
             original_name=original_name,
             file_key=file_key,
+            team=team_id,
         )
         log_operation(request, "create", "job", f"上传分发文件: {distribution_file.original_name}")
 

--- a/server/apps/job_mgmt/views/execution.py
+++ b/server/apps/job_mgmt/views/execution.py
@@ -203,16 +203,20 @@ class JobExecutionViewSet(AuthViewSet):
                 if existing_count != len(target_ids):
                     return Response({"error": "部分目标不存在"}, status=status.HTTP_400_BAD_REQUEST)
 
-        # 验证文件
+        # 越权防护：只允许复用归属于本次作业所属团队(team)的文件，
+        # 防止跨团队凭 file_id 复用/分发其他团队的文件。
+        team = data.get("team", [])
+        team_ids = [int(t) for t in team] if team else []
+
+        # 验证文件（且归属当前团队）
         file_ids = data["file_ids"]
-        distribution_files = DistributionFile.objects.filter(id__in=file_ids)
+        distribution_files = DistributionFile.objects.filter(id__in=file_ids, team__in=team_ids)
         if distribution_files.count() != len(file_ids):
             return Response({"error": "部分文件不存在或已过期"}, status=status.HTTP_400_BAD_REQUEST)
 
         username = request.user.username if request.user else ""
 
         target_path = data["target_path"]
-        team = data.get("team", [])
 
         # 高危路径检测
         check_result = DangerousChecker.check_path(target_path, team)

--- a/server/apps/monitor/services/custom_snmp_plugin.py
+++ b/server/apps/monitor/services/custom_snmp_plugin.py
@@ -6,6 +6,7 @@ from typing import Optional
 from django.db import transaction
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.safe_jinja import contains_template_syntax
 from apps.monitor.models import CollectConfig, MonitorPlugin, MonitorPluginConfigTemplate, MonitorPluginUITemplate
 from apps.monitor.utils.config_format import ConfigFormat
 from apps.monitor.utils.plugin_controller import Controller
@@ -313,6 +314,9 @@ class CustomSnmpPluginService:
             raise BaseAppException("采集片段不能为空")
         if "[[inputs.snmp]]" in normalized_snippet or "[inputs.snmp.tags]" in normalized_snippet:
             raise BaseAppException("仅支持编辑 SNMP 指标采集片段，请勿修改 inputs.snmp 主配置")
+        # 安全校验：采集片段为 SNMP 指标 TOML，不应包含模板表达式或反射用的双下划线，防止 SSTI/RCE
+        if contains_template_syntax(normalized_snippet) or "__" in normalized_snippet:
+            raise BaseAppException("采集模板片段不允许包含模板表达式（{{ }} / {% %}）或双下划线 __")
 
         child_template_id = CustomSnmpPluginService.get_child_template(plugin).id
 

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -1,6 +1,7 @@
 import uuid
 
-from jinja2 import Environment, BaseLoader, DebugUndefined
+from jinja2 import BaseLoader, DebugUndefined
+from jinja2.sandbox import ImmutableSandboxedEnvironment
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import monitor_logger as logger
@@ -27,7 +28,8 @@ class Controller:
     def jinja_env(self):
         """延迟初始化并缓存 Jinja2 Environment 对象"""
         if self._jinja_env is None:
-            self._jinja_env = Environment(loader=BaseLoader(), undefined=DebugUndefined)
+            # 使用沙箱环境，阻断用户可控采集模板内容中的 Jinja2 SSTI/RCE
+            self._jinja_env = ImmutableSandboxedEnvironment(loader=BaseLoader(), undefined=DebugUndefined)
             self._jinja_env.filters["to_toml"] = to_toml_dict
         return self._jinja_env
 

--- a/server/apps/opspilot/metis/llm/tools/fetch/http.py
+++ b/server/apps/opspilot/metis/llm/tools/fetch/http.py
@@ -6,6 +6,8 @@ import requests
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
+# SSRF 防护：URL 由 LLM/用户可控，统一走 apps.core.utils.ssrf
+from apps.core.utils.ssrf import safe_request
 from apps.opspilot.metis.llm.tools.fetch.utils import (
     format_error_response,
     parse_content_type_encoding,
@@ -55,13 +57,14 @@ def _http_get_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.get(
+        # SSRF 防护：使用 safe_request 逐跳校验重定向目标，禁止跳转到内网
+        response = safe_request(
+            "GET",
             url,
             headers=req_headers,
             params=params,
             timeout=request_timeout,
             verify=verify_ssl,
-            allow_redirects=True,
         )
 
         # 检查响应状态
@@ -122,14 +125,15 @@ def _http_post_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.post(
+        # SSRF 防护：使用 safe_request 逐跳校验重定向目标，禁止跳转到内网
+        response = safe_request(
+            "POST",
             url,
             data=data,
             json=json_data,
             headers=req_headers,
             timeout=request_timeout,
             verify=verify_ssl,
-            allow_redirects=True,
         )
 
         response.raise_for_status()
@@ -185,14 +189,15 @@ def _http_put_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.put(
+        # SSRF 防护：使用 safe_request 逐跳校验重定向目标，禁止跳转到内网
+        response = safe_request(
+            "PUT",
             url,
             data=data,
             json=json_data,
             headers=req_headers,
             timeout=request_timeout,
             verify=verify_ssl,
-            allow_redirects=True,
         )
 
         response.raise_for_status()
@@ -246,13 +251,14 @@ def _http_delete_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.delete(
+        # SSRF 防护：使用 safe_request 逐跳校验重定向目标，禁止跳转到内网
+        response = safe_request(
+            "DELETE",
             url,
             headers=req_headers,
             params=params,
             timeout=request_timeout,
             verify=verify_ssl,
-            allow_redirects=True,
         )
 
         response.raise_for_status()
@@ -307,14 +313,15 @@ def _http_patch_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.patch(
+        # SSRF 防护：使用 safe_request 逐跳校验重定向目标，禁止跳转到内网
+        response = safe_request(
+            "PATCH",
             url,
             data=data,
             json=json_data,
             headers=req_headers,
             timeout=request_timeout,
             verify=verify_ssl,
-            allow_redirects=True,
         )
 
         response.raise_for_status()

--- a/server/apps/opspilot/metis/llm/tools/fetch/utils.py
+++ b/server/apps/opspilot/metis/llm/tools/fetch/utils.py
@@ -41,7 +41,12 @@ def prepare_fetch_config(cfg: Optional[Dict[str, Any]] = None) -> Dict[str, Any]
 
 def validate_url(url: str) -> str:
     """
-    验证并规范化URL
+    验证并规范化URL，并执行 SSRF 安全校验。
+
+    URL 由 LLM/用户提供，属外部可控。除格式校验外，还会复用统一的
+    apps.core.utils.ssrf.validate_url 做 SSRF 防护：仅允许 http/https，
+    并在 DNS 解析后阻断 loopback / 私网 / link-local（含云元数据
+    169.254.169.254）/ 保留 / 组播等危险地址，防止经 Fetch 工具探测内网。
 
     Args:
         url: URL字符串
@@ -50,7 +55,7 @@ def validate_url(url: str) -> str:
         str: 规范化后的URL
 
     Raises:
-        ValueError: URL无效时抛出
+        ValueError: URL无效或命中 SSRF 受限网段时抛出（SSRFValidationError 是 ValueError 子类）
     """
     if not url or not url.strip():
         raise ValueError("URL不能为空")
@@ -66,9 +71,15 @@ def validate_url(url: str) -> str:
         parsed = urlparse(url)
         if not parsed.netloc:
             raise ValueError(f"URL格式无效: {url}")
-        return url
+    except ValueError:
+        raise
     except Exception as e:
         raise ValueError(f"URL格式无效: {url}, 错误: {str(e)}")
+
+    # SSRF 防护：统一校验目标地址，拦截内网/回环/保留地址
+    from apps.core.utils.ssrf import validate_url as ssrf_validate_url
+
+    return ssrf_validate_url(url)
 
 
 def prepare_headers(

--- a/server/apps/opspilot/utils/chat_flow_utils/engine/core/variable_manager.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/engine/core/variable_manager.py
@@ -3,7 +3,7 @@
 """
 from typing import Any, Dict, List
 
-from jinja2 import Environment, StrictUndefined
+from apps.core.utils.safe_jinja import create_secure_jinja_environment
 
 
 class VariableManager:
@@ -18,8 +18,9 @@ class VariableManager:
     def __init__(self):
         """初始化变量管理器"""
         self._variables: Dict[str, Any] = {}
-        # 创建Jinja2环境，使用StrictUndefined在变量不存在时抛出异常
-        self._jinja_env = Environment(undefined=StrictUndefined)
+        # 创建安全沙箱 Jinja2 环境（StrictUndefined：变量不存在时抛异常），
+        # 阻断 {{ ...__globals__... }} 等 SSTI/RCE 逃逸链（见 apps.core.utils.safe_jinja）
+        self._jinja_env = create_secure_jinja_environment(strict_undefined=True)
 
     def set_variable(self, name: str, value: Any) -> None:
         """设置变量

--- a/server/apps/opspilot/utils/chat_flow_utils/nodes/action/action.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/nodes/action/action.py
@@ -4,10 +4,11 @@
 import json
 from typing import Any, Dict
 
-import jinja2
 import requests
 
 from apps.core.logger import opspilot_logger as logger
+from apps.core.utils.safe_jinja import render_secure_template
+from apps.core.utils.ssrf import safe_request, validate_url
 from apps.opspilot.utils.chat_flow_utils.engine.core.base_executor import BaseNodeExecutor
 from apps.rpc.system_mgmt import SystemMgmt
 
@@ -30,8 +31,8 @@ class HttpActionNode(BaseNodeExecutor):
             return content
 
         try:
-            template = jinja2.Template(str(content))
-            return template.render(**template_context)
+            # 安全渲染：使用沙箱环境，阻断 Jinja2 SSTI/RCE（见 apps.core.utils.safe_jinja）
+            return render_secure_template(str(content), template_context)
         except Exception as e:
             logger.warning(f"HTTP节点 {node_id} 模板渲染失败: {e}")
             return content
@@ -108,37 +109,31 @@ class HttpActionNode(BaseNodeExecutor):
         """发送HTTP请求"""
         logger.info(f"HTTP动作节点 {node_id}: {method} {url}")
 
+        if method not in ("GET", "POST", "PUT", "PATCH", "DELETE"):
+            raise ValueError(f"不支持的HTTP方法: {method}")
+
+        # SSRF 防护：校验用户可控 URL，禁止指向内网/回环/保留地址，并对重定向逐跳校验
+        # （safe_request 内部调用 validate_url，见 apps.core.utils.ssrf）
+        validate_url(url)
+
         # 移除空的params以避免请求问题
         if request_kwargs.get("params") is None:
             request_kwargs.pop("params", None)
 
-        # HTTP方法映射
-        http_methods = {
-            "GET": requests.get,
-            "POST": requests.post,
-            "PUT": requests.put,
-            "PATCH": requests.patch,
-            "DELETE": requests.delete,
-        }
-
-        http_func = http_methods.get(method)
-        if not http_func:
-            raise ValueError(f"不支持的HTTP方法: {method}")
-
         # GET请求不需要请求体
         if method == "GET":
-            return http_func(url, **request_kwargs)
+            return safe_request(method, url, **request_kwargs)
 
         # 其他方法需要处理请求体
         request_data = self._prepare_request_body(config, node_id, template_context)
 
         if request_data is not None:
             if isinstance(request_data, dict):
-                return http_func(url, json=request_data, **request_kwargs)
+                return safe_request(method, url, json=request_data, **request_kwargs)
             else:
-                return http_func(url, data=request_data, **request_kwargs)
+                return safe_request(method, url, data=request_data, **request_kwargs)
         else:
-            return http_func(url, **request_kwargs)
+            return safe_request(method, url, **request_kwargs)
 
     def _process_response(self, response) -> Any:
         """处理HTTP响应"""
@@ -170,8 +165,8 @@ class NotifyNode(BaseNodeExecutor):
 
         try:
             template_context = self.variable_manager.get_all_variables()
-            template = jinja2.Template(str(content))
-            return template.render(**template_context)
+            # 安全渲染：使用沙箱环境，阻断 Jinja2 SSTI/RCE（见 apps.core.utils.safe_jinja）
+            return render_secure_template(str(content), template_context)
         except Exception as e:
             logger.warning(f"通知节点 {node_id} 内容渲染失败: {e}")
             return content

--- a/server/apps/opspilot/utils/chat_flow_utils/nodes/agent/agent.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/nodes/agent/agent.py
@@ -6,9 +6,8 @@ import json
 import time
 from typing import Any, Dict
 
-import jinja2
-
 from apps.core.logger import opspilot_logger as logger
+from apps.core.utils.safe_jinja import render_secure_template
 from apps.opspilot.models import LLMModel, LLMSkill
 from apps.opspilot.services.chat_service import ChatService, chat_service
 from apps.opspilot.utils.agent_factory import create_agent_instance
@@ -84,8 +83,8 @@ class AgentNode(BaseNodeExecutor):
             logger.info(
                 f"[Agent] 节点 {node_id} 模板变量: keys={list(template_context.keys())}, memory_context长度={len(memory_context) if memory_context else 0}"
             )
-            template = jinja2.Template(prompt)
-            rendered = template.render(**template_context)
+            # 安全渲染：使用沙箱环境，阻断 Jinja2 SSTI/RCE（见 apps.core.utils.safe_jinja）
+            rendered = render_secure_template(prompt, template_context)
             if memory_context and "memory_context" in prompt:
                 logger.info(f"[Agent] 节点 {node_id} prompt 中使用了 memory_context")
             return rendered

--- a/server/apps/opspilot/utils/chat_flow_utils/nodes/intent/intent_classifier.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/nodes/intent/intent_classifier.py
@@ -2,9 +2,8 @@
 
 from typing import Any, Dict
 
-import jinja2
-
 from apps.core.logger import opspilot_logger as logger
+from apps.core.utils.safe_jinja import render_secure_template
 from apps.opspilot.enum import SkillTypeChoices
 from apps.opspilot.services.chat_service import ChatService
 from apps.opspilot.utils.chat_flow_utils.engine.core.base_executor import BaseNodeExecutor
@@ -59,8 +58,8 @@ class IntentClassifierNode(BaseNodeExecutor):
 
         try:
             template_context = self.variable_manager.get_all_variables()
-            template = jinja2.Template(prompt)
-            return template.render(**template_context)
+            # 安全渲染：使用沙箱环境，阻断 Jinja2 SSTI/RCE（见 apps.core.utils.safe_jinja）
+            return render_secure_template(prompt, template_context)
         except Exception as e:
             logger.error("意图分类节点 %s 分类规则渲染失败: %s", node_id, str(e))
             return prompt

--- a/web/src/app/opspilot/(pages)/knowledge/preview/page.tsx
+++ b/web/src/app/opspilot/(pages)/knowledge/preview/page.tsx
@@ -8,6 +8,7 @@ import { remark } from "remark";
 import html from "remark-html";
 import gfm from "remark-gfm";
 import "github-markdown-css/github-markdown.css";
+import { sanitizeHtml } from "@/utils/sanitize";
 const FileViewer = dynamic(() => import("react-file-viewer"), {
   ssr: false,
 });
@@ -122,7 +123,7 @@ const PreviewPage: React.FC = () => {
         if (isMarkdownFile(contentType, resolvedFileName)) {
           const rawMarkdown = await blob.text();
           const processedContent = await remark().use(gfm).use(html).process(rawMarkdown);
-          setMarkdownHtml(processedContent.toString());
+          setMarkdownHtml(sanitizeHtml(processedContent.toString()));
           setFileUrl(null);
           setViewerType(null);
           setLoading(false);
@@ -173,32 +174,27 @@ const PreviewPage: React.FC = () => {
           const workbook = new ExcelJS.Workbook();
           await workbook.xlsx.load(arrayBuffer);
           const worksheet = workbook.worksheets[0];
-          let htmlStr = '<table>';
+
+          // 通过 DOM API 构建表格，单元格值统一用 textContent 写入，
+          // 任何用户/文件内容都不会被当作 HTML 解析，杜绝 XSS。
+          const table = document.createElement("table");
+          table.style.borderCollapse = "collapse";
+          table.style.width = "100%";
+
           worksheet.eachRow((row, rowNumber) => {
-            htmlStr += '<tr>';
+            const tr = document.createElement("tr");
             row.eachCell({ includeEmpty: true }, (cell) => {
-              const cellValue = cell.value?.toString() || '';
-              htmlStr += rowNumber === 1 ? `<th>${cellValue}</th>` : `<td>${cellValue}</td>`;
+              const cellEl = document.createElement(rowNumber === 1 ? "th" : "td");
+              cellEl.textContent = cell.value?.toString() || "";
+              cellEl.style.border = "1px solid #ccc";
+              cellEl.style.padding = "4px 8px";
+              tr.appendChild(cellEl);
             });
-            htmlStr += '</tr>';
-          })
-          htmlStr += '</table>';
+            table.appendChild(tr);
+          });
 
           if (xlsxContainerRef?.current) {
-            xlsxContainerRef.current.innerHTML = htmlStr;
-          }
-
-          const table = xlsxContainerRef?.current?.querySelector("table");
-          if (table) {
-            table.style.borderCollapse = "collapse";
-            table.style.width = "100%";
-            const cells = table.querySelectorAll("td, th");
-            cells.forEach((cell) => {
-              if (cell instanceof HTMLElement) {
-                cell.style.border = "1px solid #ccc";
-                cell.style.padding = "4px 8px";
-              }
-            });
+            xlsxContainerRef.current.replaceChildren(table);
           }
         } catch (error) {
           console.error("Excel render failed:", error);

--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -3,7 +3,7 @@ import {Button, ButtonProps, Drawer, Flex, Image, message as antMessage, Popconf
 import {FullscreenExitOutlined, FullscreenOutlined, PictureOutlined, SendOutlined} from '@ant-design/icons';
 import type {UploadFile} from 'antd/es/upload/interface';
 import {Bubble, Sender} from '@ant-design/x';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml as sharedSanitizeHtml } from '@/utils/sanitize';
 import Icon from '@/components/icon';
 import {useTranslation} from '@/utils/i18n';
 import MarkdownIt from 'markdown-it';
@@ -93,7 +93,7 @@ const ThinkingPanel: React.FC<{ thinking?: string; isThinking?: boolean }> = ({ 
 };
 
 const md = new MarkdownIt({
-  html: true, // Enable raw HTML (sanitized by DOMPurify)
+  html: false, // 默认不渲染原始 HTML，避免 Markdown 内嵌脚本；输出仍统一净化
   highlight: function (str: string, lang: string) {
     if (lang && hljs.getLanguage(lang)) {
       try {
@@ -104,12 +104,24 @@ const md = new MarkdownIt({
   },
 });
 
-// Sanitize HTML to prevent XSS
+// 通过公共净化工具统一处理：放行渲染所需的 button 标签与 data-* 交互属性
+// （供工具调用 / 引用 / 建议点击处理），但仍强制禁用所有 on* 事件属性、
+// javascript: 协议以及 script/iframe/style/svg/math 等危险标签。
 const sanitizeHtml = (html: string): string => {
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'span', 'div', 'a', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img', 'svg', 'use', 'button', 'style'],
-    ALLOWED_ATTR: ['class', 'style', 'href', 'target', 'rel', 'data-ref-number', 'data-chunk-id', 'data-knowledge-id', 'data-chunk-type', 'data-content', 'data-suggestion', 'data-expanded', 'data-tool-id', 'src', 'alt', 'width', 'height', 'aria-hidden'],
-    ALLOW_DATA_ATTR: true,
+  return sharedSanitizeHtml(html, {
+    allowTags: ['button'],
+    allowAttrs: [
+      'data-ref-number',
+      'data-chunk-id',
+      'data-knowledge-id',
+      'data-chunk-type',
+      'data-content',
+      'data-suggestion',
+      'data-expanded',
+      'data-tool-id',
+      'aria-hidden',
+    ],
+    allowDataAttr: true,
   });
 };
 

--- a/web/src/app/opspilot/components/custom-chat/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat/index.tsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import Icon from '@/components/icon';
 import { useTranslation } from '@/utils/i18n';
 import MarkdownIt from 'markdown-it';
-import DOMPurify from 'dompurify';
+import { sanitizeHtml } from '@/utils/sanitize';
 import hljs from 'highlight.js';
 import 'highlight.js/styles/atom-one-dark.css';
 import styles from './index.module.scss';
@@ -38,14 +38,6 @@ const md = new MarkdownIt({
     return '';
   },
 });
-
-const sanitizeHtml = (html: string): string => {
-  return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'span', 'div', 'a', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img'],
-    ALLOWED_ATTR: ['class', 'style', 'href', 'target', 'rel', 'src', 'alt', 'width', 'height'],
-    ALLOW_DATA_ATTR: false,
-  });
-};
 
 const CustomChat: React.FC<CustomChatProps> = ({ handleSendMessage, showMarkOnly = false, initialMessages = [], mode = 'chat' }) => {
   const { t } = useTranslation();

--- a/web/src/components/markdown/index.tsx
+++ b/web/src/components/markdown/index.tsx
@@ -8,6 +8,7 @@ import gfm from 'remark-gfm';
 import 'github-markdown-css/github-markdown.css';
 import styles from './index.module.scss';
 import { getClientIdFromRoute } from '@/utils/route';
+import { sanitizeHtml } from '@/utils/sanitize';
 
 interface MarkdownRendererProps {
   filePath?: string;
@@ -33,7 +34,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           .use(gfm)
           .use(html)
           .process(externalContent);
-        setContent(processedContent.toString());
+        setContent(sanitizeHtml(processedContent.toString()));
       } else {
         setContent('');
       }
@@ -67,7 +68,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
         .use(gfm)
         .use(html)
         .process(data.content);
-      setContent(processedContent.toString());
+      setContent(sanitizeHtml(processedContent.toString()));
     } catch (error) {
       message.error('Failed to load markdown content.');
       console.error(error);

--- a/web/src/utils/sanitize.ts
+++ b/web/src/utils/sanitize.ts
@@ -1,0 +1,122 @@
+import DOMPurify from 'dompurify';
+
+/**
+ * 公共 HTML 净化工具，统一防御存储型 / 反射型 XSS。
+ *
+ * 用于所有需要把字符串当 HTML 注入 DOM 的场景（dangerouslySetInnerHTML、
+ * element.innerHTML 等），尤其是 Markdown 渲染、知识库预览、聊天消息等
+ * 包含用户可控内容的位置。
+ *
+ * 统一禁用：
+ *  - 事件处理属性（onerror / onload / onclick ... 任意 on* 属性）
+ *  - javascript: / data: 等危险 URL 协议（DOMPurify 默认拦截，额外显式收紧）
+ *  - <script> / <iframe> / <object> / <embed> 等可执行/可加载外部资源标签
+ *  - 危险的 SVG / MathML 内联向量（通过 USE_PROFILES.html 仅允许 HTML 档案）
+ */
+
+// 统一禁止的事件属性（覆盖常见 on* 事件），作为 DOMPurify 默认行为之上的显式兜底。
+const FORBID_EVENT_ATTR: string[] = [
+  'onerror',
+  'onload',
+  'onclick',
+  'ondblclick',
+  'onmouseover',
+  'onmouseout',
+  'onmousemove',
+  'onmousedown',
+  'onmouseup',
+  'onfocus',
+  'onblur',
+  'onchange',
+  'oninput',
+  'onsubmit',
+  'onreset',
+  'onkeydown',
+  'onkeyup',
+  'onkeypress',
+  'onwheel',
+  'onscroll',
+  'oncontextmenu',
+  'onanimationstart',
+  'onanimationend',
+  'ontransitionend',
+  'onpointerdown',
+  'onpointerup',
+  'onpointermove',
+  'ontouchstart',
+  'ontouchend',
+  'ontouchmove',
+];
+
+// 危险标签：可执行脚本或加载外部资源 / 危险向量图与表单交互。
+const FORBID_DANGEROUS_TAGS: string[] = [
+  'script',
+  'style',
+  'iframe',
+  'object',
+  'embed',
+  'base',
+  'form',
+  'meta',
+  'link',
+  'svg',
+  'math',
+];
+
+export interface SanitizeOptions {
+  /**
+   * 额外允许的标签（在默认 html 档案基础上追加）。
+   */
+  allowTags?: string[];
+  /**
+   * 额外允许的属性。
+   */
+  allowAttrs?: string[];
+  /**
+   * 是否允许 data-* 属性。默认 false。
+   */
+  allowDataAttr?: boolean;
+}
+
+/**
+ * 默认净化：基于 DOMPurify 的 html 档案，禁用所有 on* 事件属性、
+ * javascript:/data: 协议、script/iframe/svg/math 等危险标签。
+ *
+ * 适用于绝大多数 Markdown / 富文本渲染场景，正常的标题、列表、代码块、
+ * 链接、图片、表格等都会被保留。
+ */
+export const sanitizeHtml = (
+  dirty: string | null | undefined,
+  options: SanitizeOptions = {}
+): string => {
+  if (!dirty) return '';
+
+  return DOMPurify.sanitize(dirty, {
+    USE_PROFILES: { html: true },
+    ADD_TAGS: options.allowTags,
+    ADD_ATTR: options.allowAttrs,
+    FORBID_ATTR: FORBID_EVENT_ATTR,
+    FORBID_TAGS: FORBID_DANGEROUS_TAGS,
+    ALLOW_DATA_ATTR: options.allowDataAttr ?? false,
+    // 仅允许安全的链接/资源协议，杜绝 javascript:、vbscript:、data: 脚本注入。
+    ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|tel|ftp):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i,
+  });
+};
+
+/**
+ * 转义字符串中的 HTML 特殊字符，使其作为纯文本安全展示。
+ *
+ * 用于需要在已净化的 HTML 模板里插值用户输入（如搜索高亮、代码片段高亮）
+ * 的场景：先转义用户内容，再拼接受信任的标记标签（<mark>/<span>）。
+ */
+export const escapeHtml = (value: string | null | undefined): string => {
+  if (!value) return '';
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+};
+
+export default sanitizeHtml;


### PR DESCRIPTION
## 背景

依据 2026-05 安全审计跟踪表与分析报告（外部白帽反馈监控插件 `collect_template` 存在 SSTI→RCE，复核后发现同类问题多处），统一整改跟踪表列出的全部漏洞。

## 修复内容

### 1. Jinja2 SSTI / RCE（严重）
- 新增统一安全渲染入口 `server/apps/core/utils/safe_jinja.py`：基于 `ImmutableSandboxedEnvironment` + 清空 globals，从根本上阻断 `{{ cycler.__init__.__globals__... }}`、`{{ ''.__class__.__mro__ }}` 等反射逃逸链。
- 监控插件采集模板渲染 `plugin_controller.py` 改用沙箱环境（覆盖 `collect_template` 入口与配置下发链路 `batch_setting_node_child_config` 的二次触发）。
- SNMP 采集片段保存前拒绝模板表达式 / 双下划线（`custom_snmp_plugin.py`）。
- OpsPilot ChatFlow 的 HTTP Action / 通知 / Agent Prompt / Intent 分类规则 / 变量管理器统一改安全渲染。

### 2. SSRF
- 新增统一 SSRF 校验器 `server/apps/core/utils/ssrf.py`：仅允许 http/https，DNS 解析后阻断 loopback / link-local（含云元数据 `169.254.169.254`）/ 私网 / 保留 / 组播 / CGNAT / IPv6 ULA / IPv4-mapped，并逐跳重新校验重定向防绕过。
- 应用到 OpsPilot ChatFlow HTTP Action、Fetch 工具（`fetch/utils.py` + `http.py` 五个请求实现）、Job 回调任务 `do_callback_task`（callback_url 来自外部 NATS，校验失败不重试）。

### 3. 存储型 XSS（前端）
- 新增统一净化工具 `web/src/utils/sanitize.ts`（已有 dompurify）与 `mobile/src/utils/sanitize.ts`（isomorphic-dompurify）。
- 修复 markdown 组件、知识库预览（Markdown 净化 + XLSX 单元格改用 `textContent` 不再拼 HTML）、custom-chat、custom-chat-sse（关闭 markdown-it `html`）、mobile 会话页。

### 4. 越权删除 / 复用（DistributionFile，IDOR）
- NATS 文件分发、Web 文件分发复用按 `team` 强制过滤，防止跨团队凭 `file_key` / `file_id` 复用他人文件。
- Web 上传写入 `team` 归属，供删除 / 复用越权校验。

## 测试与验证

- 新增 PoC 回归测试 `test_safe_jinja.py`、`test_ssrf.py`。
- 本地验证：所有 server 改动 `py_compile` 通过；SSTI 9 条 PoC 全部拦截、0 逃逸；SSRF 拦截脚本对内网/回环/元数据/IPv6/十进制 IP/危险协议全拦、外网放行、0 漏网；前端改动文件 type-check / eslint 0 错。
- ⚠️ 完整 pytest 未在本地运行（开发机 venv 未装 pytest、无测试 DB），测试文件留待 CI 执行。

## 影响与兼容性

- **越权修复的兼容性权衡**：历史 `team=None` 的旧分发文件，加固后复用 / 分发查询将匹配不到，需重新上传以获得归属（与已上线的开放删除接口语义一致）。
- mobile 新增依赖 `isomorphic-dompurify`。

## 未覆盖（建议后续）

审计报告「三、暂未确认」的文件型模板渲染（alerts / cmdb / log plugin_controller、node_mgmt sidecar 的 `Collector.default_config`）——模板源为本地文件、未确认用户可控，本次未改动，建议后续统一加固。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
