### PR TITLE
bugfix(opspilot): 修复 get_opspilot_module_data 裸字典取键致 KeyError 崩溃 (#3433)

### DIFF
--- a/server/apps/opspilot/nats_api.py
+++ b/server/apps/opspilot/nats_api.py
@@ -97,9 +97,13 @@ def get_opspilot_module_data(module, child_module, page, page_size, group_id):
         "rerank_model": RerankProvider,
     }
     if module != "provider":
-        model = model_map[module]
+        model = model_map.get(module)
+        if model is None:
+            return {"result": False, "message": f"Unknown module: {module}"}
     else:
-        model = provider_model_map[child_module]
+        model = provider_model_map.get(child_module)
+        if model is None:
+            return {"result": False, "message": f"Unknown child_module: {child_module}"}
     queryset = model.objects.filter(team__contains=int(group_id))
     # 计算总数
     total_count = queryset.count()

--- a/server/apps/opspilot/tests/test_nats_api_module_data.py
+++ b/server/apps/opspilot/tests/test_nats_api_module_data.py
@@ -1,0 +1,185 @@
+"""
+Tests for get_opspilot_module_data NATS handler — Issue #3433
+Validates that unknown module/child_module values return structured error
+instead of raising KeyError.
+"""
+import sys
+import importlib.util
+import types
+from pathlib import Path
+
+
+def _install(name, **attrs):
+    """Install a stub module into sys.modules."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _install_submodule(parent_name, child_name, **attrs):
+    parent = sys.modules.get(parent_name)
+    if parent is None:
+        parent = _install(parent_name)
+    full_name = f"{parent_name}.{child_name}"
+    mod = _install(full_name, **attrs)
+    setattr(parent, child_name, mod)
+    return mod
+
+
+def _make_queryset_stub(items=None):
+    """Return a stub that behaves like a Django QuerySet for our needs."""
+    items = items or []
+
+    class _QS:
+        def filter(self, **kwargs):
+            return self
+
+        def count(self):
+            return len(items)
+
+        def __getitem__(self, slc):
+            return items[slc]
+
+        def values(self, *fields):
+            return self
+
+    return _QS()
+
+
+def _make_model_stub(queryset):
+    class _Model:
+        objects = queryset
+
+    return _Model
+
+
+def _load_nats_api():
+    """
+    Load server/apps/opspilot/nats_api.py in isolation via exec_module,
+    injecting all required stubs so Django settings are never touched.
+    """
+    # ── nats_client stub ──────────────────────────────────────────────
+    registered_handlers = {}
+
+    def register(fn):
+        registered_handlers[fn.__name__] = fn
+        return fn
+
+    nats_client_stub = _install("nats_client", register=register)
+
+    # ── django.db stubs ───────────────────────────────────────────────
+    _install("django")
+    _install("django.db")
+    _install("django.db.models")
+
+    # ── Stub model classes ────────────────────────────────────────────
+    qs_stub = _make_queryset_stub()
+
+    def _model(name):
+        return _make_model_stub(qs_stub)
+
+    Bot = _model("Bot")
+    LLMSkill = _model("LLMSkill")
+    KnowledgeBase = _model("KnowledgeBase")
+    SkillTools = _model("SkillTools")
+    LLMModel = _model("LLMModel")
+    OCRProvider = _model("OCRProvider")
+    EmbedProvider = _model("EmbedProvider")
+    RerankProvider = _model("RerankProvider")
+
+    models_stub = _install(
+        "apps.opspilot.models",
+        Bot=Bot,
+        BotConversationHistory=object,
+        BotWorkFlow=object,
+        EmbedProvider=EmbedProvider,
+        KnowledgeBase=KnowledgeBase,
+        LLMModel=LLMModel,
+        LLMSkill=LLMSkill,
+        OCRProvider=OCRProvider,
+        RerankProvider=RerankProvider,
+        SkillTools=SkillTools,
+    )
+
+    # ── Other transitive stubs ────────────────────────────────────────
+    _install("apps")
+    _install("apps.core")
+    _install("apps.core.logger", opspilot_logger=__import__("logging").getLogger("test"))
+    _install("apps.opspilot")
+    _install("apps.opspilot.utils")
+    _install("apps.opspilot.utils.bot_utils", get_user_info=lambda *a, **kw: (None, None))
+    _install("apps.opspilot.utils.chat_flow_utils")
+    _install("apps.opspilot.utils.chat_flow_utils.engine")
+    _install(
+        "apps.opspilot.utils.chat_flow_utils.engine.factory",
+        create_chat_flow_engine=lambda *a, **kw: None,
+    )
+
+    # ── Load the actual module ────────────────────────────────────────
+    src = Path(__file__).parent.parent / "nats_api.py"
+    spec = importlib.util.spec_from_file_location("opspilot_nats_api", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    return mod, registered_handlers
+
+
+class TestGetOpspilotModuleDataBoundary:
+    """Issue #3433: unknown module/child_module must not raise KeyError."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.mod, cls.handlers = _load_nats_api()
+
+    def _call(self, module, child_module="", page=1, page_size=10, group_id=1):
+        fn = self.handlers["get_opspilot_module_data"]
+        return fn(module=module, child_module=child_module, page=page, page_size=page_size, group_id=group_id)
+
+    # ── R1: unknown top-level module ──────────────────────────────────
+    def test_unknown_module_returns_error_not_keyerror(self):
+        result = self._call(module="nonexistent_module")
+        assert result["result"] is False, "Expected result=False for unknown module"
+        assert "Unknown module" in result["message"]
+
+    # ── R2: unknown provider child_module ─────────────────────────────
+    def test_unknown_child_module_returns_error_not_keyerror(self):
+        result = self._call(module="provider", child_module="nonexistent_child")
+        assert result["result"] is False, "Expected result=False for unknown child_module"
+        assert "Unknown child_module" in result["message"]
+
+    # ── Regression: known modules must still work ─────────────────────
+    def test_known_module_bot_succeeds(self):
+        result = self._call(module="bot")
+        assert "count" in result
+        assert "items" in result
+
+    def test_known_module_skill_succeeds(self):
+        result = self._call(module="skill")
+        assert "count" in result
+
+    def test_known_module_knowledge_succeeds(self):
+        result = self._call(module="knowledge")
+        assert "count" in result
+
+    def test_known_module_tools_succeeds(self):
+        result = self._call(module="tools")
+        assert "count" in result
+
+    def test_known_provider_llm_model_succeeds(self):
+        result = self._call(module="provider", child_module="llm_model")
+        assert "count" in result
+
+    def test_known_provider_ocr_model_succeeds(self):
+        result = self._call(module="provider", child_module="ocr_model")
+        assert "count" in result
+
+    # ── Revert guard: empty string module also triggers error ──────────
+    def test_empty_string_module_returns_error(self):
+        result = self._call(module="")
+        assert result["result"] is False
+
+    def test_empty_string_child_module_returns_error(self):
+        result = self._call(module="provider", child_module="")
+        assert result["result"] is False


### PR DESCRIPTION
## 被破坏的不变量

`get_opspilot_module_data` NATS handler 的契约是：对任意调用方传入的 `module`/`child_module` 返回结构化响应。当前实现直接对外部输入做裸字典取键，破坏了"handler 不崩溃"这条最基本的可用性契约。

## 根因（设计层）

两处裸取键导致 KeyError 传播至 NATS 客户端，造成 handler 线程崩溃、调用方超时。同款问题已在 job_mgmt（#3430）和 operation_analysis（#3395）中被记录。

```python
model = model_map[module]           # ← 非法 module → KeyError
model = provider_model_map[child_module]  # ← 非法 child_module → KeyError
```

## 修复如何恢复不变量

将裸取键改为 `.get()` + early return，合法路径完全不变，仅在白名单之外增加防御，与现有 `result/message` 响应惯例一致。

## blast radius · 一致性

- 仅改 `server/apps/opspilot/nats_api.py` 中的 `get_opspilot_module_data` 函数，2 行核心改动
- 修复模式与同类问题（#3430、#3395）保持一致，形成统一的白名单防御范式
- 无 DB 迁移、无权限变更、无共享 util 改动

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NATS caller (monitor/alerts)\nnats_api 订阅入口"]
    end

    subgraph N["核心处理层"]
        F1["get_opspilot_module_data()\nserver/apps/opspilot/nats_api.py"]
        F2["model_map.get(module)\n→ None 检查 + early return"]
        F3["provider_model_map.get(child_module)\n→ None 检查 + early return"]
    end

    subgraph R["响应层"]
        R1["正常: {count, items}"]
        R2["防御: {result: False, message: ...}"]
    end

    T1 -->|"module='bot'/..."| F1
    F1 --> F2
    F1 --> F3
    F2 -->|"已知 module"| R1
    F2 -. "未知 module" .-> R2
    F3 -->|"已知 child_module"| R1
    F3 -. "未知 child_module" .-> R2
```

## 验证

新增 Django-free 注入式测试 `test_nats_api_module_data.py`（8 个场景）：

- 未知 module → `result=False` + `message` 含 "Unknown module"
- 未知 child_module → `result=False` + `message` 含 "Unknown child_module"
- 空串 module/child_module → 同上触发防御
- 已知合法路径（bot/skill/knowledge/tools/llm_model/ocr_model）→ 正常返回 `{count, items}`

revert 准则：将修复代码 revert 后，测试 1/2/5/6 立即因 KeyError 崩溃而 FAIL。

关联 Issue: #3433
