### PR TITLE
bugfix: [alerts] 显式捕获 AuthenticationSourceError，鉴权失败返回 403 而非 500

### DIFF
--- a/server/apps/alerts/tests/test_event_log_receiver_views.py
+++ b/server/apps/alerts/tests/test_event_log_receiver_views.py
@@ -259,6 +259,43 @@ def test_receiver_invalid_secret(monkeypatch):
     assert response.status_code == 403
 
 
+@pytest.mark.django_db
+def test_receiver_authentication_source_error_returns_403(monkeypatch):
+    """authenticate() 抛出 AuthenticationSourceError 时应返回 403 而非 500。
+
+    验证修复点：AuthenticationSourceError 被显式捕获并映射到 403，
+    revert 该 except 子句后此测试将失败。
+    """
+    from apps.alerts.error import AuthenticationSourceError
+    from apps.alerts.views import receiver as receiver_module
+
+    _make_source(source_id="src-auth-err", source_type="restful")
+
+    class FakeAdapterAuthError:
+        def __init__(self, alert_source=None, secret=None, events=None):
+            pass
+
+        def normalize_payload(self, data):
+            return [{"event_id": "E1"}]
+
+        def authenticate(self):
+            raise AuthenticationSourceError("Authentication failed")
+
+        def main(self):
+            return None
+
+    monkeypatch.setattr(
+        receiver_module.AlertSourceAdapterFactory, "get_adapter", staticmethod(lambda src: FakeAdapterAuthError)
+    )
+
+    request = _post_body({"source_id": "src-auth-err"}, secret="bad-key")
+    response = receiver_module.receiver_data(request)
+    assert response.status_code == 403
+    payload = json.loads(response.content)
+    assert payload["status"] == "error"
+    assert "Invalid secret" in payload["message"]
+
+
 def test_request_test_returns_success():
     from apps.alerts.views.receiver import request_test
 

--- a/server/apps/alerts/views/receiver.py
+++ b/server/apps/alerts/views/receiver.py
@@ -12,6 +12,7 @@ from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
 from apps.alerts.common.source_adapter.base import AlertSourceAdapterFactory
+from apps.alerts.error import AuthenticationSourceError
 from apps.alerts.models.alert_source import AlertSource
 from apps.core.logger import alert_logger as logger
 from apps.core.utils.exempt import api_exempt
@@ -67,6 +68,8 @@ def _receive_events(request, path_source_id=None, expected_source_type=None):
 
         adapter.main()
         return JsonResponse({"status": "success", "time": timezone.now().strftime("%Y-%m-%d %H:%M:%S"), "message": "Data received successfully."})
+    except AuthenticationSourceError:
+        return JsonResponse({"status": "error", "message": "Invalid secret."}, status=403)
     except ValueError as e:
         return JsonResponse({"status": "error", "message": str(e)}, status=400)
     except Exception as e:


### PR DESCRIPTION
## 被破坏的不变量

告警接收器的鉴权契约要求：凡是密钥校验失败（包括 `authenticate()` 返回 `False` 或抛出鉴权类异常），必须返回 `403 Forbidden`，而不能让调用方误判为服务端故障。

## 根因（设计层）

`AlertSourceAdapter.authenticate()` 在内部错误条件下会 `raise AuthenticationSourceError`（`base.py:104`），但 `_receive_events` 的异常捕获链只有 `except ValueError` 和 `except Exception`——`AuthenticationSourceError` 不是 `ValueError` 的子类，因此落入兜底的 `except Exception` → 返回 `500 Internal Server Error`。

这打破了鉴权失败 → 403 的不变量，使调用方把鉴权错误误判为服务端故障，触发重试并产生 5xx 监控告警噪音。

## 修复如何恢复不变量

在 `_receive_events` 的异常捕获链中，在 `except ValueError` 之前显式加入：

```python
except AuthenticationSourceError:
    return JsonResponse({"status": "error", "message": "Invalid secret."}, status=403)
```

顺序保证优先于 `ValueError` 和 `Exception` 捕获，与 `authenticate()` 返回 `False` 的 403 路径语义一致。

## blast radius · 一致性

- 改动范围：单文件 `server/apps/alerts/views/receiver.py`，不触及 model、共享 util、RPC 层
- 新增 import `AuthenticationSourceError` 来自同模块 `apps.alerts.error`，无跨包引入
- 已有的 `authenticate()` 返回 `False` → 403 路径不受影响

## 验证

新增测试 `test_receiver_authentication_source_error_returns_403`：
- 使用 monkeypatch 注入 `authenticate()` 抛出 `AuthenticationSourceError` 的 FakeAdapter
- 断言响应状态为 403，`status=error`，message 含 "Invalid secret"
- revert `except AuthenticationSourceError` 子句后该测试必然失败（落入 `except Exception` → 500），满足 revert-fail 准则

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /receiver/\n_receive_events receiver.py"]
    end

    subgraph N["核心处理层"]
        A1["adapter.authenticate()\nbase.py:104"]
        A2["返回 False → 403 ✓"]
        A3["raise AuthenticationSourceError\n→ except AuthenticationSourceError → 403 ✓（修复后）"]
    end

    subgraph C["兜底层（修复前）"]
        C1["except Exception → 500 ✗"]
    end

    T1 --> A1
    A1 -->|"False"| A2
    A1 -->|"raise"| A3
    A3 -. "修复前落入" .-> C1
```

关联 Issue: #3387