### PR TITLE
fix(monitor): 修复 MonitorPlugin 功能级授权缺失与内置只读 (BL-NEW-005 高危)

### DIFF
--- a/server/apps/monitor/tests/test_plugin_permission.py
+++ b/server/apps/monitor/tests/test_plugin_permission.py
@@ -1,0 +1,49 @@
+"""MonitorPlugin 写操作权限门禁单测（BL-NEW-005）。
+
+验证 plugin.py 视图所依赖的 HasPermission 装饰器：无监控配置权限的登录用户被拒，
+拥有权限 / 超管放行。这是修复「功能级授权缺失」所依赖的机制。
+
+注：完整的 HTTP 端点级测试（实际 PATCH/import 路由返回 403）建议在具备 DB 的 CI
+环境补充；此处以装饰器门禁为核心做无 DB 回归。
+"""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from apps.core.decorators.api_permission import HasPermission
+
+pytestmark = pytest.mark.unit
+
+_SENTINEL = "EXECUTED"
+_DENIED = "DENIED_403"
+
+
+@HasPermission("integration_configure-Add")
+def _guarded(request):
+    return _SENTINEL
+
+
+def _call(user):
+    with patch("apps.core.decorators.api_permission.WebUtils.response_403", return_value=_DENIED):
+        return _guarded(SimpleNamespace(user=user))
+
+
+def test_无监控配置权限用户被拒():
+    user = SimpleNamespace(is_superuser=False, permission=set(), locale="en")
+    assert _call(user) == _DENIED
+
+
+def test_拥有配置权限放行():
+    user = SimpleNamespace(is_superuser=False, permission={"integration_configure-Add"}, locale="en")
+    assert _call(user) == _SENTINEL
+
+
+def test_超管放行():
+    user = SimpleNamespace(is_superuser=True, permission=set(), locale="en")
+    assert _call(user) == _SENTINEL
+
+
+def test_其他无关权限不放行():
+    user = SimpleNamespace(is_superuser=False, permission={"some_other-View"}, locale="en")
+    assert _call(user) == _DENIED

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -22,6 +22,30 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
     filterset_class = MonitorPluginFilter
     pagination_class = CustomPageNumberPagination
 
+    # BL-NEW-005：MonitorPlugin 为全局资源，历史实现仅依赖全局 IsAuthenticated，
+    # 标准 CRUD 与 import/export 等自定义 Action 均未配置业务权限，任意登录用户即可
+    # 增删改 / 导入全局监控插件（功能级授权缺失、垂直越权）。下方为写操作补齐明确
+    # 权限校验，并将内置插件（is_pre）置为只读。
+    @staticmethod
+    def _ensure_modifiable(plugin):
+        """内置插件只读，禁止修改 / 删除（BL-NEW-005）。"""
+        if getattr(plugin, "is_pre", False):
+            raise BaseAppException("内置插件为只读，禁止修改或删除")
+
+    @HasPermission("integration_configure-Add")
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @HasPermission("integration_list-Setting")
+    def update(self, request, *args, **kwargs):
+        self._ensure_modifiable(self.get_object())
+        return super().update(request, *args, **kwargs)
+
+    @HasPermission("integration_list-Setting")
+    def partial_update(self, request, *args, **kwargs):
+        self._ensure_modifiable(self.get_object())
+        return super().partial_update(request, *args, **kwargs)
+
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
         serializer = self.get_serializer(queryset, many=True)
@@ -40,8 +64,10 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
 
         return WebUtils.response_success(results)
 
+    @HasPermission("integration_list-Setting")
     def destroy(self, request, *args, **kwargs):
         plugin = self.get_object()
+        self._ensure_modifiable(plugin)
         if plugin.template_type in {"api", "pull", "snmp"}:
             try:
                 plugin.delete()
@@ -68,11 +94,13 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="import")
+    @HasPermission("integration_configure-Add")
     def import_monitor_object(self, request):
         MonitorPluginService.import_monitor_plugin(request.data)
         return WebUtils.response_success()
 
     @action(methods=["get"], detail=False, url_path="export/(?P<pk>[^/.]+)")
+    @HasPermission("integration_list-View")
     def export_monitor_object(self, request, pk):
         data = MonitorPluginService.export_monitor_plugin(pk)
         return WebUtils.response_success(data)


### PR DESCRIPTION
## 漏洞 BL-NEW-005（高危）— MonitorPlugin CRUD / 导入导出：功能级授权缺失、垂直越权

### Fact-check（已在当前 master 核实）
- `config/components/drf.py`：`DEFAULT_PERMISSION_CLASSES = (IsAuthenticated,)` —— 仅要求登录。
- `monitor/views/plugin.py`：`MonitorPluginViewSet(viewsets.ModelViewSet)` 未覆盖 `permission_classes`；标准 CRUD（create/update/partial_update/destroy）与 `import`/`export` 自定义 Action **均无** `@HasPermission`（仅 `collect_template` 有）。
- `monitor/models/plugin.py`：`MonitorPlugin` 为全局资源，含内置标记 `is_pre`。

效果：任意登录用户可创建/修改/删除/导入全局监控插件，破坏采集、指标定义与监控可用性。
入口：`POST/PUT/PATCH/DELETE /api/v1/monitor/api/monitor_plugin/`、`import/`、`export/` 等。

### 修复（为写操作补齐明确权限 + 内置只读）
| 操作 | 新增权限 |
|------|----------|
| create / import | `integration_configure-Add` |
| update / partial_update / destroy | `integration_list-Setting` |
| export | `integration_list-View` |

- 新增 `_ensure_modifiable`：内置插件（`is_pre=True`）禁止修改/删除。
- 装饰器顺序 `@action` 外、`@HasPermission` 内，与既有 `collect_template` 一致；`HasPermission` 对 `self` 为 View 的绑定方法已正确取 request。
- 只读视图（list/retrieve/ui_template 等）保持现状，避免破坏监控面板。

### PoC 验证（使用真实 HasPermission 装饰器，全部 PASS）
> 社区版 checkout 完整 pytest 无法本地启动（缺企业版 license_mgmt + falkordb 等重依赖，**预存环境限制**）。故以视图所用的真实装饰器直接验证：

```
无监控配置权限用户 import -> 拒绝(403)   PASS
有 integration_configure-Add -> 放行     PASS
超管 -> 放行                              PASS
内置插件(is_pre) 改/删 -> 被拦(异常)      PASS
自建插件 改/删 -> 放行                    PASS
```

新增 `tests/test_plugin_permission.py`（无 DB，CI 可跑）覆盖权限门禁。

### Follow-up（建议后续单独处理）
- 导入 Schema 校验、操作审计日志；明确插件的「全局管理员 / 组织归属」模型；补充 HTTP 端点级测试（需 DB 的 CI 环境）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)