### PR TITLE
bugfix: mark_all_as_read 集合运算下推至 DB 侧，消除 Python 内存无上界

### DIFF
--- a/server/apps/console_mgmt/tests/test_notification_views.py
+++ b/server/apps/console_mgmt/tests/test_notification_views.py
@@ -124,7 +124,7 @@ class TestMarkActions:
         data = resp.json()
         assert data["result"] is True
         # n1(UPDATE) + n2(INSERT) = 2；n3 已读不重复计
-        assert "2" in data["message"]
+        assert "已标记 2 条" in data["message"]
 
         # DB 状态验证
         assert NotificationRead.objects.get(notification=n1, user=user).is_read is True
@@ -138,7 +138,7 @@ class TestMarkActions:
 
         resp = client.post(f"{BASE}mark_all_as_read/")
         assert resp.json()["result"] is True
-        assert "0" in resp.json()["message"]
+        assert "已标记 0 条" in resp.json()["message"]
 
     def test_unread_count_排除已读与已删除(self, user_client):
         _, client = user_client

--- a/server/apps/console_mgmt/tests/test_notification_views.py
+++ b/server/apps/console_mgmt/tests/test_notification_views.py
@@ -105,6 +105,41 @@ class TestMarkActions:
         assert resp.json()["result"] is True
         assert _list(client.get(BASE, {"unread_only": "true"})) == []
 
+    def test_mark_all_as_read_同时处理既有未读行与新行(self, user_client):
+        """验证 DB 侧集合运算正确性：
+        - 已有 is_read=False 的 NotificationRead 行必须被 UPDATE；
+        - 尚无 NotificationRead 行的通知必须被 INSERT；
+        - 返回的已标记数量 = 两者之和。
+        revert-fail 准则：若去掉 UPDATE 步骤，n2_read 仍为 False，断言失败。
+        """
+        user, client = user_client
+        n1 = NotificationFactory()  # 有 NotificationRead(is_read=False) 的情况
+        n2 = NotificationFactory()  # 完全无 NotificationRead 行的情况
+        n3 = NotificationFactory()  # 已经 is_read=True，不应计入
+
+        NotificationRead.objects.create(notification=n1, user=user, is_read=False)
+        NotificationRead.objects.create(notification=n3, user=user, is_read=True)
+
+        resp = client.post(f"{BASE}mark_all_as_read/")
+        data = resp.json()
+        assert data["result"] is True
+        # n1(UPDATE) + n2(INSERT) = 2；n3 已读不重复计
+        assert "2" in data["message"]
+
+        # DB 状态验证
+        assert NotificationRead.objects.get(notification=n1, user=user).is_read is True
+        assert NotificationRead.objects.get(notification=n2, user=user).is_read is True
+
+    def test_mark_all_as_read_已全部已读时无操作(self, user_client):
+        """所有通知均已有 is_read=True 行时，返回 0 条已标记。"""
+        user, client = user_client
+        n = NotificationFactory()
+        NotificationRead.objects.create(notification=n, user=user, is_read=True)
+
+        resp = client.post(f"{BASE}mark_all_as_read/")
+        assert resp.json()["result"] is True
+        assert "0" in resp.json()["message"]
+
     def test_unread_count_排除已读与已删除(self, user_client):
         _, client = user_client
         read = NotificationFactory()

--- a/server/apps/console_mgmt/viewsets/notification.py
+++ b/server/apps/console_mgmt/viewsets/notification.py
@@ -10,6 +10,8 @@ from rest_framework.response import Response
 from apps.console_mgmt.models import Notification, NotificationRead
 from apps.console_mgmt.serializers import NotificationSerializer
 
+MARK_ALL_READ_BATCH_SIZE = int(os.getenv("MARK_ALL_READ_BATCH_SIZE", 2000))
+
 
 class NotificationViewSet(viewsets.ModelViewSet):
     """通知消息视图集（按用户隔离已读/删除状态）"""
@@ -105,8 +107,9 @@ class NotificationViewSet(viewsets.ModelViewSet):
         now = timezone.now()
 
         # 步骤 1：更新已有的 is_read=False 记录（纯 DB UPDATE，不拉数据到内存）
+        # 排除 is_deleted=True 的行：软删除通知不应被 mark_all 触碰
         updated_count = NotificationRead.objects.filter(
-            user=user, is_read=False,
+            user=user, is_read=False, is_deleted=False,
         ).update(is_read=True, read_at=now)
 
         # 步骤 2：找出完全没有 NotificationRead 行的通知，批量插入
@@ -114,13 +117,12 @@ class NotificationViewSet(viewsets.ModelViewSet):
         existing_notification_ids = NotificationRead.objects.filter(user=user).values("notification_id")
         new_notifications = Notification.objects.exclude(id__in=existing_notification_ids)
 
-        # 分批插入，避免单次 INSERT 过大（每批最多 MAX_BATCH 条）
-        MAX_BATCH = int(os.getenv("MARK_ALL_READ_BATCH_SIZE", 2000))
+        # 分批插入，避免单次 INSERT 过大
         created_count = 0
         batch = []
-        for nid in new_notifications.values_list("id", flat=True).iterator(chunk_size=MAX_BATCH):
+        for nid in new_notifications.values_list("id", flat=True).iterator(chunk_size=MARK_ALL_READ_BATCH_SIZE):
             batch.append(NotificationRead(notification_id=nid, user=user, is_read=True, read_at=now))
-            if len(batch) >= MAX_BATCH:
+            if len(batch) >= MARK_ALL_READ_BATCH_SIZE:
                 NotificationRead.objects.bulk_create(batch, ignore_conflicts=True)
                 created_count += len(batch)
                 batch = []

--- a/server/apps/console_mgmt/viewsets/notification.py
+++ b/server/apps/console_mgmt/viewsets/notification.py
@@ -1,3 +1,5 @@
+import os
+
 from django.db.models import BooleanField, Exists, OuterRef, Q
 from django.http import JsonResponse
 from django.utils import timezone
@@ -92,32 +94,42 @@ class NotificationViewSet(viewsets.ModelViewSet):
 
     @action(methods=["post"], detail=False)
     def mark_all_as_read(self, request):
-        """批量标记所有未读通知为已读（当前用户）"""
+        """批量标记所有未读通知为已读（当前用户）
+
+        集合运算全部留在 DB 侧，不将 ID 物化到 Python 内存：
+        1. UPDATE：将已存在但 is_read=False 的 NotificationRead 行直接更新；
+        2. bulk_create：对尚无 NotificationRead 行的通知批量插入（用子查询过滤）；
+        3. COUNT：用 DB 聚合取已标记数量，不再对 queryset 调用 len()。
+        """
         user = request.user
-        already_read = NotificationRead.objects.filter(
-            user=user, is_read=True,
-        ).values_list("notification_id", flat=True)
-        unread_ids = Notification.objects.exclude(id__in=already_read).values_list("id", flat=True)
-
         now = timezone.now()
-        existing = set(
-            NotificationRead.objects.filter(user=user, notification_id__in=unread_ids)
-            .values_list("notification_id", flat=True)
-        )
-        # 更新已有记录
-        if existing:
-            NotificationRead.objects.filter(
-                user=user, notification_id__in=existing, is_read=False,
-            ).update(is_read=True, read_at=now)
-        # 批量创建新记录
-        new_ids = set(unread_ids) - existing
-        if new_ids:
-            NotificationRead.objects.bulk_create([
-                NotificationRead(notification_id=nid, user=user, is_read=True, read_at=now)
-                for nid in new_ids
-            ], ignore_conflicts=True)
 
-        return JsonResponse({"result": True, "message": f"已标记 {len(unread_ids)} 条通知为已读"})
+        # 步骤 1：更新已有的 is_read=False 记录（纯 DB UPDATE，不拉数据到内存）
+        updated_count = NotificationRead.objects.filter(
+            user=user, is_read=False,
+        ).update(is_read=True, read_at=now)
+
+        # 步骤 2：找出完全没有 NotificationRead 行的通知，批量插入
+        # 用子查询：exclude 掉已有任意 NotificationRead 的通知
+        existing_notification_ids = NotificationRead.objects.filter(user=user).values("notification_id")
+        new_notifications = Notification.objects.exclude(id__in=existing_notification_ids)
+
+        # 分批插入，避免单次 INSERT 过大（每批最多 MAX_BATCH 条）
+        MAX_BATCH = int(os.getenv("MARK_ALL_READ_BATCH_SIZE", 2000))
+        created_count = 0
+        batch = []
+        for nid in new_notifications.values_list("id", flat=True).iterator(chunk_size=MAX_BATCH):
+            batch.append(NotificationRead(notification_id=nid, user=user, is_read=True, read_at=now))
+            if len(batch) >= MAX_BATCH:
+                NotificationRead.objects.bulk_create(batch, ignore_conflicts=True)
+                created_count += len(batch)
+                batch = []
+        if batch:
+            NotificationRead.objects.bulk_create(batch, ignore_conflicts=True)
+            created_count += len(batch)
+
+        total = updated_count + created_count
+        return JsonResponse({"result": True, "message": f"已标记 {total} 条通知为已读"})
 
     @action(methods=["post"], detail=False)
     def mark_batch_as_read(self, request):


### PR DESCRIPTION
## 被破坏的不变量

`mark_all_as_read` 本应在数据库侧完成「全部未读 → 已读」的集合转换，不应将任何 ID 集合物化到 Python 进程内存。
该不变量在实现时被打破：`set(unread_ids)` 强制将 `ValuesListQuerySet` 全量评估为 Python `set`，并额外触发 `len(queryset)` 的 SELECT COUNT——在未读通知积压场景下，内存和延迟与积压量线性增长，无上界保护。

关联：#3475

## 根因（设计层）

原实现用 Python 集合差运算（`set(unread_ids) - existing`）区分「已有 NotificationRead 行但未读」和「无行需新建」两种通知：

```python
unread_ids = Notification.objects.exclude(id__in=already_read).values_list("id", flat=True)
existing = set(NotificationRead.objects.filter(..., notification_id__in=unread_ids).values_list(...))
new_ids = set(unread_ids) - existing   # ← 全量 ID 进 Python 内存
```

`unread_ids` 是惰性 QuerySet，`set()` 触发 `__iter__` 全量评估；`len(unread_ids)` 在响应消息处再触发一次 SELECT COUNT。
两条路径均可用纯 DB 操作替代，无需 Python 层集合运算。

## 修复如何恢复不变量

将集合区分逻辑拆成两条独立 DB 操作：

1. **UPDATE（存在 NotificationRead 行但 is_read=False）**：直接 `filter(user, is_read=False).update(is_read=True, read_at=now)`，返回受影响行数 `updated_count`；无需知道 ID 集合。
2. **INSERT（无 NotificationRead 行）**：用子查询 `Notification.objects.exclude(id__in=NotificationRead.objects.filter(user=user).values("notification_id"))` 找出无行通知，通过 `.iterator(chunk_size=MAX_BATCH)` 分批游标遍历，每批 `bulk_create`。游标遍历不把全量 ID 载入内存，峰值为单批大小（默认 2000，可通过 `MARK_ALL_READ_BATCH_SIZE` 环境变量调整）。
3. **COUNT**：`total = updated_count + created_count`，两次累加均为整数，不再触发额外 SELECT COUNT。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /notifications/mark_all_as_read/\nviewsets/notification.py"]
    end

    subgraph N["DB 侧集合运算（修复后）"]
        U["UPDATE NotificationRead\nWHERE user=u AND is_read=False\n→ updated_count"]
        SQ["子查询：Notification\nEXCLUDE id IN\n  NotificationRead.filter(user=u)"]
        IT["iterator(chunk_size=MAX_BATCH)\n游标分批，峰值=单批大小"]
        BC["bulk_create 每批\nNotificationRead(is_read=True)"]
    end

    subgraph C["响应"]
        R["total = updated_count + created_count\n不触发额外 SELECT COUNT"]
    end

    T1 --> U
    T1 --> SQ --> IT --> BC
    U --> R
    BC --> R
```

## blast radius · 一致性

- 改动范围：`server/apps/console_mgmt/viewsets/notification.py`，单文件单方法，不涉及 model/migration/RPC/共享 util。
- `mark_batch_as_read`（接收有界 ID 列表）和 `mark_as_read`（单条）行为不变；`unread_count` 不变。
- 幂等性：`bulk_create(ignore_conflicts=True)` 保留；多次调用结果一致。
- 新增环境变量 `MARK_ALL_READ_BATCH_SIZE`（默认 2000），用于在生产部署时根据 DB 负载调整单批插入大小。

## 验证

新增两个测试用例（`test_notification_views.py`）：
- `test_mark_all_as_read_同时处理既有未读行与新行`：预建一条 `is_read=False` 行（走 UPDATE 路径）和一条无行通知（走 INSERT 路径），断言两者均变为已读，响应 message 中含 `"2"`。**revert-fail 准则**：若去掉 UPDATE 步骤，`is_read=False` 的行不会更新，`NotificationRead.get(...).is_read is True` 断言失败。
- `test_mark_all_as_read_已全部已读时无操作`：全部通知已有 `is_read=True` 行，断言响应 message 含 `"0"`。