### PR TITLE
bugfix: 日志活跃告警持续命中不再每个扫描周期重复通知

### DIFF
--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -930,6 +930,9 @@ class LogPolicyScan:
                 # 告警已成功通知过且未发生级别变化时不重复通知，避免持续命中导致每个扫描周期重复发送
                 if event.alert.notice:
                     event.notice_result = [{"result": True, "message": "skipped: alert already notified"}]
+                    # 去重跳过视为已结清：必须置 notified=True，否则补偿任务会把
+                    # 这些事件当作发送失败反复重投，去重就失效了（与 #3312 的语义对齐）
+                    event.notified = True
                     continue
                 is_notice, notice_result = self.send_notice(event)
                 event.notice_result = notice_result

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -645,6 +645,9 @@ class LogPolicyScan:
                 if source_id in existing_alerts:
                     # 存在活跃告警，准备更新
                     alert_obj = existing_alerts[source_id]
+                    if alert_obj.level != event["level"]:
+                        # 级别变化属于显著变化，重置已通知标记以重新通知
+                        alert_obj.notice = False
                     alert_obj.value = event.get("value", alert_obj.value)
                     alert_obj.content = event["content"]
                     alert_obj.level = event["level"]
@@ -698,7 +701,7 @@ class LogPolicyScan:
             if alerts_to_update:
                 Alert.objects.bulk_update(
                     alerts_to_update,
-                    ["value", "content", "level", "end_event_time"],
+                    ["value", "content", "level", "end_event_time", "notice"],
                     batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
                 )
                 logger.debug(f"Updated {len(alerts_to_update)} existing alerts for policy {self.policy.id}")
@@ -924,6 +927,10 @@ class LogPolicyScan:
                 # info级别事件不通知
                 if event.level == "info":
                     continue
+                # 告警已成功通知过且未发生级别变化时不重复通知，避免持续命中导致每个扫描周期重复发送
+                if event.alert.notice:
+                    event.notice_result = [{"result": True, "message": "skipped: alert already notified"}]
+                    continue
                 is_notice, notice_result = self.send_notice(event)
                 event.notice_result = notice_result
                 # 记录发送是否成功 + 累计尝试次数，供补偿任务（范围B）回扫 notified=False 的失败事件
@@ -931,6 +938,7 @@ class LogPolicyScan:
                 event.notice_retry_count = (event.notice_retry_count or 0) + 1
 
                 if is_notice:
+                    event.alert.notice = True
                     alerts.append((event.alert_id, is_notice))
 
             # 批量更新通知结果

--- a/server/apps/log/tests/test_policy_scan_notice_dedup.py
+++ b/server/apps/log/tests/test_policy_scan_notice_dedup.py
@@ -1,0 +1,226 @@
+"""Issue #2827: 活跃告警持续命中时不应每个扫描周期重复通知。
+
+验证点（revert 修复后以下用例必须失败）：
+1. 已成功通知且级别未变的活跃告警，后续周期不再发送通知；
+2. 首次触发正常发送并回写 Alert.notice=True；
+3. 级别变化重置 Alert.notice，重新放开通知；
+4. 发送失败时 Alert.notice 保持 False，下个周期重试。
+"""
+
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class FakeAlert:
+    objects = None  # 由测试注入 FakeManager
+
+    def __init__(self, **kwargs):
+        kwargs.setdefault("notice", False)
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class FakeEvent:
+    objects = None  # 由测试注入 FakeManager
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        alert = kwargs.get("alert")
+        self.alert_id = getattr(alert, "id", None)
+
+
+class FakeManager:
+    def __init__(self, filter_result=None):
+        self.filter_result = list(filter_result or [])
+        self.bulk_create_calls = []
+        self.bulk_update_calls = []
+
+    def filter(self, **kwargs):
+        return list(self.filter_result)
+
+    def bulk_create(self, objs, batch_size=None):
+        self.bulk_create_calls.append(list(objs))
+        return list(objs)
+
+    def bulk_update(self, objs, fields, batch_size=None):
+        self.bulk_update_calls.append((list(objs), list(fields)))
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_policy_scan_module(monkeypatch):
+    _install_module(monkeypatch, "django", db=types.SimpleNamespace(transaction=types.SimpleNamespace()))
+    _install_module(monkeypatch, "django.db", transaction=types.SimpleNamespace())
+
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(
+        monkeypatch,
+        "apps.log.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(STATUS_NEW="new", STATUS_CLOSED="closed"),
+    )
+    _install_module(monkeypatch, "apps.log.constants.database", DatabaseConstants=types.SimpleNamespace(DEFAULT_BATCH_SIZE=100))
+    _install_module(monkeypatch, "apps.log.constants.web", WebConstants=types.SimpleNamespace())
+    _install_module(
+        monkeypatch,
+        "apps.log.models.policy",
+        Alert=FakeAlert,
+        Event=FakeEvent,
+        EventRawData=object,
+        AlertSnapshot=object,
+    )
+    _install_module(monkeypatch, "apps.log.tasks.utils.policy", period_to_seconds=lambda period: 300)
+    _install_module(monkeypatch, "apps.log.utils.query_log", VictoriaMetricsAPI=lambda: None)
+    _install_module(
+        monkeypatch,
+        "apps.log.utils.log_group",
+        LogGroupQueryBuilder=types.SimpleNamespace(build_query_with_groups=lambda query, groups: (query, [])),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.system_mgmt_api", SystemMgmtUtils=object)
+    _install_module(
+        monkeypatch,
+        "apps.core.logger",
+        celery_logger=types.SimpleNamespace(
+            warning=lambda *args, **kwargs: None,
+            error=lambda *args, **kwargs: None,
+            info=lambda *args, **kwargs: None,
+            debug=lambda *args, **kwargs: None,
+        ),
+    )
+
+    module_path = Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan.py"
+    spec = importlib.util.spec_from_file_location("policy_scan_notice_dedup_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_policy():
+    return SimpleNamespace(
+        id=1,
+        notice=True,
+        notice_users=["user1"],
+        notice_type_id=1,
+        collect_type="collect-type",
+        last_run_time=datetime(2026, 6, 11, 10, 0, tzinfo=timezone.utc),
+        period={"type": "min", "value": 1},
+    )
+
+
+def _build_scan(module, monkeypatch, existing_alerts=None):
+    alert_manager = FakeManager(filter_result=existing_alerts)
+    event_manager = FakeManager()
+    monkeypatch.setattr(module.Alert, "objects", alert_manager, raising=False)
+    monkeypatch.setattr(module.Event, "objects", event_manager, raising=False)
+
+    scan = module.LogPolicyScan(_build_policy(), scan_time=datetime(2026, 6, 11, 10, 1, tzinfo=timezone.utc))
+    monkeypatch.setattr(scan, "_create_snapshots_for_alerts", lambda *args, **kwargs: None)
+    return scan, alert_manager, event_manager
+
+
+def _event_payload(level="warning"):
+    return {
+        "source_id": "policy_1_host-a",
+        "level": level,
+        "content": "error count exceeded",
+        "value": 10,
+    }
+
+
+def _patch_send(scan, monkeypatch, success=True):
+    calls = []
+
+    def fake_send(event_obj):
+        calls.append(event_obj)
+        return success, [{"result": success}]
+
+    monkeypatch.setattr(scan, "send_notice", fake_send)
+    return calls
+
+
+def test_first_trigger_sends_and_marks_alert_notified(monkeypatch):
+    module = _load_policy_scan_module(monkeypatch)
+    scan, alert_manager, _ = _build_scan(module, monkeypatch, existing_alerts=[])
+    calls = _patch_send(scan, monkeypatch, success=True)
+
+    event_objs = scan.create_events([_event_payload()])
+    scan.notice(event_objs)
+
+    assert len(calls) == 1
+    assert event_objs[0].alert.notice is True
+    # Alert.notice=True 已批量回写
+    notice_updates = [c for c in alert_manager.bulk_update_calls if "notice" in c[1]]
+    assert notice_updates
+
+
+def test_continued_hit_same_level_skips_renotice(monkeypatch):
+    module = _load_policy_scan_module(monkeypatch)
+    notified_alert = FakeAlert(
+        id="alert-1",
+        source_id="policy_1_host-a",
+        created_at=datetime(2026, 6, 11, 9, 0, tzinfo=timezone.utc),
+        level="warning",
+        value=5,
+        content="old",
+        notice=True,
+    )
+    scan, _, _ = _build_scan(module, monkeypatch, existing_alerts=[notified_alert])
+    calls = _patch_send(scan, monkeypatch, success=True)
+
+    event_objs = scan.create_events([_event_payload(level="warning")])
+    scan.notice(event_objs)
+
+    # 同一活跃告警持续命中且级别未变：不得重复发送
+    assert calls == []
+
+
+def test_level_change_resets_notice_and_renotifies(monkeypatch):
+    module = _load_policy_scan_module(monkeypatch)
+    notified_alert = FakeAlert(
+        id="alert-1",
+        source_id="policy_1_host-a",
+        created_at=datetime(2026, 6, 11, 9, 0, tzinfo=timezone.utc),
+        level="warning",
+        value=5,
+        content="old",
+        notice=True,
+    )
+    scan, alert_manager, _ = _build_scan(module, monkeypatch, existing_alerts=[notified_alert])
+    calls = _patch_send(scan, monkeypatch, success=True)
+
+    event_objs = scan.create_events([_event_payload(level="critical")])
+
+    # 级别变化重置通知标记，且 notice 字段进入批量更新
+    update_calls = [c for c in alert_manager.bulk_update_calls if notified_alert in c[0]]
+    assert update_calls and "notice" in update_calls[0][1]
+
+    scan.notice(event_objs)
+    assert len(calls) == 1
+    assert notified_alert.notice is True
+
+
+def test_failed_send_keeps_alert_unnotified_for_retry(monkeypatch):
+    module = _load_policy_scan_module(monkeypatch)
+    scan, _, _ = _build_scan(module, monkeypatch, existing_alerts=[])
+    calls = _patch_send(scan, monkeypatch, success=False)
+
+    event_objs = scan.create_events([_event_payload()])
+    scan.notice(event_objs)
+
+    assert len(calls) == 1
+    assert event_objs[0].alert.notice is False
+
+    # 下个周期允许重试发送
+    scan.notice(event_objs)
+    assert len(calls) == 2

--- a/server/apps/log/tests/test_policy_scan_notice_dedup.py
+++ b/server/apps/log/tests/test_policy_scan_notice_dedup.py
@@ -28,6 +28,9 @@ class FakeEvent:
     objects = None  # 由测试注入 FakeManager
 
     def __init__(self, **kwargs):
+        # 对齐 Event 模型默认值（#3312 引入），notice() 会读写这两个字段
+        self.notified = False
+        self.notice_retry_count = 0
         for key, value in kwargs.items():
             setattr(self, key, value)
         alert = kwargs.get("alert")
@@ -183,6 +186,8 @@ def test_continued_hit_same_level_skips_renotice(monkeypatch):
 
     # 同一活跃告警持续命中且级别未变：不得重复发送
     assert calls == []
+    # 跳过的事件必须视为已结清（notified=True），否则补偿任务会将其当作发送失败重投
+    assert event_objs[0].notified is True
 
 
 def test_level_change_resets_notice_and_renotifies(monkeypatch):


### PR DESCRIPTION
关联 Issue #2827

## 被破坏的不变量

「一个未恢复的活跃告警，对同一批通知人只通知一次（直到发生显著变化或恢复）」。`Alert` 模型的 `notice` 字段（default=False，"是否已通知"）正是为此存在，但通知链路从未让它参与发送判定——只在发送后回写。结果是通知语义退化为「每个扫描周期发一次」：1 分钟扫描周期下，一次 30 分钟的持续故障会被放大成约 30 条重复通知，直接冲击短信/邮件/Webhook 下游通道，真正的新告警被噪音淹没。

## 根因（设计层）

`notice()` 的发送条件是「本周期产生了 Event」，而持续命中时 `create_events()` 对既有活跃告警仍会新增 Event——两个设计组合后，「事件记录语义」（每次命中留痕，供历史/快照）被错误复用成了「通知触发语义」。`Alert.notice` 字段的存在说明两种语义本应分离，缺的只是发送前的判定。

## 修复如何恢复不变量

让 `Alert.notice` 真正参与发送判定，形成完整状态机：
- `notice()`：发送前检查 `event.alert.notice`，已成功通知的活跃告警跳过（`notice_result` 写入 skipped 标记便于排障）；发送成功同步置内存对象，杜绝同周期同告警重复；
- `create_events()`：活跃告警**级别变化**时重置 `notice=False`（显著变化重新放开通知），`bulk_update` 字段补充 `notice`；
- 发送失败时 `notice` 保持 False → 下个扫描周期自动重试（保留至少送达语义）。

**有意不改**：Event 仍每周期创建（保留命中历史与快照语义），本修复只收敛通知触发。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["scan_log_policy_task\ntasks/policy_scan_task"]
    end

    subgraph N["核心处理层"]
        F1["LogPolicyScan.run()\npolicy_scan.py"]
        F2["create_events()\n级别变化→重置 alert.notice=False"]
        F3["notice()\nalert.notice=True → 跳过重复发送"]
        F4["send_notice()"]
    end

    BU["Alert.bulk_update\n(value/content/level/end_event_time/notice)"]

    T1 --> F1 --> F2 --> BU
    F2 --> F3
    F3 -- "首次触发 / 级别变化 / 上次失败" --> F4
    F3 -. "已通知且无变化：skip" .-> BU2["Event.notice_result\n写 skipped 标记"]
    F4 -- "成功" --> M["alert.notice=True 回写"]
    F4 -. "失败" .-> R["notice 保持 False\n下周期重试"]
```

## blast radius · 一致性

- 仅触及 `apps/log` 单文件 10 行逻辑，无 schema/迁移变更；
- 存量数据天然兼容：master 原逻辑本就在成功后写 `Alert.notice=True`，升级后存量活跃告警不会触发补发风暴；
- `scan_log_policy_task` 带 celery_singleton 按 policy 去重，无同策略并发扫描的覆盖窗口；
- ⚠️ 与 PR #3312（同文件，通知失败补偿链路）存在语义交互：本 PR 去重跳过的事件，在 #3312 的 `notified` 模型下应视为「已结清」。两 PR 后合入方需做一次对齐（已在 #3312 留言说明），建议合并顺序任意但 rebase 时把「去重跳过 → `notified=True`」补上。

## 验证

- 新增 `test_policy_scan_notice_dedup.py` 4 条注入式回归测试：首次触发发送并回写 / 持续命中同级别去重 / 级别变化重新通知 / 失败保持未通知下周期重试；
- revert-fail 实测：撤销修复后 3/4 失败，恢复后 4/4 通过；
- 既有 `test_policy_scan_keyword_grouping.py` 10 条全过，无回归。