### PR TITLE
fix(stargazer): fail fast on missing ansible executor + sane host-remote timeouts

### DIFF
--- a/agents/stargazer/core/ansible_rpc.py
+++ b/agents/stargazer/core/ansible_rpc.py
@@ -11,6 +11,8 @@ import uuid
 import logging
 from typing import Any, Dict, Optional
 
+from nats.errors import NoRespondersError
+
 from core.nats_utils import nats_request
 
 logger = logging.getLogger("stargazer.ansible_rpc")
@@ -79,6 +81,19 @@ async def ansible_adhoc(
 
     try:
         result = await nats_request(subject, payload=payload, timeout=nats_timeout)
+    except NoRespondersError:
+        # 没有任何 ansible-executor 订阅该 subject：通常是 ansible_node_id 配置错误
+        # （例如落到了 "default"）或对应云区域的执行节点离线。立即报错，避免空等超时。
+        logger.error(
+            f"Ansible adhoc no responders: subject={subject}, node={ansible_node_id}, "
+            f"task_id={task_id}. 没有 ansible-executor 订阅该节点，请检查 ansible_node_id "
+            f"是否正确以及对应云区域的执行节点是否在线"
+        )
+        raise RuntimeError(
+            f"No ansible executor subscribed for node '{ansible_node_id}' "
+            f"(subject={subject}); check ansible_node_id / cloud region binding "
+            f"and that the executor is online"
+        )
     except TimeoutError:
         logger.error(
             f"Ansible adhoc NATS timeout: node={ansible_node_id}, task_id={task_id}, "

--- a/agents/stargazer/core/host_remote_callback.py
+++ b/agents/stargazer/core/host_remote_callback.py
@@ -9,11 +9,29 @@ HOST_REMOTE_CALLBACK_HANDLER = "host_remote.callback"
 HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS = int(
     os.getenv("HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS", "3600")
 )
-HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS = int(
-    os.getenv("HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS", "300")
+_TASK_JOB_TIMEOUT_SECONDS = int(os.getenv("TASK_JOB_TIMEOUT", "600"))
+
+
+def _resolve_host_remote_timeout(env_name: str, ratio: float, floor: int) -> int:
+    """解析 host-remote 等待时限。
+
+    显式设置环境变量时以其为准；否则按 TASK_JOB_TIMEOUT 的比例派生，
+    保证默认配置下 submit-accept 等待与 callback 时限始终小于 worker job 超时，
+    避免等待与 arq job 超时重叠（否则会触发启动告警且行为不一致）。
+    """
+    explicit = os.getenv(env_name)
+    if explicit:
+        return int(explicit)
+    return max(floor, int(_TASK_JOB_TIMEOUT_SECONDS * ratio))
+
+
+# submit-accept 等待发生在 worker job 内部，须明显小于 job 超时
+HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS = _resolve_host_remote_timeout(
+    "HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS", 0.5, 60
 )
-HOST_REMOTE_CALLBACK_DEADLINE_SECONDS = int(
-    os.getenv("HOST_REMOTE_CALLBACK_DEADLINE_SECONDS", "1200")
+# callback 时限由 sweeper 兜底，保持小于 job 超时以避免重叠
+HOST_REMOTE_CALLBACK_DEADLINE_SECONDS = _resolve_host_remote_timeout(
+    "HOST_REMOTE_CALLBACK_DEADLINE_SECONDS", 0.8, 120
 )
 HOST_REMOTE_PROCESSING_STALE_SECONDS = int(
     os.getenv("HOST_REMOTE_PROCESSING_STALE_SECONDS", "300")

--- a/agents/stargazer/core/task_queue.py
+++ b/agents/stargazer/core/task_queue.py
@@ -25,8 +25,13 @@ def _resolve_running_flag_ttl(params: Dict[str, Any]) -> int:
     if (params or {}).get("monitor_type") != "host":
         return base_ttl
 
-    callback_deadline = int(os.getenv("HOST_REMOTE_CALLBACK_DEADLINE_SECONDS", "1200")) + 60
-    submit_accept_timeout = int(os.getenv("HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS", "300")) + 60
+    # 复用 host_remote_callback 解析后的时限，避免与其默认值不一致
+    from core import host_remote_callback
+
+    callback_deadline = host_remote_callback.HOST_REMOTE_CALLBACK_DEADLINE_SECONDS + 60
+    submit_accept_timeout = (
+        host_remote_callback.HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS + 60
+    )
     return max(base_ttl, callback_deadline, submit_accept_timeout)
 
 

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -674,7 +674,10 @@ class TestHostRemoteMonitorTask:
         )
         loaded_context = callback_contexts["collect-task-1"]
         assert loaded_context["callback_deadline_at"] is not None
-        assert loaded_context["callback_deadline_at"] >= 1234567 + 1200 * 1000
+        assert loaded_context["callback_deadline_at"] >= (
+            1234567
+            + host_remote_callback_module.HOST_REMOTE_CALLBACK_DEADLINE_SECONDS * 1000
+        )
         assert [entry[0] for entry in call_order] == ["store", "submit"]
 
     async def test_collect_host_metrics_task_publishes_error_metrics_on_submission_failure(


### PR DESCRIPTION
排查"ansible executor 不回调"时顺带发现的两个独立健壮性问题（与主修复 #3233 相互独立）。

## 1. adhoc 无响应时快速失败（node 路由错误）

当 adhoc 请求的 `ansible_node_id` 没有任何 executor 订阅时（例如未正确配置的主机导致 `ansible_node_id` 落到字面量 `"default"`，而 executor 实际订阅 `ansible.adhoc.<真实instance_id>`），原先会表现为一次不明确的失败/空等。

现在在 `ansible_adhoc` 捕获 `nats.errors.NoRespondersError`，立即抛出清晰可定位的错误，指明节点/subject 及最可能的原因（`ansible_node_id` / 云区域绑定错误，或执行节点离线）：

```
No ansible executor subscribed for node 'default' (subject=ansible.adhoc.default);
check ansible_node_id / cloud region binding and that the executor is online
```

> 注：`"default"` 来自上游（主机监控实例未绑定正确的 ansible 执行节点 / 云区域），属于配置数据问题；本改动让 agent 侧"无响应"立刻显式报错，便于定位，而非静默超时。

## 2. host-remote 等待时限随 TASK_JOB_TIMEOUT 派生

本部署 `TASK_JOB_TIMEOUT=300`，而旧的固定默认值 `HOST_REMOTE_CALLBACK_DEADLINE_SECONDS=1200`、`HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS=300` 都 `>= 300`，触发启动告警：

```
HOST_REMOTE_CALLBACK_DEADLINE_SECONDS >= TASK_JOB_TIMEOUT; waiting callbacks may overlap worker job timeout assumptions
HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS >= TASK_JOB_TIMEOUT; ...
```

改为按 `TASK_JOB_TIMEOUT` 比例派生（显式 env 仍优先生效）：
- `HOST_REMOTE_SUBMIT_ACCEPT_TIMEOUT_SECONDS = 0.5 × TASK_JOB_TIMEOUT`（下限 60）
- `HOST_REMOTE_CALLBACK_DEADLINE_SECONDS = 0.8 × TASK_JOB_TIMEOUT`（下限 120）

始终保证 `submit_accept < callback_deadline < TASK_JOB_TIMEOUT`。`core/task_queue.py` 改为复用解析后的常量，运行标记 TTL 与之一致。`tests/test_host_collector.py` 中硬编码的 `1200` 改为引用模块常量。

## 验证（真实环境）

- `TASK_JOB_TIMEOUT=300` → `submit_accept=150`、`callback_deadline=240`，两条启动告警均消失，sweeper 正常启动，NATS 连接健康（0 reset）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)