### PR TITLE
fix(monitor): 监控仪表盘缺陷修复与性能优化

### DIFF
--- a/web/src/app/monitor/api/view.ts
+++ b/web/src/app/monitor/api/view.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import useApiClient from '@/utils/request';
 import { AxiosRequestConfig } from 'axios';
 import { SearchParams } from '@/app/monitor/types/search';
@@ -7,49 +8,63 @@ import { InstanceParam } from '@/app/monitor/types';
 const useViewApi = () => {
   const { get, post } = useApiClient();
 
-  const getInstanceQuery = async (
-    params: SearchParams = {
-      query: '',
-    }
-  ) => {
-    return await get(`/monitor/api/metrics_instance/query_range/`, {
-      params,
-    });
-  };
-
-  const getInstanceSearch = async (
-    objectId: React.Key,
-    data: InstanceParam,
-    config?: AxiosRequestConfig
-  ) => {
-    return await post(
-      `/monitor/api/monitor_instance/${objectId}/search/`,
-      data,
-      config
-    );
-  };
-
-  const getInstanceQueryParams = async (
-    name: string,
-    params: {
-      monitor_object_id?: React.Key;
-    } = {},
-    config?: AxiosRequestConfig
-  ) => {
-    return await get(
-      `/monitor/api/monitor_instance/query_params_enum/${name}/`,
-      {
-        params,
-        ...config,
+  // 这些函数会被消费方放进 useEffect/useCallback 依赖数组(如各对象盘的 TopN 取数 effect)。
+  // 必须用 useCallback 固定引用,否则每次重渲染都生成新函数 → effect 反复触发 → 重复发起查询。
+  const getInstanceQuery = useCallback(
+    async (
+      params: SearchParams = {
+        query: '',
       }
-    );
-  };
+    ) => {
+      return await get(`/monitor/api/metrics_instance/query_range/`, {
+        params,
+      });
+    },
+    [get]
+  );
 
-  const getMetricsInstanceQuery = async (params: ViewInstanceSearchProps) => {
-    return await get(`/monitor/api/metrics_instance/query_by_instance/`, {
-      params,
-    });
-  };
+  const getInstanceSearch = useCallback(
+    async (
+      objectId: React.Key,
+      data: InstanceParam,
+      config?: AxiosRequestConfig
+    ) => {
+      return await post(
+        `/monitor/api/monitor_instance/${objectId}/search/`,
+        data,
+        config
+      );
+    },
+    [post]
+  );
+
+  const getInstanceQueryParams = useCallback(
+    async (
+      name: string,
+      params: {
+        monitor_object_id?: React.Key;
+      } = {},
+      config?: AxiosRequestConfig
+    ) => {
+      return await get(
+        `/monitor/api/monitor_instance/query_params_enum/${name}/`,
+        {
+          params,
+          ...config,
+        }
+      );
+    },
+    [get]
+  );
+
+  const getMetricsInstanceQuery = useCallback(
+    async (params: ViewInstanceSearchProps) => {
+      return await get(`/monitor/api/metrics_instance/query_by_instance/`, {
+        params,
+      });
+    },
+    [get]
+  );
 
   return {
     getInstanceQuery,

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -22,7 +22,8 @@ import {
   toMetricSeries,
   buildMetricItem,
   getCollectionStatus,
-  buildCollectionStatusTimeline
+  buildCollectionStatusTimeline,
+  useLoadSequence
 } from '../../shared/utils';
 import {
   CompareFavorableDirection,
@@ -326,7 +327,10 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
-  const loadSeqRef = useRef(0);
+  // 每次 loadMetrics(含静默自动刷新)递增,供 bespoke 取数面板(如 ES/PG 的 TopN)
+  // 与核心盘同步刷新——核心盘重载即 bespoke 面板重载,而非各自维护定时器。
+  const [loadTick, setLoadTick] = useState(0);
+  const loadSequence = useLoadSequence();
 
   const monitorObjectId = searchParams.get('monitorObjId') || '';
   const monitorObjectName = searchParams.get('name') || config.objectFallbackName;
@@ -438,8 +442,8 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   );
 
   const loadMetrics = useCallback(async (silent = false) => {
-    const loadSeq = loadSeqRef.current + 1;
-    loadSeqRef.current = loadSeq;
+    const loadSeq = loadSequence.begin();
+    setLoadTick((value) => value + 1);
 
     if (!silent) setLoading(true);
     try {
@@ -502,7 +506,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         }
 
         previousMetricResultsPromise.then((previousResults) => {
-          if (loadSeqRef.current !== loadSeq) return;
+          if (!loadSequence.isCurrent(loadSeq)) return;
           setPreviousSeries(Object.fromEntries(previousResults));
         });
 
@@ -512,7 +516,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
           collectionStatusPromise
         ]);
 
-        if (loadSeqRef.current !== loadSeq) return;
+        if (!loadSequence.isCurrent(loadSeq)) return;
 
         setSeries((prev) => (silent ? { ...prev, ...Object.fromEntries(summaryResults) } : Object.fromEntries(summaryResults)));
         setCollectionStatusMetric(collectionStatus);
@@ -522,7 +526,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         if (trendMetrics.length > 0) {
           runWithConcurrency(trendMetrics, METRIC_QUERY_CONCURRENCY, (metric) => loadSingleMetric(metric, timeValues))
             .then((trendResults) => {
-              if (loadSeqRef.current !== loadSeq) return;
+              if (!loadSequence.isCurrent(loadSeq)) return;
               setSeries((prev) => ({ ...prev, ...Object.fromEntries(trendResults) }));
             });
         }
@@ -533,9 +537,9 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         if (!silent) setLoading(false);
       }
     } catch {
-      if (loadSeqRef.current === loadSeq && !silent) setLoading(false);
+      if (loadSequence.isCurrent(loadSeq) && !silent) setLoading(false);
     }
-  }, [config, displayMode, getInstanceQuery, idValues, idValuesKey, instanceId, instanceIdKeys, loadSingleMetric, resolvedInstanceName, summaryMetricNames, timeValues]);
+  }, [config, displayMode, getInstanceQuery, idValues, idValuesKey, instanceId, instanceIdKeys, loadSequence, loadSingleMetric, resolvedInstanceName, summaryMetricNames, timeValues]);
 
   useEffect(() => {
     if (displayMode === 'dashboard') {
@@ -811,6 +815,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     frequence,
     setFrequence,
     metricsRefreshSignal,
+    loadTick,
     monitorObjectId,
     monitorObjectName,
     instanceId,

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -749,12 +749,16 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
           const statusColor = row.enumMap && hasMetricData(row.metric) ? formatMappedEnum(latest, row.enumMap).color : undefined;
           // sparkline 语义色:取该指标 config.color,使详情行缩略图与 KPI/趋势/异常信号条配色一致。
           const color = config.metrics.find((m) => m.name === row.metric)?.color;
+          // barValue 是「满度条」填充百分比,仅对 percent 单位有意义。其他单位(bytes/counts/rate 等)
+          // 的原始量级裁到 0–100 会得到误导性的满格条,故非百分比一律给 0。
+          const barValue =
+            row.unit === 'percent' && Number.isFinite(latest) ? Math.max(0, Math.min(100, latest)) : 0;
           return {
             label: row.label,
             value,
             viz,
             trend: series,
-            barValue: Number.isFinite(latest) ? Math.max(0, Math.min(100, latest)) : 0,
+            barValue,
             tone: row.tone ?? 'normal',
             statusColor,
             color

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
@@ -85,7 +85,7 @@ export default function ElasticsearchDashboardPage() {
 
   // 「节点压力排行」为 bespoke 取数:config-driven 核心无法表达按 node_name 的动态 TopN,
   // 故复用实例/时间上下文,自行发 topk(by node_name) 查询并解析为 BarList(照搬 postgresql dbname TopN)。
-  const { idValues, timeValues, isDashboardMode } = dashboard;
+  const { idValues, timeValues, isDashboardMode, loadTick } = dashboard;
   const [topNode, setTopNode] = useState<Record<string, BarItem[]>>({});
   const idValuesKey = JSON.stringify(idValues);
   const timeKey = JSON.stringify(timeValues);
@@ -108,8 +108,9 @@ export default function ElasticsearchDashboardPage() {
     return () => {
       active = false;
     };
+    // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery]);
+  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (
     <DashboardShell

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -21,7 +21,8 @@ import {
   parseLegacyParamList,
   formatMetricValue,
   buildPreviousPeriodTimeValues,
-  getPeriodCompare
+  getPeriodCompare,
+  useLoadSequence
 } from '../../shared/utils';
 import {
   StatCard,
@@ -136,7 +137,7 @@ export default function K8sClusterDashboardPage() {
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const loadSeqRef = useRef(0);
+  const loadSequence = useLoadSequence();
 
   // 实例列表
   useEffect(() => {
@@ -187,19 +188,19 @@ export default function K8sClusterDashboardPage() {
     });
 
   const loadAll = async (silent = false) => {
-    const seq = ++loadSeqRef.current;
+    const seq = loadSequence.begin();
     if (!silent) setLoading(true);
     const heroResults = await runGroup(QUERY_GROUPS.hero, timeValues);
-    if (loadSeqRef.current !== seq) return;
+    if (!loadSequence.isCurrent(seq)) return;
     setRaw((prev) => (silent ? { ...prev, ...Object.fromEntries(heroResults) } : Object.fromEntries(heroResults)));
     if (!silent) setLoading(false);
     runGroup(QUERY_GROUPS.panels, timeValues).then((panelResults) => {
-      if (loadSeqRef.current === seq) setRaw((prev) => ({ ...prev, ...Object.fromEntries(panelResults) }));
+      if (loadSequence.isCurrent(seq)) setRaw((prev) => ({ ...prev, ...Object.fromEntries(panelResults) }));
     });
     // KPI 卡「较上一周期」对比:取上一周期同样窗口的计数。
     const prevTv = buildPreviousPeriodTimeValues(timeValues);
     runGroup(KPI_COMPARE_KEYS, prevTv).then((prevResults) => {
-      if (loadSeqRef.current === seq) setPreviousRaw(Object.fromEntries(prevResults));
+      if (loadSequence.isCurrent(seq)) setPreviousRaw(Object.fromEntries(prevResults));
     });
   };
 

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -38,7 +38,8 @@ import {
   mergeChartSeries,
   getCollectionStatus,
   runWithConcurrency,
-  formatMetricValue
+  formatMetricValue,
+  useLoadSequence
 } from '../../shared/utils';
 import useViewApi from '@/app/monitor/api/view';
 import MetricViews from '@/app/monitor/components/metric-views';
@@ -136,7 +137,7 @@ export default function MongoDashboardPage() {
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
-  const loadSeqRef = useRef(0);
+  const loadSequence = useLoadSequence();
 
   const monitorObjectId = searchParams.get('monitorObjId') || '';
   const monitorObjectName = searchParams.get('name') || 'Mongodb';
@@ -234,8 +235,7 @@ export default function MongoDashboardPage() {
   };
 
   const loadMetrics = async (silent = false) => {
-    const loadSeq = loadSeqRef.current + 1;
-    loadSeqRef.current = loadSeq;
+    const loadSeq = loadSequence.begin();
 
     if (!silent) setLoading(true);
     try {
@@ -297,7 +297,7 @@ export default function MongoDashboardPage() {
         }
 
         previousMetricResultsPromise.then((previousResults) => {
-          if (loadSeqRef.current !== loadSeq) return;
+          if (!loadSequence.isCurrent(loadSeq)) return;
           setPreviousSeries(Object.fromEntries(previousResults));
         });
 
@@ -306,7 +306,7 @@ export default function MongoDashboardPage() {
           collectionStatusPromise
         ]);
 
-        if (loadSeqRef.current !== loadSeq) return;
+        if (!loadSequence.isCurrent(loadSeq)) return;
 
         setSeries((prev) => (silent ? { ...prev, ...Object.fromEntries(summaryResults) } : Object.fromEntries(summaryResults)));
         setCollectionStatusMetric(collectionStatus);
@@ -315,7 +315,7 @@ export default function MongoDashboardPage() {
 
         MONGODB_METRIC_GROUPS.slice(1).forEach((group) => {
           loadMetricGroup(group.names).then((results) => {
-            if (loadSeqRef.current !== loadSeq) return;
+            if (!loadSequence.isCurrent(loadSeq)) return;
             setSeries((prev) => ({ ...prev, ...Object.fromEntries(results) }));
           });
         });
@@ -326,7 +326,7 @@ export default function MongoDashboardPage() {
         if (!silent) setLoading(false);
       }
     } catch {
-      if (loadSeqRef.current === loadSeq && !silent) setLoading(false);
+      if (loadSequence.isCurrent(loadSeq) && !silent) setLoading(false);
     }
   };
 

--- a/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
@@ -49,7 +49,7 @@ export default function MssqlDashboardPage() {
 
   // 「数据库压力排行」为 bespoke 取数:config-driven 核心无法表达按 database 的动态 TopN,
   // 故复用实例/时间上下文,自行发 topk(by database) 查询并解析为 BarList。
-  const { idValues, timeValues, isDashboardMode } = dashboard;
+  const { idValues, timeValues, isDashboardMode, loadTick } = dashboard;
   const [topDb, setTopDb] = useState<Record<string, BarItem[]>>({});
   const idValuesKey = JSON.stringify(idValues);
   const timeKey = JSON.stringify(timeValues);
@@ -72,8 +72,9 @@ export default function MssqlDashboardPage() {
     return () => {
       active = false;
     };
+    // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery]);
+  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (
     <DashboardShell

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -41,7 +41,8 @@ import {
   toMetricSeries,
   buildMetricItem,
   mergeChartSeries,
-  getCollectionStatus
+  getCollectionStatus,
+  useLoadSequence
 } from '../../shared/utils';
 import {
   StatCard,
@@ -267,7 +268,7 @@ export default function MysqlDashboardPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const loadSeqRef = useRef(0);
+  const loadSequence = useLoadSequence();
   const [, setLoading] = useState(true);
   const [displayMode, setDisplayMode] = useState<'dashboard' | 'metrics'>('dashboard');
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({
@@ -394,8 +395,7 @@ export default function MysqlDashboardPage() {
   };
 
   const loadMetrics = async (silent = false) => {
-    const loadSeq = loadSeqRef.current + 1;
-    loadSeqRef.current = loadSeq;
+    const loadSeq = loadSequence.begin();
 
     if (!silent) {
       setLoading(true);
@@ -457,7 +457,7 @@ export default function MysqlDashboardPage() {
         }
 
         previousMetricResultsPromise.then((previousResults) => {
-          if (loadSeqRef.current !== loadSeq) {
+          if (!loadSequence.isCurrent(loadSeq)) {
             return;
           }
           setPreviousSeries(Object.fromEntries(previousResults));
@@ -468,7 +468,7 @@ export default function MysqlDashboardPage() {
           collectionStatusPromise
         ]);
 
-        if (loadSeqRef.current !== loadSeq) {
+        if (!loadSequence.isCurrent(loadSeq)) {
           return;
         }
 
@@ -481,7 +481,7 @@ export default function MysqlDashboardPage() {
 
         MYSQL_METRIC_GROUPS.slice(1).forEach((group) => {
           loadMetricGroup(group.names, timeValues).then((results) => {
-            if (loadSeqRef.current !== loadSeq) {
+            if (!loadSequence.isCurrent(loadSeq)) {
               return;
             }
 
@@ -494,7 +494,7 @@ export default function MysqlDashboardPage() {
         setCollectionStatusMetric(null);
       }
     } finally {
-      if (loadSeqRef.current === loadSeq) {
+      if (loadSequence.isCurrent(loadSeq)) {
         setLoading(false);
       }
     }

--- a/web/src/app/monitor/dashboards/objects/ping/config.ts
+++ b/web/src/app/monitor/dashboards/objects/ping/config.ts
@@ -161,11 +161,11 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   barPanels: [],
   details: [
     {
-      title: '网络探测详情',
-      subtitle: 'TTL 与丢包',
+      title: '探测质量细节',
+      subtitle: '延迟下界与失败结果码',
       rows: [
-        { label: '平均丢包率', metric: 'ping_packet_loss_avg', unit: 'percent', tone: 'warning' },
-        { label: '平均 TTL', metric: 'ping_ttl_avg', unit: 'counts' }
+        { label: '最小延迟', metric: 'ping_latency_min', unit: 'ms' },
+        { label: '最差结果码', metric: 'ping_result_code_max', unit: 'none' }
       ]
     }
   ]

--- a/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/postgresql/dashboard.tsx
@@ -44,7 +44,7 @@ export default function PostgresqlDashboardPage() {
 
   // 「数据库压力排行」为 bespoke 取数:config-driven 核心无法表达按 dbname 的动态 TopN,
   // 故复用实例/时间上下文,自行发 topk(by dbname) 查询并解析为 BarList。
-  const { idValues, timeValues, isDashboardMode } = dashboard;
+  const { idValues, timeValues, isDashboardMode, loadTick } = dashboard;
   const [topDb, setTopDb] = useState<Record<string, BarItem[]>>({});
   const idValuesKey = JSON.stringify(idValues);
   const timeKey = JSON.stringify(timeValues);
@@ -67,8 +67,9 @@ export default function PostgresqlDashboardPage() {
     return () => {
       active = false;
     };
+    // loadTick 随核心盘每次加载(含自动刷新)递增,使 TopN 与核心盘同步刷新。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery]);
+  }, [idValuesKey, timeKey, isDashboardMode, instanceIdKeys, getInstanceQuery, loadTick]);
 
   return (
     <DashboardShell

--- a/web/src/app/monitor/dashboards/shared/utils/index.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/index.ts
@@ -8,6 +8,7 @@ export * from './instance';
 export * from './metric-series';
 export * from './collection-status';
 export * from './concurrency';
+export * from './use-load-sequence';
 
 export const normalizeDashboardKey = (value?: string | null) => String(value || '').trim().toLowerCase();
 

--- a/web/src/app/monitor/dashboards/shared/utils/instance.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/instance.ts
@@ -2,13 +2,13 @@
  * 判定一个串是否为「不透明标识符」(base64/hash 类、无人类可读含义),用于决定是否在 UI 隐藏。
  * 命中条件:≥12 位 base64 字母表、且不含 `.:/`、且不含「单词分隔结构」。
  *
- * 分隔结构 `[a-z]+[-_][a-z0-9]`:小写单词后接 `-`/`_` 再接字母/数字,如 `mock-postgres`、
- * `postgres-5432`、`postgres_5432`。这类是可读命名,不应隐藏。
+ * 分隔结构 `[A-Za-z]+[-_][A-Za-z0-9]`:字母单词后接 `-`/`_` 再接字母/数字,如 `mock-postgres`、
+ * `PROD-DB-PRIMARY`、`REDIS_CACHE_01`、`postgres_5432`。大小写均视为可读命名,不应隐藏。
  * 真正的不透明串(base64 混合大小写无分隔,如 `bW9ja1Bvc3RncmVzNTQ`)、UUID(分隔前是十六进制
- * 数字而非小写单词,如 `a1b2c3d4-e5f6`)均不匹配此结构 → 仍判定为不透明。
+ * 数字而非字母单词,如 `a1b2c3d4-e5f6`)均不匹配此结构 → 仍判定为不透明。
  */
 const looksOpaque = (value: string): boolean =>
-  /^[A-Za-z0-9+/=_-]{12,}$/.test(value) && !/[.:/]/.test(value) && !/[a-z]+[-_][a-z0-9]/.test(value);
+  /^[A-Za-z0-9+/=_-]{12,}$/.test(value) && !/[.:/]/.test(value) && !/[A-Za-z]+[-_][A-Za-z0-9]/.test(value);
 
 export const normalizeDisplayText = (value?: string | null) => {
   if (!value) return '';

--- a/web/src/app/monitor/dashboards/shared/utils/use-load-sequence.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/use-load-sequence.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { useCallback, useMemo, useRef } from 'react';
+
+export interface LoadSequence {
+  /** Start a new load and return its token. Every previously issued token is now stale. */
+  begin: () => number;
+  /** True only when `token` is the most recently issued one — i.e. this load was not superseded. */
+  isCurrent: (token: number) => boolean;
+}
+
+/**
+ * Monotonic load-sequence guard for async metric loading.
+ *
+ * Dashboards fire overlapping loads (instance switch, time-range change, silent
+ * refresh). Late-arriving results from a superseded load must be discarded so
+ * stale data never overwrites fresh data. Call `begin()` at the start of a load,
+ * then guard every async continuation with `isCurrent(token)` before committing
+ * state. Centralizing this avoids the same off-by-one stale-guard being
+ * re-implemented (and drifting) in every bespoke dashboard.
+ */
+export function useLoadSequence(): LoadSequence {
+  const ref = useRef(0);
+  const begin = useCallback(() => {
+    ref.current += 1;
+    return ref.current;
+  }, []);
+  const isCurrent = useCallback((token: number) => ref.current === token, []);
+  return useMemo(() => ({ begin, isCurrent }), [begin, isCurrent]);
+}


### PR DESCRIPTION
## 背景

对 `web/src/app/monitor/dashboards/` 监控仪表盘做了一轮缺陷/性能扫描,本 PR 修复发现的问题,并附带一处共享逻辑重构与 ping 面板指标调整。

## 改动内容

### 🐞 缺陷修复

- **实例名显示** (`shared/utils/instance.ts`):不透明标识符判定的「可读命名」正则原为小写专用 `/[a-z]+[-_][a-z0-9]/`,导致全大写、≥12 字符且不含 `.:/` 的实例名(如 `PROD-DB-PRIMARY`、`REDIS_CACHE_01`、`ES-CLUSTER-PROD`)被误判为哈希,在实例选择器与页头显示为 `--`。改为大小写均识别的 `/[A-Za-z]+[-_][A-Za-z0-9]/`,真实 base64/UUID 仍正确隐藏。
- **详情行 barValue** (`objects/common/simple-dashboard-core.tsx`):`barValue` 原对所有单位都裁剪到 0–100(按百分比处理)。当前不可达(此处 `viz` 从不为 `'bar'`),但属潜在陷阱——一旦给 bytes/counts/rate 指标启用 bar 视图会显示误导性满格条。改为仅 `unit === 'percent'` 时裁剪。

### ⚡ 性能优化

- **view API 引用稳定 + TopN 同步刷新** (`api/view.ts` 等):`useViewApi` 每次渲染返回全新函数引用,导致 elasticsearch/postgresql/mssql 的 bespoke TopN effect(依赖数组含 `getInstanceQuery`)在每次重渲染都重发一整批 `topk` 查询——单次加载约 5~6 倍冗余请求。改动:
  - `view.ts` 取数函数全部包 `useCallback`,引用稳定。
  - 核心盘新增 `loadTick`(每次 `loadMetrics` 含静默刷新递增),三处 TopN effect 改用 `loadTick` 作刷新键,与核心盘自动刷新同步,不再依赖渲染抖动。

### ♻️ 重构 / 调整

- 抽取 `useLoadSequence` 公共钩子,统一各仪表盘的异步加载 stale-guard(`begin`/`isCurrent`),消除在 simple-dashboard-core、k8s-cluster、mongodb、mysql 中各自实现且易漂移的 off-by-one 守卫逻辑。
- ping 详情面板指标由 丢包率/TTL 调整为 最小延迟/最差结果码。

## 提交清单

| 类型 | 说明 |
|---|---|
| refactor | centralize dashboard load-sequence guard |
| feat | refine ping detail panel metrics |
| fix | stop hiding uppercase instance names as '--' |
| perf | stabilize view API callbacks and sync bespoke TopN refresh |
| fix | clamp detail barValue only for percent units |

## 测试

- [x] `pnpm type-check`:改动文件零类型错误(仓库其余 `Cannot find module` 报错为环境缺依赖,与本 PR 无关)。
- [x] `looksOpaque` 正则改动用 9 组用例验证:大写命名不再隐藏,base64/UUID 仍判定为不透明(无回归)。
- [ ] 待补:在带自动刷新的 ES/PG/MSSQL 仪表盘上人工确认 TopN 面板随刷新更新、且不再有冗余请求(可在 Network 面板核对)。