### PR TITLE
fix(opspilot): 修复 Skill 工具执行越权与 Python 沙箱逃逸 (BL-NEW-001 严重)

### DIFF
--- a/server/apps/opspilot/metis/llm/tools/python/executor.py
+++ b/server/apps/opspilot/metis/llm/tools/python/executor.py
@@ -6,7 +6,26 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from loguru import logger
 
-FORBIDDEN_PYTHON_CALLS = {"eval", "exec", "__import__"}
+# BL-NEW-001：扩充危险内建黑名单。仅靠 SAFE_BUILTINS 白名单 + 屏蔽 import 不足以
+# 防住沙箱逃逸——这些内建函数可用于反射取属性、读全局命名空间、动态编译/执行或读写
+# 文件，是绕过沙箱的常见跳板，一并在 AST 层按名字拦截。
+FORBIDDEN_PYTHON_CALLS = {
+    "eval",
+    "exec",
+    "__import__",
+    "compile",
+    "getattr",
+    "setattr",
+    "delattr",
+    "globals",
+    "locals",
+    "vars",
+    "open",
+    "input",
+    "breakpoint",
+    "memoryview",
+    "help",
+}
 FORBIDDEN_PYTHON_NODES = (ast.Import, ast.ImportFrom)
 SAFE_BUILTINS = {
     "abs": abs,
@@ -31,10 +50,30 @@ SAFE_BUILTINS = {
 }
 
 
+def _is_dunder(name: str) -> bool:
+    """判断是否为 dunder（双下划线包裹）名字，如 ``__class__``、``__globals__``。"""
+    return isinstance(name, str) and len(name) > 4 and name.startswith("__") and name.endswith("__")
+
+
 class PythonSecurityVisitor(ast.NodeVisitor):
     def visit_Call(self, node):
         if isinstance(node.func, ast.Name) and node.func.id in FORBIDDEN_PYTHON_CALLS:
             raise ValueError(f"检测到禁止调用的高危函数: {node.func.id}")
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node):
+        # BL-NEW-001：阻断 dunder 属性访问。``().__class__.__bases__[0].__subclasses__()``
+        # 这类对象继承链逃逸是绕过 SAFE_BUILTINS 限制、拿到 os/subprocess 进而执行系统
+        # 命令的关键一步，全部依赖 __class__/__bases__/__subclasses__/__globals__/
+        # __builtins__/__mro__ 等 dunder 属性。沙箱内的正常运算无需访问 dunder。
+        if _is_dunder(node.attr):
+            raise ValueError(f"检测到禁止访问的危险属性: {node.attr}")
+        self.generic_visit(node)
+
+    def visit_Name(self, node):
+        # 阻断对 dunder 标识符（如 __import__、__builtins__）的直接引用。
+        if _is_dunder(node.id):
+            raise ValueError(f"检测到禁止使用的标识符: {node.id}")
         self.generic_visit(node)
 
     def visit_Import(self, node):

--- a/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
+++ b/server/apps/opspilot/tests/test_kubernetes_data_collection_tools.py
@@ -461,7 +461,13 @@ def test_resolve_request_tools_falls_back_to_skill_tools():
         {"name": "kubernetes_data_collection", "kwargs": []}
     ]
     assert resolve_request_tools([], [{"name": "kubernetes_data_collection", "kwargs": []}]) == [{"name": "kubernetes_data_collection", "kwargs": []}]
-    assert resolve_request_tools([{"name": "override", "kwargs": []}], [{"name": "default", "kwargs": []}]) == [{"name": "override", "kwargs": []}]
+    # BL-NEW-001：请求工具必须在 Skill 授权范围内，未授权的 name 会被丢弃（不再原样覆盖）。
+    assert resolve_request_tools([{"name": "override", "kwargs": []}], [{"name": "default", "kwargs": []}]) == []
+    # 请求携带 Skill 已授权的同名工具（含运行时参数）则保留。
+    assert resolve_request_tools(
+        [{"name": "kubernetes_data_collection", "kwargs": [{"key": "kubeconfig_data", "value": "x"}]}],
+        [{"name": "kubernetes_data_collection", "kwargs": []}],
+    ) == [{"name": "kubernetes_data_collection", "kwargs": [{"key": "kubeconfig_data", "value": "x"}]}]
 
 
 def test_llm_view_execute_passes_default_collection_tools_to_stream_chat(mocker):

--- a/server/apps/opspilot/tests/test_skill_execution_params.py
+++ b/server/apps/opspilot/tests/test_skill_execution_params.py
@@ -1,6 +1,8 @@
 """opspilot.utils.skill_execution_params 纯单元测试。
 
-规格：resolve_request_tools 的优先级——请求工具优先，其次技能工具，都无则空列表。
+规格（BL-NEW-001）：resolve_request_tools 以服务端 Skill 配置为唯一授权来源，
+请求工具按 id / name 白名单过滤，未授权工具一律丢弃；请求未带 tools 时回退到
+Skill 自身配置。
 """
 
 import pytest
@@ -10,15 +12,59 @@ from apps.opspilot.utils.skill_execution_params import resolve_request_tools
 pytestmark = pytest.mark.unit
 
 
-def test_请求工具优先():
-    assert resolve_request_tools(["a"], ["b"]) == ["a"]
-
-
 def test_无请求工具时用技能工具():
-    assert resolve_request_tools([], ["b"]) == ["b"]
-    assert resolve_request_tools(None, ["b"]) == ["b"]
+    assert resolve_request_tools([], [{"id": 1, "name": "b"}]) == [{"id": 1, "name": "b"}]
+    assert resolve_request_tools(None, [{"id": 1, "name": "b"}]) == [{"id": 1, "name": "b"}]
 
 
 def test_都为空返回空列表():
     assert resolve_request_tools(None, None) == []
     assert resolve_request_tools([], []) == []
+
+
+def test_请求携带已授权id的工具予以保留():
+    """请求可为 Skill 已授权的工具携带运行时参数（如凭据）。"""
+    skill_tools = [{"id": 5, "name": "mysql", "kwargs": []}]
+    request_tools = [{"id": 5, "name": "mysql", "kwargs": [{"key": "password", "value": "x"}]}]
+    assert resolve_request_tools(request_tools, skill_tools) == request_tools
+
+
+def test_请求注入未授权id的工具被丢弃():
+    """BL-NEW-001 核心：低权限用户注入 Skill 未授权的工具 ID（如通用 Python 执行）被拒绝。"""
+    skill_tools = [{"id": 5, "name": "mysql", "kwargs": []}]
+    request_tools = [{"id": 99, "name": "python_execute", "kwargs": []}]
+    assert resolve_request_tools(request_tools, skill_tools) == []
+
+
+def test_合法name配伪造id无法绕过():
+    """用已授权工具的 name + 指向高危工具的 evil id 也无法绕过（只认 id）。"""
+    skill_tools = [{"id": 5, "name": "python_execute", "kwargs": []}]
+    request_tools = [{"id": 99, "name": "python_execute", "kwargs": []}]
+    assert resolve_request_tools(request_tools, skill_tools) == []
+
+
+def test_按name授权的内置工具予以保留():
+    """无有效 id 的内置工具按 name 白名单放行。"""
+    skill_tools = [{"name": "fileupload", "kwargs": []}]
+    request_tools = [{"name": "fileupload", "kwargs": [{"key": "k", "value": "v"}]}]
+    assert resolve_request_tools(request_tools, skill_tools) == request_tools
+
+
+def test_未授权name的内置工具被丢弃():
+    skill_tools = [{"name": "fileupload", "kwargs": []}]
+    request_tools = [{"name": "shell_execute", "kwargs": []}]
+    assert resolve_request_tools(request_tools, skill_tools) == []
+
+
+def test_混合请求仅保留授权部分():
+    skill_tools = [{"id": 5, "name": "mysql", "kwargs": []}, {"name": "fileupload", "kwargs": []}]
+    request_tools = [
+        {"id": 5, "name": "mysql", "kwargs": []},  # 授权
+        {"id": 99, "name": "python_execute", "kwargs": []},  # 未授权 id
+        {"name": "fileupload", "kwargs": []},  # 授权 name
+        {"name": "shell_execute", "kwargs": []},  # 未授权 name
+    ]
+    assert resolve_request_tools(request_tools, skill_tools) == [
+        {"id": 5, "name": "mysql", "kwargs": []},
+        {"name": "fileupload", "kwargs": []},
+    ]

--- a/server/apps/opspilot/tests/test_tool_security_guards.py
+++ b/server/apps/opspilot/tests/test_tool_security_guards.py
@@ -61,3 +61,41 @@ def test_python_execute_preserves_explicit_print_output():
 def test_python_execute_blocks_forbidden_code_patterns(code, message):
     with pytest.raises(ValueError, match=message):
         _execute_python_code(code)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        # BL-NEW-001 文档 PoC：经无害对象继承链取得 os.system 执行系统命令。
+        "().__class__.__bases__[0].__subclasses__()",
+        "''.__class__.__mro__[1].__subclasses__()",
+        "[].__class__.__base__.__subclasses__()[0].__init__.__globals__",
+        "(lambda: 0).__globals__",
+        "type('x', (), {}).__subclasses__",
+    ],
+)
+def test_python_execute_blocks_object_chain_sandbox_escape(code):
+    """对象继承链 / dunder 反射逃逸必须被拦截（攻击者借此拿到 os/subprocess）。"""
+    with pytest.raises(ValueError, match="(危险属性|禁止使用的标识符)"):
+        _execute_python_code(code)
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        ("getattr(str, 'mro')", "getattr"),
+        ("globals()", "globals"),
+        ("open('/etc/passwd')", "open"),
+        ("compile('1', 'x', 'eval')", "compile"),
+        ("vars(str)", "vars"),
+    ],
+)
+def test_python_execute_blocks_reflection_builtins(code, message):
+    """反射 / 文件 / 动态编译类内建函数被 AST 层按名字拦截。"""
+    with pytest.raises(ValueError, match=message):
+        _execute_python_code(code)
+
+
+def test_python_execute_allows_dunder_free_attribute_access():
+    """非 dunder 的普通属性访问不受影响（如 str 方法），确保不误伤正常代码。"""
+    assert _execute_python_code("'Hello'.upper()") == "HELLO"

--- a/server/apps/opspilot/utils/skill_execution_params.py
+++ b/server/apps/opspilot/utils/skill_execution_params.py
@@ -1,6 +1,51 @@
 def resolve_request_tools(request_tools, skill_tools):
-    if request_tools:
-        return request_tools
-    if skill_tools:
+    """解析本次技能执行最终使用的工具列表。
+
+    安全要求（BL-NEW-001 越权 / 代码执行）：
+        请求体中的 ``tools`` 只能用于「为 Skill 已授权的工具携带运行时参数」，
+        绝不能用于「越权添加」Skill 未授权的工具。历史实现中只要请求带了
+        ``tools`` 就原样返回，低权限用户可借此把任意全局工具 ID（如通用
+        Python / Shell 执行工具）注入到自己有权运行的 Skill，再配合沙箱逃逸
+        以服务进程权限执行任意命令。
+
+    因此这里以**服务端 Skill 配置**（``skill_tools``）作为唯一权威授权来源，
+    请求工具按白名单过滤：
+
+    - 带正整数 ``id`` 的工具：``id`` 必须命中 Skill 已授权的工具 ID。
+      （只认 ID，避免用合法 ``name`` + 伪造 ``id`` 欺骗下游按 ID 加载。）
+    - 不带有效 ``id`` 的工具（如按 name 匹配的内置工具）：``name`` 必须命中
+      Skill 已授权的工具名。
+
+    未授权的请求工具一律丢弃。请求未携带 ``tools`` 时回退到 Skill 自身配置。
+    """
+    skill_tools = skill_tools or []
+    if not request_tools:
         return skill_tools
-    return []
+
+    authorized_ids = set()
+    authorized_names = set()
+    for tool in skill_tools:
+        if not isinstance(tool, dict):
+            continue
+        tool_id = tool.get("id")
+        if isinstance(tool_id, int) and not isinstance(tool_id, bool) and tool_id > 0:
+            authorized_ids.add(tool_id)
+        name = tool.get("name")
+        if name:
+            authorized_names.add(name)
+
+    resolved = []
+    for tool in request_tools:
+        if not isinstance(tool, dict):
+            continue
+        tool_id = tool.get("id")
+        if isinstance(tool_id, int) and not isinstance(tool_id, bool) and tool_id > 0:
+            # 有效 ID：必须按 ID 命中授权集合（name 不参与判定，防伪造）。
+            if tool_id in authorized_ids:
+                resolved.append(tool)
+        else:
+            # 无有效 ID：按 name 命中授权集合（内置工具等）。
+            name = tool.get("name")
+            if name and name in authorized_names:
+                resolved.append(tool)
+    return resolved


### PR DESCRIPTION
## 漏洞 BL-NEW-001（严重）— OpsPilot Skill 工具执行：越权 + 代码执行 + 命令执行

### Fact-check（已在当前 master 代码核实）
攻击链：**低权限用户 → 注入工具 ID → 沙箱逃逸 → 以服务进程权限 RCE**

1. **请求覆盖工具** — `utils/skill_execution_params.py` 的 `resolve_request_tools` 只要请求带了 `tools` 就原样返回，覆盖 Skill 配置。
2. **按全局 ID 加载、无归属校验** — `services/chat_service.py` 的 `_process_tools_and_extra_config` 用 `SkillTools.objects.filter(id__in=...)` 按全局 ID 加载工具，未校验工具与 Skill / Team / 用户的关系。
3. **Python AST 黑名单可逃逸** — `metis/llm/tools/python/executor.py` 的 `PythonSecurityVisitor` 仅拦 `eval/exec/__import__` 和 `import`，未拦 dunder 属性访问，`().__class__.__bases__[0].__subclasses__()` 经对象继承链可取到 `os.system`。
4. **Shell 黑名单可绕过** — `metis/llm/tools/shell/shell_tools.py` 纯正则黑名单，`rm -r -f` 等可绕过。

入口：`POST /api/v1/opspilot/model_provider_mgmt/llm/execute/`、`execute_agui/`。

### 修复（断链关键点：授权校验 + 沙箱加固，二者各自即可断链，叠加为纵深防御）
- **Fix A 工具授权**（`skill_execution_params.py`）：以服务端 Skill 配置为唯一权威授权来源，请求工具按 **id / name 白名单**过滤。有正整数 id 时**只认 id**（防合法 name + 伪造 id 欺骗下游按 id 加载），未授权工具一律丢弃；请求无 `tools` 时回退 Skill 配置。这同时实现「禁止请求覆盖工具」+「仅加载 Skill 已授权工具」。
- **Fix B Python 沙箱加固**（`executor.py`）：`PythonSecurityVisitor` 增加 `visit_Attribute` / `visit_Name`，阻断所有 dunder 属性 / 标识符（`__class__/__bases__/__subclasses__/__globals__/__builtins__/__mro__` 等），并扩充危险内建黑名单（`getattr/setattr/globals/locals/vars/open/compile/...`），直接打掉对象继承链逃逸。

### PoC 验证（直接执行真实函数 + 真实 payload，全部 PASS）
> 本社区版 checkout 缺企业版 `license_mgmt` 模块且依赖 falkordb 等重型可选依赖，完整 pytest 套件在本地无法启动（**预存环境限制，与本改动无关**）。故用被修复的纯函数 + 文档 PoC payload 直接验证：

```
Fix A:
  注入未授权工具ID      -> []        PASS
  合法name+伪造id       -> []        PASS
  授权工具带运行时参数  -> 保留      PASS
  无请求工具回退        -> Skill配置 PASS
Fix B:
  ().__class__.__bases__[0].__subclasses__()  -> BLOCKED(危险属性:__subclasses__)  PASS
  (lambda:0).__globals__                      -> BLOCKED(危险属性:__globals__)      PASS
  getattr/open/compile                        -> BLOCKED(高危函数)                  PASS
  文档PoC: 经 Popen 子类取 os.system 落标记文件 -> BLOCKED，标记文件未生成          PASS
  正常代码 1+2 / 'Hello'.upper() / sum(range(5)) 不受影响                            PASS
```

新增 / 更新的 pytest 回归用例（CI 完整环境可跑）：
- `tests/test_skill_execution_params.py`：授权过滤（注入拦截 / 伪造 id 拦截 / 授权放行 / 回退）
- `tests/test_tool_security_guards.py`：对象继承链逃逸拦截 + 反射内建拦截 + 正常属性放行
- `tests/test_kubernetes_data_collection_tools.py`：原断言「请求覆盖」的用例改为符合新安全语义

### Follow-up（建议后续单独处理）
- Shell 黑名单本质不可靠：建议下线通用 Shell/SSH 工具，或把执行能力迁移到无网络、低权限的隔离 Runner（对应修复建议第 4/5 条）。Fix A 已使低权限用户无法把 Shell 工具注入到未授权 Skill，残余风险显著下降。

🤖 Generated with [Claude Code](https://claude.com/claude-code)