### PR TITLE
bugfix: 开放上传接口补单文件大小上界，防超大文件在过期前打满对象存储（Fixes #3154）

### DIFF
--- a/server/apps/job_mgmt/tests/test_open_upload.py
+++ b/server/apps/job_mgmt/tests/test_open_upload.py
@@ -97,6 +97,20 @@ class TestOpenFileUploadView:
         assert "file_key" in data["data"]
         assert data["data"]["file_key"].endswith(".rpm")
 
+    def test_oversized_file_rejected(self, monkeypatch):
+        """单文件超过大小上限 → 400（#3154：开放上传须有服务端资源上界）"""
+        monkeypatch.setattr("apps.job_mgmt.views.open_api.MAX_UPLOAD_FILE_SIZE_MB", 1)
+        file = SimpleUploadedFile("big.rpm", b"x" * (2 * 1024 * 1024))  # 2MB > 1MB 上限
+        with patch("apps.job_mgmt.views.open_api.async_to_sync") as mock_async:
+            mock_async.return_value = MagicMock()
+            response = self.client.post(
+                self.url,
+                {"file": file},
+                format="multipart",
+                HTTP_API_AUTHORIZATION=self.api_secret.api_secret,
+            )
+        assert response.status_code == 400
+
     def test_upload_default_expire_days(self):
         """不传 expire_days 时默认 7 天后过期"""
         from apps.job_mgmt.models import DistributionFile

--- a/server/apps/job_mgmt/views/open_api.py
+++ b/server/apps/job_mgmt/views/open_api.py
@@ -1,5 +1,6 @@
 """作业管理开放接口（第三方 App 调用）"""
 
+import os
 from datetime import datetime, timedelta
 
 from asgiref.sync import async_to_sync
@@ -37,6 +38,19 @@ def _parse_expire_days(raw):
     if days < 1 or days > MAX_EXPIRE_DAYS:
         return None, "expire_days 非法"
     return days, None
+
+
+def _int_env(name, default):
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+# 单文件大小上界（env 可配、保守默认；负责人可按部署调整，无需改码）。
+# TTL 只兜住保存时长，不兜单次上传体量——防止持有 UserAPISecret 的调用方
+# 用超大文件在过期前打满对象存储（issue #3154 的"大小"维度）。
+MAX_UPLOAD_FILE_SIZE_MB = _int_env("JOB_MAX_UPLOAD_FILE_SIZE_MB", 1024)
 
 
 def _get_user_team_from_request(request):
@@ -102,7 +116,8 @@ class OpenFileUploadView(APIView):
         Body: multipart/form-data { file: <binary>, expire_days: <int> }
 
     参数:
-        file: 必填，上传的文件
+        file: 必填，上传的文件（单文件大小上限默认 1024MB，
+            可由环境变量 JOB_MAX_UPLOAD_FILE_SIZE_MB 调整）
         expire_days: 可选，过期天数（默认 7，范围 1-365）
             文件在 expire_days 天后由定时任务自动清理；不存在永久保存选项。
 
@@ -130,6 +145,13 @@ class OpenFileUploadView(APIView):
         if not file:
             return Response(
                 {"detail": "未上传文件"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 单文件大小上界（防超大单文件在过期前占满存储）
+        if getattr(file, "size", 0) and file.size > MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024:
+            return Response(
+                {"detail": f"文件大小超过上限（{MAX_UPLOAD_FILE_SIZE_MB}MB）"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 


### PR DESCRIPTION
Fixes #3154

> **范围更新（rebase 后重新界定）**：上游 5056768a7 已合入"上传强制按天过期（TTL 1-365 天）+ 定时清理"，并彻底移除 `permanent` 永久保存选项——issue 的核心诉求"永久落盘无回收上限"已被上游更强方案解决。本 PR 据此收窄为 issue 中"大小"维度的剩余缺口：**单文件大小上界**。原"永久文件配额"方案已废弃。

## 被破坏的不变量

开放上传是暴露给第三方（UserAPISecret 持有方）的写入口，服务端必须对单次写入体量有自己的上界。TTL 只兜住"保存多久"，不兜"一次写多大"——在过期清理生效前，超大文件仍可打满对象存储。

## 根因（设计层）

`OpenFileUploadView.post` 对 `request.FILES` 没有任何大小校验，Django 的 `DATA_UPLOAD_MAX_MEMORY_SIZE` 不约束文件体，等于把存储体量的控制权完全交给调用方。

## 修复如何恢复不变量

在落库/上传对象存储之前校验 `file.size`，超过上限直接 400。上限默认 1024MB，`JOB_MAX_UPLOAD_FILE_SIZE_MB` 环境变量可配，负责人按部署调整无需改码。

## 调用链

```mermaid
flowchart TD
    T1["第三方 App\nPOST /api/v1/job_mgmt/api/open/upload_file"]
    G1["APISecretMiddleware 鉴权"]
    C1["⬆ 新增：单文件大小上界校验\nopen_api.py OpenFileUploadView.post"]
    F1["_parse_expire_days（上游 TTL）"]
    BU["upload_file_to_s3 + DistributionFile.create"]
    C2["cleanup_expired_distribution_files_task\n定时清理（上游）"]
    T1 --> G1 --> C1 --> F1 --> BU --> C2
```

## blast radius · 一致性

仅 `open_api.py` 单文件；校验失败响应风格与同文件既有错误一致（`{"detail": ...}` + 400）。默认 1024MB 远大于正常分发包体量，存量调用方不受影响。

## 验证

- `test_oversized_file_rejected`：上限调到 1MB 后上传 2MB 文件 → 400
- `apps/job_mgmt/tests/test_open_upload.py` 全量 15 passed（含上游 TTL 用例，rebase 后无回归）
