### PR TITLE
fix(job_mgmt): 修复作业快速执行/文件分发的跨团队水平越权 (BL-NEW-002 高危)

### DIFF
--- a/server/apps/job_mgmt/tests/test_team_authz.py
+++ b/server/apps/job_mgmt/tests/test_team_authz.py
@@ -1,0 +1,50 @@
+"""job_mgmt.utils.team_authz 纯单元测试（BL-NEW-002 水平越权修复）。
+
+规格：用户只能引用自己授权团队内的对象；无团队归属的对象对非超管一律拒绝；
+超管（authorized_team_ids=None）放行一切。
+"""
+import pytest
+
+from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_authorized_team_ids, normalize_team
+
+pytestmark = pytest.mark.unit
+
+
+def test_normalize_team_支持list_int_none():
+    assert normalize_team([1, 2, "3"]) == {1, 2, 3}
+    assert normalize_team(5) == {5}
+    assert normalize_team(None) == set()
+    assert normalize_team([]) == set()
+    assert normalize_team("bad") == set()
+
+
+def test_normalize_authorized_team_ids_从group_list提取():
+    group_list = [{"id": 1, "name": "A"}, {"id": 2, "name": "B"}, {"name": "无id"}]
+    assert normalize_authorized_team_ids(group_list) == {1, 2}
+    assert normalize_authorized_team_ids([]) == set()
+    assert normalize_authorized_team_ids(None) == set()
+
+
+def test_超管放行一切():
+    assert is_team_authorized([999], None) is True
+    assert is_team_authorized(None, None) is True
+
+
+def test_对象团队在授权范围内则放行():
+    # Script/Playbook/Target 的 team 是 list
+    assert is_team_authorized([1, 2], {1}) is True
+    assert is_team_authorized([2], {1, 2}) is True
+    # DistributionFile 的 team 是单个 int
+    assert is_team_authorized(1, {1, 2}) is True
+
+
+def test_跨团队引用被拒绝():
+    """BL-NEW-002 核心：Team A 用户（授权 {1}）引用 Team B（team=[2]）对象被拒。"""
+    assert is_team_authorized([2], {1}) is False
+    assert is_team_authorized(2, {1}) is False
+
+
+def test_无团队归属对象对非超管一律拒绝():
+    """历史遗留的无 team 文件（team=None/[]）不能被任意用户引用。"""
+    assert is_team_authorized(None, {1, 2}) is False
+    assert is_team_authorized([], {1, 2}) is False

--- a/server/apps/job_mgmt/utils/team_authz.py
+++ b/server/apps/job_mgmt/utils/team_authz.py
@@ -1,0 +1,63 @@
+"""作业执行的团队归属授权校验工具（BL-NEW-002 水平越权修复）。
+
+纯函数，无 Django / DB 依赖，便于单元测试。视图层在按 ID 加载
+Script / Playbook / Target / DistributionFile 等对象后，用这里的
+``is_team_authorized`` 校验对象的团队归属是否落在「当前用户授权团队」内，
+防止 Team A 用户引用 Team B 的脚本 / 目标 / 文件越权执行。
+"""
+from __future__ import annotations
+
+
+def normalize_team(value) -> set[int]:
+    """把对象的 team 字段规整为 int 集合。
+
+    兼容三种存储形态：
+    - JSONField 列表（Script / Playbook / Target.team，如 ``[1, 2]``）
+    - 单个整数（DistributionFile.team）
+    - ``None`` / 空（无团队归属）→ 空集合
+    """
+    if value is None:
+        return set()
+    if isinstance(value, (list, tuple, set)):
+        result: set[int] = set()
+        for item in value:
+            try:
+                result.add(int(item))
+            except (TypeError, ValueError):
+                continue
+        return result
+    try:
+        return {int(value)}
+    except (TypeError, ValueError):
+        return set()
+
+
+def normalize_authorized_team_ids(group_list) -> set[int]:
+    """从用户的 ``group_list`` 提取其有权访问的团队 ID 集合。"""
+    result: set[int] = set()
+    for group in group_list or []:
+        if isinstance(group, dict) and "id" in group:
+            try:
+                result.add(int(group["id"]))
+            except (TypeError, ValueError):
+                continue
+    return result
+
+
+def is_team_authorized(obj_team, authorized_team_ids) -> bool:
+    """对象的团队归属是否落在授权团队集合内。
+
+    Args:
+        obj_team: 对象的 team 字段（list / int / None）。
+        authorized_team_ids: 当前用户授权团队集合；``None`` 表示超管，放行一切。
+
+    Returns:
+        True 表示有权引用该对象。无团队归属（空）的对象对非超管一律拒绝
+        （杜绝历史遗留的无 team 文件被任意引用）。
+    """
+    if authorized_team_ids is None:
+        return True
+    obj_teams = normalize_team(obj_team)
+    if not obj_teams:
+        return False
+    return bool(obj_teams & set(authorized_team_ids))

--- a/server/apps/job_mgmt/views/distribution_file.py
+++ b/server/apps/job_mgmt/views/distribution_file.py
@@ -45,6 +45,10 @@ class DistributionFileViewSet(AuthViewSet):
             "name": "原始文件名.txt"
         }
         """
+        # BL-NEW-002：上传文件必须带团队归属，否则文件分发时无法做团队隔离。
+        # 校验并取得当前用户有权访问的 current_team，作为文件归属团队。
+        current_team = self._validate_current_team_permission(request)
+
         serializer = DistributionFileUploadSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
@@ -62,10 +66,11 @@ class DistributionFileViewSet(AuthViewSet):
         # 上传到 JetStream Object Store
         async_to_sync(upload_file_to_s3)(file, file_key)
 
-        # 创建数据库记录
+        # 创建数据库记录（带团队归属）
         distribution_file = DistributionFile.objects.create(
             original_name=original_name,
             file_key=file_key,
+            team=current_team,
         )
         log_operation(request, "create", "job", f"上传分发文件: {distribution_file.original_name}")
 

--- a/server/apps/job_mgmt/views/execution.py
+++ b/server/apps/job_mgmt/views/execution.py
@@ -22,6 +22,7 @@ from apps.job_mgmt.serializers.execution import (
 from apps.job_mgmt.services.dangerous_checker import DangerousChecker
 from apps.job_mgmt.services.script_params_service import ScriptParamsService
 from apps.job_mgmt.tasks import distribute_files_task, execute_playbook_task, execute_script_task
+from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_authorized_team_ids
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
@@ -44,6 +45,31 @@ class JobExecutionViewSet(AuthViewSet):
         elif self.action == "file_distribution":
             return FileDistributionSerializer
         return JobExecutionListSerializer
+
+    def _get_authorized_team_ids(self, request):
+        """当前用户有权访问的团队 ID 集合；超管返回 None（不做团队归属限制）。
+
+        用于 quick_execute / file_distribution 在按 ID 加载 Script / Playbook /
+        Target / DistributionFile 后校验对象归属，防止跨团队越权引用（BL-NEW-002）。
+        """
+        user = getattr(request, "user", None)
+        if getattr(user, "is_superuser", False):
+            return None
+        return normalize_authorized_team_ids(getattr(user, "group_list", []))
+
+    def _resolve_execution_team(self, request, data):
+        """确定本次执行归属的 team，并校验用户对其有权限。
+
+        - 请求体显式传 team：必须全部落在用户可管理范围内，否则 PermissionDenied。
+        - 未传 team：回退到已校验权限的 current_team。
+        禁止信任请求体 team 越权指定他人团队（BL-NEW-002）。
+        """
+        current_team = self._validate_current_team_permission(request)
+        requested_team = data.get("team", [])
+        if requested_team:
+            self._validate_org_field_permission(request, requested_team)
+            return requested_team
+        return [current_team]
 
     @HasPermission("job_record-View")
     def list(self, request, *args, **kwargs):
@@ -68,37 +94,46 @@ class JobExecutionViewSet(AuthViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
+        # BL-NEW-002：禁止信任请求体 team 越权；按服务端授权 team 校验所引用对象。
+        authorized_team_ids = self._get_authorized_team_ids(request)
+        team = self._resolve_execution_team(request, data)
+
         # 获取目标来源和目标列表
         target_source = data["target_source"]
         target_list = data["target_list"]
 
-        # 验证目标（仅 manual 来源需要验证 target_id 存在）
+        # 验证目标（仅 manual 来源需要验证 target_id 存在），并校验目标归属团队
         if target_source == TargetSource.MANUAL:
             target_ids = [t.get("target_id") for t in target_list if t.get("target_id")]
             if target_ids:
-                existing_count = Target.objects.filter(id__in=target_ids).count()
-                if existing_count != len(target_ids):
+                targets = list(Target.objects.filter(id__in=target_ids))
+                if len(targets) != len(set(target_ids)):
                     return Response({"error": "部分目标不存在"}, status=status.HTTP_400_BAD_REQUEST)
+                if any(not is_team_authorized(t.team, authorized_team_ids) for t in targets):
+                    return Response({"error": "部分目标不属于当前用户的团队，无权执行"}, status=status.HTTP_403_FORBIDDEN)
 
         username = request.user.username if request.user else ""
         name = data["name"]
         timeout = data.get("timeout", 600)
-        team = data.get("team", []) or [int(request.COOKIES.get("current_team") or 0)]
         params = data.get("params", [])
 
-        # 处理新格式参数：解析 is_modified=False 的参数
+        # 处理新格式参数：解析 is_modified=False 的参数（脚本须属于用户授权团队）
         script = None
         if data.get("script_id"):
             script = Script.objects.filter(id=data["script_id"]).first()
+            if not script or not is_team_authorized(script.team, authorized_team_ids):
+                return Response({"error": "脚本不存在或无权访问"}, status=status.HTTP_403_FORBIDDEN)
             # 如果前端未显式传 timeout，使用脚本库定义的超时时间
-            if script and "timeout" not in request.data:
+            if "timeout" not in request.data:
                 timeout = script.timeout
         resolved_params = ScriptParamsService.resolve_params(params, script=script)
         params_str = ScriptParamsService.params_to_string(resolved_params)
         # 根据模式创建执行记录
         if data.get("playbook_id"):
-            # Playbook 模式：params 存为 JSON 字符串，保留完整 key-value 关系
-            playbook = Playbook.objects.get(id=data["playbook_id"])
+            # Playbook 模式：params 存为 JSON 字符串，保留完整 key-value 关系（须属于用户授权团队）
+            playbook = Playbook.objects.filter(id=data["playbook_id"]).first()
+            if not playbook or not is_team_authorized(playbook.team, authorized_team_ids):
+                return Response({"error": "Playbook 不存在或无权访问"}, status=status.HTTP_403_FORBIDDEN)
             playbook_params_dict = ScriptParamsService.params_to_dict(resolved_params)
             execution = JobExecution.objects.create(
                 name=name,
@@ -123,7 +158,7 @@ class JobExecutionViewSet(AuthViewSet):
             script_type = data.get("script_type", "")
 
             if data.get("script_id"):
-                script = Script.objects.get(id=data["script_id"])
+                # 复用上方已按团队归属校验过的 script 对象，避免重复查询
                 script_content = script.content
                 script_type = script.script_type
 
@@ -192,28 +227,35 @@ class JobExecutionViewSet(AuthViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
+        # BL-NEW-002：禁止信任请求体 team 越权；按服务端授权 team 校验所引用对象。
+        authorized_team_ids = self._get_authorized_team_ids(request)
+        team = self._resolve_execution_team(request, data)
+
         # 获取目标来源和目标列表
         target_source = data["target_source"]
         target_list = data["target_list"]
 
-        # 验证目标（仅 manual 来源需要验证 target_id 存在）
+        # 验证目标（仅 manual 来源需要验证 target_id 存在），并校验目标归属团队
         if target_source == TargetSource.MANUAL:
             target_ids = [t.get("target_id") for t in target_list if t.get("target_id")]
             if target_ids:
-                existing_count = Target.objects.filter(id__in=target_ids).count()
-                if existing_count != len(target_ids):
+                targets = list(Target.objects.filter(id__in=target_ids))
+                if len(targets) != len(set(target_ids)):
                     return Response({"error": "部分目标不存在"}, status=status.HTTP_400_BAD_REQUEST)
+                if any(not is_team_authorized(t.team, authorized_team_ids) for t in targets):
+                    return Response({"error": "部分目标不属于当前用户的团队，无权分发"}, status=status.HTTP_403_FORBIDDEN)
 
-        # 验证文件
+        # 验证文件，并校验文件归属团队
         file_ids = data["file_ids"]
-        distribution_files = DistributionFile.objects.filter(id__in=file_ids)
-        if distribution_files.count() != len(file_ids):
+        distribution_files = list(DistributionFile.objects.filter(id__in=file_ids))
+        if len(distribution_files) != len(set(file_ids)):
             return Response({"error": "部分文件不存在或已过期"}, status=status.HTTP_400_BAD_REQUEST)
+        if any(not is_team_authorized(df.team, authorized_team_ids) for df in distribution_files):
+            return Response({"error": "部分文件不属于当前用户的团队，无权分发"}, status=status.HTTP_403_FORBIDDEN)
 
         username = request.user.username if request.user else ""
 
         target_path = data["target_path"]
-        team = data.get("team", [])
 
         # 高危路径检测
         check_result = DangerousChecker.check_path(target_path, team)
@@ -246,7 +288,7 @@ class JobExecutionViewSet(AuthViewSet):
             total_count=len(target_list),
             target_source=target_source,
             target_list=target_list,
-            team=data.get("team", []),
+            team=team,
             executor_user=username,
             created_by=username,
             updated_by=username,


### PR DESCRIPTION
## 漏洞 BL-NEW-002（高危）— Job 快速执行 / Playbook / 文件分发：水平越权 + 未授权任务执行

### Fact-check（已在当前 master 核实）
- `views/execution.py::quick_execute`：`Script.objects.filter(id=...)`、`Playbook.objects.get(id=...)`、`Target.objects.filter(id__in=...)` 全部按全局 ID 加载，无团队归属校验；`team` 直接取自请求体。
- `views/execution.py::file_distribution`：`DistributionFile.objects.filter(id__in=...)`、`Target` 同样按全局 ID 加载，无归属校验。
- `views/distribution_file.py::upload`：创建 `DistributionFile` 时**未写入 team**，文件无团队归属，无法做隔离。
- 入口：`POST /api/v1/job_mgmt/api/execution/quick_execute/`、`file_distribution/`。

效果：Team A 用户可引用 Team B 的脚本、Playbook、目标、已上传文件，在其他团队主机执行任务或分发文件。

### 修复（用户面 view 层授权）
- 新增纯函数 `utils/team_authz.py`：`normalize_team` / `normalize_authorized_team_ids` / `is_team_authorized`，统一团队归属判定。
- `quick_execute` / `file_distribution`：
  - 用 `_validate_current_team_permission` + `_validate_org_field_permission` 校验 team，**禁止信任请求体 team 越权**指定他人团队。
  - 加载 Script / Playbook / Target / DistributionFile 后，校验对象 `team` 与**用户授权团队**（`group_list`）有交集，否则返回 **403**。无团队归属（`None`/`[]`）的对象对非超管一律拒绝。超管不受限。
- `DistributionFileViewSet.upload`：写入 `team=当前(已校验)团队`，与开放 API 上传 `open_api.py`（本就设置 team）的行为对齐。

### PoC 验证（调用真实 `team_authz` 函数，模拟 view 的对象归属判定，全部 PASS）
> 本社区版 checkout 缺企业版 `license_mgmt` 且 Django app 依赖级联（node_mgmt→django_celery_beat→…→mlflow/falkordb 等重型可选依赖），完整 pytest 无法在本地启动（**预存环境限制，与本改动无关**）。故用真实纯函数 + view 决策路径直接验证：

```
场景（Team A 用户，授权团队 {1}）                          判定        期望
跨团队引用 Team B 脚本(team=[2])           -> 拒绝(403)   应拒绝   PASS
引用自有 Team A 脚本(team=[1])             -> 放行        应放行   PASS
引用多团队对象(team=[1,3]含自有)           -> 放行        应放行   PASS
跨团队引用 DistributionFile(team=2)        -> 拒绝(403)   应拒绝   PASS
引用自有 DistributionFile(team=1)          -> 放行        应放行   PASS
引用无team归属的历史文件(team=None / [])   -> 拒绝(403)   应拒绝   PASS
超管引用任意 Team B 对象                    -> 放行        应放行   PASS
```

`py_compile` 通过；新增 `tests/test_team_authz.py` 纯单元用例（CI 完整环境可跑）覆盖上述判定。

### Follow-up（建议后续单独处理）
- NATS 开放接口 `nats_api.py::job_file_distribute` 信任 `data.team`、按 `file_key` 全局查文件 → 需服务身份 / 租户声明 / Subject ACL（架构级，对应修复建议第 4/5 条）。
- `re_execute` / `cancel` / `targets` 经 `self.get_object()` 访问执行记录，建议复核是否已按 team 做对象级权限校验。
- `DistributionFile.team` 目前可空：本 PR 在访问层把无 team 文件视为不可引用以实现「非空」语义；如需 DB 层 NOT NULL 约束需配数据回填迁移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)