### PR TITLE
bugfix: 告警策略保存补入参校验，错配置不再静默入库等扫描时才崩（#3337）

### DIFF
--- a/server/apps/monitor/serializers/monitor_policy.py
+++ b/server/apps/monitor/serializers/monitor_policy.py
@@ -2,15 +2,96 @@ import logging
 
 from rest_framework import serializers
 
+from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.models.monitor_policy import MonitorPolicy
 
 logger = logging.getLogger(__name__)
+
+# 阈值条件合法等级 —— 取自 MonitorPolicy.LEVEL_CHOICES 的用户可选档（排除系统在无数据时自动生成的 no_data）
+_VALID_THRESHOLD_LEVELS = {"info", "warning", "error", "critical"}
+# source 合法类型 —— 其余类型在扫描器/基线构建时静默返回空目标（策略不生效），instance/organization 之外即误配
+_VALID_SOURCE_TYPES = {"instance", "organization"}
+# 聚合算法合法集合 —— 来源 apps/monitor/tasks/utils/policy_methods.py 的 METHOD 字典键；
+# 非法值会在扫描聚合处（metric_query 取 METHOD.get(algorithm)）抛 BaseAppException。改 METHOD 时需同步此集合。
+_VALID_AGGREGATION_ALGORITHMS = {
+    "sum",
+    "avg",
+    "max",
+    "min",
+    "count",
+    "max_over_time",
+    "min_over_time",
+    "avg_over_time",
+    "sum_over_time",
+    "last_over_time",
+}
 
 
 class MonitorPolicySerializer(serializers.ModelSerializer):
     class Meta:
         model = MonitorPolicy
         fields = "__all__"
+
+    def validate_threshold(self, value):
+        """校验阈值列表：每条须含合法 method/value/level，否则后台扫描计算阈值时崩。
+
+        仅校验已填写的阈值条目（空列表=未配阈值，放行）。只挡下游 policy_calculate 一定会
+        KeyError/BaseAppException 的非法配置（缺 method/value/level、method 不在合法运算符内），
+        把错误从「后台扫描时静默报错」前移到 API 边界，不误伤当前可用配置。
+        """
+        if not value:
+            return value
+        if not isinstance(value, list):
+            raise serializers.ValidationError("threshold 必须是列表")
+        valid_methods = set(AlertConstants.THRESHOLD_METHODS)
+        for index, item in enumerate(value):
+            if not isinstance(item, dict):
+                raise serializers.ValidationError(f"threshold[{index}] 必须是对象")
+            if item.get("method") not in valid_methods:
+                raise serializers.ValidationError(f"threshold[{index}].method 非法，须为 {sorted(valid_methods)} 之一")
+            if "value" not in item:
+                raise serializers.ValidationError(f"threshold[{index}] 缺少 value")
+            if item.get("level") not in _VALID_THRESHOLD_LEVELS:
+                raise serializers.ValidationError(f"threshold[{index}].level 非法，须为 {sorted(_VALID_THRESHOLD_LEVELS)} 之一")
+        return value
+
+    def validate_query_condition(self, value):
+        """校验查询条件：pmq 自定义查询须带非空 query，否则（指标型）须带 metric_id。
+
+        空 dict（未配/草稿）放行；只挡非空但下游扫描一定会 KeyError（缺 metric_id）或对 None 做
+        PromQL 查询（pmq 缺 query）的缺键配置。
+        """
+        if not value:
+            return value
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("query_condition 必须是对象")
+        if value.get("type") == "pmq":
+            if not value.get("query"):
+                raise serializers.ValidationError("query_condition.type=pmq 时必须提供非空 query")
+        elif "metric_id" not in value:
+            raise serializers.ValidationError("query_condition 缺少 metric_id")
+        return value
+
+    def validate_source(self, value):
+        """校验策略适用资源：非空时须含 type 与 values，且 type 为 instance/organization。
+
+        空 dict 放行；缺 type/values 会让扫描器/基线构建 KeyError，未知 type 则静默无目标=策略不生效。
+        """
+        if not value:
+            return value
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("source 必须是对象")
+        if "type" not in value or "values" not in value:
+            raise serializers.ValidationError("source 必须同时包含 type 与 values")
+        if value.get("type") not in _VALID_SOURCE_TYPES:
+            raise serializers.ValidationError(f"source.type 非法，须为 {sorted(_VALID_SOURCE_TYPES)} 之一")
+        return value
+
+    def validate_algorithm(self, value):
+        """校验聚合算法须为下游支持的聚合函数，否则扫描聚合时抛 BaseAppException。"""
+        if value and value not in _VALID_AGGREGATION_ALGORITHMS:
+            raise serializers.ValidationError(f"algorithm 非法，须为 {sorted(_VALID_AGGREGATION_ALGORITHMS)} 之一")
+        return value
 
     def validate_group_by(self, value):
         """校验 group_by 首位必须是监控对象的实例主键，防止下游扫描链路误判实例归属。"""

--- a/server/apps/monitor/tests/test_monitor_policy_serializer_validation.py
+++ b/server/apps/monitor/tests/test_monitor_policy_serializer_validation.py
@@ -1,0 +1,126 @@
+"""Issue #3337：告警策略序列化器入参校验（threshold/query_condition/source/algorithm）单测。
+
+MonitorPolicySerializer 继承 DRF ModelSerializer 且 import 了 Django 模型，本仓 pytest 因缺
+license_mgmt/MINIO 无法 django.setup()。这些 validate_* 方法不依赖 ORM（仅校验入参结构/枚举），
+故沿用注入式 harness：stub rest_framework / 模型 / 常量后 importlib 加载，在 bare 实例上直接调。
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class _StubValidationError(Exception):
+    pass
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_serializer_module(monkeypatch, module_name):
+    rest_serializers = _install_module(
+        monkeypatch,
+        "rest_framework.serializers",
+        ModelSerializer=object,
+        ValidationError=_StubValidationError,
+    )
+    _install_module(monkeypatch, "rest_framework", serializers=rest_serializers)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(
+            THRESHOLD_METHODS={">": 1, "<": 1, "=": 1, "!=": 1, ">=": 1, "<=": 1},
+        ),
+    )
+    _install_module(monkeypatch, "apps.monitor.models.monitor_policy", MonitorPolicy=object)
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        Path(__file__).resolve().parents[1] / "serializers" / "monitor_policy.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _serializer(module):
+    return module.MonitorPolicySerializer.__new__(module.MonitorPolicySerializer)
+
+
+def _assert_raises(fn):
+    try:
+        fn()
+    except _StubValidationError:
+        return
+    raise AssertionError("预期抛 ValidationError，但未抛出")
+
+
+# ---------------- threshold ----------------
+
+
+def test_validate_threshold_accepts_valid_and_empty(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_threshold_ok_module"))
+    assert s.validate_threshold([]) == []
+    valid = [{"method": ">", "value": 90, "level": "critical"}, {"method": "<=", "value": 1, "level": "warning"}]
+    assert s.validate_threshold(valid) == valid
+
+
+def test_validate_threshold_rejects_missing_keys_and_bad_enums(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_threshold_bad_module"))
+    _assert_raises(lambda: s.validate_threshold([{"value": 1, "level": "warning"}]))  # 缺 method
+    _assert_raises(lambda: s.validate_threshold([{"method": ">", "level": "warning"}]))  # 缺 value
+    _assert_raises(lambda: s.validate_threshold([{"method": ">", "value": 1}]))  # 缺 level
+    _assert_raises(lambda: s.validate_threshold([{"method": "=~", "value": 1, "level": "warning"}]))  # 非法 method
+    _assert_raises(lambda: s.validate_threshold([{"method": ">", "value": 1, "level": "fatal"}]))  # 非法 level
+    _assert_raises(lambda: s.validate_threshold(["not-a-dict"]))
+    _assert_raises(lambda: s.validate_threshold("not-a-list"))
+
+
+# ---------------- query_condition ----------------
+
+
+def test_validate_query_condition_pmq_requires_query(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_qc_pmq_module"))
+    assert s.validate_query_condition({"type": "pmq", "query": "up{}"}) == {"type": "pmq", "query": "up{}"}
+    _assert_raises(lambda: s.validate_query_condition({"type": "pmq"}))
+    _assert_raises(lambda: s.validate_query_condition({"type": "pmq", "query": ""}))
+
+
+def test_validate_query_condition_metric_requires_metric_id(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_qc_metric_module"))
+    assert s.validate_query_condition({"type": "metric", "metric_id": 7}) == {"type": "metric", "metric_id": 7}
+    assert s.validate_query_condition({}) == {}  # 空（草稿）放行
+    _assert_raises(lambda: s.validate_query_condition({"type": "metric"}))  # 缺 metric_id
+    _assert_raises(lambda: s.validate_query_condition({"filter": []}))  # 非 pmq 且无 metric_id
+
+
+# ---------------- source ----------------
+
+
+def test_validate_source_requires_type_values_and_valid_type(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_source_module"))
+    assert s.validate_source({}) == {}  # 空放行
+    ok = {"type": "instance", "values": ["i-1"]}
+    assert s.validate_source(ok) == ok
+    assert s.validate_source({"type": "organization", "values": [1]}) == {"type": "organization", "values": [1]}
+    _assert_raises(lambda: s.validate_source({"type": "instance"}))  # 缺 values
+    _assert_raises(lambda: s.validate_source({"values": []}))  # 缺 type
+    _assert_raises(lambda: s.validate_source({"type": "host", "values": []}))  # 非法 type
+
+
+# ---------------- algorithm ----------------
+
+
+def test_validate_algorithm_enforces_supported_set(monkeypatch):
+    s = _serializer(_load_serializer_module(monkeypatch, "mp_algo_module"))
+    for ok in ("max", "avg", "last_over_time"):
+        assert s.validate_algorithm(ok) == ok
+    assert s.validate_algorithm("") == ""  # 空放行（交由其它校验）
+    _assert_raises(lambda: s.validate_algorithm("median"))
+    _assert_raises(lambda: s.validate_algorithm("p99"))


### PR DESCRIPTION
## 被破坏的不变量

告警策略的复杂配置（阈值、查询条件、适用资源、聚合算法）本应在**保存时**就被验证合法——错配置不应静默入库。但 `MonitorPolicySerializer` 用 `fields="__all__"` 且只校验 `group_by`，其余字段前端传什么存什么。结果是：错配置顺利保存、页面提示「成功」，等后台定时扫描真正消费它时才在 Celery 抛 `KeyError`/`BaseAppException`——用户看不到、只觉得「配了告警怎么不生效」。

## 根因（设计层）

序列化器把校验责任完全下放给了**下游扫描消费方**。消费方对这些字段有明确硬性要求（缺键即 `KeyError`、非法枚举即 `BaseAppException`），但这些要求从未在 API 边界表达，错误只能在异步任务里晚暴露。

## 修复

在 `MonitorPolicySerializer` 补 4 个**保守**校验器，把「下游一定会崩 / 一定不生效」的配置挡在 API 边界，与消费方硬约束逐一对齐：

| 校验器 | 规则 | 对齐的消费方崩溃点 |
|--------|------|---------------------|
| `validate_threshold` | 每条须 `method`∈`AlertConstants.THRESHOLD_METHODS`、`value` 存在、`level`∈合法等级 | `policy_calculate.py` 读 method/value/level（KeyError）、非法 method→BaseAppException |
| `validate_query_condition` | `type=="pmq"`→须非空 `query`；否则须 `metric_id` | `metric_query.py` 取 `metric_id`（KeyError）/ pmq 缺 query 对 None 做 PromQL |
| `validate_source` | 非空时须 `type`+`values` 且 `type`∈`{instance,organization}` | `scanner.py`/`policy_baseline.py` 读 source["type"]/["values"]（KeyError）；未知 type 静默无目标=不生效 |
| `validate_algorithm` | 非空时须∈聚合函数集（`policy_methods.METHOD` 键） | `metric_query.py` `METHOD.get(algorithm)` 非法→BaseAppException |

threshold 的运算符集合**复用** `AlertConstants.THRESHOLD_METHODS`（活常量，无漂移）。

### 保守原则（不误伤存量）

- **空配置 / 空 dict / 空列表一律放行**——草稿、未配字段不拦。
- **只拒绝下游保证崩或保证不生效的配置**：被拒的存量配置本就坏（已在 Celery 静默报错或扫描出空目标），不属于「当前能正常工作却被拒」。
- **编辑既有策略只改名（PATCH 部分更新）不触发这些校验**——DRF `partial=True` 仅对入参中出现的字段调 `validate_<field>`，故不会因加校验而拦住正常编辑。
- `level` 允许 `info`（与模型 `LEVEL_CHOICES` 自洽，下游均 `.get(..., 默认)`、不崩）。

## blast radius · 一致性

- 改动仅限 `server/apps/monitor/serializers/monitor_policy.py`（+4 校验器、+3 枚举常量）。
- 同时覆盖**三条写入路径**：普通 API `MonitorPolicyViewSet`、NATS `create_monitor_policy`、策略更新——它们都用这个序列化器。
- 与 #3332（`query_condition.filter` 的 PromQL 注入转义）**正交不冲突**：本 PR 校验顶层结构/枚举，不触 filter 子结构的转义；filter 注入防护由 #3332 负责。

## 验证

- 新增 6 条单测（`test_monitor_policy_serializer_validation.py`）：合法/空配置放行、缺 method/value/level、非法 method/level、pmq 缺 query、非 pmq 缺 metric_id、source 缺键/非法 type、algorithm 非法。**revert 校验器后 6 条全部失败**。
- 本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`，监控注入式测试按既定方式用独立 harness）。
- `flake8 --max-line-length 150` 无告警。

## 后续可选增强（非本 PR 范围）

- `period` / `no_data_period` 同类（消费方对其 `type`/`value` 亦有硬约束、缺/非法即崩），可加 `validate_period` 一并收口。
- threshold `value` 的数值类型校验（下游 `float(value)`）可进一步加严。
- 三处枚举（algorithm/source-type/level）目前在序列化器内维护（避免把 tasks/VM 重依赖引入序列化器层），已注释「改 `METHOD` 时需同步」；后续可考虑提取到 `constants` 共享。
