### PR TITLE
optimization: 事件原始数据写入去 N+1，逐条 exists+save 改批量（#3335）

### DIFF
--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -60,15 +60,23 @@ class EventAlertManager:
     def _create_raw_data_records(self, events_with_raw_data, event_objs):
         event_obj_map = {obj.id: obj for obj in event_objs}
 
-        raw_data_objects = []
-        for event_info in events_with_raw_data:
-            event_id = event_info["event_id"]
-            if event_id in event_obj_map or MonitorEvent.objects.filter(id=event_id).exists():
-                raw_data_objects.append(MonitorEventRawData(event_id=event_id, data=event_info["raw_data"]))
+        # event_obj_map 是本轮刚建/回查事件的权威集合；仅对不在其中的少数 id 做一次批量存在性兜底，
+        # 取代原来逐条 .exists() 的 N 次 SELECT（正常情况下 missing_ids 为空，零额外查询）
+        missing_ids = [info["event_id"] for info in events_with_raw_data if info["event_id"] not in event_obj_map]
+        existing_missing = set()
+        if missing_ids:
+            existing_missing = set(MonitorEvent.objects.filter(id__in=missing_ids).values_list("id", flat=True))
+
+        raw_data_objects = [
+            MonitorEventRawData(event_id=info["event_id"], data=info["raw_data"])
+            for info in events_with_raw_data
+            if info["event_id"] in event_obj_map or info["event_id"] in existing_missing
+        ]
 
         if raw_data_objects:
-            for raw_data_obj in raw_data_objects:
-                raw_data_obj.save()
+            # 逐行 save() 改批量 bulk_create——S3JSONField 的上传在 pre_save 完成（bulk_create 会调用 pre_save），
+            # 行为与 save() 一致，仅把 N 次 INSERT 压成批量
+            MonitorEventRawData.objects.bulk_create(raw_data_objects, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
             logger.info(f"Created {len(raw_data_objects)} raw data records for policy {self.policy.id}")
 
     def create_events_and_alerts(self, events):

--- a/server/apps/monitor/tests/test_raw_data_records_batch.py
+++ b/server/apps/monitor/tests/test_raw_data_records_batch.py
@@ -1,0 +1,137 @@
+"""Issue #3335：事件原始数据写入去 N+1（_create_raw_data_records 批量化）单测。
+
+原实现对每条事件做一次 .exists() SELECT + 逐行 save() INSERT。本测验证：
+① 命中 event_obj_map 的事件不再逐条 SELECT（正常情况零额外查询）；
+② 写入改为单次 bulk_create；③ 不在 map 的 id 走一次批量 id__in 存在性兜底（非逐条）。
+沿用注入式 harness（pytest 因缺 license_mgmt/MINIO 无法 django.setup）。
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+class _Logger:
+    def info(self, *a, **k):
+        return None
+
+    def warning(self, *a, **k):
+        return None
+
+    def error(self, *a, **k):
+        return None
+
+    def debug(self, *a, **k):
+        return None
+
+
+def _load(monkeypatch, name, filter_calls, bulk_calls, saved):
+    class _EventQS:
+        def __init__(self, ids):
+            self.ids = list(ids)
+
+        def values_list(self, field, flat=False):
+            return list(self.ids)  # 简化：传入的 id 都视为存在
+
+    class _MonitorEvent:
+        class objects:
+            @staticmethod
+            def filter(**kwargs):
+                filter_calls.append(kwargs)
+                return _EventQS(kwargs.get("id__in", []))
+
+    class _RawData:
+        def __init__(self, event_id=None, data=None):
+            self.event_id = event_id
+            self.data = data
+
+        def save(self):
+            saved.append(self.event_id)  # 若被逐行 save（旧实现），会记录在此 → 新实现应为空
+
+        class objects:
+            @staticmethod
+            def bulk_create(objs, batch_size=None):
+                bulk_calls.append(([o.event_id for o in objs], batch_size))
+                return list(objs)
+
+    _install_module(monkeypatch, "apps.monitor.constants.alert_policy", AlertConstants=types.SimpleNamespace())
+    _install_module(
+        monkeypatch,
+        "apps.monitor.constants.database",
+        DatabaseConstants=types.SimpleNamespace(BULK_CREATE_BATCH_SIZE=100, BULK_UPDATE_BATCH_SIZE=100),
+    )
+    _install_module(monkeypatch, "apps.monitor.models", MonitorAlert=object, MonitorEvent=_MonitorEvent, MonitorEventRawData=_RawData)
+    _install_module(
+        monkeypatch,
+        "apps.monitor.services.alert_lifecycle_notify",
+        AlertLifecycleNotifier=lambda *a, **k: types.SimpleNamespace(notify_alerts=lambda *a, **k: None),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.dimension", format_dimension_str=lambda d: "")
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_Logger())
+
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan" / "event_alert_manager.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _manager(module):
+    mgr = object.__new__(module.EventAlertManager)
+    mgr.policy = types.SimpleNamespace(id=1)
+    return mgr
+
+
+def test_all_events_in_map_bulk_create_without_per_event_select(monkeypatch):
+    filter_calls, bulk_calls, saved = [], [], []
+    module = _load(monkeypatch, "raw_all_in_map_module", filter_calls, bulk_calls, saved)
+    mgr = _manager(module)
+
+    event_objs = [types.SimpleNamespace(id="e1"), types.SimpleNamespace(id="e2")]
+    events_with_raw_data = [{"event_id": "e1", "raw_data": {"a": 1}}, {"event_id": "e2", "raw_data": {"b": 2}}]
+
+    mgr._create_raw_data_records(events_with_raw_data, event_objs)
+
+    # 命中 map → 不做任何逐条/批量 SELECT
+    assert filter_calls == []
+    # 单次 bulk_create 写全部，batch_size 透传；不再逐行 save
+    assert bulk_calls == [(["e1", "e2"], 100)]
+    assert saved == []
+
+
+def test_missing_event_id_uses_single_batched_existence_check(monkeypatch):
+    filter_calls, bulk_calls, saved = [], [], []
+    module = _load(monkeypatch, "raw_missing_module", filter_calls, bulk_calls, saved)
+    mgr = _manager(module)
+
+    event_objs = [types.SimpleNamespace(id="e1")]  # e2 不在 map
+    events_with_raw_data = [{"event_id": "e1", "raw_data": {}}, {"event_id": "e2", "raw_data": {}}]
+
+    mgr._create_raw_data_records(events_with_raw_data, event_objs)
+
+    # 仅一次批量 id__in 兜底（非逐条），且只查不在 map 的 e2
+    assert filter_calls == [{"id__in": ["e2"]}]
+    # e1（map）+ e2（兜底确认存在）都写入，单次 bulk_create
+    assert bulk_calls == [(["e1", "e2"], 100)]
+    assert saved == []
+
+
+def test_empty_raw_data_skips_bulk_create(monkeypatch):
+    filter_calls, bulk_calls, saved = [], [], []
+    module = _load(monkeypatch, "raw_empty_module", filter_calls, bulk_calls, saved)
+    mgr = _manager(module)
+
+    mgr._create_raw_data_records([], [types.SimpleNamespace(id="e1")])
+
+    assert filter_calls == []
+    assert bulk_calls == []
+    assert saved == []


### PR DESCRIPTION
## 被破坏的不变量

告警扫描的事件原始数据写入，开销本应与「单轮告警条数」无关地保持平稳。但 `_create_raw_data_records` 对每条带 raw_data 的事件**逐条查库、逐行写库**：N 条告警 ≈ N 次 SELECT + N 次 INSERT。平时几条看不出，告警风暴时这条税最重，拖慢整条告警链路、抬高 DB 负载。

## 根因（设计层）

内存里 `event_obj_map` 已是本轮刚建/回查事件的权威集合，却仍对每条做一次 `.exists()` 兜底 SELECT，且逐行 `save()` 而非批量：

```python
for event_info in events_with_raw_data:
    if event_id in event_obj_map or MonitorEvent.objects.filter(id=event_id).exists():  # 每条一次 SELECT
        raw_data_objects.append(MonitorEventRawData(event_id=event_id, data=...))
for raw_data_obj in raw_data_objects:
    raw_data_obj.save()        # 每条一次 INSERT
```

## 修复

- **去逐条 SELECT**：先算出不在 `event_obj_map` 的少数 id，仅当非空时做**一次**批量 `filter(id__in=missing).values_list("id")` 兜底。正常情况下 `event_obj_map` 覆盖全部 event_id（事件以显式 uuid 为主键创建），`missing` 为空 → **零额外查询**。
- **逐行 save → 批量 bulk_create**：`MonitorEventRawData.objects.bulk_create(..., batch_size=...)`。

退化为 **≤1 次 SELECT + 1 次 bulk_create**。

## blast radius · 一致性

- 改动仅限 `event_alert_manager.py` 的 `_create_raw_data_records` 单方法。
- **行为等价**：`MonitorEventRawData.data` 是 `S3JSONField`（存 MinIO），其 S3 上传发生在 `pre_save`——`bulk_create` 同样会对每个对象调用 `field.pre_save`，故 S3 上传照常发生，仅把 N 次 DB INSERT 压成批量。无 `post_save` 依赖、无 unique 约束、每轮 event_id 为新 uuid，无并发/重复写隐患。
- **存在性兜底语义不变**：仍只为「确实存在的事件」写 raw_data，不漏不多。

## 与 #3336（PR #3350）的关系

两者同改 `event_alert_manager.py` 但 **hunk 不相邻、不重叠**（#3336 改 `create_events_and_alerts`/通知方法 + 顶部加 `transaction` import；本 PR 只改 `_create_raw_data_records`、未动 import），可自动 3-way 合并。语义上 #3350 的 `transaction.atomic()` 会把本 bulk_create 一并纳入事务，互补更优。**建议先合 #3350**，本分支再 rebase 以消除 import 区潜在文本冲突。

## 验证

- 新增 3 条单测（`test_raw_data_records_batch.py`）：①命中 map → 零 SELECT + 单次 bulk_create + 不再逐行 save；②不在 map → 一次批量 `id__in` 兜底（非逐条）；③空集跳过。**revert 旧实现后失败**。
- 本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`）。
- `flake8 --max-line-length 150` 无告警。
