### PR TITLE
bugfix: [node_mgmt] 移除 node_list RPC skip_permission 旁路，新增内部专用执行节点接口

### DIFF
--- a/agents/stargazer/service/collection_service.py
+++ b/agents/stargazer/service/collection_service.py
@@ -347,19 +347,16 @@ class CollectionService:
             return
 
         try:
-            exec_params = {"args": [{"page_size": -1, "skip_permission": True}], "kwargs": {}}
-            subject = f"{self.namespace}.node_list"
+            exec_params = {"args": [self.connect_ip], "kwargs": {}}
+            subject = f"{self.namespace}.get_node_by_ip"
             payload = json.dumps(exec_params).encode()
 
             response = await nats_request(subject, payload=payload, timeout=10.0)
 
-            if response.get("success") and response["result"]["nodes"]:
-                for node in response["result"]["nodes"]:
-                    if node["ip"] == self.connect_ip:
-                        self._node_info = node
-                        logger.info(f"✅ Found node info for {self.connect_ip}")
-                        break
-                else:
-                    logger.warning(f"⚠️  Node info not found for {self.connect_ip}")
+            if response.get("success") and response.get("result"):
+                self._node_info = response["result"]
+                logger.info(f"✅ Found node info for {self.connect_ip}")
+            else:
+                logger.warning(f"⚠️  Node info not found for {self.connect_ip}")
         except Exception as e:
             logger.warning(f"⚠️  Failed to get node info for {self.connect_ip}: {e}")

--- a/server/apps/job_mgmt/services/execution_base_service.py
+++ b/server/apps/job_mgmt/services/execution_base_service.py
@@ -247,26 +247,11 @@ class ExecutionTaskBaseService(object):
 
     @staticmethod
     def _get_ansible_node(cloud_region_id: int) -> str:
-        """
-        根据云区域ID获取 Ansible 执行节点
-
-        Args:
-            cloud_region_id: 云区域ID
-
-        Returns:
-            节点ID
-
-        Raises:
-            ValueError: 未找到可用的 Ansible 执行节点
-        """
-        node_mgmt = NodeMgmt()
-        result = node_mgmt.node_list({"cloud_region_id": cloud_region_id, "is_container": True, "page": 1, "page_size": 1, "skip_permission": True})
-        if not isinstance(result, dict):
-            raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的 Ansible 执行节点")
-        nodes = result.get("nodes", [])
-        if not nodes:
-            raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的 Ansible 执行节点")
-        return nodes[0]["id"]
+        """根据云区域ID获取 Ansible 执行（容器）节点"""
+        try:
+            return NodeMgmt().get_executor_node(cloud_region_id)
+        except Exception as e:
+            raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的 Ansible 执行节点") from e
 
     @classmethod
     def _build_host_credentials(cls, targets: list) -> list:

--- a/server/apps/job_mgmt/views/target.py
+++ b/server/apps/job_mgmt/views/target.py
@@ -21,34 +21,11 @@ from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
 def _get_executor_node(cloud_region_id: int) -> str:
-    """
-    根据云区域ID获取执行节点
-
-    Args:
-        cloud_region_id: 云区域ID
-
-    Returns:
-        节点ID
-
-    Raises:
-        ValueError: 未找到可用的执行节点
-    """
-    node_mgmt = NodeMgmt()
-    result = node_mgmt.node_list(
-        {
-            "cloud_region_id": cloud_region_id,
-            "is_container": True,
-            "page": 1,
-            "page_size": 1,
-            "skip_permission": True,
-        }
-    )
-    if not isinstance(result, dict):
-        raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的执行节点")
-    nodes = result.get("nodes", [])
-    if not nodes:
-        raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的执行节点")
-    return nodes[0]["id"]
+    """根据云区域ID获取执行（容器）节点"""
+    try:
+        return NodeMgmt().get_executor_node(cloud_region_id)
+    except Exception as e:
+        raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的执行节点") from e
 
 
 def _parse_ssh_test_result(result) -> tuple[bool, str, str, dict]:

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -583,7 +583,7 @@ def node_list(query_data: dict):
     is_manual = query_data.get("is_manual")
     is_container = query_data.get("is_container")
     permission_data = query_data.get("permission_data", {})
-    skip_permission = query_data.get("skip_permission", False)
+    # skip_permission 不再接受外部传入，强制 False（fail-closed）
     return NodeService.get_node_list(
         organization_ids,
         cloud_region_id,
@@ -596,8 +596,54 @@ def node_list(query_data: dict):
         is_manual,
         is_container,
         permission_data,
-        skip_permission,
+        skip_permission=False,
     )
+
+
+@nats_client.register
+def get_executor_node(cloud_region_id: int) -> str:
+    """获取指定云区域的执行（容器）节点——系统内部专用，不经过用户权限过滤"""
+    result = NodeService.get_node_list(
+        organization_ids=None,
+        cloud_region_id=cloud_region_id,
+        name=None,
+        ip=None,
+        os=None,
+        page=1,
+        page_size=1,
+        is_active=None,
+        is_manual=None,
+        is_container=True,
+        permission_data={},
+        skip_permission=True,
+    )
+    nodes = result.get("nodes", [])
+    if not nodes:
+        raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的执行节点")
+    return nodes[0]["id"]
+
+
+@nats_client.register
+def get_node_by_ip(ip: str) -> dict:
+    """按 IP 查找节点信息——系统内部专用（如 Stargazer agent 自发现）"""
+    result = NodeService.get_node_list(
+        organization_ids=None,
+        cloud_region_id=None,
+        name=None,
+        ip=ip,
+        os=None,
+        page=1,
+        page_size=-1,
+        is_active=None,
+        is_manual=None,
+        is_container=None,
+        permission_data={},
+        skip_permission=True,
+    )
+    for node in result.get("nodes", []):
+        if node.get("ip") == ip:
+            return node
+    return {}
 
 
 @nats_client.register

--- a/server/apps/node_mgmt/tests/test_security_fixes.py
+++ b/server/apps/node_mgmt/tests/test_security_fixes.py
@@ -13,6 +13,7 @@ import pytest
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models import CloudRegion, Node, PackageVersion, SidecarEnv
 from apps.node_mgmt.models.sidecar import NodeOrganization
+from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.services.installer_session import InstallerSessionService
 from apps.node_mgmt.services.sidecar import Sidecar
 
@@ -359,3 +360,70 @@ def test_sidecar_heartbeat_does_not_rollback_user_updated_node_organizations(mon
     assert response.status_code == 202
     orgs = set(NodeOrganization.objects.filter(node_id=node.id).values_list("organization", flat=True))
     assert orgs == {2}
+
+
+# ── Issue #3125 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+def test_issue_3125_node_list_ignores_external_skip_permission():
+    """node_list 不再接受外部 skip_permission=True，无权限上下文时返回空列表。"""
+    from apps.node_mgmt.nats.node import node_list
+
+    cloud_region = CloudRegion.objects.create(
+        name="test-3125-region", introduction="", created_by="t", updated_by="t"
+    )
+    Node.objects.create(
+        id="node-3125-a", name="node-3125-a", ip="10.3.1.1",
+        operating_system="Linux", cpu_architecture="x86_64",
+        collector_configuration_directory="/etc", metrics={}, status={},
+        tags=[], log_file_list=[], cloud_region=cloud_region,
+        created_by="t", updated_by="t",
+    )
+
+    result = node_list({"page": 1, "page_size": -1, "skip_permission": True})
+    assert result["nodes"] == [], "skip_permission=True 不应再起效，应 fail-closed 返回空"
+
+
+@pytest.mark.django_db
+def test_issue_3125_get_executor_node_returns_container_node():
+    """get_executor_node 返回指定云区域的容器节点 ID。"""
+    from apps.node_mgmt.nats.node import get_executor_node
+    from apps.node_mgmt.constants.node import NodeConstants
+
+    cloud_region = CloudRegion.objects.create(
+        name="test-3125-executor", introduction="", created_by="t", updated_by="t"
+    )
+    node = Node.objects.create(
+        id="node-3125-container", name="node-3125-container", ip="10.3.1.2",
+        operating_system="Linux", cpu_architecture="x86_64",
+        node_type=ControllerConstants.NODE_TYPE_CONTAINER,
+        collector_configuration_directory="/etc", metrics={}, status={},
+        tags=[], log_file_list=[], cloud_region=cloud_region,
+        created_by="t", updated_by="t",
+    )
+
+    result = get_executor_node(cloud_region.id)
+    assert result == node.id
+
+
+@pytest.mark.django_db
+def test_issue_3125_get_node_by_ip_returns_matching_node():
+    """get_node_by_ip 按 IP 精确匹配节点，供 Stargazer agent 自发现使用。"""
+    from apps.node_mgmt.nats.node import get_node_by_ip
+
+    cloud_region = CloudRegion.objects.create(
+        name="test-3125-byip", introduction="", created_by="t", updated_by="t"
+    )
+    Node.objects.create(
+        id="node-3125-ip", name="node-3125-ip", ip="10.3.1.3",
+        operating_system="Linux", cpu_architecture="x86_64",
+        collector_configuration_directory="/etc", metrics={}, status={},
+        tags=[], log_file_list=[], cloud_region=cloud_region,
+        created_by="t", updated_by="t",
+    )
+
+    result = get_node_by_ip("10.3.1.3")
+    assert result.get("ip") == "10.3.1.3"
+    assert result.get("id") == "node-3125-ip"
+
+    assert get_node_by_ip("10.9.9.9") == {}

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -56,6 +56,14 @@ class NodeMgmt(object):
         return_data = self.client.run("node_list", query_data)
         return return_data
 
+    def get_executor_node(self, cloud_region_id: int) -> str:
+        """获取指定云区域的执行（容器）节点，系统内部专用"""
+        return self.client.run("get_executor_node", cloud_region_id)
+
+    def get_node_by_ip(self, ip: str) -> dict:
+        """按 IP 查找节点信息，系统内部专用"""
+        return self.client.run("get_node_by_ip", ip)
+
     def get_node_names_by_ids(self, node_ids):
         """
         :param node_ids: 节点ID列表


### PR DESCRIPTION
## 问题背景

关联 Issue：#3125

`node_mgmt` 的 `node_list` NATS RPC 接受外部传入的 `skip_permission` 参数，`job_mgmt` 的执行节点选取逻辑（`test_connection`、作业执行链）显式传入 `skip_permission=True`，导致可绕过节点实例权限边界获取全量节点数据，并以跨组织执行节点发起 SSH 测试或远程命令执行。

**攻击路径：**
```
具备 target-View 的用户
  → POST /job_mgmt/target/test_connection/ (任意 cloud_region_id)
  → _get_executor_node / _get_ansible_node
  → NodeMgmt().node_list(skip_permission=True)    ← 旁路
  → NodeService.get_node_list → Node.objects.all() ← 全量节点数据暴露
```

## 变更内容

| 文件 | 说明 |
|------|------|
| `node_mgmt/nats/node.py` | `node_list` 移除外部 `skip_permission` 参数（fail-closed）；新增 `get_executor_node`、`get_node_by_ip` 系统内部专用 handler，`skip_permission` 服务端固化 |
| `rpc/node_mgmt.py` | 新增 `get_executor_node`、`get_node_by_ip` 客户端方法 |
| `job_mgmt/views/target.py` | `_get_executor_node` 改调专用 `get_executor_node` RPC |
| `job_mgmt/services/execution_base_service.py` | `_get_ansible_node` 同上 |
| `agents/stargazer/service/collection_service.py` | `set_node_info` 改调 `get_node_by_ip`，不再通过 `node_list(skip_permission=True)` 拉取全量节点 |
| `node_mgmt/tests/test_security_fixes.py` | 新增 #3125 三个验证用例 |

## 设计说明

- `CloudRegion` 为平台级共享基础设施，无 `organization` 字段，执行（容器）节点跨组织可用属于架构设计，不在本次范围内
- 本次修复核心：**将 `skip_permission` 从可外部控制的 RPC 参数，改为服务端固化的内部行为**，消除任意调用方通过传参绕过权限过滤的路径

## 测试结果

```
node_mgmt/tests/test_security_fixes.py -k 3125   3 passed ✅
node_mgmt + job_mgmt 全量测试                     369 passed，5 failed（预存在，无关本次改动）✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)