### PR TITLE
feat(monitor): add HAProxy monitoring support

### DIFF
--- a/server/apps/monitor/constants/monitor_object.py
+++ b/server/apps/monitor/constants/monitor_object.py
@@ -14,6 +14,7 @@ class MonitorObjConstants:
                 "RabbitMQ",
                 "Nginx",
                 "Apache",
+                "Haproxy",
                 "ClickHouse",
                 "Consul",
                 "Etcd",

--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -2407,6 +2407,106 @@ monitor_object_metric:
       name: Cache Retrieve Hit Count
       desc: Number of successful cache retrievals; high hit rate indicates efficient
         caching and reduced backend load
+  Haproxy:
+    haproxy_scur:
+      name: Current Sessions
+      desc: Number of active sessions currently being processed by this frontend/backend/server, reflecting real-time concurrency
+    haproxy_smax:
+      name: Max Sessions
+      desc: Maximum number of concurrent sessions observed since startup, useful for capacity planning
+    haproxy_slim:
+      name: Session Limit
+      desc: Configured session limit; current sessions approaching this value indicates risk of new connections being rejected
+    haproxy_stot:
+      name: Total Sessions
+      desc: Cumulative number of sessions handled since startup, a monotonically increasing counter measuring overall workload
+    haproxy_rate:
+      name: Session Rate
+      desc: Number of new sessions established per second over the last second, reflecting real-time connection pressure
+    haproxy_rate_max:
+      name: Max Session Rate
+      desc: Highest per-second session establishment rate observed since startup, indicating peak load
+    haproxy_qcur:
+      name: Current Queued Requests
+      desc: Number of requests currently queued waiting for an available backend server; sustained high values indicate backend saturation
+    haproxy_qmax:
+      name: Max Queued Requests
+      desc: Maximum number of queued requests observed since startup, reflecting peak backend pressure
+    haproxy_bin:
+      name: Bytes In
+      desc: Cumulative number of bytes received from clients since startup, measuring inbound traffic volume
+    haproxy_bout:
+      name: Bytes Out
+      desc: Cumulative number of bytes sent to clients since startup, measuring outbound traffic volume
+    haproxy_req_rate:
+      name: HTTP Request Rate
+      desc: Number of HTTP requests received per second over the last second, reflecting real-time request throughput
+    haproxy_req_rate_max:
+      name: Max HTTP Request Rate
+      desc: Highest per-second HTTP request rate observed since startup, indicating peak request pressure
+    haproxy_req_tot:
+      name: Total HTTP Requests
+      desc: Cumulative number of HTTP requests received since startup, a counter measuring overall request workload
+    haproxy_hrsp_2xx:
+      name: 2xx Responses
+      desc: Cumulative number of HTTP 2xx (success) responses returned, reflecting normally served requests
+    haproxy_hrsp_3xx:
+      name: 3xx Responses
+      desc: Cumulative number of HTTP 3xx (redirect) responses returned
+    haproxy_hrsp_4xx:
+      name: 4xx Responses
+      desc: Cumulative number of HTTP 4xx (client error) responses returned; sustained growth may indicate client or auth issues
+    haproxy_hrsp_5xx:
+      name: 5xx Responses
+      desc: Cumulative number of HTTP 5xx (server error) responses returned; growth usually indicates backend service faults
+    haproxy_ereq:
+      name: Request Errors
+      desc: Cumulative number of request errors (e.g. invalid requests, client timeouts before request) since startup
+    haproxy_econ:
+      name: Connection Errors
+      desc: Cumulative number of errors connecting to backend servers since startup; growth indicates backend connectivity problems
+    haproxy_eresp:
+      name: Response Errors
+      desc: Cumulative number of response errors from backend servers since startup, including aborts and bad responses
+    haproxy_dreq:
+      name: Denied Requests
+      desc: Cumulative number of requests denied by security ACL rules since startup
+    haproxy_dresp:
+      name: Denied Responses
+      desc: Cumulative number of responses denied by security ACL rules since startup
+    haproxy_wretr:
+      name: Connection Retries
+      desc: Cumulative number of times a connection to a backend server was retried since startup; high values indicate backend instability
+    haproxy_wredis:
+      name: Request Redispatches
+      desc: Cumulative number of times a request was redispatched to another backend server since startup
+    haproxy_act:
+      name: Active Servers
+      desc: Number of active (non-backup) servers currently up in this backend, reflecting available serving capacity
+    haproxy_bck:
+      name: Backup Servers
+      desc: Number of backup servers currently up in this backend, available for failover
+    haproxy_chkfail:
+      name: Failed Health Checks
+      desc: Cumulative number of failed health checks since startup; growth indicates an unstable or failing server
+    haproxy_chkdown:
+      name: Down Transitions
+      desc: Cumulative number of UP-to-DOWN transitions since startup, reflecting how often the server became unavailable
+    haproxy_downtime:
+      name: Total Downtime
+      desc: Cumulative total downtime in seconds since startup, reflecting accumulated unavailability of the server
+    haproxy_qtime:
+      name: Average Queue Time
+      desc: Average time in milliseconds spent in the queue waiting for a free server, computed over the last 1024 requests
+    haproxy_ctime:
+      name: Average Connect Time
+      desc: Average time in milliseconds to establish a connection to the backend server, computed over the last 1024 requests
+    haproxy_rtime:
+      name: Average Response Time
+      desc: Average backend response time in milliseconds, computed over the last 1024 requests; high values indicate slow backends
+    haproxy_ttime:
+      name: Average Total Time
+      desc: Average total session time in milliseconds end to end, computed over the last 1024 requests
   Node:
     node_status_condition:
       name: Node Status
@@ -3071,6 +3171,15 @@ monitor_object_metric_group:
     State: State
     Cache: Cache
     Process: Process
+  Haproxy:
+    Session: Session
+    Queue: Queue
+    Traffic: Traffic
+    Request: Request
+    Response: Response
+    Error: Error
+    Server: Server
+    Latency: Latency
   Postgres:
     Connection: Connection
     Query: Query
@@ -3498,6 +3607,9 @@ monitor_object_plugin:
     name: Apache(Telegraf)
     desc: Through the Telegraf collector, regularly collect Apache metrics including
       uptime, resource utilization, request processing efficiency, and bandwidth usage.
+  Haproxy:
+    name: Haproxy(Telegraf)
+    desc: Based on the Telegraf haproxy input, periodically collects HAProxy frontend, backend, and server runtime data including sessions, queues, traffic, HTTP responses, errors, server health, and latency.
   Hardware Server IPMI:
     name: Physical Server IPMI General(Telegraf)
     desc: Through the Telegraf collector, utilize the IPMI protocol to regularly collect
@@ -3573,6 +3685,7 @@ monitor_object_plugin:
 monitor_object:
   Dameng: Dameng Database
   Apache: Apache
+  Haproxy: Haproxy
   Firewall: Firewall
   Docker: Docker
   Scanning Device: Scanning Device

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -2065,6 +2065,106 @@ monitor_object_metric:
     apache_CacheRetrieveHitCount:
       name: 缓存命中次数
       desc: 缓存检索中成功命中的次数，高命中率表明缓存效率良好，减轻了后端负载
+  Haproxy:
+    haproxy_scur:
+      name: 当前会话数
+      desc: 该前端/后端/服务器当前正在处理的活跃会话数，反映实时并发量
+    haproxy_smax:
+      name: 最大会话数
+      desc: 启动以来观测到的最大并发会话数，可用于容量规划
+    haproxy_slim:
+      name: 会话上限
+      desc: 配置的会话上限；当前会话接近该值时存在拒绝新连接的风险
+    haproxy_stot:
+      name: 累计会话数
+      desc: 启动以来累计处理的会话总数，单调递增计数器，衡量总体负载
+    haproxy_rate:
+      name: 会话建立速率
+      desc: 最近1秒内每秒新建会话数，反映实时连接压力
+    haproxy_rate_max:
+      name: 最大会话速率
+      desc: 启动以来观测到的每秒最大会话建立速率，反映峰值负载
+    haproxy_qcur:
+      name: 当前排队请求数
+      desc: 当前等待空闲后端服务器的排队请求数，持续偏高表明后端饱和
+    haproxy_qmax:
+      name: 最大排队请求数
+      desc: 启动以来观测到的最大排队请求数，反映后端峰值压力
+    haproxy_bin:
+      name: 入站字节数
+      desc: 启动以来从客户端接收的累计字节数，衡量入站流量
+    haproxy_bout:
+      name: 出站字节数
+      desc: 启动以来发送给客户端的累计字节数，衡量出站流量
+    haproxy_req_rate:
+      name: HTTP请求速率
+      desc: 最近1秒内每秒接收的HTTP请求数，反映实时请求吞吐
+    haproxy_req_rate_max:
+      name: 最大HTTP请求速率
+      desc: 启动以来观测到的每秒最大HTTP请求速率，反映峰值请求压力
+    haproxy_req_tot:
+      name: 累计HTTP请求数
+      desc: 启动以来累计接收的HTTP请求总数，计数器，衡量总体请求负载
+    haproxy_hrsp_2xx:
+      name: 2xx响应数
+      desc: 累计返回的HTTP 2xx（成功）响应数，反映正常处理的请求
+    haproxy_hrsp_3xx:
+      name: 3xx响应数
+      desc: 累计返回的HTTP 3xx（重定向）响应数
+    haproxy_hrsp_4xx:
+      name: 4xx响应数
+      desc: 累计返回的HTTP 4xx（客户端错误）响应数，持续增长可能表明客户端或鉴权问题
+    haproxy_hrsp_5xx:
+      name: 5xx响应数
+      desc: 累计返回的HTTP 5xx（服务端错误）响应数，增长通常表明后端服务故障
+    haproxy_ereq:
+      name: 请求错误数
+      desc: 启动以来累计的请求错误数（如非法请求、请求前客户端超时）
+    haproxy_econ:
+      name: 连接错误数
+      desc: 启动以来连接后端服务器的累计错误数，增长表明后端连通性问题
+    haproxy_eresp:
+      name: 响应错误数
+      desc: 启动以来后端响应的累计错误数，包含中断和异常响应
+    haproxy_dreq:
+      name: 拒绝请求数
+      desc: 启动以来被安全ACL规则拒绝的累计请求数
+    haproxy_dresp:
+      name: 拒绝响应数
+      desc: 启动以来被安全ACL规则拒绝的累计响应数
+    haproxy_wretr:
+      name: 连接重试数
+      desc: 启动以来连接后端服务器的累计重试次数，偏高表明后端不稳定
+    haproxy_wredis:
+      name: 请求重分发数
+      desc: 启动以来请求被重新分发到其他后端服务器的累计次数
+    haproxy_act:
+      name: 活跃服务器数
+      desc: 该后端中当前在线的活跃（非备份）服务器数量，反映可用服务能力
+    haproxy_bck:
+      name: 备份服务器数
+      desc: 该后端中当前在线的备份服务器数量，用于故障切换
+    haproxy_chkfail:
+      name: 健康检查失败数
+      desc: 启动以来累计的健康检查失败次数，增长表明服务器不稳定或故障
+    haproxy_chkdown:
+      name: 下线切换次数
+      desc: 启动以来UP到DOWN的累计切换次数，反映服务器变为不可用的频率
+    haproxy_downtime:
+      name: 累计停机时长
+      desc: 启动以来累计的停机秒数，反映服务器累计不可用时长
+    haproxy_qtime:
+      name: 平均排队时间
+      desc: 最近1024个请求的平均排队等待时间（毫秒）
+    haproxy_ctime:
+      name: 平均连接时间
+      desc: 最近1024个请求建立后端连接的平均时间（毫秒）
+    haproxy_rtime:
+      name: 平均响应时间
+      desc: 最近1024个请求的后端平均响应时间（毫秒），偏高表明后端缓慢
+    haproxy_ttime:
+      name: 平均总时间
+      desc: 最近1024个请求端到端的平均会话总时间（毫秒）
   Node:
     node_status_condition:
       name: Node状态
@@ -2729,6 +2829,15 @@ monitor_object_metric_group:
     State: 状态
     Cache: 缓存
     Process: 进程
+  Haproxy:
+    Session: 会话
+    Queue: 队列
+    Traffic: 流量
+    Request: 请求
+    Response: 响应
+    Error: 错误
+    Server: 服务器
+    Latency: 延迟
   Postgres:
     Connection: 连接
     Query: 查询
@@ -3098,6 +3207,9 @@ monitor_object_plugin:
   Apache:
     name: Apache（Telegraf）
     desc: 通过Telegraf采集器定期收集Apache的运行时间、资源使用情况、请求处理效率及带宽数据。
+  Haproxy:
+    name: Haproxy（Telegraf）
+    desc: 基于Telegraf的haproxy采集器，定期采集HAProxy前端、后端及服务器的会话、队列、流量、HTTP响应、错误、服务器健康与延迟等运行数据。
   Hardware Server IPMI:
     name: 硬件服务器IPMI通用（Telegraf）
     desc: 通过Telegraf采集器利用IPMI协议定期收集硬件服务器的电源状态、风扇转速、温度等关键指标。
@@ -3149,6 +3261,7 @@ monitor_object_plugin:
 monitor_object:
   Dameng: 达梦数据库
   Apache: Apache
+  Haproxy: HAProxy
   Firewall: 防火墙
   Docker: Docker
   Scanning Device: 扫描设备

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/UI.json
@@ -1,0 +1,132 @@
+{
+  "object_name": "Haproxy",
+  "instance_type": "haproxy",
+  "collect_type": "middleware",
+  "config_type": ["haproxy"],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{url}}",
+  "form_fields": [
+    {
+      "name": "monitor_url",
+      "label": "Stats 地址",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "HAProxy stats 页地址（不含账密），Telegraf 采集时自动追加 ;csv",
+      "widget_props": {
+        "placeholder": "http://10.0.0.5:1024/haproxy?stats"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.servers[0]"
+      }
+    },
+    {
+      "name": "username",
+      "label": "用户名",
+      "type": "input",
+      "required": false,
+      "editable": false,
+      "description": "stats 页 basic-auth 用户名（未开启认证则留空）",
+      "widget_props": {
+        "placeholder": "用户名（可选）"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.servers[0]",
+        "to_form": {
+          "regex": "://([^:/@]+):[^@]*@"
+        }
+      }
+    },
+    {
+      "name": "ENV_PASSWORD",
+      "label": "密码",
+      "type": "password",
+      "required": false,
+      "editable": false,
+      "description": "stats 页 basic-auth 密码（未开启认证则留空）",
+      "widget_props": {
+        "placeholder": "密码（可选）"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PASSWORD__{{config_id}}"
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "enable_row_filter": false
+    },
+    {
+      "name": "url",
+      "label": "Stats 地址",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "http://10.0.0.5:1024/haproxy?stats"
+      },
+      "rules": [
+        {
+          "type": "pattern",
+          "pattern": "^(http|https)://.*",
+          "message": "地址需以 http:// 或 https:// 开头",
+          "excel_formula": "OR(LEFT({{CELL}},7)=\"http://\",LEFT({{CELL}},8)=\"https://\")"
+        }
+      ],
+      "change_handler": {
+        "type": "simple",
+        "source_fields": ["url"],
+        "target_field": "instance_name"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": false,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/haproxy.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/haproxy.child.toml.j2
@@ -1,0 +1,10 @@
+[[inputs.haproxy]]
+    startup_error_behavior = "retry"
+    servers = ["{% if username %}{{ url | replace('://', '://' ~ (username | urlencode) ~ ':${PASSWORD__' ~ config_id ~ '}@', 1) }}{% else %}{{ url }}{% endif %}"]
+    keep_field_names = true
+    interval = "{{ interval }}s"
+    [inputs.haproxy.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "middleware"
+        config_type = "haproxy"

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/metrics.json
@@ -1,0 +1,778 @@
+{
+  "plugin": "Haproxy",
+  "plugin_desc": "Real-time collection of HAProxy frontend, backend, and server runtime data based on the Telegraf haproxy input, including sessions, queues, traffic, HTTP responses, errors, server health, and latency, helping users diagnose load-balancing performance and availability issues.",
+  "status_query": "any({instance_type='haproxy', collect_type='middleware'}) by (instance_id)",
+  "name": "Haproxy",
+  "icon": "mm-middleware_中间件",
+  "type": "Middleware",
+  "description": "",
+  "default_metric": "any({instance_type='haproxy'}) by (instance_id)",
+  "instance_id_keys": [
+    "instance_id"
+  ],
+  "supplementary_indicators": [
+    "haproxy_scur",
+    "haproxy_rtime",
+    "haproxy_hrsp_5xx"
+  ],
+  "display_fields": [
+    {
+      "name": "Current Sessions",
+      "sort_order": 0,
+      "metrics": [
+        {
+          "plugin": "Haproxy",
+          "metric": "haproxy_scur"
+        }
+      ]
+    },
+    {
+      "name": "Average Response Time",
+      "sort_order": 1,
+      "metrics": [
+        {
+          "plugin": "Haproxy",
+          "metric": "haproxy_rtime"
+        }
+      ]
+    },
+    {
+      "name": "5xx Responses",
+      "sort_order": 2,
+      "metrics": [
+        {
+          "plugin": "Haproxy",
+          "metric": "haproxy_hrsp_5xx"
+        }
+      ]
+    }
+  ],
+  "metrics": [
+    {
+      "metric_group": "Session",
+      "name": "haproxy_scur",
+      "display_name": "Current Sessions",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of active sessions currently being processed by this frontend/backend/server, reflecting real-time concurrency",
+      "query": "haproxy_scur{__$labels__}"
+    },
+    {
+      "metric_group": "Session",
+      "name": "haproxy_smax",
+      "display_name": "Max Sessions",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Maximum number of concurrent sessions observed since startup, useful for capacity planning",
+      "query": "haproxy_smax{__$labels__}"
+    },
+    {
+      "metric_group": "Session",
+      "name": "haproxy_slim",
+      "display_name": "Session Limit",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Configured session limit; current sessions approaching this value indicates risk of new connections being rejected",
+      "query": "haproxy_slim{__$labels__}"
+    },
+    {
+      "metric_group": "Session",
+      "name": "haproxy_stot",
+      "display_name": "Total Sessions",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of sessions handled since startup, a monotonically increasing counter measuring overall workload",
+      "query": "haproxy_stot{__$labels__}"
+    },
+    {
+      "metric_group": "Session",
+      "name": "haproxy_rate",
+      "display_name": "Session Rate",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of new sessions established per second over the last second, reflecting real-time connection pressure",
+      "query": "haproxy_rate{__$labels__}"
+    },
+    {
+      "metric_group": "Session",
+      "name": "haproxy_rate_max",
+      "display_name": "Max Session Rate",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Highest per-second session establishment rate observed since startup, indicating peak load",
+      "query": "haproxy_rate_max{__$labels__}"
+    },
+    {
+      "metric_group": "Queue",
+      "name": "haproxy_qcur",
+      "display_name": "Current Queued Requests",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of requests currently queued waiting for an available backend server; sustained high values indicate backend saturation",
+      "query": "haproxy_qcur{__$labels__}"
+    },
+    {
+      "metric_group": "Queue",
+      "name": "haproxy_qmax",
+      "display_name": "Max Queued Requests",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Maximum number of queued requests observed since startup, reflecting peak backend pressure",
+      "query": "haproxy_qmax{__$labels__}"
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "haproxy_bin",
+      "display_name": "Bytes In",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of bytes received from clients since startup, measuring inbound traffic volume",
+      "query": "haproxy_bin{__$labels__}"
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "haproxy_bout",
+      "display_name": "Bytes Out",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of bytes sent to clients since startup, measuring outbound traffic volume",
+      "query": "haproxy_bout{__$labels__}"
+    },
+    {
+      "metric_group": "Request",
+      "name": "haproxy_req_rate",
+      "display_name": "HTTP Request Rate",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of HTTP requests received per second over the last second, reflecting real-time request throughput",
+      "query": "haproxy_req_rate{__$labels__}"
+    },
+    {
+      "metric_group": "Request",
+      "name": "haproxy_req_rate_max",
+      "display_name": "Max HTTP Request Rate",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Highest per-second HTTP request rate observed since startup, indicating peak request pressure",
+      "query": "haproxy_req_rate_max{__$labels__}"
+    },
+    {
+      "metric_group": "Request",
+      "name": "haproxy_req_tot",
+      "display_name": "Total HTTP Requests",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of HTTP requests received since startup, a counter measuring overall request workload",
+      "query": "haproxy_req_tot{__$labels__}"
+    },
+    {
+      "metric_group": "Response",
+      "name": "haproxy_hrsp_2xx",
+      "display_name": "2xx Responses",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of HTTP 2xx (success) responses returned, reflecting normally served requests",
+      "query": "haproxy_hrsp_2xx{__$labels__}"
+    },
+    {
+      "metric_group": "Response",
+      "name": "haproxy_hrsp_3xx",
+      "display_name": "3xx Responses",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of HTTP 3xx (redirect) responses returned",
+      "query": "haproxy_hrsp_3xx{__$labels__}"
+    },
+    {
+      "metric_group": "Response",
+      "name": "haproxy_hrsp_4xx",
+      "display_name": "4xx Responses",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of HTTP 4xx (client error) responses returned; sustained growth may indicate client or auth issues",
+      "query": "haproxy_hrsp_4xx{__$labels__}"
+    },
+    {
+      "metric_group": "Response",
+      "name": "haproxy_hrsp_5xx",
+      "display_name": "5xx Responses",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of HTTP 5xx (server error) responses returned; growth usually indicates backend service faults",
+      "query": "haproxy_hrsp_5xx{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_ereq",
+      "display_name": "Request Errors",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of request errors (e.g. invalid requests, client timeouts before request) since startup",
+      "query": "haproxy_ereq{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_econ",
+      "display_name": "Connection Errors",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of errors connecting to backend servers since startup; growth indicates backend connectivity problems",
+      "query": "haproxy_econ{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_eresp",
+      "display_name": "Response Errors",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of response errors from backend servers since startup, including aborts and bad responses",
+      "query": "haproxy_eresp{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_dreq",
+      "display_name": "Denied Requests",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of requests denied by security ACL rules since startup",
+      "query": "haproxy_dreq{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_dresp",
+      "display_name": "Denied Responses",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of responses denied by security ACL rules since startup",
+      "query": "haproxy_dresp{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_wretr",
+      "display_name": "Connection Retries",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of times a connection to a backend server was retried since startup; high values indicate backend instability",
+      "query": "haproxy_wretr{__$labels__}"
+    },
+    {
+      "metric_group": "Error",
+      "name": "haproxy_wredis",
+      "display_name": "Request Redispatches",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of times a request was redispatched to another backend server since startup",
+      "query": "haproxy_wredis{__$labels__}"
+    },
+    {
+      "metric_group": "Server",
+      "name": "haproxy_act",
+      "display_name": "Active Servers",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of active (non-backup) servers currently up in this backend, reflecting available serving capacity",
+      "query": "haproxy_act{__$labels__}"
+    },
+    {
+      "metric_group": "Server",
+      "name": "haproxy_bck",
+      "display_name": "Backup Servers",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Number of backup servers currently up in this backend, available for failover",
+      "query": "haproxy_bck{__$labels__}"
+    },
+    {
+      "metric_group": "Server",
+      "name": "haproxy_chkfail",
+      "display_name": "Failed Health Checks",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of failed health checks since startup; growth indicates an unstable or failing server",
+      "query": "haproxy_chkfail{__$labels__}"
+    },
+    {
+      "metric_group": "Server",
+      "name": "haproxy_chkdown",
+      "display_name": "Down Transitions",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative number of UP-to-DOWN transitions since startup, reflecting how often the server became unavailable",
+      "query": "haproxy_chkdown{__$labels__}"
+    },
+    {
+      "metric_group": "Server",
+      "name": "haproxy_downtime",
+      "display_name": "Total Downtime",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "s",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Cumulative total downtime in seconds since startup, reflecting accumulated unavailability of the server",
+      "query": "haproxy_downtime{__$labels__}"
+    },
+    {
+      "metric_group": "Latency",
+      "name": "haproxy_qtime",
+      "display_name": "Average Queue Time",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "ms",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Average time in milliseconds spent in the queue waiting for a free server, computed over the last 1024 requests",
+      "query": "haproxy_qtime{__$labels__}"
+    },
+    {
+      "metric_group": "Latency",
+      "name": "haproxy_ctime",
+      "display_name": "Average Connect Time",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "ms",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Average time in milliseconds to establish a connection to the backend server, computed over the last 1024 requests",
+      "query": "haproxy_ctime{__$labels__}"
+    },
+    {
+      "metric_group": "Latency",
+      "name": "haproxy_rtime",
+      "display_name": "Average Response Time",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "ms",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Average backend response time in milliseconds, computed over the last 1024 requests; high values indicate slow backends",
+      "query": "haproxy_rtime{__$labels__}"
+    },
+    {
+      "metric_group": "Latency",
+      "name": "haproxy_ttime",
+      "display_name": "Average Total Time",
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "data_type": "Number",
+      "unit": "ms",
+      "dimensions": [
+        {
+          "name": "pxname",
+          "description": "代理(前端/后端名)"
+        },
+        {
+          "name": "svname",
+          "description": "服务(FRONTEND/BACKEND/服务器名)"
+        }
+      ],
+      "description": "Average total session time in milliseconds end to end, computed over the last 1024 requests",
+      "query": "haproxy_ttime{__$labels__}"
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/policy.json
@@ -1,0 +1,102 @@
+{
+  "object": "Haproxy",
+  "plugin": "Haproxy",
+  "templates": [
+    {
+      "name": "后端响应延迟过高",
+      "alert_name": "Haproxy实例 ${resource_name} 后端响应延迟",
+      "description": "监控后端平均响应时间，延迟过高会导致用户访问变慢。需检查后端服务性能或网络链路。",
+      "metric_name": "haproxy_rtime",
+      "algorithm": "avg",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 1000,
+          "method": ">="
+        },
+        {
+          "level": "error",
+          "value": 500,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 200,
+          "method": ">="
+        }
+      ]
+    },
+    {
+      "name": "请求排队积压",
+      "alert_name": "Haproxy实例 ${resource_name} 请求排队",
+      "description": "检测等待空闲后端的排队请求数，持续积压表明后端处理能力不足。需扩容后端或排查慢请求。",
+      "metric_name": "haproxy_qcur",
+      "algorithm": "max",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 100,
+          "method": ">="
+        },
+        {
+          "level": "error",
+          "value": 50,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 10,
+          "method": ">="
+        }
+      ]
+    },
+    {
+      "name": "会话数突增",
+      "alert_name": "Haproxy实例 ${resource_name} 会话过载",
+      "description": "监控当前并发会话数，异常增长可能表明流量激增或连接堆积。需关注是否接近会话上限。",
+      "metric_name": "haproxy_scur",
+      "algorithm": "max",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 5000,
+          "method": ">="
+        },
+        {
+          "level": "error",
+          "value": 3000,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 1000,
+          "method": ">="
+        }
+      ]
+    },
+    {
+      "name": "请求速率突增",
+      "alert_name": "Haproxy实例 ${resource_name} 请求过载",
+      "description": "检测每秒HTTP请求数，异常增长可能表明流量激增或CC攻击。需结合错误率与延迟综合研判。",
+      "metric_name": "haproxy_req_rate",
+      "algorithm": "max",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 1000,
+          "method": ">="
+        },
+        {
+          "level": "error",
+          "value": 500,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 200,
+          "method": ">="
+        }
+      ]
+    }
+  ]
+}

--- a/server/apps/monitor/tests/test_haproxy_plugin.py
+++ b/server/apps/monitor/tests/test_haproxy_plugin.py
@@ -1,0 +1,104 @@
+"""Contract tests for the HAProxy monitoring plugin (Telegraf/middleware/haproxy).
+
+Validates internal consistency of the plugin's support files: units are part of
+the product unit system, every metric/group/plugin/object has bilingual
+translations, policy templates reference real metrics, and metrics carry the
+pxname/svname dimensions actually emitted by the Telegraf haproxy input
+(keep_field_names=true keeps the raw HAProxy tag names pxname/svname/type/server,
+NOT the renamed proxy/sv).
+"""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = (
+    SERVER_ROOT
+    / "apps" / "monitor" / "support-files" / "plugins"
+    / "Telegraf" / "middleware" / "haproxy"
+)
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+
+# Units supported by the product unit system (apps/monitor/utils/unit_converter.py).
+SUPPORTED_UNITS = {
+    "byteps", "bytes", "counts", "cps", "d", "gibibytes", "h", "kibibytes",
+    "kibyteps", "m", "mebibytes", "ms", "none", "ns", "pebibytes", "percent", "s",
+}
+EXPECTED_DIMENSIONS = {"pxname", "svname"}
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return json.loads((PLUGIN_DIR / "metrics.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return json.loads((PLUGIN_DIR / "policy.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_all_metric_units_are_supported(metrics):
+    bad = [m["name"] for m in metrics["metrics"] if m["unit"] not in SUPPORTED_UNITS]
+    assert bad == [], f"unsupported units on metrics: {bad}"
+
+
+@pytest.mark.unit
+def test_metrics_carry_pxname_and_svname_dimensions(metrics):
+    missing = [
+        m["name"]
+        for m in metrics["metrics"]
+        if {d["name"] for d in m.get("dimensions", [])} != EXPECTED_DIMENSIONS
+    ]
+    assert missing == [], f"metrics missing pxname/svname dimensions: {missing}"
+
+
+@pytest.mark.unit
+def test_every_metric_has_bilingual_translation(metrics, languages):
+    missing = []
+    for lang, data in languages.items():
+        group = (data.get("monitor_object_metric") or {}).get("Haproxy") or {}
+        for m in metrics["metrics"]:
+            entry = group.get(m["name"]) or {}
+            if not entry.get("name") or not entry.get("desc"):
+                missing.append(f"{lang}:{m['name']}")
+    assert missing == [], f"metrics missing name/desc translation: {missing}"
+
+
+@pytest.mark.unit
+def test_every_metric_group_has_bilingual_translation(metrics, languages):
+    groups = {m["metric_group"] for m in metrics["metrics"]}
+    missing = []
+    for lang, data in languages.items():
+        trans = (data.get("monitor_object_metric_group") or {}).get("Haproxy") or {}
+        missing += [f"{lang}:{g}" for g in groups if not trans.get(g)]
+    assert missing == [], f"metric groups missing translation: {missing}"
+
+
+@pytest.mark.unit
+def test_plugin_and_object_have_bilingual_translation(languages):
+    missing = []
+    for lang, data in languages.items():
+        plugin = (data.get("monitor_object_plugin") or {}).get("Haproxy") or {}
+        if not plugin.get("name") or not plugin.get("desc"):
+            missing.append(f"{lang}:plugin")
+        if not (data.get("monitor_object") or {}).get("Haproxy"):
+            missing.append(f"{lang}:object")
+    assert missing == [], f"missing plugin/object translation: {missing}"
+
+
+@pytest.mark.unit
+def test_policy_templates_reference_existing_metrics(metrics, policy):
+    known = {m["name"] for m in metrics["metrics"]}
+    bad = [t["metric_name"] for t in policy["templates"] if t["metric_name"] not in known]
+    assert bad == [], f"policy references unknown metrics: {bad}"

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -21,6 +21,7 @@ _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "default",
     "lower",
     "urlencode",
+    "replace",
 )
 _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "agents",

--- a/web/src/app/monitor/hooks/integration/index.tsx
+++ b/web/src/app/monitor/hooks/integration/index.tsx
@@ -13,6 +13,7 @@ import { useActiveMQConfig } from './objects/middleware/activeMQ';
 import { useWebLogicConfig } from './objects/middleware/webLogic';
 import { useNginxConfig } from './objects/middleware/nginx';
 import { useApacheConfig } from './objects/middleware/apache';
+import { useHaproxyConfig } from './objects/middleware/haproxy';
 import { useConsulConfig } from './objects/middleware/consul';
 import { useEtcdBkpullConfig } from './objects/middleware/etcd';
 import { useClickHouseConfig } from './objects/database/clickHouse';
@@ -78,6 +79,7 @@ export const useMonitorConfig = () => {
   const webLogicConfig = useWebLogicConfig();
   const nginxConfig = useNginxConfig();
   const apacheConfig = useApacheConfig();
+  const haproxyConfig = useHaproxyConfig();
   const consulConfig = useConsulConfig();
   const etcdConfig = useEtcdBkpullConfig();
   const clickHouseConfig = useClickHouseConfig();
@@ -133,6 +135,7 @@ export const useMonitorConfig = () => {
       WebLogic: webLogicConfig,
       Nginx: nginxConfig,
       Apache: apacheConfig,
+      Haproxy: haproxyConfig,
       Consul: consulConfig,
       Etcd: etcdConfig,
       ClickHouse: clickHouseConfig,

--- a/web/src/app/monitor/hooks/integration/objects/middleware/haproxy.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/middleware/haproxy.tsx
@@ -1,0 +1,10 @@
+export const useHaproxyConfig = () => {
+  return {
+    instance_type: 'haproxy',
+    dashboardDisplay: [],
+    groupIds: {},
+    collectTypes: {
+      Haproxy: 'middleware',
+    },
+  };
+};


### PR DESCRIPTION
## What
Add HAProxy as a Telegraf middleware monitoring object.

## Changes
- Telegraf `haproxy` input config (`haproxy.child.toml.j2`) with credential injection into the stats URL via `urlencode`/`replace` filters
- `metrics.json`: 33 `haproxy_*` metrics mapped 1:1 to the real stats CSV columns (`keep_field_names=true` keeps raw `pxname/svname/type/server` tags)
- `policy.json` default alert templates + `UI.json` probe form schema
- bilingual (en / zh-Hans) translations for object/plugin/metrics/groups
- register `Haproxy` in monitor object constants and web integration hooks
- consistency test (units / i18n / policy refs / pxname-svname dimensions)

## Validation
End-to-end validated on a local node: real probe dispatch (`http://<host>:8081/stats`, auth) → Telegraf collect → VictoriaMetrics (4 live series) → dashboard renders with correct instance name and online status.