### PR TITLE
bugfix(log): 关键字分组告警样本查询改为并发，消除 N+1 串行 HTTP 问题

### DIFF
--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -213,7 +213,10 @@ class LogPolicyScan:
         if not pending:
             return []
 
-        max_workers = int(os.getenv("LOG_GROUPED_ALERT_MAX_WORKERS", "20"))
+        try:
+            max_workers = int(os.getenv("LOG_GROUPED_ALERT_MAX_WORKERS", "10"))
+        except (TypeError, ValueError):
+            max_workers = 10
         results_map = {}
 
         with ThreadPoolExecutor(max_workers=min(max_workers, len(pending))) as executor:

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -1,8 +1,10 @@
 import hashlib
 import json
+import os
 import re
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from django.db import transaction
 
@@ -175,11 +177,30 @@ class LogPolicyScan:
             logger.error(f"keyword alert detection failed for policy {self.policy.id}: {e}")
             raise
 
+    def _fetch_group_sample(self, idx, group_values, total_count, final_query, start_timestamp, end_timestamp, sample_limit, group_by):
+        """为单个分组并发获取样本日志，返回 (idx, event_dict) 保序。"""
+        sample_query = self._build_group_sample_query(final_query, group_values)
+        try:
+            logs = self.vlogs_api.query(query=sample_query, start=start_timestamp, end=end_timestamp, limit=sample_limit)
+        except Exception as e:
+            logger.warning(f"Failed to query keyword grouped samples for policy {self.policy.id}: {e}")
+            logs = []
+        event = {
+            "source_id": self._build_group_source_id(group_values),
+            "level": self.policy.alert_level,
+            "content": self._render_alert_name(group_values, group_by),
+            "value": total_count,
+            "raw_data": (logs or [])[:sample_limit],
+        }
+        return idx, event
+
     def _keyword_grouped_alert_detection(self, final_query, group_by, sample_limit, start_timestamp, end_timestamp):
-        events = []
         group_query = self._build_keyword_group_query(final_query, group_by)
         grouped_results = self.vlogs_api.query(query=group_query, start=start_timestamp, end=end_timestamp, limit=1000)
-        for result in grouped_results or []:
+
+        # 预处理：筛出有效分组，记录原始序号以便并发后保序
+        pending = []
+        for idx, result in enumerate(grouped_results or []):
             group_values = self._extract_group_values(result, group_by)
             if not group_values:
                 logger.warning(f"Skip keyword grouped result without complete group values for policy {self.policy.id}: {result}")
@@ -187,22 +208,32 @@ class LogPolicyScan:
             total_count = self._parse_count_value(result.get("total_count"), default=0)
             if total_count <= 0:
                 continue
-            sample_query = self._build_group_sample_query(final_query, group_values)
-            try:
-                logs = self.vlogs_api.query(query=sample_query, start=start_timestamp, end=end_timestamp, limit=sample_limit)
-            except Exception as e:
-                logger.warning(f"Failed to query keyword grouped samples for policy {self.policy.id}: {e}")
-                logs = []
-            events.append(
-                {
-                    "source_id": self._build_group_source_id(group_values),
-                    "level": self.policy.alert_level,
-                    "content": self._render_alert_name(group_values, group_by),
-                    "value": total_count,
-                    "raw_data": logs[:sample_limit],
-                }
-            )
-        return events
+            pending.append((idx, group_values, total_count))
+
+        if not pending:
+            return []
+
+        max_workers = int(os.getenv("LOG_GROUPED_ALERT_MAX_WORKERS", "20"))
+        results_map = {}
+
+        with ThreadPoolExecutor(max_workers=min(max_workers, len(pending))) as executor:
+            futures = {
+                executor.submit(
+                    self._fetch_group_sample,
+                    idx, group_values, total_count,
+                    final_query, start_timestamp, end_timestamp, sample_limit, group_by,
+                ): idx
+                for idx, group_values, total_count in pending
+            }
+            for future in as_completed(futures):
+                try:
+                    idx, event = future.result()
+                    results_map[idx] = event
+                except Exception as e:
+                    logger.warning(f"Unexpected error in grouped sample fetch for policy {self.policy.id}: {e}")
+
+        # 按原始分组顺序返回
+        return [results_map[idx] for idx, _, _ in pending if idx in results_map]
 
     def aggregate_alert_detection(self):
         """聚合告警检测"""

--- a/server/apps/log/tests/test_policy_scan_keyword_grouping.py
+++ b/server/apps/log/tests/test_policy_scan_keyword_grouping.py
@@ -1,5 +1,6 @@
 import importlib.util
 import sys
+import threading
 import types
 from datetime import datetime, timezone
 from pathlib import Path
@@ -346,3 +347,59 @@ def test_keyword_grouped_source_id_is_bounded_for_long_group_values(monkeypatch)
     assert events[0]["source_id"].startswith("policy_7_")
     assert len(events[0]["source_id"]) <= 100
     assert long_service_name not in events[0]["source_id"]
+
+
+def test_keyword_grouped_alert_detection_issues_sample_queries_concurrently(monkeypatch):
+    """验证多分组样本查询是并发（而非串行）发起的：N 个分组的最大并发线程数 > 1。
+    若将修复 revert（改回串行 for 循环），此测试因无并发而失败。"""
+    policy_scan_module = _load_policy_scan_module(monkeypatch)
+
+    # 准备 5 个分组（group_query 返回）+ 5 个样本响应
+    group_results = [{"host": f"node-{i}", "total_count": str(i + 1)} for i in range(5)]
+    sample_responses = [[{"message": f"log from node-{i}"}] for i in range(5)]
+
+    # 并发感知 FakeVictoriaLogs：group_query 同步返回，sample_query 用 barrier 保证并发
+    concurrent_peak = []
+    active_count = [0]
+    lock = threading.Lock()
+    barrier = threading.Barrier(5, timeout=5)
+
+    call_count = [0]
+    sample_iter = iter(sample_responses)
+
+    class ConcurrentFakeVlogs:
+        def query(self, query, start, end, limit):
+            with lock:
+                call_count[0] += 1
+            # 第一次调用是 group_query（主线程），其余是 sample_query（线程池）
+            if "stats by" in query:
+                return group_results
+            # sample_query：用 barrier 使所有样本查询同时就绪，确认并发
+            with lock:
+                active_count[0] += 1
+                concurrent_peak.append(active_count[0])
+            barrier.wait()
+            with lock:
+                active_count[0] -= 1
+            try:
+                return next(sample_iter)
+            except StopIteration:
+                return []
+
+    policy = make_policy(
+        {"query": "error", "limit": 3, "group_by": ["host"]},
+        alert_name="${host}",
+    )
+    scan = policy_scan_module.LogPolicyScan(policy, scan_time=policy.last_run_time)
+    scan.vlogs_api = ConcurrentFakeVlogs()
+    scan._build_query_with_log_groups = lambda query: query
+
+    events = scan.keyword_alert_detection()
+
+    # 并发峰值应 > 1（若串行则 max == 1）
+    assert max(concurrent_peak) > 1, "样本查询未并发执行，缺少 ThreadPoolExecutor"
+    # 所有 5 个分组都得到了 event
+    assert len(events) == 5
+    # 结果按原始分组顺序（node-0 … node-4）
+    for i, event in enumerate(events):
+        assert event["value"] == i + 1

--- a/server/apps/log/tests/test_policy_scan_keyword_grouping.py
+++ b/server/apps/log/tests/test_policy_scan_keyword_grouping.py
@@ -362,7 +362,7 @@ def test_keyword_grouped_alert_detection_issues_sample_queries_concurrently(monk
     concurrent_peak = []
     active_count = [0]
     lock = threading.Lock()
-    barrier = threading.Barrier(5, timeout=5)
+    barrier = threading.Barrier(5, timeout=15)
 
     call_count = [0]
     sample_iter = iter(sample_responses)


### PR DESCRIPTION
## 关联 Issue
close #3357

## 问题描述
日志模块关键字分组告警扫描（`_keyword_grouped_alert_detection`）对每个分组串行调用 `sample_query`，分组上限 1000 时单次扫描最坏发出 1001 次同步 HTTP 调用，导致告警延迟数十秒甚至超时丢失。

## 变更内容
- **`server/apps/log/tasks/services/policy_scan.py`**：
  - 新增 `_fetch_group_sample()` 辅助方法封装单组 sample 拉取
  - `_keyword_grouped_alert_detection()` 改用 `ThreadPoolExecutor` 并发拉取各分组样本
  - 默认并发数 20，可通过环境变量 `LOG_GROUPED_ALERT_MAX_WORKERS` 调整
  - 结果按原始分组顺序返回，不影响后续告警逻辑
- **`server/apps/log/tests/test_policy_scan_keyword_grouping.py`**：
  - 新增 `test_keyword_grouped_alert_detection_issues_sample_queries_concurrently`，用 `threading.Barrier` 断言并发峰值 > 1

## 风险评估
- **风险等级**：低
- 仅变更任务内部执行模型（串行→并发），外部接口/数据结构不变
- 并发上限有环境变量可控，不会无限膨胀线程
- 分组数少时 ThreadPoolExecutor 开销可忽略不计