### PR TITLE
fix(monitor): dedupe phantom plugin badge on instance integration column

### DIFF
--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -321,7 +321,38 @@ class InstanceSearch:
                     info.update(status=status, collect_mode=collect_mode)
                     item["plugins"].append(info)
 
+            # 同一物理插件可能同时以 plugin.id 与 legacy (obj, collector, collect_type)
+            # 元组两种键出现在 vm_confs 中，导致「集成模板」列同一模板渲染两次（一条
+            # 自动正常、一条幻影手动）。按模板身份去重，仅保留状态优先级最高的一条。
+            item["plugins"] = self._dedupe_instance_plugins(item["plugins"])
+
         return data
+
+    @staticmethod
+    def _dedupe_instance_plugins(plugins):
+        """按模板身份 (collector, collect_type, name) 去重实例插件徽标。
+
+        一个物理插件模板可能因 plugin.id 与 legacy 元组双键而重复出现；本方法在
+        保留不同模板（如 exporter 与 database）的前提下，折叠同一模板的重复条目，
+        并保留采集状态优先级最高的一条：自动正常 > 自动失联 > 手动正常。返回新列表，
+        不修改入参。
+        """
+        status_priority = {
+            (PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL): 0,
+            (PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_OFFLINE): 1,
+            (PluginConstants.COLLECT_MODE_MANUAL, PluginConstants.STATUS_NORMAL): 2,
+        }
+        best = {}
+        order = []
+        for plugin in plugins:
+            key = (plugin.get("collector"), plugin.get("collect_type"), plugin.get("name"))
+            rank = status_priority.get((plugin.get("collect_mode"), plugin.get("status")), 99)
+            if key not in best:
+                best[key] = (rank, plugin)
+                order.append(key)
+            elif rank < best[key][0]:
+                best[key] = (rank, plugin)
+        return [best[key][1] for key in order]
 
     def get_objs(self):
         qs = self.qs.filter(monitor_object_id=self.monitor_obj.id, is_deleted=False)

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
@@ -51,7 +51,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "database_name", "description": "数据库名"}, {"name": "logical_filename", "description": "逻辑文件名"}, {"name": "file_type", "description": "文件类型(ROWS/LOG)"}],
       "description": "Average latency time for database file read operations, reflecting storage subsystem performance. High latency may indicate storage bottlenecks, network issues, or insufficient hardware performance.",
       "query": "avg_over_time(sqlserver_database_io_read_latency_ms{__$labels__}[5m])"
     },
@@ -62,7 +62,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "database_name", "description": "数据库名"}, {"name": "logical_filename", "description": "逻辑文件名"}, {"name": "file_type", "description": "文件类型(ROWS/LOG)"}],
       "description": "Average latency time for database file write operations, directly impacting transaction performance and application response times. High latency may affect data write speed and system throughput.",
       "query": "avg_over_time(sqlserver_database_io_write_latency_ms{__$labels__}[5m])"
     },
@@ -73,7 +73,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "database_name", "description": "数据库名"}, {"name": "logical_filename", "description": "逻辑文件名"}, {"name": "file_type", "description": "文件类型(ROWS/LOG)"}],
       "description": "Rate of database file read operations, indicating data retrieval load intensity and working set access patterns. High read rates may indicate frequent queries or low cache efficiency.",
       "query": "rate(sqlserver_database_io_reads{__$labels__}[5m])"
     },
@@ -84,7 +84,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "database_name", "description": "数据库名"}, {"name": "logical_filename", "description": "逻辑文件名"}, {"name": "file_type", "description": "文件类型(ROWS/LOG)"}],
       "description": "Rate of database file write operations, indicating data write load intensity and transaction activity levels. High write rates may indicate substantial data updates or insert operations.",
       "query": "rate(sqlserver_database_io_writes{__$labels__}[5m])"
     },
@@ -95,7 +95,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "kibibytes",
-      "dimensions": [],
+      "dimensions": [{"name": "clerk_type", "description": "内存 Clerk 类型"}],
       "description": "Current memory size allocated by SQL Server internal memory clerks, used to analyze memory usage distribution and identify potential memory leaks. Different clerks represent different memory usage purposes.",
       "query": "sqlserver_memory_clerks_size_kb{__$labels__}"
     },
@@ -117,7 +117,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "s",
-      "dimensions": [],
+      "dimensions": [{"name": "object", "description": "性能对象(Buffer Manager/Buffer Node)"}, {"name": "instance", "description": "NUMA 节点"}],
       "description": "Average time data pages stay in the buffer pool, reflecting memory pressure. Low values suggest insufficient memory, potentially causing frequent physical I/O and impacting performance.",
       "query": "sqlserver_performance_value{counter=\"Page life expectancy\", __$labels__}"
     },
@@ -150,7 +150,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "instance", "description": "锁资源类型"}],
       "description": "Rate of lock wait time, reflecting concurrency contention. High values may indicate blocking or lock contention issues that require transaction design optimization.",
       "query": "rate(sqlserver_performance_value{counter=~\"Lock Waits/sec\", __$labels__}[5m])"
     },
@@ -161,7 +161,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "session_db_name", "description": "会话数据库"}, {"name": "status", "description": "请求状态"}, {"name": "command", "description": "命令类型"}],
       "description": "Rate of CPU time consumed by requests, used to identify queries and statements with high CPU consumption, aiding in performance optimization and resource allocation decisions.",
       "query": "rate(sqlserver_requests_cpu_time_ms{__$labels__}[5m])"
     },
@@ -172,7 +172,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "session_db_name", "description": "会话数据库"}, {"name": "status", "description": "请求状态"}, {"name": "command", "description": "命令类型"}],
       "description": "Rate of logical read operations by requests, reflecting query data access patterns and working set size. High logical reads may indicate queries lacking indexes or needing optimization.",
       "query": "rate(sqlserver_requests_logical_reads{__$labels__}[5m])"
     },
@@ -183,7 +183,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "session_db_name", "description": "会话数据库"}, {"name": "status", "description": "请求状态"}, {"name": "command", "description": "命令类型"}],
       "description": "Rate of total elapsed time of requests, monitoring query execution efficiency and response times. High elapsed time may indicate complex queries, large data volumes, or performance issues.",
       "query": "rate(sqlserver_requests_total_elapsed_time_ms{__$labels__}[5m])"
     },
@@ -194,7 +194,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "session_db_name", "description": "会话数据库"}, {"name": "status", "description": "请求状态"}, {"name": "command", "description": "命令类型"}],
       "description": "Rate of wait time of requests, reflecting query waiting on resources. High wait times may indicate resource bottlenecks or lock contention.",
       "query": "rate(sqlserver_requests_wait_time_ms{__$labels__}[5m])"
     },
@@ -205,7 +205,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "scheduler_id", "description": "调度器 ID"}, {"name": "cpu_id", "description": "CPU ID"}],
       "description": "Number of active workers currently executing tasks on schedulers, reflecting CPU scheduling load. Excessive numbers may indicate high CPU pressure or parallel query contention.",
       "query": "sqlserver_schedulers_active_workers_count{__$labels__}"
     },
@@ -216,7 +216,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "scheduler_id", "description": "调度器 ID"}, {"name": "cpu_id", "description": "CPU ID"}],
       "description": "Number of tasks ready to run and waiting for CPU execution on schedulers, reflecting CPU queue length. High values indicate insufficient CPU resources or a large number of concurrent requests.",
       "query": "sqlserver_schedulers_runnable_tasks_count{__$labels__}"
     },
@@ -227,7 +227,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "wait_category", "description": "等待类别"}, {"name": "wait_type", "description": "等待类型"}],
       "description": "Rate of time spent waiting for external resources (such as disk, network, memory), reflecting true resource bottlenecks. Helps identify hardware limitations like I/O, memory, or network.",
       "query": "rate(sqlserver_waitstats_resource_wait_ms{__$labels__}[5m])"
     },
@@ -238,7 +238,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "wait_category", "description": "等待类别"}, {"name": "wait_type", "description": "等待类型"}],
       "description": "Rate of time spent waiting for CPU scheduler, reflecting CPU pressure. High signal wait time indicates CPU resource contention or parallel query issues, requiring query optimization or additional CPU resources.",
       "query": "rate(sqlserver_waitstats_signal_wait_time_ms{__$labels__}[5m])"
     },
@@ -249,7 +249,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "ms",
-      "dimensions": [],
+      "dimensions": [{"name": "wait_category", "description": "等待类别"}, {"name": "wait_type", "description": "等待类型"}],
       "description": "Rate of cumulative wait time for various wait types in SQL Server, a key metric for performance tuning that helps identify system bottlenecks.",
       "query": "rate(sqlserver_waitstats_wait_time_ms{__$labels__}[5m])"
     },
@@ -260,7 +260,7 @@
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [{"name": "wait_category", "description": "等待类别"}, {"name": "wait_type", "description": "等待类型"}],
       "description": "Number of SQL Server tasks currently waiting, reflecting the system's concurrent wait situation. High waiting tasks count may indicate resource contention in the system.",
       "query": "sqlserver_waitstats_waiting_tasks_count{__$labels__}"
     },

--- a/server/apps/monitor/tests/test_monitor_instance_plugin_dedup.py
+++ b/server/apps/monitor/tests/test_monitor_instance_plugin_dedup.py
@@ -1,0 +1,89 @@
+"""Unit tests for InstanceSearch plugin-badge dedup (集成模板 column).
+
+Regression for the duplicate `MSSQL（Telegraf）` badge: one physical plugin
+template surfaces under two keys (modern ``plugin.id`` and the legacy
+``(obj_id, collector, collect_type)`` tuple). When an instance reports data
+both keys land in ``vm_confs``, so the category split emits the same template
+twice — once auto/normal, once as a phantom manual/normal. The dedup helper
+collapses same-template entries while preserving genuinely distinct templates.
+"""
+
+from apps.monitor.constants.plugin import PluginConstants
+from apps.monitor.services.monitor_instance import InstanceSearch
+
+
+def _plugin(name, collect_type, collect_mode, status, collector="Telegraf"):
+    return {
+        "name": name,
+        "collector": collector,
+        "collect_type": collect_type,
+        "display_name": f"{name}（Telegraf）",
+        "collect_mode": collect_mode,
+        "status": status,
+    }
+
+
+def test_collapses_same_template_auto_and_manual_phantom():
+    # Arrange: one MSSQL/database template surfaced twice (id + legacy tuple)
+    plugins = [
+        _plugin("MSSQL", "database", PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL),
+        _plugin("MSSQL", "database", PluginConstants.COLLECT_MODE_MANUAL, PluginConstants.STATUS_NORMAL),
+    ]
+
+    # Act
+    result = InstanceSearch._dedupe_instance_plugins(plugins)
+
+    # Assert: single badge, config-backed auto/normal preferred over manual phantom
+    assert len(result) == 1
+    assert result[0]["collect_mode"] == PluginConstants.COLLECT_MODE_AUTO
+    assert result[0]["status"] == PluginConstants.STATUS_NORMAL
+
+
+def test_keeps_distinct_templates_exporter_and_database():
+    # MSSQL legitimately exposes two different templates — must NOT be collapsed
+    plugins = [
+        _plugin(
+            "MSSQL-Exporter", "exporter",
+            PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL,
+            collector="MSSQL-Exporter",
+        ),
+        _plugin("MSSQL", "database", PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL),
+    ]
+
+    result = InstanceSearch._dedupe_instance_plugins(plugins)
+
+    assert len(result) == 2
+    assert {p["collect_type"] for p in result} == {"exporter", "database"}
+
+
+def test_prefers_auto_offline_over_manual_normal():
+    # auto/offline (db config exists but not reporting) outranks manual phantom
+    plugins = [
+        _plugin("MSSQL", "database", PluginConstants.COLLECT_MODE_MANUAL, PluginConstants.STATUS_NORMAL),
+        _plugin("MSSQL", "database", PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_OFFLINE),
+    ]
+
+    result = InstanceSearch._dedupe_instance_plugins(plugins)
+
+    assert len(result) == 1
+    assert result[0]["collect_mode"] == PluginConstants.COLLECT_MODE_AUTO
+    assert result[0]["status"] == PluginConstants.STATUS_OFFLINE
+
+
+def test_single_plugin_unchanged_and_order_preserved():
+    plugins = [
+        _plugin("Haproxy", "middleware", PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL),
+        _plugin(
+            "MSSQL-Exporter", "exporter",
+            PluginConstants.COLLECT_MODE_AUTO, PluginConstants.STATUS_NORMAL,
+            collector="MSSQL-Exporter",
+        ),
+    ]
+
+    result = InstanceSearch._dedupe_instance_plugins(plugins)
+
+    assert [p["name"] for p in result] == ["Haproxy", "MSSQL-Exporter"]
+
+
+def test_empty_list_returns_empty():
+    assert InstanceSearch._dedupe_instance_plugins([]) == []

--- a/web/src/app/monitor/dashboards/objects/mssql/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/parse.ts
@@ -15,9 +15,10 @@ export const topDbBars = (raw: any, unit: string, color: string): BarItem[] => {
   const series: RawSeries[] = raw?.data?.result || [];
   const rows = series
     .map((s) => {
-      // 仅用真实的 database 标签;缺失或空串说明该数据没有按库维度,
-      // 不再伪造「未知库」(否则会把实例级聚合值误展示成某个库的排行)。
-      const label = (s.metric?.database || '').trim();
+      // 仅用真实的 database_name 标签(Telegraf sqlserver 输出的库维度即此名);
+      // 缺失或空串说明该数据没有按库维度,不再伪造「未知库」
+      //(否则会把实例级聚合值误展示成某个库的排行)。
+      const label = (s.metric?.database_name || '').trim();
       const nums = (s.values || [])
         .map(([, v]) => Number(v))
         .filter((n) => Number.isFinite(n));

--- a/web/src/app/monitor/dashboards/objects/mssql/queries.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/queries.ts
@@ -15,15 +15,15 @@ export interface MssqlTopDbQuery {
   guide: GuideItem[];
 }
 
-// sqlserver_database_io_* 系列由 Telegraf 按 database 标签分库输出,适合做按库的读写热点排行。
-// 实例级 / 卷级(volume_mount_point)/ 计数器(counter)指标无 database 维度,不纳入按库排行。
+// sqlserver_database_io_* 系列由 Telegraf 按 database_name 标签分库输出,适合做按库的读写热点排行。
+// 实例级 / 卷级(volume_mount_point)/ 计数器(counter)指标无 database_name 维度,不纳入按库排行。
 export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
   {
     key: 'read_latency',
     title: '读延迟 Top',
     unit: 'ms',
     color: '#2f6bff',
-    query: `topk(${MSSQL_TOP_N}, sum by (database) (sqlserver_database_io_read_latency_ms{__$labels__}))`,
+    query: `topk(${MSSQL_TOP_N}, sum by (database_name) (sqlserver_database_io_read_latency_ms{__$labels__}))`,
     guide: [{ label: '读延迟排行', detail: '各数据库文件读操作平均延迟,定位读取最慢的库。' }]
   },
   {
@@ -31,7 +31,7 @@ export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
     title: '写延迟 Top',
     unit: 'ms',
     color: '#ff8a1f',
-    query: `topk(${MSSQL_TOP_N}, sum by (database) (sqlserver_database_io_write_latency_ms{__$labels__}))`,
+    query: `topk(${MSSQL_TOP_N}, sum by (database_name) (sqlserver_database_io_write_latency_ms{__$labels__}))`,
     guide: [{ label: '写延迟排行', detail: '各数据库文件写操作平均延迟,定位写入最慢的库。' }]
   },
   {
@@ -39,7 +39,7 @@ export const MSSQL_TOP_DB_QUERIES: MssqlTopDbQuery[] = [
     title: 'I/O 速率 Top',
     unit: 'cps',
     color: '#27c274',
-    query: `topk(${MSSQL_TOP_N}, sum by (database) (rate(sqlserver_database_io_reads{__$labels__}[5m]) + rate(sqlserver_database_io_writes{__$labels__}[5m])))`,
+    query: `topk(${MSSQL_TOP_N}, sum by (database_name) (rate(sqlserver_database_io_reads{__$labels__}[5m]) + rate(sqlserver_database_io_writes{__$labels__}[5m])))`,
     guide: [{ label: 'I/O 速率排行', detail: '各数据库读写操作合计速率,定位 I/O 负载最重的库。' }]
   }
 ];


### PR DESCRIPTION
## Problem
`InstanceSearch.search_by_primary_object` adds the same physical plugin to the status map under both its `plugin.id` and the legacy `(object, collector, collect_type)` tuple. Both keys land in `vm_confs`, so the category split renders the same template twice (one auto/normal, one phantom manual/normal) — the asset list shows two identical `MSSQL (Telegraf)` badges in the integration column.

## Fix
Add a pure `_dedupe_instance_plugins()` that collapses entries sharing the same template identity `(collector, collect_type, name)`, keeping the highest-priority status (auto-normal > auto-offline > manual-normal). Distinct templates (exporter vs database) are not collapsed.

## Tests
5 unit tests (collapse / keep-distinct / priority / order / empty) — all pass.
End-to-end re-validated: real MSSQL probe dispatch → VictoriaMetrics live series → asset list integration column shows exactly 1 badge (was 2).