### PR TITLE
fix(monitor): isolate display-field metrics by plugin via collect config

### DIFF
--- a/server/apps/monitor/services/metrics.py
+++ b/server/apps/monitor/services/metrics.py
@@ -7,7 +7,10 @@ from apps.core.logger import monitor_logger as logger
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.utils.dimension import parse_instance_id
-from apps.monitor.utils.display_fields_metrics import extract_metric_names
+from apps.monitor.utils.display_fields_metrics import (
+    display_field_key,
+    extract_metric_bindings,
+)
 from apps.monitor.utils.instance_id_keys import resolve_metric_instance_id_keys
 from apps.monitor.utils.unit_converter import UnitConverter
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
@@ -193,31 +196,28 @@ class Metrics:
         if not monitor_obj:
             return instances
 
-        indicator_names = extract_metric_names(monitor_obj.display_fields) or monitor_obj.supplementary_indicators
-        if not indicator_names:
+        # 取数 key 必须与 MonitorObjectService._fill_display_metrics 一致:
+        # display_fields 绑定用 (plugin, metric) 复合 key,supplementary 兜底用裸指标名。
+        targets = Metrics._resolve_convert_targets(monitor_object_id, monitor_obj)
+        if not targets:
             return instances
 
-        metrics = Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=indicator_names).values("name", "unit", "data_type")
-        metric_unit_map = {m["name"]: m["unit"] for m in metrics}
-        metric_data_type_map = {m["name"]: m["data_type"] for m in metrics}
-
-        for metric_name in indicator_names:
-            source_unit = metric_unit_map.get(metric_name)
+        for out_key, source_unit, data_type in targets:
             if not source_unit:
                 continue
 
-            if metric_data_type_map.get(metric_name) == "Enum":
+            if data_type == "Enum":
                 for instance in instances:
-                    raw_value = instance.get(metric_name)
-                    if raw_value is not None:
-                        instance[metric_name] = {"value": str(raw_value), "unit": ""}
+                    raw_value = instance.get(out_key)
+                    if raw_value is not None and not isinstance(raw_value, dict):
+                        instance[out_key] = {"value": str(raw_value), "unit": ""}
                 continue
 
             values = []
             valid_indices = []
             for idx, instance in enumerate(instances):
-                raw_value = instance.get(metric_name)
-                if raw_value is not None:
+                raw_value = instance.get(out_key)
+                if raw_value is not None and not isinstance(raw_value, dict):
                     try:
                         values.append(float(raw_value))
                         valid_indices.append(idx)
@@ -231,9 +231,42 @@ class Metrics:
             display_unit = UnitConverter.get_display_unit(target_unit)
 
             for i, idx in enumerate(valid_indices):
-                instances[idx][metric_name] = {
+                instances[idx][out_key] = {
                     "value": str(converted_values[i]),
                     "unit": display_unit,
                 }
 
         return instances
+
+    @staticmethod
+    def _resolve_convert_targets(monitor_object_id, monitor_obj):
+        """返回 [(out_key, source_unit, data_type), ...],与回填 key 规则保持一致。"""
+        bindings = extract_metric_bindings(monitor_obj.display_fields)
+        if bindings:
+            metrics = (
+                Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=[b["metric"] for b in bindings])
+                .select_related("monitor_plugin")
+                .values("name", "unit", "data_type", "monitor_plugin__name")
+            )
+            by_plugin = {((m["monitor_plugin__name"] or ""), m["name"]): m for m in metrics}
+            by_name = {}
+            for m in metrics:
+                by_name.setdefault(m["name"], m)
+            targets = []
+            for binding in bindings:
+                plugin_name, metric_name = binding["plugin"], binding["metric"]
+                meta = by_plugin.get((plugin_name, metric_name)) if plugin_name else by_name.get(metric_name)
+                if not meta:
+                    continue
+                targets.append((display_field_key(plugin_name, metric_name), meta["unit"], meta["data_type"]))
+            return targets
+
+        supplementary = monitor_obj.supplementary_indicators
+        if not supplementary:
+            return []
+        metrics = Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=supplementary).values(
+            "name", "unit", "data_type"
+        )
+        unit_map = {m["name"]: m["unit"] for m in metrics}
+        dtype_map = {m["name"]: m["data_type"] for m in metrics}
+        return [(name, unit_map.get(name), dtype_map.get(name)) for name in supplementary]

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -13,8 +13,12 @@ from apps.monitor.models.monitor_object import (
     MonitorInstanceOrganization,
     MonitorObjectType,
 )
+from apps.monitor.models.collect_config import CollectConfig
 from apps.monitor.utils.dimension import parse_instance_id
-from apps.monitor.utils.display_fields_metrics import extract_metric_names
+from apps.monitor.utils.display_fields_metrics import (
+    display_field_key,
+    extract_metric_bindings,
+)
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 from apps.monitor.tasks.grouping_rule import sync_instance_and_group
 
@@ -144,49 +148,119 @@ class MonitorObjectService:
             result.append(MonitorObjectService._serialize_instance_list_item(obj, instance_map, org_map))
 
         if add_metrics and page_size != -1:
-            instance_ids = []
-            for instance_info in result:
-                instance_id = parse_instance_id(instance_info["instance_id"])
-                instance_ids.append(instance_id)
-
-            display_metric_names = extract_metric_names(obj_metric_map.get("display_fields", [])) or obj_metric_map.get(
-                "supplementary_indicators", []
-            )
-            metrics_obj = Metric.objects.filter(
-                monitor_object_id=monitor_object_id,
-                name__in=display_metric_names,
-            )
-            for metric_obj in metrics_obj:
-                query_parts = []
-                for i, key in enumerate(metric_obj.instance_id_keys):
-                    values_set = {re.escape(str(item[i])) for item in instance_ids if len(item) > i and item[i] is not None}
-                    if not values_set:
-                        continue
-                    values = "|".join(sorted(values_set))
-                    values = MonitorObjectService._escape_promql_label_value(values)
-                    query_parts.append(f'{key}=~"{values}"')
-
-                query = metric_obj.query
-                query = query.replace("__$labels__", f"{', '.join(query_parts)}")
-                metrics = VictoriaMetricsAPI().query(query)
-                _metric_map = {}
-                for metric in metrics.get("data", {}).get("result", []):
-                    instance_id = str(tuple([metric["metric"].get(i) for i in metric_obj.instance_id_keys]))
-                    value = metric["value"][1]
-                    if instance_id not in _metric_map:
-                        _metric_map[instance_id] = value
-                    else:
-                        try:
-                            if float(value) > float(_metric_map[instance_id]):
-                                _metric_map[instance_id] = value
-                        except (ValueError, TypeError):
-                            pass
-                for instance in result:
-                    instance[metric_obj.name] = _metric_map.get(instance["instance_id"])
+            MonitorObjectService._fill_display_metrics(monitor_object_id, obj_metric_map, result)
 
         MonitorObjectService.add_attr(result)
 
         return dict(count=count, results=result)
+
+    @staticmethod
+    def _query_metric_values(metric_obj, target_instances):
+        """对 target_instances 跑该指标的 VM 查询,返回 {instance_id: value}(同实例多值取最大)。"""
+        target_ids = [parse_instance_id(inst["instance_id"]) for inst in target_instances]
+        query_parts = []
+        for i, key in enumerate(metric_obj.instance_id_keys):
+            values_set = {re.escape(str(item[i])) for item in target_ids if len(item) > i and item[i] is not None}
+            if not values_set:
+                continue
+            # re.escape 的反斜杠需再做一次 PromQL 字符串转义,否则 VM 侧报 invalid syntax
+            values = MonitorObjectService._escape_promql_label_value("|".join(sorted(values_set)))
+            query_parts.append(f'{key}=~"{values}"')
+
+        query = metric_obj.query.replace("__$labels__", f"{', '.join(query_parts)}")
+        metrics = VictoriaMetricsAPI().query(query)
+        value_map = {}
+        for metric in metrics.get("data", {}).get("result", []):
+            instance_id = str(tuple([metric["metric"].get(i) for i in metric_obj.instance_id_keys]))
+            value = metric["value"][1]
+            if instance_id not in value_map:
+                value_map[instance_id] = value
+            else:
+                try:
+                    if float(value) > float(value_map[instance_id]):
+                        value_map[instance_id] = value
+                except (ValueError, TypeError):
+                    pass
+        return value_map
+
+    @staticmethod
+    def _fill_display_metrics(monitor_object_id, obj_metric_map, result):
+        """按 display_fields 的 (plugin, metric) 绑定回填展示指标值。
+
+        - 回填 key 用复合 key ``<plugin>::<metric>``(见 display_field_key),避免不同插件的同名
+          指标互相覆盖;
+        - 按插件(模板)隔离:只把“采集配置归属该插件”的实例纳入该绑定取数,别的插件的实例该列留空。
+          无采集配置的实例无法判定插件归属,不展示带插件的绑定指标(显示 --)。
+        - 兼容:绑定缺 plugin(遗留配置)时按指标名匹配、不做隔离、用裸指标名回填;display_fields
+          为空时退回 supplementary_indicators(裸指标名,不区分插件)。
+        """
+        bindings = extract_metric_bindings(obj_metric_map.get("display_fields", []))
+
+        if not bindings:
+            supplementary = obj_metric_map.get("supplementary_indicators", [])
+            if not supplementary:
+                return
+            for metric_obj in Metric.objects.filter(monitor_object_id=monitor_object_id, name__in=supplementary):
+                value_map = MonitorObjectService._query_metric_values(metric_obj, result)
+                for instance in result:
+                    instance[metric_obj.name] = value_map.get(instance["instance_id"])
+            return
+
+        # 实例 -> 其采集配置覆盖的插件名集合(用于按插件隔离)
+        instance_plugin_map = {}
+        cc_qs = CollectConfig.objects.filter(
+            monitor_instance_id__in=[inst["instance_id"] for inst in result],
+            monitor_plugin__isnull=False,
+        ).values_list("monitor_instance_id", "monitor_plugin__name")
+        for inst_id, plugin_name in cc_qs:
+            instance_plugin_map.setdefault(inst_id, set()).add(plugin_name)
+
+        # 同名指标可能分属多个插件,按 (plugin, name) 精确取;另留 name 兜底给遗留无 plugin 的绑定
+        metric_by_plugin = {}
+        metric_by_name = {}
+        for metric_obj in Metric.objects.filter(
+            monitor_object_id=monitor_object_id,
+            name__in=[b["metric"] for b in bindings],
+        ).select_related("monitor_plugin"):
+            plugin_name = metric_obj.monitor_plugin.name if metric_obj.monitor_plugin_id else ""
+            metric_by_plugin[(plugin_name, metric_obj.name)] = metric_obj
+            metric_by_name.setdefault(metric_obj.name, metric_obj)
+
+        # 先把每个绑定解析成 (plugin, metric, metric_obj, eligible)
+        resolved = []
+        for binding in bindings:
+            plugin_name, metric_name = binding["plugin"], binding["metric"]
+            if plugin_name:
+                metric_obj = metric_by_plugin.get((plugin_name, metric_name))
+                eligible = [
+                    inst for inst in result if plugin_name in instance_plugin_map.get(inst["instance_id"], set())
+                ]
+            else:
+                # 遗留绑定无 plugin:按名取任一插件、不隔离,保持旧行为
+                metric_obj = metric_by_name.get(metric_name)
+                eligible = result
+            if not metric_obj or not eligible:
+                continue
+            resolved.append((plugin_name, metric_name, metric_obj, eligible))
+
+        # 按「查询模板 + instance_id_keys」分组合并:同名指标(各品牌 query 相同)只发一次 VM 查询,
+        # 覆盖该组所有 eligible 实例,再按各绑定的插件分发回各自实例,避免 N 个品牌 = N 次串行查询。
+        groups = {}
+        for item in resolved:
+            metric_obj = item[2]
+            group_key = (metric_obj.query, tuple(metric_obj.instance_id_keys))
+            groups.setdefault(group_key, []).append(item)
+
+        for items in groups.values():
+            union = {}
+            for _, _, _, eligible in items:
+                for inst in eligible:
+                    union[inst["instance_id"]] = inst
+            value_map = MonitorObjectService._query_metric_values(items[0][2], list(union.values()))
+            for plugin_name, metric_name, _, eligible in items:
+                out_key = display_field_key(plugin_name, metric_name)
+                for instance in eligible:
+                    instance[out_key] = value_map.get(instance["instance_id"])
 
     @staticmethod
     def _serialize_instance_list_item(obj, instance_map, org_map):

--- a/server/apps/monitor/tests/test_display_fields_metric_union.py
+++ b/server/apps/monitor/tests/test_display_fields_metric_union.py
@@ -1,11 +1,17 @@
 import pytest
 from unittest.mock import patch
 
+from apps.monitor.models.collect_config import CollectConfig
 from apps.monitor.models.monitor_object import MonitorObject, MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.plugin import MonitorPlugin
+from apps.monitor.services.metrics import Metrics
 from apps.monitor.services.monitor_object import MonitorObjectService
-from apps.monitor.utils.display_fields_metrics import extract_metric_names
+from apps.monitor.utils.display_fields_metrics import (
+    display_field_key,
+    extract_metric_bindings,
+    extract_metric_names,
+)
 
 
 def test_extract_metric_names_union_preserves_order_and_dedups():
@@ -23,24 +29,64 @@ def test_extract_metric_names_empty():
     assert extract_metric_names(None) == []
 
 
+def test_extract_metric_bindings_keeps_plugin_and_dedups_by_pair():
+    # 同名指标分属不同插件应各保留一条;完全相同的 (plugin, metric) 去重
+    display_fields = [
+        {"name": "温度", "sort_order": 0, "metrics": [
+            {"plugin": "Switch Huawei SNMP", "metric": "device_temperature_celsius"},
+            {"plugin": "Switch Cisco SNMP", "metric": "device_temperature_celsius"}]},
+        {"name": "CPU", "sort_order": 1, "metrics": [
+            {"plugin": "Switch Huawei SNMP", "metric": "device_temperature_celsius"},  # dup pair
+            {"plugin": "Switch Huawei SNMP", "metric": "device_cpu_usage"}]},
+    ]
+    assert extract_metric_bindings(display_fields) == [
+        {"plugin": "Switch Huawei SNMP", "metric": "device_temperature_celsius"},
+        {"plugin": "Switch Cisco SNMP", "metric": "device_temperature_celsius"},
+        {"plugin": "Switch Huawei SNMP", "metric": "device_cpu_usage"},
+    ]
+
+
+def test_display_field_key_composite_and_legacy():
+    assert display_field_key("Switch Huawei SNMP", "device_temperature_celsius") == \
+        "Switch Huawei SNMP::device_temperature_celsius"
+    # 无插件(遗留)退化为裸指标名
+    assert display_field_key("", "device_temperature_celsius") == "device_temperature_celsius"
+
+
+def _mk_metric(obj, plugin, name):
+    group = MetricGroup.objects.create(monitor_object=obj, monitor_plugin=plugin, name=f"G-{plugin.name}")
+    return Metric.objects.create(
+        monitor_object=obj, monitor_plugin=plugin, metric_group=group, name=name,
+        display_name=name, query=f"{name}{{__$labels__}}", unit="percent",
+        data_type="Number", instance_id_keys=["instance_id"],
+    )
+
+
+def _mk_collect_config(cfg_id, instance, plugin):
+    return CollectConfig.objects.create(
+        id=cfg_id, monitor_instance=instance, monitor_plugin=plugin,
+        collector="Telegraf", collect_type="snmp", config_type="child", file_type="toml",
+    )
+
+
 @pytest.mark.django_db
 @patch("apps.monitor.services.monitor_object.VictoriaMetricsAPI")
 def test_get_monitor_instance_queries_display_fields_metrics(mock_vm):
-    mock_vm.return_value.query.return_value = {"data": {"result": []}}
+    # 实例有 CollectConfig 归属插件 P → 该绑定取数会跑,且回填用复合 key
+    mock_vm.return_value.query.return_value = {"data": {"result": [
+        {"metric": {"instance_id": "i1"}, "value": [0, "42"]},
+    ]}}
     obj = MonitorObject.objects.create(
         name="UTHostU", level="base",
         default_metric="any({instance_type='UTHostU'}) by (instance_id)",
-        instance_id_keys=["instance_id"],
-        supplementary_indicators=[],
+        instance_id_keys=["instance_id"], supplementary_indicators=[],
         display_fields=[{"name": "CPU", "sort_order": 0,
                          "metrics": [{"plugin": "P", "metric": "cpu_usage_total"}]}],
     )
     plugin = MonitorPlugin.objects.create(name="P")
-    group = MetricGroup.objects.create(monitor_object=obj, monitor_plugin=plugin, name="Base")
-    Metric.objects.create(monitor_object=obj, monitor_plugin=plugin, metric_group=group,
-                          name="cpu_usage_total", display_name="CPU", query="cpu_usage_total{__$labels__}",
-                          unit="percent", data_type="Number", instance_id_keys=["instance_id"])
-    MonitorInstance.objects.create(id="('i1',)", name="i1", monitor_object=obj)
+    _mk_metric(obj, plugin, "cpu_usage_total")
+    inst = MonitorInstance.objects.create(id="('i1',)", name="i1", monitor_object=obj)
+    _mk_collect_config("cc-i1-P", inst, plugin)
 
     res = MonitorObjectService.get_monitor_instance(
         obj.id, page=1, page_size=10, name=None,
@@ -49,3 +95,94 @@ def test_get_monitor_instance_queries_display_fields_metrics(mock_vm):
     queried = [c.args[0] for c in mock_vm.return_value.query.call_args_list]
     assert any("cpu_usage_total" in q for q in queried)
     assert res["count"] == 1
+    # 复合 key 回填,而非裸指标名
+    assert res["results"][0]["P::cpu_usage_total"] == "42"
+    assert "cpu_usage_total" not in res["results"][0]
+
+    # convert 须用同一复合 key 包成 {value, unit}(回归:类内自引用曾误用别名 MetricsService)
+    Metrics.convert_instance_list_metrics(obj.id, res["results"])
+    converted = res["results"][0]["P::cpu_usage_total"]
+    assert isinstance(converted, dict) and float(converted["value"]) == 42.0
+
+
+@pytest.mark.django_db
+@patch("apps.monitor.services.monitor_object.VictoriaMetricsAPI")
+def test_display_fields_isolated_by_plugin(mock_vm):
+    # 同名指标(温度)绑了 Huawei + Cisco 两个插件;实例只归属 Huawei →
+    # 只在 Huawei 复合 key 上有值,Cisco 复合 key 不应出现(别的品牌不串)。
+    mock_vm.return_value.query.return_value = {"data": {"result": [
+        {"metric": {"instance_id": "hw1"}, "value": [0, "55"]},
+    ]}}
+    obj = MonitorObject.objects.create(
+        name="UTSwitchU", level="base",
+        default_metric="any({instance_type='UTSwitchU'}) by (instance_id)",
+        instance_id_keys=["instance_id"], supplementary_indicators=[],
+        display_fields=[{"name": "温度", "sort_order": 0, "metrics": [
+            {"plugin": "Switch Huawei SNMP", "metric": "device_temperature_celsius"},
+            {"plugin": "Switch Cisco SNMP", "metric": "device_temperature_celsius"}]}],
+    )
+    huawei = MonitorPlugin.objects.create(name="Switch Huawei SNMP")
+    cisco = MonitorPlugin.objects.create(name="Switch Cisco SNMP")
+    _mk_metric(obj, huawei, "device_temperature_celsius")
+    _mk_metric(obj, cisco, "device_temperature_celsius")
+    hw = MonitorInstance.objects.create(id="('hw1',)", name="huawei-switch", monitor_object=obj)
+    _mk_collect_config("cc-hw1", hw, huawei)
+    # 一台没有任何 CollectConfig 的实例(演示数据形态)
+    MonitorInstance.objects.create(id="('mock1',)", name="netgear-switch", monitor_object=obj)
+
+    res = MonitorObjectService.get_monitor_instance(
+        obj.id, page=1, page_size=10, name=None,
+        qs=MonitorInstance.objects.all(), add_metrics=True,
+    )
+    rows = {r["instance_id"]: r for r in res["results"]}
+    hw_row = rows["('hw1',)"]
+    mock_row = rows["('mock1',)"]
+    hw_key = "Switch Huawei SNMP::device_temperature_celsius"
+    cisco_key = "Switch Cisco SNMP::device_temperature_celsius"
+    # Huawei 实例:只在 Huawei key 有值,不串到 Cisco key
+    assert hw_row.get(hw_key) == "55"
+    assert cisco_key not in hw_row
+    # 无 CollectConfig 的实例:两个插件 key 都不出现(显示 --)
+    assert hw_key not in mock_row
+    assert cisco_key not in mock_row
+
+
+@pytest.mark.django_db
+@patch("apps.monitor.services.monitor_object.VictoriaMetricsAPI")
+def test_display_fields_batches_one_query_per_metric(mock_vm):
+    # 同名指标绑了华为+思科两个插件、两台实例各归属其一:应只发 1 次该指标的 VM 查询(批量),
+    # 且各自只在自己品牌的复合 key 上拿到值(隔离)。
+    mock_vm.return_value.query.return_value = {"data": {"result": [
+        {"metric": {"instance_id": "hw1"}, "value": [0, "55"]},
+        {"metric": {"instance_id": "ci1"}, "value": [0, "60"]},
+    ]}}
+    obj = MonitorObject.objects.create(
+        name="UTSwitchB", level="base",
+        default_metric="any({instance_type='UTSwitchB'}) by (instance_id)",
+        instance_id_keys=["instance_id"], supplementary_indicators=[],
+        display_fields=[{"name": "温度", "sort_order": 0, "metrics": [
+            {"plugin": "Switch Huawei SNMP", "metric": "device_temperature_celsius"},
+            {"plugin": "Switch Cisco SNMP", "metric": "device_temperature_celsius"}]}],
+    )
+    huawei = MonitorPlugin.objects.create(name="Switch Huawei SNMP")
+    cisco = MonitorPlugin.objects.create(name="Switch Cisco SNMP")
+    _mk_metric(obj, huawei, "device_temperature_celsius")
+    _mk_metric(obj, cisco, "device_temperature_celsius")
+    hw = MonitorInstance.objects.create(id="('hw1',)", name="hw", monitor_object=obj)
+    ci = MonitorInstance.objects.create(id="('ci1',)", name="ci", monitor_object=obj)
+    _mk_collect_config("cc-hw1b", hw, huawei)
+    _mk_collect_config("cc-ci1b", ci, cisco)
+
+    res = MonitorObjectService.get_monitor_instance(
+        obj.id, page=1, page_size=10, name=None,
+        qs=MonitorInstance.objects.all(), add_metrics=True,
+    )
+    queried = [c.args[0] for c in mock_vm.return_value.query.call_args_list]
+    # 两个品牌同名同 query → 合并成一次查询(而非每品牌一次)
+    temp_queries = [q for q in queried if "device_temperature_celsius" in q]
+    assert len(temp_queries) == 1, f"expected 1 batched query, got {len(temp_queries)}: {temp_queries}"
+    rows = {r["instance_id"]: r for r in res["results"]}
+    hw_key = "Switch Huawei SNMP::device_temperature_celsius"
+    cisco_key = "Switch Cisco SNMP::device_temperature_celsius"
+    assert rows["('hw1',)"].get(hw_key) == "55" and cisco_key not in rows["('hw1',)"]
+    assert rows["('ci1',)"].get(cisco_key) == "60" and hw_key not in rows["('ci1',)"]

--- a/server/apps/monitor/utils/display_fields_metrics.py
+++ b/server/apps/monitor/utils/display_fields_metrics.py
@@ -1,5 +1,46 @@
+# 展示指标(display_fields)的取数 key 工具。
+#
+# 一个监控对象下可能挂多个插件,且不同插件常定义“同名”指标(如交换机各品牌都叫
+# device_temperature_celsius)。若仅按指标名回填实例值,会出现“别的品牌也展示了温度”
+# 以及同名指标互相覆盖。因此展示指标的回填 key 统一用 (plugin, metric) 复合 key,
+# 前后端必须用同一套规则拼 key(见 web 端 displayFieldKey)。
+
+DISPLAY_FIELD_KEY_SEP = "::"
+
+
+def display_field_key(plugin, metric):
+    """展示指标回填用的复合 key:有插件用 ``<plugin>::<metric>``,无插件(遗留/补充指标)退化为裸指标名。"""
+    if plugin:
+        return f"{plugin}{DISPLAY_FIELD_KEY_SEP}{metric}"
+    return metric
+
+
+def extract_metric_bindings(display_fields):
+    """从 display_fields 抽取 (plugin, metric) 绑定的并集(保持首次出现顺序,去重)。
+
+    返回 ``[{"plugin": <插件名或空串>, "metric": <指标名>}, ...]``。
+    """
+    bindings = []
+    seen = set()
+    for col in display_fields or []:
+        for binding in col.get("metrics", []):
+            metric = binding.get("metric")
+            if not metric:
+                continue
+            plugin = binding.get("plugin") or ""
+            dedup_key = (plugin, metric)
+            if dedup_key not in seen:
+                seen.add(dedup_key)
+                bindings.append({"plugin": plugin, "metric": metric})
+    return bindings
+
+
 def extract_metric_names(display_fields):
-    """从 display_fields 抽取所有绑定指标名的并集（保持首次出现顺序，去重）。"""
+    """从 display_fields 抽取所有绑定指标名的并集(保持首次出现顺序,去重)。
+
+    仅用于不区分插件的旧路径(如 supplementary_indicators 兜底)。展示指标取数请用
+    ``extract_metric_bindings`` + ``display_field_key``。
+    """
     names = []
     seen = set()
     for col in display_fields or []:

--- a/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
@@ -392,6 +392,8 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
                     >
                       <Select
                         className="flex-1"
+                        showSearch
+                        optionFilterProp="label"
                         value={binding.plugin || undefined}
                         placeholder={t('monitor.object.selectTemplate')}
                         options={currentPlugins.map((p) => ({
@@ -404,6 +406,8 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
                       />
                       <Select
                         className="flex-1"
+                        showSearch
+                        optionFilterProp="label"
                         value={binding.metric || undefined}
                         placeholder={t('monitor.object.selectMetric')}
                         disabled={!binding.plugin}

--- a/web/src/app/monitor/(pages)/view/viewHive.tsx
+++ b/web/src/app/monitor/(pages)/view/viewHive.tsx
@@ -34,6 +34,18 @@ const { Option } = Select;
 
 const HEXAGON_AREA = 6400; // 格子的面积
 
+// 展示指标值现按 (plugin, metric) 复合 key 回填(后端 display_field_key)。蜂巢图的指标选择
+// 只携带指标名,故按名解析:先取裸 key(遗留/补充指标),否则取任一 `<plugin>::<metric>` key。
+// 按插件隔离保证同一实例对同一指标名至多有一个插件的值,扫描不会取错。
+const readDisplayMetricCell = (item: TableDataItem, metricName: string) => {
+  if (item[metricName] != null) return item[metricName];
+  const suffix = `::${metricName}`;
+  for (const key of Object.keys(item)) {
+    if (key.endsWith(suffix) && item[key] != null) return item[key];
+  }
+  return undefined;
+};
+
 const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
   const { isLoading } = useApiClient();
   const { getMonitorMetrics } = useMonitorApi();
@@ -287,6 +299,7 @@ const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
         (item) => item.name === metricName
       );
       if (tagetMerticItem) {
+        const cellValue = readDisplayMetricCell(item, metricName);
         return {
           name: '',
           description: (
@@ -294,13 +307,13 @@ const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
               <div>{item.instance_name}</div>
               {`${tagetMerticItem.display_name}: ${getEnumValueUnit(
                 tagetMerticItem,
-                item[metricName]
+                cellValue
               )}`}
             </>
           ),
           fill: queryMetric
-            ? handleHexColor(item[metricName], hexColor)
-            : handleFillColor(tagetMerticItem, item[metricName])
+            ? handleHexColor(cellValue, hexColor)
+            : handleFillColor(tagetMerticItem, cellValue)
         };
       }
       return {

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -38,6 +38,12 @@ const { Option } = Select;
 // 视图列表的展示列类型（来自对象的 display_fields 配置）
 type DisplayCol = NonNullable<ObjectItem['display_fields']>[number];
 
+// 展示指标回填值的复合 key，必须与后端 display_field_key 保持一致：
+// 有插件用 `<plugin>::<metric>`（避免不同插件同名指标互相覆盖/串数据），无插件退化为裸指标名。
+const DISPLAY_FIELD_KEY_SEP = '::';
+const displayFieldKey = (plugin?: string, metric?: string): string =>
+  plugin ? `${plugin}${DISPLAY_FIELD_KEY_SEP}${metric}` : (metric ?? '');
+
 const ViewList: React.FC<ViewListProps> = ({
   objects,
   objectId,
@@ -289,7 +295,9 @@ const ViewList: React.FC<ViewListProps> = ({
         // 解析某行在某列应展示的绑定指标值（按绑定顺序取首个有值），返回 {value, unit, metricName}
         const resolveCell = (record: TableDataItem, col: DisplayCol) => {
           for (const binding of col.metrics || []) {
-            const cell = record[binding.metric] as { value?: string | number; unit?: string } | undefined;
+            const cell = record[displayFieldKey(binding.plugin, binding.metric)] as
+              | { value?: string | number; unit?: string }
+              | undefined;
             const v = cell?.value;
             if (v != null && v !== '') {
               return { value: v, unit: cell?.unit, metricName: binding.metric };


### PR DESCRIPTION
## 问题

监控对象的「展示指标」列按 `(plugin, metric)` 绑定,但实例列表取数只按**指标名**查询/回填。对挂多个插件、且各插件定义同名归一化指标的对象(交换机各品牌、Host/Firewall/Router/Loadbalance 等),会出现:

1. 某列绑定了 A 插件,却把所有插件实例的该指标都显示出来(别的品牌/插件的数据串台);
2. 不同插件的同名指标在同一 key 下互相覆盖。

## 修复

- **复合 key**:展示指标回填用 `<plugin>::<metric>`(`display_field_key`),同名指标不再互相覆盖;遗留无 plugin 绑定与 `supplementary_indicators` 仍用裸指标名。
- **按插件隔离**:经 `CollectConfig` 求出实例的插件归属,某绑定只对「归属该插件」的实例取数;无采集配置的实例不展示带插件的绑定指标。
- `convert_instance_list_metrics` 对齐为同一复合 key、按 `(plugin, name)` 取单位。
- **批量查询**:按 `(query, instance_id_keys)` 分组,同名指标(各品牌 query 相同)只发一次 VM 查询再按插件分发,避免「N 个品牌 = N 次串行查询」。
- 前端 `viewList`/`viewHive` 按复合 key 读值;展示指标配置下拉支持输入搜索。

## 测试

`apps/monitor/tests/test_display_fields_metric_union.py`:复合 key 提取、按插件隔离、批量「同名指标一次查询」、convert 包装,共 7 个用例通过。

无模型变更,无需迁移。
