### PR TITLE
bugfix: 监控总览统计统一 scope 口径，非超管且无 team 不再返回全平台计数（#3342）

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -1038,6 +1038,19 @@ def mm_query(query: str, step="5m", *args, **kwargs):
     return _build_vm_query_failure_result(resp, "查询单个指标数据失败")
 
 
+def _scope_count_queryset(qs, *, is_superuser: bool, team, org_field: str):
+    """总览计数的统一 scope 口径：超管→全量；非超管→必须按 team 收窄。
+
+    非超管且无 team 视为**零授权**，返回空集（qs.none()）而非全量——
+    否则会把全平台跨组织计数泄露给一个没有任何组织归属的普通用户。
+    """
+    if is_superuser:
+        return qs
+    if not team:
+        return qs.none()
+    return qs.filter(**{org_field: team}).distinct()
+
+
 @nats_client.register
 def get_monitor_statistics(user_info=None, **kwargs):
     """监控中心总览统计
@@ -1055,40 +1068,45 @@ def get_monitor_statistics(user_info=None, **kwargs):
     team = user_info.get("team")
     is_superuser = bool(user_info.get("is_superuser"))
 
-    def _scope_instance(qs):
-        if is_superuser or not team:
-            return qs
-        return qs.filter(monitorinstanceorganization__organization=team).distinct()
-
-    def _scope_policy(qs):
-        if is_superuser or not team:
-            return qs
-        return qs.filter(policyorganization__organization=team).distinct()
-
     # ============ 资源概览 ============
+    # 监控对象/对象类型属平台级目录（各组织一致），非租户数据，不做组织收窄
     monitor_object_total = MonitorObject.objects.count()
     monitor_object_visible = MonitorObject.objects.filter(is_visible=True).count()
     monitor_object_category = MonitorObjectType.objects.count()
 
-    instance_qs = _scope_instance(MonitorInstance.objects.filter(is_deleted=False))
+    instance_qs = _scope_count_queryset(
+        MonitorInstance.objects.filter(is_deleted=False),
+        is_superuser=is_superuser,
+        team=team,
+        org_field="monitorinstanceorganization__organization",
+    )
     monitor_instance_total = instance_qs.count()
     monitor_instance_active = instance_qs.filter(is_active=True).count()
     monitor_instance_inactive = instance_qs.filter(is_active=False).count()
 
     # ============ 能力概览 ============
+    # 插件/指标/指标分组同属平台级目录，不做组织收窄
     plugin_total = MonitorPlugin.objects.count()
     plugin_builtin = MonitorPlugin.objects.filter(is_pre=True).count()
     plugin_custom = MonitorPlugin.objects.filter(is_pre=False).count()
     metric_total = Metric.objects.count()
     metric_group_total = MetricGroup.objects.count()
+    # 采集配置按实例归属收窄：超管→全量；非超管→跟随 instance_qs（无 team 时为空集→0）
     collect_config_total = (
-        CollectConfig.objects.filter(monitor_instance_id__in=instance_qs.values_list("id", flat=True)).count()
-        if not (is_superuser or not team)
-        else CollectConfig.objects.count()
+        CollectConfig.objects.count()
+        if is_superuser
+        else CollectConfig.objects.filter(monitor_instance_id__in=instance_qs.values_list("id", flat=True)).count()
     )
 
     # ============ 告警概览 ============
-    policy_qs = _scope_policy(MonitorPolicy.objects.all())
+    # 策略按组织收窄；下游 alert/event/snapshot/baseline 均以 policy_qs 的 id 集合间接收窄，
+    # 故非超管且无 team 时 policy_qs 为空集，所有告警类计数随之归零
+    policy_qs = _scope_count_queryset(
+        MonitorPolicy.objects.all(),
+        is_superuser=is_superuser,
+        team=team,
+        org_field="policyorganization__organization",
+    )
     policy_total = policy_qs.count()
     policy_enabled = policy_qs.filter(enable=True).count()
     policy_disabled = policy_qs.filter(enable=False).count()

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -364,3 +364,184 @@ def test_mm_query_returns_failure_when_victoriametrics_reports_error_without_det
     result = module.mm_query("up")
 
     assert result == {"result": False, "data": [], "message": "查询单个指标数据失败"}
+
+
+# ============ 总览统计 scope 收口（Issue #3342）============
+
+
+class _ScopeFakeQS:
+    """仅用于 _scope_count_queryset 单测：记录 none/filter/distinct 调用。"""
+
+    def __init__(self, tag="full"):
+        self.tag = tag
+        self.filter_kwargs = None
+        self.distinct_called = False
+
+    def none(self):
+        return _ScopeFakeQS("none")
+
+    def filter(self, **kwargs):
+        new = _ScopeFakeQS("filtered")
+        new.filter_kwargs = kwargs
+        return new
+
+    def distinct(self):
+        self.distinct_called = True
+        return self
+
+
+def test_scope_count_queryset_superuser_returns_full(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_scope_superuser_test_module")
+    qs = _ScopeFakeQS("full")
+    assert module._scope_count_queryset(qs, is_superuser=True, team=None, org_field="x") is qs
+
+
+def test_scope_count_queryset_non_superuser_no_team_returns_none(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_scope_no_team_test_module")
+    qs = _ScopeFakeQS("full")
+    # 非超管 + 空 team → 零授权空集（修复点；revert 后会返回 full，本断言失败）
+    for empty_team in (None, "", 0):
+        result = module._scope_count_queryset(qs, is_superuser=False, team=empty_team, org_field="x")
+        assert result.tag == "none"
+
+
+def test_scope_count_queryset_non_superuser_with_team_filters(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_scope_team_test_module")
+    qs = _ScopeFakeQS("full")
+    result = module._scope_count_queryset(
+        qs, is_superuser=False, team=5, org_field="policyorganization__organization"
+    )
+    assert result.tag == "filtered"
+    assert result.filter_kwargs == {"policyorganization__organization": 5}
+    assert result.distinct_called
+
+
+class _ScopedIdList(list):
+    def __init__(self, scope):
+        super().__init__([] if scope == "none" else [1, 2, 3])
+        self.scope = scope
+
+
+class _StatsFakeQS:
+    """模拟统计查询集：count 由作用域决定（full=100 / team=7 / none=0）。
+
+    filter 按 kwargs 推断作用域：组织维度过滤→team；policy_id__in/monitor_instance_id__in
+    继承传入 id 集合的作用域；其余过滤（is_active/status/created_at__gte…）不改作用域。
+    """
+
+    _COUNTS = {"full": 100, "team": 7, "none": 0}
+
+    def __init__(self, scope="full"):
+        self.scope = scope
+
+    def all(self):
+        return self
+
+    def none(self):
+        return _StatsFakeQS("none")
+
+    def distinct(self):
+        return self
+
+    def exclude(self, **kwargs):
+        return self
+
+    def filter(self, **kwargs):
+        org_keys = {"monitorinstanceorganization__organization", "policyorganization__organization"}
+        if org_keys & set(kwargs):
+            return _StatsFakeQS("team")
+        for key in ("policy_id__in", "monitor_instance_id__in"):
+            if key in kwargs:
+                return _StatsFakeQS(getattr(kwargs[key], "scope", "full"))
+        return self
+
+    def values_list(self, *args, **kwargs):
+        return _ScopedIdList(self.scope)
+
+    def count(self):
+        return self._COUNTS[self.scope]
+
+
+class _StatsFakeModel:
+    def __init__(self, scope="full"):
+        self.objects = _StatsFakeQS(scope)
+
+
+_STATS_MODEL_NAMES = [
+    "MonitorObject",
+    "MonitorObjectType",
+    "MonitorInstance",
+    "MonitorPlugin",
+    "Metric",
+    "MetricGroup",
+    "CollectConfig",
+    "MonitorPolicy",
+    "MonitorAlert",
+    "MonitorEvent",
+    "MonitorAlertMetricSnapshot",
+    "PolicyInstanceBaseline",
+]
+
+_ORG_SCOPED_KEYS = [
+    "monitor_instance_total",
+    "monitor_instance_active",
+    "monitor_instance_inactive",
+    "collect_config_total",
+    "policy_total",
+    "policy_enabled",
+    "policy_disabled",
+    "policy_threshold",
+    "policy_no_data",
+    "alert_history",
+    "alert_current",
+    "alert_today",
+    "alert_recovered",
+    "alert_closed",
+    "event_total",
+    "event_today",
+    "alert_snapshot_total",
+    "no_data_baseline_total",
+]
+
+_CATALOG_KEYS = ["monitor_object_total", "plugin_total", "metric_total", "metric_group_total"]
+
+
+def _install_stats_models(monkeypatch, module):
+    for name in _STATS_MODEL_NAMES:
+        monkeypatch.setattr(module, name, _StatsFakeModel("full"))
+
+
+def test_get_monitor_statistics_non_superuser_without_team_zeroes_org_counts(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_stats_no_team_test_module")
+    _install_stats_models(monkeypatch, module)
+
+    data = module.get_monitor_statistics(user_info={"is_superuser": False})["data"]
+
+    # 组织域计数全部归零，不再泄露全平台跨组织数字（revert 收口后这些会变成 100）
+    for key in _ORG_SCOPED_KEYS:
+        assert data[key] == 0, f"{key} 应为 0，实际 {data[key]}"
+    # 平台级目录计数（对象/插件/指标）非租户数据，保持全局
+    for key in _CATALOG_KEYS:
+        assert data[key] == 100, f"{key} 应保持全局 100，实际 {data[key]}"
+
+
+def test_get_monitor_statistics_non_superuser_with_team_scopes_counts(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_stats_team_test_module")
+    _install_stats_models(monkeypatch, module)
+
+    data = module.get_monitor_statistics(user_info={"is_superuser": False, "team": 5})["data"]
+
+    for key in _ORG_SCOPED_KEYS:
+        assert data[key] == 7, f"{key} 应按 team 收窄为 7，实际 {data[key]}"
+    for key in _CATALOG_KEYS:
+        assert data[key] == 100
+
+
+def test_get_monitor_statistics_superuser_returns_full_counts(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_stats_superuser_test_module")
+    _install_stats_models(monkeypatch, module)
+
+    data = module.get_monitor_statistics(user_info={"is_superuser": True})["data"]
+
+    for key in _ORG_SCOPED_KEYS + _CATALOG_KEYS:
+        assert data[key] == 100, f"{key} 超管应为全量 100，实际 {data[key]}"


### PR DESCRIPTION
## 被破坏的不变量

监控总览统计 `get_monitor_statistics` 返回的组织域计数（实例 / 采集配置 / 策略 / 告警 / 事件 / 快照 / 基线）本应**只反映调用者有权看到的组织范围**：超管看全平台，普通用户看自己组织。但 scope 收窄被两套不一致的判断绕过——**一个非超管、且账号未绑定任何团队的普通用户，会拿到全平台跨组织的总数**，隔着仪表盘看到别的组织的规模。

## 根因（设计层）

scope 收窄有两套口径，且都在"空 team"时放行全量：

- `_scope_instance` / `_scope_policy` 短路 `if is_superuser or not team: return qs` —— 非超管 + 空 team 直接返回**全量** queryset；
- `collect_config_total` 用 `if not (is_superuser or not team)` 否则 `.count()` 全量，同样的 `or not team` 泄露分支；
- `alert/event/snapshot/baseline` 用 `if not is_superuser` + `policy_id__in=policy_qs...`，但空 team 时 `policy_qs` 本身已是全量，于是这些计数也变全局。

问题的本质：**"无组织归属"这一信号被当成了"放行全量"，而非"零授权"**。读接口缺身份即拒，这个统计接口却把缺身份默认成了"看全部"。

## 修复如何恢复不变量

抽出模块级、可单测的统一口径函数，把三处 scope 收敛到一条规则：

```python
def _scope_count_queryset(qs, *, is_superuser, team, org_field):
    if is_superuser:
        return qs                      # 超管→全量
    if not team:
        return qs.none()               # 非超管且无 team→零授权空集（不再泄露全平台）
    return qs.filter(**{org_field: team}).distinct()  # 非超管→按 team 收窄
```

- `instance_qs` / `policy_qs` 改用它；非超管且无 team 时为空集。
- `collect_config_total` 改为 `is_superuser→全量，否则跟随 instance_qs`（无 team 即 `__in=空集`→0）。
- `alert/event/snapshot/baseline` 经 `policy_qs` 的 id 集合间接收窄，`policy_qs` 空集 → 这些计数随之归零，口径自然统一。

口径统一为：**超管→全量；非超管→必须按 team 收窄；非超管且无 team→零授权（0）**。

### 平台级目录计数保持全局（刻意为之）

监控对象 / 对象类型 / 插件 / 指标 / 指标分组属**平台级目录定义**（各组织一致，非租户数据，相关模型无 organization 字段），保持全局计数不变——它们不是"别的组织的数据"，而是平台能力的规模。本次只收口真正按组织隔离的资源计数。

## blast radius · 一致性

- 改动仅限 `server/apps/monitor/nats/monitor.py` 单文件单函数 + 新增一个纯函数；不触 core/共享 util。
- **超管 / 有 team 路径行为完全不变**：超管三处均返回全量；有 team 等价于原 `_scope_*` 的 `filter(org_field=team).distinct()`。
- 调用方仅 operation_analysis 总览仪表盘（`source_api.json` / `builtin_canvases.yaml` 引用 `monitor/get_monitor_statistics`），其注入的 `team` 为正整数 cookie，正常流程不受影响；返回 dict 的 key 与结构零改动，前端值卡片照常渲染。

## 调用链

```mermaid
flowchart TD
    U["用户：非超管 + 空 team"] --> OA["operation_analysis 总览仪表盘"]
    OA --> G["get_monitor_statistics :1054"]
    G --> S{"_scope_count_queryset<br/>超管? 有 team?"}
    S -- "超管" --> FULL["全量计数"]
    S -- "非超管 + 有 team" --> SCOPED["filter(org=team) 收窄计数"]
    S -- "非超管 + 无 team（本次修复）" --> NONE["qs.none() → 组织域计数全部 0<br/>不再泄露全平台"]
    NONE -. "alert/event/snapshot/baseline<br/>经 policy_qs id 集合间接归零" .-> NONE
```

## 验证

- 新增 6 条测试（`test_nats_create_handlers.py`）：
  - 3 条 `_scope_count_queryset` 单测：超管→原样全量；非超管+无 team（含 `None`/`""`/`0`）→空集；非超管+有 team→`filter(org_field=team).distinct()`。
  - 3 条 `get_monitor_statistics` 端到端（FakeQS 模拟 filter/none/values_list/count 链路，`policy_id__in` 正确继承作用域）：**非超管+无 team → 18 项组织域计数全部 0 且 4 项目录计数仍为全局 100**；非超管+有 team → 收窄为 7；超管 → 全量 100。
  - **revert 收口后**单测与端到端各至少 1 条立即失败（已实测）。
- 全文件 16 条测试通过；本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`，监控注入式测试按既定方式用独立 harness）。
- `flake8 --max-line-length 150` 无告警。
