### PR TITLE
fix(monitor): freeze dashboard time window per refresh so multi-series tooltips align

### DIFF
--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -17,6 +17,7 @@ import {
   getLatestChartValue,
   mergeChartSeries,
   buildPreviousPeriodTimeValues,
+  freezeTimeValues,
   getPeriodCompare,
   runWithConcurrency,
   toMetricSeries,
@@ -448,7 +449,10 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     if (!silent) setLoading(true);
     try {
       if (displayMode === 'dashboard') {
-        const previousTimeValues = buildPreviousPeriodTimeValues(timeValues);
+        // 本次刷新冻结一个绝对时间窗,所有序列(含 KPI/采集状态/趋势/对比)复用,
+        // 避免每条序列各自现算 now 导致时间戳网格错位、多序列面板 tooltip 只显示一条。
+        const frozenTimeValues = freezeTimeValues(timeValues);
+        const previousTimeValues = buildPreviousPeriodTimeValues(frozenTimeValues);
         const compareMetrics = config.metrics.filter((m) => config.summaryCards.some((c) => c.compare && c.metric === m.name));
 
         // ── Group 1: summary metrics (StatCard values) ──
@@ -458,10 +462,10 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         const summaryResultsPromise = runWithConcurrency(
           summaryMetrics,
           METRIC_QUERY_CONCURRENCY,
-          (metric) => loadSingleMetric(metric, timeValues)
+          (metric) => loadSingleMetric(metric, frozenTimeValues)
         );
         const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(
-          buildSearchParams(config.collectionStatusQuery, 'counts', idValues, instanceIdKeys, timeValues, undefined, false)
+          buildSearchParams(config.collectionStatusQuery, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false)
         )
           .then((result) =>
             toMetricSeries(
@@ -524,7 +528,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
 
         // ── Group 2: trend/chart metrics — loaded async in background ──
         if (trendMetrics.length > 0) {
-          runWithConcurrency(trendMetrics, METRIC_QUERY_CONCURRENCY, (metric) => loadSingleMetric(metric, timeValues))
+          runWithConcurrency(trendMetrics, METRIC_QUERY_CONCURRENCY, (metric) => loadSingleMetric(metric, frozenTimeValues))
             .then((trendResults) => {
               if (!loadSequence.isCurrent(loadSeq)) return;
               setSeries((prev) => ({ ...prev, ...Object.fromEntries(trendResults) }));

--- a/web/src/app/monitor/dashboards/shared/utils/time.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/time.ts
@@ -1,6 +1,21 @@
 import { TimeValuesProps } from '@/app/monitor/types';
 import { getRecentTimeRange } from '@/app/monitor/utils/common';
 
+/**
+ * 把"近 N 分钟"这类相对时间窗(originValue 模式,每次取数都现算 dayjs() now)
+ * 解析并冻结成一个绝对的 [start, end] 窗口。
+ *
+ * 同一个面板的多条序列是各自独立发起 range 查询的,如果每条都各自现算时间窗,
+ * start 锚点会相差几十~几百毫秒,Prometheus/VM 按 start+k*step 返回时间戳,
+ * 网格随之错位、交错,合并(按精确时间戳做 key)后每行只有一条序列有值、
+ * 另一条被填 null;connectNulls 把线连满,但 axis tooltip 在同一个 x 上只能命中一条。
+ * 在一次刷新开始时冻结一次、所有序列复用,即可让网格对齐、tooltip 同时显示多条。
+ */
+export const freezeTimeValues = (timeValues: TimeValuesProps): TimeValuesProps => {
+  const [startTime, endTime] = getRecentTimeRange(timeValues);
+  return { timeRange: [startTime, endTime], originValue: 0 };
+};
+
 export const buildPreviousPeriodTimeValues = (timeValues: TimeValuesProps): TimeValuesProps | null => {
   const [startTime, endTime] = getRecentTimeRange(timeValues);
   if (!startTime || !endTime) return null;


### PR DESCRIPTION
## 问题

多序列趋势面板(如 PostgreSQL / MSSQL 的「缓存与磁盘读」)的 tooltip 在同一个时间点只显示一条序列,需要 hover 到不同时间点才能分别看到另一条——表现为「不是 2 个维度,而是不同时间各显示一个」。

## 根因

同一面板的每条序列是各自独立发起的 range 查询,时间窗在每次 `buildSearchParams` 内部用 `dayjs()`(当前时刻)现算。并发取数下各序列的 `start` 锚点相差几十~几百毫秒,Prometheus/VictoriaMetrics 按 `start + k*step` 返回时间戳,导致各序列时间戳落在**错位的网格**上。

`mergeChartSeries` 按精确时间戳做合并键,错位的点永远不落同一行,缺席序列被填 `null`;图表 `connectNulls: true` 把两条线都连满(视觉正常),但 `trigger: 'axis'` 的 tooltip 在任一 x 上只能解析到一条非 null 序列。

## 改动

- **`shared/utils/time.ts`**:新增 `freezeTimeValues()`,把「近 N 分钟」相对窗口一次性解析成绝对的 `[start, end]`。
- **`objects/common/simple-dashboard-core.tsx`**:在每次 `loadMetrics` 刷新开头冻结一次窗口,供汇总(KPI)、采集状态、趋势、对比期所有查询复用,使全部序列共享同一 step 网格。

自动刷新仍每轮重新冻结、窗口照常前移,只在单轮内对齐。

## 影响范围

所有经 `simple-dashboard-core` 渲染的对象(mysql / mongodb / elasticsearch / postgresql / mssql / k8s …)的多序列趋势面板。

## 验证

- 实时 VictoriaMetrics 比对:冻结窗口后两条序列时间戳网格一致,合并后同一行两值齐全。
- `tsc --noEmit`:改动文件无新增类型错误。
- 手动:刷新页面 hover「缓存与磁盘读」,tooltip 同时显示「缓存命中 + 磁盘读取」两条值。

## Test plan

- [ ] hover 多序列面板,tooltip 同时显示全部序列
- [ ] 切换时间范围 / 自动刷新后仍对齐
- [ ] 对比期(同比)序列正常