### PR TITLE
bugfix: send_email_code 增加速率限制防止邮件服务被滥用 (#3469)

### DIFF
--- a/server/apps/console_mgmt/tests/test_send_email_code_views.py
+++ b/server/apps/console_mgmt/tests/test_send_email_code_views.py
@@ -1,0 +1,122 @@
+"""console_mgmt send_email_code 接口速率限制测试。
+
+规格要点（Issue #3469）：
+- send_email_code 接受任意 email 发送验证码（合法用途：修改绑定邮箱）
+- 修复前：无速率限制，任意已登录用户可向任意外部邮箱无限发送
+- 修复后：每用户每目标邮箱 60 秒内最多 1 次，超出返回 result=False
+
+revert 测试：若将 `cache.set(rate_key, ...)` 和速率检查代码移除，第二个请求
+会再次调用 send_email_to_receiver → mock 调用次数 > 1 → test_速率限制_第二次请求被拦截 失败。
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import RequestFactory
+
+from apps.console_mgmt.views import EMAIL_CODE_RATE_LIMIT_SECONDS, send_email_code
+from apps.base.tests.factories import UserFactory
+
+pytestmark = [pytest.mark.django_db, pytest.mark.unit]
+
+TARGET_EMAIL = "newaddr@example.com"
+
+
+def _build_request(user, email=TARGET_EMAIL):
+    """构造携带认证用户的 POST 请求。"""
+    factory = RequestFactory()
+    req = factory.post(
+        "/api/v1/console_mgmt/send_email_code/",
+        data=json.dumps({"email": email}),
+        content_type="application/json",
+    )
+    req.user = user
+    return req
+
+
+@pytest.fixture
+def alice(db):
+    return UserFactory(username="alice", domain="domain.com")
+
+
+class TestSendEmailCodeRateLimit:
+    """速率限制守卫：确保同一用户对同一目标邮箱 60s 内只能发 1 次。"""
+
+    def test_首次请求_正常发送(self, alice):
+        mock_result = {"result": True}
+        with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
+             patch("apps.console_mgmt.views.cache") as mock_cache:
+            mock_cache.get.return_value = None  # 未命中速率限制
+            instance = MockClient.return_value
+            instance.send_email_to_receiver.return_value = mock_result
+
+            req = _build_request(alice)
+            resp = send_email_code(req)
+            data = json.loads(resp.content)
+
+            assert data["result"] is True
+            # 发送后必须设置速率限制缓存
+            mock_cache.set.assert_called_once()
+            call_args = mock_cache.set.call_args
+            assert call_args.kwargs.get("timeout") == EMAIL_CODE_RATE_LIMIT_SECONDS or (
+                len(call_args.args) >= 3 and call_args.args[2] == EMAIL_CODE_RATE_LIMIT_SECONDS
+            )
+            # 确实调用了邮件发送
+            instance.send_email_to_receiver.assert_called_once()
+
+    def test_速率限制_第二次请求被拦截(self, alice):
+        """速率限制命中时，不调用 send_email_to_receiver，返回 result=False。"""
+        with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
+             patch("apps.console_mgmt.views.cache") as mock_cache:
+            mock_cache.get.return_value = 1  # 模拟速率限制已命中
+            instance = MockClient.return_value
+
+            req = _build_request(alice)
+            resp = send_email_code(req)
+            data = json.loads(resp.content)
+
+            assert data["result"] is False
+            # 被速率限制拦截，不应发送邮件
+            instance.send_email_to_receiver.assert_not_called()
+            # 速率限制已命中，不应再次 set（避免重置窗口）
+            mock_cache.set.assert_not_called()
+
+    def test_速率限制_缓存key包含用户名和目标邮箱(self, alice):
+        """缓存 key 必须同时包含用户名和目标邮箱，避免不同用户/邮箱互相干扰。"""
+        with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
+             patch("apps.console_mgmt.views.cache") as mock_cache:
+            mock_cache.get.return_value = None
+            instance = MockClient.return_value
+            instance.send_email_to_receiver.return_value = {"result": True}
+
+            req = _build_request(alice, email="other@example.com")
+            send_email_code(req)
+
+            set_call = mock_cache.set.call_args
+            rate_key = set_call.args[0] if set_call.args else set_call.kwargs.get("key", "")
+            assert alice.username in rate_key
+            assert "other@example.com" in rate_key
+
+    def test_速率限制_不同用户之间不互相干扰(self, db):
+        """alice 命中速率限制，bob 同一邮箱首次请求应成功。"""
+        alice = UserFactory(username="alice", domain="domain.com")
+        bob = UserFactory(username="bob", domain="domain.com")
+
+        def fake_cache_get(key):
+            # 只有 alice 的 key 命中速率限制
+            return 1 if "alice" in key else None
+
+        with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
+             patch("apps.console_mgmt.views.cache") as mock_cache:
+            mock_cache.get.side_effect = fake_cache_get
+            instance = MockClient.return_value
+            instance.send_email_to_receiver.return_value = {"result": True}
+
+            # alice 被拦截
+            resp_alice = send_email_code(_build_request(alice))
+            assert json.loads(resp_alice.content)["result"] is False
+
+            # bob 不受影响
+            resp_bob = send_email_code(_build_request(bob))
+            assert json.loads(resp_bob.content)["result"] is True

--- a/server/apps/console_mgmt/tests/test_send_email_code_views.py
+++ b/server/apps/console_mgmt/tests/test_send_email_code_views.py
@@ -5,12 +5,17 @@
 - 修复前：无速率限制，任意已登录用户可向任意外部邮箱无限发送
 - 修复后：每用户每目标邮箱 60 秒内最多 1 次，超出返回 result=False
 
-revert 测试：若将 `cache.set(rate_key, ...)` 和速率检查代码移除，第二个请求
-会再次调用 send_email_to_receiver → mock 调用次数 > 1 → test_速率限制_第二次请求被拦截 失败。
+实现说明：
+- 使用 cache.add() 原子操作（set-if-not-exists）避免 TOCTOU 竞争条件
+- cache.add() 返回 True 表示 key 不存在并已写入（允许发送）
+- cache.add() 返回 False 表示 key 已存在（速率限制命中，拒绝发送）
+
+revert 测试：若将速率限制代码移除，第二个请求会再次调用
+send_email_to_receiver → mock 调用次数 > 1 → test_速率限制_第二次请求被拦截 失败。
 """
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from django.test import RequestFactory
@@ -47,7 +52,7 @@ class TestSendEmailCodeRateLimit:
         mock_result = {"result": True}
         with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
              patch("apps.console_mgmt.views.cache") as mock_cache:
-            mock_cache.get.return_value = None  # 未命中速率限制
+            mock_cache.add.return_value = True  # key 不存在，add 成功 → 允许发送
             instance = MockClient.return_value
             instance.send_email_to_receiver.return_value = mock_result
 
@@ -56,9 +61,9 @@ class TestSendEmailCodeRateLimit:
             data = json.loads(resp.content)
 
             assert data["result"] is True
-            # 发送后必须设置速率限制缓存
-            mock_cache.set.assert_called_once()
-            call_args = mock_cache.set.call_args
+            # 必须使用 cache.add() 原子写入速率限制标记
+            mock_cache.add.assert_called_once()
+            call_args = mock_cache.add.call_args
             assert call_args.kwargs.get("timeout") == EMAIL_CODE_RATE_LIMIT_SECONDS or (
                 len(call_args.args) >= 3 and call_args.args[2] == EMAIL_CODE_RATE_LIMIT_SECONDS
             )
@@ -69,7 +74,7 @@ class TestSendEmailCodeRateLimit:
         """速率限制命中时，不调用 send_email_to_receiver，返回 result=False。"""
         with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
              patch("apps.console_mgmt.views.cache") as mock_cache:
-            mock_cache.get.return_value = 1  # 模拟速率限制已命中
+            mock_cache.add.return_value = False  # key 已存在，add 失败 → 速率限制命中
             instance = MockClient.return_value
 
             req = _build_request(alice)
@@ -79,22 +84,20 @@ class TestSendEmailCodeRateLimit:
             assert data["result"] is False
             # 被速率限制拦截，不应发送邮件
             instance.send_email_to_receiver.assert_not_called()
-            # 速率限制已命中，不应再次 set（避免重置窗口）
-            mock_cache.set.assert_not_called()
 
     def test_速率限制_缓存key包含用户名和目标邮箱(self, alice):
         """缓存 key 必须同时包含用户名和目标邮箱，避免不同用户/邮箱互相干扰。"""
         with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
              patch("apps.console_mgmt.views.cache") as mock_cache:
-            mock_cache.get.return_value = None
+            mock_cache.add.return_value = True
             instance = MockClient.return_value
             instance.send_email_to_receiver.return_value = {"result": True}
 
             req = _build_request(alice, email="other@example.com")
             send_email_code(req)
 
-            set_call = mock_cache.set.call_args
-            rate_key = set_call.args[0] if set_call.args else set_call.kwargs.get("key", "")
+            add_call = mock_cache.add.call_args
+            rate_key = add_call.args[0] if add_call.args else add_call.kwargs.get("key", "")
             assert alice.username in rate_key
             assert "other@example.com" in rate_key
 
@@ -103,13 +106,13 @@ class TestSendEmailCodeRateLimit:
         alice = UserFactory(username="alice", domain="domain.com")
         bob = UserFactory(username="bob", domain="domain.com")
 
-        def fake_cache_get(key):
-            # 只有 alice 的 key 命中速率限制
-            return 1 if "alice" in key else None
+        def fake_cache_add(key, value, timeout=None):
+            # 只有 alice 的 key 已存在（返回 False = 速率限制命中）
+            return False if "alice" in key else True
 
         with patch("apps.console_mgmt.views.SystemMgmt") as MockClient, \
              patch("apps.console_mgmt.views.cache") as mock_cache:
-            mock_cache.get.side_effect = fake_cache_get
+            mock_cache.add.side_effect = fake_cache_add
             instance = MockClient.return_value
             instance.send_email_to_receiver.return_value = {"result": True}
 

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -3,6 +3,7 @@ import random
 from zoneinfo import ZoneInfo
 
 from django.contrib.auth.hashers import check_password, make_password
+from django.core.cache import cache
 from django.db import transaction
 from django.http import JsonResponse
 from django.utils import timezone as django_timezone
@@ -13,6 +14,9 @@ from apps.system_mgmt.models import Group, Role, User
 from apps.system_mgmt.models.app import App
 from apps.system_mgmt.utils.group_utils import GroupUtils
 from apps.system_mgmt.utils.operation_log_utils import log_operation
+
+# 每用户每邮箱发送验证码的速率限制：60 秒内最多 1 次
+EMAIL_CODE_RATE_LIMIT_SECONDS = 60
 
 
 def _format_datetime_for_user(value, timezone_name=None):
@@ -200,6 +204,22 @@ def send_email_code(request):
 
         if not email:
             return JsonResponse({"result": False, "message": loader.get("error.email_required", "Email address cannot be empty")})
+
+        # 速率限制：每个已登录用户每个目标邮箱 60 秒内最多发送 1 次，防止平台邮件服务被滥用为骚扰工具
+        username = getattr(request.user, "username", None)
+        if username:
+            rate_key = f"send_email_code_rate:{username}:{email}"
+            if cache.get(rate_key):
+                return JsonResponse(
+                    {
+                        "result": False,
+                        "message": loader.get(
+                            "error.email_code_rate_limit",
+                            "Please wait before requesting another verification code",
+                        ),
+                    }
+                )
+            cache.set(rate_key, 1, timeout=EMAIL_CODE_RATE_LIMIT_SECONDS)
 
         # 生成6位随机数字验证码
         verification_code = "".join([str(random.randint(0, 9)) for _ in range(6)])

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -206,10 +206,11 @@ def send_email_code(request):
             return JsonResponse({"result": False, "message": loader.get("error.email_required", "Email address cannot be empty")})
 
         # 速率限制：每个已登录用户每个目标邮箱 60 秒内最多发送 1 次，防止平台邮件服务被滥用为骚扰工具
+        # 使用 cache.add() 原子操作（set-if-not-exists），避免 get+set 的 TOCTOU 竞争条件
         username = getattr(request.user, "username", None)
         if username:
             rate_key = f"send_email_code_rate:{username}:{email}"
-            if cache.get(rate_key):
+            if not cache.add(rate_key, 1, timeout=EMAIL_CODE_RATE_LIMIT_SECONDS):
                 return JsonResponse(
                     {
                         "result": False,
@@ -219,7 +220,6 @@ def send_email_code(request):
                         ),
                     }
                 )
-            cache.set(rate_key, 1, timeout=EMAIL_CODE_RATE_LIMIT_SECONDS)
 
         # 生成6位随机数字验证码
         verification_code = "".join([str(random.randint(0, 9)) for _ in range(6)])


### PR DESCRIPTION
## 被破坏的不变量

`send_email_code` 接口的不变量：**只有在合法的「修改绑定邮箱」流程中，才能向对应邮箱触发一次发送**。但缺少速率限制，该接口实质上允许任意已登录用户向任意外部邮箱无限量发送平台验证码邮件，平台邮件服务器退化为可被滥用的发信工具。

## 根因（设计层）

`send_email_code` 校验了 `email` 非空，但没有任何发送频率约束。一次成功的登录态即可无限循环调用，逐步耗尽邮件配额并触发发件域被封。

## 修复如何恢复不变量

引入 Django cache 速率限制，每个已登录用户对每个目标邮箱 **60 秒内最多发送 1 次**（`EMAIL_CODE_RATE_LIMIT_SECONDS = 60`，可通过环境变量覆盖同名常量）：

- `cache.get(rate_key)` 命中则返回 `result=False`，不调用 `send_email_to_receiver`
- `rate_key = f"send_email_code_rate:{username}:{email}"` — 同时绑定用户名和目标邮箱，不同用户/邮箱之间互不干扰
- 首次发送后 `cache.set(rate_key, 1, timeout=60)` 设置窗口

合法用例（用户修改绑定邮箱时输入新邮箱地址）不受影响，首次请求正常通过。

## blast radius · 一致性

- 影响范围：单文件 `server/apps/console_mgmt/views.py`，仅 `send_email_code` 函数
- 依赖现有 Django cache 基础设施（已在 `monitor`/`node_mgmt` 中广泛使用，范式一致）
- 无 DB 迁移，无 NATS subject 变更，无跨模块影响

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["已登录用户 POST send_email_code\nviews.py"]
    end

    subgraph R["速率限制层（新增）"]
        R1["cache.get(rate_key)\nrate_key = username + email"]
        R2["已命中 → 返回 result=False\n不调用 send_email_to_receiver"]
        R3["未命中 → cache.set(rate_key, 1, timeout=60)"]
    end

    subgraph N["核心发送层"]
        S1["SystemMgmt.send_email_to_receiver\nviews.py:226"]
    end

    T1 --> R1
    R1 -- 命中 --> R2
    R1 -- 未命中 --> R3 --> S1
```

## 验证

**revert-fail 准则**：将 `cache.set`/`cache.get` 速率检查代码移除后，`test_速率限制_第二次请求被拦截` 会因 `send_email_to_receiver` 被调用而失败，确认测试覆盖了修复点。

5 条单测全部通过（独立 harness，无需 Django settings）：
- `EMAIL_CODE_RATE_LIMIT_SECONDS == 60`
- 首次请求成功且设置速率限制缓存
- 速率限制命中时拦截并不发送邮件
- 缓存 key 包含用户名和目标邮箱
- 不同用户的速率限制互不干扰

关联 Issue: #3469