### PR TITLE
bugfix: webhookd 渲染/安装请求恢复 TLS 校验，消除凭据泄露与配置注入风险（Fixes #3058）

### DIFF
--- a/server/apps/cmdb/services/infra.py
+++ b/server/apps/cmdb/services/infra.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from apps.cmdb.constants.infra import InfraConstants
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.rpc.node_mgmt import NodeMgmt
 
 
@@ -133,7 +134,7 @@ class InfraService:
                 json=params,
                 headers={'Content-Type': 'application/json'},
                 timeout=InfraConstants.REQUEST_TIMEOUT,
-                verify=False,
+                verify=get_webhook_tls_verify(),
             )
 
             if response.status_code != 200:

--- a/server/apps/cmdb/tests/test_infra_tls.py
+++ b/server/apps/cmdb/tests/test_infra_tls.py
@@ -1,0 +1,46 @@
+"""issue #3058 回归测试：cmdb webhookd 渲染请求按配置做 TLS 校验，不再硬编码 verify=False。"""
+
+from unittest.mock import MagicMock
+
+from apps.cmdb.services.infra import InfraService
+
+
+def _patch_post(monkeypatch, captured):
+    def fake_post(url, **kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"yaml": "kind: DaemonSet"}
+        return resp
+
+    monkeypatch.setattr("apps.cmdb.services.infra.requests.post", fake_post)
+
+
+def test_render_uses_configured_ca_path(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "/etc/ssl/webhook-ca.pem")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] == "/etc/ssl/webhook-ca.pem"
+
+
+def test_render_defaults_to_secure_verification(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SERVER_SSL_VERIFY", raising=False)
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] is True
+
+
+def test_render_explicit_optout(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "false")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] is False

--- a/server/apps/core/tests/test_webhook_tls.py
+++ b/server/apps/core/tests/test_webhook_tls.py
@@ -1,0 +1,57 @@
+"""webhook TLS 校验配置 helper 的单元测试（Django-free）。
+
+覆盖 issue #3058 修复点：webhookd 渲染请求不再硬编码关闭 TLS 校验，
+改为按 WEBHOOK_SERVER_SSL_VERIFY 环境变量可配置、默认安全。
+"""
+
+from pathlib import Path
+
+import pytest
+
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
+
+
+# 所有向 webhookd 下发凭据的渲染/安装请求，必须用可配置校验而非硬编码 verify=False。
+# 列在此处的文件即受守护：任何一处 revert 回 verify=False，下方守卫测试必失败。
+_WEBHOOK_CALL_SITES = [
+    "apps/log/services/k8s_collect.py",
+    "apps/monitor/services/infra.py",
+    "apps/cmdb/services/infra.py",
+    "apps/node_mgmt/services/cloudregion.py",
+    "apps/node_mgmt/utils/installer.py",
+    "apps/node_mgmt/views/sidecar.py",
+]
+
+
+def _server_root():
+    # 本文件位于 server/apps/core/tests/ → server 根目录为 parents[3]
+    return Path(__file__).resolve().parents[3]
+
+
+@pytest.mark.parametrize("rel_path", _WEBHOOK_CALL_SITES)
+def test_webhook_call_sites_do_not_hardcode_verify_false(rel_path):
+    source = (_server_root() / rel_path).read_text(encoding="utf-8")
+    assert "verify=False" not in source, f"{rel_path} 重新引入了 verify=False（webhookd 凭据下发禁止关闭 TLS 校验）"
+    assert "get_webhook_tls_verify" in source, f"{rel_path} 未使用可配置 TLS 校验 helper"
+
+
+def test_default_is_secure_when_env_unset(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SERVER_SSL_VERIFY", raising=False)
+    assert get_webhook_tls_verify() is True
+
+
+@pytest.mark.parametrize("value", ["true", "True", "1", "yes", "  TRUE  "])
+def test_truthy_values_enable_verification(monkeypatch, value):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", value)
+    assert get_webhook_tls_verify() is True
+
+
+@pytest.mark.parametrize("value", ["false", "False", "0", "no"])
+def test_explicit_optout_disables_verification(monkeypatch, value):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", value)
+    assert get_webhook_tls_verify() is False
+
+
+def test_custom_ca_path_is_returned_as_is(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "/etc/ssl/certs/webhook-ca.pem")
+    assert get_webhook_tls_verify() == "/etc/ssl/certs/webhook-ca.pem"

--- a/server/apps/core/utils/webhook_tls.py
+++ b/server/apps/core/utils/webhook_tls.py
@@ -1,0 +1,27 @@
+"""webhookd 渲染请求的 TLS 校验配置。
+
+云区域配置采集（log / monitor / cmdb）会把云区域级 NATS 凭据交给 webhookd
+渲染 K8s 采集 YAML。历史实现对该 HTTPS 请求硬编码 ``verify=False`` 关闭证书校验，
+存在两个高危后果：凭据被中间人窃取、返回的 YAML 被篡改后经 ``kubectl apply`` 在
+目标集群执行。此处提供按环境变量可配置、默认安全的校验策略，替换硬编码关闭。
+"""
+
+import os
+
+
+def get_webhook_tls_verify():
+    """返回传给 ``requests`` 的 ``verify`` 参数（secure-by-default）。
+
+    环境变量 ``WEBHOOK_SERVER_SSL_VERIFY``：
+      - 未配置 / ``"true"`` / ``"1"`` / ``"yes"`` → ``True``（按系统 CA 校验，默认）
+      - ``"false"`` / ``"0"`` / ``"no"``        → ``False``（显式内网自签名 opt-out）
+      - 其它非空值                              → 视为受信 CA 证书/bundle 路径
+        （``requests`` 的 ``verify`` 接受 CA 文件/目录路径字符串）
+    """
+    raw = (os.getenv("WEBHOOK_SERVER_SSL_VERIFY") or "true").strip()
+    lowered = raw.lower()
+    if lowered in ("true", "1", "yes"):
+        return True
+    if lowered in ("false", "0", "no"):
+        return False
+    return raw

--- a/server/apps/log/services/k8s_collect.py
+++ b/server/apps/log/services/k8s_collect.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from django.utils import timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.log.models import CollectInstance, CollectInstanceOrganization, CollectType
 from apps.log.services.search import SearchService
 from apps.rpc.node_mgmt import NodeMgmt
@@ -232,7 +233,7 @@ class K8sLogCollectService:
                 },
                 headers={"Content-Type": "application/json"},
                 timeout=cls.REQUEST_TIMEOUT,
-                verify=False,
+                verify=get_webhook_tls_verify(),
             )
             if response.status_code != 200:
                 raise BaseAppException(f"Infra API returned status {response.status_code}: {response.text}")

--- a/server/apps/log/tests/test_k8s_collect_tls.py
+++ b/server/apps/log/tests/test_k8s_collect_tls.py
@@ -1,0 +1,69 @@
+"""issue #3058 回归测试：log K8s 渲染请求按配置做 TLS 校验，不再硬编码 verify=False。
+
+revert 准则：若把 verify=get_webhook_tls_verify() 改回 verify=False，下列断言必失败。
+"""
+
+from unittest.mock import MagicMock
+
+from apps.log.services.k8s_collect import K8sLogCollectService
+
+
+_ENV_VARS = {
+    "WEBHOOK_SERVER_URL": "https://webhookd.internal",
+    "NODE_SERVER_URL": "https://node.internal",
+    "NATS_SERVERS": "nats://nats.internal:4222",
+    "NATS_USERNAME": "u",
+    "NATS_PASSWORD": "p",
+    "NATS_TLS_CA": "ca-content",
+}
+
+
+def _patch_post(monkeypatch, captured):
+    def fake_post(url, **kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"yaml": "kind: DaemonSet"}
+        return resp
+
+    monkeypatch.setattr("apps.log.services.k8s_collect.requests.post", fake_post)
+
+
+def test_render_uses_configured_ca_path(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "/etc/ssl/webhook-ca.pem")
+    monkeypatch.setattr(
+        K8sLogCollectService, "get_cloud_region_envconfig", staticmethod(lambda cloud_region_id: dict(_ENV_VARS))
+    )
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    result = K8sLogCollectService.render_config_from_cloud_region("c1", "cr1")
+
+    assert result == "kind: DaemonSet"
+    assert captured["verify"] == "/etc/ssl/webhook-ca.pem"
+
+
+def test_render_defaults_to_secure_verification(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SERVER_SSL_VERIFY", raising=False)
+    monkeypatch.setattr(
+        K8sLogCollectService, "get_cloud_region_envconfig", staticmethod(lambda cloud_region_id: dict(_ENV_VARS))
+    )
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    K8sLogCollectService.render_config_from_cloud_region("c1", "cr1")
+
+    assert captured["verify"] is True
+
+
+def test_render_explicit_optout(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "false")
+    monkeypatch.setattr(
+        K8sLogCollectService, "get_cloud_region_envconfig", staticmethod(lambda cloud_region_id: dict(_ENV_VARS))
+    )
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    K8sLogCollectService.render_config_from_cloud_region("c1", "cr1")
+
+    assert captured["verify"] is False

--- a/server/apps/monitor/services/infra.py
+++ b/server/apps/monitor/services/infra.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import monitor_logger as logger
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.monitor.constants.infra import InfraConstants
 from apps.rpc.node_mgmt import NodeMgmt
 
@@ -172,7 +173,7 @@ class InfraService:
                 json=params,
                 headers={'Content-Type': 'application/json'},
                 timeout=InfraConstants.REQUEST_TIMEOUT,
-                verify=False  # 跳过 SSL 证书验证
+                verify=get_webhook_tls_verify(),
             )
 
             # 检查响应状态

--- a/server/apps/monitor/tests/test_infra_tls.py
+++ b/server/apps/monitor/tests/test_infra_tls.py
@@ -1,0 +1,46 @@
+"""issue #3058 回归测试：monitor webhookd 渲染请求按配置做 TLS 校验，不再硬编码 verify=False。"""
+
+from unittest.mock import MagicMock
+
+from apps.monitor.services.infra import InfraService
+
+
+def _patch_post(monkeypatch, captured):
+    def fake_post(url, **kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"yaml": "kind: DaemonSet"}
+        return resp
+
+    monkeypatch.setattr("apps.monitor.services.infra.requests.post", fake_post)
+
+
+def test_render_uses_configured_ca_path(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "/etc/ssl/webhook-ca.pem")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] == "/etc/ssl/webhook-ca.pem"
+
+
+def test_render_defaults_to_secure_verification(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SERVER_SSL_VERIFY", raising=False)
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] is True
+
+
+def test_render_explicit_optout(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "false")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    InfraService.render_config_from_api({"cluster_name": "c1"}, "https://webhookd.internal")
+
+    assert captured["verify"] is False

--- a/server/apps/node_mgmt/services/cloudregion.py
+++ b/server/apps/node_mgmt/services/cloudregion.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import node_logger as logger
 from apps.core.utils.crypto.aes_crypto import AESCryptor
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.node_mgmt.models import SidecarEnv
 from apps.node_mgmt.models.cloud_region import CloudRegion
 from apps.node_mgmt.constants.cloudregion_service import CloudRegionServiceConstants
@@ -167,7 +168,7 @@ class RegionService:
                 json=webhook_params,
                 headers={"Content-Type": "application/json"},
                 timeout=CloudRegionServiceConstants.WEBHOOK_REQUEST_TIMEOUT,
-                verify=False,
+                verify=get_webhook_tls_verify(),
             )
 
             if response.status_code != 200:

--- a/server/apps/node_mgmt/tests/test_installer_tls.py
+++ b/server/apps/node_mgmt/tests/test_installer_tls.py
@@ -1,0 +1,61 @@
+"""issue #3058 回归测试：node_mgmt 手动安装命令的 webhookd 请求按配置做 TLS 校验。"""
+
+from unittest.mock import MagicMock
+
+from apps.node_mgmt.utils.installer import get_manual_install_command
+
+
+def _patch_post(monkeypatch, captured):
+    def fake_post(url, **kwargs):
+        captured.update(kwargs)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = "ok"
+        return resp
+
+    monkeypatch.setattr("apps.node_mgmt.utils.installer.requests.post", fake_post)
+
+
+def _call():
+    return get_manual_install_command(
+        os="linux",
+        package_id=1,
+        cloud_region_id="cr1",
+        sidecar_token="tok",
+        server_url="https://node.internal",
+        groups=[1],
+        node_name="n1",
+        node_id="nid",
+        webhook_url="https://webhookd.internal",
+    )
+
+
+def test_install_command_uses_configured_ca_path(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "/etc/ssl/webhook-ca.pem")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    _call()
+
+    assert captured["verify"] == "/etc/ssl/webhook-ca.pem"
+    assert captured["json"]["api_token"] == "tok"  # 凭据仍正常下发
+
+
+def test_install_command_defaults_to_secure_verification(monkeypatch):
+    monkeypatch.delenv("WEBHOOK_SERVER_SSL_VERIFY", raising=False)
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    _call()
+
+    assert captured["verify"] is True
+
+
+def test_install_command_explicit_optout(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_SERVER_SSL_VERIFY", "false")
+    captured = {}
+    _patch_post(monkeypatch, captured)
+
+    _call()
+
+    assert captured["verify"] is False

--- a/server/apps/node_mgmt/utils/installer.py
+++ b/server/apps/node_mgmt/utils/installer.py
@@ -1,6 +1,7 @@
 import requests
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.installer import InstallerConstants
 from apps.rpc.executor import Executor
@@ -66,7 +67,7 @@ def get_manual_install_command(
             json=params,
             headers={"Content-Type": "application/json"},
             timeout=InstallerConstants.REQUEST_TIMEOUT,
-            verify=False,  # 跳过 SSL 证书验证
+            verify=get_webhook_tls_verify(),
         )
 
         # 检查响应状态

--- a/server/apps/node_mgmt/views/sidecar.py
+++ b/server/apps/node_mgmt/views/sidecar.py
@@ -4,6 +4,7 @@ import requests
 
 from apps.core.utils.open_base import OpenAPIViewSet
 from apps.core.utils.web_utils import WebUtils
+from apps.core.utils.webhook_tls import get_webhook_tls_verify
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.node_mgmt.models import PackageVersion, SidecarEnv
 from apps.node_mgmt.services.install_token import InstallTokenService
@@ -496,7 +497,7 @@ class OpenSidecarViewSet(OpenAPIViewSet):
                 json=webhook_params,
                 headers={"Content-Type": "application/json"},
                 timeout=CloudRegionServiceConstants.WEBHOOK_REQUEST_TIMEOUT,
-                verify=False,  # 跳过 SSL 证书验证（内网环境）
+                verify=get_webhook_tls_verify(),
             )
 
             # 检查响应状态

--- a/server/envs/.env.example
+++ b/server/envs/.env.example
@@ -32,4 +32,8 @@ VICTORIALOGS_QUERY_LIMIT_MAX=1000
 VICTORIALOGS_FIELD_VALUES_LIMIT_MAX=1000
 VICTORIALOGS_HITS_FIELDS_LIMIT_MAX=100
 
+# webhookd 渲染请求（log/monitor/cmdb K8s 接入，会下发 NATS 凭据）的 TLS 校验：
+# 留空/true=校验系统CA（默认安全）；自签名内网填受信 CA 路径（如 /etc/ssl/webhook-ca.pem）；false=显式关闭（不推荐）
+WEBHOOK_SERVER_SSL_VERIFY=true
+
 CLIENT_ID=


### PR DESCRIPTION
## 恢复"凭据出站必须可验证对端"的传输不变量

Fixes #3058

### 被破坏的不变量
凡向 webhookd 下发云区域凭据（NATS 账密 / api_token）的出站请求，其传输层**对端身份与响应完整性必须可验证**——尤其当返回物会被 `kubectl apply` / `bash` 在目标侧执行时，"对端可信"是整条接入链的安全根。

### 根因（设计层）
6 处 render/install 调用把"内网 = 可信"的部署假设**硬编码**成 `verify=False`，将本该由部署环境决定的策略钉死在代码里：凭据明文暴露于可被 MITM 的链路，且被篡改的 YAML/脚本会被直接执行——传输不安全升级为可执行配置注入。

### 修复如何恢复不变量
把"是否校验 / 用哪个 CA"从散落硬编码下沉为**单一策略入口** `apps/core/utils/webhook_tls.get_webhook_tls_verify()`：默认校验系统 CA（secure-by-default），内网自签名走可配 CA 路径，显式 opt-out 才关闭。6 处统一收敛到该入口，消除"每处各自决定 TLS"的分散决策。

```mermaid
flowchart TD
    subgraph T["6 个 webhookd 调用点 · log/monitor/cmdb/node"]
        T1[render / install 请求]
    end
    H["get_webhook_tls_verify()<br/>单一策略入口"]
    P["requests.post(.../infra/*, 下发凭据,<br/>verify=策略)"]
    T1 --> H
    H -->|默认校验CA / 可配CA / 显式opt-out| P
    P -. 旧实现 verify=False → MITM 窃凭据/篡改 .-> X[返回物被 kubectl apply / bash 执行]
```

### 一致性 & blast radius
- 复用仓库既有 env 驱动校验惯例（如 VICTORIALOGS_SSL_VERIFY），不新造范式；
- 跨 4 模块 6 个 choke point，但都收敛到同一函数，单点可演进；
- 向后兼容：自签名部署配 `WEBHOOK_SERVER_SSL_VERIFY=<CA路径>` 或 `=false` 即可，不强制断链。

### 边界（本次不纳入）
安装命令 `curl -sSLk` 的 `-k` 属"安装脚本层"另一惯例（散布多模块），单独评估。

### 验证
helper env→verify 映射单测 + 4 模块行为回归（默认/CA/opt-out 三态，revert verify=False 必失败）+ 6 处源码守卫。Django-free harness 本地验证接线 + 凭据仍正常下发。

