### PR TITLE
fix(monitor): URL-encode credentials in DB collector connection templates

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mongodb/mongodb.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mongodb/mongodb.child.toml.j2
@@ -2,7 +2,7 @@
     startup_error_behavior = "retry"
     servers = [
         {% if username %}
-        "mongodb://{{ username }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/?connect=direct"
+        "mongodb://{{ username | urlencode }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/?connect=direct"
         {% else %}
         "mongodb://{{ host }}:{{ port }}/?connect=direct"
         {% endif %}

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/mssql.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/mssql.child.toml.j2
@@ -1,6 +1,6 @@
 [[inputs.sqlserver]]
     startup_error_behavior = "retry"
-    servers = ["sqlserver://{{ username }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}?database={{ database | default('master') }}&app+name=telegraf&encrypt=disable"]
+    servers = ["sqlserver://{{ username | urlencode }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}?database={{ database | default('master') | urlencode }}&app+name=telegraf&encrypt=disable"]
     database_type = "SQLServer"
     exclude_query = ["SQLServerAvailabilityReplicaStates", "SQLServerDatabaseReplicaStates"]
     interval = "{{ interval }}s"

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/postgres.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/postgres.child.toml.j2
@@ -1,6 +1,6 @@
 [[inputs.postgresql]]
     startup_error_behavior = "retry"
-    address = "postgres://{{ username }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/{{ dbname | default('postgres') }}?sslmode=disable"
+    address = "postgres://{{ username | urlencode }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/{{ dbname | default('postgres') | urlencode }}?sslmode=disable"
     ignored_databases = ["template0", "template1"]
     interval = "{{ interval }}s"
     [inputs.postgresql.tags]

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -20,6 +20,7 @@ _DEFAULT_JINJA_ENV = Environment()
 _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "default",
     "lower",
+    "urlencode",
 )
 _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "agents",


### PR DESCRIPTION
URL-encode the username and database name in the URL-form DSN for the postgres/mssql/mongodb collection templates, so reserved characters (`@ : / ? #` etc.) in those fields no longer corrupt the generated connection string. Also enables the `urlencode` Jinja filter in the sandboxed render whitelist.

- `postgres/mssql/mongodb.child.toml.j2`: `{{ username | urlencode }}`, and url-encode the database name where present
- `plugin_controller.py`: add `urlencode` to `_MONITOR_TEMPLATE_ALLOWED_FILTERS`

MySQL is intentionally left unchanged: its go-sql-driver DSN is not URL-format and must not be percent-encoded. Passwords stay as runtime `${PASSWORD__<id>}` placeholders and are not encodable at render time.