### PR TITLE
fix(monitor): PostgreSQL 按库维度用 Telegraf 原生 db 标签(原 dbname 不匹配)

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
@@ -20,7 +20,7 @@
       "unit": "short",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -36,7 +36,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -52,7 +52,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -68,7 +68,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -84,7 +84,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -100,7 +100,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -116,7 +116,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -132,7 +132,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -148,7 +148,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -164,7 +164,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -180,7 +180,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -196,7 +196,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -212,7 +212,7 @@
       "unit": "cps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],
@@ -228,7 +228,7 @@
       "unit": "byteps",
       "dimensions": [
         {
-          "name": "dbname",
+          "name": "db",
           "description": "Database name"
         }
       ],

--- a/web/src/app/monitor/dashboards/objects/postgresql/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/postgresql/parse.ts
@@ -7,17 +7,17 @@ interface RawSeries {
 }
 
 /**
- * 把「按 dbname 聚合 + topk」查询的原始结果(result.data.result 多序列)
- * 解析成按值降序的 BarList items:每序列取最新值、取 dbname label、按值排序。
+ * 把「按 db 聚合 + topk」查询的原始结果(result.data.result 多序列)
+ * 解析成按值降序的 BarList items:每序列取最新值、取 db(库名)label、按值排序。
  * topk 已在查询层限制条数;此处仅排序 + 格式化,数据缺失时返回空数组(空态)。
  */
 export const topDbBars = (raw: any, unit: string, color: string): BarItem[] => {
   const series: RawSeries[] = raw?.data?.result || [];
   const rows = series
     .map((s) => {
-      // 仅用真实的 dbname/datname 标签;缺失或空串说明该数据没有按库维度,
-      // 不再伪造「未知库」(否则会把实例级聚合值误展示成某个库的排行)。
-      const label = (s.metric?.dbname || s.metric?.datname || '').trim();
+      // 仅用真实的 db(库名,Telegraf postgresql 原生标签)/datname 标签;缺失或空串说明该数据
+      // 没有按库维度,不再伪造「未知库」(否则会把实例级聚合值误展示成某个库的排行)。
+      const label = (s.metric?.db || s.metric?.datname || '').trim();
       const nums = (s.values || [])
         .map(([, v]) => Number(v))
         .filter((n) => Number.isFinite(n));

--- a/web/src/app/monitor/dashboards/objects/postgresql/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/postgresql/queries.ts
@@ -10,19 +10,19 @@ export interface PgTopDbQuery {
   /** formatMetricValue 用的单位 */
   unit: string;
   color: string;
-  /** 按 dbname 聚合 + topk 的查询;__$labels__ 由 buildSearchParams 注入实例过滤 */
+  /** 按 db(库名,Telegraf postgresql input 的原生标签)聚合 + topk 的查询;__$labels__ 由 buildSearchParams 注入实例过滤 */
   query: string;
   guide: GuideItem[];
 }
 
-// 注:checkpoint / buffer 等实例级指标无 dbname 维度,不纳入按库排行(见 DASHBOARD_DESCRIPTION.md)。
+// 注:checkpoint / buffer 等实例级指标无 db 维度,不纳入按库排行(见 DASHBOARD_DESCRIPTION.md)。
 export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
   {
     key: 'numbackends',
     title: '连接数 Top',
     unit: 'counts',
     color: '#2f6bff',
-    query: `topk(${PG_TOP_N}, sum by (dbname) (postgresql_numbackends{__$labels__}))`,
+    query: `topk(${PG_TOP_N}, sum by (db) (postgresql_numbackends{__$labels__}))`,
     guide: [{ label: '连接数排行', detail: '各数据库当前活跃会话数,定位连接集中在哪个库。' }]
   },
   {
@@ -30,7 +30,7 @@ export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
     title: '事务回滚 Top',
     unit: 'cps',
     color: '#ff4d4f',
-    query: `topk(${PG_TOP_N}, sum by (dbname) (rate(postgresql_xact_rollback{__$labels__}[5m])))`,
+    query: `topk(${PG_TOP_N}, sum by (db) (rate(postgresql_xact_rollback{__$labels__}[5m])))`,
     guide: [{ label: '回滚排行', detail: '各数据库事务回滚速率,定位失败 / 冲突集中的库。' }]
   },
   {
@@ -38,7 +38,7 @@ export const PG_TOP_DB_QUERIES: PgTopDbQuery[] = [
     title: '临时文件 Top',
     unit: 'cps',
     color: '#faad14',
-    query: `topk(${PG_TOP_N}, sum by (dbname) (rate(postgresql_temp_files{__$labels__}[5m])))`,
+    query: `topk(${PG_TOP_N}, sum by (db) (rate(postgresql_temp_files{__$labels__}[5m])))`,
     guide: [{ label: '临时文件排行', detail: '各数据库临时文件创建速率,定位复杂查询 / work_mem 压力大的库。' }]
   }
 ];


### PR DESCRIPTION
## 问题

PostgreSQL 探针把「按库」维度声明成了 `dbname`,但 telegraf `inputs.postgresql` 实际把库名打成 **`db`** 标签(裸 `[[inputs.postgresql]]`,无自定义 tag_columns)。维度名不匹配导致:

- 指标视图里按库的序列**没有维度信息**(维度标签匹配不到,显示空);
- PostgreSQL 仪表盘「数据库压力排行」面板用 `sum by (dbname)` 聚合 → **查不到分组、面板空**。

和 HAProxy 探针之前 `proxy/sv` vs 实际 `pxname/svname` 是同一类「声明维度名 ≠ 真实 telegraf tag」的问题。

## 改动

| 文件 | 改动 |
|---|---|
| `support-files/plugins/Telegraf/database/postgres/metrics.json` | 14 个按库指标的维度 `dbname` → `db` |
| `web/.../dashboards/objects/postgresql/queries.ts` | 3 处 `sum by (dbname)` → `sum by (db)` |
| `web/.../dashboards/objects/postgresql/parse.ts` | 取 `metric.db` 作库名(保留 `datname` 兜底) |

## 影响

- 接真实 telegraf 时,按库维度/排行恢复正常。
- 仅探针元数据 + 仪表盘查询字符串改动,无逻辑/接口变更。

## 测试

- [x] metrics.json JSON 合法性校验通过。
- [x] 改动后维度名与 telegraf postgresql input 原生 `db` 标签一致。
- [ ] 待:接真实 PostgreSQL 目标验证「数据库压力排行」面板按 db 出数据。