### PR TITLE
fix：机房机柜视图改为白色系并优化详情交互

### DIFF
--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/deviceDetailDrawer.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/deviceDetailDrawer.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '@/utils/i18n';
 import { useInstanceApi, useModelApi } from '@/app/cmdb/api';
 import type { RackDevice } from '@/app/cmdb/types/rackRoom';
 import { deviceColor, deviceTypeName, TECH } from '@/app/cmdb/utils/rackRoomLayout';
+import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 
 interface Props {
   device: RackDevice | null;
@@ -111,7 +112,7 @@ const DeviceDetailDrawer: React.FC<Props> = ({ device, open, onClose }) => {
       styles={{
         body: { padding: 0, background: TECH.bg0 },
         content: { background: TECH.bg0 },
-        wrapper: { boxShadow: '-12px 0 40px rgba(0,0,0,0.55)' },
+        wrapper: { boxShadow: '-12px 0 40px rgba(23,54,106,0.15)' },
       }}
     >
       {device && (
@@ -136,8 +137,8 @@ const DeviceDetailDrawer: React.FC<Props> = ({ device, open, onClose }) => {
               <div className="dd-grid">
                 {rows.map((row) => (
                   <div className="dd-row" key={row.k}>
-                    <span className="dd-k" title={row.k}>{row.k}</span>
-                    <span className="dd-v" title={row.v}>{row.v}</span>
+                    <EllipsisWithTooltip text={row.k} className="dd-k" />
+                    <EllipsisWithTooltip text={row.v} className="dd-v" />
                   </div>
                 ))}
               </div>
@@ -162,17 +163,19 @@ const DeviceDetailDrawer: React.FC<Props> = ({ device, open, onClose }) => {
           border-bottom: 1px solid ${TECH.line};
         }
         .dd-led { width: 10px; height: 10px; border-radius: 50%; flex: none; }
-        .dd-name { font-size: 16px; font-weight: 600; color: #fff;
+        .dd-name { font-size: 16px; font-weight: 600; color: ${TECH.text};
           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .dd-sub { display: flex; align-items: center; gap: 10px; margin-top: 6px; }
         .dd-u { font-size: 12px; color: ${TECH.textDim}; font-family: ui-monospace, monospace; }
         .dd-body { flex: 1; overflow: auto; padding: 8px 14px; }
         .dd-grid { display: flex; flex-direction: column; }
-        .dd-row { display: flex; justify-content: space-between; gap: 14px;
-          padding: 11px 6px; border-bottom: 1px dashed ${TECH.line}; }
-        .dd-k { color: ${TECH.textDim}; font-size: 13px; flex: none; max-width: 42%;
+        .dd-row { display: flex; justify-content: space-between; align-items: baseline;
+          gap: 14px; padding: 11px 6px; border-bottom: 1px dashed ${TECH.line}; }
+        .dd-row :global(.dd-k) { color: ${TECH.textDim}; font-size: 13px;
+          flex: none; max-width: 42%;
           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .dd-v { color: ${TECH.text}; font-size: 13px; text-align: right;
+        .dd-row :global(.dd-v) { color: ${TECH.text}; font-size: 13px;
+          flex: 1; min-width: 0; text-align: right;
           white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
         .dd-empty { padding: 40px; text-align: center; color: ${TECH.textDim}; }
         .dd-ft { padding: 14px 16px; border-top: 1px solid ${TECH.line}; }

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/rackElevation.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/rackElevation.tsx
@@ -116,17 +116,17 @@ const RackElevation: React.FC<Props> = ({ modelId, instId, embedded, onDeviceCli
         <svg width={SVG_W} height={svgH} style={{ display: 'block', margin: '0 auto' }}>
           <defs>
             <linearGradient id="rkFrame" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0" stopColor="#1a2742" />
-              <stop offset="0.5" stopColor="#0f1830" />
-              <stop offset="1" stopColor="#1a2742" />
+              <stop offset="0" stopColor="#eef2f8" />
+              <stop offset="0.5" stopColor="#e0e7f2" />
+              <stop offset="1" stopColor="#eef2f8" />
             </linearGradient>
             <linearGradient id="rkRail" x1="0" y1="0" x2="1" y2="0">
-              <stop offset="0" stopColor="#33486f" />
-              <stop offset="1" stopColor="#1b2640" />
+              <stop offset="0" stopColor="#d6dde9" />
+              <stop offset="1" stopColor="#c3ccda" />
             </linearGradient>
             <linearGradient id="rkDev" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0" stopColor="#1d2c4a" />
-              <stop offset="1" stopColor="#0e1830" />
+              <stop offset="0" stopColor="#fbfdff" />
+              <stop offset="1" stopColor="#eaf0f8" />
             </linearGradient>
             <filter id="rkGlow" x="-40%" y="-40%" width="180%" height="180%">
               <feGaussianBlur stdDeviation="2.4" result="b" />
@@ -145,8 +145,8 @@ const RackElevation: React.FC<Props> = ({ modelId, instId, embedded, onDeviceCli
           <rect x={FRAME_X + FRAME_W - 9} y={RACK_TOP} width={9} height={u * uPx} fill="url(#rkRail)" />
           {Array.from({ length: u }).map((_, i) => (
             <g key={`h${i}`}>
-              <circle cx={FRAME_X + 4.5} cy={RACK_TOP + i * uPx + uPx / 2} r={1.1} fill="#0a1020" />
-              <circle cx={FRAME_X + FRAME_W - 4.5} cy={RACK_TOP + i * uPx + uPx / 2} r={1.1} fill="#0a1020" />
+              <circle cx={FRAME_X + 4.5} cy={RACK_TOP + i * uPx + uPx / 2} r={1.1} fill="#9aa7bd" />
+              <circle cx={FRAME_X + FRAME_W - 4.5} cy={RACK_TOP + i * uPx + uPx / 2} r={1.1} fill="#9aa7bd" />
             </g>
           ))}
 
@@ -176,7 +176,7 @@ const RackElevation: React.FC<Props> = ({ modelId, instId, embedded, onDeviceCli
               <g key={d.inst_id} className="rk-dev" style={{ cursor: 'pointer' }}
                 onClick={() => onDevice(d)}>
                 <rect x={dx} y={y + 1.5} width={wDev} height={h} rx={3}
-                  fill="url(#rkDev)" stroke={bad ? TECH.danger : 'rgba(120,170,255,0.35)'}
+                  fill="url(#rkDev)" stroke={bad ? TECH.danger : 'rgba(23,54,106,0.18)'}
                   strokeWidth={bad ? 1.6 : 0.8}
                   filter={bad ? 'url(#rkGlow)' : undefined} />
                 <rect x={dx + 3} y={y + 4} width={3.5} height={Math.max(h - 5, 4)} rx={1.5}
@@ -184,7 +184,7 @@ const RackElevation: React.FC<Props> = ({ modelId, instId, embedded, onDeviceCli
                 {h > 22 && !conflicted && [0, 1, 2].map((k) => (
                   <line key={k} x1={tx + 4} x2={tx + 58}
                     y1={cy - 4 + k * 4} y2={cy - 4 + k * 4}
-                    stroke="rgba(120,160,220,0.16)" strokeWidth={1.4} />
+                    stroke="rgba(23,54,106,0.12)" strokeWidth={1.4} />
                 ))}
                 <circle cx={dx + wDev - 9} cy={cy} r={2.1} fill={bad ? TECH.danger : TECH.ok}
                   filter="url(#rkGlow)" />
@@ -229,15 +229,15 @@ const RackElevation: React.FC<Props> = ({ modelId, instId, embedded, onDeviceCli
         .rk-ov-i {
           flex: 1; display: flex; flex-direction: column; align-items: center;
           gap: 2px; padding: 6px 4px; border-radius: 8px;
-          background: rgba(120,160,255,0.05); border: 1px solid ${TECH.line};
+          background: rgba(23,54,106,0.04); border: 1px solid ${TECH.line};
         }
         .rk-ov-i :global(b) { font-size: 17px; font-weight: 600; color: ${TECH.text};
           font-family: ui-monospace, monospace; line-height: 1.1; }
         .rk-ov-i :global(i) { font-size: 11px; color: ${TECH.textDim}; font-style: normal; }
-        .rk-ov-i.hl { background: rgba(63,208,255,0.1); border-color: rgba(63,208,255,0.4); }
+        .rk-ov-i.hl { background: rgba(47,116,230,0.1); border-color: rgba(47,116,230,0.35); }
         .rk-ov-i.hl :global(b) { color: ${TECH.cyan}; }
         .rk-dev :global(rect) { transition: filter .15s; }
-        .rk-dev:hover :global(text) { fill: #fff; }
+        .rk-dev:hover :global(text) { fill: ${TECH.cyan}; }
       `}</style>
     </div>
   );

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/roomFloorPlan.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/roomFloorPlan.tsx
@@ -133,7 +133,7 @@ const RoomFloorPlan: React.FC<Props> = ({ modelId, instId }) => {
         styles={{
           body: { padding: 0, background: TECH.bg1 },
           content: { background: TECH.bg1 },
-          wrapper: { boxShadow: '-12px 0 40px rgba(0,0,0,0.5)' },
+          wrapper: { boxShadow: '-12px 0 40px rgba(23,54,106,0.15)' },
         }}
       >
         {rack && (
@@ -192,7 +192,7 @@ const RoomFloorPlan: React.FC<Props> = ({ modelId, instId }) => {
             radial-gradient(1200px 500px at 20% -10%, ${TECH.panelHi}, transparent),
             linear-gradient(180deg, ${TECH.bg1}, ${TECH.bg0});
           border: 1px solid ${TECH.line};
-          box-shadow: inset 0 0 60px rgba(0,0,0,0.4);
+          box-shadow: inset 0 0 60px rgba(23,54,106,0.05);
         }
         .rf-canvas {
           position: relative;
@@ -229,7 +229,7 @@ const RoomFloorPlan: React.FC<Props> = ({ modelId, instId }) => {
           width: 7px; height: 7px; border-radius: 50%;
         }
         .rf-rack-name {
-          color: #fff; font-size: 12px; font-weight: 600; line-height: 1.2;
+          color: ${TECH.text}; font-size: 12px; font-weight: 600; line-height: 1.2;
           letter-spacing: -0.2px;
           white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
           margin-top: 2px; padding-right: 12px;
@@ -245,7 +245,7 @@ const RoomFloorPlan: React.FC<Props> = ({ modelId, instId }) => {
         .rf-rack-free > b { font-weight: 600; font-family: ui-monospace, monospace; }
         .rf-bar {
           position: absolute; left: 10px; right: 10px; bottom: 18px; height: 5px;
-          border-radius: 3px; background: rgba(255,255,255,0.08); overflow: hidden;
+          border-radius: 3px; background: rgba(23,54,106,0.1); overflow: hidden;
         }
         .rf-bar > i { display: block; height: 100%; border-radius: 3px; }
         .rf-rack-usage {
@@ -257,7 +257,7 @@ const RoomFloorPlan: React.FC<Props> = ({ modelId, instId }) => {
         .rd-hd { display: flex; align-items: center; gap: 12px; padding: 18px 20px; }
         .rd-led { width: 11px; height: 11px; border-radius: 50%; flex: none; }
         .rd-name {
-          font-size: 17px; font-weight: 600; color: #fff;
+          font-size: 17px; font-weight: 600; color: ${TECH.text};
           white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
         }
         .rd-sub { display: flex; align-items: center; gap: 10px; margin-top: 6px; }

--- a/web/src/app/cmdb/utils/rackRoomLayout.ts
+++ b/web/src/app/cmdb/utils/rackRoomLayout.ts
@@ -1,19 +1,19 @@
 import type { RoomLayoutData } from '@/app/cmdb/types/rackRoom';
 
-// 科技写实主题色板（深色背景 + 霓虹描边）
+// 主题色板（白色系，与周边页面一致；accent 蓝为主色）
 export const TECH = {
-  bg0: '#0a0f1c',
-  bg1: '#0e1424',
-  panel: '#111a2e',
-  panelHi: '#16223c',
-  line: 'rgba(86,160,255,0.16)',
-  lineHi: 'rgba(120,190,255,0.5)',
-  cyan: '#3fd0ff',
-  text: '#dbe6ff',
-  textDim: '#7e92bd',
-  ok: '#36e6a0',
-  warn: '#ffb547',
-  danger: '#ff5a6a',
+  bg0: '#ffffff',
+  bg1: '#f6f8fc',
+  panel: '#ffffff',
+  panelHi: '#eef3fb',
+  line: 'rgba(23,54,106,0.12)',
+  lineHi: 'rgba(23,54,106,0.26)',
+  cyan: '#2f74e6',
+  text: '#1f2a3d',
+  textDim: '#7c8aa6',
+  ok: '#1f9d6b',
+  warn: '#d9871a',
+  danger: '#e24b4a',
 };
 
 // 机柜类型枚举 → 主色（普通/网络/存储/配电/配线/其他）


### PR DESCRIPTION
- 配色由深色科技风改为白色系（TECH 调色板 + SVG 渐变/描边/阴影/文字色），与周边页面统一，仅改颜色不动布局
- 设备详情抽屉的键/值过长时用 EllipsisWithTooltip，溢出才弹 Tooltip 显示完整内容