### PR TITLE
fix(log): wrap create_events DB writes in transaction.atomic() to prevent orphaned records

### DIFF
--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -691,42 +691,49 @@ class LogPolicyScan:
                     )
                 )
 
-            # 3. 批量执行数据库操作
-            # 批量创建新告警
-            if alerts_to_create:
-                Alert.objects.bulk_create(alerts_to_create, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
-                logger.debug(f"Created {len(alerts_to_create)} new alerts for policy {self.policy.id}")
+            # 3. 批量执行数据库操作（外层事务保证 Alert/Event/EventRawData 原子性）
+            # 任一步失败（包括 EventRawData.save() 触发的 S3 上传异常）均回滚全部 DB 写入，
+            # 避免"告警有、数据无"的孤儿记录。
+            # 注意：S3JSONField.pre_save() 在 DB 写入前上传至 MinIO；若 MinIO 失败则抛异常
+            # → 事务回滚，DB 保持一致。快照写入在事务外独立执行（各自已有 atomic 保护）。
+            with transaction.atomic():
+                # 批量创建新告警
+                if alerts_to_create:
+                    Alert.objects.bulk_create(alerts_to_create, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
+                    logger.debug(f"Created {len(alerts_to_create)} new alerts for policy {self.policy.id}")
 
-            # 批量更新现有告警
-            if alerts_to_update:
-                Alert.objects.bulk_update(
-                    alerts_to_update,
-                    ["value", "content", "level", "end_event_time", "notice"],
-                    batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
-                )
-                logger.debug(f"Updated {len(alerts_to_update)} existing alerts for policy {self.policy.id}")
+                # 批量更新现有告警
+                if alerts_to_update:
+                    Alert.objects.bulk_update(
+                        alerts_to_update,
+                        ["value", "content", "level", "end_event_time", "notice"],
+                        batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
+                    )
+                    logger.debug(f"Updated {len(alerts_to_update)} existing alerts for policy {self.policy.id}")
 
-            # 批量创建事件记录
-            event_objs = Event.objects.bulk_create(create_events, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
+                # 批量创建事件记录
+                event_objs = Event.objects.bulk_create(create_events, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
 
-            # 批量创建事件原始数据记录（关联到已创建的事件对象）
-            if event_id_to_raw_data:
-                create_raw_data = []
-                for event_obj in event_objs:
-                    if event_obj.id in event_id_to_raw_data:
-                        create_raw_data.append(
-                            EventRawData(
-                                event=event_obj,  # 使用 event 字段，而不是 event_id
-                                data=event_id_to_raw_data[event_obj.id],
+                # 批量创建事件原始数据记录（关联到已创建的事件对象）
+                if event_id_to_raw_data:
+                    create_raw_data = []
+                    for event_obj in event_objs:
+                        if event_obj.id in event_id_to_raw_data:
+                            create_raw_data.append(
+                                EventRawData(
+                                    event=event_obj,  # 使用 event 字段，而不是 event_id
+                                    data=event_id_to_raw_data[event_obj.id],
+                                )
                             )
-                        )
 
-                # 逐个保存原始数据记录以确保 S3JSONField 能正确上传数据
-                for raw_data_obj in create_raw_data:
-                    raw_data_obj.save()
-                logger.debug(f"Created {len(create_raw_data)} raw data records for policy {self.policy.id}")
+                    # 逐个保存原始数据记录以确保 S3JSONField 能正确上传数据
+                    for raw_data_obj in create_raw_data:
+                        raw_data_obj.save()
+                    logger.debug(f"Created {len(create_raw_data)} raw data records for policy {self.policy.id}")
 
             # 为告警创建或更新快照（传递原始数据映射）
+            # 快照写入在事务外执行：每条快照各自有 atomic 保护，且 S3JSONField 写 MinIO
+            # 不应阻塞主事务；快照失败不影响告警/事件已提交的数据。
             self._create_snapshots_for_alerts(event_objs, alerts_to_create, events, event_id_to_raw_data)
 
             logger.info(f"Created {len(event_objs)} events for policy {self.policy.id}")

--- a/server/apps/log/tests/test_create_events_atomic_3367.py
+++ b/server/apps/log/tests/test_create_events_atomic_3367.py
@@ -1,0 +1,281 @@
+"""
+Issue #3367: create_events 多步写无外层事务 → Alert/Event/EventRawData 部分失败数据不一致
+
+验证 create_events 的 Alert + Event + EventRawData 写操作被包裹在同一个 transaction.atomic() 中：
+- 若 EventRawData.save() 失败，前面已写入的 Alert / Event 应随事务回滚，不留孤儿记录。
+
+使用 Django-free 注入式测试（不依赖 ORM/settings），可通过独立 harness 运行：
+    uv run pytest server/apps/log/tests/test_create_events_atomic_3367.py -v
+"""
+import importlib.util
+import sys
+import types
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 覆盖 conftest.py 的 autouse 夹具（Django-free 测试无需 settings 注入）
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def use_dummy_cache_backend():
+    """No-op override: 本文件是 Django-free 注入式测试，不需要 settings 夹具。"""
+
+
+@pytest.fixture(autouse=True)
+def disable_auth_middleware():
+    """No-op override: 本文件是 Django-free 注入式测试，不需要 settings 夹具。"""
+
+
+# ---------------------------------------------------------------------------
+# 依赖注入工具
+# ---------------------------------------------------------------------------
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_policy_scan_module(monkeypatch, transaction_mock):
+    """加载 policy_scan.py，注入伪依赖（无 Django settings / ORM）。"""
+    _install_module(monkeypatch, "django", db=types.SimpleNamespace(transaction=transaction_mock))
+    _install_module(monkeypatch, "django.db", transaction=transaction_mock)
+
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(
+        monkeypatch,
+        "apps.log.constants.alert_policy",
+        AlertConstants=types.SimpleNamespace(STATUS_NEW="new", STATUS_CLOSED="closed"),
+    )
+    _install_module(
+        monkeypatch,
+        "apps.log.constants.database",
+        DatabaseConstants=types.SimpleNamespace(DEFAULT_BATCH_SIZE=100),
+    )
+    _install_module(monkeypatch, "apps.log.constants.web", WebConstants=types.SimpleNamespace())
+    _install_module(
+        monkeypatch,
+        "apps.log.models.policy",
+        Alert=object,
+        Event=object,
+        EventRawData=object,
+        AlertSnapshot=object,
+    )
+    _install_module(monkeypatch, "apps.log.tasks.utils.policy", period_to_seconds=lambda period: 300)
+    _install_module(monkeypatch, "apps.log.utils.query_log", VictoriaMetricsAPI=lambda: None)
+    _install_module(
+        monkeypatch,
+        "apps.log.utils.log_group",
+        LogGroupQueryBuilder=types.SimpleNamespace(build_query_with_groups=lambda query, groups: (query, [])),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.system_mgmt_api", SystemMgmtUtils=object)
+    _install_module(
+        monkeypatch,
+        "apps.core.logger",
+        celery_logger=types.SimpleNamespace(
+            warning=lambda *a, **kw: None,
+            error=lambda *a, **kw: None,
+            info=lambda *a, **kw: None,
+            debug=lambda *a, **kw: None,
+        ),
+    )
+
+    module_path = Path(__file__).resolve().parents[1] / "tasks" / "services" / "policy_scan.py"
+    spec = importlib.util.spec_from_file_location("policy_scan_atomic_3367_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# 辅助：构造最小 policy / scan 对象
+# ---------------------------------------------------------------------------
+
+def _make_scan(module, policy, transaction_mock):
+    scan = object.__new__(module.LogPolicyScan)
+    scan.policy = policy
+    scan.scan_time = datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+    # 让 _create_snapshots_for_alerts 空转，不影响本次验证焦点
+    scan._create_snapshots_for_alerts = lambda *a, **kw: None
+    return scan
+
+
+# ---------------------------------------------------------------------------
+# 测试 1：正常路径——所有写操作在同一个 atomic() 内执行
+# ---------------------------------------------------------------------------
+
+def test_create_events_db_writes_inside_atomic(monkeypatch):
+    """正常路径：Alert / Event / EventRawData 的 DB 写在 transaction.atomic() 上下文内。"""
+    # --- 记录 atomic 上下文进入/退出 ---
+    atomic_entered = []
+    atomic_exited = []
+
+    class FakeAtomic:
+        def __enter__(self):
+            atomic_entered.append(True)
+            return self
+
+        def __exit__(self, *args):
+            atomic_exited.append(True)
+            return False  # 不吞异常
+
+    transaction_mock = SimpleNamespace(atomic=lambda: FakeAtomic())
+
+    module = _load_policy_scan_module(monkeypatch, transaction_mock)
+
+    policy = SimpleNamespace(
+        id=42,
+        collect_type="keyword",
+        period={"type": "min", "value": 5},
+        last_run_time=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    scan = _make_scan(module, policy, transaction_mock)
+
+    # --- 伪造 ORM ---
+    fake_alert_id = uuid.uuid4().hex
+    fake_alert = SimpleNamespace(id=fake_alert_id, source_id="src1", created_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    alert_cls = MagicMock()
+    alert_cls.objects.filter.return_value = []  # 无已存在告警
+    alert_cls.objects.bulk_create.return_value = [fake_alert]
+
+    # bulk_create 返回传入的实际对象，确保 event_obj.id 与 event_id_to_raw_data 的 key 匹配
+    event_cls = MagicMock()
+    event_cls.objects.bulk_create.side_effect = lambda objs, **kwargs: list(objs)
+
+    raw_data_obj = MagicMock()
+
+    def fake_raw_data_cls(**kwargs):
+        return raw_data_obj
+
+    # 注入到模块命名空间
+    module.Alert = alert_cls
+    module.Event = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+    module.Event.objects = event_cls.objects
+    module.EventRawData = fake_raw_data_cls
+
+    events = [
+        {
+            "source_id": "src1",
+            "level": "error",
+            "content": "test error",
+            "raw_data": {"log": "line1"},
+        }
+    ]
+
+    scan.create_events(events)
+
+    # atomic() 应当被进入并退出（正常路径下退出时无异常）
+    assert atomic_entered, "transaction.atomic() 未被进入 — create_events 缺少外层事务"
+    assert atomic_exited, "transaction.atomic() 未正常退出"
+    # EventRawData.save() 应在 atomic 内调用
+    raw_data_obj.save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 测试 2：EventRawData.save() 失败 → atomic 上下文捕获异常并 re-raise
+#         （即异常会传播给 atomic.__exit__，事务回滚）
+# ---------------------------------------------------------------------------
+
+def test_create_events_raw_data_failure_propagates_through_atomic(monkeypatch):
+    """
+    EventRawData.save() 抛出异常时，异常应通过 atomic().__exit__ 传播出去
+    （Django 的 atomic 会在 __exit__ 收到异常时标记回滚）。
+    验证：异常确实从 create_events 向上抛出，且 atomic.__exit__ 收到了异常。
+    """
+    exit_exc_info = []
+
+    class FakeAtomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            exit_exc_info.append((exc_type, exc_val))
+            return False  # 不吞异常，确保它继续向上传播
+
+    transaction_mock = SimpleNamespace(atomic=lambda: FakeAtomic())
+    module = _load_policy_scan_module(monkeypatch, transaction_mock)
+
+    policy = SimpleNamespace(
+        id=99,
+        collect_type="keyword",
+        period={"type": "min", "value": 5},
+        last_run_time=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    scan = _make_scan(module, policy, transaction_mock)
+
+    alert_cls = MagicMock()
+    alert_cls.objects.filter.return_value = []
+    alert_cls.objects.bulk_create.return_value = []
+
+    # bulk_create 返回传入的实际对象，确保 event_obj.id 与 event_id_to_raw_data 的 key 匹配
+    event_cls = MagicMock()
+    event_cls.objects.bulk_create.side_effect = lambda objs, **kwargs: list(objs)
+
+    class FakeRawDataObj:
+        def save(self):
+            raise IOError("MinIO timeout simulated")
+
+    def fake_raw_data_cls(**kw):
+        return FakeRawDataObj()
+
+    module.Alert = alert_cls
+    module.Event = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+    module.Event.objects = event_cls.objects
+    module.EventRawData = fake_raw_data_cls
+
+    events = [
+        {
+            "source_id": "src_fail",
+            "level": "warning",
+            "content": "fail case",
+            "raw_data": {"log": "line_fail"},
+        }
+    ]
+
+    import pytest
+    with pytest.raises(IOError, match="MinIO timeout simulated"):
+        scan.create_events(events)
+
+    # atomic.__exit__ 必须收到异常——这是 Django 判断是否回滚的入口
+    assert exit_exc_info, "atomic().__exit__ 未收到异常 — 说明 DB 写入不在 atomic 上下文内，事务无法回滚"
+    exc_type, exc_val = exit_exc_info[0]
+    assert exc_type is IOError, f"期望 IOError，实际收到 {exc_type}"
+    assert "MinIO timeout" in str(exc_val)
+
+
+# ---------------------------------------------------------------------------
+# 测试 3：空 events → 直接返回 []，不进入 atomic
+# ---------------------------------------------------------------------------
+
+def test_create_events_empty_returns_empty_no_atomic(monkeypatch):
+    """空 events 列表应立即返回 []，无需进入事务。"""
+    atomic_called = []
+
+    class FakeAtomic:
+        def __enter__(self):
+            atomic_called.append(True)
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    transaction_mock = SimpleNamespace(atomic=lambda: FakeAtomic())
+    module = _load_policy_scan_module(monkeypatch, transaction_mock)
+
+    policy = SimpleNamespace(id=1, collect_type="kw", period={"type": "min", "value": 1},
+                             last_run_time=datetime(2026, 1, 1, tzinfo=timezone.utc))
+    scan = _make_scan(module, policy, transaction_mock)
+
+    result = scan.create_events([])
+    assert result == []
+    assert not atomic_called, "空 events 时不应进入 transaction.atomic()"


### PR DESCRIPTION
## 问题

`create_events` 依次执行 `Alert.bulk_create` → `Alert.bulk_update` → `Event.bulk_create` → `EventRawData.save()` 四步写操作，**没有外层事务保护**。

当 `EventRawData.save()` 触发 S3/MinIO 上传异常时，前面已落库的 Alert 和 Event 行不会回滚，产生**孤儿记录**（告警有、原始数据无），同时补偿任务也无法正确重投这些部分失败的事件。

## 修复

用 `transaction.atomic()` 包裹四步 DB 写入，任一步失败即整体回滚，消除孤儿记录风险。

快照写入维持在事务外（各快照已有独立 `atomic` 保护），快照失败不阻塞告警/事件数据的持久化。

## 变更文件

- `server/apps/log/tasks/services/policy_scan.py` — `create_events()` 加外层 `transaction.atomic()`
- `server/apps/log/tests/test_create_events_atomic_3367.py` — 3 条 Django-free 注入式测试（正常路径/S3 失败回滚/空事件）

## 测试

```
uv run pytest apps/log/tests/test_create_events_atomic_3367.py -v -p no:django --override-ini="addopts="
# 3 passed
```

Closes #3367