### PR TITLE
bugfix: 告警扫描多表写入事务化，通知延后到提交后发出（#3336）

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -1,5 +1,7 @@
 import uuid
 
+from django.db import transaction
+
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import MonitorAlert, MonitorEvent, MonitorEventRawData
@@ -94,48 +96,66 @@ class EventAlertManager:
                 new_alert_events.append(event)
 
         new_alerts = []
-        if new_alert_events:
-            new_alerts = self._create_alerts_from_events(new_alert_events)
+        upgraded_alerts = []
+        # 建告警 → 建事件 → 写原始数据 → 升级既有告警 全部包进一个事务，避免中途失败留下
+        # 「有告警无事件」的半截数据；通知改到事务提交后（on_commit）发出，保证通知永不早于事件落库。
+        with transaction.atomic():
+            if new_alert_events:
+                new_alerts = self._create_alerts_from_events(new_alert_events)
 
-            if len(new_alerts) != len(new_alert_events):
-                logger.error(f"Alert creation mismatch: expected {len(new_alert_events)}, got {len(new_alerts)} for policy {self.policy.id}")
+                if len(new_alerts) != len(new_alert_events):
+                    logger.error(f"Alert creation mismatch: expected {len(new_alert_events)}, got {len(new_alerts)} for policy {self.policy.id}")
 
-            alert_map = {self._build_alert_key(alert.metric_instance_id, alert.alert_type): alert for alert in new_alerts}
-            for event in new_alert_events:
-                alert = alert_map.get(
-                    self._build_alert_key(
-                        event.get("metric_instance_id", ""),
-                        self._get_event_alert_type(event),
+                alert_map = {self._build_alert_key(alert.metric_instance_id, alert.alert_type): alert for alert in new_alerts}
+                for event in new_alert_events:
+                    alert = alert_map.get(
+                        self._build_alert_key(
+                            event.get("metric_instance_id", ""),
+                            self._get_event_alert_type(event),
+                        )
                     )
+                    if alert:
+                        event["alert_id"] = alert.id
+                        event["_alert_obj"] = alert
+                    else:
+                        logger.error(f"Failed to get alert for event metric_instance {event.get('metric_instance_id')} in policy {self.policy.id}")
+                        event["alert_id"] = None
+
+            valid_events = [e for e in (new_alert_events + existing_alert_events) if e.get("alert_id")]
+
+            if len(valid_events) != len(new_alert_events) + len(existing_alert_events):
+                logger.warning(
+                    f"Filtered out {len(new_alert_events) + len(existing_alert_events) - len(valid_events)} "
+                    f"events without alert_id for policy {self.policy.id}"
                 )
-                if alert:
-                    event["alert_id"] = alert.id
-                    event["_alert_obj"] = alert
-                else:
-                    logger.error(f"Failed to get alert for event metric_instance {event.get('metric_instance_id')} in policy {self.policy.id}")
-                    event["alert_id"] = None
 
-        valid_events = [e for e in (new_alert_events + existing_alert_events) if e.get("alert_id")]
+            event_objs = self.create_events(valid_events)
 
-        if len(valid_events) != len(new_alert_events) + len(existing_alert_events):
-            logger.warning(
-                f"Filtered out {len(new_alert_events) + len(existing_alert_events) - len(valid_events)} "
-                f"events without alert_id for policy {self.policy.id}"
+            if existing_alert_events:
+                upgraded_alerts = self._update_existing_alerts_from_events(existing_alert_events) or []
+
+            logger.info(
+                f"Created events and alerts: "
+                f"{len(new_alert_events)} new alerts, "
+                f"{len(existing_alert_events)} existing alerts, "
+                f"{len(event_objs)} events created"
             )
 
-        event_objs = self.create_events(valid_events)
-
-        if existing_alert_events:
-            self._update_existing_alerts_from_events(existing_alert_events)
-
-        logger.info(
-            f"Created events and alerts: "
-            f"{len(new_alert_events)} new alerts, "
-            f"{len(existing_alert_events)} existing alerts, "
-            f"{len(event_objs)} events created"
-        )
+            self._schedule_notifications(new_alerts, upgraded_alerts)
 
         return event_objs, new_alerts
+
+    def _schedule_notifications(self, new_alerts, upgraded_alerts):
+        """把告警通知推迟到当前事务提交后发出，保证通知永不早于告警/事件落库。
+
+        在事务回滚时这些 on_commit 回调不会执行，因此也不会对未落库的数据发通知。
+        """
+        if not self.policy.notice:
+            return
+        if new_alerts:
+            transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created"))
+        if upgraded_alerts:
+            transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(upgraded_alerts, action="upgraded"))
 
     def _get_alert_metric_instance_id(self, alert) -> str:
         if alert.metric_instance_id:
@@ -206,9 +226,7 @@ class EventAlertManager:
 
         logger.info(f"Created {len(new_alerts)} new alerts for policy {self.policy.id}")
 
-        if new_alerts and self.policy.notice:
-            AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created")
-
+        # 通知由 create_events_and_alerts 在事务提交后统一发（_schedule_notifications），此处不再内联，避免通知早于事件落库
         return new_alerts
 
     def _format_dimension_str(self, dimensions: dict) -> str:
@@ -216,7 +234,7 @@ class EventAlertManager:
 
     def _update_existing_alerts_from_events(self, event_data_list):
         if not event_data_list:
-            return
+            return []
 
         alert_level_updates = []
 
@@ -248,5 +266,5 @@ class EventAlertManager:
             )
             logger.info(f"Updated {len(alert_level_updates)} alerts with higher severity levels")
 
-            if self.policy.notice:
-                AlertLifecycleNotifier(self.policy).notify_alerts(alert_level_updates, action="upgraded")
+        # 升级通知同样由 create_events_and_alerts 在事务提交后统一发（_schedule_notifications）
+        return alert_level_updates

--- a/server/apps/monitor/tests/test_event_alert_transaction.py
+++ b/server/apps/monitor/tests/test_event_alert_transaction.py
@@ -1,0 +1,183 @@
+"""Issue #3336：告警扫描多表写入事务化 + 通知延后到提交后（event_alert_manager）。
+
+验证 Django-free 逻辑：① create_events_and_alerts 把写操作包进 transaction.atomic；
+② 告警通知不再内联发出，而是注册到 transaction.on_commit（保证通知永不早于事件落库）；
+③ _create_alerts_from_events / _update_existing_alerts_from_events 不再内联通知。
+沿用注入式 harness（pytest 因缺 license_mgmt/MINIO 无法 django.setup）。
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+class _Logger:
+    def info(self, *a, **k):
+        return None
+
+    def warning(self, *a, **k):
+        return None
+
+    def error(self, *a, **k):
+        return None
+
+    def debug(self, *a, **k):
+        return None
+
+
+class _Atomic:
+    def __init__(self, log):
+        self._log = log
+
+    def __enter__(self):
+        self._log.append("atomic-enter")
+        return self
+
+    def __exit__(self, *exc):
+        self._log.append("atomic-exit")
+        return False
+
+
+def _load_event_alert_manager(monkeypatch, module_name, notify_log, on_commit_callbacks, atomic_log):
+    _install_module(
+        monkeypatch,
+        "django.db",
+        transaction=types.SimpleNamespace(
+            atomic=lambda *a, **k: _Atomic(atomic_log),
+            on_commit=lambda cb: on_commit_callbacks.append(cb),  # 仅捕获，不立即执行 → 可断言「延后」
+        ),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(LEVEL_WEIGHT={"warning": 2, "error": 3, "critical": 4}),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_CREATE_BATCH_SIZE=100, BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.monitor.models",
+        MonitorAlert=object,
+        MonitorEvent=object,
+        MonitorEventRawData=object,
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.dimension", format_dimension_str=lambda dimensions: "")
+
+    def _make_notifier(policy):
+        return types.SimpleNamespace(
+            notify_alerts=lambda alerts, action: notify_log.append((action, [getattr(a, "id", a) for a in alerts]))
+        )
+
+    _install_module(monkeypatch, "apps.monitor.services.alert_lifecycle_notify", AlertLifecycleNotifier=_make_notifier)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _bare_manager(module, policy):
+    manager = object.__new__(module.EventAlertManager)
+    manager.policy = policy
+    manager.instances_map = {}
+    manager.active_alerts = []
+    return manager
+
+
+def test_create_events_and_alerts_defers_notification_to_on_commit(monkeypatch):
+    notify_log, on_commit_callbacks, atomic_log = [], [], []
+    module = _load_event_alert_manager(monkeypatch, "eam_defer_module", notify_log, on_commit_callbacks, atomic_log)
+
+    created_alert = types.SimpleNamespace(id=202, metric_instance_id="('h1',)", alert_type="alert")
+    manager = _bare_manager(module, types.SimpleNamespace(id=1, notice=True))
+    manager._create_alerts_from_events = lambda events: [created_alert]
+    manager.create_events = lambda events: list(events)
+    manager._update_existing_alerts_from_events = lambda events: []
+
+    event = {"metric_instance_id": "('h1',)", "monitor_instance_id": "h1", "level": "critical", "value": 9, "content": "x"}
+    event_objs, new_alerts = manager.create_events_and_alerts([event])
+
+    # 写操作包进了事务
+    assert atomic_log == ["atomic-enter", "atomic-exit"]
+    # 调用结束时通知尚未发出（延后到 on_commit），且注册了一个提交后回调
+    assert notify_log == []
+    assert len(on_commit_callbacks) == 1
+    assert new_alerts == [created_alert]
+
+    # 模拟事务提交：执行 on_commit 回调后，通知才发出
+    for cb in on_commit_callbacks:
+        cb()
+    assert notify_log == [("created", [202])]
+
+
+def test_schedule_notifications_respects_notice_flag(monkeypatch):
+    notify_log, on_commit_callbacks, atomic_log = [], [], []
+    module = _load_event_alert_manager(monkeypatch, "eam_notice_module", notify_log, on_commit_callbacks, atomic_log)
+
+    created = types.SimpleNamespace(id=1)
+    upgraded = types.SimpleNamespace(id=2)
+
+    # notice=False → 不注册任何通知
+    m_off = _bare_manager(module, types.SimpleNamespace(id=1, notice=False))
+    m_off._schedule_notifications([created], [upgraded])
+    assert on_commit_callbacks == []
+
+    # notice=True → created + upgraded 各注册一个，执行后按 action 发出
+    m_on = _bare_manager(module, types.SimpleNamespace(id=1, notice=True))
+    m_on._schedule_notifications([created], [upgraded])
+    assert len(on_commit_callbacks) == 2
+    for cb in on_commit_callbacks:
+        cb()
+    assert ("created", [1]) in notify_log
+    assert ("upgraded", [2]) in notify_log
+
+
+def test_create_alerts_helper_no_longer_notifies_inline(monkeypatch):
+    notify_log, on_commit_callbacks, atomic_log = [], [], []
+    module = _load_event_alert_manager(monkeypatch, "eam_helper_module", notify_log, on_commit_callbacks, atomic_log)
+
+    class _Alert:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+            self.id = 500
+
+    # MonitorAlert 需可作构造器（_create_alerts_from_events 内 MonitorAlert(...)），
+    # 且 objects.bulk_create 返回带 id 的对象（触发 hasattr(new_alerts[0],"id") 为真、跳过 refetch 分支）
+    class _AlertModel:
+        objects = types.SimpleNamespace(
+            bulk_create=lambda objs, batch_size=None: [_Alert(id=500, metric_instance_id="('h1',)", alert_type="alert")]
+        )
+
+        def __init__(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(module, "MonitorAlert", _AlertModel, raising=False)
+
+    manager = _bare_manager(
+        module,
+        types.SimpleNamespace(id=1, notice=True, no_data_level="warning", notice_type_ids=[], notice_users=[], last_run_time=None),
+    )
+    events = [{"metric_instance_id": "('h1',)", "monitor_instance_id": "h1", "level": "critical", "value": 9, "content": "x", "dimensions": {}}]
+
+    result = manager._create_alerts_from_events(events)
+
+    # 真实辅助方法返回告警，但不再内联发任何通知
+    assert len(result) == 1
+    assert notify_log == []
+    assert on_commit_callbacks == []

--- a/server/apps/monitor/tests/test_policy_scan_failure_handling.py
+++ b/server/apps/monitor/tests/test_policy_scan_failure_handling.py
@@ -998,6 +998,19 @@ def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
     )
     _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
 
+    class _Atomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    _install_module(
+        monkeypatch,
+        "django.db",
+        transaction=types.SimpleNamespace(atomic=lambda *a, **k: _Atomic(), on_commit=lambda cb: cb()),
+    )
+
     module = _load_module(
         "monitor_policy_event_alert_manager_key_test_module",
         Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py",
@@ -1020,7 +1033,7 @@ def test_threshold_event_does_not_reuse_active_no_data_alert(monkeypatch):
     existing_updates = []
 
     manager = object.__new__(module.EventAlertManager)
-    manager.policy = types.SimpleNamespace(id=1006, name="mixed-policy")
+    manager.policy = types.SimpleNamespace(id=1006, name="mixed-policy", notice=True)
     manager.active_alerts = [active_no_data_alert]
     manager._create_alerts_from_events = lambda events: created_from_events.extend(events) or [created_alert]
     manager.create_events = lambda events: persisted_events.extend(events) or events


### PR DESCRIPTION
## 被破坏的不变量

一次告警扫描要写好几张表（告警、事件、事件原始数据、升级既有告警），这些写操作本应**要么全成、要么全不成**；而「告警已通知」这件对外可见的事，本应**只在对应数据真正落库之后**发生。但当前两条不变量都被破坏：整段写无事务，且通知在事件落库**之前**就发出。

## 根因（设计层）

`create_events_and_alerts` 的调用顺序是：

```
_create_alerts_from_events(...)   # 内部 bulk_create 告警，并在 :210 内联 notify(created) —— 通知先发
create_events(...)                # 事件此刻才落库
```

通知被塞在「建告警」步骤内部、早于「建事件」；且整段无 `transaction.atomic`（全文件命中 0 次）。于是：中途任一步失败 → 留下「有告警无事件」的半截数据；通知已发但事件还没落库的时间窗内，用户点进通知**查无对应事件**。

## 修复

把写入和通知两件事各归其位：

1. **写入事务化**：用单个 `with transaction.atomic()` 包裹「建告警 → 建事件 → 写原始数据 → 升级既有告警」，中途失败整体回滚，不再留半截数据。
2. **通知延后到提交后**：新增 `_schedule_notifications`，把 created/upgraded 通知改为 `transaction.on_commit(...)` 注册——**通知只在事务提交后发出，永不早于事件落库**；事务回滚时回调不执行，也不会对未落库数据发通知。
3. 两个 helper 不再内联通知：`_create_alerts_from_events` 去掉内联 created 通知；`_update_existing_alerts_from_events` 去掉内联 upgraded 通知并返回升级告警列表交给调度。`policy.notice` 开关语义保持不变。

## blast radius · 一致性

- 改动仅限 `event_alert_manager.py`（+`_schedule_notifications`，重排两个 helper 的通知职责）。
- **唯一生产调用方**是 `scanner.py` 的扫描任务，调用链上**无外层事务/重试包装**，故此处 `atomic()` 即最外层事务、`on_commit` 在其提交后触发，时机正确。
- 两个 helper 与 `create_events_and_alerts` 均只在本文件内部调用，无其它调用方依赖旧的「内联通知 / 返回 None」行为（`_update_existing_alerts_from_events` 改返回 `[]` 的唯一消费点已 `or []` 兜底）。

## 与 #3341 的合并顺序（请注意）

#3341（新建告警推送失败永不重试）涉及同文件原 `:210` 内联 created 通知区域，且与 justin 在途未推上游的「告警生命周期通知三层闭环」工作重叠。本 PR 已删除该内联通知、集中到 `_schedule_notifications`。**建议本 PR 先合**，#3341 的 created 补偿在 `_schedule_notifications` 基础上重做（而非另起冲突改动）。

## 验证

- 新增 3 条单测（`test_event_alert_transaction.py`）：①通知延后到 on_commit（调用结束 notify 未发、注册了提交后回调、执行回调才发）②`notice` 开关（False 不注册）③helper 不再内联通知。**revert 生产代码后 3 条全失败**（含 `_schedule_notifications` 不存在）。
- 既有 `create_events_and_alerts` 测试补 `django.db` 事务桩 + `policy.notice` 适配事务化，保持通过。
- 本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`）。
- `flake8 --max-line-length 150` 无告警。

## 后续可选

- 可补一条「事务回滚 → on_commit 回调不执行」的显式断言。
- `on_commit` 在「提交成功」与「回调执行」间的极窄进程崩溃窗口仍可能丢通知——由既有告警通知补偿任务部分兜底（与 #3341 同域，一并演进）。
