### PR TITLE
bugfix(system_mgmt): NATS reset_pwd handler 增加调用方身份校验

### DIFF
--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -318,8 +318,11 @@ def reset_pwd(request):
         if not username or not password:
             return JsonResponse({"result": False, "message": loader.get("error.password_required", "Username or password cannot be empty")})
 
+        # 从 cookie 中读取调用方 token，转发给 NATS handler 进行身份校验
+        caller_token = request.COOKIES.get("bklite_token", "")
+
         client = SystemMgmt()
-        res = client.reset_pwd(username, domain, password)
+        res = client.reset_pwd(username, domain, password, caller_token=caller_token)
 
         # 如果密码重置成功，记录操作日志
         if res.get("result"):

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -320,6 +320,8 @@ def reset_pwd(request):
 
         # 从 cookie 中读取调用方 token，转发给 NATS handler 进行身份校验
         caller_token = request.COOKIES.get("bklite_token", "")
+        if not caller_token:
+            return JsonResponse({"result": False, "message": loader.get("error.please_provide_token", "Please provide Token")})
 
         client = SystemMgmt()
         res = client.reset_pwd(username, domain, password, caller_token=caller_token)

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -444,6 +444,13 @@ def reset_pwd(request):
 
         # 从 cookie 中读取调用方 token，转发给 NATS handler 进行身份校验
         caller_token = request.COOKIES.get("bklite_token", "")
+        if not caller_token:
+            return JsonResponse(
+                {
+                    "result": False,
+                    "message": _get_loader(request).get("error.please_provide_token", "Please provide Token"),
+                }
+            )
 
         client = _create_system_mgmt_client()
         res = client.reset_pwd(username, domain, password, caller_token=caller_token)

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -442,8 +442,11 @@ def reset_pwd(request):
                 }
             )
 
+        # 从 cookie 中读取调用方 token，转发给 NATS handler 进行身份校验
+        caller_token = request.COOKIES.get("bklite_token", "")
+
         client = _create_system_mgmt_client()
-        res = client.reset_pwd(username, domain, password)
+        res = client.reset_pwd(username, domain, password, caller_token=caller_token)
 
         if not res.get("result"):
             logger.warning(f"Password reset failed for user: {username}")

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -149,13 +149,16 @@ class SystemMgmt(object):
         return_data = self.client.run("login", username=username, password=password)
         return return_data
 
-    def reset_pwd(self, username, domain, password):
+    def reset_pwd(self, username, domain, password, caller_token=""):
         """
         :param username: 用户名
-        :param domain: 用户名
+        :param domain: 域
         :param password: 密码
+        :param caller_token: 调用方 JWT token（必须与 username 对应的会话 token 一致）
         """
-        return_data = self.client.run("reset_pwd", username=username, domain=domain, password=password)
+        return_data = self.client.run(
+            "reset_pwd", username=username, domain=domain, password=password, caller_token=caller_token
+        )
         return return_data
 
     def revoke_token(self, token):

--- a/server/apps/rpc/tests/test_system_mgmt_client.py
+++ b/server/apps/rpc/tests/test_system_mgmt_client.py
@@ -40,11 +40,20 @@ def test_verify_token_转发(client):
 
 
 def test_reset_pwd_转发全部具名参数(client):
+    client.reset_pwd("alice", "domain.com", "newpw", caller_token="tok123")
+    assert client.client.calls[0] == (
+        "reset_pwd",
+        (),
+        {"username": "alice", "domain": "domain.com", "password": "newpw", "caller_token": "tok123"},
+    )
+
+
+def test_reset_pwd_缺省caller_token时转发空字符串(client):
     client.reset_pwd("alice", "domain.com", "newpw")
     assert client.client.calls[0] == (
         "reset_pwd",
         (),
-        {"username": "alice", "domain": "domain.com", "password": "newpw"},
+        {"username": "alice", "domain": "domain.com", "password": "newpw", "caller_token": ""},
     )
 
 

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -1259,9 +1259,11 @@ def reset_pwd(username, domain, password, caller_token=""):
         return {"result": False, "message": "caller_token is required"}
     try:
         caller = _verify_token(caller_token)
-    except Exception as e:
-        return {"result": False, "message": f"Unauthorized: {e}"}
-    if caller.username != username or (domain and getattr(caller, "domain", "") != domain):
+    except Exception:
+        return {"result": False, "message": "Unauthorized: invalid token"}
+    caller_domain = getattr(caller, "domain", "") or "domain.com"
+    target_domain = domain or "domain.com"
+    if caller.username != username or caller_domain != target_domain:
         return {"result": False, "message": "Unauthorized: caller does not match target user"}
 
     filter_kwargs = {"username": username}

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -1246,12 +1246,24 @@ def login(username, password):
 
 
 @nats_client.register
-def reset_pwd(username, domain, password):
+def reset_pwd(username, domain, password, caller_token=""):
     """
     重置用户密码（NATS接口）
 
-    会进行密码复杂度校验
+    会进行密码复杂度校验，以及调用方身份校验——caller_token 必须是有效的
+    JWT 会话 token，且 token 所属用户必须与 username 一致（自助改密），
+    以阻止任意内网服务通过 NATS 总线篡改他人密码。
     """
+    # 调用方身份校验：验证 caller_token 有效，且属于请求的同一用户
+    if not caller_token:
+        return {"result": False, "message": "caller_token is required"}
+    try:
+        caller = _verify_token(caller_token)
+    except Exception as e:
+        return {"result": False, "message": f"Unauthorized: {e}"}
+    if caller.username != username or (domain and getattr(caller, "domain", "") != domain):
+        return {"result": False, "message": "Unauthorized: caller does not match target user"}
+
     filter_kwargs = {"username": username}
     if domain:
         filter_kwargs["domain"] = domain

--- a/server/apps/system_mgmt/tests/nats_api_test.py
+++ b/server/apps/system_mgmt/tests/nats_api_test.py
@@ -16,7 +16,7 @@ from apps.job_mgmt.services.script_execution_runner import ScriptExecutionRunner
 from apps.rpc.ansible import AnsibleExecutor
 from apps.system_mgmt import nats_api
 from apps.system_mgmt.models import User
-from apps.system_mgmt.nats_api import get_all_users, get_authorized_groups_scoped
+from apps.system_mgmt.nats_api import get_all_users, get_authorized_groups_scoped, reset_pwd
 from apps.system_mgmt.utils.channel_utils import send_email_to_user
 
 logger = logging.getLogger(__name__)
@@ -1389,3 +1389,72 @@ def test_channel_viewset_rejects_opspilot_managed_channel():
 
     normal = Channel(name="m2", channel_type=ChannelChoices.NATS, config={"namespace": "x"}, team=[1], description="")
     assert viewset._reject_if_opspilot_managed(request, normal) is None
+
+
+# ── reset_pwd 调用方身份校验测试（Issue #3441）─────────────────────────────────
+
+
+def _make_caller(username, domain="domain.com"):
+    """构造一个伪调用方用户对象（用于 _verify_token 返回值）。"""
+    return types.SimpleNamespace(username=username, domain=domain)
+
+
+def test_reset_pwd_无caller_token时拒绝请求(monkeypatch):
+    """caller_token 缺失时应直接拒绝，不执行任何 DB 写入。"""
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: _make_caller("alice"))
+    result = reset_pwd("alice", "domain.com", "NewPass123!", caller_token="")
+    assert result["result"] is False
+    assert "caller_token" in result["message"]
+
+
+def test_reset_pwd_caller_token无效时拒绝请求(monkeypatch):
+    """_verify_token 抛异常（token 过期/篡改）时应返回 Unauthorized。"""
+
+    def _raise(token):
+        raise Exception("Token is invalid")
+
+    monkeypatch.setattr(nats_api, "_verify_token", _raise)
+    result = reset_pwd("alice", "domain.com", "NewPass123!", caller_token="bad.token")
+    assert result["result"] is False
+    assert "Unauthorized" in result["message"]
+
+
+def test_reset_pwd_caller与目标用户不一致时拒绝(monkeypatch):
+    """token 属于 bob，却要重置 alice 的密码——应拒绝（防止跨账号密码覆盖）。"""
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: _make_caller("bob"))
+    result = reset_pwd("alice", "domain.com", "NewPass123!", caller_token="bob.token")
+    assert result["result"] is False
+    assert "Unauthorized" in result["message"]
+
+
+def test_reset_pwd_caller与目标用户一致时允许执行(monkeypatch):
+    """token 属于 alice，重置 alice 自己的密码——应通过校验并更新密码。"""
+    caller = _make_caller("alice", "domain.com")
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: caller)
+
+    saved = {}
+
+    class _FakeUser:
+        username = "alice"
+        domain = "domain.com"
+        temporary_pwd = True
+
+        def save(self):
+            saved["password"] = self.password
+            saved["temporary_pwd"] = self.temporary_pwd
+
+    class _FakeQS:
+        def first(self):
+            return _FakeUser()
+
+    class _FakeManager:
+        def filter(self, **kwargs):
+            return _FakeQS()
+
+    monkeypatch.setattr(nats_api.User, "objects", _FakeManager())
+
+    # 使用真实的 PasswordValidator（不 mock，确保测试覆盖完整路径）
+    result = reset_pwd("alice", "domain.com", "ValidPass1!", caller_token="alice.token")
+    assert result["result"] is True
+    assert "password" in saved  # 密码已被写入
+    assert saved["temporary_pwd"] is False

--- a/server/apps/system_mgmt/tests/nats_api_test.py
+++ b/server/apps/system_mgmt/tests/nats_api_test.py
@@ -1458,3 +1458,43 @@ def test_reset_pwd_caller与目标用户一致时允许执行(monkeypatch):
     assert result["result"] is True
     assert "password" in saved  # 密码已被写入
     assert saved["temporary_pwd"] is False
+
+
+def test_reset_pwd_空domain与default_domain等价_不被跨domain绕过(monkeypatch):
+    """caller.domain='domain.com' 与 target domain='' 应被视为同一域，不应误拒或被绕过。"""
+    # caller domain 为 domain.com（默认域），目标 domain 为空（等价 domain.com）
+    caller = _make_caller("alice", "domain.com")
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: caller)
+
+    saved = {}
+
+    class _FakeUser:
+        username = "alice"
+        domain = "domain.com"
+        temporary_pwd = True
+
+        def save(self):
+            saved["password"] = self.password
+            saved["temporary_pwd"] = self.temporary_pwd
+
+    class _FakeQS:
+        def first(self):
+            return _FakeUser()
+
+    class _FakeManager:
+        def filter(self, **kwargs):
+            return _FakeQS()
+
+    monkeypatch.setattr(nats_api.User, "objects", _FakeManager())
+    # domain="" should normalise to "domain.com" on both sides → allowed
+    result = reset_pwd("alice", "", "ValidPass1!", caller_token="alice.token")
+    assert result["result"] is True
+
+
+def test_reset_pwd_不同domain时拒绝(monkeypatch):
+    """caller 属于 domain.com，target domain 为 corp.com——应拒绝跨域改密。"""
+    caller = _make_caller("alice", "domain.com")
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: caller)
+    result = reset_pwd("alice", "corp.com", "ValidPass1!", caller_token="alice.token")
+    assert result["result"] is False
+    assert "Unauthorized" in result["message"]


### PR DESCRIPTION
## 被破坏的不变量

**密码重置必须由账号持有人自主发起，或由已认证超管通过 RBAC 授权操作。**

当前 `reset_pwd` NATS handler 无任何调用方校验：只需提供目标 `username + domain + password`，任意能接入 NATS 总线的进程均可以一条消息重置任意用户（含超管）的登录密码，完成账号接管。

---

## 根因（设计层）

`reset_pwd` 被设计为"内部总线接口"，隐式信任所有 NATS 发布方为可信服务。但内网横移后任何被攻陷的微服务均可发布消息，"内网可信"假设在攻击场景下不成立。这与 HTTP 入口（`core/views/index_view.py`、`console_mgmt/views.py`）已做 `request.user` 认证形成了防线断层——绕过 HTTP 层直接打 NATS 即可绕过所有认证。

---

## 修复如何恢复不变量

新增 `caller_token` 参数（`str`，默认空），在 handler 入口执行两步校验：

1. `_verify_token(caller_token)` — 验证 token 签名有效、未过期、未吊销，返回 `caller` 用户对象
2. `caller.username == username` — 断言 token 持有者即为目标用户（自助改密语义）

任何不满足以上条件的请求均以 `{"result": False, "message": "Unauthorized: …"}` 拒绝，DB 写入不执行。

HTTP 入口调用侧（`index_view.py`、`console_mgmt/views.py`）从 HttpOnly cookie `bklite_token` 读取当前会话 token 透传至 RPC，存量 HTTP 调用路径零感知变化。

---

## blast radius · 一致性

| 涉及文件 | 角色 | 影响 |
|---------|------|------|
| `system_mgmt/nats_api.py` | NATS handler | 新增 `caller_token` 参数（默认 `""`），旧调用方若不传将被拒绝 |
| `rpc/system_mgmt.py` | RPC 封装 | 透传 `caller_token`，签名向后兼容 |
| `core/views/index_view.py` | HTTP 入口 A | 自动读 cookie，无 API 变化 |
| `console_mgmt/views.py` | HTTP 入口 B | 自动读 cookie，无 API 变化 |

无 agent 端调用方（`agents/` 内无 `reset_pwd` 调用），无跨系统协议变更。

---

## 验证

- **Revert-fail 准则**：还原 `caller_token` 守卫后，T1/T2/T3 测试从 `result=False` 翻为通过（不覆盖修复的测试则不受影响）——满足"revert 后测试必须失败"。
- **新增测试**：`nats_api_test.py` 增加 4 个场景（无 token / 无效 token / 跨账号 / 合法自助改密）；`test_system_mgmt_client.py` 更新 RPC 转发契约。
- **本地验证**：通过 `/tmp/verify_reset_pwd_fix.py` 独立 harness 验证（规避 license_mgmt 缺失导致的 Django settings 加载失败），所有场景通过。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（HTTP 入口）"]
        T1["reset_pwd(request)\nindex_view.py / console_mgmt/views.py\n读 bklite_token cookie → caller_token"]
    end

    subgraph R["RPC 层"]
        R1["SystemMgmt.reset_pwd(username, domain, password, caller_token)\nrpc/system_mgmt.py"]
    end

    subgraph N["NATS handler（system_mgmt）"]
        G1{"caller_token 非空？"}
        G2{"_verify_token 成功？"}
        G3{"caller.username == username？"}
        F1["User.objects.filter(...).first()"]
        F2["PasswordValidator.validate_password(password)"]
        F3["user.password = make_password(password)\nuser.save()"]
    end

    subgraph E["拒绝出口"]
        E1["return {result: False, message: 'caller_token is required'}"]
        E2["return {result: False, message: 'Unauthorized: …'}"]
        E3["return {result: False, message: 'Unauthorized: caller does not match…'}"]
    end

    T1 --> R1 --> G1
    G1 -- "否" --> E1
    G1 -- "是" --> G2
    G2 -- "异常" --> E2
    G2 -- "成功" --> G3
    G3 -- "不一致" --> E3
    G3 -- "一致" --> F1 --> F2 --> F3
```

关联 Issue #3441