### PR TITLE
bugfix: 批量组织角色详情接口补对象级权限收口（Fixes #3035）

### DIFF
--- a/server/apps/system_mgmt/tests/test_group_batch_permission.py
+++ b/server/apps/system_mgmt/tests/test_group_batch_permission.py
@@ -1,0 +1,55 @@
+"""issue #3035 回归测试：批量组织角色详情接口必须做对象级权限收口。
+
+revert 准则：移除 batch_get_group_detail_with_roles 中的 authorized_group_ids 过滤后，
+test_..._skips_unauthorized_groups 必失败（未授权组织会被泄露）。
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from apps.system_mgmt.models import Group
+from apps.system_mgmt.viewset.group_viewset import GroupViewSet
+
+
+def _request(user, data):
+    return SimpleNamespace(user=user, data=data)
+
+
+@pytest.mark.django_db
+def test_batch_group_detail_skips_unauthorized_groups():
+    authorized = Group.objects.create(name="Authorized Org", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="Other Org", parent_id=0, is_virtual=False)
+
+    # 非超管用户：具备 user_group-View 模块权限，但只在 authorized 组织内
+    user = SimpleNamespace(
+        is_superuser=False,
+        permission={"system-manager": {"user_group-View"}},
+        group_list=[{"id": authorized.id}],
+        locale="en",
+    )
+    request = _request(user, {"group_ids": [authorized.id, other.id]})
+
+    response = GroupViewSet().batch_get_group_detail_with_roles(request)
+    payload = json.loads(response.content)
+
+    assert payload["result"] is True
+    returned_ids = {item["group_id"] for item in payload["data"]}
+    assert authorized.id in returned_ids
+    assert other.id not in returned_ids  # 未授权组织角色配置不得泄露
+
+
+@pytest.mark.django_db
+def test_batch_group_detail_superuser_sees_all():
+    g1 = Group.objects.create(name="Org1", parent_id=0, is_virtual=False)
+    g2 = Group.objects.create(name="Org2", parent_id=0, is_virtual=False)
+
+    user = SimpleNamespace(is_superuser=True, permission={}, group_list=[], locale="en")
+    request = _request(user, {"group_ids": [g1.id, g2.id]})
+
+    response = GroupViewSet().batch_get_group_detail_with_roles(request)
+    payload = json.loads(response.content)
+
+    returned_ids = {item["group_id"] for item in payload["data"]}
+    assert returned_ids == {g1.id, g2.id}

--- a/server/apps/system_mgmt/viewset/group_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_viewset.py
@@ -370,9 +370,16 @@ class GroupViewSet(LanguageViewSet, ViewSetUtils):
 
         all_groups = {g.id: g for g in Group.objects.prefetch_related("roles").all()}
 
+        # 对象级权限收口：非超管仅可读取自身有权访问的组织，未授权 group_id 直接跳过。
+        # 与单组织接口 get_group_detail_with_roles 的 _validate_group_permission 同一套校验，
+        # 避免批量入口绕过对象级权限泄露跨组织角色配置。superuser 返回 None 表示放行全部。
+        authorized_group_ids = self._get_user_group_ids(request.user)
+
         results = []
         for gid in group_ids:
             gid = int(gid)
+            if authorized_group_ids is not None and gid not in authorized_group_ids:
+                continue
             group = all_groups.get(gid)
             if not group:
                 continue


### PR DESCRIPTION
## 恢复"对象级读必须在模块级之上再做组织收口"的权限分层

Fixes #3035

### 被破坏的不变量
系统管理的权限模型是**两层**：模块级（`HasPermission`）决定"能不能用这个功能"，对象级（`_validate_group_permission`）决定"能不能看这条组织数据"。任何返回组织敏感数据的接口，二者缺一不可。单组织接口已正确遵守这一分层。

### 根因（设计层）
批量接口作为"性能优化"复用了查询逻辑，却只继承模块级 `HasPermission("user_group-View")`，**丢失了对象级收口**——权限分层在批量路径被打穿，持模块级只读权限者即可枚举任意组织的角色绑定与继承拓扑。

### 修复如何恢复不变量
在批量路径补回对象级收口，且**复用与单接口同一事实源** `_get_user_group_ids`，而非另写一套判断：非超管仅处理自身有权访问的组织，未授权 `group_id` fail-closed 跳过，superuser 放行全部。

```mermaid
flowchart TD
    A[持 user_group-View 用户 POST 任意 group_ids] --> M[模块级 HasPermission 通过]
    M --> O[对象级收口 _get_user_group_ids 同一事实源]
    O -->|超管| P[放行全部]
    O -->|gid ∉ 授权| S[跳过·不返回 fail-closed]
    O -->|gid ∈ 授权| R[返回该组织角色详情]
```

### 一致性
与单组织接口同源同语义（超管放行、组织成员判定一致），不引入第二套权限判断，杜绝"两套实现漂移"。

### 验证
回归测试 revert 准则成立（去掉收口则未授权组织进结果，断言必失败）；覆盖未授权不可见 + 超管全可见。（pytest 受 license_mgmt 阻断，测试 SimpleNamespace 直调方法、CI 可跑。）

