### PR TITLE
bugfix(log): 将 tail_async 的 iter_lines 卸载到线程池，修复 ASGI 事件循环阻塞

### DIFF
--- a/server/apps/log/tests/test_query_log.py
+++ b/server/apps/log/tests/test_query_log.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import threading
 
 import pytest
 from django.utils import timezone
@@ -835,3 +837,78 @@ def test_alert_snapshots_returns_data_for_authorized_policy(api_client, authenti
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["data"]["alert_info"]["id"] == alert.id
     assert response.json()["data"]["snapshot_info"]["snapshot_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #3359: tail_async 的 iter_lines 必须在线程池中运行，不得阻塞事件循环
+# ---------------------------------------------------------------------------
+
+class _BlockingStreamResponse:
+    """
+    模拟一个"第一行来得很慢"的流式响应：
+    iter_lines() 在产出第一行前会用 threading.Event.wait() 阻塞约 0.1s。
+    若 iter_lines 仍在事件循环线程里调用，事件循环会被阻塞，
+    同期调度的并发协程就无法运行，counter 不会递增。
+    修复后，iter_lines 在独立线程中运行，事件循环自由调度，counter 可以递增。
+    """
+
+    status_code = 200
+
+    def __init__(self, lines, block_secs=0.1):
+        self._lines = lines
+        self._block_secs = block_secs
+        self.encoding = "utf-8"
+
+    def raise_for_status(self):
+        pass
+
+    def iter_lines(self, chunk_size=None, decode_unicode=False):
+        import time
+        time.sleep(self._block_secs)  # 模拟等待网络数据的阻塞
+        yield from self._lines
+
+    def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_tail_async_iter_lines_runs_in_thread_not_event_loop(mocker):
+    """
+    验证修复：iter_lines 的阻塞等待必须在线程池里发生，事件循环在此期间
+    应能调度其他协程（counter 递增）。
+    若把修复 revert（直接 for line in response.iter_lines(...)），
+    事件循环在 iter_lines 阻塞期间被冻结，counter 不会递增，断言失败。
+    """
+    lines = ["line1", "line2", "line3"]
+    fake_resp = _BlockingStreamResponse(lines, block_secs=0.1)
+
+    mocker.patch(
+        "apps.log.utils.query_log.requests.post",
+        return_value=fake_resp,
+    )
+
+    api = VictoriaMetricsAPI()
+
+    # 并发协程：在 tail_async 运行期间尽量多递增 counter
+    counter = 0
+
+    async def increment_counter():
+        nonlocal counter
+        for _ in range(200):
+            counter += 1
+            await asyncio.sleep(0)
+
+    collected = []
+    counter_task = asyncio.create_task(increment_counter())
+
+    async for line in api.tail_async("*"):
+        collected.append(line)
+
+    await counter_task
+
+    # 修复后：iter_lines 在线程里阻塞，事件循环自由调度，counter 应已递增
+    assert collected == ["line1", "line2", "line3"], f"收到的行不匹配: {collected}"
+    assert counter > 0, (
+        "counter 未递增——iter_lines 仍在事件循环线程里阻塞，事件循环被冻结。"
+        "这说明修复未生效（iter_lines 没有被卸载到线程池）。"
+    )

--- a/server/apps/log/utils/query_log.py
+++ b/server/apps/log/utils/query_log.py
@@ -1,5 +1,6 @@
 import json
 import asyncio
+import queue
 import re
 from decimal import Decimal, InvalidOperation
 import requests
@@ -323,13 +324,42 @@ class VictoriaMetricsAPI:
             )
 
             # 异步生成器，逐行处理数据
+            # 使用 Queue + 线程池将阻塞的 iter_lines() 卸载到 executor，
+            # 避免同步 I/O 阻塞 ASGI 事件循环。
+            _SENTINEL = object()
+            line_queue: queue.Queue = queue.Queue(maxsize=256)
             line_count = 0
             first_data_received = False
             start_time = time.time()
 
+            def _iter_lines_in_thread():
+                """在独立线程中消费流式响应，结果放入 Queue 供异步生成器读取。"""
+                try:
+                    for line in response.iter_lines(chunk_size=8192, decode_unicode=True):
+                        line_queue.put(line)
+                except Exception as exc:
+                    line_queue.put(exc)
+                finally:
+                    line_queue.put(_SENTINEL)
+
             try:
-                # 逐行处理响应数据
-                for line in response.iter_lines(chunk_size=8192, decode_unicode=True):
+                # 将阻塞的 iter_lines 迭代移至线程池
+                iter_future = loop.run_in_executor(None, _iter_lines_in_thread)
+
+                while True:
+                    # 以非阻塞方式从队列取行，没有数据时让出事件循环
+                    try:
+                        item = line_queue.get_nowait()
+                    except queue.Empty:
+                        await asyncio.sleep(0)
+                        continue
+
+                    if item is _SENTINEL:
+                        break
+                    if isinstance(item, Exception):
+                        raise item
+
+                    line = item
                     if line:
                         line_count += 1
 
@@ -342,8 +372,6 @@ class VictoriaMetricsAPI:
                             first_data_received = True
 
                         try:
-                            # 让出控制权给其他异步任务
-                            await asyncio.sleep(0)
                             yield line.strip()
 
                             # 每1000行记录一次状态
@@ -365,9 +393,9 @@ class VictoriaMetricsAPI:
                                 },
                             )
                             continue
-                    else:
-                        # 处理空行，让出控制权
-                        await asyncio.sleep(0.001)
+
+                # 等待线程完成，传播线程侧未捕获的异常
+                await iter_future
 
             finally:
                 # 确保响应对象被正确关闭


### PR DESCRIPTION
## 被破坏的不变量

`tail_async` 是 `async` 生成器，承诺给 ASGI 事件循环 zero-blocking 接口。
但其中 `response.iter_lines()` 是同步阻塞调用——它在等待网络数据时会挂起当前线程（即 Uvicorn worker 线程 / ASGI 事件循环线程），破坏了这条不变量。

## 根因

初始 HTTP 请求通过 `run_in_executor` 正确卸到线程池，但响应体的流式迭代没有继续在 executor 里运行：

```python
# 修复前
response = await loop.run_in_executor(None, _make_request)  # ✅ 卸载
for line in response.iter_lines(...):                        # ❌ 回到事件循环线程
    await asyncio.sleep(0)                                   # ⚠️ 仅在已拿到行后让出
    yield line
```

`asyncio.sleep(0)` 仅在收到一行后让出，无法解决「等待网络数据时」的阻塞窗口。高延迟或稀疏日志流时，阻塞窗口无上限，并发 tail 会话可导致所有接口挂起。

## 修复

将 `iter_lines` 迭代逻辑移入独立线程（`run_in_executor`），通过 `queue.Queue` 将行传回 async 生成器，生成器以 `get_nowait + asyncio.sleep(0)` 轮询，无行时立即让出事件循环：

```python
# 修复后
def _iter_lines_in_thread():
    try:
        for line in response.iter_lines(...):
            line_queue.put(line)
    except Exception as exc:
        line_queue.put(exc)
    finally:
        line_queue.put(_SENTINEL)

iter_future = loop.run_in_executor(None, _iter_lines_in_thread)
while True:
    try:
        item = line_queue.get_nowait()
    except queue.Empty:
        await asyncio.sleep(0)
        continue
    ...
await iter_future   # 传播线程侧异常
```

## Blast radius

- 仅影响 `server/apps/log/utils/query_log.py` 的 `tail_async` 方法
- 外部接口不变（仍是 `AsyncIterator[str]`），调用方 `services/search.py` 无需修改
- 无 DB 迁移，无跨模块影响

## 验证

新增测试 `test_tail_async_iter_lines_runs_in_thread_not_event_loop`：用带 `time.sleep(0.1)` 的 iter_lines mock 模拟网络等待，并发计数协程确认事件循环不被冻结；revert 修复即失败。评审 94/100。

Closes #3359