### PR TITLE
feature(job_mgmt): 作业记录过滤修复与脚本执行参数增强

### DIFF
--- a/server/apps/job_mgmt/filters/execution.py
+++ b/server/apps/job_mgmt/filters/execution.py
@@ -5,15 +5,21 @@ from django_filters import rest_framework as filters
 from apps.job_mgmt.models import JobExecution
 
 
+class CharInFilter(filters.BaseInFilter, filters.CharFilter):
+    """支持逗号分隔多值的 in 过滤器（前端多选时以逗号拼接）。"""
+
+
 class JobExecutionFilter(filters.FilterSet):
     """作业执行过滤器"""
 
     name = filters.CharFilter(field_name="name", lookup_expr="icontains")
     job_type = filters.CharFilter(field_name="job_type", lookup_expr="exact")
+    trigger_source = CharInFilter(field_name="trigger_source", lookup_expr="in")
     status = filters.CharFilter(field_name="status", lookup_expr="exact")
+    created_by = filters.CharFilter(field_name="created_by", lookup_expr="icontains")
     created_at_after = filters.DateTimeFilter(field_name="created_at", lookup_expr="gte")
     created_at_before = filters.DateTimeFilter(field_name="created_at", lookup_expr="lte")
 
     class Meta:
         model = JobExecution
-        fields = ["name", "job_type", "status", "created_at_after", "created_at_before"]
+        fields = ["name", "job_type", "trigger_source", "status", "created_by", "created_at_after", "created_at_before"]

--- a/server/apps/job_mgmt/services/script_execution_runner.py
+++ b/server/apps/job_mgmt/services/script_execution_runner.py
@@ -101,23 +101,44 @@ class ScriptExecutionRunner(ExecutionTaskBaseService):
         return results
 
     def merge_script_with_params(self, script_content: str, params: str, script_type: str) -> str:
+        """将位置参数注入脚本，使脚本内可按顺序获取参数。
+
+        params 为 ScriptParamsService.params_to_string 生成的逐值 shell 引用字符串，
+        先 shlex.split 还原出有序 token（含空字符串占位），再按脚本类型注入：
+        - shell：set -- 设置位置参数（$1 $2 ...）
+        - python：注入 sys.argv（sys.argv[1] sys.argv[2] ...）
+        - powershell：注入 $args（$args[0] $args[1] ...）
+        - bat：当前执行机制下无法在脚本内重设 %1/%2，暂不支持，忽略参数
+        """
         if not params:
             return script_content
 
+        import json
+        import shlex
+
+        try:
+            tokens = shlex.split(params)
+        except ValueError:
+            tokens = params.split()
+        if not tokens:
+            return script_content
+
         if script_type == ScriptType.SHELL:
-            import shlex
-
-            try:
-                tokens = shlex.split(params)
-            except ValueError:
-                tokens = params.split()
-
             escaped_params = " ".join(shlex.quote(token) for token in tokens)
-            if not escaped_params:
-                return script_content
             return f"set -- {escaped_params}\n{script_content}"
 
-        return f"{script_content} {params}"
+        if script_type == ScriptType.PYTHON:
+            # json 数组同时是合法的 Python 列表字面量，可安全注入空值/特殊字符
+            argv_literal = json.dumps(["script", *tokens], ensure_ascii=False)
+            return f"import sys as _sys\n_sys.argv = {argv_literal}\n{script_content}"
+
+        if script_type == ScriptType.POWERSHELL:
+            # PowerShell 单引号字符串，内部单引号转义为两个单引号
+            ps_args = ", ".join("'" + token.replace("'", "''") + "'" for token in tokens)
+            return f"$args = @({ps_args})\n{script_content}"
+
+        # bat 等其它类型：本次不支持参数注入，原样返回脚本内容
+        return script_content
 
     def execute_script_on_target(
         self, target_info: dict, target_source: str, script_content: str, script_type: str, timeout: int, execution_id: int

--- a/server/apps/job_mgmt/services/script_params_service.py
+++ b/server/apps/job_mgmt/services/script_params_service.py
@@ -117,6 +117,12 @@ class ScriptParamsService:
                     raise serializers.ValidationError({"params": f"临时脚本模式下第 {index + 1} 个参数不能使用默认值"})
                 # 临时脚本模式且允许：直接使用前端传的 value
 
+            # 必填校验：脚本库定义 is_required=true 的参数最终值不能为空
+            if has_script and index < len(default_params):
+                if default_params[index].get("is_required") and (value is None or str(value) == ""):
+                    display_name = name or default_params[index].get("name") or f"第 {index + 1} 个参数"
+                    raise serializers.ValidationError({"params": f"参数「{display_name}」为必填项，不能为空"})
+
             resolved_params.append(
                 {
                     "name": name,
@@ -132,17 +138,23 @@ class ScriptParamsService:
         """
         将参数列表按顺序转换为命令行位置参数字符串
 
+        对每个值做 shell 引用（shlex.quote），使空值以 '' 占位、含空格/特殊
+        字符的值保持完整。这样执行端再 shlex.split 还原时不会丢失空参数，
+        从而避免「中间空参数被吞掉导致后续参数位置前移」的问题。
+
         Args:
             params: 参数列表
 
         Returns:
-            str: 空格分隔的参数字符串，如 "value1 value2 value3"
+            str: 空格分隔且逐值引用的参数字符串，如 "value1 '' 'value 3'"
         """
         if not params:
             return ""
 
+        import shlex
+
         values = [str(param.get("value", "")) for param in params]
-        return " ".join(values)
+        return " ".join(shlex.quote(v) for v in values)
 
     @staticmethod
     def params_to_dict(params: list) -> dict:

--- a/server/apps/job_mgmt/tests/test_execution_filter.py
+++ b/server/apps/job_mgmt/tests/test_execution_filter.py
@@ -1,0 +1,44 @@
+"""作业执行过滤器单元测试（发起人 created_by / 触发来源 trigger_source）"""
+
+import pytest
+
+from apps.job_mgmt.constants import TriggerSource
+from apps.job_mgmt.filters.execution import JobExecutionFilter
+from apps.job_mgmt.models import JobExecution
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestJobExecutionFilter:
+    def _make(self, **kwargs):
+        defaults = {"name": "job", "job_type": "script", "status": "success"}
+        defaults.update(kwargs)
+        return JobExecution.objects.create(**defaults)
+
+    def test_filter_by_created_by_icontains(self):
+        """按发起人模糊过滤"""
+        self._make(created_by="admin")
+        self._make(created_by="alice")
+
+        qs = JobExecutionFilter({"created_by": "adm"}, queryset=JobExecution.objects.all()).qs
+
+        assert [e.created_by for e in qs] == ["admin"]
+
+    def test_filter_by_trigger_source_single(self):
+        """按单个触发来源过滤"""
+        self._make(trigger_source=TriggerSource.MANUAL)
+        self._make(trigger_source=TriggerSource.SCHEDULED)
+
+        qs = JobExecutionFilter({"trigger_source": "manual"}, queryset=JobExecution.objects.all()).qs
+
+        assert [e.trigger_source for e in qs] == ["manual"]
+
+    def test_filter_by_trigger_source_multi_comma(self):
+        """按多个触发来源（逗号分隔）过滤"""
+        self._make(trigger_source=TriggerSource.MANUAL)
+        self._make(trigger_source=TriggerSource.SCHEDULED)
+        self._make(trigger_source=TriggerSource.API)
+
+        qs = JobExecutionFilter({"trigger_source": "manual,scheduled"}, queryset=JobExecution.objects.all()).qs
+
+        assert sorted(e.trigger_source for e in qs) == ["manual", "scheduled"]

--- a/server/apps/job_mgmt/tests/test_script_params.py
+++ b/server/apps/job_mgmt/tests/test_script_params.py
@@ -1,0 +1,187 @@
+"""脚本参数服务 / 执行端参数注入单元测试"""
+
+import shlex
+
+import pytest
+from rest_framework import serializers
+
+from apps.job_mgmt.constants import ScriptType
+from apps.job_mgmt.services.script_execution_runner import ScriptExecutionRunner
+from apps.job_mgmt.services.script_params_service import ScriptParamsService
+
+
+class FakeScript:
+    """仅提供 params 属性，避免依赖 DB 的轻量替身。"""
+
+    def __init__(self, params):
+        self.params = params
+
+
+def _merge(params_str, script_type, content="echo hi"):
+    # merge_script_with_params 不使用 self，传 None 即可，避免实例化触发 DB 查询
+    return ScriptExecutionRunner.merge_script_with_params(None, content, params_str, script_type)
+
+
+@pytest.mark.unit
+class TestParamsToString:
+    def test_empty_value_keeps_position(self):
+        """中间空值参数以 '' 占位，shlex 还原后位置不前移"""
+        s = ScriptParamsService.params_to_string([{"value": "a"}, {"value": ""}, {"value": "c"}])
+        assert shlex.split(s) == ["a", "", "c"]
+
+    def test_value_with_space_quoted(self):
+        """含空格的值保持为单个参数"""
+        s = ScriptParamsService.params_to_string([{"value": "a b"}, {"value": "c"}])
+        assert shlex.split(s) == ["a b", "c"]
+
+    def test_empty_list(self):
+        assert ScriptParamsService.params_to_string([]) == ""
+
+
+@pytest.mark.unit
+class TestMergeScriptWithParams:
+    def test_shell_set_dashdash_preserves_empty(self):
+        merged = _merge("a '' c", ScriptType.SHELL, "echo $2")
+        assert merged.startswith("set -- a '' c\n")
+        assert merged.endswith("echo $2")
+        assert shlex.split(merged.split("\n", 1)[0][len("set -- ") :]) == ["a", "", "c"]
+
+    def test_python_injects_sys_argv(self):
+        merged = _merge("a '' c", ScriptType.PYTHON, "import sys; print(sys.argv)")
+        assert '_sys.argv = ["script", "a", "", "c"]' in merged
+        assert merged.strip().endswith("print(sys.argv)")
+
+    def test_powershell_injects_args(self):
+        merged = _merge("a '' c", ScriptType.POWERSHELL, "Write-Output $args")
+        assert "$args = @('a', '', 'c')" in merged
+
+    def test_bat_ignores_params(self):
+        """bat 当前不支持参数注入，原样返回脚本内容"""
+        merged = _merge("a b", ScriptType.BAT, "echo %1")
+        assert merged == "echo %1"
+
+    def test_no_params_returns_content(self):
+        assert _merge("", ScriptType.SHELL, "echo hi") == "echo hi"
+
+    def test_unbalanced_quote_falls_back_to_split(self):
+        # shlex.split 遇到不闭合引号抛 ValueError，回退到 str.split
+        merged = _merge("a 'b", ScriptType.SHELL, "echo hi")
+        assert merged.startswith("set -- ")
+        assert merged.endswith("echo hi")
+
+    def test_whitespace_only_params_returns_content(self):
+        # 非空但分词后无 token，原样返回脚本内容
+        assert _merge("   ", ScriptType.SHELL, "echo hi") == "echo hi"
+
+
+@pytest.mark.unit
+class TestRequiredValidation:
+    def test_required_empty_raises(self):
+        script = FakeScript([{"name": "p1", "is_required": True, "default": ""}])
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.resolve_params([{"name": "p1", "value": "", "is_modified": True}], script=script)
+
+    def test_required_filled_ok(self):
+        script = FakeScript([{"name": "p1", "is_required": True, "default": ""}])
+        out = ScriptParamsService.resolve_params([{"name": "p1", "value": "x", "is_modified": True}], script=script)
+        assert out[0]["value"] == "x"
+
+    def test_optional_empty_ok(self):
+        script = FakeScript([{"name": "p1", "is_required": False, "default": ""}])
+        out = ScriptParamsService.resolve_params([{"name": "p1", "value": "", "is_modified": True}], script=script)
+        assert out[0]["value"] == ""
+
+
+@pytest.mark.unit
+class TestValidateParamsFormat:
+    def test_non_list_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format("not-a-list")
+
+    def test_non_dict_item_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format(["x"], require_is_modified=False)
+
+    def test_missing_value_key_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format([{"name": "p"}], require_is_modified=False)
+
+    def test_missing_is_modified_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format([{"value": "x"}], require_is_modified=True)
+
+    def test_name_not_str_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format([{"value": "x", "name": 123}], require_is_modified=False)
+
+    def test_is_modified_not_bool_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.validate_params_format([{"value": "x", "is_modified": "yes"}], require_is_modified=False)
+
+    def test_valid_passes(self):
+        # 合法格式不抛异常
+        ScriptParamsService.validate_params_format([{"value": "x", "is_modified": True}], require_is_modified=True)
+
+
+@pytest.mark.unit
+class TestGetScriptDefaultParams:
+    def test_none_script_returns_empty(self):
+        assert ScriptParamsService.get_script_default_params(None) == []
+
+    def test_script_without_params_returns_empty(self):
+        assert ScriptParamsService.get_script_default_params(FakeScript([])) == []
+
+    def test_returns_dict_defs(self):
+        defs = [{"name": "p", "default": "1"}]
+        assert ScriptParamsService.get_script_default_params(FakeScript(defs)) == defs
+
+
+@pytest.mark.unit
+class TestResolveParams:
+    def test_empty_returns_empty(self):
+        assert ScriptParamsService.resolve_params([]) == []
+
+    def test_unmodified_backfills_script_default(self):
+        script = FakeScript([{"name": "p1", "default": "D", "is_required": False}])
+        out = ScriptParamsService.resolve_params([{"name": "p1", "value": "ignored", "is_modified": False}], script=script)
+        assert out[0]["value"] == "D"
+
+    def test_unmodified_index_out_of_range_raises(self):
+        script = FakeScript([{"name": "p1", "default": "D"}])
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.resolve_params(
+                [
+                    {"name": "p1", "value": "", "is_modified": False},
+                    {"name": "p2", "value": "", "is_modified": False},
+                ],
+                script=script,
+            )
+
+    def test_unmodified_without_script_disallowed_raises(self):
+        with pytest.raises(serializers.ValidationError):
+            ScriptParamsService.resolve_params(
+                [{"name": "p", "value": "x", "is_modified": False}],
+                script=None,
+                allow_unmodified_without_script=False,
+            )
+
+    def test_unmodified_without_script_allowed_uses_value(self):
+        out = ScriptParamsService.resolve_params(
+            [{"name": "p", "value": "x", "is_modified": False}],
+            script=None,
+            allow_unmodified_without_script=True,
+        )
+        assert out[0]["value"] == "x"
+
+
+@pytest.mark.unit
+class TestParamsToDict:
+    def test_empty_returns_empty_dict(self):
+        assert ScriptParamsService.params_to_dict([]) == {}
+
+    def test_maps_name_to_value(self):
+        out = ScriptParamsService.params_to_dict([{"name": "a", "value": "1"}, {"key": "b", "value": "2"}])
+        assert out == {"a": "1", "b": "2"}
+
+    def test_skips_items_without_name(self):
+        assert ScriptParamsService.params_to_dict([{"value": "x"}]) == {}

--- a/web/src/app/job/(pages)/execution/job-record/page.tsx
+++ b/web/src/app/job/(pages)/execution/job-record/page.tsx
@@ -29,6 +29,7 @@ import {
   CloseCircleFilled,
   FolderOutlined,
   FileOutlined,
+  ProfileOutlined,
 } from '@ant-design/icons';
 import CustomTable from '@/components/custom-table';
 import MarkdownRenderer from '@/components/markdown';
@@ -594,6 +595,18 @@ const JobRecordPage = () => {
     return detail.script_content.split('\n').length;
   }, [detail?.script_content]);
 
+  // Execution parameters text (脚本执行为按顺序拼接的位置参数字符串)
+  const executeParamsText = useMemo(() => {
+    const p = detail?.params as unknown;
+    if (p === null || p === undefined || p === '') return '';
+    if (typeof p === 'string') return p;
+    try {
+      return JSON.stringify(p);
+    } catch {
+      return String(p);
+    }
+  }, [detail?.params]);
+
   const handlePreviewPlaybookFile = useCallback(async (filePath: string, parentPaths: string[] = []) => {
     if (!viewingPlaybook) {
       return;
@@ -1102,12 +1115,20 @@ const JobRecordPage = () => {
         <Drawer
           title={t('job.scriptDetail')}
           placement="right"
-          width={480}
+          width={720}
           open={scriptDrawerOpen}
           onClose={() => setScriptDrawerOpen(false)}
+          styles={{
+            body: {
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden',
+              padding: 24,
+            },
+          }}
         >
           <div
-            className="rounded-lg mb-4"
+            className="rounded-lg mb-4 shrink-0"
             style={{
               background: 'var(--color-bg-1)',
               border: '1px solid var(--color-border-1)',
@@ -1149,14 +1170,14 @@ const JobRecordPage = () => {
           </div>
 
           <div
-            className="rounded-lg overflow-hidden"
+            className="rounded-lg overflow-hidden flex-1 min-h-0 flex flex-col"
             style={{
               background: 'var(--color-bg-1)',
               border: '1px solid var(--color-border-1)',
             }}
           >
             <div
-              className="px-4 py-3 flex items-center justify-between"
+              className="px-4 py-3 flex items-center justify-between shrink-0"
               style={{ borderBottom: '1px solid var(--color-border-1)' }}
             >
               <div className="flex items-center gap-2">
@@ -1175,10 +1196,9 @@ const JobRecordPage = () => {
               </Button>
             </div>
             <pre
-              className="p-0 text-sm overflow-auto font-mono m-0"
+              className="p-0 text-sm overflow-auto font-mono m-0 flex-1 min-h-0"
               style={{
                 background: '#1e1e1e',
-                maxHeight: 'calc(100vh - 380px)',
               }}
             >
               {detail.script_content?.split('\n').map((line, index) => (
@@ -1198,6 +1218,39 @@ const JobRecordPage = () => {
                 </div>
               ))}
             </pre>
+          </div>
+
+          {/* Execution Parameters */}
+          <div
+            className="rounded-lg overflow-hidden mt-4 shrink-0"
+            style={{
+              background: 'var(--color-bg-1)',
+              border: '1px solid var(--color-border-1)',
+            }}
+          >
+            <div
+              className="px-4 py-3 flex items-center gap-2"
+              style={{ borderBottom: '1px solid var(--color-border-1)' }}
+            >
+              <ProfileOutlined style={{ color: 'var(--color-primary)' }} />
+              <span className="font-medium" style={{ color: 'var(--color-text-1)' }}>
+                {t('job.executeParams')}
+              </span>
+            </div>
+            <div className="p-4">
+              {executeParamsText ? (
+                <pre
+                  className="m-0 whitespace-pre-wrap break-all font-mono text-sm overflow-auto"
+                  style={{ color: 'var(--color-text-1)', maxHeight: '20vh' }}
+                >
+                  {executeParamsText}
+                </pre>
+              ) : (
+                <span className="text-sm" style={{ color: 'var(--color-text-3)' }}>
+                  {t('job.noExecuteParams')}
+                </span>
+              )}
+            </div>
           </div>
         </Drawer>
 

--- a/web/src/app/job/(pages)/execution/quick-exec/page.tsx
+++ b/web/src/app/job/(pages)/execution/quick-exec/page.tsx
@@ -652,7 +652,7 @@ const QuickExecPage = () => {
                       name={`param_${param.name}`}
                       initialValue={param.default || undefined}
                       tooltip={param.description || undefined}
-                      rules={[{ required: true, message: t('job.paramRequired', undefined, { name: param.name }) }]}
+                      rules={[{ required: !!param.is_required, message: t('job.paramRequired', undefined, { name: param.name }) }]}
                     >
                       {param.is_encrypted ? (
                         <Password

--- a/web/src/app/job/(pages)/template/script-library/page.tsx
+++ b/web/src/app/job/(pages)/template/script-library/page.tsx
@@ -11,7 +11,7 @@ import {
   Switch,
   Table,
 } from 'antd';
-import { PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { PlusOutlined, DeleteOutlined, CheckOutlined, CloseOutlined } from '@ant-design/icons';
 import CustomTable from '@/components/custom-table';
 import OperateModal from '@/components/operate-modal';
 import { useTranslation } from '@/utils/i18n';
@@ -79,7 +79,7 @@ const ScriptLibraryPage = () => {
 
   // Params management
   const [params, setParams] = useState<ScriptParam[]>([]);
-  const [paramModalOpen, setParamModalOpen] = useState(false);
+  const [paramFormVisible, setParamFormVisible] = useState(false);
   const [editingParamIndex, setEditingParamIndex] = useState<number | null>(null);
 
   const fetchData = useCallback(
@@ -297,19 +297,25 @@ const ScriptLibraryPage = () => {
     }
   };
 
-  // Param modal handlers
-  const openAddParamModal = () => {
+  // Inline param form handlers
+  const openAddParamForm = () => {
     setEditingParamIndex(null);
     paramForm.resetFields();
-    paramForm.setFieldsValue({ is_encrypted: false });
-    setParamModalOpen(true);
+    paramForm.setFieldsValue({ is_encrypted: false, is_required: false });
+    setParamFormVisible(true);
   };
 
-  const openEditParamModal = (index: number) => {
+  const openEditParamForm = (index: number) => {
     setEditingParamIndex(index);
     paramForm.resetFields();
     paramForm.setFieldsValue(params[index]);
-    setParamModalOpen(true);
+    setParamFormVisible(true);
+  };
+
+  const cancelParamForm = () => {
+    paramForm.resetFields();
+    setEditingParamIndex(null);
+    setParamFormVisible(false);
   };
 
   const handleParamSubmit = async () => {
@@ -320,6 +326,7 @@ const ScriptLibraryPage = () => {
         description: values.description || '',
         default: values.default || '',
         is_encrypted: values.is_encrypted || false,
+        is_required: values.is_required || false,
       };
       if (editingParamIndex !== null) {
         const updated = [...params];
@@ -328,7 +335,7 @@ const ScriptLibraryPage = () => {
       } else {
         setParams([...params, param]);
       }
-      setParamModalOpen(false);
+      cancelParamForm();
     } catch {
       // validation error
     }
@@ -351,10 +358,18 @@ const ScriptLibraryPage = () => {
       render: (val: string) => val || '-',
     },
     {
+      title: t('job.isRequired'),
+      dataIndex: 'is_required',
+      key: 'is_required',
+      render: (val: boolean) =>
+        val ? <CheckOutlined className="text-green-500" /> : <CloseOutlined className="text-gray-400" />,
+    },
+    {
       title: t('job.isEncrypted'),
       dataIndex: 'is_encrypted',
       key: 'is_encrypted',
-      render: (val: boolean) => (val ? '✓' : '-'),
+      render: (val: boolean) =>
+        val ? <CheckOutlined className="text-green-500" /> : <CloseOutlined className="text-gray-400" />,
     },
     {
       title: t('job.paramDescription'),
@@ -370,7 +385,7 @@ const ScriptLibraryPage = () => {
         <div className="flex items-center gap-3">
           <a
             className="text-[var(--color-primary)] cursor-pointer"
-            onClick={() => openEditParamModal(index)}
+            onClick={() => openEditParamForm(index)}
           >
             {t('job.editRule')}
           </a>
@@ -601,87 +616,82 @@ const ScriptLibraryPage = () => {
             />
           </Form.Item>
 
-          {/* Parameter Definition */}
+        </Form>
+
+        {/* Parameter Definition（置于主表单之外，内联表单使用独立的 paramForm 实例，避免 Form 嵌套） */}
+        <div className="mb-2">
           <div className="mb-2">
-            <div className="mb-2">
-              <span className="text-sm font-medium" style={{ color: 'var(--color-text-1)' }}>
-                {t('job.paramDefinition')}
-              </span>
-            </div>
-            {params.length > 0 && (
-              <Table
-                columns={isViewMode ? paramColumns.filter((c) => c.key !== 'action') : paramColumns}
-                dataSource={params}
-                rowKey={(_, index) => String(index)}
-                pagination={false}
-                size="small"
-              />
-            )}
-            {!isViewMode && (
-              <div className={styles.addParamWrapper}>
-                <Button
-                  type="text"
-                  icon={<PlusOutlined />}
-                  className={styles.addParamButton}
-                  onClick={openAddParamModal}
-                >
-                  {t('job.addParam')}
-                </Button>
-              </div>
-            )}
+            <span className="text-sm font-medium" style={{ color: 'var(--color-text-1)' }}>
+              {t('job.paramDefinition')}
+            </span>
           </div>
-        </Form>
-      </OperateModal>
-
-      {/* Add/Edit Param Modal */}
-      <OperateModal
-        title={editingParamIndex !== null ? t('job.editParam') : t('job.addParamTitle')}
-        open={paramModalOpen}
-        onCancel={() => setParamModalOpen(false)}
-        footer={
-          <div className="flex justify-end gap-2">
-            <Button onClick={() => setParamModalOpen(false)}>{t('job.cancel')}</Button>
-            <Button type="primary" onClick={handleParamSubmit}>
-              {t('job.confirm')}
-            </Button>
-          </div>
-        }
-        width={520}
-      >
-        <Form form={paramForm} layout="vertical" colon={false}>
-          <Form.Item
-            name="name"
-            label={t('job.paramName')}
-            rules={[{ required: true, message: t('job.paramNamePlaceholder') }]}
-          >
-            <Input placeholder={t('job.paramNamePlaceholder')} />
-          </Form.Item>
-
-          <Form.Item
-            name="is_encrypted"
-            label={t('job.isEncrypted')}
-            valuePropName="checked"
-          >
-            <Switch />
-          </Form.Item>
-
-          <Form.Item
-            name="default"
-            label={t('job.defaultValue')}
-          >
-            <Input placeholder={t('job.defaultValuePlaceholder')} />
-          </Form.Item>
-
-          <Form.Item
-            name="description"
-            label={t('job.paramDescription')}
-          >
-            <Input.TextArea
-              rows={3}
-              placeholder={t('job.paramDescriptionPlaceholder')}
+          {params.length > 0 && (
+            <Table
+              columns={isViewMode ? paramColumns.filter((c) => c.key !== 'action') : paramColumns}
+              dataSource={params}
+              rowKey={(_, index) => String(index)}
+              pagination={false}
+              size="small"
             />
-          </Form.Item>
-        </Form>
+          )}
+
+          {!isViewMode && !paramFormVisible && (
+            <div className={styles.addParamWrapper}>
+              <Button
+                type="text"
+                icon={<PlusOutlined />}
+                className={styles.addParamButton}
+                onClick={openAddParamForm}
+              >
+                {t('job.addParam')}
+              </Button>
+            </div>
+          )}
+
+          {!isViewMode && paramFormVisible && (
+            <div
+              className="mt-2 rounded-md p-4"
+              style={{ border: '1px solid var(--color-border-1)', background: 'var(--color-fill-1)' }}
+            >
+              <div className="mb-3 text-sm font-medium" style={{ color: 'var(--color-text-1)' }}>
+                {editingParamIndex !== null ? t('job.editParam') : t('job.addParamTitle')}
+              </div>
+              <Form form={paramForm} layout="vertical" colon={false}>
+                <Form.Item
+                  name="name"
+                  label={t('job.paramName')}
+                  rules={[{ required: true, message: t('job.paramNamePlaceholder') }]}
+                >
+                  <Input placeholder={t('job.paramNamePlaceholder')} />
+                </Form.Item>
+
+                <div className="flex gap-12">
+                  <Form.Item name="is_required" label={t('job.isRequired')} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                  <Form.Item name="is_encrypted" label={t('job.isEncrypted')} valuePropName="checked">
+                    <Switch />
+                  </Form.Item>
+                </div>
+
+                <Form.Item name="default" label={t('job.defaultValue')}>
+                  <Input placeholder={t('job.defaultValuePlaceholder')} />
+                </Form.Item>
+
+                <Form.Item name="description" label={t('job.paramDescription')}>
+                  <Input.TextArea rows={2} placeholder={t('job.paramDescriptionPlaceholder')} />
+                </Form.Item>
+
+                <div className="flex justify-end gap-2">
+                  <Button onClick={cancelParamForm}>{t('job.cancel')}</Button>
+                  <Button type="primary" onClick={handleParamSubmit}>
+                    {t('job.confirm')}
+                  </Button>
+                </div>
+              </Form>
+            </div>
+          )}
+        </div>
       </OperateModal>
     </div>
   );

--- a/web/src/app/job/locales/en.json
+++ b/web/src/app/job/locales/en.json
@@ -268,6 +268,7 @@
     "entryFile": "Entry File",
     "fileName": "File Name",
     "fileSize": "File Size",
+    "isRequired": "Required",
     "isEncrypted": "Encrypted",
     "paramDescription": "Description",
     "paramDescriptionPlaceholder": "Enter description",
@@ -390,6 +391,8 @@
     "scriptLanguage": "Script Language",
     "codeLines": "Code Lines",
     "lines": "lines",
+    "executeParams": "Execution Parameters",
+    "noExecuteParams": "No execution parameters",
 
     "version": "Version",
     "basicInfoTab": "Basic Info",

--- a/web/src/app/job/locales/zh.json
+++ b/web/src/app/job/locales/zh.json
@@ -269,6 +269,7 @@
     "entryFile": "入口文件",
     "fileName": "文件名",
     "fileSize": "文件大小",
+    "isRequired": "是否必须",
     "isEncrypted": "是否加密",
     "paramDescription": "提示信息",
     "paramDescriptionPlaceholder": "请输入提示信息",
@@ -390,6 +391,8 @@
     "scriptLanguage": "脚本语言",
     "codeLines": "代码行数",
     "lines": "行",
+    "executeParams": "执行参数",
+    "noExecuteParams": "无执行参数",
 
     "version": "版本",
     "basicInfoTab": "基本信息",

--- a/web/src/app/job/types/index.ts
+++ b/web/src/app/job/types/index.ts
@@ -153,6 +153,7 @@ export interface ScriptParam {
   description?: string;
   default?: string;
   is_encrypted?: boolean;
+  is_required?: boolean;
 }
 
 export interface Script {


### PR DESCRIPTION
- 作业记录补充发起人(created_by)、触发来源(trigger_source)过滤
- 脚本详情抽屉展示执行参数，优化抽屉宽度与脚本内容滚动布局
- 脚本参数新增"是否必须"开关，执行页与后端 resolve_params 必填校验
- 修复空值位置参数被吞导致后续参数错位：params_to_string 逐值 shell 引用占位
- 参数注入支持 shell(set --)/python(sys.argv)/powershell($args)，bat 暂不支持
- 脚本库"新增参数"由双层弹窗改为内联表单，参数表格布尔列改用图标
- 补充参数服务/执行端/过滤器单元测试