### PR TITLE
bugfix: 修复供应商连接测试 SSRF 误拦截及错误信息不展示问题

### DIFF
--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -187,6 +187,15 @@ def safe_request_llm_endpoint(
         raise SafeRequestsError(f"HTTP 请求失败: {e}")
 
 
+def safe_get_llm_endpoint(url: str, **kwargs: Any) -> Response:
+    """安全的 GET 请求（LLM/Rerank 端点宽松模式）
+
+    允许私网地址和 localhost，仅阻断云元数据地址。
+    适用于内网部署的 LLM/Rerank/Embedding 端点（vLLM, Ollama, LocalAI 等）。
+    """
+    return safe_request_llm_endpoint("GET", url, **kwargs)
+
+
 def safe_post_llm_endpoint(url: str, **kwargs: Any) -> Response:
     """安全的 POST 请求（LLM/Rerank 端点宽松模式）
 

--- a/server/apps/opspilot/services/model_vendor_sync_service.py
+++ b/server/apps/opspilot/services/model_vendor_sync_service.py
@@ -5,7 +5,7 @@ from typing import ContextManager, cast
 from django.db import transaction
 
 from apps.core.utils.loader import LanguageLoader
-from apps.core.utils.safe_requests import safe_get, safe_post
+from apps.core.utils.safe_requests import safe_get_llm_endpoint, safe_post_llm_endpoint
 from apps.opspilot.models import EmbedProvider, LLMModel, OCRProvider, RerankProvider
 
 logger = logging.getLogger(__name__)
@@ -72,7 +72,7 @@ class ModelVendorSyncService:
             raise ValueError(loader.get("error.vendor_api_base_required", "供应商 API 地址不能为空"))
         if not api_key:
             raise ValueError(loader.get("error.vendor_api_key_required", "供应商 API Key 不能为空"))
-        response = safe_get(
+        response = safe_get_llm_endpoint(
             f"{normalized_api_base}/models",
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=15,
@@ -100,7 +100,7 @@ class ModelVendorSyncService:
         normalized_api_base = (api_base or "https://api.anthropic.com").rstrip("/")
         test_model = model or "claude-3-haiku-20240307"
 
-        response = safe_post(
+        response = safe_post_llm_endpoint(
             f"{normalized_api_base}/v1/messages",
             headers={
                 "x-api-key": api_key,

--- a/web/src/app/opspilot/api/provider.ts
+++ b/web/src/app/opspilot/api/provider.ts
@@ -65,9 +65,13 @@ export const useProviderApi = () => {
     await del(`/opspilot/model_provider_mgmt/model_vendor/${id}/`);
   };
 
-  const testVendorConnection = async (payload: TestVendorConnectionPayload): Promise<{ success: boolean }> => {
-    await post('/opspilot/model_provider_mgmt/model_vendor/test_connection/', payload);
-    return { success: true };
+  const testVendorConnection = async (payload: TestVendorConnectionPayload): Promise<{ success: boolean; message?: string }> => {
+    try {
+      await post('/opspilot/model_provider_mgmt/model_vendor/test_connection/', payload);
+      return { success: true };
+    } catch (err: any) {
+      return { success: false, message: err?.message };
+    }
   };
 
   const fetchModelGroups = async (_type: string, provider_type?: string): Promise<ModelGroup[]> => {

--- a/web/src/app/opspilot/components/provider/vendorBasicInfo.tsx
+++ b/web/src/app/opspilot/components/provider/vendorBasicInfo.tsx
@@ -116,7 +116,7 @@ const VendorBasicInfo: React.FC<VendorBasicInfoProps> = ({ vendorId, onUpdated }
         return;
       }
 
-      message.error(t('provider.vendor.testFailed'));
+      message.error(result.message || t('provider.vendor.testFailed'));
     } catch (error: any) {
       if (error?.errorFields) {
         message.error(t('provider.vendor.validationError'));

--- a/web/src/app/opspilot/components/provider/vendorModal.tsx
+++ b/web/src/app/opspilot/components/provider/vendorModal.tsx
@@ -216,7 +216,7 @@ const VendorModal: React.FC<VendorModalProps> = ({
         return;
       }
 
-      message.error(t('provider.vendor.testFailed'));
+      message.error(result.message || t('provider.vendor.testFailed'));
     } catch (error: any) {
       if (error?.errorFields) {
         setSubmitError(t('provider.vendor.validationError'));


### PR DESCRIPTION
后端:
- safe_requests.py: 新增 safe_get_llm_endpoint() 宽松模式 GET 封装
- model_vendor_sync_service.py: test_connection 使用 LLM 宽松 SSRF 策略 允许访问内网地址（vLLM/Ollama 等私有化部署），仅阻断云元数据地址

前端:
- provider.ts: testVendorConnection 捕获异常并返回 { success, message }
- vendorBasicInfo.tsx: 测试失败时展示后端返回的具体错误信息
- vendorModal.tsx: 测试失败时展示后端返回的具体错误信息