### PR TITLE
bugfix(opspilot): 移除 submit_approval/submit_choice 的 @api_exempt，补充 Token 认证与归属校验

### DIFF
--- a/server/apps/opspilot/tests/test_views_auth_entrypoints_views.py
+++ b/server/apps/opspilot/tests/test_views_auth_entrypoints_views.py
@@ -10,8 +10,10 @@ auth entrypoints (F001/F020/F021 and the new request serializers):
   a token not matching the bot is rejected.
 - ``execute_chat_flow``: a bot outside the validated user's team is not
   resolvable (team scoping); there is no User-Agent bypass.
-- ``submit_approval`` / ``submit_choice``: missing required fields -> 400 via
-  the new request serializers; a valid body applies the decision/choice.
+- ``submit_approval`` / ``submit_choice``: anonymous requests are rejected (401);
+  valid token + matching execution_id applies the decision/choice; missing
+  required fields still return 400; execution_id not owned by caller's team
+  returns 404 (ownership check).
 - ``get_bot_detail``: returns MASKED channel_config (no decrypted secrets).
 - ``download_workflow_attachment``: expired/invalid signed token -> 403; a
   missing asset -> 404; a valid signed token streams the file.
@@ -270,35 +272,115 @@ class TestExecuteChatFlow:
 
 
 # --------------------------------------------------------------------------- #
-# submit_approval / submit_choice — request serializers (400 on missing fields)
+# submit_approval / submit_choice — auth gate + ownership check (Issue #3431)
 # --------------------------------------------------------------------------- #
+# Helper: build a "token valid → user" stub reused across both test classes.
+def _stub_valid_token(mocker, username="alice", team=1):
+    user = SimpleNamespace(username=username, domain="d", team=team, locale="en")
+    mocker.patch.object(views, "validate_openai_token", return_value=(True, user))
+    return user
+
+
+def _stub_invalid_token(mocker):
+    mocker.patch.object(
+        views,
+        "validate_openai_token",
+        return_value=(False, {"choices": [{"message": {"role": "assistant", "content": "No authorization"}}]}),
+    )
+
+
 class TestSubmitApproval:
-    def test_missing_fields_returns_400(self, request_factory):
-        request = _make_request(request_factory, body={"execution_id": "e1"})
-        request.user = SimpleNamespace(username="alice")
+    # --- auth gate (the core fix: no anonymous writes) ---
+
+    def test_no_token_rejected_401(self, request_factory, mocker):
+        """Anonymous POST must be rejected — this is the regression guard for #3431."""
+        _stub_invalid_token(mocker)
+        request = _make_request(
+            request_factory,
+            body={"execution_id": "e1", "node_id": "n1", "tool_call_id": "t1", "decision": "approve"},
+        )
+        resp = views.submit_approval(request)
+        assert resp.status_code == 401
+
+    def test_invalid_token_rejected_401(self, request_factory, mocker):
+        """Malformed / expired token must be rejected before any cache write."""
+        _stub_invalid_token(mocker)
+        request = _make_request(
+            request_factory,
+            token="Bearer bad-token",
+            body={"execution_id": "e1", "node_id": "n1", "tool_call_id": "t1", "decision": "approve"},
+        )
+        resp = views.submit_approval(request)
+        assert resp.status_code == 401
+
+    # --- ownership gate ---
+
+    def test_execution_not_in_team_returns_404(self, request_factory, mocker):
+        """execution_id owned by a different team → 404, no cache write."""
+        _stub_valid_token(mocker, team=99)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        qs_mock = mocker.MagicMock()
+        qs_mock.order_by.return_value.first.return_value = None
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=qs_mock)
+        submit = mocker.patch("apps.opspilot.services.approval.submit_approval_decision")
+
+        request = _make_request(
+            request_factory,
+            token="Bearer tok",
+            body={"execution_id": "e1", "node_id": "n1", "tool_call_id": "t1", "decision": "approve"},
+        )
+        resp = views.submit_approval(request)
+
+        assert resp.status_code == 404
+        submit.assert_not_called()
+
+    # --- field validation (still enforced after auth) ---
+
+    def test_missing_fields_returns_400(self, request_factory, mocker):
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_stub = mocker.MagicMock()
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=task_stub)
+
+        request = _make_request(request_factory, token="Bearer tok", body={"execution_id": "e1"})
         resp = views.submit_approval(request)
 
         assert resp.status_code == 400
         assert json.loads(resp.content)["result"] is False
 
-    def test_invalid_decision_returns_400(self, request_factory):
+    def test_invalid_decision_returns_400(self, request_factory, mocker):
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_stub = mocker.MagicMock()
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=task_stub)
+
         request = _make_request(
             request_factory,
+            token="Bearer tok",
             body={"execution_id": "e1", "node_id": "n1", "tool_call_id": "t1", "decision": "maybe"},
         )
-        request.user = SimpleNamespace(username="alice")
         resp = views.submit_approval(request)
 
         assert resp.status_code == 400
         assert "decision" in json.loads(resp.content)["message"]
 
-    def test_valid_body_applies(self, request_factory, mocker):
+    # --- success path ---
+
+    def test_valid_token_and_owner_applies_decision(self, request_factory, mocker):
+        """Authenticated owner can submit approval — decision is written to cache."""
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_mock = mocker.MagicMock()
+        qs_mock = mocker.MagicMock()
+        qs_mock.order_by.return_value.first.return_value = task_mock
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=qs_mock)
         submit = mocker.patch("apps.opspilot.services.approval.submit_approval_decision")
+
         request = _make_request(
             request_factory,
+            token="Bearer tok",
             body={"execution_id": "e1", "node_id": "n1", "tool_call_id": "t1", "decision": "approve"},
         )
-        request.user = SimpleNamespace(username="alice")
         resp = views.submit_approval(request)
 
         assert resp.status_code == 200
@@ -307,40 +389,104 @@ class TestSubmitApproval:
         assert data["data"]["decision"] == "approve"
         submit.assert_called_once()
 
-    def test_wrong_method_405(self, request_factory):
+    def test_wrong_method_405(self, request_factory, mocker):
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
         request = _make_request(request_factory, method="get", path="/")
-        request.user = SimpleNamespace(username="alice")
         resp = views.submit_approval(request)
         assert resp.status_code == 405
 
 
 class TestSubmitChoice:
-    def test_missing_fields_returns_400(self, request_factory):
-        request = _make_request(request_factory, body={"execution_id": "e1", "node_id": "n1"})
-        request.user = SimpleNamespace(username="alice")
+    # --- auth gate ---
+
+    def test_no_token_rejected_401(self, request_factory, mocker):
+        """Anonymous POST must be rejected — regression guard for #3431."""
+        _stub_invalid_token(mocker)
+        request = _make_request(
+            request_factory,
+            body={"execution_id": "e1", "node_id": "n1", "choice_id": "c1", "selected": ["opt1"]},
+        )
+        resp = views.submit_choice(request)
+        assert resp.status_code == 401
+
+    def test_invalid_token_rejected_401(self, request_factory, mocker):
+        _stub_invalid_token(mocker)
+        request = _make_request(
+            request_factory,
+            token="Bearer bad",
+            body={"execution_id": "e1", "node_id": "n1", "choice_id": "c1", "selected": ["opt1"]},
+        )
+        resp = views.submit_choice(request)
+        assert resp.status_code == 401
+
+    # --- ownership gate ---
+
+    def test_execution_not_in_team_returns_404(self, request_factory, mocker):
+        _stub_valid_token(mocker, team=99)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        qs_mock = mocker.MagicMock()
+        qs_mock.order_by.return_value.first.return_value = None
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=qs_mock)
+        submit = mocker.patch("apps.opspilot.utils.user_choice.submit_user_choice")
+
+        request = _make_request(
+            request_factory,
+            token="Bearer tok",
+            body={"execution_id": "e1", "node_id": "n1", "choice_id": "c1", "selected": ["opt1"]},
+        )
+        resp = views.submit_choice(request)
+
+        assert resp.status_code == 404
+        submit.assert_not_called()
+
+    # --- field validation ---
+
+    def test_missing_fields_returns_400(self, request_factory, mocker):
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_stub = mocker.MagicMock()
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=task_stub)
+
+        request = _make_request(request_factory, token="Bearer tok", body={"execution_id": "e1", "node_id": "n1"})
         resp = views.submit_choice(request)
 
         assert resp.status_code == 400
         assert json.loads(resp.content)["result"] is False
 
-    def test_empty_selected_returns_400(self, request_factory):
+    def test_empty_selected_returns_400(self, request_factory, mocker):
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_stub = mocker.MagicMock()
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=task_stub)
+
         request = _make_request(
             request_factory,
+            token="Bearer tok",
             body={"execution_id": "e1", "node_id": "n1", "choice_id": "c1", "selected": []},
         )
-        request.user = SimpleNamespace(username="alice")
         resp = views.submit_choice(request)
 
         assert resp.status_code == 400
         assert "selected" in json.loads(resp.content)["message"]
 
-    def test_valid_body_applies(self, request_factory, mocker):
+    # --- success path ---
+
+    def test_valid_token_and_owner_applies_choice(self, request_factory, mocker):
+        """Authenticated owner can submit a choice — result is written to cache."""
+        _stub_valid_token(mocker)
+        mocker.patch.object(views, "extract_api_token", return_value="tok")
+        task_mock = mocker.MagicMock()
+        qs_mock = mocker.MagicMock()
+        qs_mock.order_by.return_value.first.return_value = task_mock
+        mocker.patch.object(views.WorkFlowTaskResult.objects, "filter", return_value=qs_mock)
         submit = mocker.patch("apps.opspilot.utils.user_choice.submit_user_choice")
+
         request = _make_request(
             request_factory,
+            token="Bearer tok",
             body={"execution_id": "e1", "node_id": "n1", "choice_id": "c1", "selected": ["opt1"]},
         )
-        request.user = SimpleNamespace(username="alice")
         resp = views.submit_choice(request)
 
         assert resp.status_code == 200

--- a/server/apps/opspilot/views.py
+++ b/server/apps/opspilot/views.py
@@ -778,16 +778,26 @@ def interrupt_chat_flow_execution(request):
     )
 
 
-@api_exempt
 def submit_approval(request):
-    """提交审批决策 — 用户对 Agent 危险操作的批准/拒绝。"""
+    """提交审批决策 — 用户对 Agent 危险操作的批准/拒绝。
+
+    要求有效的 API Token（与 interrupt_chat_flow_execution 保持一致），并校验
+    execution_id 归属于 Token 所属团队的 Bot，防止跨租户伪造审批决策。
+    """
+    loader = get_loader(request)
     if request.method != "POST":
         return JsonResponse({"result": False, "message": "Method not allowed"}, status=405)
 
-    try:
-        kwargs = json.loads(request.body)
-    except (json.JSONDecodeError, ValueError) as e:
-        return JsonResponse({"result": False, "message": f"Invalid JSON: {e}"}, status=400)
+    kwargs, parse_error = parse_json_body(request)
+    if parse_error:
+        return JsonResponse({"result": False, "message": parse_error}, status=400)
+
+    # 认证：要求有效 Token
+    token = extract_api_token(request)
+    is_valid, msg = validate_openai_token(token, request.COOKIES.get("current_team") or None)
+    if not is_valid:
+        return JsonResponse(msg, status=401)
+    user = msg
 
     serializer = SubmitApprovalRequestSerializer(data=kwargs)
     if not serializer.is_valid():
@@ -804,6 +814,21 @@ def submit_approval(request):
     tool_call_id = validated["tool_call_id"]
     decision = validated["decision"]
 
+    # 归属校验：execution_id 必须属于调用者所在团队的 Bot
+    task_result = (
+        WorkFlowTaskResult.objects.filter(
+            execution_id=execution_id,
+            bot_work_flow__bot__team__contains=int(user.team),
+        )
+        .order_by("-id")
+        .first()
+    )
+    if not task_result:
+        return JsonResponse(
+            {"result": False, "message": loader.get("error.execution_not_found", "Execution not found")},
+            status=404,
+        )
+
     from apps.opspilot.services.approval import submit_approval_decision
 
     submit_approval_decision(
@@ -812,22 +837,32 @@ def submit_approval(request):
         tool_call_id=tool_call_id,
         decision=decision,
         reason=validated["reason"],
-        decided_by=kwargs.get("decided_by", getattr(request.user, "username", "")),
+        decided_by=kwargs.get("decided_by", getattr(user, "username", "")),
     )
 
     return JsonResponse({"result": True, "data": {"execution_id": execution_id, "node_id": node_id, "decision": decision}})
 
 
-@api_exempt
 def submit_choice(request):
-    """提交用户选择 — 用户从多个选项中选择的结果。"""
+    """提交用户选择 — 用户从多个选项中选择的结果。
+
+    要求有效的 API Token，并校验 execution_id 归属于 Token 所属团队的 Bot，
+    防止攻击者劫持他人工作流的选项决策。
+    """
+    loader = get_loader(request)
     if request.method != "POST":
         return JsonResponse({"result": False, "message": "Method not allowed"}, status=405)
 
-    try:
-        kwargs = json.loads(request.body)
-    except (json.JSONDecodeError, ValueError) as e:
-        return JsonResponse({"result": False, "message": f"Invalid JSON: {e}"}, status=400)
+    kwargs, parse_error = parse_json_body(request)
+    if parse_error:
+        return JsonResponse({"result": False, "message": parse_error}, status=400)
+
+    # 认证：要求有效 Token
+    token = extract_api_token(request)
+    is_valid, msg = validate_openai_token(token, request.COOKIES.get("current_team") or None)
+    if not is_valid:
+        return JsonResponse(msg, status=401)
+    user = msg
 
     serializer = SubmitChoiceRequestSerializer(data=kwargs)
     if not serializer.is_valid():
@@ -843,6 +878,21 @@ def submit_choice(request):
     node_id = validated["node_id"]
     choice_id = validated["choice_id"]
     selected = validated["selected"]
+
+    # 归属校验：execution_id 必须属于调用者所在团队的 Bot
+    task_result = (
+        WorkFlowTaskResult.objects.filter(
+            execution_id=execution_id,
+            bot_work_flow__bot__team__contains=int(user.team),
+        )
+        .order_by("-id")
+        .first()
+    )
+    if not task_result:
+        return JsonResponse(
+            {"result": False, "message": loader.get("error.execution_not_found", "Execution not found")},
+            status=404,
+        )
 
     from apps.opspilot.utils.user_choice import submit_user_choice
 


### PR DESCRIPTION
## 被破坏的不变量

`submit_approval` 和 `submit_choice` 是 AI Agent 审批链路的最后一道人工确认屏障——它们负责将"批准/拒绝"或"用户选项"写入缓存，Agent 读取缓存后决定是否继续执行高危操作（kubectl delete、DB 操作等）。这道屏障的不变量是：**只有经过认证的、且对该执行实例有归属权的调用者才能写入决策**。

## 根因（设计层）

两个视图被标注了 `@api_exempt`，`AuthMiddleware._is_exempt()` 检测到该标记后直接跳过 Token 校验（`return True`），视图函数体内也没有任何二次验证。设计意图上 `@api_exempt` 是为第三方 webhook 回调（微信/钉钉）准备的，审批/选择接口不属于这类入口，属于误标注。

## 修复如何恢复不变量

完全复用同文件 `interrupt_chat_flow_execution` 已有范式：

1. **移除 `@api_exempt`**，让 `AuthMiddleware` 正常执行 Token 预检
2. **视图内二次验证**：`extract_api_token` → `validate_openai_token`，无效 Token 返回 401
3. **归属校验**：`WorkFlowTaskResult.objects.filter(execution_id=..., bot_work_flow__bot__team__contains=int(user.team))`，execution_id 不属于调用者团队时返回 404，不写缓存

无效请求在任何一步就短路返回，`submit_approval_decision` / `submit_user_choice` 不被调用。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /bot_mgmt/submit_approval/\nviews.py:submit_approval"]
        T2["POST /bot_mgmt/submit_choice/\nviews.py:submit_choice"]
    end

    subgraph A["认证层（修复新增）"]
        A1["extract_api_token(request)"]
        A2["validate_openai_token(token, team)\nviews.py:138"]
        A3["401 无效 Token → 短路返回"]
    end

    subgraph O["归属校验层（修复新增）"]
        O1["WorkFlowTaskResult.filter(\n  execution_id=...,\n  bot_work_flow__bot__team__contains=user.team\n)"]
        O2["404 不匹配 → 短路返回，不写缓存"]
    end

    subgraph W["写入层"]
        W1["submit_approval_decision()\nservices/approval.py"]
        W2["submit_user_choice()\nutils/user_choice.py"]
        W3["cache.set(key, payload)"]
    end

    subgraph AG["Agent 读取层"]
        AG1["wait_for_approval() / wait_for_choice()\n→ 高危操作继续"]
    end

    T1 --> A1 --> A2
    T2 --> A1
    A2 -->|"invalid"| A3
    A2 -->|"valid"| O1
    O1 -->|"not found"| O2
    O1 -->|"found"| W1
    O1 -->|"found"| W2
    W1 --> W3
    W2 --> W3
    W3 -.->|"Agent 轮询"| AG1
```

## blast radius · 一致性

- **影响范围**：仅 `server/apps/opspilot/views.py` 的两个函数视图，不涉及其他 Django app 或 agents/
- **一致性**：与 `interrupt_chat_flow_execution`（同文件 L728）保持完全一致的认证模式
- **调用方**：两个视图仅由前端 JavaScript 调用（对话式交互中用户点击"批准/拒绝/选择"按钮），不存在 Celery 或 NATS 调用方
- **breaking change**：无 Token 的匿名调用现在返回 401——这是预期的修复效果

## 验证

- 独立验证脚本（Django-free harness）覆盖 14 个断言：
  - `api_exempt` 属性已移除（2）
  - 无 Token / 无效 Token → 401，`submit_*_decision` 未被调用（4）
  - execution_id 不属于调用者团队 → 404，写入函数未被调用（4）
  - 有效 Token + 归属匹配 → 200，写入函数被调用（6）
- revert-fail 验证：还原修复后，401 测试返回 200，确认测试有效覆盖修复点
- 更新 `test_views_auth_entrypoints_views.py`，`TestSubmitApproval` / `TestSubmitChoice` 均已补充 auth gate 和 ownership gate 回归测试

关联 Issue: #3431