### PR TITLE
bugfix: 监控 NATS 写接口补身份闸，消除缺身份即用默认账号建库的鉴权旁路（#3339）

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -407,8 +407,8 @@ def _get_monitor_instance_permission(monitor_obj_id: str, user_info: dict):
 def _normalize_permission_user(user):
     if hasattr(user, "username") and hasattr(user, "domain"):
         return user
-    if isinstance(user, str) and user:
-        return SimpleNamespace(username=user, domain="domain.com")
+    if isinstance(user, str) and user.strip():
+        return SimpleNamespace(username=user.strip(), domain="domain.com")
     return user
 
 

--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -291,7 +291,23 @@ def _create_monitor_policy_payload(data: dict, operator: str = "api", domain: st
     return policy, MonitorPolicySerializer(policy).data
 
 
+def _require_authenticated_actor(user_info: Optional[dict]):
+    """写接口身份闸：必须携带可解析的已认证身份才允许写库。
+
+    缺身份时不再回退默认 api/domain.com 账号继续建库——对齐读接口
+    _get_monitor_instance_permission 的身份校验（缺用户即拒），消除"写比读松"的鉴权旁路：
+    仅凭向 NATS subject 发消息、不带任何身份即可新建监控对象/告警策略的攻击面。
+    校验失败时返回与读接口一致的失败结构。
+    """
+    if not isinstance(user_info, dict) or not _normalize_permission_user(user_info.get("user")):
+        return {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    return None
+
+
 def _execute_nats_create(create_func, data: dict, user_info: Optional[dict] = None):
+    identity_error = _require_authenticated_actor(user_info)
+    if identity_error:
+        return identity_error
     try:
         operator, domain = _resolve_nats_actor(user_info)
         _, result_data = create_func(data, operator=operator, domain=domain)

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -180,8 +180,8 @@ def test_execute_nats_create_rejects_user_info_without_user(monkeypatch):
         called["count"] += 1
         return object(), {"id": "metric"}
 
-    # user_info 是 dict 但缺 user（或 user 为空）→ 不再回退默认账号，直接拒
-    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"domain": "tenant-a.com"}):
+    # user_info 是 dict 但缺 user（或 user 为空/纯空白）→ 不再回退默认账号，直接拒
+    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"user": "  "}, {"user": "\t"}, {"domain": "tenant-a.com"}):
         result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=bad_user_info)
         assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
 

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -156,6 +156,66 @@ def test_execute_nats_create_uses_domain_from_user_info_for_string_users(monkeyp
     }
 
 
+def test_execute_nats_create_rejects_missing_user_info(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_missing_user_info_test_module")
+
+    called = {"count": 0}
+
+    def fake_create(payload, operator="api", domain="domain.com"):
+        called["count"] += 1
+        return object(), {"id": "metric"}
+
+    result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=None)
+
+    assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    assert called["count"] == 0
+
+
+def test_execute_nats_create_rejects_user_info_without_user(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_no_user_test_module")
+
+    called = {"count": 0}
+
+    def fake_create(payload, operator="api", domain="domain.com"):
+        called["count"] += 1
+        return object(), {"id": "metric"}
+
+    # user_info 是 dict 但缺 user（或 user 为空）→ 不再回退默认账号，直接拒
+    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"domain": "tenant-a.com"}):
+        result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=bad_user_info)
+        assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+
+    assert called["count"] == 0
+
+
+def test_create_monitor_policy_rejects_anonymous_caller_without_side_effects(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_policy_anonymous_test_module")
+
+    view_calls = []
+
+    class ExplodingMonitorPolicySerializer:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("匿名调用不应触达序列化/写库")
+
+    class ExplodingViewSet:
+        def __getattr__(self, name):
+            def _boom(*args, **kwargs):
+                view_calls.append(name)
+                raise AssertionError("匿名调用不应触发任何写副作用")
+
+            return _boom
+
+    monkeypatch.setattr(module, "MonitorPolicySerializer", ExplodingMonitorPolicySerializer)
+    monkeypatch.setattr(module, "_get_monitor_policy_viewset", ExplodingViewSet)
+
+    result = module.create_monitor_policy(
+        {"name": "evil policy", "schedule": "*/5 * * * *", "organizations": [1]},
+    )
+
+    assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    assert view_calls == []
+
+
 def test_create_monitor_policy_maps_api_create_side_effects(monkeypatch):
     module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_monitor_policy_test_module")
 


### PR DESCRIPTION
## 被破坏的不变量

监控的写操作本应与读操作持有**同一条身份边界**：无可解析的已认证身份，就不得访问监控数据。读接口 `_get_monitor_instance_permission` 正是这么做的——缺用户/组织即拒。但 NATS 暴露的 `create_*` 写接口（建监控对象 / 插件 / 指标 / 指标分组 / 对象类型 / **告警策略**）却在 `user_info` 缺失时**回退默认系统账号 `api/domain.com` 继续写库**，全程零身份、零权限校验。

结果是"写比读松"的不对称：任何能向该 NATS subject 发消息的客户端，**不带任何身份**即可新建告警策略（并指定通知给谁、用什么渠道），污染监控配置。这与已修复的 #3125（node_list `skip_permission` 旁路）属同一类鉴权旁路。

## 根因（设计层）

`create_*` handler 统一经 `_execute_nats_create → _resolve_nats_actor`。`_resolve_nats_actor` 的设计目的是**归属**（把 `created_by/domain` 落到调用者头上，见 commit `dc28f7496` "restore actor context"），它在 `user_info` 非 dict 时返回 `("api","domain.com")` 作为缺省 maintainer。问题在于 `_execute_nats_create` 把这个"缺省归属"误用成了"缺省授权"——拿到默认 actor 就直接写库，**身份缺失这一信号被默认值吞掉了**，从未上升为一次拒绝。读路径有身份闸、写路径没有，边界就此被绕过。

## 修复如何恢复不变量

在 `_execute_nats_create` 写库前增加身份闸 `_require_authenticated_actor`，把"缺身份"重新变成一次显式拒绝，与读接口对齐：

```python
def _require_authenticated_actor(user_info):
    if not isinstance(user_info, dict) or not _normalize_permission_user(user_info.get("user")):
        return {"result": False, "data": [], "message": "缺少用户或组织信息"}
    return None
```

- 缺身份（`user_info` 非 dict / 无 user / user 为空）→ 返回与读接口**完全一致**的失败结构，不再回退默认账号、不再写库。
- 已认证用户路径**完全不变**：actor 归属（`created_by/updated_by/domain`）照旧由 `_resolve_nats_actor` 解析。

### 关于 user vs user+team 的非对称（刻意为之）

读接口要求 `user` **且** `team`，因为它要做 team 维度的权限过滤；写路径目前没有 team 级授权模型（只盖 `created_by/domain`）。因此本次写闸只要求 `user`：
- 强加 `team` 会破坏既有的已认证调用契约（现有测试用 `{"user":"alice"}` 无 team），且并不增加真实 authz；
- "已认证用户的细粒度 create 授权（谁有权建库 / 建策略）"是更深的授权模型问题，**超出本旁路修复范围**，建议作为后续 enhancement 跟进。本 PR 只负责堵住**匿名**写入这一明确攻击面，恢复"写不松于读"的对称性。

## blast radius · 一致性

- 改动仅限 `server/apps/monitor/nats/monitor.py` 单文件单入口；6 个 `create_*` handler 全部经 `_execute_nats_create`，单闸即全覆盖，无遗漏 handler。
- 复用既有 `_normalize_permission_user` 与读接口同款失败结构，未引入新概念、不触 core/共享 util。
- **无存量调用方受影响**：全仓 `server/` 与 `agents/` 均无 `create_*` subject 的发起方（仅 `apps/rpc/monitor.py` 的 wrapper，且其本身零调用），web 不直连 NATS。任何因此被拒的调用，正是此前依赖该旁路的匿名写入。

## 调用链

```mermaid
flowchart TD
    MSG["NATS 消息<br/>user_info 调用方可控/可空"] --> H["create_* handler :471-516<br/>6 个写接口统一入口"]
    H --> E["_execute_nats_create :294"]
    E --> G{"_require_authenticated_actor<br/>缺身份？"}
    G -- "是（本次新增闸）" --> REJ["拒绝：缺少用户或组织信息<br/>不写库"]
    G -- "否（已认证）" --> R["_resolve_nats_actor :157<br/>解析 actor 归属"]
    R --> W["写库：MonitorPolicy / Object…<br/>created_by/domain 归属调用者"]

    RD["读 handler"] --> P["_get_monitor_instance_permission :378<br/>缺身份即拒"]
    P -. "写闸与读闸对齐" .-> G
```

## 验证

- 新增 3 条回归测试（`test_nats_create_handlers.py`）：①`user_info=None` 被拒且 `create_func` 不触达；②dict 缺 user 的多种形态（`{}`/`{"user":None}`/`{"user":""}`/仅 domain）全被拒；③匿名 `create_monitor_policy` 被拒且**不触达序列化与 viewset 任何写副作用**（爆炸式 stub 断言）。**revert 身份闸后这 3 条必失败**（缺省回退会让匿名写入成功）。
- 既有 10 条测试全部保持通过（已认证 `{"user":"alice"}` 契约不破）。
- 本地以 Django-free 独立 harness 实跑全部 13 条：13/13 通过（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`，监控注入式测试按既定方式用独立 harness 验证）。
- `flake8 --max-line-length 150` 无告警。
