### PR TITLE
fix(monitor): use computed success-rate query in website dashboard

### DIFF
--- a/web/src/app/monitor/dashboards/objects/website/config.ts
+++ b/web/src/app/monitor/dashboards/objects/website/config.ts
@@ -1,5 +1,11 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 
+// http_node_success_rate 不是 telegraf 上报的原始指标,而是 metrics.json 里按表达式实时计算的
+// (与「全量指标」视图一致)。仪表盘必须用同款表达式,不能直接查裸指标名 http_node_success_rate
+// ——后者只有预置种子数据(website_01/02/03)才有存储序列,真实下发实例查不到 → 三卡片无数据。
+const SUCCESS_RATE_EXPR =
+  'avg(count_over_time(http_response_result_type{result="success",__$labels__}[5m]) / count_over_time(http_response_result_type{__$labels__}[5m]) * 100)';
+
 export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'website',
   pageTitle: '网站监控仪表盘',
@@ -13,7 +19,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '探测成功率',
       description: '网站探测节点平均成功率。',
       unit: 'percent',
-      query: 'avg(http_node_success_rate{__$labels__})',
+      query: SUCCESS_RATE_EXPR,
       color: '#27c274'
     },
     {
@@ -21,7 +27,7 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '失败占比',
       description: '网站探测节点平均失败占比。',
       unit: 'percent',
-      query: 'clamp_max(100 - avg(http_node_success_rate{__$labels__}), 100)',
+      query: `clamp_max(100 - ${SUCCESS_RATE_EXPR}, 100)`,
       color: '#ff8a1f'
     },
     {


### PR DESCRIPTION
## Problem

On the Website monitoring dashboard, three cards rendered **暂无数据 (no data)** for real dispatched probes:
- 探测成功率 (success-rate summary card)
- 可用性分布 (availability ring)
- 探测成功率趋势 (success-rate trend)

Meanwhile the **全量指标 (full metric view)** for the same instance showed 单点成功率 = 100% correctly.

## Root cause

The dashboard config queried `http_node_success_rate` as if it were a **stored** metric:

```ts
query: 'avg(http_node_success_rate{__$labels__})'
```

But `http_node_success_rate` is **not emitted by telegraf** — it is a view-time *computed* metric defined in the plugin `metrics.json`:

```
count_over_time(http_response_result_type{result="success",__$labels__}[5m])
  / count_over_time(http_response_result_type{__$labels__}[5m]) * 100
```

The raw `http_node_success_rate` series only exists for seeded demo instances (`website_01/02/03`), which is why the dashboard looked fine during development but returned nothing for real probes. The 全量指标 view worked because it uses the computed expression from `metrics.json`.

## Fix

Replace the raw-metric reference with the same computed expression used by the metric view, extracted to a shared `SUCCESS_RATE_EXPR` constant and reused by both the success-rate and failure-rate metrics. No change to product metric semantics — behavior now matches the 全量指标 view.

## Verification

- New expression queried against a live instance returns 探测成功率 `100` / 失败占比 `0`, consistent with the 全量指标 view.
- `ESLint` passes on the changed file.

Single file changed: `web/src/app/monitor/dashboards/objects/website/config.ts`.