### PR TITLE
fix: 移除硬编码加密密钥/默认凭据/泄露 Token (BL-NEW-006 高危-部署)

### DIFF
--- a/algorithms/classify_anomaly_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_anomaly_server/support-files/scripts/train-model.sh
@@ -20,10 +20,13 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-10.10.41.149:9000}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-minio}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-x6dES11CBh2omEuuujMK96Q0GWHrSCQ6}"
+# MinIO 连接配置（必须通过环境变量提供）
+# BL-NEW-006：删除脚本内置的固定内网地址、默认账号与泄露的真实密钥。
+# 改为强制要求环境变量，未提供时直接失败退出（${VAR:?}），不再内置任何凭据。
+# ⚠️ 历史版本中内置的 MINIO_SECRET_KEY 已泄露，运维须立即在 MinIO 侧轮换该密钥。
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量（不再使用脚本内置默认值）}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -32,7 +35,8 @@ DATASET_NAME="${2:-${DATASET_NAME:-anomaly_train_data.zip}}"
 CONFIG_NAME="$3"
 
 # MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://10.10.41.149:15000}"
+# BL-NEW-006：移除硬编码的内网 MLflow 地址，强制由环境变量提供。
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -62,16 +66,8 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方通过 ${VAR:?...} 强制校验：缺失任一环境变量时
+# 脚本会立即报错退出，不再内置任何默认地址 / 账号 / 密钥（BL-NEW-006）。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/server/apps/cmdb/constants/constants.py
+++ b/server/apps/cmdb/constants/constants.py
@@ -764,4 +764,7 @@ VIEW = "View"
 APP_NAME = "cmdb"
 
 # ===========
-SECRET_KEY = os.getenv("SECRET_KEY", "cmdb_secret_key_2025_cb9c88c61e374c51a9a83f1b2b2c1b1d")
+# BL-NEW-006：移除源码内置的固定加密密钥（源码/库泄露后可被用于解密凭据）。
+# 与 Django 主 SECRET_KEY（config/components/base.py）一致，仅从环境变量读取；
+# 未配置时为空串，凭据加解密会显式失败，而非静默使用已知的硬编码密钥。
+SECRET_KEY = os.getenv("SECRET_KEY", "")

--- a/server/apps/operation_analysis/constants/constants.py
+++ b/server/apps/operation_analysis/constants/constants.py
@@ -48,7 +48,9 @@ class TopologyType:
     ]
 
 
-SECRET_KEY = os.getenv("SECRET_KEY", "operation_analysis_secret_key_2025")
+# BL-NEW-006：移除源码内置的固定加密密钥，仅从环境变量读取（与 Django 主
+# SECRET_KEY 一致），未配置时为空串而非已知硬编码密钥。
+SECRET_KEY = os.getenv("SECRET_KEY", "")
 
 # ===== 实例权限 =====
 PERMISSION_DIRECTORY = "directory"  # 目录

--- a/server/config/components/minio.py
+++ b/server/config/components/minio.py
@@ -8,8 +8,11 @@ from typing import List, Tuple
 MINIO_BUCKET_CHECK_ON_SAVE = True
 MINIO_ENDPOINT = os.getenv("MINIO_ENDPOINT", "minio:9000")
 MINIO_USE_HTTPS = os.getenv("MINIO_USE_HTTPS", "0") == "1"
-MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
-MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "minioadmin")
+# BL-NEW-006：移除内置的默认对象存储凭据（默认凭据可导致对象存储未授权访问）。
+# 仅从环境变量读取，未配置时为空，连接将因凭据无效而失败，而非以众所周知的
+# 默认账户访问对象存储。
+MINIO_ACCESS_KEY = os.getenv("MINIO_ACCESS_KEY", "")
+MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY", "")
 MINIO_URL_EXPIRY_HOURS = timedelta(days=7)
 MINIO_CONSISTENCY_CHECK_ON_START = False
 


### PR DESCRIPTION
## 漏洞 BL-NEW-006（高危·部署相关）— 硬编码密钥 / 默认凭据 / 敏感信息泄露

### Fact-check（已在当前 master 核实）
- `apps/cmdb/constants/constants.py`：`SECRET_KEY = os.getenv("SECRET_KEY", "cmdb_secret_key_2025_…")` —— 源码内置固定加密密钥（被 `PasswordCrypto` 用于凭据加解密）。
- `apps/operation_analysis/constants/constants.py`：同样内置固定 `SECRET_KEY`。
- `config/components/minio.py`：`MINIO_ACCESS_KEY/MINIO_SECRET_KEY` 默认 `minioadmin`（众所周知默认凭据）。
- `algorithms/classify_anomaly_server/.../train-model.sh`：内置内网地址、默认账号，以及**疑似真实的 MinIO 密钥**。

效果：源码/库泄露后可解密敏感配置；默认凭据可导致对象存储未授权访问；训练脚本泄露真实密钥与内网拓扑。

### 修复（删除所有固定 fallback）
- cmdb / operation_analysis `SECRET_KEY`：移除硬编码值，仅 `os.getenv("SECRET_KEY", "")`（与 Django 主 SECRET_KEY 一致），未配置即为空、加解密显式失败，而非静默使用已知密钥。
- `minio.py`：移除默认账户，`os.getenv(..., "")`；缺失则凭据为空、连接失败。
- `train-model.sh`：删除内置内网地址 / 默认账号 / 泄露密钥；`MINIO_*` 与 `MLFLOW_TRACKING_URI` 改 `${VAR:?...}` 强制要求环境变量、缺失即失败退出；移除残留内网 IP 的示例与默认。

### PoC 验证（按文档「清除环境变量后验证」思路，全部 PASS）
```
源码字面值清零(grep)：cmdb_secret_key_2025 / operation_analysis_secret_key_2025
                      / 泄露MinIO密钥 / minioadmin / 内网IP 10.10.41.149  -> 全部 0  PASS
清除环境变量后 minio.py：MINIO_ACCESS_KEY='' MINIO_SECRET_KEY=''（非默认账户）   PASS
SECRET_KEY 现为 os.getenv("SECRET_KEY", "")（无硬编码）                          PASS
train-model.sh 缺 MINIO_*/MLFLOW 环境变量 -> 立即 fail-fast 退出（bash -n 通过）  PASS
```

### ⚠️ 运维必读（安全行动）
源码泄露即密钥泄露。请**立即轮换**历史已内置/泄露的密钥与 MinIO Token：
- 历史 `SECRET_KEY`（cmdb / operation_analysis）；
- `train-model.sh` 中内置过的 MinIO 密钥；
并确认部署环境已注入 `SECRET_KEY`、`MINIO_ACCESS_KEY`、`MINIO_SECRET_KEY`、`MLFLOW_TRACKING_URI`（见 `server/envs/.env.example`）。

### Follow-up（修复建议其余项）
- 集中式启动断言：`SECRET_KEY` 为空即拒绝启动（避免破坏广泛的模块导入，宜放在启动校验处）；
- 迁移 KMS / Secret Manager，凭据加密升级为 AEAD；
- CI 增加 Secret 扫描，防止再次提交明文密钥。

🤖 Generated with [Claude Code](https://claude.com/claude-code)