### PR TITLE
feat(monitor): unified, resizable object sidebar across view/dashboard/event/integration

### DIFF
--- a/web/src/app/monitor/(pages)/event/alert/index.module.scss
+++ b/web/src/app/monitor/(pages)/event/alert/index.module.scss
@@ -4,18 +4,17 @@
     width: 100%;
 
     .filters {
-        width: 210px;
-        min-width: 210px;
+        width: 100%;
         background-color: var(--color-bg-1);
         padding: 20px;
-        margin-right: 10px;
         height: calc(100vh - 144px);
         overflow-y: auto;
     }
 
     .alarmList {
-        width: calc(100vw - 246px);
-        min-width: 800px;
+        flex: 1;
+        min-width: 0;
+        margin-left: 10px;
 
         .searchCondition {
             padding: 10px 20px;

--- a/web/src/app/monitor/(pages)/event/alert/page.tsx
+++ b/web/src/app/monitor/(pages)/event/alert/page.tsx
@@ -48,6 +48,7 @@ import alertStyle from './index.module.scss';
 import { LEVEL_MAP } from '@/app/monitor/constants';
 import useMonitorApi from '@/app/monitor/api/index';
 import TreeSelector from '@/app/monitor/components/treeSelector';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import { cloneDeep } from 'lodash';
 const { Search } = Input;
 const { Option } = Select;
@@ -330,6 +331,7 @@ const Alert: React.FC = () => {
           title: item.display_name || '--',
           label: item.name || '--',
           key: item.id,
+          icon: item.icon,
           children: []
         });
         return acc;
@@ -586,15 +588,17 @@ const Alert: React.FC = () => {
   return (
     <div className="w-full">
       <div className={alertStyle.alert}>
-        <div className={alertStyle.filters}>
-          <TreeSelector
-            loading={treeLoading}
-            showAllMenu
-            data={treeData}
-            defaultSelectedKey="all"
-            onNodeSelect={handleObjectChange}
-          />
-        </div>
+        <ResizableSidebar collapseStorageKey="monitor.event.alert.sidebarCollapsed">
+          <div className={alertStyle.filters}>
+            <TreeSelector
+              loading={treeLoading}
+              showAllMenu
+              data={treeData}
+              defaultSelectedKey="all"
+              onNodeSelect={handleObjectChange}
+            />
+          </div>
+        </ResizableSidebar>
         <div className={alertStyle.alarmList}>
           <Tabs activeKey={activeTab} items={tabs} onChange={changeTab} />
           <div className={alertStyle.searchCondition}>

--- a/web/src/app/monitor/(pages)/event/strategy/index.module.scss
+++ b/web/src/app/monitor/(pages)/event/strategy/index.module.scss
@@ -1,10 +1,12 @@
 .asset {
     display: flex;
     overflow: hidden;
+    width: 100%;
 
     .assetTree {
         display: flex;
         flex-direction: column;
+        width: 100%;
         height: calc(100vh - 146px);
         padding: 20px 10px;
         background-color: var(--color-bg-1);
@@ -17,6 +19,8 @@
     }
 
     .table {
+        flex: 1;
+        min-width: 0;
         background: var(--color-bg-1);
         height: calc(100vh - 146px);
         padding: 20px;
@@ -35,7 +39,7 @@
 }
 
 .asset .table :global(.ant-table) {
-    width: calc(100vw - 280px);
+    width: 100%;
 }
 
 .strategy {

--- a/web/src/app/monitor/(pages)/event/strategy/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/page.tsx
@@ -23,6 +23,7 @@ import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { PlusOutlined } from '@ant-design/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
 import TreeSelector from '@/app/monitor/components/treeSelector';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
 
@@ -311,6 +312,7 @@ const Strategy: React.FC = () => {
           title: (item.display_name || '--') + `(${item.policy_count})`,
           label: item.name || '--',
           key: item.id,
+          icon: item.icon,
           children: []
         });
         return acc;
@@ -357,14 +359,16 @@ const Strategy: React.FC = () => {
   return (
     <Spin spinning={treeLoading}>
       <div className={assetStyle.asset}>
-        <div className={assetStyle.assetTree}>
-          <TreeSelector
-            data={treeData}
-            defaultSelectedKey={defaultSelectObj as string}
-            loading={treeLoading}
-            onNodeSelect={handleObjectChange}
-          />
-        </div>
+        <ResizableSidebar collapseStorageKey="monitor.event.strategy.sidebarCollapsed">
+          <div className={assetStyle.assetTree}>
+            <TreeSelector
+              data={treeData}
+              defaultSelectedKey={defaultSelectObj as string}
+              loading={treeLoading}
+              onNodeSelect={handleObjectChange}
+            />
+          </div>
+        </ResizableSidebar>
         <div className={assetStyle.table}>
           <div className={assetStyle.search}>
             <div>

--- a/web/src/app/monitor/(pages)/event/template/index.module.scss
+++ b/web/src/app/monitor/(pages)/event/template/index.module.scss
@@ -1,5 +1,6 @@
 .container {
     display: flex;
+    width: 100%;
     height: calc(100vh - 146px);
     overflow: hidden;
 
@@ -7,7 +8,7 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        width: 200px;
+        width: 100%;
         padding: 20px 10px;
         background-color: var(--color-bg-1);
         overflow-y: auto;
@@ -24,6 +25,7 @@
         padding: 20px;
         margin-left: 10px;
         flex: 1;
+        min-width: 0;
         height: 100%;
         overflow-y: auto;
         padding-bottom: 96px;

--- a/web/src/app/monitor/(pages)/event/template/page.tsx
+++ b/web/src/app/monitor/(pages)/event/template/page.tsx
@@ -11,6 +11,7 @@ import { findLabelById, getIconByObjectName } from '@/app/monitor/utils/common';
 import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { useSearchParams } from 'next/navigation';
 import TreeSelector from '@/app/monitor/components/treeSelector';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import { cloneDeep } from 'lodash';
 import BulkApplyModal from './bulkApplyModal';
 import {
@@ -173,6 +174,7 @@ const Template: React.FC = () => {
           title: item.display_name || '--',
           label: item.name || '--',
           key: item.id,
+          icon: item.icon,
           children: []
         });
         return acc;
@@ -234,14 +236,16 @@ const Template: React.FC = () => {
 
   return (
     <div className={templateStyle.container}>
-      <div className={templateStyle.containerTree}>
-        <TreeSelector
-          data={treeData}
-          defaultSelectedKey={defaultSelectObj as string}
-          loading={treeLoading}
-          onNodeSelect={handleObjectChange}
-        />
-      </div>
+      <ResizableSidebar collapseStorageKey="monitor.event.template.sidebarCollapsed">
+        <div className={templateStyle.containerTree}>
+          <TreeSelector
+            data={treeData}
+            defaultSelectedKey={defaultSelectObj as string}
+            loading={treeLoading}
+            onNodeSelect={handleObjectChange}
+          />
+        </div>
+      </ResizableSidebar>
 
       <div className={templateStyle.table}>
         <div className={templateStyle.toolbar}>

--- a/web/src/app/monitor/(pages)/integration/asset/index.module.scss
+++ b/web/src/app/monitor/(pages)/integration/asset/index.module.scss
@@ -3,8 +3,6 @@
     overflow: hidden;
 
     .tree {
-        width: 210px;
-        min-width: 210px;
         display: flex;
         flex-direction: column;
         height: calc(100vh - 146px);
@@ -19,11 +17,11 @@
     }
 
     .table {
-        width: calc(100vw - 250px);
+        flex: 1;
+        min-width: 0;
         background: var(--color-bg-1);
         height: calc(100vh - 146px);
         padding: 20px;
-        margin-left: 10px;
 
         .search {
             display: flex;

--- a/web/src/app/monitor/(pages)/integration/asset/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/page.tsx
@@ -49,6 +49,7 @@ import Permission from '@/components/permission';
 import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import type { TableProps, MenuProps } from 'antd';
 import { cloneDeep } from 'lodash';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 
 type TableRowSelection<T extends object = object> =
   TableProps<T>['rowSelection'];
@@ -445,8 +446,11 @@ const Asset = () => {
         }
         if (!isDerivativeObject(item, data)) {
           acc[item.type].children.push({
-            title: `${item.display_name || '--'}(${item.instance_count ?? 0})`,
+            title: item.display_name || '--',
+            label: item.name || '--',
             key: item.id,
+            icon: item.icon,
+            count: item.instance_count ?? 0,
             children: []
           });
         }
@@ -503,14 +507,16 @@ const Asset = () => {
 
   return (
     <div className={assetStyle.asset}>
-      <div className={assetStyle.tree}>
-        <TreeSelector
-          data={treeData}
-          defaultSelectedKey={defaultSelectObj as string}
-          onNodeSelect={handleObjectChange}
-          loading={treeLoading}
-        />
-      </div>
+      <ResizableSidebar collapseStorageKey="monitor.integration.asset.sidebarCollapsed">
+        <div className={assetStyle.tree}>
+          <TreeSelector
+            data={treeData}
+            defaultSelectedKey={defaultSelectObj as string}
+            onNodeSelect={handleObjectChange}
+            loading={treeLoading}
+          />
+        </div>
+      </ResizableSidebar>
       <div className={assetStyle.table}>
         <div className={assetStyle.search}>
           <Input

--- a/web/src/app/monitor/(pages)/integration/group/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/group/page.tsx
@@ -218,8 +218,7 @@ const GroupPage = () => {
     try {
       setTreeLoading(type !== 'timer');
       const params = {
-        name: '',
-        add_instance_count: true
+        name: ''
       };
       const data = await getMonitorObject(params);
       setObjects(data);
@@ -244,7 +243,6 @@ const GroupPage = () => {
           title: item.display_name || '--',
           key: item.id,
           icon: item.icon,
-          count: item.instance_count || 0,
           children: []
         });
         return acc;

--- a/web/src/app/monitor/(pages)/integration/group/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/group/page.tsx
@@ -25,6 +25,7 @@ import { showGroupName } from '@/app/monitor/utils/common';
 import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 
 const GroupPage = () => {
   const { isLoading } = useApiClient();
@@ -217,7 +218,8 @@ const GroupPage = () => {
     try {
       setTreeLoading(type !== 'timer');
       const params = {
-        name: ''
+        name: '',
+        add_instance_count: true
       };
       const data = await getMonitorObject(params);
       setObjects(data);
@@ -241,6 +243,8 @@ const GroupPage = () => {
         acc[item.type].children.push({
           title: item.display_name || '--',
           key: item.id,
+          icon: item.icon,
+          count: item.instance_count || 0,
           children: []
         });
         return acc;
@@ -281,17 +285,19 @@ const GroupPage = () => {
   };
 
   return (
-    <div className="flex overflow-hidden">
-      <div className="w-[210px] min-w-[210px] flex flex-col h-[calc(100vh-146px)] overflow-y-auto overflow-x-hidden p-[20px_10px] bg-[var(--color-bg-1)]">
-        <TreeSelector
-          showAllMenu
-          data={treeData}
-          defaultSelectedKey={'all'}
-          onNodeSelect={handleObjectChange}
-          loading={treeLoading}
-        />
-      </div>
-      <div className="w-[calc(100vw-250px)] bg-[var(--color-bg-1)] h-[calc(100vh-146px)] p-[20px] ml-[10px]">
+    <div className="w-full flex overflow-hidden">
+      <ResizableSidebar collapseStorageKey="monitor.integration.group.sidebarCollapsed">
+        <div className="flex flex-col h-[calc(100vh-146px)] overflow-y-auto overflow-x-hidden p-[20px_10px] bg-[var(--color-bg-1)]">
+          <TreeSelector
+            showAllMenu
+            data={treeData}
+            defaultSelectedKey={'all'}
+            onNodeSelect={handleObjectChange}
+            loading={treeLoading}
+          />
+        </div>
+      </ResizableSidebar>
+      <div className="flex-1 min-w-0 bg-[var(--color-bg-1)] h-[calc(100vh-146px)] p-[20px]">
         <div className="flex items-center justify-between mb-[10px]">
           <Input
             allowClear

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -35,6 +35,7 @@ import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { isDerivativeObject } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
 import CreateTemplateModal from './createTemplateModal';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 
 const { confirm } = Modal;
 
@@ -142,7 +143,9 @@ const Integration = () => {
   const getObjects = async () => {
     try {
       setTreeLoading(true);
-      const data: ObjectItem[] = await getMonitorObject();
+      const data: ObjectItem[] = await getMonitorObject({
+        add_instance_count: true
+      });
       const _treeData = getTreeData(cloneDeep(data));
       setTreeData(_treeData);
       setObjects(data);
@@ -166,6 +169,8 @@ const Integration = () => {
             title: item.display_name || '--',
             label: item.name || '--',
             key: item.id,
+            icon: item.icon,
+            count: item.instance_count || 0,
             children: []
           });
         }
@@ -340,22 +345,24 @@ const Integration = () => {
 
   return (
     <div className="w-full flex overflow-hidden">
-      <div className="h-[calc(100vh-146px)] pt-5 px-2.5 pb-2.5 bg-[var(--color-bg-1)] w-[210px] min-w-[210px] mr-2.5 overflow-y-auto">
-        <TreeSelector
-          showAllMenu
-          data={treeData}
-          defaultSelectedKey={
-            searchParams.get('objId')
-              ? Number(searchParams.get('objId'))
-              : 'all'
-          }
-          loading={treeLoading}
-          draggable
-          onNodeSelect={handleObjectChange}
-          onNodeDrag={handleNodeDrag}
-        />
-      </div>
-      <div className="w-full bg-[var(--color-bg-1)] p-5">
+      <ResizableSidebar collapseStorageKey="monitor.integration.list.sidebarCollapsed">
+        <div className="h-[calc(100vh-146px)] pt-5 px-2.5 pb-2.5 bg-[var(--color-bg-1)] overflow-y-auto">
+          <TreeSelector
+            showAllMenu
+            data={treeData}
+            defaultSelectedKey={
+              searchParams.get('objId')
+                ? Number(searchParams.get('objId'))
+                : 'all'
+            }
+            loading={treeLoading}
+            draggable
+            onNodeSelect={handleObjectChange}
+            onNodeDrag={handleNodeDrag}
+          />
+        </div>
+      </ResizableSidebar>
+      <div className="flex-1 min-w-0 bg-[var(--color-bg-1)] p-5">
         <div className="mb-[20px] flex items-start justify-between gap-[16px]">
           <div className="flex flex-1 items-start">
             <Input

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -143,9 +143,7 @@ const Integration = () => {
   const getObjects = async () => {
     try {
       setTreeLoading(true);
-      const data: ObjectItem[] = await getMonitorObject({
-        add_instance_count: true
-      });
+      const data: ObjectItem[] = await getMonitorObject();
       const _treeData = getTreeData(cloneDeep(data));
       setTreeData(_treeData);
       setObjects(data);
@@ -170,7 +168,6 @@ const Integration = () => {
             label: item.name || '--',
             key: item.id,
             icon: item.icon,
-            count: item.instance_count || 0,
             children: []
           });
         }

--- a/web/src/app/monitor/(pages)/integration/object/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/object/page.tsx
@@ -25,6 +25,7 @@ import ObjectModal from './objectModal';
 import DisplayFieldsModal from './displayFieldsModal';
 import useObjectApi from './api';
 import TreeSelector from '@/app/monitor/components/treeSelector';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 
 const ObjectPage = () => {
   const { isLoading } = useApiClient();
@@ -524,31 +525,33 @@ const ObjectPage = () => {
   return (
     <div className="w-full flex overflow-hidden">
       {/* 左侧对象类型列表 */}
-      <div className="h-[calc(100vh-146px)] bg-[var(--color-bg-1)] w-[220px] min-w-[220px] mr-2.5 overflow-hidden flex flex-col">
-        <div className="flex items-center justify-between px-2.5 pt-5 mb-[15px]">
-          <span className="font-semibold">
-            {t('monitor.object.objectType')}
-          </span>
-          <Permission requiredPermissions={['Add']}>
-            <Button
-              size="small"
-              icon={<PlusOutlined />}
-              onClick={() => openTypeModal('add')}
-              title={t('monitor.object.addType')}
+      <ResizableSidebar collapseStorageKey="monitor.integration.object.sidebarCollapsed">
+        <div className="h-[calc(100vh-146px)] bg-[var(--color-bg-1)] overflow-hidden flex flex-col">
+          <div className="flex items-center justify-between px-2.5 pt-5 mb-[15px]">
+            <span className="font-semibold">
+              {t('monitor.object.objectType')}
+            </span>
+            <Permission requiredPermissions={['Add']}>
+              <Button
+                size="small"
+                icon={<PlusOutlined />}
+                onClick={() => openTypeModal('add')}
+                title={t('monitor.object.addType')}
+              />
+            </Permission>
+          </div>
+          <div className="flex-1 overflow-y-auto px-2.5 pb-2.5">
+            <TreeSelector
+              data={treeData}
+              defaultSelectedKey={defaultSelectedKey}
+              loading={typeLoading}
+              draggable
+              onNodeSelect={handleNodeSelect}
+              onNodeDrag={handleNodeDrag}
             />
-          </Permission>
+          </div>
         </div>
-        <div className="flex-1 overflow-y-auto px-2.5 pb-2.5">
-          <TreeSelector
-            data={treeData}
-            defaultSelectedKey={defaultSelectedKey}
-            loading={typeLoading}
-            draggable
-            onNodeSelect={handleNodeSelect}
-            onNodeDrag={handleNodeDrag}
-          />
-        </div>
-      </div>
+      </ResizableSidebar>
 
       {/* 右侧对象列表 */}
       <div className="flex-1 flex flex-col bg-[var(--color-bg-1)] p-5 overflow-hidden">

--- a/web/src/app/monitor/(pages)/view/index.module.scss
+++ b/web/src/app/monitor/(pages)/view/index.module.scss
@@ -5,14 +5,12 @@
         height: calc(100vh - 90px);
         padding: 20px 10px 10px 10px;
         background: var(--color-bg-1);
-        width: 210px;
-        min-width: 210px;
-        margin-right: 10px;
         overflow-y: auto;
     }
 
     .table {
-        width: calc(100vw - 256px);
+        flex: 1;
+        min-width: 0;
         padding: 20px;
         background: var(--color-bg-1);
         height: calc(100vh - 90px);

--- a/web/src/app/monitor/(pages)/view/page.tsx
+++ b/web/src/app/monitor/(pages)/view/page.tsx
@@ -9,6 +9,7 @@ import viewStyle from './index.module.scss';
 import TreeSelector from '@/app/monitor/components/treeSelector';
 import ViewList from './viewList';
 import ViewHive from './viewHive';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import { cloneDeep } from 'lodash';
 
 const Integration = () => {
@@ -90,14 +91,16 @@ const Integration = () => {
 
   return (
     <div className={`${viewStyle.view} w-full`}>
-      <div className={viewStyle.tree}>
-        <TreeSelector
-          data={treeData}
-          defaultSelectedKey={defaultSelectObj as string}
-          loading={treeLoading}
-          onNodeSelect={handleObjectChange}
-        />
-      </div>
+      <ResizableSidebar collapseStorageKey="monitor.view.sidebarCollapsed">
+        <div className={viewStyle.tree}>
+          <TreeSelector
+            data={treeData}
+            defaultSelectedKey={defaultSelectObj as string}
+            loading={treeLoading}
+            onNodeSelect={handleObjectChange}
+          />
+        </div>
+      </ResizableSidebar>
       <div className={viewStyle.table}>
         {showTab && (
           <Segmented

--- a/web/src/app/monitor/(pages)/view/page.tsx
+++ b/web/src/app/monitor/(pages)/view/page.tsx
@@ -67,9 +67,11 @@ const Integration = () => {
         };
       }
       acc[item.type].children.push({
-        title: (item.display_name || '--') + `(${item.instance_count || 0})`,
+        title: item.display_name || '--',
         label: item.name || '--',
         key: item.id,
+        icon: item.icon,
+        count: item.instance_count || 0,
         children: [],
       });
       return acc;

--- a/web/src/app/monitor/components/objectIcon/index.tsx
+++ b/web/src/app/monitor/components/objectIcon/index.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+
+// 监控对象图标的统一渲染入口。图标名优先取后端对象的 `icon` 字段(与集成对象页一致),
+// 缺省/加载失败时回退到默认图标。视图左侧树、仪表盘侧边栏等共用此组件,保证全站对象图标一致。
+// 用原生 <img>(与集成对象页同款约定):本地 SVG 矢量图无需 next/image 优化,且可避免其
+// 「flex 布局下仅一个维度被修改」的宽高比告警;object-fit: contain 保证非正方形图标不变形。
+export const DEFAULT_OBJECT_ICON = 'cc-default_默认';
+
+interface ObjectIconProps {
+  icon?: string;
+  fallback?: string;
+  size?: number;
+  className?: string;
+}
+
+export const ObjectIcon: React.FC<ObjectIconProps> = ({
+  icon,
+  fallback = DEFAULT_OBJECT_ICON,
+  size = 16,
+  className
+}) => {
+  const src = `/assets/icons/${icon || fallback}.svg`;
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={src}
+      alt={icon || fallback}
+      width={size}
+      height={size}
+      className={className}
+      style={{ width: size, height: size, objectFit: 'contain', flexShrink: 0 }}
+      onError={(e) => {
+        const img = e.currentTarget;
+        if (!img.src.endsWith(`/assets/icons/${fallback}.svg`)) {
+          img.src = `/assets/icons/${fallback}.svg`;
+        }
+      }}
+    />
+  );
+};
+
+export default ObjectIcon;

--- a/web/src/app/monitor/components/resizableSidebar/clamp.ts
+++ b/web/src/app/monitor/components/resizableSidebar/clamp.ts
@@ -1,0 +1,10 @@
+// Clamp a sidebar width into [min, max]; NaN/invalid → fallback.
+export const clampWidth = (
+  value: number,
+  min: number,
+  max: number,
+  fallback: number
+): number => {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(value)));
+};

--- a/web/src/app/monitor/components/resizableSidebar/index.module.scss
+++ b/web/src/app/monitor/components/resizableSidebar/index.module.scss
@@ -1,0 +1,78 @@
+.wrap {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  height: 100%;
+}
+
+.panel {
+  height: 100%;
+  overflow: hidden;
+  transition: width 0.2s ease;
+}
+
+.inner {
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}
+
+.collapsed .inner {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+  touch-action: none;
+}
+
+.handle::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 2px;
+  width: 1px;
+  height: 100%;
+  background: var(--color-border-2, #e5e6eb);
+  transition: background 0.2s;
+}
+
+.handle:hover::after,
+.dragging .handle::after {
+  background: var(--color-primary-6, #165dff);
+}
+
+.collapsed .handle {
+  display: none;
+}
+
+.toggle {
+  position: absolute;
+  top: 50%;
+  right: -13px;
+  transform: translateY(-50%);
+  z-index: 11;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-2, #d6e0ee);
+  background: var(--color-bg-1, #fff);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 10px;
+  color: var(--color-text-3, #6b809b);
+  box-shadow: 0 4px 12px rgba(32, 55, 93, 0.12);
+}
+
+.toggle:hover {
+  color: var(--color-primary-6, #165dff);
+}

--- a/web/src/app/monitor/components/resizableSidebar/index.tsx
+++ b/web/src/app/monitor/components/resizableSidebar/index.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { clampWidth } from './clamp';
+import styles from './index.module.scss';
+
+interface ResizableSidebarProps {
+  storageKey?: string;
+  collapseStorageKey?: string;
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+  collapsible?: boolean;
+  children: React.ReactNode;
+}
+
+const readNumber = (key: string, fallback: number): number => {
+  if (typeof window === 'undefined') return fallback;
+  const raw = window.localStorage.getItem(key);
+  const n = raw == null ? NaN : Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const readBool = (key: string): boolean => {
+  if (typeof window === 'undefined') return false;
+  return window.localStorage.getItem(key) === '1';
+};
+
+export const ResizableSidebar: React.FC<ResizableSidebarProps> = ({
+  storageKey = 'monitor.objectTree.width',
+  collapseStorageKey,
+  defaultWidth = 216,
+  minWidth = 180,
+  maxWidth = 480,
+  collapsible = true,
+  children
+}) => {
+  const [width, setWidth] = useState(defaultWidth);
+  const [collapsed, setCollapsed] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    setWidth(clampWidth(readNumber(storageKey, defaultWidth), minWidth, maxWidth, defaultWidth));
+    if (collapseStorageKey) setCollapsed(readBool(collapseStorageKey));
+  }, [storageKey, collapseStorageKey, defaultWidth, minWidth, maxWidth]);
+
+  const onMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!dragRef.current) return;
+      const next = clampWidth(
+        dragRef.current.startWidth + (e.clientX - dragRef.current.startX),
+        minWidth,
+        maxWidth,
+        defaultWidth
+      );
+      setWidth(next);
+    },
+    [minWidth, maxWidth, defaultWidth]
+  );
+
+  const onMouseUp = useCallback(() => {
+    dragRef.current = null;
+    setDragging(false);
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    setWidth((w) => {
+      if (typeof window !== 'undefined') window.localStorage.setItem(storageKey, String(w));
+      return w;
+    });
+  }, [onMouseMove, storageKey]);
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      dragRef.current = { startX: e.clientX, startWidth: width };
+      setDragging(true);
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    },
+    [width, onMouseMove, onMouseUp]
+  );
+
+  useEffect(() => {
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [onMouseMove, onMouseUp]);
+
+  const toggleCollapsed = () => {
+    setCollapsed((c) => {
+      const next = !c;
+      if (collapseStorageKey && typeof window !== 'undefined') {
+        window.localStorage.setItem(collapseStorageKey, next ? '1' : '0');
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className={`${styles.wrap} ${dragging ? styles.dragging : ''} ${collapsed ? styles.collapsed : ''}`}>
+      <div className={styles.panel} style={{ width: collapsed ? 0 : width }}>
+        <div className={styles.inner}>{children}</div>
+      </div>
+      {!collapsed && <div className={styles.handle} onMouseDown={onMouseDown} />}
+      {collapsible && (
+        <div className={styles.toggle} onClick={toggleCollapsed}>
+          {collapsed ? <RightOutlined /> : <LeftOutlined />}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResizableSidebar;

--- a/web/src/app/monitor/components/treeSelector/index.module.scss
+++ b/web/src/app/monitor/components/treeSelector/index.module.scss
@@ -1,0 +1,55 @@
+// 仅对带 meta(图标/计数)的叶子节点撑满整行,使标签可截断、计数右对齐且不被裁掉;
+// 用稳定的全局标记类 .treeMetaNode(由 renderTitle 直接加在节点上,非 CSS Module 哈希类)
+// 配合 :has() 精确限定作用域,既不影响集成/事件等纯文本节点,又避免「:global() 外的局部类
+// 在 :has() 中不被哈希」导致选择器整体失配(长名称如 Elasticsearch 不截断、计数被裁)的坑。
+// 把带 meta 的整行约束到容器宽度,否则 Ant 的 treenode 行会按内容撑宽(缩进 + 长名称 + 计数)
+// 超出左栏,导致 flex:1 无可压缩空间、标签不截断、计数被裁。仅作用于 meta 行(:has),不影响其它页面。
+.treeWrap :global(.ant-tree-treenode:has(.treeMetaNode)) {
+  width: 100%;
+}
+
+.treeWrap :global(.ant-tree-node-content-wrapper:has(.treeMetaNode)) {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+
+// Ant 在 wrapper 与我们的 .node 之间还有一层 .ant-tree-title(默认按内容宽度,不收缩),
+// 必须让它也成为可收缩的 flex 项,标签的 ellipsis 才会生效、计数才不被挤出。
+.treeWrap :global(.ant-tree-node-content-wrapper:has(.treeMetaNode) .ant-tree-title) {
+  flex: 1;
+  min-width: 0;
+}
+
+.node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  // 末尾留白,避免计数徽标紧贴节点右边缘被裁切
+  padding-right: 4px;
+}
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.count {
+  flex-shrink: 0;
+  margin-left: 8px;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-3, #86909c);
+}

--- a/web/src/app/monitor/components/treeSelector/index.module.scss
+++ b/web/src/app/monitor/components/treeSelector/index.module.scss
@@ -42,6 +42,12 @@
   flex: 1;
   min-width: 0;
   overflow: hidden;
+}
+
+// EllipsisWithTooltip 的内层 div 自身需要截断样式,否则它测不出溢出(tooltip 不触发)、
+// 且丢失「…」省略号。给它 nowrap+ellipsis 才能正确截断并触发悬浮全名。
+.ellipsis {
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/web/src/app/monitor/components/treeSelector/index.tsx
+++ b/web/src/app/monitor/components/treeSelector/index.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from '@/utils/i18n';
 import type { TreeProps, TreeDataNode } from 'antd';
 import { cloneDeep } from 'lodash';
 import ObjectIcon from '@/app/monitor/components/objectIcon';
+import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import styles from './index.module.scss';
 
 const { Search } = Input;
@@ -230,7 +231,12 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
         <span className={styles.icon}>
           <ObjectIcon icon={item.icon} />
         </span>
-        <span className={styles.label}>{item.title}</span>
+        <span className={styles.label}>
+          <EllipsisWithTooltip
+            className={styles.ellipsis}
+            text={typeof item.title === 'string' ? item.title : ''}
+          />
+        </span>
         {item.count != null ? (
           <span className={styles.count}>{item.count}</span>
         ) : null}

--- a/web/src/app/monitor/components/treeSelector/index.tsx
+++ b/web/src/app/monitor/components/treeSelector/index.tsx
@@ -4,6 +4,8 @@ import { TreeItem, TableDataItem, TreeSortData } from '@/app/monitor/types';
 import { useTranslation } from '@/utils/i18n';
 import type { TreeProps, TreeDataNode } from 'antd';
 import { cloneDeep } from 'lodash';
+import ObjectIcon from '@/app/monitor/components/objectIcon';
+import styles from './index.module.scss';
 
 const { Search } = Input;
 
@@ -216,6 +218,26 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
     onNodeDrag && onNodeDrag(getTreeSortData(_data), _data);
   };
 
+  // 叶子节点带 icon/count 时渲染「图标 + 标签 + 计数徽标」,否则按纯文本(向后兼容既有调用方)。
+  const renderTitle = (node: TreeDataNode) => {
+    const item = node as unknown as TreeItem;
+    const hasMeta = !!item.icon || item.count != null;
+    if (!hasMeta) {
+      return <span>{item.title}</span>;
+    }
+    return (
+      <span className={`${styles.node} treeMetaNode`}>
+        <span className={styles.icon}>
+          <ObjectIcon icon={item.icon} />
+        </span>
+        <span className={styles.label}>{item.title}</span>
+        {item.count != null ? (
+          <span className={styles.count}>{item.count}</span>
+        ) : null}
+      </span>
+    );
+  };
+
   const getTreeSortData = (data: any[]) => {
     return data.map((item) => {
       return {
@@ -239,16 +261,19 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
           onSearch={handleSearchTree}
         />
         {treeData.length ? (
-          <Tree
-            showLine
-            draggable={draggable}
-            selectedKeys={selectedKeys}
-            expandedKeys={expandedKeys}
-            treeData={treeData}
-            onExpand={(keys) => setExpandedKeys(keys)}
-            onSelect={handleSelect}
-            onDrop={onDrop}
-          />
+          <div className={styles.treeWrap}>
+            <Tree
+              showLine
+              draggable={draggable}
+              selectedKeys={selectedKeys}
+              expandedKeys={expandedKeys}
+              treeData={treeData}
+              titleRender={renderTitle}
+              onExpand={(keys) => setExpandedKeys(keys)}
+              onSelect={handleSelect}
+              onDrop={onDrop}
+            />
+          </div>
         ) : (
           <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
         )}

--- a/web/src/app/monitor/components/treeSelector/index.tsx
+++ b/web/src/app/monitor/components/treeSelector/index.tsx
@@ -232,10 +232,11 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
           <ObjectIcon icon={item.icon} />
         </span>
         <span className={styles.label}>
-          <EllipsisWithTooltip
-            className={styles.ellipsis}
-            text={typeof item.title === 'string' ? item.title : ''}
-          />
+          {typeof item.title === 'string' ? (
+            <EllipsisWithTooltip className={styles.ellipsis} text={item.title} />
+          ) : (
+            item.title
+          )}
         </span>
         {item.count != null ? (
           <span className={styles.count}>{item.count}</span>

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.module.scss
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.module.scss
@@ -4,6 +4,8 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+  // 外壳本身透明,补回侧边栏底色,避免树列表透出页面背景、与其它树页面(白底)不一致
+  background: var(--color-bg-1);
 }
 
 .searchBox {

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.module.scss
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.module.scss
@@ -1,36 +1,9 @@
-.sidebar {
-  position: relative;
-  width: 216px;
-  min-width: 216px;
-  height: 100%;
-  border-right: 1px solid var(--color-border-1, #e5e6eb);
-  background:
-    linear-gradient(180deg, rgba(247, 250, 255, 0.98) 0%, rgba(255, 255, 255, 0.98) 100%),
-    var(--color-bg-1, #fff);
-  transition: width 0.3s ease, min-width 0.3s ease;
-  display: flex;
-  flex-direction: column;
-  flex-shrink: 0;
-
-  &.collapsed {
-    width: 0;
-    min-width: 0;
-    border-right: none;
-  }
-}
-
 .sidebarInner {
   display: flex;
   flex-direction: column;
-  width: 216px;
+  width: 100%;
   height: 100%;
   overflow: hidden;
-  transition: opacity 0.2s ease;
-
-  .collapsed & {
-    opacity: 0;
-    pointer-events: none;
-  }
 }
 
 .searchBox {
@@ -188,32 +161,6 @@
   font-weight: inherit;
 }
 
-.toggleBtn {
-  position: absolute;
-  top: 50%;
-  right: -13px;
-  transform: translateY(-50%);
-  z-index: 10;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  border: 1px solid rgba(214, 224, 238, 0.96);
-  background: linear-gradient(180deg, #ffffff 0%, #f4f8ff 100%);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 10px;
-  color: #6b809b;
-  transition: color 0.2s, box-shadow 0.2s, transform 0.2s;
-  box-shadow: 0 8px 18px rgba(32, 55, 93, 0.12);
-
-  &:hover {
-    color: var(--color-primary-6, #165dff);
-    box-shadow: 0 10px 22px rgba(28, 74, 150, 0.16);
-  }
-}
-
 .layout {
   display: flex;
   // 绑定到视口可用高度,使 sidebar 与 content 各自独立滚动、整页 body 不滚动。
@@ -231,21 +178,7 @@
   min-width: 0;
 }
 
-@media (max-width: 1200px) {
-  .sidebar,
-  .sidebarInner {
-    width: 200px;
-    min-width: 200px;
-  }
-}
-
 @media (max-width: 768px) {
-  .sidebar,
-  .sidebarInner {
-    width: 188px;
-    min-width: 188px;
-  }
-
   .searchBox {
     padding: 12px 10px 10px;
   }
@@ -257,13 +190,6 @@
   .item {
     padding: 8px 10px 8px 0;
   }
-}
-
-:global(html.dark) .sidebar {
-  border-right-color: rgba(54, 74, 100, 0.88);
-  background:
-    linear-gradient(180deg, rgba(11, 21, 34, 0.98) 0%, rgba(13, 25, 40, 0.98) 100%),
-    #0d1828;
 }
 
 :global(html.dark) .searchBox {
@@ -280,8 +206,7 @@
 :global(html.dark) .searchInput :global(.ant-input),
 :global(html.dark) .searchInput :global(.ant-input::placeholder),
 :global(html.dark) .groupHeader,
-:global(html.dark) .item,
-:global(html.dark) .toggleBtn {
+:global(html.dark) .item {
   color: #b8c7da;
 }
 
@@ -308,10 +233,4 @@
   color: #dce8ff;
   background: linear-gradient(90deg, rgba(34, 68, 121, 0.92) 0%, rgba(24, 45, 78, 0.82) 100%);
   box-shadow: inset 0 0 0 1px rgba(118, 160, 255, 0.18);
-}
-
-:global(html.dark) .toggleBtn {
-  border-color: rgba(55, 75, 101, 0.96);
-  background: linear-gradient(180deg, #142235 0%, #101a29 100%);
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
 }

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
@@ -3,10 +3,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Input } from 'antd';
 import { DownOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { PROFESSIONAL_DASHBOARDS, PROFESSIONAL_DASHBOARD_GROUPS } from '../registry';
 import { normalizeDashboardKey } from '../shared/utils';
+import ObjectIcon from '@/app/monitor/components/objectIcon';
 import styles from './dashboard-sidebar.module.scss';
 
 interface DashboardSidebarProps {
@@ -34,22 +34,6 @@ const ICON_MAP: Record<string, string> = {
 };
 
 const DEFAULT_ICON = 'mm-middleware_中间件';
-
-const ObjectIcon = ({ iconKey }: { iconKey: string }) => {
-  const [failed, setFailed] = useState(false);
-  const resolvedKey = failed ? DEFAULT_ICON : iconKey;
-
-  return (
-    <Image
-      src={`/assets/icons/${resolvedKey}.svg`}
-      alt={resolvedKey}
-      width={16}
-      height={16}
-      style={{ flexShrink: 0 }}
-      onError={() => setFailed(true)}
-    />
-  );
-};
 
 export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) => {
   const [collapsed, setCollapsed] = useState(false);
@@ -159,7 +143,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
                       >
                         <span className={styles.itemBranch} />
                         <span className={styles.itemIcon}>
-                          <ObjectIcon iconKey={item.iconKey} />
+                          <ObjectIcon icon={item.iconKey} fallback={DEFAULT_ICON} />
                         </span>
                         <span className={styles.itemLabel}>{item.label}</span>
                       </button>

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
@@ -2,11 +2,12 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import { Input } from 'antd';
-import { DownOutlined, LeftOutlined, RightOutlined } from '@ant-design/icons';
+import { DownOutlined } from '@ant-design/icons';
 import { useRouter } from 'next/navigation';
 import { PROFESSIONAL_DASHBOARDS, PROFESSIONAL_DASHBOARD_GROUPS } from '../registry';
 import { normalizeDashboardKey } from '../shared/utils';
 import ObjectIcon from '@/app/monitor/components/objectIcon';
+import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import styles from './dashboard-sidebar.module.scss';
 
 interface DashboardSidebarProps {
@@ -36,7 +37,6 @@ const ICON_MAP: Record<string, string> = {
 const DEFAULT_ICON = 'mm-middleware_中间件';
 
 export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) => {
-  const [collapsed, setCollapsed] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
   const router = useRouter();
@@ -106,7 +106,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
   const normalizedCurrent = normalizeDashboardKey(currentObjectKey);
 
   return (
-    <div className={`${styles.sidebar} ${collapsed ? styles.collapsed : ''}`}>
+    <ResizableSidebar collapseStorageKey="monitor.dashboard.sidebarCollapsed">
       <div className={styles.sidebarInner}>
         <div className={styles.searchBox}>
           <Input.Search
@@ -155,9 +155,6 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
           })}
         </div>
       </div>
-      <div className={styles.toggleBtn} onClick={() => setCollapsed(!collapsed)}>
-        {collapsed ? <RightOutlined /> : <LeftOutlined />}
-      </div>
-    </div>
+    </ResizableSidebar>
   );
 };

--- a/web/src/app/monitor/types/index.ts
+++ b/web/src/app/monitor/types/index.ts
@@ -53,6 +53,10 @@ export interface TreeItem {
   title: React.ReactElement | string;
   key: string | number;
   label?: string;
+  // 叶子节点可选:对象图标名(后端 icon 字段)与实例计数;由 treeSelector 渲染为图标+计数徽标。
+  // 不传则按纯文本渲染(向后兼容既有调用方)。
+  icon?: string;
+  count?: number;
   children: TreeItem[];
 }
 
@@ -211,6 +215,8 @@ export interface ObjectItem {
   collector?: string;
   collect_type?: string;
   display_type?: string;
+  icon?: string;
+  instance_count?: number;
   display_fields?: { name: string; sort_order: number; metrics: { plugin: string; metric: string }[] }[];
   options?: ObjectItem[];
   label?: string;


### PR DESCRIPTION
## Summary

Unifies the monitor "object tree" left sidebar across all four areas (视图 / 仪表盘 / 事件 / 集成) into one consistent, resizable shell, and fixes long-name occlusion.

Previously the same object tree was rendered several different ways: the view/event/integration pages used the shared Ant-Tree `treeSelector` (plain text, fixed width), while the dashboard used a bespoke sidebar — inconsistent look, and long object names (e.g. multiple `Sangfor…`) were truncated with no way to read them.

## What changed

- **New shared shell `ResizableSidebar`** (`monitor/components/resizableSidebar`): drag-to-resize via a right-edge handle, width persisted to localStorage, and a collapse toggle. Width is shared across the object-tree sidebars (`monitor.objectTree.width`); collapse state is remembered per page.
- **`treeSelector`** now renders an optional leaf **icon** + right-aligned **count badge**, and shows the **full name in a tooltip** when truncated (`EllipsisWithTooltip`). Nodes without icon/count stay plain text, so the 8 existing consumers are unaffected; drag-sort/search/`showAllMenu` preserved. Truncation layout is scoped to meta rows via a `:has(.treeMetaNode)` marker.
- **Shared `ObjectIcon`** component (single source for object-icon rendering; backend `icon` field + fallback).
- **Per area:**
  - 视图: icons + instance count + resizable shell.
  - 集成: icons + resizable shell on all tabs; instance **count only on 资产** (where instances are actually listed) — counts were intentionally dropped on the 接入/分组 tabs to avoid mismatching the template/rule panels there.
  - 事件: icons + resizable shell, no counts; "全部" node kept.
  - 仪表盘: reuses the shell (drag/collapse/memory) while keeping its router navigation; sidebar background restored for consistency.

## Verification

No web unit-test runner in this project (lint + type-check are the gates). Verified live in a running dev instance across all pages:
- drag-resize + width persistence + collapse work; long names truncate with a full-name tooltip and the count is no longer clipped;
- integration drag-sort intact; event pages show icons and no counts; dashboard navigation + icons intact; no new console warnings.
- `pnpm lint` clean on changed files; `pnpm type-check` clean for `monitor/*` (pre-existing `log/`+`opspilot/` missing-dependency errors are unrelated).

Scoped to `web/src/app/monitor/*` only.