### PR TITLE
bugfix: [cmdb] Neo4j 路径 field/value 参数化，消除 Cypher 注入风险

### DIFF
--- a/server/apps/cmdb/graph/neo4j.py
+++ b/server/apps/cmdb/graph/neo4j.py
@@ -7,7 +7,7 @@ from neo4j import GraphDatabase
 from neo4j.graph import Path
 
 from apps.cmdb.constants.constants import INSTANCE, ModelConstraintKey
-from apps.cmdb.graph.format_type import FORMAT_TYPE
+from apps.cmdb.graph.format_type import FORMAT_TYPE_PARAMS, ParameterCollector
 from apps.cmdb.services.unique_rule import raise_unique_rule_conflict_if_needed
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
@@ -298,52 +298,44 @@ class Neo4jClient:
             results.append(result)
         return results
 
-    def format_search_params(self, params: list, param_type: str = "AND"):
+    def format_search_params(self, params: list, param_type: str = "AND", collector: ParameterCollector = None):
         """
-        查询参数格式化:
-        bool: {"field": "is_host", "type": "bool", "value": True} -> "n.is_host = True"
+        参数化查询格式化（使用 FORMAT_TYPE_PARAMS 消除 Cypher 注入风险）。
 
-        time: {"field": "create_time", "type": "time", "start": "", "end": ""} -> "n.time >= '2022-01-01 08:00:00' AND n.time <= '2022-01-02 08:00:00'"     # noqa
+        返回 (params_str, query_params) 元组：
+          - params_str: 带 $placeholder 的 Cypher WHERE 子句片段
+          - query_params: 传给 session.run 的参数字典
 
-        str=: {"field": "name", "type": "str=", "value": "host"} -> "n.name = 'host'"
-        str<>: {"field": "name", "type": "str<>", "value": "host"} -> "n.name <> 'host'"
-        str*: {"field": "name", "type": "str*", "value": "host"} -> "n.name =~ '.*host.*'"
-        str[]: {"field": "name", "type": "str[]", "value": ["host"]} -> "n.name IN ["host"]"
-
-        int=: {"field": "mem", "type": "int=", "value": 200} -> "n.mem = 200"
-        int>: {"field": "mem", "type": "int>", "value": 200} -> "n.mem > 200"
-        int<: {"field": "mem", "type": "int<", "value": 200} -> "n.mem < 200"
-        int<>: {"field": "mem", "type": "int<>", "value": 200} -> "n.mem <> 200"
-        int[]: {"field": "mem", "type": "int[]", "value": [200]} -> "n.mem IN [200]"
-
-        id=: {"field": "id", "type": "id=", "value": 115} -> "n(id) = 115"
-        id[]: {"field": "id", "type": "id[]", "value": [115,116]} -> "n(id) IN [115,116]"
-
-        list[]: {"field": "test", "type": "list[]", "value": [1,2]} -> "ANY(x IN value WHERE x IN n.test)"
+        bool: {"field": "is_host", "type": "bool", "value": True} -> "n.is_host = $bool1"
+        str=: {"field": "name", "type": "str=", "value": "host"} -> "n.name = $str1"
+        id=:  {"field": "id",   "type": "id=",  "value": 115}   -> "ID(n) = $id1"
         """
+        if collector is None:
+            collector = ParameterCollector()
 
-        params_str = ""
-        param_type = f" {param_type} "
+        parts = []
+        sep = f" {param_type} "
         for param in params:
-            method = FORMAT_TYPE.get(param["type"])
+            method = FORMAT_TYPE_PARAMS.get(param["type"])
             if not method:
                 continue
+            parts.append(method(param, collector))
 
-            params_str += method(param)
-            params_str += param_type
-
-        return f"({params_str[: -len(param_type)]})" if params_str else params_str
+        params_str = f"({sep.join(parts)})" if parts else ""
+        return params_str, collector.get_params()
 
     def format_final_params(self, search_params: list, search_param_type: str = "AND", permission_params=""):
-        search_params_str = self.format_search_params(search_params, search_param_type)
+        """组合用户查询条件与权限条件，返回 (combined_str, query_params) 元组。"""
+        collector = ParameterCollector()
+        search_params_str, query_params = self.format_search_params(search_params, search_param_type, collector)
 
         if not search_params_str:
-            return permission_params
+            return permission_params, query_params
 
         if not permission_params:
-            return search_params_str
+            return search_params_str, query_params
 
-        return f"{search_params_str} AND {permission_params}"
+        return f"{search_params_str} AND {permission_params}", query_params
 
     def query_entity(
         self,
@@ -376,7 +368,7 @@ class Neo4jClient:
             or_condition_str = " OR ".join(or_conditions)
 
             # 将OR条件与其他条件结合
-            params_str = self.format_search_params(params, param_type=param_type)
+            params_str, query_params = self.format_search_params(params, param_type=param_type)
             if params_str:
                 params_str = f"({params_str}) AND ({or_condition_str})"
             else:
@@ -387,7 +379,7 @@ class Neo4jClient:
                 params_str = f"{params_str} AND {permission_params}"
         else:
             # 原有逻辑
-            params_str = self.format_final_params(params, search_param_type=param_type, permission_params=permission_params)
+            params_str, query_params = self.format_final_params(params, search_param_type=param_type, permission_params=permission_params)
 
         params_str = f"WHERE {params_str}" if params_str else params_str
 
@@ -399,10 +391,10 @@ class Neo4jClient:
         count_str = f"MATCH (n{label_str}) {params_str} RETURN COUNT(n) AS count"
         count = None
         if page:
-            count = self.session.run(count_str).single()["count"]
+            count = self.session.run(count_str, **query_params).single()["count"]
             sql_str += f" SKIP {page['skip']} LIMIT {page['limit']}"
 
-        objs = self.session.run(sql_str)
+        objs = self.session.run(sql_str, **query_params)
         return self.entity_to_list(objs), count
 
     def query_entity_by_id(self, id: int):
@@ -444,10 +436,10 @@ class Neo4jClient:
         查询边
         """
         label_str = f":{label}" if label else ""
-        params_str = self.format_search_params(params, param_type)
+        params_str, query_params = self.format_search_params(params, param_type)
         params_str = f"WHERE {params_str}" if params_str else params_str
 
-        objs = self.session.run(f"MATCH p=((a)-[n{label_str}]->(b)) {params_str} RETURN p")
+        objs = self.session.run(f"MATCH p=((a)-[n{label_str}]->(b)) {params_str} RETURN p", **query_params)
 
         return self.edge_to_list(objs, return_entity)
 
@@ -544,10 +536,10 @@ class Neo4jClient:
         """移除某些实体的某些属性"""
         label_str = f":{label}" if label else ""
         properties_str = self.format_properties_remove(attrs)
-        params_str = self.format_search_params(params)
+        params_str, query_params = self.format_search_params(params)
         params_str = f"WHERE {params_str}" if params_str else params_str
 
-        self.session.run(f"MATCH (n{label_str}) {params_str} REMOVE {properties_str} RETURN n")
+        self.session.run(f"MATCH (n{label_str}) {params_str} REMOVE {properties_str} RETURN n", **query_params)
 
     def batch_delete_entity(self, label: str, entity_ids: list):
         """批量删除实体"""
@@ -576,23 +568,23 @@ class Neo4jClient:
         """实体对象查询"""
 
         label_str = f":{label}" if label else ""
-        params_str = self.format_final_params(params, permission_params=permission_params)
+        params_str, query_params = self.format_final_params(params, permission_params=permission_params)
         params_str = f"WHERE {params_str}" if params_str else params_str
 
         sql_str = f"MATCH (n{label_str}) {params_str} RETURN n"
 
-        inst_objs = self.session.run(sql_str)
+        inst_objs = self.session.run(sql_str, **query_params)
         return inst_objs
 
     def query_topo(self, label: str, inst_id: int):
         """查询实例拓扑"""
 
         label_str = f":{label}" if label else ""
-        params_str = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
+        params_str, query_params = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
         if params_str:
             params_str = f"AND {params_str}"
-        src_objs = self.session.run(f"MATCH p=(n{label_str})-[*]->(m{label_str}) WHERE NOT (m)-->() {params_str} RETURN p")
-        dst_objs = self.session.run(f"MATCH p=(m{label_str})-[*]->(n{label_str}) WHERE NOT (m)<--() {params_str} RETURN p")
+        src_objs = self.session.run(f"MATCH p=(n{label_str})-[*]->(m{label_str}) WHERE NOT (m)-->() {params_str} RETURN p", **query_params)
+        dst_objs = self.session.run(f"MATCH p=(m{label_str})-[*]->(n{label_str}) WHERE NOT (m)<--() {params_str} RETURN p", **query_params)
 
         return dict(src_result=self.format_topo(inst_id, src_objs, True), dst_result=self.format_topo(inst_id, dst_objs, False))
 
@@ -602,11 +594,11 @@ class Neo4jClient:
         probe_depth = depth + 1
 
         label_str = f":{label}" if label else ""
-        params_str = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
+        params_str, query_params = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
         where_clause = f"WHERE {params_str}" if params_str else ""
 
-        src_objs = self.session.run(f"MATCH p=(n{label_str})-[*1..{probe_depth}]->(m{label_str}) {where_clause} RETURN p")
-        dst_objs = self.session.run(f"MATCH p=(m{label_str})-[*1..{probe_depth}]->(n{label_str}) {where_clause} RETURN p")
+        src_objs = self.session.run(f"MATCH p=(n{label_str})-[*1..{probe_depth}]->(m{label_str}) {where_clause} RETURN p", **query_params)
+        dst_objs = self.session.run(f"MATCH p=(m{label_str})-[*1..{probe_depth}]->(n{label_str}) {where_clause} RETURN p", **query_params)
 
         return dict(
             src_result=self.format_topo_lite(inst_id, src_objs, True, depth=depth, exclude_ids=exclude_ids),
@@ -792,12 +784,12 @@ class Neo4jClient:
     def query_topo_test_config(self, label: str, inst_id: int, model_id: str):
         """查询实例拓扑"""
         label_str = f":{label}" if label else ""
-        params_str = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
+        params_str, query_params = self.format_search_params([{"field": "id", "type": "id=", "value": inst_id}])
         if params_str:
             params_str = f"AND {params_str}"
 
-        src_objs = self.session.run(self.convert_to_cypher_match(label_str, model_id, params_str, dst=False))
-        dst_objs = self.session.run(self.convert_to_cypher_match(label_str, model_id, params_str, dst=True))
+        src_objs = self.session.run(self.convert_to_cypher_match(label_str, model_id, params_str, dst=False), **query_params)
+        dst_objs = self.session.run(self.convert_to_cypher_match(label_str, model_id, params_str, dst=True), **query_params)
 
         return dict(src_result=self.format_topo(inst_id, src_objs, True), dst_result=self.format_topo(inst_id, dst_objs, False))
 
@@ -923,12 +915,13 @@ class Neo4jClient:
         instance_permission_params = instance_permission_params or {}
         label_str = f":{label}" if label else ""
 
+        combined_collector = ParameterCollector()
         if format_permission_dict:
             permission_filters = []
             for organization_id, query_list in format_permission_dict.items():
                 organization_query = [{"field": "organization", "type": "list[]", "value": [organization_id]}]
-                base_permission_str = self.format_search_params(organization_query, param_type="AND")
-                org_permission_str = self.format_search_params(query_list, param_type="OR")
+                base_permission_str, _ = self.format_search_params(organization_query, param_type="AND", collector=combined_collector)
+                org_permission_str, _ = self.format_search_params(query_list, param_type="OR", collector=combined_collector)
 
                 if base_permission_str and org_permission_str:
                     permission_filters.append(f"({base_permission_str} AND {org_permission_str})")
@@ -940,7 +933,11 @@ class Neo4jClient:
                 permission_params = f"{permission_params} AND {formatted_permission}" if permission_params else formatted_permission
 
         # 首先应用基础查询参数和组织权限
-        final_params_str = self.format_final_params(params, permission_params=permission_params)
+        final_params_str, _ = self.format_search_params(params, collector=combined_collector)
+        if final_params_str and permission_params:
+            final_params_str = f"{final_params_str} AND {permission_params}"
+        elif permission_params:
+            final_params_str = permission_params
 
         # 在组织权限基础上，添加实例权限过滤
         instance_permission_str = self.format_instance_permission_params(instance_permission_params, created)
@@ -952,7 +949,7 @@ class Neo4jClient:
             final_params_str = f"WHERE {final_params_str}"
 
         count_sql = f"MATCH (n{label_str}) {final_params_str} RETURN n.{group_by_attr} AS {group_by_attr}, COUNT(n) AS count"
-        data = self.session.run(count_sql)
+        data = self.session.run(count_sql, **combined_collector.get_params())
 
         return {i[group_by_attr]: i["count"] for i in data}
 

--- a/server/apps/cmdb/graph/neo4j.py
+++ b/server/apps/cmdb/graph/neo4j.py
@@ -358,17 +358,21 @@ class Neo4jClient:
             inst_names = permission_or_creator_filter.get("inst_names", [])
             creator = permission_or_creator_filter.get("creator")
 
-            # 构建OR条件：有权限的实例 OR 自己创建的实例
+            # 构建OR条件：有权限的实例 OR 自己创建的实例（参数化，避免注入）
+            perm_collector = ParameterCollector()
             or_conditions = []
             if inst_names:
-                or_conditions.append(f"n.inst_name IN {inst_names}")
+                perm_param = perm_collector.add_param(inst_names, prefix="perm_inst")
+                or_conditions.append(f"n.inst_name IN {perm_param}")
             if creator:
-                or_conditions.append(f"n._creator = '{creator}'")
+                perm_param = perm_collector.add_param(creator, prefix="perm_creator")
+                or_conditions.append(f"n._creator = {perm_param}")
 
             or_condition_str = " OR ".join(or_conditions)
 
             # 将OR条件与其他条件结合
-            params_str, query_params = self.format_search_params(params, param_type=param_type)
+            params_str, query_params = self.format_search_params(params, param_type=param_type, collector=perm_collector)
+            query_params = perm_collector.get_params()
             if params_str:
                 params_str = f"({params_str}) AND ({or_condition_str})"
             else:
@@ -984,8 +988,8 @@ class Neo4jClient:
         # 组合权限条件和全文检索条件
         where_condition = f"({final_permission_condition}) AND" if final_permission_condition else ""
 
-        query = f"""MATCH (n:{INSTANCE}) WHERE {where_condition} ANY(key IN keys(n) WHERE (NOT n[key] IS NULL AND ANY(value IN n[key] WHERE toString(value) CONTAINS '{search}'))) RETURN n"""  # noqa
-        objs = self.session.run(query)
+        query = f"""MATCH (n:{INSTANCE}) WHERE {where_condition} ANY(key IN keys(n) WHERE (NOT n[key] IS NULL AND ANY(value IN n[key] WHERE toString(value) CONTAINS $search))) RETURN n"""  # noqa
+        objs = self.session.run(query, search=search)
         return self.entity_to_list(objs)
 
     def batch_save_entity(

--- a/server/apps/cmdb/tests/test_neo4j_client.py
+++ b/server/apps/cmdb/tests/test_neo4j_client.py
@@ -63,9 +63,11 @@ class FakeSession:
     def __init__(self, result_records=None):
         self._records = result_records if result_records is not None else []
         self.last_query = None
+        self.last_params = {}
 
     def run(self, query, *args, **kwargs):
         self.last_query = query
+        self.last_params = kwargs
         return FakeRunResult(self._records)
 
     def close(self):
@@ -154,14 +156,39 @@ def test_format_properties_remove():
 
 
 def test_format_search_params_str_eq():
+    """format_search_params 返回 (str, dict) 元组，str 使用 $placeholder 不含原始值。"""
     c = _client()
-    out = c.format_search_params([{"field": "name", "type": "str=", "value": "h"}])
-    assert "n.name" in out
+    params_str, query_params = c.format_search_params([{"field": "name", "type": "str=", "value": "h"}])
+    assert "n.name" in params_str
+    # 参数化：原始值在 query_params 中，不在 CQL 字符串内
+    assert "h" not in params_str
+    assert "h" in query_params.values()
+
+
+def test_format_search_params_injection_value():
+    """注入载荷在 query_params 中，不出现在 CQL 字符串里（核心防注入验证）。"""
+    c = _client()
+    injection = "foo'] RETURN n //"
+    params_str, query_params = c.format_search_params([{"field": "name", "type": "str=", "value": injection}])
+    # 注入字符串绝不能直接拼进 CQL
+    assert injection not in params_str
+    assert "RETURN" not in params_str
+    # 注入值通过参数传递
+    assert injection in query_params.values()
+
+
+def test_format_search_params_injection_field():
+    """非法 field 名（含注入字符）应被 CQLValidator 拒绝。"""
+    from apps.core.exceptions.base_app_exception import BaseAppException
+    c = _client()
+    with pytest.raises((BaseAppException, Exception)):
+        c.format_search_params([{"field": "name'] RETURN n //", "type": "str=", "value": "v"}])
 
 
 def test_format_final_params():
     c = _client()
-    assert c.format_final_params([], permission_params="n.org=1") == "n.org=1"
+    combined_str, query_params = c.format_final_params([], permission_params="n.org=1")
+    assert combined_str == "n.org=1"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 被破坏的不变量

Neo4j 查询层有一条契约：**用户传入的查询参数（field 名、value 值）必须经过校验/参数化，不得直接拼入 CQL 字符串**。FalkorDB 路径已遵守这条契约（使用 `CQLValidator.validate_field` + `ParameterCollector`），但 Neo4j 路径的 `format_search_params` 完全跳过了这两步，直接 f-string 拼接。

## 根因（设计层）

`Neo4jClient.format_search_params` 在构建 WHERE 子句时调用 `FORMAT_TYPE`（非参数化版），把 `field` 和 `value` 原样插入 Cypher 字符串。攻击者只需在 `value` 中注入 `foo'] RETURN n //` 即可改写整条查询，效果等同 SQL 注入。社区版默认使用 Neo4j 后端（无 FalkorDB 时），攻击面覆盖所有已登录用户可触达的实例搜索接口。

## 修复如何恢复不变量

1. `neo4j.py` 导入替换：`FORMAT_TYPE` → `FORMAT_TYPE_PARAMS + ParameterCollector`（FalkorDB 路径已有的正确范式）。
2. `format_search_params` 改为接收可选 `collector` 参数，返回 `(cypher_str_with_placeholders, params_dict)` 元组；field 名经 `CQLValidator.validate_field` 白名单校验，value 值经 `collector.add_param` 替换为 `$placeholder`。
3. 所有 `session.run(cql)` 调用统一改为 `session.run(cql, **query_params)`，参数不再出现在 CQL 字符串内。
4. `entity_count` 中多路 `format_search_params` 共享同一 `ParameterCollector`，避免参数名冲突。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /api/instance/search/\nviews/instance.py"]
    end

    subgraph N["Neo4j 查询层（修复前 → 修复后）"]
        F1["format_search_params\nneo4j.py"]
        F2["FORMAT_TYPE_PARAMS + CQLValidator\nformat_type.py / validators.py"]
        F3["session.run(cql, **params)\nneo4j.py"]
    end

    subgraph C["参数化执行"]
        C1["Neo4j driver 参数绑定\n$placeholder → 值"]
    end

    T1 --> F1
    F1 --> F2
    F2 --> F3
    F3 --> C1
```

## blast radius · 一致性

- 改动范围：`server/apps/cmdb/graph/neo4j.py`（单文件）+ 对应测试文件。
- 不涉及 FalkorDB 路径（已安全），不改接口签名，不改 DB schema，不影响 agents/。
- `format_search_params` 返回类型由 `str` 改为 `(str, dict)` 元组，仅 Neo4jClient 内部方法消费，无外部调用方受影响。

## 验证

- 新增测试验证注入载荷不出现在 CQL 字符串、非法 field 名被 CQLValidator 拒绝；revert 修复代码后这两条测试失败。
- 现有 `test_neo4j_client.py` 全部更新适配新签名并通过。

关联 Issue #3373