### PR TITLE
bugfix: 为危险规则检查添加缓存，消除高频执行路径无效 DB 压力 #3423

### DIFF
--- a/server/apps/job_mgmt/apps.py
+++ b/server/apps/job_mgmt/apps.py
@@ -8,3 +8,4 @@ class JobMgmtConfig(AppConfig):
 
     def ready(self):
         import apps.job_mgmt.nats_api  # noqa
+        import apps.job_mgmt.signals  # noqa

--- a/server/apps/job_mgmt/services/dangerous_checker.py
+++ b/server/apps/job_mgmt/services/dangerous_checker.py
@@ -10,7 +10,7 @@ from apps.core.logger import job_logger as logger
 from apps.job_mgmt.constants import DangerousLevel, MatchType
 from apps.job_mgmt.models import DangerousPath, DangerousRule
 
-# 规则缓存 TTL（秒），可通过环境变量覆盖；默认 120s
+# 规则缓存 TTL（秒），进程启动时从环境变量读取，修改后需重启服务生效；默认 120s
 _RULES_CACHE_TTL = int(os.getenv("DANGEROUS_RULES_CACHE_TTL", "120"))
 
 # 缓存 key

--- a/server/apps/job_mgmt/services/dangerous_checker.py
+++ b/server/apps/job_mgmt/services/dangerous_checker.py
@@ -1,11 +1,53 @@
 """危险规则检查服务"""
 
+import os
 import re
 from typing import List
+
+from django.core.cache import cache
 
 from apps.core.logger import job_logger as logger
 from apps.job_mgmt.constants import DangerousLevel, MatchType
 from apps.job_mgmt.models import DangerousPath, DangerousRule
+
+# 规则缓存 TTL（秒），可通过环境变量覆盖；默认 120s
+_RULES_CACHE_TTL = int(os.getenv("DANGEROUS_RULES_CACHE_TTL", "120"))
+
+# 缓存 key
+_CMD_RULES_CACHE_KEY = "dangerous_checker:cmd_rules"
+_PATH_RULES_CACHE_KEY = "dangerous_checker:path_rules"
+
+
+def _get_cmd_rules() -> list:
+    """获取启用的命令规则（带缓存）。
+
+    缓存格式：list[dict]，字段 id / name / pattern / level / team。
+    TTL 由 DANGEROUS_RULES_CACHE_TTL 环境变量控制，默认 120s。
+    规则变更时通过 post_save/post_delete 信号主动失效（见 signals.py）。
+    """
+    rules = cache.get(_CMD_RULES_CACHE_KEY)
+    if rules is None:
+        rules = list(
+            DangerousRule.objects.filter(is_enabled=True).values("id", "name", "pattern", "level", "team")
+        )
+        cache.set(_CMD_RULES_CACHE_KEY, rules, _RULES_CACHE_TTL)
+    return rules
+
+
+def _get_path_rules() -> list:
+    """获取启用的路径规则（带缓存）。
+
+    缓存格式：list[dict]，字段 id / name / pattern / level / match_type / team。
+    TTL 由 DANGEROUS_RULES_CACHE_TTL 环境变量控制，默认 120s。
+    规则变更时通过 post_save/post_delete 信号主动失效（见 signals.py）。
+    """
+    rules = cache.get(_PATH_RULES_CACHE_KEY)
+    if rules is None:
+        rules = list(
+            DangerousPath.objects.filter(is_enabled=True).values("id", "name", "pattern", "level", "match_type", "team")
+        )
+        cache.set(_PATH_RULES_CACHE_KEY, rules, _RULES_CACHE_TTL)
+    return rules
 
 
 class DangerousCheckResult:
@@ -28,15 +70,26 @@ class DangerousCheckResult:
         return not self.has_forbidden
 
     def add_match(self, rule, matched_content: str):
-        """添加匹配结果"""
+        """添加匹配结果。rule 可为 ORM 对象或 dict（缓存格式）。"""
+        if isinstance(rule, dict):
+            rule_id = rule["id"]
+            rule_name = rule["name"]
+            pattern = rule["pattern"]
+            level = rule["level"]
+        else:
+            rule_id = rule.id
+            rule_name = rule.name
+            pattern = rule.pattern
+            level = rule.level
+
         match_info = {
-            "rule_id": rule.id,
-            "rule_name": rule.name,
-            "pattern": rule.pattern,
-            "level": rule.level,
+            "rule_id": rule_id,
+            "rule_name": rule_name,
+            "pattern": pattern,
+            "level": level,
             "matched_content": matched_content,
         }
-        if rule.level == DangerousLevel.FORBIDDEN:
+        if level == DangerousLevel.FORBIDDEN:
             self.has_forbidden = True
             self.forbidden.append(match_info)
         else:
@@ -128,6 +181,9 @@ class DangerousChecker:
         """
         检查脚本内容中的危险命令
 
+        规则集从缓存读取（TTL 由 DANGEROUS_RULES_CACHE_TTL 环境变量控制，默认 120s），
+        规则变更时通过 post_save/post_delete 信号主动失效，避免每次执行都打 DB。
+
         Args:
             script_content: 脚本内容
             team: 团队ID列表，用于过滤规则
@@ -137,17 +193,14 @@ class DangerousChecker:
         """
         result = DangerousCheckResult()
 
-        # 获取启用的命令规则
-        rules = DangerousRule.objects.filter(is_enabled=True)
+        rules = _get_cmd_rules()
 
         # 按组织过滤（空列表表示全局规则）
         if team:
-            from django.db.models import Q
-
-            rules = rules.filter(Q(team=[]) | Q(team__overlap=team))
+            rules = [r for r in rules if not r["team"] or bool(set(r["team"]) & set(team))]
 
         for rule in rules:
-            matches = DangerousChecker._match_pattern(rule.pattern, script_content)
+            matches = DangerousChecker._match_pattern(rule["pattern"], script_content)
             for matched_content in matches:
                 result.add_match(rule, matched_content)
 
@@ -158,6 +211,9 @@ class DangerousChecker:
         """
         检查目标路径是否为危险路径
 
+        规则集从缓存读取（TTL 由 DANGEROUS_RULES_CACHE_TTL 环境变量控制，默认 120s），
+        规则变更时通过 post_save/post_delete 信号主动失效，避免每次执行都打 DB。
+
         Args:
             target_path: 目标路径
             team: 团队ID列表，用于过滤规则
@@ -167,17 +223,14 @@ class DangerousChecker:
         """
         result = DangerousCheckResult()
 
-        # 获取启用的路径规则
-        rules = DangerousPath.objects.filter(is_enabled=True)
+        rules = _get_path_rules()
 
         # 按组织过滤
         if team:
-            from django.db.models import Q
-
-            rules = rules.filter(Q(team=[]) | Q(team__overlap=team))
+            rules = [r for r in rules if not r["team"] or bool(set(r["team"]) & set(team))]
 
         for rule in rules:
-            matches = DangerousChecker._match_path_pattern(rule.pattern, target_path, rule.match_type)
+            matches = DangerousChecker._match_path_pattern(rule["pattern"], target_path, rule["match_type"])
             for matched_content in matches:
                 result.add_match(rule, matched_content)
 

--- a/server/apps/job_mgmt/signals.py
+++ b/server/apps/job_mgmt/signals.py
@@ -1,5 +1,6 @@
 """job_mgmt 信号处理：规则变更时主动失效缓存。"""
 
+from django.core.cache import cache
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -13,14 +14,10 @@ from apps.job_mgmt.services.dangerous_checker import (
 @receiver([post_save, post_delete], sender=DangerousRule)
 def invalidate_cmd_rules_cache(sender, **kwargs):
     """DangerousRule 新增/修改/删除时失效命令规则缓存。"""
-    from django.core.cache import cache
-
     cache.delete(_CMD_RULES_CACHE_KEY)
 
 
 @receiver([post_save, post_delete], sender=DangerousPath)
 def invalidate_path_rules_cache(sender, **kwargs):
     """DangerousPath 新增/修改/删除时失效路径规则缓存。"""
-    from django.core.cache import cache
-
     cache.delete(_PATH_RULES_CACHE_KEY)

--- a/server/apps/job_mgmt/signals.py
+++ b/server/apps/job_mgmt/signals.py
@@ -1,0 +1,26 @@
+"""job_mgmt 信号处理：规则变更时主动失效缓存。"""
+
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from apps.job_mgmt.models import DangerousPath, DangerousRule
+from apps.job_mgmt.services.dangerous_checker import (
+    _CMD_RULES_CACHE_KEY,
+    _PATH_RULES_CACHE_KEY,
+)
+
+
+@receiver([post_save, post_delete], sender=DangerousRule)
+def invalidate_cmd_rules_cache(sender, **kwargs):
+    """DangerousRule 新增/修改/删除时失效命令规则缓存。"""
+    from django.core.cache import cache
+
+    cache.delete(_CMD_RULES_CACHE_KEY)
+
+
+@receiver([post_save, post_delete], sender=DangerousPath)
+def invalidate_path_rules_cache(sender, **kwargs):
+    """DangerousPath 新增/修改/删除时失效路径规则缓存。"""
+    from django.core.cache import cache
+
+    cache.delete(_PATH_RULES_CACHE_KEY)

--- a/server/apps/job_mgmt/tests/test_dangerous_checker.py
+++ b/server/apps/job_mgmt/tests/test_dangerous_checker.py
@@ -1,24 +1,35 @@
 """job_mgmt.services.dangerous_checker 纯逻辑测试。
 
 规格：脚本/路径危险规则匹配与结果聚合，是命令分发的安全闸门。
-覆盖纯逻辑部分（匹配算法 + 结果聚合），不依赖 DB。
+覆盖纯逻辑部分（匹配算法 + 结果聚合）和缓存层，不依赖 DB。
 """
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
 from apps.job_mgmt.constants import DangerousLevel, MatchType
 from apps.job_mgmt.services.dangerous_checker import (
+    _CMD_RULES_CACHE_KEY,
+    _PATH_RULES_CACHE_KEY,
     DangerousChecker,
     DangerousCheckResult,
+    _get_cmd_rules,
+    _get_path_rules,
 )
 
 pytestmark = pytest.mark.unit
 
 
 def _rule(level, pattern="rm -rf", name="r", rid=1):
+    """返回 ORM 对象风格的 SimpleNamespace（供 add_match 兼容路径使用）。"""
     return SimpleNamespace(id=rid, name=name, pattern=pattern, level=level)
+
+
+def _rule_dict(level, pattern="rm -rf", name="r", rid=1, team=None):
+    """返回缓存格式的 dict（供 check_command/check_path 内部使用）。"""
+    return {"id": rid, "name": name, "pattern": pattern, "level": level, "team": team or []}
 
 
 class TestMatchPattern:
@@ -77,3 +88,122 @@ class TestDangerousCheckResult:
         d = r.to_dict()
         assert d["is_safe"] is False
         assert set(d) == {"is_safe", "can_execute", "has_warning", "has_forbidden", "warnings", "forbidden"}
+
+    def test_add_match_接受dict格式规则(self):
+        """add_match 必须同时支持 ORM 对象和 dict（缓存格式）。"""
+        r = DangerousCheckResult()
+        r.add_match(_rule_dict(DangerousLevel.FORBIDDEN, pattern="rm -rf"), "rm -rf /")
+        assert r.has_forbidden is True
+        assert r.forbidden[0]["pattern"] == "rm -rf"
+
+
+class TestCmdRulesCache:
+    """验证 _get_cmd_rules 缓存行为：命中缓存不走 DB，未命中时写缓存。"""
+
+    def test_缓存未命中时查询DB并写入缓存(self):
+        fake_rules = [_rule_dict(DangerousLevel.FORBIDDEN)]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None  # 模拟缓存未命中
+
+        mock_qs = MagicMock()
+        mock_qs.filter.return_value.values.return_value = iter(fake_rules)
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache), \
+             patch("apps.job_mgmt.services.dangerous_checker.DangerousRule") as mock_model:
+            mock_model.objects = mock_qs
+            result = _get_cmd_rules()
+
+        # 结果应为 DB 返回的规则列表
+        assert result == fake_rules
+        # 应写入缓存
+        mock_cache.set.assert_called_once()
+        set_args = mock_cache.set.call_args
+        assert set_args[0][0] == _CMD_RULES_CACHE_KEY
+
+    def test_缓存命中时不查询DB(self):
+        fake_rules = [_rule_dict(DangerousLevel.CONFIRM)]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = fake_rules  # 模拟缓存命中
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache), \
+             patch("apps.job_mgmt.services.dangerous_checker.DangerousRule") as mock_model:
+            result = _get_cmd_rules()
+
+        # 缓存命中：不应查询 DB
+        mock_model.objects.filter.assert_not_called()
+        assert result == fake_rules
+
+    def test_check_command_使用缓存规则不直接查DB(self):
+        """check_command 必须通过 _get_cmd_rules 获取规则，不直接调用 ORM。
+
+        若 revert 修复（改回直接 DangerousRule.objects.filter），
+        此测试会因 mock_cache.get 从未被调用而失败。
+        """
+        fake_rules = [_rule_dict(DangerousLevel.FORBIDDEN, pattern="rm -rf")]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = fake_rules  # 缓存已热
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache), \
+             patch("apps.job_mgmt.services.dangerous_checker.DangerousRule") as mock_model:
+            result = DangerousChecker.check_command("sudo rm -rf /")
+
+        # 应命中缓存（get 被调用，key 正确）
+        mock_cache.get.assert_called_with(_CMD_RULES_CACHE_KEY)
+        # 不应直接查 DB
+        mock_model.objects.filter.assert_not_called()
+        # 应检测到禁止规则
+        assert result.has_forbidden is True
+
+    def test_check_command_团队过滤在Python层完成(self):
+        """team 过滤必须在 Python 层完成（缓存 dict 列表），不再走 ORM Q 过滤。"""
+        rules = [
+            _rule_dict(DangerousLevel.FORBIDDEN, pattern="rm -rf", rid=1, team=[]),  # 全局规则，应命中
+            _rule_dict(DangerousLevel.FORBIDDEN, pattern="mkfs", rid=2, team=[99]),  # 其他团队规则，应过滤
+        ]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = rules
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache):
+            result = DangerousChecker.check_command("mkfs /dev/sda; rm -rf /", team=[1])
+
+        # team=99 的规则不属于 team=[1]，只有全局规则（team=[]）匹配
+        matched_ids = [f["rule_id"] for f in result.forbidden]
+        assert 1 in matched_ids  # 全局规则命中
+        assert 2 not in matched_ids  # 其他团队规则被过滤
+
+
+class TestPathRulesCache:
+    """验证 _get_path_rules 缓存行为。"""
+
+    def test_缓存未命中时查询DB并写入缓存(self):
+        fake_rules = [{"id": 1, "name": "p", "pattern": "/etc", "level": DangerousLevel.FORBIDDEN,
+                       "match_type": MatchType.EXACT, "team": []}]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        mock_qs = MagicMock()
+        mock_qs.filter.return_value.values.return_value = iter(fake_rules)
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache), \
+             patch("apps.job_mgmt.services.dangerous_checker.DangerousPath") as mock_model:
+            mock_model.objects = mock_qs
+            result = _get_path_rules()
+
+        assert result == fake_rules
+        mock_cache.set.assert_called_once()
+        assert mock_cache.set.call_args[0][0] == _PATH_RULES_CACHE_KEY
+
+    def test_check_path_使用缓存规则不直接查DB(self):
+        """check_path 必须通过 _get_path_rules 获取规则，不直接调用 ORM。"""
+        fake_rules = [{"id": 1, "name": "p", "pattern": "/etc", "level": DangerousLevel.FORBIDDEN,
+                       "match_type": MatchType.EXACT, "team": []}]
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = fake_rules
+
+        with patch("apps.job_mgmt.services.dangerous_checker.cache", mock_cache), \
+             patch("apps.job_mgmt.services.dangerous_checker.DangerousPath") as mock_model:
+            result = DangerousChecker.check_path("/etc/passwd")
+
+        mock_cache.get.assert_called_with(_PATH_RULES_CACHE_KEY)
+        mock_model.objects.filter.assert_not_called()
+        assert result.has_forbidden is True


### PR DESCRIPTION
## 被破坏的不变量

`DangerousChecker.check_command` / `check_path` 作为脚本执行的安全闸门，其契约是"基于当前启用规则集判断脚本是否安全"。规则集（pattern、is_enabled）是低频变更的静态配置，应当被视为**只读查找表**——每次执行前重新全量拉取打破了这一契约，将本应透明的静态读操作变成了与执行频率线性相关的 DB 写压力。

## 根因（设计层）

`check_command`/`check_path` 每次调用都执行 `DangerousRule.objects.filter(is_enabled=True)`，没有任何缓存。规则集在业务运行期间几乎不变，但每次作业执行（手动触发 + Celery 定时任务）都会产生一次全量 `SELECT`。高频定时任务场景下（如每分钟触发），每分钟至少一次全表扫描；规则表随团队增长后，代价线性上升，瓶颈直接暴露在关键执行路径上。

## 修复如何恢复不变量

引入 Django 缓存层（`cache.get/set`），将规则集缓存为 `list[dict]`：

- **`_get_cmd_rules()` / `_get_path_rules()`**：缓存未命中时查询 DB 并写入缓存，命中时直接返回——DB 查询由"每次执行必做"降为"仅首次或 TTL 过期后触发"。
- **TTL**：由 `DANGEROUS_RULES_CACHE_TTL` 环境变量控制，默认 120s，可按实际场景调整（建议值：高频场景 60s，低频场景 300s）。
- **主动失效**：在 `signals.py` 注册 `post_save`/`post_delete` receiver，`DangerousRule`/`DangerousPath` 变更时立即 `cache.delete` 对应 key，规则生效无需等待 TTL 自然过期。
- **team 过滤**：改在 Python 层对缓存 dict 列表过滤（`set(rule["team"]) & set(team)`），不再在 ORM 层走 `Q(team=[]) | Q(team__overlap=team)`，避免每次带团队上下文的检查仍绕过缓存触发 DB。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["用户手动提交执行\nviews/execution.py"]
        T2["Celery Beat 定时任务\ntasks.py execute_scheduled_task"]
    end

    subgraph C["缓存层（新增）"]
        C1["_get_cmd_rules()\n_CMD_RULES_CACHE_KEY"]
        C2["cache.get → 命中直接返回\n未命中 → DB + cache.set"]
    end

    subgraph N["核心检查层"]
        N1["DangerousChecker.check_command()\nservices/dangerous_checker.py"]
        N2["_match_pattern(rule.pattern, script)"]
    end

    subgraph S["失效层（新增）"]
        S1["DangerousRule post_save/post_delete\nsignals.py"]
        S2["cache.delete(_CMD_RULES_CACHE_KEY)"]
    end

    T1 --> N1
    T2 --> N1
    N1 --> C1 --> C2
    C2 --> N2
    S1 --> S2 --> C1
```

## blast radius · 一致性

- **影响范围**：仅 `apps/job_mgmt`，不触及 core/rpc/base 或其他 app。
- **缓存后端**：复用项目现有 Django cache 配置（默认 LocMemCache，生产为 Redis），无需额外基础设施。
- **一致性窗口**：最坏情况为一个 TTL（默认 120s）内规则变更对新执行不可见；信号主动失效在规则保存/删除时立即生效，实际窗口极短。
- **`check_path` 同步修复**：路径规则同样存在相同问题，一并引入缓存（`_PATH_RULES_CACHE_KEY`），与 `check_command` 设计对称。

## 验证

- **revert-fail 验证通过**：将修复代码还原为直接 ORM 调用后，`test_check_command_使用缓存规则不直接查DB` 等测试立即失败（mock 检测到 `DangerousRule.objects.filter` 被直接调用）。
- **新增测试**：`TestCmdRulesCache` / `TestPathRulesCache` 覆盖：缓存未命中写 DB + 写缓存、缓存命中不查 DB、team 过滤在 Python 层完成、`add_match` 兼容 dict 格式。
- **已有测试**：`TestMatchPattern`、`TestMatchPathPattern`、`TestDangerousCheckResult` 全部保持通过，无回归。

关联 Issue: #3423