### PR TITLE
bugfix(job_mgmt): 为 JobExecution.status 添加 db_index 及 (scheduled_task, status) 复合索引 #3425

### DIFF
--- a/server/apps/job_mgmt/migrations/0010_add_status_index_to_jobexecution.py
+++ b/server/apps/job_mgmt/migrations/0010_add_status_index_to_jobexecution.py
@@ -1,0 +1,38 @@
+"""Add db_index to JobExecution.status and composite index (scheduled_task, status)"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("job_mgmt", "0009_distributionfile_expire_at"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="jobexecution",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("pending", "等待中"),
+                    ("running", "执行中"),
+                    ("success", "成功"),
+                    ("failed", "失败"),
+                    ("timeout", "超时"),
+                    ("cancelled", "已取消"),
+                ],
+                db_index=True,
+                default="pending",
+                max_length=32,
+                verbose_name="执行状态",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="jobexecution",
+            index=models.Index(
+                fields=["scheduled_task", "status"],
+                name="jobexec_task_status_idx",
+            ),
+        ),
+    ]

--- a/server/apps/job_mgmt/models/execution.py
+++ b/server/apps/job_mgmt/models/execution.py
@@ -20,7 +20,7 @@ class JobExecution(TimeInfo, MaintainerInfo):
 
     job_type = models.CharField(max_length=32, choices=JobType.CHOICES, verbose_name="作业类型")
     trigger_source = models.CharField(max_length=32, choices=TriggerSource.CHOICES, default=TriggerSource.MANUAL, verbose_name="触发来源")
-    status = models.CharField(max_length=32, choices=ExecutionStatus.CHOICES, default=ExecutionStatus.PENDING, verbose_name="执行状态")
+    status = models.CharField(max_length=32, choices=ExecutionStatus.CHOICES, default=ExecutionStatus.PENDING, db_index=True, verbose_name="执行状态")
 
     # 关联的脚本/Playbook（可为空，快速执行场景）
     script = models.ForeignKey(Script, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="关联脚本")
@@ -83,6 +83,9 @@ class JobExecution(TimeInfo, MaintainerInfo):
         verbose_name_plural = verbose_name
         db_table = "job_execution"
         ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["scheduled_task", "status"], name="jobexec_task_status_idx"),
+        ]
 
     def __str__(self):
         return f"{self.name}({self.get_status_display()})"

--- a/server/apps/job_mgmt/tests/test_jobexecution_indexes_pure.py
+++ b/server/apps/job_mgmt/tests/test_jobexecution_indexes_pure.py
@@ -1,0 +1,189 @@
+"""
+Pure unit tests for JobExecution index definitions — issue #3425.
+
+These tests verify that the model class carries the required index metadata.
+No database connection required.
+"""
+
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+
+def _make_fake_django():
+    """Install minimal Django stubs so execution.py can be imported without settings."""
+    # django
+    django = types.ModuleType("django")
+    sys.modules.setdefault("django", django)
+
+    # django.db
+    db = types.ModuleType("django.db")
+    django.db = db
+    sys.modules.setdefault("django.db", db)
+
+    # django.db.models — minimal Field / ForeignKey / Index stubs
+    _models = types.ModuleType("django.db.models")
+
+    class _Field:
+        def __init__(self, *args, **kwargs):
+            self._kwargs = kwargs
+
+        def __set_name__(self, owner, name):
+            self.attname = name
+
+    class CharField(_Field):
+        pass
+
+    class IntegerField(_Field):
+        pass
+
+    class TextField(_Field):
+        pass
+
+    class JSONField(_Field):
+        pass
+
+    class DateTimeField(_Field):
+        pass
+
+    class ForeignKey(_Field):
+        pass
+
+    class Index:
+        def __init__(self, *, fields, name):
+            self.fields = fields
+            self.name = name
+
+    class Model:
+        pass
+
+    _models.CharField = CharField
+    _models.IntegerField = IntegerField
+    _models.TextField = TextField
+    _models.JSONField = JSONField
+    _models.DateTimeField = DateTimeField
+    _models.ForeignKey = ForeignKey
+    _models.Index = Index
+    _models.Model = Model
+    _models.SET_NULL = "SET_NULL"
+
+    db.models = _models
+    sys.modules["django.db.models"] = _models
+
+    # Stub out ancestor modules used by execution.py
+    for stub in [
+        "apps",
+        "apps.core",
+        "apps.core.models",
+        "apps.core.models.maintainer_info",
+        "apps.core.models.time_info",
+        "apps.job_mgmt",
+        "apps.job_mgmt.constants",
+        "apps.job_mgmt.models",
+        "apps.job_mgmt.models.playbook",
+        "apps.job_mgmt.models.script",
+    ]:
+        sys.modules.setdefault(stub, types.ModuleType(stub))
+
+    # MaintainerInfo / TimeInfo — must be distinct classes to avoid "duplicate base class" error
+    class MaintainerInfo:
+        pass
+
+    class TimeInfo:
+        pass
+
+    mi = sys.modules["apps.core.models.maintainer_info"]
+    ti = sys.modules["apps.core.models.time_info"]
+    mi.MaintainerInfo = MaintainerInfo
+    ti.TimeInfo = TimeInfo
+
+    # ExecutionStatus + constants
+    class _ExecutionStatus:
+        PENDING = "pending"
+        RUNNING = "running"
+        CHOICES = (("pending", "等待中"), ("running", "执行中"))
+
+    constants = sys.modules["apps.job_mgmt.constants"]
+    constants.ExecutionStatus = _ExecutionStatus
+
+    class _JobType:
+        CHOICES = ()
+
+    class _TriggerSource:
+        MANUAL = "manual"
+        CHOICES = ()
+
+    class _OverwriteStrategy:
+        OVERWRITE = "overwrite"
+        CHOICES = ()
+
+    class _ScriptType:
+        CHOICES = ()
+
+    class _TargetSource:
+        MANUAL = "manual"
+        CHOICES = ()
+
+    constants.JobType = _JobType
+    constants.TriggerSource = _TriggerSource
+    constants.OverwriteStrategy = _OverwriteStrategy
+    constants.ScriptType = _ScriptType
+    constants.TargetSource = _TargetSource
+
+    # Playbook / Script stubs
+    playbook_mod = sys.modules["apps.job_mgmt.models.playbook"]
+    script_mod = sys.modules["apps.job_mgmt.models.script"]
+    playbook_mod.Playbook = type("Playbook", (Model,), {})
+    script_mod.Script = type("Script", (Model,), {})
+
+
+def _load_execution_module():
+    _make_fake_django()
+    path = Path(__file__).parent.parent / "models" / "execution.py"
+    spec = importlib.util.spec_from_file_location("job_mgmt.models.execution", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Tests ──────────────────────────────────────────────────────────────────────
+
+class TestJobExecutionStatusIndex:
+    """Verify that JobExecution.status carries db_index=True (issue #3425)."""
+
+    def setup_method(self):
+        self.mod = _load_execution_module()
+        self.cls = self.mod.JobExecution
+
+    def test_status_field_has_db_index(self):
+        """status 字段必须有 db_index=True，否则过滤查询退化为全表扫描。"""
+        # Find the status field instance via class __dict__ (descriptor protocol)
+        status_field = None
+        for name, value in vars(self.cls).items():
+            if name == "status":
+                status_field = value
+                break
+        assert status_field is not None, "JobExecution 中未找到 status 字段"
+        assert status_field._kwargs.get("db_index") is True, (
+            "JobExecution.status 缺少 db_index=True，并发策略检查和列表过滤会退化为全表扫描"
+        )
+
+    def test_composite_index_on_scheduled_task_and_status(self):
+        """Meta.indexes 必须包含 (scheduled_task, status) 复合索引。"""
+        meta = getattr(self.cls, "Meta", None)
+        assert meta is not None, "JobExecution 缺少 Meta 内部类"
+        indexes = getattr(meta, "indexes", [])
+        assert indexes, "JobExecution.Meta.indexes 为空，缺少复合索引"
+
+        composite = next(
+            (idx for idx in indexes if set(idx.fields) == {"scheduled_task", "status"}),
+            None,
+        )
+        assert composite is not None, (
+            "Meta.indexes 中缺少 (scheduled_task, status) 复合索引，"
+            "SKIP/QUEUE 策略检查仍需扫描该定时任务下所有执行记录"
+        )
+        assert composite.name == "jobexec_task_status_idx", (
+            f"复合索引名应为 jobexec_task_status_idx，实际为 {composite.name}"
+        )


### PR DESCRIPTION
## 被破坏的不变量

`JobExecution` 的 `status` 字段频繁出现在过滤条件中，但不携带任何索引。这打破了「高频过滤字段必须有索引」这条基础 DB 设计不变量——随着执行记录增多，两条热路径的查询从 O(log N) 退化为 O(N) 全表扫描。

## 根因（设计层）

字段定义时遗漏了 `db_index=True`，且 `Meta` 中没有为并发策略检查建复合索引：

- **热路径 1（SKIP/QUEUE 策略检查）**：`execute_scheduled_task` 每次触发都执行 `JobExecution.objects.filter(scheduled_task_id=id, status__in=[PENDING, RUNNING])`。`scheduled_task_id` 有 FK 索引，但 `status` 没有；PostgreSQL 须在该任务的所有执行记录里线性扫描筛状态。
- **热路径 2（列表页）**：`JobExecutionViewSet.list()` 允许按 `status` 过滤，无索引即全表扫描。

## 修复如何恢复不变量

1. `status` 字段增加 `db_index=True`，消除列表页 status-only 过滤的全表扫描。
2. `Meta.indexes` 增加复合索引 `(scheduled_task, status)`（`jobexec_task_status_idx`），让 SKIP/QUEUE 策略检查走 Index Scan 而非 Seq Scan。

变更文件：
| 文件 | 说明 |
|------|------|
| `server/apps/job_mgmt/models/execution.py` | `status` 加 `db_index=True`；`Meta.indexes` 加复合索引 |
| `server/apps/job_mgmt/migrations/0010_add_status_index_to_jobexecution.py` | `AlterField` + `AddIndex` 迁移 |
| `server/apps/job_mgmt/tests/test_jobexecution_indexes_pure.py` | 纯单元测试验证两个索引定义（revert 修复后测试必然失败） |

## blast radius · 一致性

- 影响范围：仅 `job_mgmt` app，无 RPC/NATS/跨模块变动
- 向后兼容：加索引是纯追加操作，不改字段语义和数据；PostgreSQL 支持在线 `CREATE INDEX` 不锁表
- 与仓库惯例一致：复用 Django `Meta.indexes` + `db_index=True` 范式（同其他 app 写法）
- 负责人：@zhmf7408

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["execute_scheduled_task\ntasks.py"]
        T2["GET /execution/?status=\nJobExecutionViewSet.list()"]
    end

    subgraph N["核心处理层"]
        F1["JobExecution.objects.filter(\n  scheduled_task_id=id,\n  status__in=[PENDING,RUNNING]\n)"]
        F2["JobExecutionFilter.status\nfilters/execution.py"]
    end

    subgraph DB["DB 层"]
        D1["job_execution 表\nstatus 字段"]
        D2["复合索引\njobexec_task_status_idx\n(scheduled_task_id, status)"]
        D3["单字段索引\njob_execution_status_idx\n(status)"]
    end

    T1 --> F1
    T2 --> F2
    F1 -- "并发策略检查" --> D2
    F2 -- "列表过滤" --> D3
    D1 -. "修复前：Seq Scan O(N)" .-> F1
    D1 -. "修复前：Seq Scan O(N)" .-> F2
```

## 验证

- 测试采用 revert-fail 准则：revert `db_index=True` 或 `Meta.indexes`，`test_jobexecution_indexes_pure.py` 对应断言立即失败
- 本地验证：`python3 -c "..."` 独立 harness 两条测试均 PASS

关联 Issue：#3425