### PR TITLE
feat(monitor): 新增思科交换机监控（采集插件 + 专业仪表盘 + 品牌标识）

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -2023,6 +2023,27 @@ monitor_object_metric:
     device_total_outgoing_sflow_traffic:
       name: Device Total Outgoing sFlow Traffic Rate
       desc: This metric represents the average rate of total bytes sent by the entire device from sFlow over the past 5 minutes, measured in bytes per second. It helps administrators monitor outbound traffic derived from sFlow samples for capacity planning and troubleshooting.
+    device_cpu_usage:
+      name: CPU Utilization
+      desc: This metric reports the CPU utilization of the device control plane (typically the 5-minute average), as a percentage. Sustained high CPU usage can indicate control-plane overload, routing instability, or attack traffic, and may lead to slow management response or packet processing delays. Sourced from vendor-specific SNMP OIDs and normalized to a 0-100 percentage.
+    device_memory_usage:
+      name: Memory Utilization
+      desc: This metric reports overall memory utilization of the device, computed as used / (used + free) * 100 across all memory pools. High memory usage may indicate memory leaks, oversized routing/MAC/ARP tables, or insufficient capacity, and can cause instability or failed allocations.
+    device_memory_used:
+      name: Memory Used
+      desc: This metric reports the number of bytes currently in use for each memory pool of the device. It helps administrators understand the absolute memory consumption per pool (for example Processor or I/O pools) and identify which pool is under pressure.
+    device_memory_free:
+      name: Memory Free
+      desc: This metric reports the number of free bytes available in each memory pool of the device. Together with the used bytes it determines overall memory utilization; a persistently low free value indicates memory pressure on that pool.
+    device_temperature_celsius:
+      name: Temperature
+      desc: This metric reports the temperature reading of each hardware sensor on the device, in degrees Celsius. Abnormally high temperatures may indicate fan failure, blocked airflow, or excessive ambient heat, and can trigger thermal protection or hardware damage if left unaddressed.
+    device_fan_state:
+      name: Fan Status
+      desc: This metric reports the operational state of each cooling fan on the device. A non-normal state (warning, critical, shutdown, or notFunctioning) indicates a cooling fault that can quickly lead to overheating and should be investigated immediately.
+    device_psu_state:
+      name: Power Supply Status
+      desc: This metric reports the operational state of each power supply unit on the device. A non-normal state signals a power redundancy or hardware fault; on devices with redundant PSUs a single failure may not cause an outage but removes redundancy and must be remediated promptly.
   Router:
     snmp_uptime:
       name: System Uptime
@@ -3331,6 +3352,10 @@ monitor_object_metric_group:
     Packet Loss: Packet Loss
     Bandwidth: Bandwidth
     Traffic: Traffic
+    CPU: CPU
+    Memory: Memory
+    Temperature: Temperature
+    Hardware Status: Hardware Status
   ElasticSearch:
     Base: Base
     Node: Node
@@ -3486,6 +3511,12 @@ monitor_object_plugin:
     desc: Through the Telegraf collector, utilize the SNMP protocol to regularly collect
       key IF-MIB metrics from switch interfaces, including traffic volume, packet
       loss, and error counts.
+  Switch Cisco SNMP:
+    name: Cisco (Telegraf)
+    desc: Cisco-specific SNMP collection template for switches. In addition to standard
+      IF-MIB interface metrics, it collects Cisco private OIDs for device health
+      including CPU utilization, memory pools, temperature sensors, fan and
+      power-supply status.
   Switch Flow NetFlow:
     name: Switch Flow Analysis (NetFlow)
     desc: Use NetFlow to collect switch traffic and convert it into normalized device

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -1755,6 +1755,27 @@ monitor_object_metric:
     device_total_outgoing_sflow_traffic:
       name: 设备 sFlow 发送总流量速率
       desc: 此指标表示整个设备在过去5分钟内基于 sFlow 采样计算出的发送总字节流量平均速率，单位为字节每秒，可用于容量规划和流量排障。
+    device_cpu_usage:
+      name: CPU 使用率
+      desc: 该指标表示设备控制平面的 CPU 使用率（通常为 5 分钟平均值），单位为百分比。CPU 持续偏高可能意味着控制平面过载、路由震荡或异常流量，会导致管理响应变慢或转发延迟。数据来源于各品牌私有 SNMP OID，并归一化为 0-100 的百分比。
+    device_memory_usage:
+      name: 内存使用率
+      desc: 该指标表示设备整体内存使用率，按 已用/(已用+空闲)*100 在所有内存池上汇总计算，单位为百分比。内存偏高可能由内存泄漏、路由/MAC/ARP 表项过大或容量不足导致，可能引发不稳定或分配失败。
+    device_memory_used:
+      name: 内存已用量
+      desc: 该指标表示设备各内存池当前已使用的字节数。它帮助管理员了解每个内存池（如 Processor、I/O 池）的绝对内存消耗，并定位承压的内存池。
+    device_memory_free:
+      name: 内存空闲量
+      desc: 该指标表示设备各内存池当前空闲可用的字节数。它与已用量一起决定整体内存使用率；空闲量持续偏低说明该内存池存在内存压力。
+    device_temperature_celsius:
+      name: 温度
+      desc: 该指标表示设备各硬件温度传感器的读数，单位为摄氏度。温度异常升高可能意味着风扇故障、散热受阻或环境过热，若不处理可能触发热保护或损坏硬件。
+    device_fan_state:
+      name: 风扇状态
+      desc: 该指标表示设备各散热风扇的运行状态。非正常状态（告警、严重、关闭或故障）表示散热故障，可能迅速导致过热，应立即排查。
+    device_psu_state:
+      name: 电源状态
+      desc: 该指标表示设备各电源模块的运行状态。非正常状态表示电源冗余缺失或硬件故障；在具备冗余电源的设备上，单个故障可能不会立即中断业务，但会失去冗余，需尽快修复。
   Router:
     snmp_uptime:
       name: 系统运行时间
@@ -2989,6 +3010,10 @@ monitor_object_metric_group:
     Packet Loss: 数据包丢失
     Bandwidth: 带宽
     Traffic: 流量
+    CPU: CPU
+    Memory: 内存
+    Temperature: 温度
+    Hardware Status: 硬件状态
   ElasticSearch:
     Base: 集群健康
     Node: 节点资源
@@ -3129,6 +3154,9 @@ monitor_object_plugin:
   Switch SNMP General:
     name: 交换机通用（Telegraf）
     desc: 通过Telegraf采集器利用SNMP协议定期收集交换机各接口的流量、丢包数、错包数等IF-MIB关键指标。
+  Switch Cisco SNMP:
+    name: 思科（Telegraf）
+    desc: 思科交换机专用 SNMP 采集模板。在标准 IF-MIB 接口指标之外，额外采集思科私有 OID 的设备健康指标：CPU 使用率、内存池、温度传感器、风扇与电源状态。
   Switch Flow NetFlow:
     name: 交换机流量分析（NetFlow）
     desc: 使用 NetFlow 对交换机进行流量分析采集，并转换为标准化设备流量指标。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/UI.json
@@ -1,0 +1,320 @@
+{
+  "object_name": "Switch",
+  "instance_type": "switch",
+  "collect_type": "snmp_cisco",
+  "config_type": [
+    "cisco"
+  ],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_cisco_{{ip}}",
+  "form_fields": [
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "监控的目标主机的 IP 地址，用于标识数据收集的来源",
+      "widget_props": {
+        "placeholder": "目标主机 IP"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": "://([^:]+):"
+        }
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "editable": false,
+      "default_value": 161,
+      "description": "配置SNMP端口号，通常使用161端口与设备进行通信",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "SNMP 端口",
+        "addonAfter": ""
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": ":(\\d+)$"
+        }
+      }
+    },
+    {
+      "name": "version",
+      "label": "版本",
+      "type": "select",
+      "required": true,
+      "editable": false,
+      "default_value": 2,
+      "description": "指定要使用的 SNMP 协议版本，例如 v2c 或 v3，定义通信机制和安全级别",
+      "options": [
+        {
+          "label": "v2c",
+          "value": 2
+        },
+        {
+          "label": "v3",
+          "value": 3
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择 SNMP 版本"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.version"
+      }
+    },
+    {
+      "name": "community",
+      "label": "团体名",
+      "type": "input",
+      "required": true,
+      "default_value": "public",
+      "description": "用于 SNMPv2c 的认证字符串，类似于密码，允许访问设备的 SNMP 数据",
+      "widget_props": {
+        "placeholder": "SNMP Community 字符串"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 2
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.community",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_name",
+      "label": "名称",
+      "type": "input",
+      "required": true,
+      "description": "用于 SNMPv3 认证的用户名",
+      "widget_props": {
+        "placeholder": "安全名称"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_name",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_level",
+      "label": "级别",
+      "type": "select",
+      "required": true,
+      "default_value": "authPriv",
+      "description": "安全级别设置，例如 authPriv 表示同时使用认证和隐私（加密）",
+      "options": [
+        {
+          "label": "noAuthNoPriv",
+          "value": "noAuthNoPriv"
+        },
+        {
+          "label": "authNoPriv",
+          "value": "authNoPriv"
+        },
+        {
+          "label": "authPriv",
+          "value": "authPriv"
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择安全级别"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_level",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_protocol",
+      "label": "认证协议",
+      "type": "input",
+      "required": false,
+      "default_value": "SHA",
+      "description": "用于保护认证过程的认证协议",
+      "widget_props": {
+        "placeholder": "认证协议 (MD5/SHA)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_password",
+      "label": "认证密码",
+      "type": "password",
+      "required": false,
+      "description": "用于认证的密码，与选择的认证协议对应",
+      "widget_props": {
+        "placeholder": "认证密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_protocol",
+      "label": "加密协议",
+      "type": "input",
+      "required": false,
+      "default_value": "AES",
+      "description": "用于保护传输数据的加密协议",
+      "widget_props": {
+        "placeholder": "加密协议 (DES/AES)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_password",
+      "label": "加密密码",
+      "type": "password",
+      "required": false,
+      "description": "用于加密的密码，与选择的加密协议对应",
+      "widget_props": {
+        "placeholder": "加密密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "timeout",
+      "label": "超时时间",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "超时时间（秒）",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.timeout",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "采集间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "options_key": "node_ids_option",
+      "enable_row_filter": false
+    },
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "widget_props": {
+        "placeholder": "请输入 IP 地址"
+      },
+      "change_handler": {
+        "type": "simple",
+        "source_fields": [
+          "ip"
+        ],
+        "target_field": "instance_name"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ],
+  "extra_edit_fields": {
+    "agents": {
+      "origin_path": "child.content.config.agents",
+      "to_api": {
+        "template": "udp://{{ip}}:{{port}}",
+        "array": true
+      }
+    }
+  }
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/cisco.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/cisco.child.toml.j2
@@ -1,0 +1,97 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "{{ auth_password }}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "{{ priv_password }}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_cisco"
+        config_type = "cisco"
+        brand = "cisco"
+    # ---- System ----
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+    # ---- Interfaces (generic IF-MIB, auto-walked column names) ----
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.2.2"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.2.2.1.2"
+        name = "ifDescr"
+        is_tag = true
+    # ---- Cisco CPU utilization (CISCO-PROCESS-MIB cpmCPUTotal5minRev) ----
+    [[inputs.snmp.table]]
+        name = "device_cpu"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.109.1.1.1.1.8"
+        name = "usage"
+    # ---- Cisco Memory pool (CISCO-MEMORY-POOL-MIB) ----
+    [[inputs.snmp.table]]
+        name = "device_memory"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.48.1.1.1.2"
+        name = "name"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.48.1.1.1.5"
+        name = "used"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.48.1.1.1.6"
+        name = "free"
+    # ---- Cisco Temperature sensors (CISCO-ENVMON-MIB) ----
+    [[inputs.snmp.table]]
+        name = "device_temperature"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.3.1.2"
+        name = "descr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.3.1.3"
+        name = "celsius"
+    # ---- Cisco Fans (CISCO-ENVMON-MIB ciscoEnvMonFanState) ----
+    [[inputs.snmp.table]]
+        name = "device_fan"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.4.1.2"
+        name = "descr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.4.1.3"
+        name = "state"
+    # ---- Cisco Power supplies (CISCO-ENVMON-MIB ciscoEnvMonSupplyState) ----
+    [[inputs.snmp.table]]
+        name = "device_psu"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.5.1.2"
+        name = "descr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.9.9.13.1.5.1.3"
+        name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/metrics.json
@@ -1,0 +1,91 @@
+{
+  "plugin": "Switch Cisco SNMP",
+  "plugin_desc": "Cisco-specific SNMP collection for switches. In addition to standard IF-MIB interface metrics, it collects Cisco private OIDs for device health: CPU utilization, memory pools, temperature sensors, fan and power-supply status.",
+  "status_query": "any({instance_type='switch', collect_type='snmp_cisco'}) by (instance_id)",
+  "name": "Switch",
+  "icon": "mm-switch_交换机",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='switch'}) by (instance_id)",
+  "instance_id_keys": ["instance_id"],
+  "supplementary_indicators": ["device_cpu_usage", "device_memory_usage"],
+  "metrics": [
+    {
+      "metric_group": "CPU",
+      "name": "device_cpu_usage",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "display_name": "CPU Utilization",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the CPU utilization of the Cisco device control plane (5-minute average, CISCO-PROCESS-MIB cpmCPUTotal5minRev). Sustained high CPU usage can indicate control-plane overload, routing instability, or attack traffic, and may lead to slow management response or packet processing delays."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_used",
+      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "display_name": "Memory Used",
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "name", "description": "Memory pool name"}],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the number of bytes currently in use for each Cisco memory pool (CISCO-MEMORY-POOL-MIB). It helps administrators understand the absolute memory consumption per pool (for example Processor or I/O pools) and identify which pool is under pressure."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_free",
+      "query": "device_memory_free{instance_type='switch', __$labels__}",
+      "display_name": "Memory Free",
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "name", "description": "Memory pool name"}],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the number of free bytes available in each Cisco memory pool. Together with the used bytes it determines overall memory utilization; a persistently low free value indicates memory pressure on that pool."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_usage",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "display_name": "Memory Utilization",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports overall memory utilization of the Cisco device, computed as used / (used + free) * 100 across all memory pools. High memory usage may indicate memory leaks, oversized routing/MAC/ARP tables, or insufficient capacity, and can cause instability or failed allocations."
+    },
+    {
+      "metric_group": "Temperature",
+      "name": "device_temperature_celsius",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "display_name": "Temperature",
+      "data_type": "Number",
+      "unit": "celsius",
+      "dimensions": [{"name": "descr", "description": "Sensor description"}],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the temperature reading of each Cisco hardware sensor (CISCO-ENVMON-MIB), in degrees Celsius. Abnormally high temperatures may indicate fan failure, blocked airflow, or excessive ambient heat, and can trigger thermal protection or hardware damage if left unaddressed."
+    },
+    {
+      "metric_group": "Hardware Status",
+      "name": "device_fan_state",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "display_name": "Fan Status",
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
+      "dimensions": [{"name": "descr", "description": "Fan description"}],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the operational state of each Cisco cooling fan (CISCO-ENVMON-MIB ciscoEnvMonFanState). A non-normal state (warning, critical, shutdown, or notFunctioning) indicates a cooling fault that can quickly lead to overheating and should be investigated immediately."
+    },
+    {
+      "metric_group": "Hardware Status",
+      "name": "device_psu_state",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "display_name": "Power Supply Status",
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
+      "dimensions": [{"name": "descr", "description": "Power supply description"}],
+      "instance_id_keys": ["instance_id"],
+      "description": "This metric reports the operational state of each Cisco power supply unit (CISCO-ENVMON-MIB ciscoEnvMonSupplyState). A non-normal state signals a power redundancy or hardware fault; on devices with redundant PSUs a single failure may not cause an outage but removes redundancy and must be remediated promptly."
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_cisco/switch/policy.json
@@ -1,0 +1,68 @@
+{
+  "object": "Switch",
+  "plugin": "Switch Cisco SNMP",
+  "templates": [
+  {
+    "name": "Cisco交换机CPU使用率过高",
+    "alert_name": "交换机${resource_name} CPU 使用率过高",
+    "description": "监控 Cisco 设备控制平面的 CPU 使用率，当持续高于阈值时触发告警，提示可能存在控制平面过载、路由震荡或异常流量，避免管理响应变慢或转发受影响。",
+    "metric_name": "device_cpu_usage",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 90, "method": ">" },
+        { "level": "error", "value": 80, "method": ">" },
+        { "level": "warning", "value": 70, "method": ">" }
+    ]
+  },
+  {
+    "name": "Cisco交换机内存使用率过高",
+    "alert_name": "交换机${resource_name} 内存使用率过高",
+    "description": "监控 Cisco 设备整体内存使用率，当超过阈值时触发告警，便于及时发现内存泄漏、表项过大或容量不足等问题，防止设备不稳定或分配失败。",
+    "metric_name": "device_memory_usage",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 90, "method": ">" },
+        { "level": "error", "value": 80, "method": ">" },
+        { "level": "warning", "value": 70, "method": ">" }
+    ]
+  },
+  {
+    "name": "Cisco交换机温度过高",
+    "alert_name": "交换机${resource_name} 传感器 ${metric_descr} 温度过高",
+    "description": "监控 Cisco 设备各硬件温度传感器读数，当温度超过安全阈值时触发告警，提示可能存在风扇故障、散热不良或环境过热，避免触发热保护或硬件损坏。",
+    "metric_name": "device_temperature_celsius",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 70, "method": ">" },
+        { "level": "error", "value": 60, "method": ">" },
+        { "level": "warning", "value": 50, "method": ">" }
+    ]
+  },
+  {
+    "name": "Cisco交换机风扇异常",
+    "alert_name": "交换机${resource_name} 风扇 ${metric_descr} 状态异常",
+    "description": "监控 Cisco 设备各散热风扇的运行状态，当风扇处于非正常状态（告警/严重/关闭/故障）时触发告警，散热故障可能迅速导致过热，应立即排查处理。",
+    "metric_name": "device_fan_state",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "warning", "value": 2, "method": "=" },
+        { "level": "critical", "value": 3, "method": "=" },
+        { "level": "critical", "value": 4, "method": "=" },
+        { "level": "critical", "value": 6, "method": "=" }
+    ]
+  },
+  {
+    "name": "Cisco交换机电源异常",
+    "alert_name": "交换机${resource_name} 电源 ${metric_descr} 状态异常",
+    "description": "监控 Cisco 设备各电源模块的运行状态，当电源处于非正常状态时触发告警，提示电源冗余缺失或硬件故障，即使有冗余也应尽快修复以恢复冗余能力。",
+    "metric_name": "device_psu_state",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "warning", "value": 2, "method": "=" },
+        { "level": "critical", "value": 3, "method": "=" },
+        { "level": "critical", "value": 4, "method": "=" },
+        { "level": "critical", "value": 6, "method": "=" }
+    ]
+  }
+  ]
+}

--- a/web/public/assets/icons/mm-cisco_思科.svg
+++ b/web/public/assets/icons/mm-cisco_思科.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <defs>
+    <linearGradient id="ciscoBlue" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1ba0d7"/>
+      <stop offset="1" stop-color="#0d7fb8"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="url(#ciscoBlue)"/>
+  <g fill="#ffffff">
+    <rect x="26" y="58" width="6" height="20" rx="3"/>
+    <rect x="38" y="46" width="6" height="32" rx="3"/>
+    <rect x="50" y="34" width="6" height="44" rx="3"/>
+    <rect x="62" y="46" width="6" height="32" rx="3"/>
+    <rect x="74" y="34" width="6" height="44" rx="3"/>
+    <rect x="86" y="46" width="6" height="32" rx="3"/>
+  </g>
+  <text x="60" y="98" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#ffffff" letter-spacing="1">CISCO</text>
+</svg>

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -16,7 +16,7 @@ import useMonitorApi from '@/app/monitor/api';
 import useIntegrationApi from '@/app/monitor/api/integration';
 import { EllipsisOutlined, PlusOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
-import { getIconByObjectName } from '@/app/monitor/utils/common';
+import { getIconByObjectName, getPluginBrandIcon } from '@/app/monitor/utils/common';
 import { useRouter } from 'next/navigation';
 import {
   ModalRef,
@@ -417,7 +417,7 @@ const Integration = () => {
                       <div className="flex items-center space-x-4 my-2">
                         <div className="w-14 h-14 min-w-[56px] rounded-lg flex items-center justify-center bg-[var(--color-fill-1)]">
                           <img
-                            src={`/assets/icons/${getIconByObjectName(objectName, objects)}.svg`}
+                            src={`/assets/icons/${getPluginBrandIcon(app.name) || getIconByObjectName(objectName, objects)}.svg`}
                             alt={objectName}
                             className="w-12 h-12"
                             onError={(e) => {

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -572,6 +572,8 @@ export interface DashboardShellProps {
   dashboard: ReturnType<typeof useSimpleDashboardData>;
   /** Dashboard content (only shown in dashboard display mode). */
   dashboardContent: React.ReactNode;
+  /** 可选品牌标签（如 'Cisco'）：共享对象仪表盘按实例品牌在头部高亮显示，便于辨认当前盘属于哪个品牌。 */
+  brandLabel?: string;
   styles: DashboardStyles;
 }
 
@@ -582,6 +584,7 @@ export interface DashboardShellProps {
 export const DashboardShell = ({
   dashboard,
   dashboardContent,
+  brandLabel,
   styles
 }: DashboardShellProps) => (
   <div className={styles.page}>
@@ -601,9 +604,29 @@ export const DashboardShell = ({
         />
         <DashboardInstanceCard
           instanceName={dashboard.resolvedInstanceName}
-          metaItems={dashboard.objectMetaItems.map((item, index) => (
-            <span key={index} className={styles.instanceMetaInline}>{item}</span>
-          ))}
+          metaItems={[
+            ...(brandLabel
+              ? [
+                <span
+                  key="brand"
+                  style={{
+                    background: '#1ba0d7',
+                    color: '#fff',
+                    padding: '1px 10px',
+                    borderRadius: '10px',
+                    fontWeight: 600,
+                    fontSize: '12px',
+                    lineHeight: '18px'
+                  }}
+                >
+                  {brandLabel}
+                </span>
+              ]
+              : []),
+            ...dashboard.objectMetaItems.map((item, index) => (
+              <span key={index} className={styles.instanceMetaInline}>{item}</span>
+            ))
+          ]}
           icon={<DatabaseOutlined />}
           selectorValue={dashboard.instanceSelectValue}
           selectorLoading={dashboard.instanceLoading}

--- a/web/src/app/monitor/dashboards/objects/switch/config.ts
+++ b/web/src/app/monitor/dashboards/objects/switch/config.ts
@@ -1,0 +1,207 @@
+import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+
+export const SWITCH_DASHBOARD_CONFIG: SimpleDashboardConfig = {
+  routeKey: 'switch',
+  pageTitle: '交换机监控仪表盘',
+  objectFallbackName: 'Switch',
+  instanceType: 'switch',
+  collectionStatusQuery:
+    "count({instance_type='switch', __$labels__}) by (instance_id)",
+  metaItems: ['Telegraf', 'snmp'],
+  metrics: [
+    {
+      name: 'snmp_uptime',
+      display_name: '运行时长',
+      description: '设备自上次重启以来的持续运行时间，反映设备稳定性。',
+      unit: 's',
+      query: 'sum(snmp_uptime{__$labels__} / 100) by (instance_id)',
+      color: '#597ef7'
+    },
+    {
+      name: 'device_cpu_usage',
+      display_name: 'CPU 使用率',
+      description: '设备控制平面 CPU 使用率（5 分钟平均），持续偏高说明控制平面过载或异常流量。',
+      unit: 'percent',
+      query: 'device_cpu_usage{__$labels__}',
+      color: '#2f6bff'
+    },
+    {
+      name: 'device_memory_usage',
+      display_name: '内存使用率',
+      description: '设备整体内存使用率，按各内存池已用/(已用+空闲) 汇总计算。',
+      unit: 'percent',
+      query:
+        'sum(device_memory_used{__$labels__}) by (instance_id) / (sum(device_memory_used{__$labels__}) by (instance_id) + sum(device_memory_free{__$labels__}) by (instance_id)) * 100',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'device_memory_used',
+      display_name: '内存已用',
+      description: '设备各内存池当前已使用的字节数之和。',
+      unit: 'bytes',
+      query: 'sum(device_memory_used{__$labels__}) by (instance_id)',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'device_memory_free',
+      display_name: '内存空闲',
+      description: '设备各内存池当前空闲可用的字节数之和。',
+      unit: 'bytes',
+      query: 'sum(device_memory_free{__$labels__}) by (instance_id)',
+      color: '#27c274'
+    },
+    {
+      name: 'device_temperature_celsius',
+      display_name: '最高温度',
+      description: '设备各温度传感器读数中的最高值（摄氏度），用于一眼判断散热风险。',
+      unit: 'celsius',
+      query: 'max(device_temperature_celsius{__$labels__}) by (instance_id)',
+      color: '#f5222d'
+    },
+    {
+      name: 'device_fan_state',
+      display_name: '风扇状态',
+      description: '设备风扇的最坏运行状态。非正常状态表示散热故障，应立即排查。',
+      unit: 'none',
+      query: 'max(device_fan_state{__$labels__}) by (instance_id)',
+      color: '#13c2c2'
+    },
+    {
+      name: 'device_psu_state',
+      display_name: '电源状态',
+      description: '设备电源模块的最坏运行状态。非正常状态表示电源冗余缺失或硬件故障。',
+      unit: 'none',
+      query: 'max(device_psu_state{__$labels__}) by (instance_id)',
+      color: '#722ed1'
+    },
+    {
+      name: 'device_total_incoming_traffic',
+      display_name: '入向总流量',
+      description: '设备所有接口入向流量速率之和（字节/秒）。',
+      unit: 'byteps',
+      query: 'sum(rate(interface_ifInOctets{__$labels__}[5m])) by (instance_id)',
+      color: '#27c274'
+    },
+    {
+      name: 'device_total_outgoing_traffic',
+      display_name: '出向总流量',
+      description: '设备所有接口出向流量速率之和（字节/秒）。',
+      unit: 'byteps',
+      query: 'sum(rate(interface_ifOutOctets{__$labels__}[5m])) by (instance_id)',
+      color: '#2f6bff'
+    }
+  ],
+  summaryCards: [
+    {
+      title: '运行时长',
+      metric: 'snmp_uptime',
+      unit: 's',
+      formatter: 'duration',
+      isUptimeCard: true,
+      icon: 'clock',
+      color: '#597ef7',
+      guide: [{ label: '运行时长', detail: '设备自上次重启后的持续运行时间；期间发生重启会重新计时。' }],
+      footer: [{ label: '启动', metric: 'snmp_uptime', formatter: 'startedAt' }]
+    },
+    {
+      title: 'CPU 使用率',
+      metric: 'device_cpu_usage',
+      unit: 'percent',
+      color: '#2f6bff',
+      icon: 'thunder',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: 'CPU 使用率', detail: '控制平面 CPU 使用率，逼近 100% 说明处理能力将耗尽。' }]
+    },
+    {
+      title: '内存使用率',
+      metric: 'device_memory_usage',
+      unit: 'percent',
+      color: '#ff8a1f',
+      icon: 'memory',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '内存使用率', detail: '整体内存使用率，持续偏高可能由内存泄漏或表项过大导致。' }],
+      footer: [{ label: '已用', metric: 'device_memory_used', unit: 'bytes' }]
+    },
+    {
+      title: '最高温度',
+      metric: 'device_temperature_celsius',
+      unit: 'celsius',
+      color: '#f5222d',
+      icon: 'health',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '最高温度', detail: '所有传感器中的最高温度。异常升高可能是风扇故障或散热不良。' }]
+    },
+    {
+      title: '入向总流量',
+      metric: 'device_total_incoming_traffic',
+      unit: 'byteps',
+      color: '#27c274',
+      icon: 'api',
+      guide: [{ label: '入向总流量', detail: '设备所有接口入向流量速率之和。' }],
+      footer: [{ label: '出向', metric: 'device_total_outgoing_traffic', unit: 'byteps' }]
+    },
+    {
+      title: '出向总流量',
+      metric: 'device_total_outgoing_traffic',
+      unit: 'byteps',
+      color: '#2f6bff',
+      icon: 'api',
+      guide: [{ label: '出向总流量', detail: '设备所有接口出向流量速率之和。' }]
+    }
+  ],
+  charts: [
+    {
+      title: 'CPU 与内存使用率趋势',
+      subtitle: 'CPU、内存',
+      metric: 'device_cpu_usage',
+      guide: [{ label: '资源使用率', detail: '对比 CPU 与内存使用率，两者持续高位说明设备负载吃紧。' }],
+      series: [
+        { metric: 'device_cpu_usage', label: 'CPU 使用率', color: '#2f6bff', unit: 'percent' },
+        { metric: 'device_memory_usage', label: '内存使用率', color: '#ff8a1f', unit: 'percent' }
+      ]
+    },
+    {
+      title: '设备收发流量趋势',
+      subtitle: '入向、出向',
+      metric: 'device_total_incoming_traffic',
+      guide: [{ label: '收发流量', detail: '对比设备入向与出向总流量速率，识别流量突增或异常。' }],
+      series: [
+        { metric: 'device_total_incoming_traffic', label: '入向', color: '#27c274', unit: 'byteps' },
+        { metric: 'device_total_outgoing_traffic', label: '出向', color: '#2f6bff', unit: 'byteps' }
+      ]
+    },
+    {
+      title: '温度趋势',
+      subtitle: '最高传感器温度',
+      metric: 'device_temperature_celsius',
+      guide: [{ label: '温度', detail: '设备最高传感器温度随时间变化，持续上升需关注散热。' }],
+      series: [
+        { metric: 'device_temperature_celsius', label: '最高温度', color: '#f5222d', unit: 'celsius' }
+      ]
+    },
+    {
+      title: '风扇状态',
+      subtitle: '状态值随时间（1=正常）',
+      metric: 'device_fan_state',
+      guide: [{ label: '风扇状态', detail: '风扇状态值随时间变化，1 为正常；折线偏离 1（2 告警 / 3 严重 / 6 故障）即出现散热异常，可一眼看出异常时刻。' }],
+      series: [
+        { metric: 'device_fan_state', label: '风扇状态', color: '#13c2c2', unit: 'none' }
+      ]
+    },
+    {
+      title: '电源状态',
+      subtitle: '状态值随时间（1=正常）',
+      metric: 'device_psu_state',
+      guide: [{ label: '电源状态', detail: '电源模块状态值随时间变化，1 为正常；折线偏离 1 即电源冗余缺失或硬件故障，可一眼看出异常时刻。' }],
+      series: [
+        { metric: 'device_psu_state', label: '电源状态', color: '#722ed1', unit: 'none' }
+      ]
+    }
+  ],
+  ringPanels: [],
+  statusPanels: [],
+  details: []
+};

--- a/web/src/app/monitor/dashboards/objects/switch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/switch/dashboard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import React from 'react';
+import { useSimpleDashboardData } from '../common/simple-dashboard-core';
+import {
+  DashboardShell,
+  FlexiblePanelSection,
+  KpiSection,
+  useFilteredChartPanels,
+  useFilteredSummaryCards
+} from '../common/dashboard-components';
+import { TrendChartPanel } from '../../shared/widgets';
+import { getBrandLabel } from '@/app/monitor/utils/common';
+import { SWITCH_DASHBOARD_CONFIG } from './config';
+import styles from './index.module.scss';
+
+// 通用交换机始终展示的面板（所有品牌都采集 IF-MIB 接口 / 运行时长 / 流量）
+const UNIVERSAL_KPI = ['运行时长', '入向总流量', '出向总流量'];
+const HEALTH_KPI = ['CPU 使用率', '内存使用率', '最高温度'];
+// 仅当实例采集到厂商私有健康指标（如思科 CPU/内存/温度）时才显示的健康面板
+const HEALTH_METRICS = [
+  'device_cpu_usage',
+  'device_memory_usage',
+  'device_temperature_celsius',
+  'device_fan_state'
+];
+
+const CHART_TITLES = [
+  'CPU 与内存使用率趋势',
+  '设备收发流量趋势',
+  '温度趋势',
+  '风扇状态',
+  '电源状态'
+];
+
+export default function SwitchDashboardPage() {
+  const dashboard = useSimpleDashboardData(SWITCH_DASHBOARD_CONFIG);
+
+  // 品牌自适应：只有当实例真正采集到健康指标（CPU/内存/温度有数据）时，才渲染健康面板。
+  // 通用交换机（仅 IF-MIB）这些指标无数据 → 不渲染，避免出现空面板。
+  const hasHealthData = (dashboard.summaryCards || []).some(
+    (c) =>
+      HEALTH_METRICS.includes(c.card?.metric) &&
+      Array.isArray(c.trendData) &&
+      c.trendData.length > 0
+  );
+
+  // 健康场景：运行时长 + CPU/内存/温度 + 入向 = 5 张 + 采集状态卡 = 6（kpiCols=6 正好一行）
+  // 通用场景：运行时长 + 入向 + 出向 = 3 张 + 采集状态卡 = 4
+  const kpiTitles = hasHealthData
+    ? ['运行时长', ...HEALTH_KPI, '入向总流量']
+    : UNIVERSAL_KPI;
+  const summaryCards = useFilteredSummaryCards(dashboard.summaryCards, kpiTitles);
+  const charts = useFilteredChartPanels(dashboard.chartPanels, CHART_TITLES);
+
+  const cpuMemChart = charts.find((c) => c?.chart.title === 'CPU 与内存使用率趋势');
+  const trafficChart = charts.find((c) => c?.chart.title === '设备收发流量趋势');
+  const tempChart = charts.find((c) => c?.chart.title === '温度趋势');
+  const fanChart = charts.find((c) => c?.chart.title === '风扇状态');
+  const psuChart = charts.find((c) => c?.chart.title === '电源状态');
+
+  const renderTrend = (chart: (typeof charts)[number], className: string) =>
+    chart ? (
+      <TrendChartPanel
+        key={chart.chart.title}
+        title={chart.chart.title}
+        subtitle={chart.chart.subtitle}
+        guide={chart.chart.guide}
+        legends={chart.legends}
+        data={chart.data}
+        metric={chart.metric}
+        unit={chart.unit}
+        loading={dashboard.loading}
+        seriesStyles={chart.seriesStyles}
+        onXRangeChange={dashboard.onXRangeChange}
+        className={`${className} ${styles.compactTrend}`}
+        styles={styles}
+      />
+    ) : null;
+
+  // 共享 Switch 盘按当前实例品牌在头部标识（如 Cisco），便于辨认自适应切到的是哪个品牌的盘。
+  // 品牌按 instance_id 识别（而非显示名）：品牌采集模板会把 collect_type（如 snmp_cisco）写进
+  // instance_id 模板，因此 instance_id 是与品牌强绑定的可靠信号，不受用户自定义/ sysName 实例名影响。
+  const brandLabel = getBrandLabel(
+    (dashboard.idValues?.length ? dashboard.idValues.join('_') : '') ||
+      String(dashboard.instanceId ?? '')
+  );
+
+  return (
+    <DashboardShell
+      dashboard={dashboard}
+      brandLabel={brandLabel}
+      styles={styles}
+      dashboardContent={
+        <>
+          <div className={styles.sectionLabel}>健康概览</div>
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
+
+          {hasHealthData ? (
+            <>
+              {/* Row 1: CPU&内存 span6 + 收发流量 span6 */}
+              <div className={styles.sectionLabel}>性能趋势</div>
+              <FlexiblePanelSection styles={styles}>
+                {renderTrend(cpuMemChart, styles.span6)}
+                {renderTrend(trafficChart, styles.span6)}
+              </FlexiblePanelSection>
+
+              {/* Row 2: 温度 + 风扇状态 + 电源状态 三张折线 span4 */}
+              <div className={styles.sectionLabel}>温度与硬件状态</div>
+              <FlexiblePanelSection styles={styles}>
+                {renderTrend(tempChart, styles.span4)}
+                {renderTrend(fanChart, styles.span4)}
+                {renderTrend(psuChart, styles.span4)}
+              </FlexiblePanelSection>
+            </>
+          ) : (
+            <>
+              {/* 通用交换机：只展示收发流量趋势（接口/流量是所有交换机都有的标准指标） */}
+              <div className={styles.sectionLabel}>流量趋势</div>
+              <FlexiblePanelSection styles={styles}>
+                {renderTrend(trafficChart, styles.span12)}
+              </FlexiblePanelSection>
+            </>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/switch/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/switch/index.module.scss
@@ -1,0 +1,44 @@
+@use '../common/simple-dashboard.module.scss';
+
+// 区块小标题:给分区加语义标题,提升可扫读性(与 redis/postgresql 同款)
+.sectionLabel {
+  margin: 2px 2px 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eceff4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8c95a8;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 8px;
+}
+
+:global(html.dark) .sectionLabel {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+// 紧凑折线:压缩 chartWrap 高度(与 host 同款)
+.compactTrend {
+  .chartWrap {
+    height: 164px;
+  }
+}
+
+@media (max-width: 768px) {
+  .compactTrend {
+    .chartWrap {
+      height: 138px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
+}

--- a/web/src/app/monitor/dashboards/objects/switch/index.ts
+++ b/web/src/app/monitor/dashboards/objects/switch/index.ts
@@ -1,0 +1,1 @@
+export { default } from './dashboard';

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -19,6 +19,7 @@ import WebsiteDashboard from './objects/website';
 import K8sClusterDashboard from './objects/k8s-cluster';
 import K8sNodeDashboard from './objects/k8s-node';
 import K8sPodDashboard from './objects/k8s-pod';
+import SwitchDashboard from './objects/switch';
 import { normalizeDashboardKey } from './shared/utils';
 
 export const PROFESSIONAL_DASHBOARD_GROUPS = {
@@ -172,6 +173,15 @@ export const PROFESSIONAL_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
     objectDisplayName: 'Ping',
     inheritedPermissionPath: '/monitor/view',
     component: PingDashboard
+  },
+  {
+    key: 'switch',
+    aliases: ['交换机'],
+    groupKey: 'network',
+    objectName: 'Switch',
+    objectDisplayName: '交换机',
+    inheritedPermissionPath: '/monitor/view',
+    component: SwitchDashboard
   },
   {
     key: 'k8s-cluster',

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/switch.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/switch.tsx
@@ -3,39 +3,69 @@ export const useSwitchConfig = () => {
     instance_type: 'switch',
     dashboardDisplay: [
       {
-        indexId: 'device_total_outgoing_traffic',
+        indexId: 'device_cpu_usage',
         displayType: 'single',
         sortIndex: 0,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '15%'
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_memory_usage',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_incoming_traffic',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_outgoing_traffic',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
         }
       },
       {
         indexId: 'snmp_uptime',
         displayType: 'lineChart',
-        sortIndex: 1,
+        sortIndex: 4,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '40%'
+          width: '49%'
         }
       },
       {
-        indexId: 'device_total_incoming_traffic',
+        indexId: 'device_temperature_celsius',
         displayType: 'lineChart',
-        sortIndex: 2,
-        displayDimension: [],
+        sortIndex: 5,
+        displayDimension: ['descr'],
         style: {
           height: '200px',
-          width: '40%'
+          width: '49%'
         }
       },
       {
         indexId: 'interfaces',
         displayType: 'multipleIndexsTable',
-        sortIndex: 3,
+        sortIndex: 6,
         displayDimension: [
           'ifOperStatus',
           'ifHighSpeed',
@@ -50,6 +80,26 @@ export const useSwitchConfig = () => {
           height: '400px',
           width: '100%'
         }
+      },
+      {
+        indexId: 'device_fan_state',
+        displayType: 'lineChart',
+        sortIndex: 7,
+        displayDimension: ['descr'],
+        style: {
+          height: '200px',
+          width: '49%'
+        }
+      },
+      {
+        indexId: 'device_psu_state',
+        displayType: 'lineChart',
+        sortIndex: 8,
+        displayDimension: ['descr'],
+        style: {
+          height: '200px',
+          width: '49%'
+        }
       }
     ],
     groupIds: {
@@ -58,6 +108,7 @@ export const useSwitchConfig = () => {
     },
     collectTypes: {
       'Switch SNMP General': 'snmp',
+      'Switch Cisco SNMP': 'snmp_cisco',
       'Switch Flow NetFlow': 'netflow',
       'Switch Flow sFlow': 'sflow'
     }

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -494,6 +494,19 @@ export const getIconByObjectName = (objectName = '', objects: ObjectItem[]) => {
   );
 };
 
+// 品牌专属采集模板/实例（如思科交换机）的品牌识别：按名称匹配 → 提供品牌 logo 图标与品牌标签。
+const BRANDS: { match: RegExp; label: string; icon: string }[] = [
+  { match: /cisco/i, label: 'Cisco', icon: 'mm-cisco_思科' }
+];
+
+// 按插件名取品牌 logo 图标；未命中返回 undefined（调用方回退监控对象图标）。
+export const getPluginBrandIcon = (pluginName = ''): string | undefined =>
+  BRANDS.find((brand) => brand.match.test(pluginName))?.icon;
+
+// 按名称（实例名/插件名）取品牌标签（如 'Cisco'），用于在共享仪表盘头部标识当前品牌；未命中返回 undefined。
+export const getBrandLabel = (text = ''): string | undefined =>
+  BRANDS.find((brand) => brand.match.test(text))?.label;
+
 export const getRecentTimeRange = (timeValues: TimeValuesProps) => {
   if (timeValues.originValue) {
     const beginTime: number = dayjs()


### PR DESCRIPTION
## 背景 / What
在「交换机」监控对象下新增**思科（Cisco）专用采集模板**，作为独立采集卡片（collect_type=`snmp_cisco`），并配套品牌自适应的专业监控仪表盘与品牌标识。

## 改动 / Changes
- **采集插件** `Telegraf/snmp_cisco/switch`：在标准 IF-MIB 接口指标之外，采集思科私有 OID 的设备健康指标 —— CPU（CISCO-PROCESS-MIB）、内存池（CISCO-MEMORY-POOL-MIB）、温度/风扇/电源状态（CISCO-ENVMON-MIB）；含接入表单与告警策略。风扇/电源告警按确切故障态匹配（warning=2，critical=3/4/6），空槽位 notPresent(5) 不误报、warning 不漏报。
- **品牌自适应专业仪表盘**（注册到「网络」分组）：通用交换机只展示通用面板（运行时长/流量），有健康数据的品牌实例额外展示 CPU/内存/温度 KPI 与 温度/风扇/电源 折线图；采集状态查询与 collect_type 无关，覆盖所有交换机采集来源。
- **品牌标识**：集成卡片显示思科 logo，仪表盘头部显示品牌标签；品牌由 instance_id（携带 snmp_cisco 采集类型）推导，而非显示名。
- 卡片标题「思科（Telegraf）」/「Cisco (Telegraf)」；中英文案。

## 测试 / Test plan
- [x] JSON / YAML 校验通过；`pnpm type-check` 在改动文件 0 报错
- [x] `python manage.py plugin_init` 导入成功（插件 + 告警策略）
- [x] 本地 mock 数据验证：集成卡片、专业仪表盘、采集状态、品牌标签均正常显示
- [ ] 现网思科设备 SNMP OID 复核（CPU index / 温度·风扇·电源传感器表）

> 说明：卡片/头部的思科图标为**原创风格占位图标**（非官方商标精确还原），如需官方素材可替换同名 `web/public/assets/icons/mm-cisco_思科.svg`。