### PR TITLE
fix(opspilot): 修复 Fetch/网站加载的重定向 SSRF 绕过 (BL-NEW-003 高危)

### DIFF
--- a/server/apps/opspilot/metis/llm/loader/website_loader.py
+++ b/server/apps/opspilot/metis/llm/loader/website_loader.py
@@ -5,14 +5,14 @@ import tempfile
 from typing import List, Optional
 from urllib.parse import urljoin, urlparse
 
-import httpx
 from bs4 import BeautifulSoup
 from langchain_community.document_loaders import RecursiveUrlLoader
 from langchain_community.document_transformers import BeautifulSoupTransformer
 from langchain_core.documents import Document
 from loguru import logger
 
-from apps.core.utils.ssrf_validator import SSRFValidator
+from apps.core.utils.safe_requests import SafeRequestsError, safe_get
+from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 
 
 class WebSiteLoader:
@@ -33,8 +33,16 @@ class WebSiteLoader:
         # SSRF 防护：验证起始 URL
         validated_url = SSRFValidator.validate(self.url)
 
-        # 加载网页文本内容
-        loader = RecursiveUrlLoader(validated_url, max_depth=self.max_depth)
+        # 加载网页文本内容。
+        # prevent_outside=True（显式声明）：递归抓取只跟随起始 URL 子路径内的链接，
+        # 公网页面里嵌入的内网/跨域链接不会被抓取，缓解递归爬取 SSRF（BL-NEW-003）。
+        # 注意：对「起始域内的页面再 302 跳到内网」这类场景，完整防护仍需在部署侧叠加
+        # 出站代理 / 网络 ACL（见修复建议）。
+        loader = RecursiveUrlLoader(
+            validated_url,
+            max_depth=self.max_depth,
+            prevent_outside=True,
+        )
         web_docs = loader.load()
 
         transformer = BeautifulSoupTransformer()
@@ -190,32 +198,31 @@ class WebSiteLoader:
             图片二进制数据，失败返回None
         """
         try:
-            # SSRF 防护：验证图片 URL
-            validated_url = SSRFValidator.validate(img_url)
+            # SSRF 防护：经统一安全客户端下载，禁用自动重定向并对每一跳 Location
+            # 做 SSRF 校验，杜绝「公网图片 URL 302 跳内网/云元数据」的绕过（BL-NEW-003）。
+            response = safe_get(img_url, timeout=timeout, allow_redirects=True)
 
-            with httpx.Client(timeout=timeout, follow_redirects=True) as client:
-                response = client.get(validated_url)
+            if response.status_code != 200:
+                logger.warning(f"下载图片失败 [{img_url}], 状态码: {response.status_code}")
+                return None
 
-                if response.status_code != 200:
-                    logger.warning(f"下载图片失败 [{img_url}], 状态码: {response.status_code}")
-                    return None
+            # 检查内容类型
+            content_type = response.headers.get("content-type", "")
+            if not content_type.startswith("image/"):
+                logger.warning(f"URL不是图片类型 [{img_url}], content-type: {content_type}")
+                return None
 
-                # 检查内容类型
-                content_type = response.headers.get("content-type", "")
-                if not content_type.startswith("image/"):
-                    logger.warning(f"URL不是图片类型 [{img_url}], content-type: {content_type}")
-                    return None
+            # 检查文件大小
+            content = response.content
+            if len(content) > max_size:
+                logger.warning(f"图片过大 [{img_url}], 大小: {len(content)} bytes, 超过限制: {max_size} bytes")
+                return None
 
-                # 检查文件大小
-                content = response.content
-                if len(content) > max_size:
-                    logger.warning(f"图片过大 [{img_url}], 大小: {len(content)} bytes, 超过限制: {max_size} bytes")
-                    return None
+            return content
 
-                return content
-
-        except httpx.TimeoutException:
-            logger.warning(f"下载图片超时 [{img_url}]")
+        except (SSRFError, SafeRequestsError) as e:
+            # 被 SSRF 校验拦截或请求失败：跳过该图片，不影响整体加载
+            logger.warning(f"下载图片被拦截或失败 [{img_url}]: {e}")
             return None
         except Exception as e:
             logger.error(f"下载图片异常 [{img_url}]: {e}")

--- a/server/apps/opspilot/metis/llm/tools/fetch/http.py
+++ b/server/apps/opspilot/metis/llm/tools/fetch/http.py
@@ -1,4 +1,9 @@
-"""HTTP请求工具 - 使用requests库"""
+"""HTTP请求工具 - 使用统一的安全 HTTP 客户端 (safe_requests)
+
+BL-NEW-003：本模块原先直接用 requests.* 且 allow_redirects=True，只校验初始 URL，
+重定向 Location 不再校验，攻击者可让公网 URL 返回 302 跳到内网/云元数据实现 SSRF
+绕过。改为统一走 apps.core.utils.safe_requests，对每一跳重定向目标都做 SSRF 校验。
+"""
 
 from typing import Any, Dict, Optional, Union
 
@@ -6,6 +11,7 @@ import requests
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
+from apps.core.utils.safe_requests import safe_delete, safe_get, safe_patch, safe_post, safe_put
 from apps.opspilot.metis.llm.tools.fetch.utils import (
     format_error_response,
     parse_content_type_encoding,
@@ -55,7 +61,8 @@ def _http_get_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.get(
+        # 走安全客户端：禁用 requests 自动重定向，逐跳对 Location 做 SSRF 校验后再跟随
+        response = safe_get(
             url,
             headers=req_headers,
             params=params,
@@ -122,7 +129,7 @@ def _http_post_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.post(
+        response = safe_post(
             url,
             data=data,
             json=json_data,
@@ -185,7 +192,7 @@ def _http_put_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.put(
+        response = safe_put(
             url,
             data=data,
             json=json_data,
@@ -246,7 +253,7 @@ def _http_delete_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.delete(
+        response = safe_delete(
             url,
             headers=req_headers,
             params=params,
@@ -307,7 +314,7 @@ def _http_patch_impl(
             pass  # 使用默认值
 
     try:
-        response = requests.patch(
+        response = safe_patch(
             url,
             data=data,
             json=json_data,

--- a/server/apps/opspilot/tests/workflow/cases/test_ssrf_high_risk_components.py
+++ b/server/apps/opspilot/tests/workflow/cases/test_ssrf_high_risk_components.py
@@ -469,23 +469,66 @@ class TestFetchToolSSRFProtection:
             _http_patch_impl("http://169.254.169.254/latest/meta-data/")
 
     @patch("socket.getaddrinfo")
-    @patch("requests.get")
-    def test_http_get_allows_public_url(self, mock_get, mock_getaddrinfo):
-        """Public URL is allowed in HTTP GET."""
+    @patch("apps.core.utils.safe_requests.requests.request")
+    def test_http_get_allows_public_url(self, mock_request, mock_getaddrinfo):
+        """Public URL is allowed in HTTP GET（经 safe_requests 安全客户端）。"""
         from apps.opspilot.metis.llm.tools.fetch.http import _http_get_impl
 
         mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 443))]
         mock_response = MagicMock()
+        mock_response.is_redirect = False
         mock_response.status_code = 200
         mock_response.text = "<html>Example</html>"
         mock_response.headers = {"Content-Type": "text/html"}
         mock_response.encoding = "utf-8"
         mock_response.url = "https://example.com/"
         mock_response.raise_for_status = MagicMock()
-        mock_get.return_value = mock_response
+        mock_request.return_value = mock_response
 
         result = _http_get_impl("https://example.com/")
         assert result.get("success") is True
+
+    @patch("socket.getaddrinfo")
+    @patch("apps.core.utils.safe_requests.requests.request")
+    def test_http_get_blocks_redirect_to_metadata(self, mock_request, mock_getaddrinfo):
+        """BL-NEW-003: 公网 URL 302 跳转到云元数据地址被逐跳 SSRF 校验拦截。
+
+        初始 URL 解析为公网 IP 通过校验；服务端返回 302，Location 指向 AWS 元数据。
+        safe_requests 在跟随前对 Location 做 SSRF 校验 → 抛 SSRFError → Fetch 工具
+        返回失败而非内网内容。
+        """
+        from apps.opspilot.metis.llm.tools.fetch.http import _http_get_impl
+
+        # 初始 example.com 解析为公网 IP（通过初始校验）
+        mock_getaddrinfo.return_value = [(2, 1, 6, "", ("93.184.216.34", 443))]
+        redirect_resp = MagicMock()
+        redirect_resp.is_redirect = True
+        redirect_resp.headers = {"Location": "http://169.254.169.254/latest/meta-data/"}
+        mock_request.return_value = redirect_resp
+
+        result = _http_get_impl("https://example.com/redirect")
+        assert result.get("success") is False
+
+    @patch("socket.getaddrinfo")
+    @patch("apps.core.utils.safe_requests.requests.request")
+    def test_http_get_blocks_redirect_to_private_ip(self, mock_request, mock_getaddrinfo):
+        """BL-NEW-003: 公网 URL 302 跳转到内网私有地址被拦截。"""
+        from apps.opspilot.metis.llm.tools.fetch.http import _http_get_impl
+
+        # 初始 URL 公网；Location 主机解析到内网（DNS 解析后 IP 校验拦截）
+        def _resolve(host, *args, **kwargs):
+            if host == "example.com":
+                return [(2, 1, 6, "", ("93.184.216.34", 443))]
+            return [(2, 1, 6, "", ("10.0.0.5", 80))]
+
+        mock_getaddrinfo.side_effect = _resolve
+        redirect_resp = MagicMock()
+        redirect_resp.is_redirect = True
+        redirect_resp.headers = {"Location": "http://internal.attacker-controlled.com/"}
+        mock_request.return_value = redirect_resp
+
+        result = _http_get_impl("https://example.com/redirect")
+        assert result.get("success") is False
 
 
 # ===========================================================================


### PR DESCRIPTION
## 漏洞 BL-NEW-003（高危）— OpsPilot Fetch / 网站知识加载 / 图片 OCR：SSRF（重定向绕过）

### Fact-check（已在当前 master 核实）
- `metis/llm/tools/fetch/http.py`：`http_get/post/put/delete/patch` 直接用 `requests.*` 且 `allow_redirects=True`，仅 `validate_url` 校验**初始** URL，重定向 Location **不再校验**。
- `metis/llm/loader/website_loader.py::_download_image`：`httpx.Client(follow_redirects=True)`，同样只校验初始图片 URL。
- `website_loader.load`：`RecursiveUrlLoader` 递归抓取发现的链接未逐链 SSRF 校验。

效果：公网 URL 返回 302 → Location 指向回环/私网/云元数据/K8s 控制面，服务端跟随并把响应带回用户或写入知识库。

> 关键背景：仓库已有统一安全客户端 `apps.core.utils.safe_requests`（`ModelVendorSyncService` 已迁移使用），它**禁用自动重定向 + 逐跳 `SSRFValidator` 校验**。本漏洞本质是 Fetch/网站加载**未迁移**到该客户端。

### 修复（统一使用安全 HTTP Client，对齐修复建议第 1 条）
- `fetch/http.py`：5 个方法改用 `safe_get/safe_post/safe_put/safe_delete/safe_patch`（`allow_redirects=True`，由安全客户端逐跳校验 Location 后再跟随）。
- `website_loader._download_image`：改用 `safe_get` 下载图片，逐跳校验重定向；并妥善捕获 `SSRFError/SafeRequestsError`（跳过该图片不影响整体加载）。
- `website_loader.load`：显式 `prevent_outside=True`，递归抓取只跟随起始 URL 子路径内链接，缓解「公网页面嵌入内网链接」的递归爬取 SSRF。

### PoC 验证（直接导入真实 `_http_get_impl`，mock `requests.request` 模拟 302，全部 PASS）
> 本社区版 checkout 完整 pytest 无法本地启动（缺企业版 license_mgmt + falkordb 等重依赖，**预存环境限制**）。故直接驱动真实函数验证：

```
公网302→AWS元数据被拦截      -> success=False (禁止访问云元数据地址:169.254.169.254)  PASS
公网302→内网10.x被拦截       -> success=False (禁止的网段 10.0.0.0/8)               PASS
直接请求元数据被拦截          -> raised SSRFError                                    PASS
正常公网GET成功(不误伤)       -> success=True, status=200                            PASS
```

更新/新增 `test_ssrf_high_risk_components.py`：
- `test_http_get_allows_public_url` 改 patch `safe_requests.requests.request`（迁移后正确 mock 点）。
- 新增 `test_http_get_blocks_redirect_to_metadata` / `test_http_get_blocks_redirect_to_private_ip`。

### Follow-up（建议后续单独处理）
- 递归爬虫「起始域内页面再 302 跳内网」及整体出站控制：部署侧叠加**出站代理 / 网络 ACL**（对应修复建议最后一条）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)