### PR TITLE
fix(monitor): add 3 missing postgres metrics referenced by policy.json

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -763,6 +763,15 @@ monitor_object_metric:
     postgresql_maxwritten_clean_rate:
       name: Background Clean Page Write Rate
       desc: Indicates high write pressure
+    postgresql_blk_write_time:
+      name: Disk Block Write Time Rate
+      desc: Rate of cumulative block write time (pg_stat_database.blk_write_time), in milliseconds of write time per second. High values indicate disk I/O write pressure or a storage bottleneck.
+    postgresql_active_time:
+      name: SQL Active Execution Time Rate
+      desc: Rate of cumulative SQL execution time (pg_stat_database.active_time), in milliseconds of active execution per second. Sustained high values indicate long-running or heavily concurrent statements.
+    postgresql_sessions_killed:
+      name: Abnormally Terminated Sessions Rate
+      desc: Rate of sessions terminated by fatal errors such as administrator commands, idle-session timeout, or deadlock resolution (pg_stat_database.sessions_killed), in sessions per second. A rising rate signals connection instability.
   RabbitMQ:
     rabbitmq_node_uptime:
       name: Node Uptime

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -699,6 +699,15 @@ monitor_object_metric:
     postgresql_maxwritten_clean_rate:
       name: 后台干净页写入速率
       desc: 表示写入压力过高导致的提前清理
+    postgresql_blk_write_time:
+      name: 磁盘块写入耗时速率
+      desc: 累计数据块写入耗时（pg_stat_database.blk_write_time）的速率，表示每秒累积的写入耗时（毫秒/秒）。数值偏高表明磁盘 I/O 写入压力大或存储存在瓶颈
+    postgresql_active_time:
+      name: SQL 活跃执行耗时速率
+      desc: 累计 SQL 语句执行耗时（pg_stat_database.active_time）的速率，表示每秒累积的活跃执行耗时（毫秒/秒）。持续偏高表明存在异常长事务或高并发语句执行
+    postgresql_sessions_killed:
+      name: 会话异常终止速率
+      desc: 因管理员命令、空闲会话超时、死锁处理等致命错误被终止的会话速率（pg_stat_database.sessions_killed，个/秒）。速率上升表明连接不稳定
   RabbitMQ:
     rabbitmq_node_uptime:
       name: 节点运行时间

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
@@ -300,6 +300,54 @@
       "dimensions": [],
       "description": "Indicates high write pressure",
       "query": "rate(postgresql_maxwritten_clean{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Cache",
+      "name": "postgresql_blk_write_time",
+      "display_name": "Disk Block Write Time Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "msps",
+      "dimensions": [
+        {
+          "name": "db",
+          "description": "Database name"
+        }
+      ],
+      "description": "Rate of cumulative time spent writing data file blocks (pg_stat_database.blk_write_time), expressed as milliseconds of write time accrued per second. High values indicate disk I/O write pressure or a storage bottleneck.",
+      "query": "rate(postgresql_blk_write_time{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Connection",
+      "name": "postgresql_active_time",
+      "display_name": "SQL Active Execution Time Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "msps",
+      "dimensions": [
+        {
+          "name": "db",
+          "description": "Database name"
+        }
+      ],
+      "description": "Rate of cumulative time spent executing SQL statements (pg_stat_database.active_time), expressed as milliseconds of active execution accrued per second. Sustained high values indicate abnormally long-running or heavily concurrent statement execution.",
+      "query": "rate(postgresql_active_time{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Connection",
+      "name": "postgresql_sessions_killed",
+      "display_name": "Abnormally Terminated Sessions Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [
+        {
+          "name": "db",
+          "description": "Database name"
+        }
+      ],
+      "description": "Rate of database sessions terminated by fatal errors such as administrator commands, idle-session timeout, or deadlock resolution (pg_stat_database.sessions_killed), expressed as sessions per second. A rising rate signals connection instability.",
+      "query": "rate(postgresql_sessions_killed{__$labels__}[5m])"
     }
   ]
 }

--- a/server/apps/monitor/tests/test_postgres_plugin.py
+++ b/server/apps/monitor/tests/test_postgres_plugin.py
@@ -1,0 +1,113 @@
+"""Contract tests for the Postgres monitoring plugin (Telegraf/database/postgres).
+
+Validates internal consistency of the plugin's support files: every policy
+template references a metric that actually exists in metrics.json (otherwise the
+alert template cannot be instantiated — Metric lookup in metric_query raises
+"metric does not exist"), units belong to the product unit system, every metric
+carries the `db` dimension emitted by the Telegraf postgresql input, and every
+metric / metric group has bilingual translations.
+"""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+PLUGIN_DIR = (
+    SERVER_ROOT
+    / "apps" / "monitor" / "support-files" / "plugins"
+    / "Telegraf" / "database" / "postgres"
+)
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+
+# Units supported by the product unit system (apps/monitor/utils/unit_converter.py).
+SUPPORTED_UNITS = {
+    "byteps", "bytes", "counts", "cps", "d", "gibibytes", "h", "kibibytes",
+    "kibyteps", "m", "mebibytes", "ms", "msps", "none", "ns", "pebibytes",
+    "percent", "s", "short", "µs",
+}
+# pg_stat_database-derived metrics carry the per-database `db` label; cluster-wide
+# pg_stat_bgwriter metrics (checkpoints/buffers) legitimately have no dimension.
+DB_SCOPED_METRICS = {
+    "postgresql_blk_write_time",
+    "postgresql_active_time",
+    "postgresql_sessions_killed",
+}
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return json.loads((PLUGIN_DIR / "metrics.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return json.loads((PLUGIN_DIR / "policy.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_policy_templates_reference_existing_metrics(metrics, policy):
+    known = {m["name"] for m in metrics["metrics"]}
+    bad = [t["metric_name"] for t in policy["templates"] if t["metric_name"] not in known]
+    assert bad == [], f"policy references unknown metrics: {bad}"
+
+
+@pytest.mark.unit
+def test_all_metric_units_are_supported(metrics):
+    bad = [m["name"] for m in metrics["metrics"] if m["unit"] not in SUPPORTED_UNITS]
+    assert bad == [], f"unsupported units on metrics: {bad}"
+
+
+@pytest.mark.unit
+def test_dimensions_are_well_formed(metrics):
+    """Every declared dimension must have a name and a description."""
+    bad = [
+        m["name"]
+        for m in metrics["metrics"]
+        for d in m.get("dimensions", [])
+        if not d.get("name") or not d.get("description")
+    ]
+    assert bad == [], f"metrics with malformed dimensions: {bad}"
+
+
+@pytest.mark.unit
+def test_db_scoped_metrics_carry_db_dimension(metrics):
+    """pg_stat_database metrics must expose the per-database `db` label."""
+    by_name = {m["name"]: m for m in metrics["metrics"]}
+    missing = [
+        name
+        for name in DB_SCOPED_METRICS
+        if "db" not in {d["name"] for d in by_name.get(name, {}).get("dimensions", [])}
+    ]
+    assert missing == [], f"db-scoped metrics missing db dimension: {missing}"
+
+
+@pytest.mark.unit
+def test_every_metric_has_bilingual_translation(metrics, languages):
+    missing = []
+    for lang, data in languages.items():
+        group = (data.get("monitor_object_metric") or {}).get("Postgres") or {}
+        for m in metrics["metrics"]:
+            entry = group.get(m["name"]) or {}
+            if not entry.get("name") or not entry.get("desc"):
+                missing.append(f"{lang}:{m['name']}")
+    assert missing == [], f"metrics missing name/desc translation: {missing}"
+
+
+@pytest.mark.unit
+def test_every_metric_group_has_bilingual_translation(metrics, languages):
+    groups = {m["metric_group"] for m in metrics["metrics"]}
+    missing = []
+    for lang, data in languages.items():
+        trans = (data.get("monitor_object_metric_group") or {}).get("Postgres") or {}
+        missing += [f"{lang}:{g}" for g in groups if not trans.get(g)]
+    assert missing == [], f"metric groups missing translation: {missing}"


### PR DESCRIPTION
## Problem

The PostgreSQL plugin's `policy.json` references three metrics that are **not defined** in its `metrics.json`:

- `postgresql_blk_write_time`
- `postgresql_active_time`
- `postgresql_sessions_killed`

Alert instantiation resolves `metric_name` → a `Metric` row (`metric_query.py`: `Metric.objects.filter(id=metric_id).first()`). When the metric is missing it raises `metric does not exist`, so those 3 alert templates can never be turned into usable alerts.

These three fields are in fact collected by telegraf `inputs.postgresql` (`pg_stat_database`, verified on a real PG15 instance), so the fix is to define them in `metrics.json` rather than touch the policy.

## Changes

- **metrics.json**: add the 3 metrics with `rate(...[5m])` queries and the `db` dimension (they are cumulative-time / counter fields). Units use `msps` (ms per second) for the rate-of-ms counters and `cps` for the killed-sessions rate.
- **language/zh-Hans.yaml + language/en.yaml**: bilingual metric names and descriptions.
- **tests/test_postgres_plugin.py** (new): asserts every `policy.json` `metric_name` exists in `metrics.json`, plus unit/dimension/bilingual well-formedness. 6 tests pass; existing 20 plugin tests unaffected.

## Validation

End-to-end re-validated against a real instance: the 3 new metrics each return 2 series (db `postgres`+`repmgr`), `rate()` queries hit, liveness unaffected, metric definitions render-ready.

## Note

The new metrics show up in the frontend "all metrics" UI only after `plugin_init` re-import at release (provisioning, not a code change).