### PR TITLE
bugfix(system_mgmt): verify_otp_code NATS handler 增加速率限制防止 OTP 暴力枚举

### DIFF
--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -274,8 +274,8 @@ class SystemMgmt(object):
         return_data = self.client.run("verify_bk_token", bk_token=bk_token)
         return return_data
 
-    def verify_otp_code(self, username, otp_code):
-        return_data = self.client.run("verify_otp_code", username=username, otp_code=otp_code)
+    def verify_otp_code(self, username, otp_code, client_ip=""):
+        return_data = self.client.run("verify_otp_code", username=username, otp_code=otp_code, client_ip=client_ip)
         return return_data
 
     def verify_otp_code_by_user_id(self, user_id, otp_code):

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -1424,11 +1424,31 @@ def generate_qr_code_by_user_id(user_id):
 
 # 验证OTP代码
 @nats_client.register
-def verify_otp_code(username, otp_code):
-    user = User.objects.get(username=username)
+def verify_otp_code(username, otp_code, client_ip=""):
+    """
+    Verify OTP code for a user by username.
+
+    Requires client_ip for rate limiting. Falls back to empty string when not
+    provided (legacy callers), but rate limiting is still applied per IP+username.
+    """
+    # Check rate limit before any DB lookup
+    is_limited, remaining = check_rate_limit(client_ip, username)
+    if is_limited:
+        return {"result": False, "message": "Too many failed attempts. Please try again later."}
+
+    user = User.objects.filter(username=username).first()
+    if not user:
+        return {"result": False, "message": "User not found"}
+
+    if not user.otp_secret:
+        return {"result": False, "message": "OTP not configured for this user"}
+
     totp = pyotp.TOTP(user.otp_secret)
     if totp.verify(otp_code):
+        reset_rate_limit(client_ip, username)
         return {"result": True, "message": "Verification successful"}
+
+    record_failed_attempt(client_ip, username)
     return {"result": False, "message": "Invalid OTP code"}
 
 

--- a/server/apps/system_mgmt/tests/test_verify_otp_code_rate_limit.py
+++ b/server/apps/system_mgmt/tests/test_verify_otp_code_rate_limit.py
@@ -1,0 +1,220 @@
+"""
+Tests for verify_otp_code NATS handler rate limiting.
+
+Issue #3440: verify_otp_code had no rate limiting, allowing brute-force
+enumeration of any user's OTP within a single 30-second TOTP window.
+
+These tests verify that the fix correctly enforces rate limiting and failure
+counting in verify_otp_code, matching the behaviour of verify_otp_login.
+"""
+
+import pytest
+import pyotp
+from django.contrib.auth.hashers import make_password
+
+from apps.system_mgmt.models import User
+from apps.system_mgmt.otp_challenge import RATE_LIMIT_MAX_ATTEMPTS, record_failed_attempt
+
+
+@pytest.fixture
+def use_locmem_cache(settings):
+    """Use local memory cache for testing instead of dummy cache."""
+    settings.CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "test-verify-otp-code",
+        }
+    }
+
+
+@pytest.fixture
+def clear_cache(use_locmem_cache):
+    """Clear cache before and after each test."""
+    from django.core.cache import cache
+
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def otp_user(db):
+    """Create a test user with OTP configured."""
+    secret = pyotp.random_base32()
+    user = User.objects.create(
+        username="otp_test_user",
+        password=make_password("testpass"),
+        display_name="OTP Test User",
+        domain="domain.com",
+        locale="en",
+        timezone="UTC",
+        disabled=False,
+        otp_secret=secret,
+    )
+    return user
+
+
+class TestVerifyOtpCodeRateLimit:
+    """Verify that verify_otp_code enforces rate limiting (Issue #3440 fix)."""
+
+    @pytest.mark.django_db
+    def test_rate_limit_blocks_after_max_failed_attempts(self, clear_cache, otp_user):
+        """
+        After RATE_LIMIT_MAX_ATTEMPTS failed OTP guesses from the same IP,
+        further calls must return result=False with a rate-limit message.
+
+        This is the core regression test: reverting the fix causes this to fail
+        because the old verify_otp_code never calls check_rate_limit.
+        """
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        client_ip = "10.0.0.1"
+        username = otp_user.username
+
+        # Exhaust the rate limit with wrong OTP codes
+        for _ in range(RATE_LIMIT_MAX_ATTEMPTS):
+            result = verify_otp_code(username=username, otp_code="000000", client_ip=client_ip)
+            # Each attempt before the limit is hit should return invalid OTP
+            assert result["result"] is False
+            assert "rate" not in result["message"].lower(), (
+                f"Hit rate limit too early (attempt {_ + 1})"
+            )
+
+        # One more attempt should now be rate-limited
+        result = verify_otp_code(username=username, otp_code="000001", client_ip=client_ip)
+
+        assert result["result"] is False
+        assert "rate" in result["message"].lower() or "many" in result["message"].lower(), (
+            f"Expected rate-limit message, got: {result['message']!r}"
+        )
+
+    @pytest.mark.django_db
+    def test_correct_otp_succeeds_before_rate_limit(self, clear_cache, otp_user):
+        """A correct OTP code should still succeed when under the rate limit."""
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        client_ip = "10.0.0.2"
+        totp = pyotp.TOTP(otp_user.otp_secret)
+        correct_code = totp.now()
+
+        result = verify_otp_code(
+            username=otp_user.username,
+            otp_code=correct_code,
+            client_ip=client_ip,
+        )
+
+        assert result["result"] is True
+        assert result["message"] == "Verification successful"
+
+    @pytest.mark.django_db
+    def test_correct_otp_resets_rate_limit_counter(self, clear_cache, otp_user):
+        """
+        A successful OTP verification should reset the failure counter,
+        so subsequent failures start from zero again.
+        """
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        client_ip = "10.0.0.3"
+        username = otp_user.username
+
+        # Record some (but not max) failed attempts
+        for _ in range(RATE_LIMIT_MAX_ATTEMPTS - 1):
+            verify_otp_code(username=username, otp_code="000000", client_ip=client_ip)
+
+        # A correct OTP clears the counter
+        totp = pyotp.TOTP(otp_user.otp_secret)
+        correct_code = totp.now()
+        result = verify_otp_code(username=username, otp_code=correct_code, client_ip=client_ip)
+        assert result["result"] is True
+
+        # After the reset, we should have the full quota again
+        # (RATE_LIMIT_MAX_ATTEMPTS more failures before hitting limit)
+        for i in range(RATE_LIMIT_MAX_ATTEMPTS):
+            result = verify_otp_code(username=username, otp_code="000000", client_ip=client_ip)
+            assert result["result"] is False
+            assert "rate" not in result["message"].lower(), (
+                f"Hit rate limit too early after reset (attempt {i + 1})"
+            )
+
+    @pytest.mark.django_db
+    def test_rate_limit_checked_before_db_lookup(self, clear_cache, otp_user):
+        """
+        When already rate-limited, verify_otp_code must return the rate-limit
+        response without hitting the database — i.e. the check happens first.
+        This also means a non-existent username cannot be used to probe rate state.
+        """
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        client_ip = "10.0.0.4"
+        username = otp_user.username
+
+        # Pre-fill the rate limit counter directly
+        for _ in range(RATE_LIMIT_MAX_ATTEMPTS):
+            record_failed_attempt(client_ip, username)
+
+        # Even a correct OTP is blocked at the rate-limit gate
+        totp = pyotp.TOTP(otp_user.otp_secret)
+        correct_code = totp.now()
+
+        result = verify_otp_code(username=username, otp_code=correct_code, client_ip=client_ip)
+
+        assert result["result"] is False
+        assert "rate" in result["message"].lower() or "many" in result["message"].lower()
+
+    @pytest.mark.django_db
+    def test_rate_limit_is_per_ip_and_username(self, clear_cache, otp_user):
+        """
+        Rate limiting must be scoped to (IP, username). A different IP must
+        not be blocked by another IP's failures.
+        """
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        username = otp_user.username
+        blocked_ip = "10.0.0.5"
+        clean_ip = "10.0.0.6"
+
+        # Exhaust limit for blocked_ip
+        for _ in range(RATE_LIMIT_MAX_ATTEMPTS):
+            verify_otp_code(username=username, otp_code="000000", client_ip=blocked_ip)
+
+        blocked_result = verify_otp_code(username=username, otp_code="000000", client_ip=blocked_ip)
+        assert blocked_result["result"] is False
+        assert "rate" in blocked_result["message"].lower() or "many" in blocked_result["message"].lower()
+
+        # clean_ip must still get an "invalid OTP" response, not a rate-limit
+        clean_result = verify_otp_code(username=username, otp_code="000000", client_ip=clean_ip)
+        assert clean_result["result"] is False
+        assert "rate" not in clean_result["message"].lower()
+
+    @pytest.mark.django_db
+    def test_nonexistent_user_returns_not_found(self, clear_cache):
+        """verify_otp_code should return user-not-found for unknown usernames."""
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        result = verify_otp_code(
+            username="no_such_user_xyz",
+            otp_code="123456",
+            client_ip="10.0.0.7",
+        )
+
+        assert result["result"] is False
+        assert "not found" in result["message"].lower()
+
+    @pytest.mark.django_db
+    def test_legacy_call_without_client_ip_still_rate_limits(self, clear_cache, otp_user):
+        """
+        Callers that omit client_ip (backward-compatible default="") must still
+        hit rate limiting — the empty string is a valid key prefix and all
+        legacy callers share the same "" bucket per username.
+        """
+        from apps.system_mgmt.nats_api import verify_otp_code
+
+        username = otp_user.username
+
+        # Exhaust with no client_ip (legacy call style)
+        for _ in range(RATE_LIMIT_MAX_ATTEMPTS):
+            verify_otp_code(username=username, otp_code="000000")
+
+        result = verify_otp_code(username=username, otp_code="000000")
+        assert result["result"] is False
+        assert "rate" in result["message"].lower() or "many" in result["message"].lower()


### PR DESCRIPTION
## 被破坏的不变量

OTP（TOTP）的安全模型有一个核心不变量：**在单个 30 秒时间窗口内，攻击者不能穷举全部 10^6 个 6 位 OTP 组合**。该不变量依赖两个条件：① 人工输入速度不够快；② 机器调用有速率限制。

`verify_otp_code` NATS handler 破坏了条件 ②，使 MFA 形同虚设。

## 根因（设计层）

`verify_otp_code` 是 OTP 验证的早期实现，从未跟进后来加入 `verify_otp_login` 的速率限制逻辑。两个接口并存、安全级别不一致，而 RPC 层 `rpc/system_mgmt.py` 将 `verify_otp_code` 暴露给其他服务调用。

具体缺失：
- 无 `check_rate_limit` 调用——任何调用方均可无限尝试
- 无 `record_failed_attempt` 调用——失败不累积计数
- 无 `reset_rate_limit` 调用——即便有计数，成功后也不会清零
- `User.objects.get(username=...)` 在用户不存在时抛出 `DoesNotExist` 异常（未处理）

## 修复如何恢复不变量

完全对齐 `verify_otp_login` 的防护模式，复用已有的 `otp_challenge.py` 工具函数：

```python
# 修复前（nats_api.py:1427）
def verify_otp_code(username, otp_code):
    user = User.objects.get(username=username)  # 未处理 DoesNotExist
    totp = pyotp.TOTP(user.otp_secret)
    if totp.verify(otp_code):
        return {"result": True, "message": "Verification successful"}
    return {"result": False, "message": "Invalid OTP code"}

# 修复后
def verify_otp_code(username, otp_code, client_ip=""):
    is_limited, remaining = check_rate_limit(client_ip, username)  # ← 入口速率检查
    if is_limited:
        return {"result": False, "message": "Too many failed attempts..."}
    user = User.objects.filter(username=username).first()           # ← 安全查询
    if not user:
        return {"result": False, "message": "User not found"}
    if not user.otp_secret:
        return {"result": False, "message": "OTP not configured for this user"}
    totp = pyotp.TOTP(user.otp_secret)
    if totp.verify(otp_code):
        reset_rate_limit(client_ip, username)                       # ← 成功后重置
        return {"result": True, "message": "Verification successful"}
    record_failed_attempt(client_ip, username)                      # ← 失败计数
    return {"result": False, "message": "Invalid OTP code"}
```

`client_ip=""` 默认值保证现有调用方零改动（向后兼容）。RPC 存根 `rpc/system_mgmt.py` 同步新增 `client_ip` 参数，上层调用方可逐步传入真实 IP 以获得精准隔离。

## blast radius · 一致性

- 影响范围：`server/apps/system_mgmt/nats_api.py`（handler）+ `server/apps/rpc/system_mgmt.py`（RPC 存根），改动互相配套
- agents/ 及 web/ 均未直接调用 `verify_otp_code`，无需变更
- 复用 `otp_challenge.py` 中已有的 `check_rate_limit` / `record_failed_attempt` / `reset_rate_limit`——与 `verify_otp_login` 的防护逻辑完全一致，不引入新的工具函数
- `RATE_LIMIT_MAX_ATTEMPTS=5` / `RATE_LIMIT_TTL=300s` 配置沿用现有值（已被 `verify_otp_login` 生产验证），如需调整可在 `otp_challenge.py` 统一修改

## 调用链

```mermaid
flowchart TD
    subgraph T["调用层"]
        T1["RPC 调用方\nrpc/system_mgmt.py:277"]
        T2["NATS 直接发布方\n（外部服务）"]
    end

    subgraph N["verify_otp_code handler\nnats_api.py:1427"]
        N1["check_rate_limit(client_ip, username)\notp_challenge.py:83"]
        N2["User.objects.filter(username).first()"]
        N3["totp.verify(otp_code)"]
        N4["reset_rate_limit()\notp_challenge.py:123"]
        N5["record_failed_attempt()\notp_challenge.py:105"]
    end

    T1 --> N1
    T2 --> N1
    N1 -->|未超限| N2
    N1 -->|已超限| BLOCK["返回 result:False\n速率限制提示"]
    N2 --> N3
    N3 -->|OTP 正确| N4 --> OK["返回 result:True"]
    N3 -->|OTP 错误| N5 --> FAIL["返回 result:False\nInvalid OTP code"]
```

## 验证

新增 `test_verify_otp_code_rate_limit.py`，7 个测试场景：
- 连续失败 `RATE_LIMIT_MAX_ATTEMPTS` 次后触发限速
- 正确 OTP 重置失败计数器
- 限速前正确 OTP 仍可通过
- 已达上限时即便 OTP 正确也被拦截（rate-limit gate 先于 DB 查询）
- 不同 IP 之间互相隔离
- 不存在的用户名返回 User not found
- 遗留调用方（无 client_ip）仍受速率保护

将修复代码 revert 后，上述 T1（速率限制触发）测试必然失败，满足 revert-fail 准则。