### PR TITLE
fix(monitor): resolve instance_id lookup error and metric label i18n in display config

### DIFF
--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -438,3 +438,65 @@ def test_effective_plugins_action_returns_service_data(monkeypatch):
 
     assert service_calls["args"] == (7, "('host-a',)", "zh-Hans")
     assert payload["data"] == expected
+
+
+def test_effective_plugins_action_normalizes_clean_instance_id(db, monkeypatch):
+    """前端传干净标量(如 "host-a"),实例在库中存为元组串 "('host-a',)"。
+
+    视图必须把入参归一为存储键形态再做存在性校验与服务调用,否则误报"监控实例不存在"
+    (回归自 fbc8ef34a「feat: filter monitor view plugins by reported data」)。
+    """
+    monitor_object = MonitorObject.objects.create(
+        name="Host",
+        display_name="Host",
+        instance_id_keys=["instance_id"],
+    )
+    MonitorInstance.objects.create(
+        id="('host-a',)",
+        name="Host A",
+        monitor_object=monitor_object,
+    )
+
+    service_calls = {}
+    expected = [{"id": 12, "name": "HostRemote"}]
+
+    class StubService:
+        @staticmethod
+        def get_effective_plugins(monitor_object_id, instance_id, locale):
+            service_calls["args"] = (monitor_object_id, instance_id, locale)
+            return expected
+
+    monkeypatch.setattr(monitor_instance_view, "MonitorEffectivePluginService", StubService)
+    # 仅 mock actor_context(超管,跳过组织权限),保留真实 _ensure_operate_instances 以触发存在性查询。
+    monkeypatch.setattr(
+        monitor_instance_view,
+        "_build_actor_context",
+        lambda request: {
+            "is_superuser": True,
+            "current_team": 1,
+            "username": "tester",
+            "domain": "default",
+            "group_list": [],
+            "include_children": False,
+        },
+    )
+
+    request = types.SimpleNamespace(
+        GET={"instance_id": "host-a"},  # 前端下传的是干净标量,而非存储用的元组串
+        COOKIES={"current_team": "1"},
+        user=types.SimpleNamespace(
+            username="tester",
+            domain="default",
+            locale="zh-Hans",
+            is_superuser=True,
+            group_list=[],
+        ),
+    )
+
+    response = monitor_instance_view.MonitorInstanceViewSet().effective_plugins(
+        request, str(monitor_object.id)
+    )
+    payload = json.loads(response.content)
+
+    assert service_calls["args"] == (monitor_object.id, "('host-a',)", "zh-Hans")
+    assert payload["data"] == expected

--- a/server/apps/monitor/views/monitor_instance.py
+++ b/server/apps/monitor/views/monitor_instance.py
@@ -21,6 +21,7 @@ from apps.monitor.services.policy_source_cleanup import cleanup_policy_sources
 from apps.monitor.services.flow_onboarding import FlowOnboardingService
 from apps.monitor.services.effective_plugins import MonitorEffectivePluginService
 from apps.monitor.services.metrics import Metrics as MetricsService
+from apps.monitor.utils.dimension import normalize_instance_identity
 from apps.monitor.utils.pagination import parse_page_params
 from apps.rpc.node_mgmt import NodeMgmt
 
@@ -246,6 +247,11 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
         instance_id = request.GET.get("instance_id")
         if not instance_id:
             raise BaseAppException("instance_id is required")
+
+        # 前端下传的可能是干净标量(如 "mssql_1433"),而实例ID在库中以元组串形态存储
+        # (如 "('mssql_1433',)")。统一归一为存储键形态,兼容两种输入,既匹配存在性校验,
+        # 也保证 get_effective_plugins 内部按存储键比对上报数据,避免误报"监控实例不存在"。
+        instance_id = normalize_instance_identity(instance_id)["storage_instance_key"]
 
         actor_context = _build_actor_context(request)
         _ensure_operate_instances(request, [instance_id], actor_context)

--- a/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
@@ -56,6 +56,8 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
     const dragIndexRef = useRef<number | null>(null);
     // 镜像 pluginsMap，供 loadNodeOptions 同步读取已加载状态（避免在 setState updater 内做副作用）
     const pluginsMapRef = useRef<Record<number, PluginOption[]>>({});
+    // 正在请求中的指标 key，避免预热与下拉懒加载并发重复请求同一插件
+    const inflightMetricsRef = useRef<Set<string>>(new Set());
 
     useEffect(() => {
       pluginsMapRef.current = pluginsMap;
@@ -81,6 +83,7 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
         setLoading(true);
         dirtyRef.current = new Set();
         pluginsMapRef.current = {};
+        inflightMetricsRef.current = new Set();
         setColumnsMap({});
         setPluginsMap({});
         setMetricsMap({});
@@ -191,16 +194,34 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
     const ensureMetrics = async (plugin: string) => {
       if (activeId == null || !plugin) return;
       const key = metricsKey(activeId, plugin);
-      if (metricsMap[key]) return;
+      if (metricsMap[key] || inflightMetricsRef.current.has(key)) return;
       const pluginOpt = currentPlugins.find((p) => p.name === plugin);
       if (!pluginOpt) return;
+      inflightMetricsRef.current.add(key);
       try {
         const metrics = await getObjectMetrics(activeId, pluginOpt.id);
         setMetricsMap((prev) => ({ ...prev, [key]: metrics || [] }));
       } catch {
         message.error(t('common.operationFailed'));
+      } finally {
+        inflightMetricsRef.current.delete(key);
       }
     };
+
+    // 预热已绑定指标的插件选项：否则初次渲染时 Select 的 value（指标原始名）在空 options
+    // 里匹配不到对应项，antd 会回退显示原始名（英文），点开下拉懒加载后才变成中文展示名。
+    useEffect(() => {
+      if (activeId == null || currentPlugins.length === 0) return;
+      const boundPlugins = new Set(
+        currentColumns
+          .flatMap((c) => c.metrics)
+          .map((m) => m.plugin)
+          .filter(Boolean)
+      );
+      boundPlugins.forEach((plugin) => ensureMetrics(plugin));
+      // ensureMetrics 依赖随渲染重建，且内部已用 metricsMap/inflight 双重去重，无需纳入依赖
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [activeId, currentPlugins, currentColumns]);
 
     const updateBindingPlugin = async (
       colIdx: number,


### PR DESCRIPTION
## 背景

修复监控模块两个独立缺陷,均与「实例 ID 以字符串化元组形态存储」(`('mssql_1433',)`) 的既有约定相关。

## 修复 1:全量指标页报「监控实例不存在」

- 现象:同一实例,监控仪表盘正常,但「全量指标」页弹出 `监控实例不存在`,影响所有实例。
- 根因:`effective_plugins` 接口收到前端拆包后的干净 ID(`mssql_1433`),却直接 `filter(id=...)` 匹配 DB 中存储的元组形态(`('mssql_1433',)`),恒不命中。该接口自 "filter monitor view plugins by reported data" 引入后才被全量指标页调用,故此前无此问题。
- 改动:`server/apps/monitor/views/monitor_instance.py` 在实例校验前对 `instance_id` 做形态归一(兼容裸值与元组串),并补充 `test_monitor_instance_view.py` 用例。

## 修复 2:展示指标配置下拉初次显示英文原始名

- 现象:「展示指标配置」弹窗中,已绑定指标初次渲染显示英文原始名(如 `sqlserver_database_io_read_latency_ms`),点开下拉后才变中文展示名。
- 根因:指标选项仅在 `onDropdownVisibleChange` 懒加载,初次渲染时 Select 的 value 在空 options 中匹配不到,antd 回退显示原始值。
- 改动:`web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx` 在节点与插件就绪后,对已绑定指标的插件预热指标选项;并加在途去重避免预热与懒加载重复请求。

## 验证

- 后端:`test_monitor_instance_view.py` 新增用例覆盖元组形态查询。
- 前端:ESLint 通过;type-check 本文件无报错(web 无单测框架)。
