### PR TITLE
bugfix: system_mgmt 操作人上下文补回 group_list，对齐三处 actor_context 契约（#3334）

### DIFF
--- a/server/apps/monitor/tests/test_system_mgmt_actor_context.py
+++ b/server/apps/monitor/tests/test_system_mgmt_actor_context.py
@@ -1,0 +1,86 @@
+"""Issue #3334：system_mgmt 视图的「当前操作人」上下文此前缺 group_list，与 monitor_instance/
+node_mgmt 两处不一致——而用户面 scoped 查询（get_group_users_scoped / search_channel_list_scoped）
+依赖 group_list 做组织范围判断。本测验证 system_mgmt 的 _build_actor_context 现包含 group_list。
+
+沿用注入式 harness（pytest 因缺 license_mgmt/MINIO 无法 django.setup）。
+"""
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_system_mgmt_view(monkeypatch):
+    class ViewSet:
+        pass
+
+    def action(*args, **kwargs):
+        def decorator(func):
+            return func
+
+        return decorator
+
+    _install_module(monkeypatch, "rest_framework.viewsets", ViewSet=ViewSet)
+    _install_module(monkeypatch, "rest_framework.decorators", action=action)
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(monkeypatch, "apps.core.utils.web_utils", WebUtils=types.SimpleNamespace(response_success=lambda data=None: data))
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.user_group",
+        normalize_user_group_ids=lambda groups: [
+            int(group.get("id") if isinstance(group, dict) else group)
+            for group in groups
+            if (group.get("id") if isinstance(group, dict) else group) is not None
+        ],
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.system_mgmt_api", SystemMgmtUtils=object)
+
+    spec = importlib.util.spec_from_file_location(
+        "monitor_system_mgmt_view_test_module",
+        Path(__file__).resolve().parents[1] / "views" / "system_mgmt.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _request(group_list, current_team="7"):
+    return types.SimpleNamespace(
+        COOKIES={"current_team": current_team, "include_children": "1"},
+        user=types.SimpleNamespace(username="u", domain="domain.com", is_superuser=False, group_list=group_list),
+    )
+
+
+def test_actor_context_includes_group_list_for_integer_groups(monkeypatch):
+    module = _load_system_mgmt_view(monkeypatch)
+    ctx = module._build_actor_context(_request([7, 9]))
+    # 此前缺失，现与 monitor_instance/node_mgmt 一致填充 group_list
+    assert ctx["group_list"] == [7, 9]
+    # 其余字段不变
+    assert ctx["current_team"] == 7
+    assert ctx["username"] == "u"
+    assert ctx["is_superuser"] is False
+
+
+def test_actor_context_normalizes_token_group_dicts(monkeypatch):
+    module = _load_system_mgmt_view(monkeypatch)
+    ctx = module._build_actor_context(_request([{"id": "8", "name": "team-a"}]))
+    assert ctx["group_list"] == [8]
+
+
+def test_actor_context_defaults_group_list_when_user_has_none(monkeypatch):
+    module = _load_system_mgmt_view(monkeypatch)
+    request = types.SimpleNamespace(
+        COOKIES={"current_team": "7"},
+        user=types.SimpleNamespace(username="u", domain="domain.com", is_superuser=False),  # 无 group_list 属性
+    )
+    ctx = module._build_actor_context(request)
+    assert ctx["group_list"] == []

--- a/server/apps/monitor/views/system_mgmt.py
+++ b/server/apps/monitor/views/system_mgmt.py
@@ -2,6 +2,7 @@ from rest_framework.decorators import action
 from rest_framework.viewsets import ViewSet
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
 
@@ -22,6 +23,9 @@ def _build_actor_context(request):
         "current_team": current_team,
         "include_children": request.COOKIES.get("include_children", "0") == "1",
         "is_superuser": request.user.is_superuser,
+        # 与 monitor_instance/node_mgmt 两处保持一致：用户面 scoped 查询（get_group_users_scoped /
+        # search_channel_list_scoped）依赖 group_list 做组织范围判断，此前缺失会导致 scope 判错（#3334）
+        "group_list": normalize_user_group_ids(getattr(request.user, "group_list", [])),
     }
 
 


### PR DESCRIPTION
## 被破坏的不变量

监控有三处各自组装「当前操作人」上下文（用于数据权限/组织范围判断）：`monitor_instance.py`、`node_mgmt.py`、`system_mgmt.py` 各一份 `_build_actor_context`。前两份逐字相同、都含 `group_list`；`system_mgmt` 这份是近似复制粘贴但**漏了 `group_list`**。同一职责的上下文契约本应单一一致，这里却分叉了。

## 根因（设计层）

`_build_actor_context` 被复制三份且已分叉，缺单一来源。`group_list` 在 actor_context 契约里是**有效字段**——进程内授权路径 `services/node_mgmt.py` 直接读 `actor_context["group_list"]` 算组织范围（经 monitor_instance/node_mgmt 两份上下文）。`system_mgmt` 这份漏掉它，属契约不一致：权限规则一旦调整容易只改到一两处，也为后续鉴权 bug 埋雷。

## 修复

给 `system_mgmt.py` 的 `_build_actor_context` 补回缺失字段，与另两处逐字对齐：

```python
"group_list": normalize_user_group_ids(getattr(request.user, "group_list", [])),
```

## 行为影响（已据下游核验，零回归）

- `system_mgmt` 的 `get_user_all`/`search_channel_list` 走 NATS scoped 查询（`get_group_users_scoped`/`search_channel_list_scoped`），**服务端从 DB 重载 `user_obj.group_list`、当前并不消费 `actor_context.group_list`**——故本次补全对这两个端点是**行为等价**（零回归）。
- 价值在于：消除三处分叉、与 A/B 的 actor_context 契约对齐、并防御未来 scoped 实现改读 `actor_context.group_list`（届时缺字段会因空 group_list 把 scope 收紧到"看不到"）。
- `organization_rule.py`/`manual_collect.py` 用的是 `monitor_instance` 那份（一直含 group_list），**不受本次改动影响**。

> 说明：这是**契约一致性补全**，不是修一个当前可触发的越权——避免把它读成 "system_mgmt 现在判错权限"。

## blast radius · 一致性

- 改动仅限 `system_mgmt.py` 的 `_build_actor_context`（+1 import、+1 字段）。
- `normalize_user_group_ids` 与另两处同源（`apps.core.utils.user_group`），归一化 int / `{"id": ...}` 字典 / 缺省 `[]` 行为一致。

## 验证

- 新增 3 条单测（`test_system_mgmt_actor_context.py`）：整型组 `[7,9]`、token 字典组 `[{"id":"8"}]→[8]` 归一化、用户无 `group_list` 属性时默认 `[]`。**revert 后 `ctx["group_list"]` KeyError 失败**。
- 本地以 Django-free 独立 harness 验证（本仓 pytest 因缺 license_mgmt/MINIO 配置无法在 collection 前完成 `django.setup()`）。
- `flake8 --max-line-length 150` 无告警。

## 后续

- 三处 `_build_actor_context` 仍是复制粘贴，**抽到单一公共 helper** 的去重重构（issue 的建议方向）留作后续——它会牵动多个视图 import 与既有测试 harness（如 `test_node_mgmt_actor_context.py` 直接加载视图模块测真实 helper），单独处理以免本 bugfix 扩张。本 PR 先把"漏字段"这个实际不一致补平。
