### PR TITLE
bugfix: 监控通知人列表按授权范围收口，修复全平台用户泄露与越权通知（Fixes #3140）

### DIFF
--- a/server/apps/monitor/tests/test_system_mgmt_view.py
+++ b/server/apps/monitor/tests/test_system_mgmt_view.py
@@ -1,0 +1,52 @@
+"""issue #3140 回归测试：监控通知人列表必须按调用方授权范围收口，不返回全平台用户。
+
+revert 准则：
+- 若 view 的 get_user_all 改回不传 actor_context，test_view_passes_actor_context 必失败；
+- 若 util 改回总是调 get_group_users（无作用域），test_util_routes_to_scoped 必失败。
+"""
+
+import types
+
+from apps.monitor.utils import system_mgmt_api
+from apps.monitor.views import system_mgmt as sm_view
+
+
+def test_view_get_user_all_passes_actor_context(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(sm_view, "_build_actor_context", lambda request: {"current_team": 7, "username": "u"})
+    monkeypatch.setattr(
+        sm_view.SystemMgmtUtils,
+        "get_user_all",
+        staticmethod(lambda actor_context=None, **kw: captured.update(actor_context=actor_context) or []),
+    )
+    monkeypatch.setattr(sm_view.WebUtils, "response_success", staticmethod(lambda data: data))
+
+    request = types.SimpleNamespace(COOKIES={"current_team": "7"})
+    sm_view.SystemMgmtView().get_user_all(request)
+
+    # 视图必须把 actor_context 透传给 util（不再无作用域取全量）
+    assert captured["actor_context"] == {"current_team": 7, "username": "u"}
+
+
+def test_util_get_user_all_routes_to_scoped(monkeypatch):
+    calls = []
+
+    class _Client:
+        def get_group_users(self, group=None, include_children=False):
+            calls.append(("unscoped", group))
+            return {"data": []}
+
+        def get_group_users_scoped(self, actor_context, group=None, include_children=False):
+            calls.append(("scoped", actor_context))
+            return {"data": []}
+
+    monkeypatch.setattr(system_mgmt_api, "SystemMgmt", _Client)
+
+    # 带 actor_context → 走 scoped
+    system_mgmt_api.SystemMgmtUtils.get_user_all(actor_context={"current_team": 7})
+    # 无 actor_context → 走 unscoped（仅系统内部）
+    system_mgmt_api.SystemMgmtUtils.get_user_all()
+
+    assert calls[0][0] == "scoped"
+    assert calls[0][1] == {"current_team": 7}
+    assert calls[1][0] == "unscoped"

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -4,7 +4,12 @@ from apps.rpc.system_mgmt import SystemMgmt
 class SystemMgmtUtils:
     @staticmethod
     def get_user_all(actor_context=None, group=None, include_children=False):
-        result = SystemMgmt().get_group_users(group=group, include_children=include_children)
+        # 带 actor_context（用户面调用）走授权范围收口的 scoped 查询，避免返回全平台用户（#3140）；
+        # 无 actor_context 仅供系统内部调用方使用。
+        if actor_context is not None:
+            result = SystemMgmt().get_group_users_scoped(actor_context, group=group, include_children=include_children)
+        else:
+            result = SystemMgmt().get_group_users(group=group, include_children=include_children)
         return result["data"]
 
     @staticmethod

--- a/server/apps/monitor/views/system_mgmt.py
+++ b/server/apps/monitor/views/system_mgmt.py
@@ -28,7 +28,9 @@ def _build_actor_context(request):
 class SystemMgmtView(ViewSet):
     @action(methods=["get"], detail=False, url_path="user_all")
     def get_user_all(self, request):
-        data = SystemMgmtUtils.get_user_all()
+        # 通知人列表必须收口到调用方授权范围，避免把全平台用户暴露给任意登录用户（#3140）
+        actor_context = _build_actor_context(request)
+        data = SystemMgmtUtils.get_user_all(actor_context=actor_context)
         return WebUtils.response_success(data)
 
     @action(methods=["get"], detail=False, url_path="search_channel_list")


### PR DESCRIPTION
## 恢复"用户面列表查询必须收口到授权范围"的边界

Fixes #3140

### 被破坏的不变量
凡是**用户面**的"列出系统用户"查询，返回集都必须**收口到调用方当前授权范围**——绝不能把全平台用户暴露给任意已登录用户。

### 根因（设计层）
监控通知人入口 `get_user_all` 漏传 `actor_context`，直接走了**无作用域**的 `get_group_users(group=None)`（→ `User.objects.all()`），返回全平台用户；并允许跨组织用户 ID 写入 `notice_users` 进入通知链路。平台**已建有收口版** `get_group_users_scoped`，同一视图里的 `search_channel_list` 也已用该模式——唯独这个接口被漏改。

### 修复如何恢复不变量
让 `get_user_all` 跟齐同文件 `search_channel_list`：先 `_build_actor_context(request)`，再把 `actor_context` 透传到 util；util 据此走 `get_group_users_scoped`（按授权组过滤、空范围返回空、显式指定越权组也返回空）。

```mermaid
flowchart TD
    A["GET /monitor/api/system_mgmt/user_all/"] --> V["SystemMgmtView.get_user_all"]
    V --> C["_build_actor_context(request)<br/>username/current_team/is_superuser"]
    C --> U["SystemMgmtUtils.get_user_all(actor_context=...)"]
    U --> S["get_group_users_scoped<br/>按授权范围过滤"]
    U -. "旧实现: 无 actor_context" .-> X["get_group_users(group=None)<br/>→ 全平台用户(泄露)"]
```

### blast radius · 一致性
- 仅 monitor：该 util 的唯一调用方就是此视图；修复与同文件 `search_channel_list` 同模式，不引入新范式。
- `alerts` 模块的 `get_user_all` 是**另一个** util（系统侧按 username 反查、非用户面暴露），非同类，不纳入。
- 评审另发现 `log/views/system_mgmt.py` 的 `get_user_all` 有同类未授权校验风险——属独立 issue，本 PR 不含，将另行处理。

### 验证
回归测试覆盖两层：视图是否透传 `actor_context`、util 是否据此路由到 scoped。revert 任一改动（视图不传 / util 总走无作用域）测试必失败。Django-free harness 本地验证 util 路由通过。（仓库 pytest 受 license_mgmt 阻断，测试纯 monkeypatch、CI 可跑。）

### 已知限制
`notice_users` 保存时的二次组织校验属纵深防御；本接口收口后前端已只见授权范围用户，如需防构造请求直接 POST 越权 `notice_users`，可另做 serializer 校验（本次不纳入）。

建议 reviewer：monitor 负责人 @baiyf-git（如需添加请告知）。
