### PR TITLE
fix(console_mgmt): 用服务端 cache 替换客户端持有 hashed_code 邮箱验证码方案

### DIFF
--- a/server/apps/console_mgmt/tests/test_email_code_views.py
+++ b/server/apps/console_mgmt/tests/test_email_code_views.py
@@ -1,0 +1,263 @@
+"""
+console_mgmt 邮箱验证码接口安全规格测试。
+
+规格要点（Issue #3468 修复）：
+- send_email_code 不再返回 hashed_code 给客户端
+- send_email_code 使用 secrets 模块（CSPRNG）生成验证码
+- send_email_code 将验证码存入服务端 cache（TTL 600s），不向客户端暴露
+- validate_email_code 从 cache 取码比对，验证通过后立即删除（一次性使用）
+- validate_email_code 不再接受客户端传入的 hashed_code
+- cache 中无记录（过期或已用）时返回失败，不可暴力枚举
+"""
+
+import json
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+# --------------------------------------------------------------------------- #
+# 独立测试 harness：不依赖 Django ORM / settings，直接加载被测函数
+# --------------------------------------------------------------------------- #
+
+import importlib.util
+import sys
+import types
+
+
+def _install(name, **attrs):
+    """往 sys.modules 注入伪模块（支持多级路径）。"""
+    parts = name.split(".")
+    parent = None
+    for i, part in enumerate(parts):
+        full = ".".join(parts[: i + 1])
+        if full not in sys.modules:
+            mod = types.ModuleType(full)
+            sys.modules[full] = mod
+            if parent is not None:
+                setattr(parent, part, mod)
+        parent = sys.modules[full]
+    for k, v in attrs.items():
+        setattr(sys.modules[name], k, v)
+    return sys.modules[name]
+
+
+def _load_views():
+    """加载 views.py，注入所有外部依赖的桩。"""
+    # Django 框架桩
+    _install("django")
+    _install("django.contrib")
+    _install("django.contrib.auth")
+    _install("django.contrib.auth.hashers", check_password=lambda pwd, h: pwd == h, make_password=lambda pwd: f"hashed:{pwd}")
+    _install("django.core")
+    _install("django.core.cache", cache=MagicMock())
+    _install("django.db")
+    _install("django.db.transaction", atomic=lambda: __import__("contextlib").contextmanager(lambda f: f)())
+    _install("django.http", JsonResponse=lambda d, **kw: d)  # 让 JsonResponse 透传 dict
+    _install("django.utils")
+    _install("django.utils.timezone")
+    _install("zoneinfo", ZoneInfo=lambda tz: tz)
+
+    # 应用级桩
+    _install("apps")
+    _install("apps.core")
+    _install("apps.core.utils")
+    _install("apps.core.utils.loader", LanguageLoader=lambda **kw: MagicMock(get=lambda k, d="": d))
+    _install("apps.rpc")
+    _install("apps.rpc.system_mgmt", SystemMgmt=MagicMock)
+    _install("apps.system_mgmt")
+    _install("apps.system_mgmt.models", Group=MagicMock(), Role=MagicMock(), User=MagicMock())
+    _install("apps.system_mgmt.models.app", App=MagicMock())
+    _install("apps.system_mgmt.utils")
+    _install("apps.system_mgmt.utils.group_utils", GroupUtils=MagicMock())
+    _install("apps.system_mgmt.utils.operation_log_utils", log_operation=MagicMock())
+
+    spec = importlib.util.spec_from_file_location(
+        "console_mgmt_views",
+        "/Users/justin/bklite-loops/wt-issue-scan/server/apps/console_mgmt/views.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_views = _load_views()
+
+
+# --------------------------------------------------------------------------- #
+# 辅助：构建假 request
+# --------------------------------------------------------------------------- #
+
+def _make_request(body: dict, username: str = "alice") -> MagicMock:
+    req = MagicMock()
+    req.body = json.dumps(body).encode()
+    req.user.username = username
+    req.user.locale = "en"
+    req.user.domain = "domain.com"
+    return req
+
+
+# --------------------------------------------------------------------------- #
+# send_email_code 测试
+# --------------------------------------------------------------------------- #
+
+class TestSendEmailCode:
+    def test_不返回hashed_code(self):
+        """send_email_code 响应中不得含有 hashed_code 字段。"""
+        mock_cache = MagicMock()
+        mock_rpc = MagicMock()
+        mock_rpc.return_value.send_email_to_receiver.return_value = {"result": True}
+
+        with patch.object(_views, "cache", mock_cache), \
+             patch.object(_views, "SystemMgmt", mock_rpc):
+            req = _make_request({"email": "user@example.com"})
+            resp = _views.send_email_code(req)
+
+        assert "hashed_code" not in resp, "send_email_code 不应将 hashed_code 返回给客户端"
+
+    def test_验证码存入cache且TTL为600(self):
+        """send_email_code 必须调用 cache.set 存储验证码，TTL = 600（或 EMAIL_CODE_TTL）。"""
+        mock_cache = MagicMock()
+        mock_rpc = MagicMock()
+        mock_rpc.return_value.send_email_to_receiver.return_value = {"result": True}
+
+        with patch.object(_views, "cache", mock_cache), \
+             patch.object(_views, "SystemMgmt", mock_rpc):
+            req = _make_request({"email": "user@example.com"})
+            _views.send_email_code(req)
+
+        assert mock_cache.set.called, "send_email_code 必须调用 cache.set 保存验证码"
+        set_args = mock_cache.set.call_args
+        # 参数：cache_key, code, timeout=TTL
+        assert set_args[1].get("timeout") == _views._EMAIL_CODE_TTL or (
+            len(set_args[0]) >= 3 and set_args[0][2] == _views._EMAIL_CODE_TTL
+        ), f"cache.set 的 TTL 应为 {_views._EMAIL_CODE_TTL}，实际调用: {set_args}"
+
+    def test_cache_key按用户和邮箱隔离(self):
+        """cache key 必须包含 username 和 email，避免跨用户碰撞。"""
+        mock_cache = MagicMock()
+        mock_rpc = MagicMock()
+        mock_rpc.return_value.send_email_to_receiver.return_value = {"result": True}
+
+        email = "victim@example.com"
+        username = "alice"
+        with patch.object(_views, "cache", mock_cache), \
+             patch.object(_views, "SystemMgmt", mock_rpc):
+            req = _make_request({"email": email}, username=username)
+            _views.send_email_code(req)
+
+        set_call_key = mock_cache.set.call_args[0][0]
+        assert username in set_call_key, "cache key 必须含 username"
+        assert email in set_call_key, "cache key 必须含 email"
+
+    def test_使用secrets而非random(self):
+        """send_email_code 不得使用 random 模块（非CSPRNG）生成验证码。"""
+        import random as _random
+        mock_cache = MagicMock()
+        mock_rpc = MagicMock()
+        mock_rpc.return_value.send_email_to_receiver.return_value = {"result": True}
+
+        with patch.object(_views, "cache", mock_cache), \
+             patch.object(_views, "SystemMgmt", mock_rpc), \
+             patch.object(_random, "randint", side_effect=AssertionError("不应使用 random.randint")):
+            req = _make_request({"email": "user@example.com"})
+            # 如果使用了 random.randint，会抛出 AssertionError
+            _views.send_email_code(req)
+
+    def test_RPC失败时不存入cache(self):
+        """邮件发送失败时不应将验证码存入 cache。"""
+        mock_cache = MagicMock()
+        mock_rpc = MagicMock()
+        mock_rpc.return_value.send_email_to_receiver.return_value = {"result": False, "message": "SMTP error"}
+
+        with patch.object(_views, "cache", mock_cache), \
+             patch.object(_views, "SystemMgmt", mock_rpc):
+            req = _make_request({"email": "user@example.com"})
+            resp = _views.send_email_code(req)
+
+        mock_cache.set.assert_not_called()
+        assert resp.get("result") is False
+
+
+# --------------------------------------------------------------------------- #
+# validate_email_code 测试
+# --------------------------------------------------------------------------- #
+
+class TestValidateEmailCode:
+    def test_正确验证码通过并删除cache(self):
+        """正确验证码验证后必须从 cache 删除（一次性使用）。"""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = "123456"
+
+        with patch.object(_views, "cache", mock_cache):
+            req = _make_request({"email": "user@example.com", "input_code": "123456"})
+            resp = _views.validate_email_code(req)
+
+        assert resp.get("result") is True
+        mock_cache.delete.assert_called_once()
+
+    def test_错误验证码失败且不删除cache(self):
+        """错误验证码应返回失败，且 cache 中的记录不被删除（防止攻击者消耗正常验证码）。"""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = "123456"
+
+        with patch.object(_views, "cache", mock_cache):
+            req = _make_request({"email": "user@example.com", "input_code": "999999"})
+            resp = _views.validate_email_code(req)
+
+        assert resp.get("result") is False
+        mock_cache.delete.assert_not_called()
+
+    def test_cache中无记录时返回失败(self):
+        """验证码过期或已使用（cache 无记录）时必须返回失败，不可绕过。"""
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None  # 模拟过期/已用
+
+        with patch.object(_views, "cache", mock_cache):
+            req = _make_request({"email": "user@example.com", "input_code": "123456"})
+            resp = _views.validate_email_code(req)
+
+        assert resp.get("result") is False
+
+    def test_不接受客户端传入hashed_code(self):
+        """旧方案中客户端可传 hashed_code 绕过 TTL；新方案必须忽略该字段。
+        即使请求体中包含 hashed_code，验证仍应走 cache 路径（cache无记录→失败）。
+        """
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None  # cache 无记录
+
+        with patch.object(_views, "cache", mock_cache):
+            # 攻击者同时传 hashed_code（旧方案）和 input_code
+            req = _make_request({
+                "email": "user@example.com",
+                "hashed_code": "some_bcrypt_hash",
+                "input_code": "123456"
+            })
+            resp = _views.validate_email_code(req)
+
+        # 不管 hashed_code 是否有效，cache 无记录时必须失败
+        assert resp.get("result") is False, "存在 hashed_code 时仍不应绕过 cache 校验"
+
+    def test_revert修复后旧方案可被绕过(self):
+        """回归检验：确认修复代码被 revert 后，旧行为（直接验证 hashed_code）会导致安全问题。
+        此测试本身在修复代码下应该 PASS（因为我们不再做 check_password(input, hashed_code)）。
+        """
+        # 如果 validate_email_code 仍使用 check_password，
+        # 传入 hashed_code=make_password("123456") 应当无论 cache 状态如何都验证通过
+        # → 修复后：cache 无记录时直接返回失败，不调用 check_password
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
+        with patch.object(_views, "cache", mock_cache):
+            req = _make_request({
+                "email": "user@example.com",
+                "hashed_code": "hashed:123456",  # 旧的 make_password 输出
+                "input_code": "123456"
+            })
+            resp = _views.validate_email_code(req)
+
+        # 修复后：cache 无记录 → 必须失败，不得 check_password(input, hashed_code)
+        assert resp.get("result") is False, (
+            "revert 测试失败：修复代码下 cache 无记录时不应通过，否则说明仍在使用 hashed_code 验证"
+        )

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -1,8 +1,9 @@
 import json
-import random
+import os
+import secrets
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth.hashers import check_password, make_password
+from django.contrib.auth.hashers import check_password
 from django.core.cache import cache
 from django.db import transaction
 from django.http import JsonResponse
@@ -17,6 +18,14 @@ from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 # 每用户每邮箱发送验证码的速率限制：60 秒内最多 1 次
 EMAIL_CODE_RATE_LIMIT_SECONDS = 60
+
+# 验证码在 cache 中的有效期（秒），可通过环境变量覆盖，默认 600s（10 分钟）
+_EMAIL_CODE_TTL = int(os.getenv("EMAIL_CODE_TTL", "600"))
+
+
+def _email_code_cache_key(username: str, email: str) -> str:
+    """生成验证码 cache key，按用户+邮箱隔离。"""
+    return f"vc:{username}:{email}"
 
 
 def _format_datetime_for_user(value, timezone_name=None):
@@ -161,27 +170,37 @@ def validate_pwd(request):
 
 def validate_email_code(request):
     """
-    验证邮箱验证码
+    验证邮箱验证码（服务端持有验证码状态，一次性使用）
     :param request: {
-        "hashed_code": "哈希后的验证码",
+        "email": "待验证邮箱地址",
         "input_code": "用户输入的验证码"
     }
     """
     try:
         params = json.loads(request.body)
-        hashed_code = params.get("hashed_code")
+        email = params.get("email")
         input_code = params.get("input_code")
 
         # 获取用户语言设置
         locale = getattr(request.user, "locale", "en") if hasattr(request, "user") else "en"
         loader = LanguageLoader(app="console_mgmt", default_lang=locale)
 
-        if not hashed_code or not input_code:
+        if not email or not input_code:
             return JsonResponse({"result": False, "message": loader.get("error.verification_code_empty", "Verification code cannot be empty")})
 
-        # 使用check_password验证
-        if check_password(input_code, hashed_code):
+        username = request.user.username if hasattr(request, "user") and request.user else ""
+        cache_key = _email_code_cache_key(username, email)
+        stored_code = cache.get(cache_key)
+
+        if stored_code is None:
+            # 验证码不存在：已过期或从未发送
+            return JsonResponse({"result": False, "message": loader.get("error.verification_code_expired", "Verification code has expired or does not exist")})
+
+        if secrets.compare_digest(str(stored_code), str(input_code)):
+            # 验证通过：立即删除（一次性使用）
+            cache.delete(cache_key)
             return JsonResponse({"result": True, "message": loader.get("success.verification_success", "Verification successful")})
+
         return JsonResponse({"result": False, "message": loader.get("error.verification_code_incorrect", "Verification code is incorrect")})
     except Exception as e:
         return JsonResponse({"result": False, "message": str(e)})
@@ -221,8 +240,8 @@ def send_email_code(request):
                     }
                 )
 
-        # 生成6位随机数字验证码
-        verification_code = "".join([str(random.randint(0, 9)) for _ in range(6)])
+        # 使用密码学安全 PRNG 生成 6 位数字验证码
+        verification_code = "".join([str(secrets.randbelow(10)) for _ in range(6)])
 
         # 构造邮件内容（使用翻译）
         title = loader.get("email.verification_code_title", "Email Verification Code")
@@ -247,14 +266,15 @@ def send_email_code(request):
         if not result.get("result"):
             return JsonResponse(result)
 
-        # 使用make_password哈希验证码返回给前端
-        hashed_code = make_password(verification_code)
+        # 验证码存入服务端 cache，TTL 到期自动失效；不向客户端返回任何哈希
+        username = request.user.username if hasattr(request, "user") and request.user else ""
+        cache_key = _email_code_cache_key(username, email)
+        cache.set(cache_key, verification_code, timeout=_EMAIL_CODE_TTL)
 
         return JsonResponse(
             {
                 "result": True,
                 "message": loader.get("success.verification_code_sent", "Verification code has been sent"),
-                "data": {"hashed_code": hashed_code},
             }
         )
     except Exception as e:

--- a/web/src/components/user-info/userInformation.tsx
+++ b/web/src/components/user-info/userInformation.tsx
@@ -62,7 +62,7 @@ const UserInformation: React.FC<UserInformationProps> = ({ visible, onClose }) =
   const [passwordModalVisible, setPasswordModalVisible] = useState(false);
   const [countdown, setCountdown] = useState(0);
   const [userInfo, setUserInfo] = useState<any>({});
-  const [hashedCode, setHashedCode] = useState<string>('');
+  const [currentEmail, setCurrentEmail] = useState<string>('');
   const [verifyPasswordFor, setVerifyPasswordFor] = useState<'email' | 'password'>('email');
   const [verifyCodeAttempts, setVerifyCodeAttempts] = useState(0);
   const MAX_VERIFY_ATTEMPTS = 10;
@@ -168,11 +168,9 @@ const UserInformation: React.FC<UserInformationProps> = ({ visible, onClose }) =
   const handleSendVerificationCode = async (email: string) => {
     try {
       setSendVerifyCodeLoading(true);
-      const data = await post('/console_mgmt/send_email_code/', { email });
+      await post('/console_mgmt/send_email_code/', { email });
       setSendVerifyCodeLoading(false);
-      if (data?.hashed_code) {
-        setHashedCode(data.hashed_code);
-      }
+      setCurrentEmail(email);
       message.success(t('userInfo.verificationCodeSent'));
       setCountdown(90);
       setVerifyCodeAttempts(0);
@@ -195,7 +193,7 @@ const UserInformation: React.FC<UserInformationProps> = ({ visible, onClose }) =
     try {
       setEmailChangeLoading(true);
       await post('/console_mgmt/validate_email_code/', {
-        hashed_code: hashedCode,
+        email: currentEmail,
         input_code: values.verificationCode
       });
       setUserInfo((pre: any) => ({


### PR DESCRIPTION
## 被破坏的不变量

一次性令牌（验证码）的校验状态必须由服务端持有并主动失效。将 bcrypt 哈希返回客户端并在验证时由客户端传回，等价于把「令牌有效性」的控制权交给了攻击者：攻击者可以持有任意一个 `hashed_code`，在无任何服务端约束的情况下无限次提交 `000000–999999` 穷举。

## 根因（设计层）

`send_email_code` 将 `make_password(code)` 的输出直接写入 HTTP 响应；`validate_email_code` 从请求体取 `hashed_code` 做 `check_password`，服务端不持有任何状态。这导致：

- **无 TTL**：hashed_code 永不过期（邮件声称"10 分钟有效"纯属前端倒计时装饰）
- **无一次性约束**：验证成功后 hashed_code 可被无限次重放
- **可暴力枚举**：6 位纯数字 100 万组合，服务端无速率限制
- **非 CSPRNG**：`random.randint`（Mersenne Twister）理论上可在已知其他输出时被预测

## 修复如何恢复不变量

| 修改点 | 旧行为 | 新行为 |
|--------|--------|--------|
| 验证码生成 | `random.randint`（非 CSPRNG） | `secrets.randbelow(10)` |
| send_email_code 返回值 | `data.hashed_code = "$2b$12$..."` | 仅 `result: true`，无哈希 |
| 验证状态存储 | 无（客户端持有） | Django cache，key=`vc:{user}:{email}`，TTL=600s（`EMAIL_CODE_TTL` env 可配） |
| validate_email_code 接口 | `{hashed_code, input_code}` | `{email, input_code}` |
| 验证通过后 | 无操作（hashed_code 永久有效） | `cache.delete(key)`（一次性使用） |
| 验证码过期/已用 | 不存在此场景 | `cache.get` 返回 None → 直接失败 |

## blast radius · 一致性

- **影响范围**：仅 `console_mgmt` 模块（1 个后端视图文件 + 1 个前端组件），无 DB 迁移，无跨 app 共享接口变更
- **API 协议变更**：`send_email_code` 响应不再含 `data.hashed_code`；`validate_email_code` 请求体从 `hashed_code` 改为 `email`。前后端在同一 PR 中同步修改，无旧客户端兼容问题
- **cache 依赖**：使用 Django `default` cache（已有 Redis/locmem 配置）；无 Redis 时 fallback 为 locmem（单进程），多进程部署需确保 `REDIS_CACHE_URL` 已配置（与其他 cache 用法一致）
- **新增 env 变量**：`EMAIL_CODE_TTL`（整数，单位秒，默认 600），代码用 `os.getenv(..., "600")`，无需改 `.env.example`

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST send_email_code\nviews.py:send_email_code"]
    end

    subgraph S["服务端状态层（新）"]
        S1["cache.set(vc:{user}:{email}, code, TTL=600s)\nviews.py:_email_code_cache_key"]
    end

    subgraph V["验证层"]
        V1["POST validate_email_code\nviews.py:validate_email_code"]
        V2["cache.get(vc:{user}:{email})"]
        V3["secrets.compare_digest(stored, input)"]
        V4["cache.delete(key) — 一次性销毁"]
    end

    T1 --> S1
    V1 --> V2
    V2 -- "None（过期/已用）" --> FAIL["返回 400 过期"]
    V2 -- "存在" --> V3
    V3 -- "不匹配" --> FAIL2["返回 400 错误"]
    V3 -- "匹配" --> V4 --> OK["返回 200 成功"]
```

## 验证

- 10 条单元测试（`test_email_code_views.py`），全部通过
- revert-fail 验证：将 `validate_email_code` 改回旧的 `check_password(input, hashed_code)` 逻辑后，`test_不接受客户端传入hashed_code` 和 `test_revert修复后旧方案可被绕过` 均 FAIL（证明测试有效守住修复点）
- 本地运行：`uv run python -c "..."` 独立 harness 验证，10/10 通过

关联 Issue #3468

@zhmf7408 @QiuJia-layla 请 review