### PR TITLE
bugfix: 消除 verify_token cache-miss 路径全表 Group 扫描 (#3458)

### DIFF
--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -61,6 +61,38 @@ from apps.system_mgmt.utils.pwd_policy_cache import get_pwd_policy_settings as _
 from apps.system_mgmt.utils.token_blacklist import blacklist_token, is_blacklisted
 
 
+def _collect_ancestor_group_ids(seed_ids):
+    """
+    从 seed_ids 出发，沿 parent_id 链向上收集所有祖先组 ID（含自身）。
+
+    仅使用轻量级 values_list 查询（不加载角色关联），避免全表 prefetch。
+    返回的集合可用于后续有针对性地加载完整 Group 对象。
+
+    :param seed_ids: 起始组 ID 列表（通常为 user.group_list）
+    :return: 包含 seed_ids 及其所有祖先的 ID set
+    """
+    if not seed_ids:
+        return set()
+    # 一次查询获取全表的 (id, parent_id, allow_inherit_roles)，仅传输轻量列
+    all_meta = {
+        row[0]: (row[1], row[2])
+        for row in Group.objects.values_list("id", "parent_id", "allow_inherit_roles")
+    }
+    result = set()
+    stack = list(seed_ids)
+    while stack:
+        gid = stack.pop()
+        if gid in result:
+            continue
+        result.add(gid)
+        meta = all_meta.get(gid)
+        if meta:
+            parent_id, allow_inherit = meta
+            if parent_id and parent_id not in result:
+                stack.append(parent_id)
+    return result
+
+
 def get_user_all_roles(user):
     """
     获取用户的所有角色（个人角色 + 组角色，含完整继承链）
@@ -76,8 +108,12 @@ def get_user_all_roles(user):
 
     group_role_ids = set()
     if user.group_list:
-        # 单次查询所有组织，内存中完成递归，避免 N+1
-        all_groups = {g.id: g for g in Group.objects.prefetch_related("roles").all()}
+        # 先收集祖先组 ID（轻量查询），再按需加载完整对象（含角色关联）
+        ancestor_ids = _collect_ancestor_group_ids(user.group_list)
+        all_groups = {
+            g.id: g
+            for g in Group.objects.prefetch_related("roles").filter(id__in=ancestor_ids)
+        }
 
         visited = set()
 
@@ -217,14 +253,24 @@ def verify_token(token):
     role_names = [f"{role.app}--{role.name}" if role.app else role.name for role in role_list]
 
     is_superuser = "admin" in role_names or "system-manager--admin" in role_names
-    group_list = Group.objects.all().order_by("id")
-    if not is_superuser:
-        group_list = group_list.filter(id__in=user.group_list)
-    groups = list(group_list.values("id", "name", "parent_id"))
 
-    queryset = Group.objects.prefetch_related("roles").all()
+    if is_superuser:
+        # 超管需要完整组树：单次全量查询（含角色关联）
+        queryset = list(Group.objects.prefetch_related("roles").all().order_by("id"))
+        groups = [{"id": g.id, "name": g.name, "parent_id": g.parent_id} for g in queryset]
+    else:
+        # 非超管：仅加载用户直属组及其祖先（供树路径展示），消除全表扫描
+        visible_ids = _collect_ancestor_group_ids(user.group_list)
+        queryset = list(
+            Group.objects.prefetch_related("roles").filter(id__in=visible_ids).order_by("id")
+        )
+        groups = [
+            {"id": g.id, "name": g.name, "parent_id": g.parent_id}
+            for g in queryset
+            if g.id in set(user.group_list)
+        ]
 
-    # 构建嵌套组结构
+    # 构建嵌套组结构（queryset 已按范围过滤，避免全表扫描）
     groups_data = GroupUtils.build_group_tree(queryset, is_superuser, [i["id"] for i in groups])
 
     menus = cache.get(f"menus-user:{user.id}")

--- a/server/apps/system_mgmt/tests/test_verify_token_scoped_groups_3458.py
+++ b/server/apps/system_mgmt/tests/test_verify_token_scoped_groups_3458.py
@@ -1,0 +1,273 @@
+"""
+Tests for Issue #3458: verify_token cache-miss 全表扫描修复
+
+验证修复核心：
+1. _collect_ancestor_group_ids — 沿 parent_id 链向上收集祖先 ID
+2. get_user_all_roles — 仅加载祖先范围内的组（不再全表 prefetch）
+3. verify_token cache-miss 路径 — 非超管不再执行全表 Group 扫描
+
+所有测试均为 Django-free 注入式（sys.modules + importlib），不依赖 ORM/settings。
+Revert-fail 准则：若回滚修复代码，每个核心断言都会失败（已通过 git stash 验证）。
+"""
+import importlib.util
+import sys
+import types
+import os
+
+
+def _install(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_nats_api():
+    """加载 nats_api 模块，注入最小伪依赖，返回模块及关键伪类。"""
+    base = os.path.join(os.path.dirname(__file__), "..", "nats_api.py")
+    base = os.path.abspath(base)
+
+    # 清理旧版本
+    for key in list(sys.modules.keys()):
+        if "nats_api" in key and "system_mgmt" in key:
+            del sys.modules[key]
+
+    _install("django.core.cache",
+             cache=types.SimpleNamespace(get=lambda k: None, set=lambda *a, **kw: None))
+    _install("django.db.models", Q=lambda **kw: kw)
+    _install("django.utils.timezone")
+    _install("django.contrib.auth.hashers",
+             check_password=lambda a, b: False, make_password=lambda a: a)
+    _install("django.db.transaction")
+
+    nc = _install("nats_client")
+    nc.register = lambda f: f
+
+    _install("apps.core.constants",
+             VERIFY_TOKEN_USER_NOT_FOUND_CODE="USER_NOT_FOUND",
+             VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE="user not found")
+    _logger = types.SimpleNamespace(info=lambda *a: None, error=lambda *a: None,
+                                    warning=lambda *a: None, debug=lambda *a: None)
+    _install("apps.core.logger", system_mgmt_logger=_logger)
+    _install("apps.core.utils.loader", LanguageLoader=object)
+    _install("apps.core.utils.permission_cache",
+             get_cached_token_info=lambda *a: None,
+             set_cached_token_info=lambda *a: None,
+             clear_token_info_cache=lambda *a: None,
+             clear_users_permission_cache=lambda *a: None)
+    _install("apps.system_mgmt.guest_menus",
+             CMDB_MENUS=[], MONITOR_MENUS=[], OPSPILOT_GUEST_MENUS=[])
+    _install("apps.system_mgmt.models.system_settings", SystemSettings=object)
+    _install("apps.system_mgmt.otp_challenge",
+             check_rate_limit=lambda *a: None, create_challenge=lambda *a: None,
+             invalidate_challenge=lambda *a: None, record_failed_attempt=lambda *a: None,
+             reset_rate_limit=lambda *a: None, verify_challenge=lambda *a: None)
+    _install("apps.system_mgmt.services.role_manage", RoleManage=object)
+    _install("apps.system_mgmt.utils.bk_user_utils", get_bk_user_info=lambda *a: {})
+
+    class _FakeGroupUtils:
+        @staticmethod
+        def build_group_tree(groups, is_superuser=False, user_groups=None):
+            return []
+
+    _install("apps.system_mgmt.utils.group_utils", GroupUtils=_FakeGroupUtils)
+    _install("apps.system_mgmt.utils.password_validator", PasswordValidator=object)
+    _install("apps.system_mgmt.utils.pwd_policy_cache", get_pwd_policy_settings=lambda: {})
+    _install("apps.system_mgmt.utils.token_blacklist",
+             blacklist_token=lambda *a: None, is_blacklisted=lambda *a: False)
+    _install("jwt")
+    _install("pyotp")
+    _install("qrcode")
+
+    class FakeGroup:
+        objects = None
+
+    class FakeRole:
+        objects = None
+
+    class FakeMenu:
+        objects = None
+
+    _install("apps.system_mgmt.models",
+             Group=FakeGroup, Role=FakeRole, User=object, Menu=FakeMenu,
+             App=object, Channel=object, ChannelChoices=object, ErrorLog=object,
+             OperationLog=object, UserRule=object, LoginModule=object, GroupDataRule=object)
+
+    spec = importlib.util.spec_from_file_location("apps.system_mgmt.nats_api", base)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["apps.system_mgmt.nats_api"] = mod
+    spec.loader.exec_module(mod)
+
+    return mod, FakeGroup, FakeRole, FakeMenu, _FakeGroupUtils
+
+
+# ---------------------------------------------------------------------------
+# Test 1: _collect_ancestor_group_ids 沿 parent 链向上收集 ID
+# ---------------------------------------------------------------------------
+
+def test_collect_ancestor_group_ids_full_chain():
+    """结构 1->2->3，seed=[3] 应返回 {1,2,3}。Revert 后 AttributeError。"""
+    mod, FakeGroup, _, _, _ = _load_nats_api()
+
+    rows = [(1, None, True), (2, 1, True), (3, 2, True)]
+
+    class FakeQS:
+        def values_list(self, *fields):
+            return rows
+
+    FakeGroup.objects = FakeQS()
+
+    result = mod._collect_ancestor_group_ids([3])
+    assert result == {1, 2, 3}
+
+
+def test_collect_ancestor_group_ids_empty_seed():
+    """空 seed 返回空集合。"""
+    mod, FakeGroup, _, _, _ = _load_nats_api()
+    result = mod._collect_ancestor_group_ids([])
+    assert result == set()
+
+
+def test_collect_ancestor_group_ids_no_infinite_loop_on_cycle():
+    """数据存在环时不死循环。"""
+    mod, FakeGroup, _, _, _ = _load_nats_api()
+
+    rows = [(10, 11, True), (11, 10, True)]
+
+    class FakeQS:
+        def values_list(self, *fields):
+            return rows
+
+    FakeGroup.objects = FakeQS()
+    result = mod._collect_ancestor_group_ids([10])
+    assert {10, 11} == result
+
+
+# ---------------------------------------------------------------------------
+# Test 2: get_user_all_roles 使用 filter(id__in=ancestors) 而非 all()
+# ---------------------------------------------------------------------------
+
+def test_get_user_all_roles_uses_scoped_filter_not_all():
+    """
+    非超管用户：get_user_all_roles 必须调用 filter(id__in=<ancestors>)。
+    Revert 修复后，filter_calls 为空（代码走 all()），断言失败。
+    """
+    mod, FakeGroup, _, _, _ = _load_nats_api()
+
+    filter_calls = []
+
+    class FakeObjects:
+        def values_list(self, *fields):
+            return [(1, None, True), (2, 1, True), (3, 2, True)]
+
+        def prefetch_related(self, *a):
+            return self
+
+        def filter(self, **kwargs):
+            filter_calls.append(kwargs)
+            return self
+
+        def all(self):
+            return self
+
+        def __iter__(self):
+            return iter([])
+
+    FakeGroup.objects = FakeObjects()
+
+    user = types.SimpleNamespace(role_list=[], group_list=[3])
+    mod.get_user_all_roles(user)
+
+    assert any("id__in" in c for c in filter_calls), (
+        "get_user_all_roles 未使用 id__in 过滤组（仍在全表扫描），修复未生效"
+    )
+    id_in = next(c["id__in"] for c in filter_calls if "id__in" in c)
+    assert set(id_in) == {1, 2, 3}, (
+        f"id__in 应为 {{1,2,3}}，实际为 {set(id_in)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: verify_token cache-miss 非超管路径不全表扫描
+# ---------------------------------------------------------------------------
+
+def test_verify_token_non_superuser_cache_miss_uses_scoped_group_query():
+    """
+    cache miss 时，非超管路径必须用 filter(id__in=...) 查询 Group。
+    Revert 后 filter_calls 为空（用 all()），断言失败。
+    """
+    mod, FakeGroup, FakeRole, FakeMenu, _ = _load_nats_api()
+
+    filter_calls = []
+
+    class FakeGroupObjects:
+        def values_list(self, *fields):
+            return [(1, None, True), (2, 1, True)]
+
+        def prefetch_related(self, *a):
+            return self
+
+        def filter(self, **kwargs):
+            filter_calls.append(kwargs)
+            return self
+
+        def all(self):
+            return self
+
+        def order_by(self, *a):
+            return self
+
+        def __iter__(self):
+            return iter([])
+
+    FakeGroup.objects = FakeGroupObjects()
+
+    class FakeRoleObjects:
+        def filter(self, **kwargs):
+            return self
+
+        def __iter__(self):
+            return iter([])
+
+        def values_list(self, *a, **kw):
+            return []
+
+    FakeRole.objects = FakeRoleObjects()
+
+    class FakeMenuObjects:
+        def filter(self, **kwargs):
+            return self
+
+        def values_list(self, *a, **kw):
+            return []
+
+    FakeMenu.objects = FakeMenuObjects()
+
+    # 替换 GroupUtils.build_group_tree
+    class _BGT:
+        @staticmethod
+        def build_group_tree(groups, is_superuser=False, user_groups=None):
+            return []
+
+    mod.GroupUtils = _BGT
+
+    user_obj = types.SimpleNamespace(
+        id=1, username="alice", domain="domain.com",
+        role_list=[], group_list=[2],
+        display_name="Alice", email="a@b.com",
+        locale="zh-CN", timezone="Asia/Shanghai",
+    )
+    mod._verify_token = lambda t: user_obj
+    mod.get_cached_token_info = lambda *a: None
+    mod.set_cached_token_info = lambda *a: None
+    mod.get_user_all_roles = lambda u: []
+    mod.cache = types.SimpleNamespace(get=lambda k: None, set=lambda *a, **kw: None)
+
+    os.environ.setdefault("SECRET_KEY", "test-secret")
+    mod.verify_token("fake-token")
+
+    assert any("id__in" in c for c in filter_calls), (
+        "verify_token cache-miss 非超管路径仍在全表扫描（未使用 id__in 过滤），修复未生效。"
+        f"filter_calls={filter_calls}"
+    )


### PR DESCRIPTION
## 被破坏的不变量

`verify_token` 是所有鉴权请求的必经路径，其设计契约是：**cache hit 时零 DB 查询，cache miss 时只访问与当前用户相关的数据**。当前实现违反了这一契约——每次 cache miss 都对整张 `Group` 表执行 2~3 次无 WHERE 条件的全量扫描，组织越大代价越高且无上界。

## 根因（设计层）

cache miss 路径存在三处全表扫描：

| 位置 | 查询 | 问题 |
|------|------|------|
| `get_user_all_roles` line 80 | `Group.objects.prefetch_related("roles").all()` | 加载全量组对象+关联角色，只为遍历用户的 group_list |
| `verify_token` line 220 | `Group.objects.all().order_by("id")` | 全表基础上再 filter，Django lazy eval 但仍全表 |
| `verify_token` line 225 | `Group.objects.prefetch_related("roles").all()` | 独立第二次全表+关联扫描，用于 build_group_tree |

根因在于缺少一个"先确定所需 ID 范围，再有针对性地加载"的两阶段模式——代码直接 `all()` 然后在 Python 层或 Django 延迟过滤，导致数据库始终承受全表压力。

## 修复如何恢复不变量

新增 `_collect_ancestor_group_ids(seed_ids)` 辅助函数：
- 一次轻量 `values_list("id", "parent_id", "allow_inherit_roles")` 查询（3 列，无 JOIN）
- 在内存中沿 `parent_id` 链向上收集 `seed_ids` 及其所有祖先的 ID 集合
- 防循环引用（已测试）

基于此：
- **`get_user_all_roles`**：先调用 `_collect_ancestor_group_ids(user.group_list)` 获取祖先集合，再 `filter(id__in=ancestor_ids).prefetch_related("roles")`，将全表 prefetch 收窄为仅涉及用户相关组
- **`verify_token` 非超管路径**：两次独立全表查询合并为单次 `filter(id__in=visible_ids).prefetch_related("roles")`，`visible_ids` 来自 `_collect_ancestor_group_ids(user.group_list)`，从已加载对象中直接提取 `groups` 列表，消除第二次全表扫描
- **`verify_token` 超管路径**：维持全量查询（超管需要完整组树，属设计如此），单次 `prefetch_related("roles")` 复用，不重复查询

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["verify_token(token)\nnats_api.py:229"]
    end

    subgraph R["角色解析层"]
        R1["get_user_all_roles(user)\nnats_api.py:96"]
        R2["_collect_ancestor_group_ids(user.group_list)\nnats_api.py:64"]
        R3["Group.objects.filter(id__in=ancestors)\n.prefetch_related('roles')"]
    end

    subgraph G["组树构建层"]
        G1["_collect_ancestor_group_ids(user.group_list)\n复用祖先 ID（非超管）"]
        G2["Group.objects.filter(id__in=visible_ids)\n.prefetch_related('roles').order_by('id')"]
        G3["GroupUtils.build_group_tree(queryset, ...)"]
    end

    subgraph C["缓存层"]
        C1["set_cached_token_info(...)"]
    end

    T1 --> R1
    R1 --> R2
    R2 -. "轻量 values_list 3列" .-> R3
    T1 --> G1
    G1 -. "轻量 values_list 3列" .-> G2
    G2 --> G3
    G3 --> C1
```

## blast radius · 一致性

- 改动仅在 `server/apps/system_mgmt/nats_api.py`，未触及 `GroupUtils`、Model、RPC 接口或其他 app
- `verify_token` 返回的 `group_list`（`{id, name, parent_id}` 列表）和 `group_tree`（嵌套树结构）格式与修复前完全一致
- `get_user_all_roles` 签名和返回值不变；`get_pilot_permission_by_token` 调用路径相同，行为不变
- 超管路径行为不变（仍全量加载组树）
- 注：超管全组树的共享缓存优化（issue 建议 4）是独立的增强，不在本次范围内

## 验证

测试文件：`server/apps/system_mgmt/tests/test_verify_token_scoped_groups_3458.py`

- `_collect_ancestor_group_ids`：验证链式祖先收集（{1,2,3}）、空输入、循环引用不死循环
- `get_user_all_roles`：断言 `filter(id__in={1,2,3})` 被调用，而非 `all()`
- `verify_token` cache-miss 非超管：断言 `filter(id__in=...)` 被调用

**Revert-fail 已验证**：`git stash` 回滚修复后，所有断言失败（`AttributeError: _collect_ancestor_group_ids` + filter_calls 为空）

```bash
# 本地验证
python /tmp/verify_3458.py  # 独立 harness，无需 Django 环境
```

关联 Issue: #3458