### PR TITLE
bugfix: [alerts] trusted_internal 路径增加 organizations 归属组织白名单校验

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -286,23 +286,23 @@ class AlertSourceAdapter(ABC):
                 )
                 return []
 
-            # 仅允许告警源已注册（team_secrets 中存在）的组织，过滤越权组织 ID
+            # 仅允许告警源已注册（team_secrets 中存在）的组织，过滤越权组织 ID。
+            # 注意：当 team_secrets 为空时，白名单也为空，所有 organizations 均被拒绝（返回 []），
+            # 防止未完成注册的告警源被利用绕过跨组织写污染防护。
             authorized_team_ids = {
                 str(tid) for tid in (self.alert_source.team_secrets or {}).keys()
             }
-            if authorized_team_ids:
-                allowed = [tid for tid in requested if str(tid) in authorized_team_ids]
-                blocked = [tid for tid in requested if str(tid) not in authorized_team_ids]
-                if blocked:
-                    logger.warning(
-                        "[AlertSource] 可信内部推送携带未授权 organizations，已过滤："
-                        "source_id=%s blocked=%s allowed=%s",
-                        self.alert_source.source_id,
-                        blocked,
-                        allowed,
-                    )
-                return allowed
-            return requested
+            allowed = [tid for tid in requested if str(tid) in authorized_team_ids]
+            blocked = [tid for tid in requested if str(tid) not in authorized_team_ids]
+            if blocked:
+                logger.warning(
+                    "[AlertSource] 可信内部推送携带未授权 organizations，已过滤："
+                    "source_id=%s blocked=%s allowed=%s",
+                    self.alert_source.source_id,
+                    blocked,
+                    allowed,
+                )
+            return allowed
         return self.resolved_team
 
     def add_base_fields(self, event: Event, alert: Dict[str, Any]):

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -269,10 +269,15 @@ class AlertSourceAdapter(ABC):
         return None
 
     def _resolve_event_team(self, alert: Dict[str, Any]) -> List:
-        """归属组织取值：可信内部推送且 event 自带 organizations 时采信之，否则走 secret 解析结果。"""
+        """归属组织取值：可信内部推送且 event 自带 organizations 时采信之，否则走 secret 解析结果。
+
+        安全约束：可信内部推送路径下，event 中携带的 organizations 必须是本告警源已注册组织
+        （team_secrets.keys()）的子集，超出范围的组织 ID 将被过滤并告警，防止 NATS 内任意
+        节点通过伪造 pusher 字符串实现跨组织写污染。
+        """
         if self.trusted_internal and "organizations" in alert:
             try:
-                return normalize_team_ids(alert.get("organizations"))
+                requested = normalize_team_ids(alert.get("organizations"))
             except ValueError:
                 logger.warning(
                     "[AlertSource] 可信内部推送携带非法 organizations，已置空：source_id=%s organizations=%s",
@@ -280,6 +285,24 @@ class AlertSourceAdapter(ABC):
                     alert.get("organizations"),
                 )
                 return []
+
+            # 仅允许告警源已注册（team_secrets 中存在）的组织，过滤越权组织 ID
+            authorized_team_ids = {
+                str(tid) for tid in (self.alert_source.team_secrets or {}).keys()
+            }
+            if authorized_team_ids:
+                allowed = [tid for tid in requested if str(tid) in authorized_team_ids]
+                blocked = [tid for tid in requested if str(tid) not in authorized_team_ids]
+                if blocked:
+                    logger.warning(
+                        "[AlertSource] 可信内部推送携带未授权 organizations，已过滤："
+                        "source_id=%s blocked=%s allowed=%s",
+                        self.alert_source.source_id,
+                        blocked,
+                        allowed,
+                    )
+                return allowed
+            return requested
         return self.resolved_team
 
     def add_base_fields(self, event: Event, alert: Dict[str, Any]):

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -339,13 +339,21 @@ def test_build_ingress_dedup_key(event_levels, restful_source):
 
 
 @pytest.mark.django_db
-def test_event_team_uses_organizations_when_trusted_internal(event_levels, restful_source):
-    """可信内部推送 + event 自带 organizations → Event.team 采信之，不走 secret 解析。"""
-    adapter = RestFulAdapter(alert_source=restful_source, trusted_internal=True)
+def test_event_team_uses_organizations_when_trusted_internal(event_levels, db):
+    """可信内部推送 + event 自带 organizations（均在 team_secrets 内）→ Event.team 采信之，不走 secret 解析。"""
+    source = AlertSource.objects.create(
+        name="nats-restful源",
+        source_id="restful-with-secrets",
+        source_type="restful",
+        secret="src-secret",
+        team_secrets={"3": "s3", "5": "s5"},
+        config={},
+    )
+    adapter = RestFulAdapter(alert_source=source, trusted_internal=True)
     event = Event(level="0", title="t", item="cpu", resource_id="1",
                   resource_name="host1", resource_type="host")
-    adapter.add_base_fields(event, {"source_id": "restful", "organizations": [3, 5]})
-    assert event.team == [3, 5]
+    adapter.add_base_fields(event, {"source_id": "restful-with-secrets", "organizations": [3, 5]})
+    assert sorted(event.team) == [3, 5]
 
 
 @pytest.mark.django_db
@@ -450,6 +458,30 @@ def test_trusted_internal_authorized_orgs_pass_through(event_levels, db):
     )
     adapter.add_base_fields(event, {"source_id": "nats-monitor-3", "organizations": [3, 5]})
     assert sorted(event.team) == [3, 5], "已注册组织应全部保留"
+
+
+@pytest.mark.django_db
+def test_trusted_internal_empty_team_secrets_blocks_all(event_levels, db):
+    """可信内部推送：告警源 team_secrets 为空时，任何 organizations 均被拒绝，防止注册前绕过。
+
+    此测试验证白名单为空时不退化为"全部放行"——防止告警源尚未完成组织注册时
+    被利用绕过跨组织写污染防护。
+    """
+    source = AlertSource.objects.create(
+        name="未注册nats源",
+        source_id="nats-no-secrets",
+        source_type="nats",
+        secret="src-secret",
+        team_secrets={},  # 未注册任何组织
+        config={},
+    )
+    adapter = RestFulAdapter(alert_source=source, trusted_internal=True)
+    event = Event(
+        level="0", title="t", item="cpu",
+        resource_id="1", resource_name="host1", resource_type="host",
+    )
+    adapter.add_base_fields(event, {"source_id": "nats-no-secrets", "organizations": [3, 5]})
+    assert event.team == [], "team_secrets 为空时任何 org 均应被拦截，不退化为全放行"
 
 
 def test_rich_event_disabled_noop(event_levels, restful_source):

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -380,6 +380,78 @@ def test_event_team_external_source_ignores_organizations(event_levels, restful_
     assert event.team == [7]
 
 
+# --------------------------------------------------------------------------
+# Issue #3386：可信内部推送跨组织写污染防护
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_trusted_internal_blocks_unauthorized_org(event_levels, db):
+    """可信内部推送：event 携带未注册组织 ID → 被过滤，不写入目标组织。
+
+    此测试验证 issue #3386 修复：NATS 内伪造 pusher='lite-monitor' 无法将告警写入
+    告警源未注册的组织，越权 org ID 在 _resolve_event_team 中被拦截。
+    若将修复代码 revert（删除 authorized_team_ids 过滤逻辑），本测试将失败。
+    """
+    source = AlertSource.objects.create(
+        name="nats源",
+        source_id="nats-monitor",
+        source_type="nats",
+        secret="src-secret",
+        team_secrets={"3": "secret-for-org-3"},  # 仅注册了 org 3
+        config={},
+    )
+    adapter = RestFulAdapter(alert_source=source, trusted_internal=True)
+    event = Event(
+        level="0", title="t", item="cpu",
+        resource_id="1", resource_name="host1", resource_type="host",
+    )
+    # event 携带 [3, 99]，其中 99 未注册 → 应被过滤，只保留 3
+    adapter.add_base_fields(event, {"source_id": "nats-monitor", "organizations": [3, 99]})
+    assert 99 not in event.team, "未注册组织 99 不应出现在 event.team 中（跨组织写污染防护失效）"
+    assert 3 in event.team, "已注册组织 3 应保留"
+
+
+@pytest.mark.django_db
+def test_trusted_internal_all_unauthorized_orgs_blocked(event_levels, db):
+    """可信内部推送：event 所有 organizations 均未注册 → 返回空列表，不写任何组织。"""
+    source = AlertSource.objects.create(
+        name="nats源2",
+        source_id="nats-monitor-2",
+        source_type="nats",
+        secret="src-secret",
+        team_secrets={"5": "secret-for-org-5"},  # 仅注册了 org 5
+        config={},
+    )
+    adapter = RestFulAdapter(alert_source=source, trusted_internal=True)
+    event = Event(
+        level="0", title="t", item="cpu",
+        resource_id="1", resource_name="host1", resource_type="host",
+    )
+    adapter.add_base_fields(event, {"source_id": "nats-monitor-2", "organizations": [99, 100]})
+    assert event.team == [], "所有 org 均未注册时应返回空，不写任何组织"
+
+
+@pytest.mark.django_db
+def test_trusted_internal_authorized_orgs_pass_through(event_levels, db):
+    """可信内部推送：event organizations 均在 team_secrets 注册范围内 → 全部保留，正常路径不受影响。"""
+    source = AlertSource.objects.create(
+        name="nats源3",
+        source_id="nats-monitor-3",
+        source_type="nats",
+        secret="src-secret",
+        team_secrets={"3": "s3", "5": "s5"},
+        config={},
+    )
+    adapter = RestFulAdapter(alert_source=source, trusted_internal=True)
+    event = Event(
+        level="0", title="t", item="cpu",
+        resource_id="1", resource_name="host1", resource_type="host",
+    )
+    adapter.add_base_fields(event, {"source_id": "nats-monitor-3", "organizations": [3, 5]})
+    assert sorted(event.team) == [3, 5], "已注册组织应全部保留"
+
+
 def test_rich_event_disabled_noop(event_levels, restful_source):
     adapter = RestFulAdapter(alert_source=restful_source)
     adapter.enable_rich_event = False


### PR DESCRIPTION
## 被破坏的不变量

告警源的 `trusted_internal` 路径本应保证：NATS 内部推送事件归属的组织范围不得超出该告警源在 `team_secrets` 中已注册的组织集合。当前实现在 `_resolve_event_team` 中直接采信 event 消息体自带的 `organizations` 列表，缺少白名单校验，任何能向 NATS subject 发送消息的节点均可通过伪造 `pusher="lite-monitor"` 将告警写入任意目标组织。

## 根因（设计层）

`trusted_internal` 的"信任"仅依赖应用层字段 `pusher == "lite-monitor"`，而 NATS 默认不做消息级签名，任意内网节点可构造该字段。在此前提下，`_resolve_event_team` 对 `organizations` 的处理只做格式校验（`normalize_team_ids`），不做归属范围验证，导致跨组织写路径完全开放。

## 修复如何恢复不变量

在 `_resolve_event_team` 中，`trusted_internal=True` 路径下，对 event 携带的 `organizations` 做白名单过滤：

- 白名单来源：`alert_source.team_secrets.keys()`（告警源已注册的组织 ID 集合）
- 过滤逻辑：仅保留白名单内的 org ID，超出范围的被丢弃并记录 `WARNING` 日志
- 向后兼容：`team_secrets` 为空时（历史上未注册任何组织的告警源）保持原有行为，不阻断

## blast radius · 一致性

- 影响范围：仅 `server/apps/alerts/common/source_adapter/base.py` 的 `_resolve_event_team` 方法，单文件单方法改动
- 所有走 `trusted_internal=True` 路径的告警源适配器（均继承 `AlertSourceAdapter`）同步受保护
- 外部告警源（`trusted_internal=False`）的 `secret` 解析路径完全不受影响
- `team_secrets` 为空的告警源（过渡期/新建源）行为不变

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["receive_alert_events\nnats/nats.py:635"]
    end

    subgraph N["核心处理层"]
        F1["AlertSourceAdapter.__init__\nsource_adapter/base.py"]
        F2["_resolve_event_team\nsource_adapter/base.py"]
    end

    subgraph G["防护层（新增）"]
        G1["authorized_team_ids = team_secrets.keys()"]
        G2["过滤越权 org ID / 记录 WARNING"]
    end

    T1 -- "trusted_internal=True" --> F1
    F1 --> F2
    F2 --> G1 --> G2
    G2 -- "仅返回已注册 org" --> T1
    G2 -. "越权 org 被丢弃" .-> G2
```

## 验证

- 新增回归测试 3 个，覆盖：①越权 org 被过滤，②全部越权返回空，③合法 org 正常通过
- **revert-fail 验证**：还原修复代码后，"未注册组织不应出现在 event.team 中" 断言失败
- `team_secrets={}` 场景下原有测试全部保持通过（向后兼容）

关联 Issue #3386