### PR TITLE
bugfix: 日志告警通知失败补偿，兜住瞬时通道故障导致的永久漏通知

### DIFF
--- a/server/apps/log/config.py
+++ b/server/apps/log/config.py
@@ -1,0 +1,9 @@
+from celery.schedules import crontab
+
+# 各 app 的 CELERY_BEAT_SCHEDULE 由 config/components/celery.py 自动合并
+CELERY_BEAT_SCHEDULE = {
+    "compensate_log_notice": {
+        "task": "apps.log.tasks.policy.compensate_log_notice_task",
+        "schedule": crontab(minute="*/5"),  # 每5分钟回扫一次发送失败的告警通知
+    },
+}

--- a/server/apps/log/constants/alert_policy.py
+++ b/server/apps/log/constants/alert_policy.py
@@ -18,8 +18,10 @@ class AlertConstants:
     NOTICE_COMPENSATE_MAX_RETRY = int(os.getenv("LOG_NOTICE_COMPENSATE_MAX_RETRY", "5"))  # 单事件最多被补偿重投次数
     NOTICE_COMPENSATE_WINDOW_SECONDS = int(os.getenv("LOG_NOTICE_COMPENSATE_WINDOW_SECONDS", str(24 * 3600)))  # 仅补偿近 N 秒内失败事件
     NOTICE_COMPENSATE_BATCH_SIZE = int(os.getenv("LOG_NOTICE_COMPENSATE_BATCH_SIZE", "200"))  # 单次补偿处理事件数上限
-    # 最小 age 门槛：仅补偿落库已超 N 秒的事件，确保本轮扫描的同步通知（notice()）已完成，杜绝与首发并发双投
-    NOTICE_COMPENSATE_MIN_AGE_SECONDS = int(os.getenv("LOG_NOTICE_COMPENSATE_MIN_AGE_SECONDS", "60"))
+    # 最小 age 门槛：仅补偿落库已超 N 秒的事件，降低与扫描线程同步通知（notice()）并发双投的概率。
+    # 默认 600s：notice() 在通道故障下逐事件内联重试，慢路径可达分钟级；
+    # 补偿是兜底层，延后无伤大雅，门槛必须大于 notice() 的最坏耗时量级才有效。
+    NOTICE_COMPENSATE_MIN_AGE_SECONDS = int(os.getenv("LOG_NOTICE_COMPENSATE_MIN_AGE_SECONDS", "600"))
 
     # 告警状态
     STATUS_NEW = "new"

--- a/server/apps/log/constants/alert_policy.py
+++ b/server/apps/log/constants/alert_policy.py
@@ -1,3 +1,6 @@
+import os
+
+
 class AlertConstants:
     """告警相关常量"""
 
@@ -6,6 +9,17 @@ class AlertConstants:
     MAX_BACKFILL_SECONDS = 24 * 3600  # 最大补偿时间范围（秒）
     INGEST_DELAY_SECONDS = 60  # 日志查询安全延迟（秒）
     WINDOW_OVERLAP_SECONDS = 0  # 预留窗口重叠能力，当前默认关闭避免重复事件
+
+    # 通知发送可靠性配置（均给保守默认 + env 可调，详见 PR 说明）
+    # A 内联重试：单次发送遇瞬时通道故障时的总尝试次数（含首发）
+    NOTICE_SEND_MAX_ATTEMPTS = int(os.getenv("LOG_NOTICE_SEND_MAX_ATTEMPTS", "3"))
+    NOTICE_SEND_RETRY_BACKOFF_SECONDS = float(os.getenv("LOG_NOTICE_SEND_RETRY_BACKOFF_SECONDS", "1"))
+    # B 持久化补偿：周期任务回扫近期发送失败事件重投
+    NOTICE_COMPENSATE_MAX_RETRY = int(os.getenv("LOG_NOTICE_COMPENSATE_MAX_RETRY", "5"))  # 单事件最多被补偿重投次数
+    NOTICE_COMPENSATE_WINDOW_SECONDS = int(os.getenv("LOG_NOTICE_COMPENSATE_WINDOW_SECONDS", str(24 * 3600)))  # 仅补偿近 N 秒内失败事件
+    NOTICE_COMPENSATE_BATCH_SIZE = int(os.getenv("LOG_NOTICE_COMPENSATE_BATCH_SIZE", "200"))  # 单次补偿处理事件数上限
+    # 最小 age 门槛：仅补偿落库已超 N 秒的事件，确保本轮扫描的同步通知（notice()）已完成，杜绝与首发并发双投
+    NOTICE_COMPENSATE_MIN_AGE_SECONDS = int(os.getenv("LOG_NOTICE_COMPENSATE_MIN_AGE_SECONDS", "60"))
 
     # 告警状态
     STATUS_NEW = "new"

--- a/server/apps/log/migrations/0016_event_notified_event_notice_retry_count.py
+++ b/server/apps/log/migrations/0016_event_notified_event_notice_retry_count.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+def mark_existing_events_settled(apps, schema_editor):
+    """存量事件不追溯补偿：统一标记为已通知，避免补偿任务上线后对历史事件发起重发风暴。
+
+    新机制只对本迁移之后产生的事件生效（notified 默认 False，由通知流程置位）。
+    """
+    Event = apps.get_model("log", "Event")
+    Event.objects.update(notified=True)
+
+
+def reverse_noop(apps, schema_editor):
+    # 字段会被一并删除，无需逆向数据处理
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("log", "0015_alter_alertsnapshot_snapshots"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="notified",
+            field=models.BooleanField(db_index=True, default=False, verbose_name="通知是否已成功"),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="notice_retry_count",
+            field=models.IntegerField(default=0, verbose_name="通知重试次数"),
+        ),
+        migrations.RunPython(mark_existing_events_settled, reverse_noop),
+    ]

--- a/server/apps/log/models/policy.py
+++ b/server/apps/log/models/policy.py
@@ -97,6 +97,8 @@ class Event(TimeInfo):
     level = models.CharField(max_length=20, verbose_name="事件级别")
     content = models.TextField(blank=True, verbose_name="事件内容")
     notice_result = models.JSONField(default=list, verbose_name="通知结果")
+    notified = models.BooleanField(default=False, db_index=True, verbose_name="通知是否已成功")
+    notice_retry_count = models.IntegerField(default=0, verbose_name="通知重试次数")
 
     class Meta:
         verbose_name = "事件记录"

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -4,7 +4,8 @@ from datetime import datetime, timedelta, timezone
 import time
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.log.constants.alert_policy import AlertConstants
-from apps.log.models.policy import Policy
+from apps.log.constants.database import DatabaseConstants
+from apps.log.models.policy import Alert, Event, Policy
 from apps.core.logger import celery_logger as logger
 from apps.log.tasks.services.policy_scan import LogPolicyScan
 from apps.log.tasks.utils.policy import period_to_seconds
@@ -99,3 +100,81 @@ def scan_log_policy_task(policy_id):
         duration = time.time() - start_time
         logger.error(f"日志策略 [{policy_id}] 执行失败（系统异常），耗时: {duration:.2f}s，错误: {str(e)}", exc_info=True)
         raise
+
+
+@shared_task(base=Singleton, raise_on_duplicate=False)
+def compensate_log_notice_task():
+    """日志告警通知补偿（范围B）。
+
+    回扫近 NOTICE_COMPENSATE_WINDOW_SECONDS 内、发送未成功（notified=False）且重投未超限的事件并重发，
+    兜住瞬时通道故障导致的永久漏通知。仅处理 notice 开启、策略启用、非 info 级别的事件；
+    存量历史事件已在迁移中标记为 notified=True，不在补偿范围内（避免重发风暴）。
+    """
+    start_time = time.time()
+    now = datetime.now(timezone.utc)
+    window_start = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_WINDOW_SECONDS)
+    # 仅补偿落库已超 MIN_AGE 的事件：保证本轮扫描的同步 notice() 已完成，杜绝与首发并发双投
+    settle_before = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS)
+
+    pending = list(
+        Event.objects.filter(
+            notified=False,
+            notice_retry_count__lt=AlertConstants.NOTICE_COMPENSATE_MAX_RETRY,
+            event_time__gte=window_start,
+            created_at__lte=settle_before,
+            policy__notice=True,
+            policy__enable=True,
+        )
+        .exclude(level=AlertConstants.LEVEL_INFO)
+        .select_related("policy")
+        .order_by("event_time")[: AlertConstants.NOTICE_COMPENSATE_BATCH_SIZE]
+    )
+
+    if not pending:
+        duration = time.time() - start_time
+        logger.info(f"日志通知补偿：无待补偿事件，耗时: {duration:.2f}s")
+        return {"success": True, "scanned": 0, "compensated": 0, "duration": duration}
+
+    scanners = {}  # 按策略复用 scanner，避免重复构造
+    updated_events = []
+    success_alert_ids = set()
+
+    for event in pending:
+        policy = event.policy
+        # 无通知人 → 永远发不出，直接标记已处理避免无意义重投占用配额
+        if not policy.notice_users:
+            event.notified = True
+            updated_events.append(event)
+            continue
+
+        scanner = scanners.get(policy.id)
+        if scanner is None:
+            scanner = LogPolicyScan(policy)
+            scanners[policy.id] = scanner
+
+        # 单次发送：补偿任务的周期回扫本身即外层重试，避免在 worker 内叠加内联 sleep 阻塞
+        is_notice, notice_result = scanner.send_notice(event, max_attempts=1)
+        event.notice_result = notice_result
+        event.notified = is_notice
+        event.notice_retry_count = (event.notice_retry_count or 0) + 1
+        updated_events.append(event)
+        if is_notice:
+            success_alert_ids.add(event.alert_id)
+
+    if updated_events:
+        Event.objects.bulk_update(
+            updated_events,
+            ["notice_result", "notified", "notice_retry_count"],
+            batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
+        )
+
+    if success_alert_ids:
+        Alert.objects.bulk_update(
+            [Alert(id=alert_id, notice=True) for alert_id in success_alert_ids],
+            ["notice"],
+            batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
+        )
+
+    duration = time.time() - start_time
+    logger.info(f"日志通知补偿完成：扫描 {len(pending)} 个事件，成功补发 {len(success_alert_ids)} 个告警，耗时: {duration:.2f}s")
+    return {"success": True, "scanned": len(pending), "compensated": len(success_alert_ids), "duration": duration}

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -113,7 +113,8 @@ def compensate_log_notice_task():
     start_time = time.time()
     now = datetime.now(timezone.utc)
     window_start = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_WINDOW_SECONDS)
-    # 仅补偿落库已超 MIN_AGE 的事件：保证本轮扫描的同步 notice() 已完成，杜绝与首发并发双投
+    # 仅补偿落库已超 MIN_AGE 的事件：等待本轮扫描的同步 notice() 完成，降低与首发并发双投的概率
+    # （门槛取值须大于 notice() 最坏耗时量级，见 AlertConstants 说明；通知语义为 at-least-once）
     settle_before = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS)
 
     pending = list(

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import re
+import time
 import uuid
 
 from django.db import transaction
@@ -872,29 +873,44 @@ class LogPolicyScan:
 
         return title, content
 
-    def send_notice(self, event_obj):
-        """发送通知"""
+    def send_notice(self, event_obj, max_attempts=None):
+        """发送通知
+
+        内联重试（范围A）：单次发送遇瞬时通道故障时按 max_attempts 重试 + 线性退避，
+        兜住亚秒级通道抖动；仍失败则返回 (False, 最后一次结果)，由持久化补偿任务（范围B）后续重投。
+        补偿任务本身即外层重试循环，调用时传 max_attempts=1 做单次发送，避免在 worker 内叠加 sleep 阻塞。
+        """
         if not self.policy.notice_users:
             return False, []
 
         # 使用新的格式化方法
         title, content = self._format_notice_content(event_obj)
 
-        try:
-            result = SystemMgmtUtils.send_msg_with_channel(self.policy.notice_type_id, title, content, self.policy.notice_users)
-            # 检查发送结果
-            if result.get("result") is False:
-                msg = f"send notice failed for policy {self.policy.id}: {result.get('message', 'Unknown error')}"
-                logger.error(msg)
-                return False, result
-            else:
-                logger.info(f"send notice success for policy {self.policy.id}: {result}")
-                return True, result
-        except Exception as e:
-            msg = f"send notice exception for policy {self.policy.id}: {e}"
-            logger.error(msg, exc_info=True)
-            result = {"result": False, "message": msg}
-            return False, result
+        if max_attempts is None:
+            max_attempts = AlertConstants.NOTICE_SEND_MAX_ATTEMPTS
+        max_attempts = max(max_attempts, 1)
+        last_result = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = SystemMgmtUtils.send_msg_with_channel(self.policy.notice_type_id, title, content, self.policy.notice_users)
+                # 检查发送结果
+                if result.get("result") is False:
+                    last_result = result
+                    msg = f"send notice failed for policy {self.policy.id} (attempt {attempt}/{max_attempts}): {result.get('message', 'Unknown error')}"
+                    logger.error(msg)
+                else:
+                    logger.info(f"send notice success for policy {self.policy.id} (attempt {attempt}/{max_attempts})")
+                    return True, result
+            except Exception as e:
+                msg = f"send notice exception for policy {self.policy.id} (attempt {attempt}/{max_attempts}): {e}"
+                logger.error(msg, exc_info=True)
+                last_result = {"result": False, "message": msg}
+
+            # 非末次尝试 → 线性退避后重试
+            if attempt < max_attempts:
+                time.sleep(AlertConstants.NOTICE_SEND_RETRY_BACKOFF_SECONDS * attempt)
+
+        return False, last_result if last_result is not None else {"result": False, "message": "Unknown error"}
 
     def notice(self, event_objs):
         """通知"""
@@ -910,6 +926,9 @@ class LogPolicyScan:
                     continue
                 is_notice, notice_result = self.send_notice(event)
                 event.notice_result = notice_result
+                # 记录发送是否成功 + 累计尝试次数，供补偿任务（范围B）回扫 notified=False 的失败事件
+                event.notified = is_notice
+                event.notice_retry_count = (event.notice_retry_count or 0) + 1
 
                 if is_notice:
                     alerts.append((event.alert_id, is_notice))
@@ -917,7 +936,7 @@ class LogPolicyScan:
             # 批量更新通知结果
             Event.objects.bulk_update(
                 event_objs,
-                ["notice_result"],
+                ["notice_result", "notified", "notice_retry_count"],
                 batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
             )
             logger.info(f"Completed notification for {len(event_objs)} events")

--- a/server/apps/log/tests/test_notice_compensation.py
+++ b/server/apps/log/tests/test_notice_compensation.py
@@ -1,0 +1,279 @@
+"""Issue #2923：日志告警通知失败补偿。
+
+覆盖两层防线：
+- 范围A 内联重试：send_notice 遇瞬时通道故障按 NOTICE_SEND_MAX_ATTEMPTS 重试。
+- 范围B 持久化补偿：compensate_log_notice_task 回扫 notified=False 的近期失败事件重投。
+
+沿用本目录既有的 Django-free 注入式 harness（sys.modules 伪依赖 + importlib 按路径加载），
+不依赖 Django settings / ORM，规避 license_mgmt 缺失导致的 settings 加载失败。
+"""
+import importlib.util
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+SERVER_DIR = Path(__file__).resolve().parents[3]
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _fake_alert_constants():
+    return types.SimpleNamespace(
+        STATUS_NEW="new",
+        STATUS_CLOSED="closed",
+        LEVEL_INFO="info",
+        NOTICE_SEND_MAX_ATTEMPTS=3,
+        NOTICE_SEND_RETRY_BACKOFF_SECONDS=0,  # 测试不真正 sleep
+        NOTICE_COMPENSATE_MAX_RETRY=5,
+        NOTICE_COMPENSATE_WINDOW_SECONDS=24 * 3600,
+        NOTICE_COMPENSATE_BATCH_SIZE=200,
+    )
+
+
+def _fake_logger():
+    return types.SimpleNamespace(
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+
+def _load_policy_scan(monkeypatch, system_mgmt_utils):
+    _install_module(monkeypatch, "django", db=types.SimpleNamespace(transaction=types.SimpleNamespace()))
+    _install_module(monkeypatch, "django.db", transaction=types.SimpleNamespace())
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(monkeypatch, "apps.log.constants.alert_policy", AlertConstants=_fake_alert_constants())
+    _install_module(monkeypatch, "apps.log.constants.database", DatabaseConstants=types.SimpleNamespace(DEFAULT_BATCH_SIZE=100))
+    _install_module(monkeypatch, "apps.log.constants.web", WebConstants=types.SimpleNamespace(URL="http://test"))
+    _install_module(monkeypatch, "apps.log.models.policy", Alert=object, Event=object, EventRawData=object, AlertSnapshot=object)
+    _install_module(monkeypatch, "apps.log.tasks.utils.policy", period_to_seconds=lambda period: 300)
+    _install_module(monkeypatch, "apps.log.utils.query_log", VictoriaMetricsAPI=lambda: None)
+    _install_module(
+        monkeypatch,
+        "apps.log.utils.log_group",
+        LogGroupQueryBuilder=types.SimpleNamespace(build_query_with_groups=lambda query, groups: (query, [])),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.system_mgmt_api", SystemMgmtUtils=system_mgmt_utils)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_fake_logger())
+
+    module_path = SERVER_DIR / "apps" / "log" / "tasks" / "services" / "policy_scan.py"
+    spec = importlib.util.spec_from_file_location("policy_scan_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_policy(**overrides):
+    base = dict(
+        id=7,
+        name="测试策略",
+        notice=True,
+        enable=True,
+        notice_type_id=3,
+        notice_users=["u1"],
+        last_run_time=datetime(2026, 6, 9, 8, 0, tzinfo=timezone.utc),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_event(policy, **overrides):
+    base = dict(
+        id="evt-1",
+        alert_id="alert-1",
+        policy=policy,
+        level="error",
+        content="some error",
+        event_time=datetime(2026, 6, 9, 8, 0, tzinfo=timezone.utc),
+        created_at=datetime(2026, 6, 9, 8, 0, tzinfo=timezone.utc),
+        notice_result=[],
+        notified=False,
+        notice_retry_count=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _RecordingSender:
+    """模拟 SystemMgmtUtils：前 fail_times 次返回失败，之后成功。"""
+
+    def __init__(self, fail_times):
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def send_msg_with_channel(self, channel_id, title, content, users):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            return {"result": False, "message": f"transient {self.calls}"}
+        return {"result": True, "message": "ok"}
+
+
+# ---------- 范围A：send_notice 内联重试 ----------
+
+def test_send_notice_retries_until_success(monkeypatch):
+    sender = _RecordingSender(fail_times=2)
+    mod = _load_policy_scan(monkeypatch, type("S", (), {"send_msg_with_channel": staticmethod(sender.send_msg_with_channel)}))
+    scan = mod.LogPolicyScan(_make_policy())
+
+    ok, result = scan.send_notice(_make_event(scan.policy))
+
+    assert ok is True
+    assert result.get("result") is True
+    assert sender.calls == 3  # 失败2次后第3次成功（revert 掉重试循环则只调用1次、返回 False）
+
+
+def test_send_notice_exhausts_attempts_and_returns_last_failure(monkeypatch):
+    sender = _RecordingSender(fail_times=99)
+    mod = _load_policy_scan(monkeypatch, type("S", (), {"send_msg_with_channel": staticmethod(sender.send_msg_with_channel)}))
+    scan = mod.LogPolicyScan(_make_policy())
+
+    ok, result = scan.send_notice(_make_event(scan.policy))
+
+    assert ok is False
+    assert result.get("result") is False
+    assert sender.calls == 3  # 用尽 NOTICE_SEND_MAX_ATTEMPTS
+
+
+def test_send_notice_without_users_short_circuits(monkeypatch):
+    sender = _RecordingSender(fail_times=0)
+    mod = _load_policy_scan(monkeypatch, type("S", (), {"send_msg_with_channel": staticmethod(sender.send_msg_with_channel)}))
+    scan = mod.LogPolicyScan(_make_policy(notice_users=[]))
+
+    ok, result = scan.send_notice(_make_event(scan.policy))
+
+    assert ok is False
+    assert result == []
+    assert sender.calls == 0
+
+
+# ---------- 范围B：compensate_log_notice_task 选取 + 重投 ----------
+
+class _FakeQS:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def filter(self, **kw):
+        res = self.items
+        for k, v in kw.items():
+            if k == "notified":
+                res = [e for e in res if e.notified == v]
+            elif k == "notice_retry_count__lt":
+                res = [e for e in res if e.notice_retry_count < v]
+            elif k == "event_time__gte":
+                res = [e for e in res if e.event_time >= v]
+            elif k == "created_at__lte":
+                res = [e for e in res if e.created_at <= v]
+            elif k == "policy__notice":
+                res = [e for e in res if e.policy.notice == v]
+            elif k == "policy__enable":
+                res = [e for e in res if e.policy.enable == v]
+            else:
+                raise AssertionError(f"未预期的 filter 条件: {k}")
+        return _FakeQS(res)
+
+    def exclude(self, **kw):
+        res = self.items
+        for k, v in kw.items():
+            assert k == "level"
+            res = [e for e in res if e.level != v]
+        return _FakeQS(res)
+
+    def select_related(self, *a):
+        return self
+
+    def order_by(self, *a):
+        return _FakeQS(sorted(self.items, key=lambda e: e.event_time))
+
+    def __getitem__(self, sl):
+        return self.items[sl]
+
+
+def _load_compensate_task(monkeypatch, events, sender, bulk_recorder):
+    policy_scan_mod = _load_policy_scan(monkeypatch, type("S", (), {"send_msg_with_channel": staticmethod(sender.send_msg_with_channel)}))
+
+    class FakeEvent:
+        objects = SimpleNamespace(
+            filter=lambda **kw: _FakeQS(events).filter(**kw),
+            bulk_update=lambda objs, fields, batch_size=None: bulk_recorder.setdefault("event", []).append((list(objs), list(fields))),
+        )
+
+    class FakeAlert:
+        def __init__(self, id=None, notice=None):
+            self.id = id
+            self.notice = notice
+
+        objects = SimpleNamespace(
+            bulk_update=lambda objs, fields, batch_size=None: bulk_recorder.setdefault("alert", []).append((list(objs), list(fields))),
+        )
+
+    _install_module(monkeypatch, "celery", shared_task=lambda *a, **k: (lambda f: f), Singleton=object)
+    _install_module(monkeypatch, "celery_singleton", Singleton=object)
+    _install_module(monkeypatch, "apps.log.models.policy", Alert=FakeAlert, Event=FakeEvent, Policy=object)
+    _install_module(monkeypatch, "apps.log.tasks.services.policy_scan", LogPolicyScan=policy_scan_mod.LogPolicyScan)
+    _install_module(monkeypatch, "apps.log.tasks.utils.policy", period_to_seconds=lambda p: 300)
+
+    module_path = SERVER_DIR / "apps" / "log" / "tasks" / "policy.py"
+    spec = importlib.util.spec_from_file_location("log_policy_tasks_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, FakeAlert
+
+
+def test_compensate_resends_failed_event_and_marks_notified(monkeypatch):
+    sender = _RecordingSender(fail_times=0)  # 补偿时通道已恢复
+    policy = _make_policy()
+    failed = _make_event(policy, id="evt-fail", notified=False, notice_retry_count=1, event_time=datetime.now(timezone.utc))
+    bulk = {}
+    mod, _ = _load_compensate_task(monkeypatch, [failed], sender, bulk)
+
+    result = mod.compensate_log_notice_task()
+
+    assert result["compensated"] == 1
+    assert failed.notified is True
+    assert failed.notice_retry_count == 2
+    assert sender.calls == 1
+    assert "event" in bulk and "alert" in bulk  # 事件 + 告警通知状态都被回写
+
+
+def test_compensate_skips_settled_info_and_exhausted_events(monkeypatch):
+    sender = _RecordingSender(fail_times=0)
+    policy = _make_policy()
+    now = datetime.now(timezone.utc)
+    candidates = [
+        _make_event(policy, id="ok", notified=True, event_time=now),  # 已成功
+        _make_event(policy, id="info", level="info", notified=False, event_time=now),  # info 不通知
+        _make_event(policy, id="exhausted", notified=False, notice_retry_count=5, event_time=now),  # 超重投上限
+        _make_event(policy, id="stale", notified=False, event_time=now - timedelta(days=2)),  # 超出补偿时间窗
+        _make_event(policy, id="fresh", notified=False, event_time=now, created_at=now),  # 刚落库，未过 MIN_AGE，防与首发并发双投
+        _make_event(policy, id="target", notified=False, event_time=now),  # 唯一应被补偿（created_at 默认久远）
+    ]
+    bulk = {}
+    mod, _ = _load_compensate_task(monkeypatch, candidates, sender, bulk)
+
+    result = mod.compensate_log_notice_task()
+
+    assert sender.calls == 1  # 只对 target 发了一次
+    assert result["scanned"] == 1
+
+
+def test_compensate_marks_no_user_event_settled_without_sending(monkeypatch):
+    sender = _RecordingSender(fail_times=0)
+    policy = _make_policy(notice_users=[])  # 无通知人
+    evt = _make_event(policy, id="no-user", notified=False, event_time=datetime.now(timezone.utc))
+    bulk = {}
+    mod, _ = _load_compensate_task(monkeypatch, [evt], sender, bulk)
+
+    result = mod.compensate_log_notice_task()
+
+    assert sender.calls == 0
+    assert evt.notified is True  # 直接收敛，避免无意义重投占配额
+    assert result["compensated"] == 0

--- a/server/apps/log/tests/test_notice_compensation.py
+++ b/server/apps/log/tests/test_notice_compensation.py
@@ -35,6 +35,7 @@ def _fake_alert_constants():
         NOTICE_COMPENSATE_MAX_RETRY=5,
         NOTICE_COMPENSATE_WINDOW_SECONDS=24 * 3600,
         NOTICE_COMPENSATE_BATCH_SIZE=200,
+        NOTICE_COMPENSATE_MIN_AGE_SECONDS=60,  # fresh 用例依赖 age 门槛过滤刚落库事件
     )
 
 


### PR DESCRIPTION
## 被破坏的不变量

日志告警通知应保证**「达到通知级别的事件至少送达一次」**。当前实现把这条不变量退化成了「至多一次，且首发失败即零次」。

## 根因（设计层）

通知链路是 fire-and-forget：

- `send_notice()` 发送失败只返回失败结果，`notice()` 把失败结果写回 `Event.notice_result` 后即结束，**没有重试、没有待发送状态、没有补偿队列**；
- `run()` 只消费「本轮扫描刚创建的事件」，**不存在任何回扫历史 `notice_result=失败` 事件的路径**。

于是一旦首轮发送碰上瞬时通道故障（通道抖动 / 限流 / 短时不可用），而后续扫描窗口又不再产生新事件，这条告警就**永久漏通知**——失败被「记录」了，却从未被「收敛」。这不是某一行写错，而是通知链路缺少「送达状态机 + 兜底闭环」这一层设计。

## 修复如何恢复不变量

引入事件级送达状态（`Event.notified` / `notice_retry_count`）+ 两层防线，把「至少一次」重新焊死：

- **范围A 内联重试**：`send_notice` 遇瞬时故障按 `NOTICE_SEND_MAX_ATTEMPTS`（默认3）重试 + 线性退避，吸收亚秒级抖动。
- **范围B 持久化补偿**：新增 `compensate_log_notice_task`（beat 每5分钟）回扫近 `NOTICE_COMPENSATE_WINDOW_SECONDS`（默认24h）内 `notified=False` 且重投未超限的事件单次重投，吸收通道宕机数分钟 / 进程重启的场景。补偿成功即翻 `notified=True` 并回写 `Alert.notice`。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（每周期扫描）"]
        T1["LogPolicyScan.run()\ntasks/services/policy_scan.py"]
    end
    BU["create_events() 落库\nEvent.notified=False"]
    subgraph N["首发层"]
        F1["notice(event_objs)"]
        F2["send_notice() 内联重试 N 次"]
    end
    subgraph C["补偿层（beat 每5分钟）"]
        C1["compensate_log_notice_task\ntasks/policy.py"]
        C2["回扫 notified=False·未超限·已过MIN_AGE 事件"]
        C3["send_notice(max_attempts=1) 单次重投"]
    end
    T1 --> BU --> F1 --> F2
    F2 -- "成功" --> OK["notified=True\nAlert.notice=True"]
    F2 -. "失败/异常" .-> KEEP["notified=False 留待补偿"]
    KEEP -.-> C1 --> C2 --> C3
    C3 -- "成功" --> OK
    C3 -. "再失败且未超限" .-> KEEP
```

## blast radius · 一致性

- **触及面**：仅 `apps/log` 模块。Event 加 2 字段 + 迁移 `0016`；新增 1 个 beat 周期任务（沿用仓库既有的 `apps/<app>/config.py` → `config/components/celery.py` 自动合并机制）。
- **向后兼容**：迁移把**存量事件统一标记 `notified=True`**（历史不追溯），避免补偿任务上线瞬间对历史失败事件发起重发风暴；新机制只对上线后产生的事件生效。
- **并发安全**：补偿仅取 `created_at` 已超 `NOTICE_COMPENSATE_MIN_AGE_SECONDS`（默认60s）的事件，确保同周期的首发 `notice()` 已完成，杜绝与首发并发双投；补偿用 `Singleton` 防自身并发，且单次发送不在 worker 内叠加 sleep。
- **可控性**：批量上限 / 时间窗 / 重投上限三重边界 + 无通知人事件直接收敛，5 个阈值均 `os.getenv` 可配（保守默认），上线后可按实际通道数调。
- **同源待跟进**：`monitor` 的 `AlertLifecycleNotifier`（`apps/monitor/services/alert_lifecycle_notify.py`）失败时同样只落 `notice_logs`、无重试/补偿，是**同一缺口**；本次按 issue 范围只修 log，建议对 monitor 单独立项用同样范式补齐。

## 验证

注入式单测（`apps/log/tests/test_notice_compensation.py`，沿用本目录既有的 sys.modules 伪依赖 + importlib 加载机制，规避 license_mgmt 缺失致 settings 加载失败）：

- 内联重试：失败2次→第3次成功（call==3）/ 用尽3次→失败 / 无通知人→不发；
- 补偿任务：失败事件重发→`notified=True`、回写 Alert / 已成功·info·超重投·超时间窗·未过MIN_AGE 五类全部正确跳过 / 无通知人事件直接收敛。

**revert-fail 准则**：移除重试循环 → 重试用例 call 退化为1、断言失败；移除任一补偿过滤条件 → 跳过用例的 `_FakeQS` 对未预期 filter 抛错或选取集合变化而失败。
