### PR TITLE
fix(job_mgmt): re_execute 补团队归属校验，堵跨团队越权重执行（安全债 #3403）

### DIFF
--- a/server/apps/job_mgmt/services/execution_service.py
+++ b/server/apps/job_mgmt/services/execution_service.py
@@ -257,8 +257,21 @@ class ExecutionService:
         return execution
 
     @classmethod
-    def create_re_execution(cls, *, original: JobExecution, username: str) -> JobExecution:
-        """重新执行：基于原执行记录创建新执行并派发。"""
+    def create_re_execution(cls, *, original: JobExecution, username: str, authorized_team_ids) -> JobExecution:
+        """重新执行：基于原执行记录创建新执行并派发。
+
+        与 quick_execute / file_distribution 一致，执行前校验调用者对原作业 team
+        （及引用的 script / playbook）有权限，消除跨团队水平越权重执行（#3403）。
+        ``authorized_team_ids`` 为 ``None`` 表示超管，放行一切。
+        """
+        # 团队归属校验（须在创建/派发前）
+        if not is_team_authorized(original.team, authorized_team_ids):
+            raise ExecutionAuthorizationError("无权重新执行该作业", status_code=403)
+        if original.script and not is_team_authorized(original.script.team, authorized_team_ids):
+            raise ExecutionAuthorizationError("原关联脚本不属于当前用户的团队，无权执行", status_code=403)
+        if original.playbook and not is_team_authorized(original.playbook.team, authorized_team_ids):
+            raise ExecutionAuthorizationError("原关联 Playbook 不属于当前用户的团队，无权执行", status_code=403)
+
         target_list = original.target_list or []
         if not target_list:
             raise ExecutionAuthorizationError("原执行目标已不存在", status_code=400)

--- a/server/apps/job_mgmt/tests/test_execution_service.py
+++ b/server/apps/job_mgmt/tests/test_execution_service.py
@@ -386,13 +386,13 @@ class TestCreateReExecution:
         original = self._make_original(target_list=[])
         with patch(DISPATCH_PATH):
             with pytest.raises(ExecutionAuthorizationError) as exc:
-                ExecutionService.create_re_execution(original=original, username="bob")
+                ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={1})
         assert exc.value.status_code == 400
 
     def test_script_re_execution_sets_manual_trigger(self):
         original = self._make_original()
         with patch(DISPATCH_PATH, return_value="celery-1"):
-            execution = ExecutionService.create_re_execution(original=original, username="bob")
+            execution = ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={1})
         assert execution.id != original.id
         assert execution.trigger_source == TriggerSource.MANUAL
         assert execution.job_type == JobType.SCRIPT
@@ -402,5 +402,40 @@ class TestCreateReExecution:
         original = self._make_original(job_type=JobType.PLAYBOOK, playbook=None)
         with patch(DISPATCH_PATH):
             with pytest.raises(ExecutionAuthorizationError) as exc:
-                ExecutionService.create_re_execution(original=original, username="bob")
+                ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={1})
         assert exc.value.status_code == 400
+
+    # ---------- #3403：团队归属校验 ---------- #
+    def test_cross_team_raises_403_before_create(self):
+        original = self._make_original(team=[1])
+        with patch(DISPATCH_PATH) as dispatch:
+            with pytest.raises(ExecutionAuthorizationError) as exc:
+                ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={99})
+        assert exc.value.status_code == 403
+        dispatch.assert_not_called()
+        # 越权时不得创建新执行（库中仅剩原始那 1 条）
+        assert JobExecution.objects.count() == 1
+
+    def test_superuser_bypasses_team_check(self):
+        original = self._make_original(team=[999])
+        with patch(DISPATCH_PATH, return_value="celery-1"):
+            execution = ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids=None)
+        assert execution.trigger_source == TriggerSource.MANUAL
+
+    def test_referenced_script_cross_team_raises_403(self):
+        script = Script.objects.create(name="s", content="echo", script_type="shell", team=[99])
+        original = self._make_original(team=[1], script=script)
+        with patch(DISPATCH_PATH) as dispatch:
+            with pytest.raises(ExecutionAuthorizationError) as exc:
+                ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={1})
+        assert exc.value.status_code == 403
+        dispatch.assert_not_called()
+
+    def test_referenced_playbook_cross_team_raises_403(self):
+        playbook = Playbook.objects.create(name="p", version="v1.0.0", team=[99])
+        original = self._make_original(team=[1], job_type=JobType.PLAYBOOK, playbook=playbook)
+        with patch(DISPATCH_PATH) as dispatch:
+            with pytest.raises(ExecutionAuthorizationError) as exc:
+                ExecutionService.create_re_execution(original=original, username="bob", authorized_team_ids={1})
+        assert exc.value.status_code == 403
+        dispatch.assert_not_called()

--- a/server/apps/job_mgmt/views/execution.py
+++ b/server/apps/job_mgmt/views/execution.py
@@ -255,9 +255,11 @@ class JobExecutionViewSet(AuthViewSet):
         """
         original = self.get_object()
         username = request.user.username if request.user else ""
+        # BL-NEW-002 / #3403：与 quick_execute 一致，按服务端授权 team 校验原作业归属
+        authorized_team_ids = self._get_authorized_team_ids(request)
 
         try:
-            execution = ExecutionService.create_re_execution(original=original, username=username)
+            execution = ExecutionService.create_re_execution(original=original, username=username, authorized_team_ids=authorized_team_ids)
         except (ExecutionAuthorizationError, ExecutionDispatchError) as e:
             return Response({"error": e.message}, status=e.status_code)
 


### PR DESCRIPTION
re_execute 此前直接用 original.team/script/playbook 创建新执行，未校验调用者 权限，与 quick_execute/file_distribution 的防护不对称，可跨团队越权重新执行 他人历史作业（脚本/剧本/文件分发）。

- ExecutionService.create_re_execution 增 authorized_team_ids 参，创建/派发前 校验 original.team 及引用的 script/playbook 归属，否则 403（超管 None 放行）
- 视图 re_execute 传入服务端授权 team
- 补 service 层 403 / 超管放行 / 引用脚本·Playbook 跨团队 测试

对应 TencentBlueKing/bk-lite#3403