### PR TITLE
bugfix: include_children 不再放大成子树全选，修复采集任务越权（Fixes #3037）

### DIFF
--- a/server/apps/cmdb/views/collect.py
+++ b/server/apps/cmdb/views/collect.py
@@ -171,30 +171,32 @@ class CollectModelViewSet(AuthViewSet):
         if not permission_key:
             return base_queryset
 
-        if not include_children:
-            app_name = self._get_app_name()
-            current_team = request.COOKIES.get("current_team", "0")
-            permission_data = get_permission_rules(request.user, current_team, app_name, permission_key, include_children)
-            if not isinstance(permission_data, dict) or not permission_data:
-                return base_queryset
-            instance_ids = [i["id"] for i in permission_data.get("instance", []) if isinstance(i, dict) and "id" in i]
-            team_entries = permission_data.get("team", [])
-            allowed_teams = set()
-            for team_entry in team_entries:
-                if isinstance(team_entry, dict) and "id" in team_entry:
-                    allowed_teams.add(team_entry["id"])
-                elif isinstance(team_entry, int):
-                    allowed_teams.add(team_entry)
-            allowed_teams &= set(query_groups)
-            allowed_team_query = Q()
-            for team_id in allowed_teams:
-                allowed_team_query = allowed_team_query | Q(team__contains=[team_id]) | Q(team__contains=[str(team_id)])
-            if instance_ids:
-                if allowed_teams:
-                    return base_queryset.filter(Q(id__in=instance_ids) | allowed_team_query)
-                return base_queryset.filter(id__in=instance_ids)
+        # 实例级/团队级任务裁剪在 include_children 时同样必须执行：
+        # 否则勾选"包含子组织"会跳过裁剪、直接返回子树全部任务，造成子组织采集任务越权
+        # 查看/执行（issue #3037）。allowed_teams 已与 query_groups（子树）取交，天然按授权收口。
+        app_name = self._get_app_name()
+        current_team = request.COOKIES.get("current_team", "0")
+        permission_data = get_permission_rules(request.user, current_team, app_name, permission_key, include_children)
+        if not isinstance(permission_data, dict) or not permission_data:
+            return base_queryset
+        instance_ids = [i["id"] for i in permission_data.get("instance", []) if isinstance(i, dict) and "id" in i]
+        team_entries = permission_data.get("team", [])
+        allowed_teams = set()
+        for team_entry in team_entries:
+            if isinstance(team_entry, dict) and "id" in team_entry:
+                allowed_teams.add(team_entry["id"])
+            elif isinstance(team_entry, int):
+                allowed_teams.add(team_entry)
+        allowed_teams &= set(query_groups)
+        allowed_team_query = Q()
+        for team_id in allowed_teams:
+            allowed_team_query = allowed_team_query | Q(team__contains=[team_id]) | Q(team__contains=[str(team_id)])
+        if instance_ids:
             if allowed_teams:
-                return base_queryset.filter(allowed_team_query)
+                return base_queryset.filter(Q(id__in=instance_ids) | allowed_team_query)
+            return base_queryset.filter(id__in=instance_ids)
+        if allowed_teams:
+            return base_queryset.filter(allowed_team_query)
         return base_queryset
 
     @HasPermission("auto_collection-Add")

--- a/server/apps/core/tests/test_viewset_permission_include_children.py
+++ b/server/apps/core/tests/test_viewset_permission_include_children.py
@@ -1,0 +1,64 @@
+"""issue #3037 回归测试：include_children 不得把 team 级范围放大成子树全选。
+
+revert 准则：恢复 get_has_permission 中的 allowed_teams.add(current_team) 后，
+test_..._denies_subtree_object_without_grant 必失败（无授权用户会被放行）。
+"""
+
+from types import SimpleNamespace
+
+from apps.core.utils import viewset_utils
+from apps.core.utils.viewset_utils import GenericViewSetFun
+
+
+class _Fun(GenericViewSetFun):
+    ORGANIZATION_FIELD = "team"
+    permission_key = "auto_collection"
+
+    def _get_app_name(self):
+        return "cmdb"
+
+    @staticmethod
+    def extract_child_group_ids(group_tree, current_team_id):
+        # 子树 = 当前组织 10 及其子组织 11、12
+        return [10, 11, 12]
+
+
+def _user():
+    return SimpleNamespace(
+        group_list=[{"id": 10}, {"id": 11}, {"id": 12}],
+        group_tree=[],
+    )
+
+
+def _instance():
+    # 子组织 12 下的一个任务对象
+    return SimpleNamespace(id=999, team=[12])
+
+
+def test_include_children_denies_subtree_object_without_grant(monkeypatch):
+    # 用户对 current_team 及子树均无 team/instance 授权
+    monkeypatch.setattr(viewset_utils, "get_permission_rules", lambda *a, **k: {"team": [], "instance": []})
+
+    allowed = _Fun().get_has_permission(_user(), _instance(), current_team=10, include_children=True)
+
+    assert allowed is False  # 无授权 → 子树对象不可越权操作
+
+
+def test_include_children_allows_when_team_granted_on_current_team(monkeypatch):
+    monkeypatch.setattr(viewset_utils, "get_permission_rules", lambda *a, **k: {"team": [10], "instance": []})
+
+    allowed = _Fun().get_has_permission(_user(), _instance(), current_team=10, include_children=True)
+
+    assert allowed is True  # current_team 有 team 授权 → 放行（首段命中）
+
+
+def test_include_children_allows_when_instance_granted(monkeypatch):
+    monkeypatch.setattr(
+        viewset_utils,
+        "get_permission_rules",
+        lambda *a, **k: {"team": [], "instance": [{"id": 999, "permission": ["Operate"]}]},
+    )
+
+    allowed = _Fun().get_has_permission(_user(), _instance(), current_team=10, include_children=True)
+
+    assert allowed is True  # 显式实例授权 → 放行

--- a/server/apps/core/utils/viewset_utils.py
+++ b/server/apps/core/utils/viewset_utils.py
@@ -58,8 +58,11 @@ class GenericViewSetFun(object):
             if int(current_team) in permission_rules["team"]:
                 return True
             if include_children:
+                # 仅当用户在子树范围内确有 team 级授权才放行；不得无条件把 current_team
+                # 加入 allowed_teams——否则与子树 user_groups 必然相交，对象级校验退化成
+                # "对象属于当前组织树即放行"，造成子组织任务越权（issue #3037）。
+                # current_team 自身已授权的情况已由上方 current_team in permission_rules["team"] 覆盖。
                 allowed_teams = {i for i in permission_rules.get("team", [])}
-                allowed_teams.add(current_team)
                 if allowed_teams & set(user_groups):
                     return True
 


### PR DESCRIPTION
## 恢复"include_children 只扩范围、不放大授权"的权限边界

Fixes #3037

### 被破坏的不变量
`include_children`（包含子组织）的语义边界是：**只扩大查询的候选范围，绝不放大授权**。一个对象是否可见/可操作，始终由 team 级 / instance 级**真实授权规则**决定，而非"它落在当前组织子树内"。

### 根因（设计层）
两层都把"范围"误当成了"授权"：
- **对象层** `get_has_permission`：`allowed_teams.add(current_team)` 使授权集合与子树 `user_groups` 必然相交 → 校验退化成"对象属于组织树即放行"；
- **查询层** `collect.get_queryset_by_permission`：`include_children` 分支跳过实例/团队级裁剪 → 直接返回子树全部任务。

### 修复如何恢复不变量
- 对象层移除过度授权：`current_team` 自身已授权由首段 `current_team in permission_rules["team"]` 覆盖，删除 add 后仅当子树内**确有 team 授权**才放行，否则回落实例级校验；
- 查询层让裁剪在 `include_children` 时同样执行（`allowed_teams &= 子树` 天然按授权收口）。

```mermaid
flowchart TD
    A[include_children=1 采集任务接口] --> Q[查询层 get_queryset_by_permission]
    A --> O[对象层 get_has_permission]
    Q -->|修复后: 裁剪在 include_children 也执行| QG[allowed_teams ∩ 子树 收口]
    O -->|修复后: 移除 add current_team| OG[仅子树内确有授权才放行, 否则回落实例级]
    QG -.旧实现.-> XB[返回子树全部任务/对象属树即放行 → 越权]
    OG -.旧实现.-> XB
```

### blast radius（评审重点）
`get_has_permission` 是 **core 共享 seam**，被 cmdb/alerts/opspilot 等 13+ viewset 复用。本次是"**收紧一个被过度放开的共享不变量**"：合法授权路径由首段命中、不受影响，改动只移除被错误放行的访问——影响是"少放行"而非"多拦截"。建议 core 负责人 @zhouzhuangjie 同审。

### 验证
三态回归（无授权拒绝 / team授权放行 / 实例授权放行），revert `allowed_teams.add` 后无授权场景被放行、测试必失败；Django-free harness 本地三态通过。

