### PR TITLE
optimization: 监控实例列表页插件状态查询去重并发，消除串行 N+1（#3338）

### DIFF
--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -1,8 +1,11 @@
+import os
 import re
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import monitor_logger as logger
 from apps.core.utils.loader import LanguageLoader
 from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.monitor_object import MonitorObjConstants
@@ -18,6 +21,10 @@ from apps.monitor.models import (
 from apps.monitor.services.monitor_object import MonitorObjectService
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
+
+# 实例列表页插件状态查询的最大并发度：每个插件的 status_query 是一次独立 VM 读，
+# 去重后并发拉取以消除「插件越多越慢」的串行 N+1。保守默认 8，可经 env 调。
+PLUGIN_STATUS_QUERY_MAX_WORKERS = int(os.getenv("MONITOR_PLUGIN_STATUS_QUERY_MAX_WORKERS", "8"))
 
 
 class InstanceSearch:
@@ -232,6 +239,12 @@ class InstanceSearch:
 
         instance_id_keys = self.obj_metric_map.get("instance_id_keys")
 
+        # 先去重各插件的 status_query 并并发拉取状态映射，避免在下面的插件循环里逐个串行发 VM 查询
+        status_map_by_query = self._batch_plugin_status_maps(
+            instance_id_keys,
+            {plugin.status_query for plugin in plugins},
+        )
+
         for plugin in plugins:
             # 添加翻译属性
             plugin_key_name = f"{LanguageConstants.MONITOR_OBJECT_PLUGIN}.{plugin.name}"
@@ -248,7 +261,7 @@ class InstanceSearch:
             legacy_plugin_key = (self.monitor_obj.id, plugin.collector, plugin.collect_type)
             plugin_map.setdefault(legacy_plugin_key, plugin_info)
 
-            status_map = self.get_plugin_normal_status_map(instance_id_keys, plugin.status_query)
+            status_map = status_map_by_query.get(plugin.status_query, {})
             plugin_status_map[plugin.id] = status_map
             if legacy_plugin_key_counts[legacy_plugin_key] == 1:
                 plugin_status_map[legacy_plugin_key] = status_map
@@ -422,6 +435,31 @@ class InstanceSearch:
                 for obj in results
             ],
         )
+
+    def _batch_plugin_status_maps(self, instance_id_keys, queries):
+        """并发拉取多个插件 status_query 的正常状态映射，返回 {query: status_map}。
+
+        每个 query 是一次独立的 VM 读，去重相同 query 后并发执行——结果与逐个串行查询完全一致，
+        只是把插件列表页的 N 次串行 VM 查询压成一批并发，消除「插件越多越慢」。
+        单个 query 失败降级为空映射、不影响其余 query（与原逐个调用各自独立的语义一致）。
+        """
+        unique_queries = [query for query in queries if query and str(query).strip()]
+        if not unique_queries:
+            return {}
+        max_workers = min(len(unique_queries), PLUGIN_STATUS_QUERY_MAX_WORKERS)
+        status_map_by_query = {}
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_query = {
+                executor.submit(self.get_plugin_normal_status_map, instance_id_keys, query): query for query in unique_queries
+            }
+            for future in as_completed(future_to_query):
+                query = future_to_query[future]
+                try:
+                    status_map_by_query[query] = future.result()
+                except Exception as exc:
+                    logger.warning("get_plugin_normal_status_map failed, query=%s, error=%s", query, exc)
+                    status_map_by_query[query] = {}
+        return status_map_by_query
 
     def get_plugin_normal_status_map(self, instance_id_keys, query):
         if not query or not str(query).strip():

--- a/server/apps/monitor/tests/test_monitor_instance_status_batch.py
+++ b/server/apps/monitor/tests/test_monitor_instance_status_batch.py
@@ -1,0 +1,134 @@
+"""Issue #3338：实例列表页插件状态查询并发去重（_batch_plugin_status_maps）单测。
+
+monitor_instance.py 直接 import 了一批 Django 模型，本仓 pytest 因缺 license_mgmt/MINIO
+无法完成 django.setup()，故沿用注入式 harness：sys.modules 注入伪依赖 + importlib 加载被测模块，
+仅验证 Django-free 的并发去重逻辑（不碰 ORM）。
+"""
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_monitor_instance_module(monkeypatch, module_name):
+    class _Dummy:
+        pass
+
+    class _Logger:
+        def warning(self, *args, **kwargs):
+            return None
+
+        def info(self, *args, **kwargs):
+            return None
+
+        def error(self, *args, **kwargs):
+            return None
+
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=type("BaseAppException", (Exception,), {}))
+    _install_module(monkeypatch, "apps.core.logger", monitor_logger=_Logger())
+    _install_module(monkeypatch, "apps.core.utils.loader", LanguageLoader=_Dummy)
+    _install_module(monkeypatch, "apps.monitor.constants.language", LanguageConstants=types.SimpleNamespace(MONITOR_OBJECT_PLUGIN="plugin"))
+    _install_module(monkeypatch, "apps.monitor.constants.monitor_object", MonitorObjConstants=types.SimpleNamespace())
+    _install_module(monkeypatch, "apps.monitor.constants.plugin", PluginConstants=types.SimpleNamespace())
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        Metric=_Dummy,
+        MonitorObject=_Dummy,
+        CollectConfig=_Dummy,
+        MonitorPlugin=_Dummy,
+        MonitorInstanceOrganization=_Dummy,
+        MonitorInstance=_Dummy,
+    )
+    _install_module(monkeypatch, "apps.monitor.services.monitor_object", MonitorObjectService=_Dummy)
+    _install_module(monkeypatch, "apps.monitor.utils.dimension", parse_instance_id=lambda value: value)
+    _install_module(monkeypatch, "apps.monitor.utils.victoriametrics_api", VictoriaMetricsAPI=_Dummy)
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        Path(__file__).resolve().parents[1] / "services" / "monitor_instance.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bare_search(module):
+    # 跳过 __init__（其会查 DB），仅测 _batch_plugin_status_maps 自身逻辑
+    return module.InstanceSearch.__new__(module.InstanceSearch)
+
+
+def test_batch_dedups_identical_queries_and_runs_once(monkeypatch):
+    module = _load_monitor_instance_module(monkeypatch, "monitor_instance_dedup_test_module")
+    search = _bare_search(module)
+
+    lock = threading.Lock()
+    calls = []
+
+    def fake_status_map(instance_id_keys, query):
+        with lock:
+            calls.append(query)
+        return {f"inst::{query}": "2026-06-15T00:00:00+00:00"}
+
+    monkeypatch.setattr(search, "get_plugin_normal_status_map", fake_status_map)
+
+    # 3 个插件、2 个去重后的 query（q_a 出现两次）
+    result = search._batch_plugin_status_maps(["instance_id"], {"q_a", "q_b"})
+
+    # 相同 query 只查一次：调用次数 == 去重后 query 数
+    assert sorted(calls) == ["q_a", "q_b"]
+    assert result == {
+        "q_a": {"inst::q_a": "2026-06-15T00:00:00+00:00"},
+        "q_b": {"inst::q_b": "2026-06-15T00:00:00+00:00"},
+    }
+
+
+def test_batch_skips_blank_queries(monkeypatch):
+    module = _load_monitor_instance_module(monkeypatch, "monitor_instance_blank_test_module")
+    search = _bare_search(module)
+
+    calls = []
+    monkeypatch.setattr(search, "get_plugin_normal_status_map", lambda keys, query: calls.append(query) or {})
+
+    result = search._batch_plugin_status_maps(["instance_id"], {"", None, "  ", "real_q"})
+
+    assert calls == ["real_q"]
+    assert result == {"real_q": {}}
+
+
+def test_batch_isolates_single_query_failure(monkeypatch):
+    module = _load_monitor_instance_module(monkeypatch, "monitor_instance_failure_test_module")
+    search = _bare_search(module)
+
+    def fake_status_map(instance_id_keys, query):
+        if query == "boom":
+            raise RuntimeError("VM down")
+        return {"ok": query}
+
+    monkeypatch.setattr(search, "get_plugin_normal_status_map", fake_status_map)
+
+    result = search._batch_plugin_status_maps(["instance_id"], {"boom", "good"})
+
+    # 单 query 失败降级为空映射，不影响其余 query
+    assert result == {"boom": {}, "good": {"ok": "good"}}
+
+
+def test_batch_empty_returns_empty(monkeypatch):
+    module = _load_monitor_instance_module(monkeypatch, "monitor_instance_empty_test_module")
+    search = _bare_search(module)
+
+    called = []
+    monkeypatch.setattr(search, "get_plugin_normal_status_map", lambda keys, query: called.append(query) or {})
+
+    assert search._batch_plugin_status_maps(["instance_id"], set()) == {}
+    assert called == []


### PR DESCRIPTION
## 被破坏的不变量

监控实例列表页（用户高频入口）的渲染开销，本应与「监控对象挂多少插件」**无关地保持平稳**。但 `search_by_primary_object` 在插件循环内逐个调 `get_plugin_normal_status_map`，每个插件的 `status_query` 各发一次 `VictoriaMetricsAPI().query()`——**串行 N 次**，插件越多页面越慢。

## 根因（设计层）

每个插件的状态查询是一次独立的 VM 读，但它们被放在插件循环里**逐个同步发起**，既没有去重相同 `status_query`，也没有并发：

```python
for plugin in plugins:
    ...
    status_map = self.get_plugin_normal_status_map(instance_id_keys, plugin.status_query)  # 串行 ×N
```

查询次数 = 插件数，且彼此独立、互不依赖——是典型可并行化的串行 N+1。

## 修复

把"逐个串行查"改成"去重 + 一批并发查"，循环里改为查预算好的结果：

```python
status_map_by_query = self._batch_plugin_status_maps(
    instance_id_keys, {plugin.status_query for plugin in plugins})
...
status_map = status_map_by_query.get(plugin.status_query, {})
```

`_batch_plugin_status_maps`：
- 去重 `status_query`（过滤空白）→ 相同 query 只查一次；
- `ThreadPoolExecutor(max_workers=min(n, PLUGIN_STATUS_QUERY_MAX_WORKERS))` 并发拉取，`as_completed` 汇总为 `{query: status_map}`（汇总写入全在主线程，无竞态）；
- 单个 query 失败降级为空映射 + `logger.warning`，不影响其余 query（与原各插件独立调用的语义一致）；
- 并发度 `PLUGIN_STATUS_QUERY_MAX_WORKERS` 保守默认 8、经 `MONITOR_PLUGIN_STATUS_QUERY_MAX_WORKERS` env 可调。

## blast radius · 一致性

- 改动仅限 `server/apps/monitor/services/monitor_instance.py` 单文件 + 新增一个方法；唯一调用方就是该列表页路径。
- **结果与原逐个串行查询完全一致**：相同 query 共享同一个 status_map（下游仅只读迭代，无 mutate，对象别名安全）；空白/None `status_query` 经 `.get(..., {})` 仍得 `{}`（与原 `get_plugin_normal_status_map` 对空白 query 返回 `{}` 一致）；`legacy_plugin_key` 分支逻辑未改，赋值逐字相同。
- 线程安全：`VictoriaMetricsAPI` 每次新建实例、无共享可变状态。
- `ThreadPoolExecutor` 用 `with` 上下文，自动 shutdown，无资源泄露。

## 验证

- 新增 4 条单测（`test_monitor_instance_status_batch.py`）：相同 query 只查一次（断言调用次数 == 去重 query 数）/ 跳过空白 query / 单 query 失败隔离 / 空集返回空。**移除 `_batch_plugin_status_maps` 后 4 条全部失败**（load-bearing）。
- 本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`，监控注入式测试按既定方式用独立 harness）。
- `flake8 --max-line-length 150` 无告警。

## 后续可选增强（非本 PR 范围）

- 本 PR 做的是**单次请求内**去重 + 并发；issue 另提到的「跨请求对相同 `status_query` 做短 TTL 缓存」可作为后续增强进一步降 VM 读压。
- 多用户同时刷列表页时整体并发 = 用户数 × min(去重 query 数, 8)，如观测到 VM 读尖峰可再引入全局限流/缓存。
