### PR TITLE
bugfix(log): PolicyViewSet 列表接口引入请求级缓存 + DB 层权限过滤，消除双倍全量加载

### DIFF
--- a/server/apps/log/tests/test_policy_queryset_cache.py
+++ b/server/apps/log/tests/test_policy_queryset_cache.py
@@ -292,16 +292,28 @@ class TestPolicyQuerysetCache(unittest.TestCase):
 
     def test_db_filter_applied_before_python_loop_for_specific_collect_type(self):
         """
-        When collect_type_id='10' is provided, the ORM chain must call .filter(collect_type_id='10')
+        When collect_type_id='10' is provided, the ORM chain must call .filter(Q(collect_type_id='10') | Q(collect_type_id__isnull=True))
         on base_qs (result of prefetch_related) BEFORE the Python for-loop so fewer rows are loaded.
+        原逻辑：指定 collect_type_id 时同时保留全局策略（collect_type_id IS NULL），语义不变。
         """
+        import django.db.models as djm
+
         vs = self._new_viewset()
         req = _fake_request()
         _, base_qs, _ = _patch_db(self.mod, self.policies[:1])
 
         vs._get_accessible_policy_queryset(req, collect_type_id="10")
 
-        base_qs.filter.assert_called_once_with(collect_type_id="10")
+        base_qs.filter.assert_called_once()
+        call_args = base_qs.filter.call_args
+        self.assertEqual(len(call_args.args), 1, "filter() should be called with a single Q object")
+        q_arg = call_args.args[0]
+        self.assertIsInstance(q_arg, djm.Q, "filter() argument must be a Q object")
+        # Q(collect_type_id='10') | Q(collect_type_id__isnull=True)
+        self.assertEqual(q_arg.connector, "OR")
+        children = q_arg.children
+        self.assertIn(("collect_type_id", "10"), children)
+        self.assertIn(("collect_type_id__isnull", True), children)
 
     def test_db_filter_applied_for_global(self):
         """When collect_type_id='global', filter(collect_type_id__isnull=True) must be applied on base_qs."""

--- a/server/apps/log/tests/test_policy_queryset_cache.py
+++ b/server/apps/log/tests/test_policy_queryset_cache.py
@@ -1,0 +1,328 @@
+"""
+测试 PolicyViewSet._get_accessible_policy_queryset 的请求级缓存行为。
+
+验证目标（Issue #3358）：
+  - 同一 request 内多次调用同一 collect_type_id 时，只执行一次全量 DB 扫描（RPC 调用）。
+  - 同一 request 内以不同 collect_type_id 调用时，各自独立缓存，互不污染。
+  - 不同 request 之间缓存相互隔离。
+  - collect_type_id 指定时，DB 层 filter 在 Python 遍历前已生效。
+
+测试策略：用 unittest.mock 注入伪依赖，用 SimpleNamespace 模拟 request（支持 setattr），
+Django-free，可直接用 uv run python 跑。
+"""
+import sys
+import types
+import importlib.util
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, call
+
+
+# ---------------------------------------------------------------------------
+# 最小伪依赖注入
+# ---------------------------------------------------------------------------
+
+def _make_fake_module(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+# Global mocks — reset per test
+_get_permissions_rules_mock = MagicMock()
+_check_instance_permission_mock = MagicMock()
+_filter_instances_with_permissions_mock = MagicMock()
+
+
+def _inject_stubs():
+    # django_celery_beat
+    sys.modules["django_celery_beat"] = _make_fake_module("django_celery_beat")
+    sys.modules["django_celery_beat.models"] = _make_fake_module(
+        "django_celery_beat.models", PeriodicTask=MagicMock(), CrontabSchedule=MagicMock()
+    )
+
+    # rest_framework
+    sys.modules["rest_framework"] = _make_fake_module("rest_framework")
+    sys.modules["rest_framework.viewsets"] = _make_fake_module(
+        "rest_framework.viewsets", ModelViewSet=object, ReadOnlyModelViewSet=object
+    )
+    sys.modules["rest_framework.decorators"] = _make_fake_module(
+        "rest_framework.decorators", action=lambda **kw: (lambda f: f)
+    )
+
+    # django.db.models (available without settings)
+    import django.db.models as _djm
+    sys.modules.setdefault("django.db.models", _djm)
+
+    # apps.core
+    sys.modules["apps"] = _make_fake_module("apps")
+    sys.modules["apps.core"] = _make_fake_module("apps.core")
+    sys.modules["apps.core.exceptions"] = _make_fake_module("apps.core.exceptions")
+    sys.modules["apps.core.exceptions.base_app_exception"] = _make_fake_module(
+        "apps.core.exceptions.base_app_exception", BaseAppException=Exception
+    )
+
+    # apps.core.utils.permission_utils — key mock point
+    perm_mod = _make_fake_module(
+        "apps.core.utils.permission_utils",
+        get_permission_rules=MagicMock(return_value={}),
+        get_permissions_rules=_get_permissions_rules_mock,
+        permission_filter=MagicMock(),
+        check_instance_permission=_check_instance_permission_mock,
+        filter_instances_with_permissions=_filter_instances_with_permissions_mock,
+        get_instance_permissions=MagicMock(return_value=[]),
+    )
+    sys.modules["apps.core.utils"] = _make_fake_module("apps.core.utils")
+    sys.modules["apps.core.utils.permission_utils"] = perm_mod
+
+    sys.modules["apps.core.utils.web_utils"] = _make_fake_module(
+        "apps.core.utils.web_utils", WebUtils=MagicMock()
+    )
+
+    # apps.log.*
+    sys.modules["apps.log"] = _make_fake_module("apps.log")
+    sys.modules["apps.log.constants"] = _make_fake_module("apps.log.constants")
+    sys.modules["apps.log.constants.permission"] = _make_fake_module(
+        "apps.log.constants.permission",
+        PermissionConstants=SimpleNamespace(POLICY_MODULE="policy", DEFAULT_PERMISSION="Read"),
+    )
+    sys.modules["apps.log.constants.alert_policy"] = _make_fake_module(
+        "apps.log.constants.alert_policy", AlertConstants=MagicMock()
+    )
+    sys.modules["apps.log.filters"] = _make_fake_module("apps.log.filters")
+    sys.modules["apps.log.filters.policy"] = _make_fake_module(
+        "apps.log.filters.policy",
+        PolicyFilter=MagicMock(),
+        AlertFilter=MagicMock(),
+        EventFilter=MagicMock(),
+        EventRawDataFilter=MagicMock(),
+    )
+    sys.modules["apps.log.models"] = _make_fake_module("apps.log.models")
+    sys.modules["apps.log.models.policy"] = _make_fake_module(
+        "apps.log.models.policy",
+        Policy=MagicMock(),
+        PolicyOrganization=MagicMock(),
+        Alert=MagicMock(),
+        Event=MagicMock(),
+        EventRawData=MagicMock(),
+    )
+    sys.modules["apps.log.serializers"] = _make_fake_module("apps.log.serializers")
+    sys.modules["apps.log.serializers.policy"] = _make_fake_module(
+        "apps.log.serializers.policy",
+        PolicySerializer=MagicMock(),
+        AlertSerializer=MagicMock(),
+        EventSerializer=MagicMock(),
+        EventRawDataSerializer=MagicMock(),
+    )
+    sys.modules["config"] = _make_fake_module("config")
+    sys.modules["config.drf"] = _make_fake_module("config.drf")
+    sys.modules["config.drf.pagination"] = _make_fake_module(
+        "config.drf.pagination", CustomPageNumberPagination=MagicMock()
+    )
+
+
+import os as _os
+
+_POLICY_PATH = _os.path.join(
+    _os.path.dirname(__file__), "..", "views", "policy.py"
+)
+
+
+def _load_policy_module():
+    # Always reload so that module-level symbols pick up the latest sys.modules stubs
+    spec = importlib.util.spec_from_file_location("apps.log.views.policy", _POLICY_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_request():
+    """Use SimpleNamespace so setattr/getattr work correctly (unlike MagicMock)."""
+    req = SimpleNamespace()
+    req.COOKIES = {"current_team": "1", "include_children": "0"}
+    req.user = MagicMock()
+    return req
+
+
+def _make_policy_obj(policy_id, collect_type_id=None, org_ids=None):
+    obj = MagicMock()
+    obj.id = policy_id
+    obj.collect_type_id = collect_type_id
+    org_rels = []
+    for oid in (org_ids or [1]):
+        rel = MagicMock()
+        rel.organization = oid
+        org_rels.append(rel)
+    obj.policyorganization_set.all.return_value = org_rels
+    return obj
+
+
+def _patch_db(mod, policies):
+    """Patch Policy.objects so that the QuerySet iteration returns `policies`.
+
+    ORM chain: Policy.objects.select_related(...) -> chain
+               chain.prefetch_related(...)        -> base_qs
+               base_qs.filter(...)                -> filtered_qs  (when collect_type_id given)
+
+    For assertions:
+      - DB-filter tests assert on base_qs.filter (the object the code actually calls filter on).
+      - No-filter tests assert base_qs.filter.assert_not_called().
+    """
+    # base_qs: returned by chain.prefetch_related(); iterable for no-filter path
+    base_qs = MagicMock()
+    base_qs.__iter__ = MagicMock(return_value=iter(policies))
+
+    # filtered_qs: returned by base_qs.filter(); iterable for filtered path
+    filtered_qs = MagicMock()
+    filtered_qs.__iter__ = MagicMock(return_value=iter(policies))
+    base_qs.filter.return_value = filtered_qs
+
+    chain = MagicMock()
+    chain.prefetch_related.return_value = base_qs
+
+    mod.Policy.objects.select_related.return_value = chain
+    mod.Policy.objects.filter.return_value = MagicMock()
+    return chain, base_qs, filtered_qs
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPolicyQuerysetCache(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        _inject_stubs()
+        cls.mod = _load_policy_module()
+        cls.PolicyViewSet = cls.mod.PolicyViewSet
+
+    def setUp(self):
+        # Reset mocks between tests
+        _get_permissions_rules_mock.reset_mock()
+        _get_permissions_rules_mock.return_value = {
+            "data": {"all": {"team": [1]}},
+            "team": [1],
+        }
+        _check_instance_permission_mock.reset_mock()
+        _check_instance_permission_mock.return_value = True
+        _filter_instances_with_permissions_mock.reset_mock()
+        _filter_instances_with_permissions_mock.return_value = {}
+
+        self.mod.Policy.objects.reset_mock()
+
+        self.policies = [
+            _make_policy_obj(1, collect_type_id=10, org_ids=[1]),
+            _make_policy_obj(2, collect_type_id=20, org_ids=[2]),
+        ]
+
+    def _new_viewset(self):
+        return object.__new__(self.PolicyViewSet)
+
+    def test_same_collect_type_id_cached_on_second_call(self):
+        """
+        Second call with same collect_type_id (None) should NOT invoke get_permissions_rules again.
+        If this test fails after reverting the cache code, it means the test is correctly guarding.
+        """
+        vs = self._new_viewset()
+        req = _fake_request()
+        _patch_db(self.mod, self.policies[:1])
+
+        vs._get_accessible_policy_queryset(req, collect_type_id=None)
+        count_after_first = _get_permissions_rules_mock.call_count  # should be 1
+
+        vs._get_accessible_policy_queryset(req, collect_type_id=None)
+        count_after_second = _get_permissions_rules_mock.call_count  # should still be 1
+
+        self.assertEqual(count_after_first, 1, "First call should invoke get_permissions_rules once")
+        self.assertEqual(
+            count_after_second,
+            count_after_first,
+            "Cached second call must NOT invoke get_permissions_rules again",
+        )
+
+    def test_different_collect_type_ids_have_separate_caches(self):
+        """
+        Calls with different collect_type_ids each trigger their own DB scan,
+        but subsequent calls with the same id are served from cache.
+        """
+        vs = self._new_viewset()
+        req = _fake_request()
+        _patch_db(self.mod, self.policies[:1])
+
+        # First call: collect_type_id=None
+        vs._get_accessible_policy_queryset(req, collect_type_id=None)
+        count_1 = _get_permissions_rules_mock.call_count
+
+        # Second call: different key — must trigger new scan
+        vs._get_accessible_policy_queryset(req, collect_type_id="10")
+        count_2 = _get_permissions_rules_mock.call_count
+
+        self.assertEqual(count_2, count_1 + 1, "New collect_type_id should trigger a fresh scan")
+
+        # Third call: same key as second — must be cached
+        vs._get_accessible_policy_queryset(req, collect_type_id="10")
+        count_3 = _get_permissions_rules_mock.call_count
+
+        self.assertEqual(count_3, count_2, "Repeat key should be served from cache")
+
+    def test_different_requests_have_isolated_caches(self):
+        """Cache must not leak between separate request objects."""
+        vs = self._new_viewset()
+        req_a = _fake_request()
+        req_b = _fake_request()
+        _patch_db(self.mod, self.policies[:1])
+
+        vs._get_accessible_policy_queryset(req_a, collect_type_id=None)
+        count_after_a = _get_permissions_rules_mock.call_count
+
+        vs._get_accessible_policy_queryset(req_b, collect_type_id=None)
+        count_after_b = _get_permissions_rules_mock.call_count
+
+        self.assertEqual(
+            count_after_b,
+            count_after_a + 1,
+            "Second request must trigger a fresh scan (no cross-request cache leakage)",
+        )
+
+    def test_db_filter_applied_before_python_loop_for_specific_collect_type(self):
+        """
+        When collect_type_id='10' is provided, the ORM chain must call .filter(collect_type_id='10')
+        on base_qs (result of prefetch_related) BEFORE the Python for-loop so fewer rows are loaded.
+        """
+        vs = self._new_viewset()
+        req = _fake_request()
+        _, base_qs, _ = _patch_db(self.mod, self.policies[:1])
+
+        vs._get_accessible_policy_queryset(req, collect_type_id="10")
+
+        base_qs.filter.assert_called_once_with(collect_type_id="10")
+
+    def test_db_filter_applied_for_global(self):
+        """When collect_type_id='global', filter(collect_type_id__isnull=True) must be applied on base_qs."""
+        vs = self._new_viewset()
+        req = _fake_request()
+        _, base_qs, _ = _patch_db(self.mod, self.policies[:1])
+
+        vs._get_accessible_policy_queryset(req, collect_type_id="global")
+
+        base_qs.filter.assert_called_once_with(collect_type_id__isnull=True)
+
+    def test_no_db_filter_when_no_collect_type_id(self):
+        """When collect_type_id is None, no DB filter is applied (all policies loaded)."""
+        vs = self._new_viewset()
+        req = _fake_request()
+        _, base_qs, _ = _patch_db(self.mod, self.policies[:1])
+
+        vs._get_accessible_policy_queryset(req, collect_type_id=None)
+
+        base_qs.filter.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/server/apps/log/views/policy.py
+++ b/server/apps/log/views/policy.py
@@ -237,7 +237,10 @@ class PolicyViewSet(viewsets.ModelViewSet):
         if only_global:
             base_qs = base_qs.filter(collect_type_id__isnull=True)
         elif normalized_collect_type_id is not None:
-            base_qs = base_qs.filter(collect_type_id=normalized_collect_type_id)
+            # 原逻辑：指定 collect_type_id 时同时保留 collect_type_id 为 NULL 的全局策略
+            base_qs = base_qs.filter(
+                models.Q(collect_type_id=normalized_collect_type_id) | models.Q(collect_type_id__isnull=True)
+            )
 
         accessible_instances = []
         accessible_policy_ids = []

--- a/server/apps/log/views/policy.py
+++ b/server/apps/log/views/policy.py
@@ -205,6 +205,18 @@ class PolicyViewSet(viewsets.ModelViewSet):
         return queryset.select_related("collect_type").distinct()
 
     def _get_accessible_policy_queryset(self, request, collect_type_id=None):
+        cache_key = "_policy_accessible_queryset_cache"
+        cache = getattr(request, cache_key, None)
+        if cache is None:
+            cache = {}
+            setattr(request, cache_key, cache)
+
+        normalized_collect_type_id = None if collect_type_id in (None, "", "all") else str(collect_type_id)
+        cache_field = normalized_collect_type_id if normalized_collect_type_id is not None else "__none__"
+        if cache_field in cache:
+            cached_ids, cached_map = cache[cache_field]
+            return Policy.objects.filter(id__in=cached_ids), cached_map
+
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permissions_result = get_permissions_rules(
             request.user,
@@ -218,25 +230,18 @@ class PolicyViewSet(viewsets.ModelViewSet):
 
         policy_permissions = permissions_result.get("data", {})
         current_teams = permissions_result.get("team", [])
-        target_collect_type_id = str(collect_type_id) if collect_type_id and collect_type_id != "global" else None
         only_global = collect_type_id == "global"
 
-        all_policies = Policy.objects.select_related("collect_type").prefetch_related("policyorganization_set").all()
+        # Apply DB-layer collect_type filtering before Python-loop to reduce rows loaded
+        base_qs = Policy.objects.select_related("collect_type").prefetch_related("policyorganization_set")
+        if only_global:
+            base_qs = base_qs.filter(collect_type_id__isnull=True)
+        elif normalized_collect_type_id is not None:
+            base_qs = base_qs.filter(collect_type_id=normalized_collect_type_id)
 
         accessible_instances = []
         accessible_policy_ids = []
-        for policy_obj in all_policies:
-            policy_collect_type_id = str(policy_obj.collect_type_id) if policy_obj.collect_type_id is not None else None
-
-            if only_global and policy_collect_type_id is not None:
-                continue
-
-            if target_collect_type_id and policy_collect_type_id not in [
-                target_collect_type_id,
-                None,
-            ]:
-                continue
-
+        for policy_obj in base_qs:
             teams = {org.organization for org in policy_obj.policyorganization_set.all()}
             has_permission = check_instance_permission(
                 policy_obj.collect_type_id,
@@ -258,6 +263,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
             )
 
         permission_map = filter_instances_with_permissions(accessible_instances, policy_permissions, current_teams)
+        cache[cache_field] = (accessible_policy_ids, permission_map)
         queryset = Policy.objects.filter(id__in=accessible_policy_ids)
         return queryset, permission_map
 


### PR DESCRIPTION
## 关联 Issue
close #3358

## 问题描述
`PolicyViewSet._get_accessible_policy_queryset` 在同一个 List 请求中被调用两次：
一次生成 queryset、一次计算权限映射。每次调用都会执行 `Policy.objects.select_related(...).prefetch_related(...).all()`，将全表 Policy 加载到 Python 内存后逐条过滤。策略表增长后：
- 内存：每次请求将全表带入 Python 进程
- 时间：双倍全量扫描，响应时间线性劣化
- 扩展性：无 DB 层预过滤，collect_type_id 过滤完全在 Python 侧

## 变更内容

### `server/apps/log/views/policy.py`
- **请求级缓存**：`_get_accessible_policy_queryset` 首次调用结果挂载在 `request._policy_accessible_queryset_cache[key]`，同一请求内相同 `collect_type_id` 直接返回缓存，无需重复 RPC+扫表
- **DB 层预过滤**：`collect_type_id` 过滤从 Python `for` 循环内的 `continue` 判断，前移至 ORM `.filter()` 调用，减少 `prefetch_related` 拉取的行数

### `server/apps/log/tests/test_policy_queryset_cache.py`（新增）
6 条 Django-free 单元测试（`unittest.mock` + `SimpleNamespace`，无需 Django 环境）：
- `test_same_collect_type_id_cached_on_second_call`：同 key 第二次调用命中缓存，`get_permissions_rules` 只调一次
- `test_different_collect_type_ids_have_separate_caches`：不同 key 各自独立触发扫描，重复 key 命中缓存
- `test_different_requests_have_isolated_caches`：不同 request 对象缓存互不污染
- `test_db_filter_applied_before_python_loop_for_specific_collect_type`：指定 collect_type_id 时 DB filter 生效
- `test_db_filter_applied_for_global`：`collect_type_id='global'` 时 filter `__isnull=True` 生效
- `test_no_db_filter_when_no_collect_type_id`：未指定时不加 DB filter

## 风险评估
- **风险等级**：低
- 缓存仅在单次请求生命周期内，随 request 对象消亡，无跨请求数据泄露
- `collect_type_id` 过滤逻辑语义不变，仅执行层从 Python 移到 DB
- 不影响 API 返回结构