### PR TITLE
bugfix: [cmdb] create_model/duplicate_model 改用定点查询替代全量 MODEL 扫描

### DIFF
--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -511,7 +511,13 @@ class ModelManage(object):
         data.update(attrs=json.dumps(attrs), unique_rules="[]")
 
         with GraphClient() as ag:
-            exist_items, _ = ag.query_entity(MODEL, [])
+            # 仅查询与新模型存在唯一性冲突可能的节点（model_id 或 model_name 匹配），
+            # 避免全量加载所有 MODEL 节点做内存比对（O(N) → O(冲突候选数)）。
+            conflict_filter = [
+                {"field": "model_id", "type": "str=", "value": data.get("model_id", "")},
+                {"field": "model_name", "type": "str=", "value": data.get("model_name", "")},
+            ]
+            exist_items, _ = ag.query_entity(MODEL, conflict_filter, param_type="OR")
             result = ag.create_entity(MODEL, data, CREATE_MODEL_CHECK_ATTR, exist_items)
             classification_info = ClassificationManage.search_model_classification_info(data["classification_id"])
             _ = ag.create_edge(
@@ -671,7 +677,13 @@ class ModelManage(object):
 
         # 一次性创建模型（包含所有属性）
         with GraphClient() as ag:
-            exist_items, _ = ag.query_entity(MODEL, [])
+            # 仅查询与新模型存在唯一性冲突可能的节点（model_id 或 model_name 匹配），
+            # 避免全量加载所有 MODEL 节点做内存比对（O(N) → O(冲突候选数)）。
+            conflict_filter = [
+                {"field": "model_id", "type": "str=", "value": new_model_data.get("model_id", "")},
+                {"field": "model_name", "type": "str=", "value": new_model_data.get("model_name", "")},
+            ]
+            exist_items, _ = ag.query_entity(MODEL, conflict_filter, param_type="OR")
             new_model = ag.create_entity(MODEL, new_model_data, CREATE_MODEL_CHECK_ATTR, exist_items)
 
             # 创建模型与分类的关联

--- a/server/apps/cmdb/tests/test_model_service_graph_mock.py
+++ b/server/apps/cmdb/tests/test_model_service_graph_mock.py
@@ -163,3 +163,112 @@ def test_create_model_attr_duplicate(fake_graph):
     )
     with pytest.raises(BaseAppException):
         ModelManage.create_model_attr("host", {"attr_id": "ip", "attr_name": "IP", "attr_type": "str"})
+
+
+# --------------------------------------------------------------------------
+# create_model — 定点查询唯一性校验（issue #3379）
+# --------------------------------------------------------------------------
+
+
+def _patch_create_model_side_effects(monkeypatch):
+    """屏蔽 create_model 的图/DB 副作用（分类查询、字段分组、缓存、变更记录）。"""
+    import apps.cmdb.services.model as model_mod
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.classification.ClassificationManage.search_model_classification_info",
+        lambda classification_id: {"_id": 99},
+    )
+    monkeypatch.setattr("apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change", lambda model_id: None)
+    monkeypatch.setattr(model_mod, "create_change_record", lambda **kw: None)
+    monkeypatch.setattr(model_mod.FIELD_GROUP_MANAGER, "create", lambda **kw: None)
+
+
+@pytest.mark.django_db
+def test_create_model_uses_targeted_conflict_query(fake_graph, monkeypatch):
+    """create_model 必须用 model_id/model_name OR 条件查询，而非全量加载所有 MODEL 节点。
+
+    验证点：query_entity 调用的 params 参数不为空列表。
+    revert 修复后（params=[]）此断言失败，证明测试覆盖了修复点。
+    """
+    from apps.cmdb.services.model import ModelManage
+
+    _patch_create_model_side_effects(monkeypatch)
+
+    fake = fake_graph(
+        "apps.cmdb.services.model",
+        create_entity={"model_id": "new_model", "model_name": "新模型", "_id": 10},
+        create_edge={},
+    )
+
+    data = {
+        "model_id": "new_model",
+        "model_name": "新模型",
+        "classification_id": "infra",
+    }
+    ModelManage.create_model(data)
+
+    # 找出 query_entity 调用
+    qe_calls = [(args, kwargs) for name, args, kwargs in fake.calls if name == "query_entity"]
+    assert qe_calls, "query_entity 未被调用"
+
+    # 修复后第一个 query_entity 调用（唯一性校验）传入的 params 不应为空列表
+    first_params = qe_calls[0][0][1] if len(qe_calls[0][0]) > 1 else qe_calls[0][1].get("params", [])
+    assert first_params != [], (
+        "create_model 仍在用全量查询（params=[]）；应改为定点过滤 model_id/model_name"
+    )
+    # 确认过滤条件包含 model_id 和 model_name 字段
+    filtered_fields = {f["field"] for f in first_params}
+    assert "model_id" in filtered_fields, "唯一性查询必须包含 model_id 过滤条件"
+    assert "model_name" in filtered_fields, "唯一性查询必须包含 model_name 过滤条件"
+
+
+@pytest.mark.django_db
+def test_create_model_raises_on_duplicate_model_id(fake_graph, monkeypatch):
+    """create_model 在 model_id 重复时必须抛出异常，即使只返回少量冲突候选节点。"""
+    from apps.cmdb.services.model import ModelManage
+    from apps.core.exceptions.base_app_exception import BaseAppException
+
+    _patch_create_model_side_effects(monkeypatch)
+
+    # 定点查询返回一个 model_id 相同的已有模型（模拟重复）
+    fake_graph(
+        "apps.cmdb.services.model",
+        query_entity=(
+            [{"model_id": "new_model", "model_name": "其他名称", "_id": 5}],
+            1,
+        ),
+    )
+
+    data = {
+        "model_id": "new_model",
+        "model_name": "新模型",
+        "classification_id": "infra",
+    }
+    with pytest.raises(BaseAppException):
+        ModelManage.create_model(data)
+
+
+@pytest.mark.django_db
+def test_create_model_raises_on_duplicate_model_name(fake_graph, monkeypatch):
+    """create_model 在 model_name 重复时必须抛出异常。"""
+    from apps.cmdb.services.model import ModelManage
+    from apps.core.exceptions.base_app_exception import BaseAppException
+
+    _patch_create_model_side_effects(monkeypatch)
+
+    # 定点查询返回一个 model_name 相同的已有模型（模拟重复）
+    fake_graph(
+        "apps.cmdb.services.model",
+        query_entity=(
+            [{"model_id": "other_id", "model_name": "新模型", "_id": 6}],
+            1,
+        ),
+    )
+
+    data = {
+        "model_id": "new_model",
+        "model_name": "新模型",
+        "classification_id": "infra",
+    }
+    with pytest.raises(BaseAppException):
+        ModelManage.create_model(data)


### PR DESCRIPTION
## 被破坏的不变量

`create_model` 和 `duplicate_model` 的唯一性校验不变量：**写入新模型前，只需确认即将写入的 model_id/model_name 在图中不存在**。这个不变量被错误实现为「全量拉取所有模型节点 → 内存过滤」，而非「按精确条件定点查询」。

## 根因（设计层）

`ag.create_entity` 接受外部传入的 `exist_items` 列表做内存唯一性比对。调用方在 `create_model` 和 `duplicate_model` 中无条件调用 `ag.query_entity(MODEL, [])` 全量拉取所有 MODEL 节点（无过滤条件），而 `query_entity` 本身支持精确条件过滤（`param_type="OR"`），这一能力完全未被利用。随模型数量增长，每次新建模型的图传输和内存开销呈 O(N) 线性劣化且无上界保护。

## 修复如何恢复不变量

将全量查询改为仅查询有唯一性冲突可能的候选节点：

```python
conflict_filter = [
    {"field": "model_id", "type": "str=", "value": data.get("model_id", "")},
    {"field": "model_name", "type": "str=", "value": data.get("model_name", "")},
]
exist_items, _ = ag.query_entity(MODEL, conflict_filter, param_type="OR")
```

`create_entity` 的签名和内部唯一性校验逻辑**完全不变**，只是传入的 `exist_items` 从全量缩小为冲突候选集（正常情况为空集，冲突时为 1–2 个节点）。

## blast radius · 一致性

- 仅修改 `server/apps/cmdb/services/model.py` 中两处（`create_model` L514、`duplicate_model` L674）
- `create_entity` 接口、返回值、异常类型全部不变
- 与同文件 `update_model` 已有的定点查询模式（L799 带 `str<>` 过滤）保持一致
- 无 DB migration，无 API 变更，无跨模块影响

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["用户 POST /cmdb/model/\nviews/model.py"]
        T2["duplicate_model API\nviews/model.py"]
    end

    subgraph N["核心处理层（修复后）"]
        F1["create_model(data)\nmodel.py:499"]
        F2["duplicate_model(...)\nmodel.py:640"]
        F3["query_entity(MODEL, conflict_filter, OR)\n← 仅加载 model_id/model_name 匹配节点"]
        F4["create_entity(MODEL, data, CHECK_ATTR, exist_items)\n内存唯一性比对（exist_items 已是最小集）"]
    end

    subgraph OLD["修复前（已消除）"]
        B1["query_entity(MODEL, [])\n← 无过滤，全量拉取所有模型 O(N)"]
    end

    T1 --> F1
    T2 --> F2
    F1 --> F3
    F2 --> F3
    F3 --> F4
    F4 -->|model_id/name 重复| ERR["抛出 BaseAppException"]
    F4 -->|唯一| OK["写入新 MODEL 节点"]

    B1 -. "已替换为" .-> F3
```

## 验证

- **revert-fail 准则**：将修复 revert（改回 `query_entity(MODEL, [])`），测试 `test_create_model_uses_targeted_conflict_query` 中 `assert params != []` 立即失败
- 新增测试覆盖：定点查询断言、`model_id` 重复拒绝、`model_name` 重复拒绝
- 独立验证脚本（`/tmp/verify_3379.py`）4 项断言全部通过

关联 Issue: #3379