### PR TITLE
fix(core): APISecretMiddleware 改用 _api_current_team 注入 team 上下文，统一 get_current_team 读取入口

### DIFF
--- a/server/apps/alerts/utils/permission_scope.py
+++ b/server/apps/alerts/utils/permission_scope.py
@@ -5,10 +5,11 @@ from rest_framework.exceptions import PermissionDenied
 from apps.alerts.constants.constants import LogTargetType
 from apps.alerts.models.models import Alert, Incident
 from apps.system_mgmt.utils.group_utils import GroupUtils
+from apps.core.utils.team_utils import get_current_team
 
 
 def get_current_team_from_request(request, required=False):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         return None if not required else 0
     try:

--- a/server/apps/alerts/views/alert_source.py
+++ b/server/apps/alerts/views/alert_source.py
@@ -28,6 +28,7 @@ from config.drf.pagination import CustomPageNumberPagination
 from config.drf.viewsets import ModelViewSet
 
 from apps.alerts.constants.constants import SNMP_TRAP_SOURCE_ID
+from apps.core.utils.team_utils import get_current_team
 
 K8S_SOURCE_ID = "k8s"
 K8S_IMAGE_REFERENCE = "ghcr.io/resmoio/kubernetes-event-exporter:latest"
@@ -47,7 +48,7 @@ K8S_DOWNLOAD_FILES = {
 
 
 def _get_valid_current_team(request):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         raise BaseAppException("缺少 current_team 参数")
 

--- a/server/apps/base/user_api_secret_mgmt/views.py
+++ b/server/apps/base/user_api_secret_mgmt/views.py
@@ -7,6 +7,7 @@ from apps.base.models.user import UserAPISecret
 from apps.base.user_api_secret_mgmt.serializers import UserAPISecretCreateSerializer, UserAPISecretSerializer
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.loader import LanguageLoader
+from apps.core.utils.team_utils import get_current_team
 
 
 def _get_loader(request) -> LanguageLoader:
@@ -16,7 +17,7 @@ def _get_loader(request) -> LanguageLoader:
 
 
 def _parse_current_team(request, loader: LanguageLoader):
-    current_team = request.COOKIES.get("current_team", "0")
+    current_team = get_current_team(request, "0")
     try:
         return int(current_team), None
     except (TypeError, ValueError):
@@ -40,7 +41,7 @@ class UserAPISecretViewSet(viewsets.ModelViewSet):
         if not request or not user or not user.is_authenticated:
             return UserAPISecret.objects.none()
 
-        current_team = request.COOKIES.get("current_team", "0")
+        current_team = get_current_team(request, "0")
         try:
             current_team = int(current_team)
         except (TypeError, ValueError):

--- a/server/apps/cmdb/serializers/subscription.py
+++ b/server/apps/cmdb/serializers/subscription.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from apps.cmdb.constants.subscription import FilterType, TriggerType
 from apps.cmdb.models.subscription_rule import SubscriptionRule
 from apps.cmdb.utils.subscription_utils import check_subscription_manage_permission
+from apps.core.utils.team_utils import get_current_team
 
 
 class SubscriptionRuleSerializer(serializers.ModelSerializer):
@@ -49,7 +50,7 @@ class SubscriptionRuleSerializer(serializers.ModelSerializer):
         if not request:
             return False
         return check_subscription_manage_permission(
-            obj.organization, request.COOKIES.get("current_team")
+            obj.organization, get_current_team(request)
         )
 
     def validate_name(self, value):

--- a/server/apps/cmdb/services/collect_tool_service.py
+++ b/server/apps/cmdb/services/collect_tool_service.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import ValidationError
 
 from apps.cmdb.models.collect_model import CollectModels
 from apps.rpc.stargazer import Stargazer
+from apps.core.utils.team_utils import get_current_team
 
 MASKED_PASSWORD = "••••••"
 
@@ -43,7 +44,7 @@ class CollectToolService:
         return {
             "username": getattr(request.user, "username", ""),
             "domain": getattr(request.user, "domain", ""),
-            "current_team": request.COOKIES.get("current_team"),
+            "current_team": get_current_team(request),
             "include_children": include_children,
         }
 

--- a/server/apps/cmdb/services/config_file_service.py
+++ b/server/apps/cmdb/services/config_file_service.py
@@ -16,6 +16,7 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.system_mgmt.utils.group_utils import GroupUtils
+from apps.core.utils.team_utils import get_current_team
 
 MAX_CONFIG_FILE_SIZE_LIMIT = 5 * 1024 * 1024
 
@@ -612,7 +613,7 @@ class ConfigFileService(object):
 
     @staticmethod
     def filter_queryset_by_task_permission(request, queryset):
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return queryset.none()
 

--- a/server/apps/cmdb/utils/base.py
+++ b/server/apps/cmdb/utils/base.py
@@ -5,6 +5,7 @@
 from apps.core.logger import cmdb_logger as logger
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.cmdb.constants.constants import PERMISSION_TASK
+from apps.core.utils.team_utils import get_current_team
 
 
 def get_cmdb_rules(request, permission_key=PERMISSION_TASK) -> dict:
@@ -134,7 +135,7 @@ def get_current_team_from_request(request, required: bool = True) -> int:
     """
     从请求 Cookie 中获取 current_team，并做严格校验。
     """
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         if required:
             raise BaseAppException("缺少 current_team 参数")

--- a/server/apps/cmdb/views/collect.py
+++ b/server/apps/cmdb/views/collect.py
@@ -34,6 +34,7 @@ from apps.cmdb.serializers.collect_serializer import (
     CollectModelIdStatusSerializer,
 )
 from apps.cmdb.services.collect_service import CollectModelService
+from apps.core.utils.team_utils import get_current_team
 
 
 class CollectModelViewSet(AuthViewSet):
@@ -175,7 +176,7 @@ class CollectModelViewSet(AuthViewSet):
         # 否则勾选"包含子组织"会跳过裁剪、直接返回子树全部任务，造成子组织采集任务越权
         # 查看/执行（issue #3037）。allowed_teams 已与 query_groups（子树）取交，天然按授权收口。
         app_name = self._get_app_name()
-        current_team = request.COOKIES.get("current_team", "0")
+        current_team = get_current_team(request, "0")
         permission_data = get_permission_rules(request.user, current_team, app_name, permission_key, include_children)
         if not isinstance(permission_data, dict) or not permission_data:
             return base_queryset
@@ -253,7 +254,7 @@ class CollectModelViewSet(AuthViewSet):
             "permission_data": {
                 "username": request.user.username,
                 "domain": request.user.domain,
-                "current_team": request.COOKIES.get("current_team"),
+                "current_team": get_current_team(request),
             },
             "node_type": "container",
         }

--- a/server/apps/cmdb/views/instance.py
+++ b/server/apps/cmdb/views/instance.py
@@ -30,6 +30,7 @@ from apps.core.logger import cmdb_logger as logger
 from apps.core.utils.web_utils import WebUtils
 from apps.rpc.node_mgmt import NodeMgmt
 from apps.system_mgmt.utils.group_utils import GroupUtils
+from apps.core.utils.team_utils import get_current_team
 
 
 class InstanceViewSet(CmdbPermissionMixin, viewsets.ViewSet):
@@ -200,7 +201,7 @@ class InstanceViewSet(CmdbPermissionMixin, viewsets.ViewSet):
     def search(self, request):
         """
         查询实例权限：
-        1. 若前端不做组织筛选，默认查询组织 request.COOKIES.get("current_team")
+        1. 若前端不做组织筛选，默认查询组织 get_current_team(request)
             若做组织筛选，则查询所选组织
         2. 用户所在的组织，and （组织单独设置的实例权限过滤条件 or 创建人是我）
         3. 若有额外的字段过滤条件，则在上述基础上做and过滤
@@ -671,7 +672,7 @@ class InstanceViewSet(CmdbPermissionMixin, viewsets.ViewSet):
     @action(methods=["post"], detail=False, url_path=r"(?P<model_id>.+?)/inst_import")
     def inst_import(self, request, model_id):
         try:
-            current_team_raw = request.COOKIES.get("current_team")
+            current_team_raw = get_current_team(request)
             if not current_team_raw:
                 return JsonResponse(
                     {

--- a/server/apps/cmdb/views/subscription.py
+++ b/server/apps/cmdb/views/subscription.py
@@ -9,6 +9,7 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 class SubscriptionViewSet(viewsets.ModelViewSet):
@@ -20,7 +21,7 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
     pagination_class = CustomPageNumberPagination
 
     def get_queryset(self):
-        current_team = self.request.COOKIES.get("current_team")
+        current_team = get_current_team(self.request)
         if current_team in (None, ""):
             return SubscriptionRule.objects.none()
         try:
@@ -124,5 +125,5 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
     def _check_manage_permission(rule: SubscriptionRule, request) -> bool:
         """检查当前用户是否有权限管理指定规则。"""
         return check_subscription_manage_permission(
-            rule.organization, request.COOKIES.get("current_team")
+            rule.organization, get_current_team(request)
         )

--- a/server/apps/core/middlewares/api_middleware.py
+++ b/server/apps/core/middlewares/api_middleware.py
@@ -67,10 +67,12 @@ class APISecretMiddleware(MiddlewareMixin):
             request.session.cycle_key()
 
         # API Key 调用不携带 current_team cookie，用 API Key 绑定的组织自动填充
+        # 使用 request._api_current_team 属性（而非直接写 request.COOKIES 只读 dict）
+        # 下游通过 apps.core.utils.team_utils.get_current_team(request) 统一读取
         if not request.COOKIES.get("current_team"):
             group_list = getattr(user, "group_list", [])
             if group_list:
-                request.COOKIES["current_team"] = str(group_list[0])
+                request._api_current_team = str(group_list[0])
 
         return None
 

--- a/server/apps/core/tests/test_api_middleware_team_injection.py
+++ b/server/apps/core/tests/test_api_middleware_team_injection.py
@@ -1,0 +1,182 @@
+"""
+测试 APISecretMiddleware 的 team 上下文注入行为，以及 get_current_team 工具函数。
+
+Issue #3486：中间件不应直接写 request.COOKIES（只读 dict），应通过
+request._api_current_team 属性注入，下游统一使用 get_current_team(request) 读取。
+
+测试策略：使用 revert-fail 准则——将 _handle_successful_auth 中的
+request._api_current_team = ... 改回 request.COOKIES[...] = ... 后，这些测试会失败。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.core.utils.team_utils import get_current_team
+
+
+# ---------------------------------------------------------------------------
+# 辅助：构造轻量 request mock
+# ---------------------------------------------------------------------------
+
+def _make_request(cookies=None, api_current_team=None):
+    """构造只包含 COOKIES 和可选 _api_current_team 的轻量 request。"""
+    req = SimpleNamespace(
+        COOKIES=dict(cookies or {}),
+        META={},
+        session=SimpleNamespace(session_key="fake-key"),
+    )
+    if api_current_team is not None:
+        req._api_current_team = api_current_team
+    return req
+
+
+# ---------------------------------------------------------------------------
+# get_current_team 工具函数测试
+# ---------------------------------------------------------------------------
+
+class TestGetCurrentTeam:
+    """验证 get_current_team 读取优先级：_api_current_team > COOKIES > default"""
+
+    def test_api_attr_takes_priority_over_cookie(self):
+        """当 _api_current_team 和 COOKIES 都存在时，返回 _api_current_team 的值。"""
+        req = _make_request(
+            cookies={"current_team": "99"},
+            api_current_team="7",
+        )
+        assert get_current_team(req) == "7"
+
+    def test_cookie_used_when_no_api_attr(self):
+        """没有 _api_current_team 时，从 COOKIES 读取。"""
+        req = _make_request(cookies={"current_team": "42"})
+        assert get_current_team(req) == "42"
+
+    def test_default_when_neither_present(self):
+        """既没有 _api_current_team 也没有 cookie 时，返回 default。"""
+        req = _make_request()
+        assert get_current_team(req) is None
+        assert get_current_team(req, "0") == "0"
+
+    def test_api_attr_zero_string_is_returned_not_default(self):
+        """_api_current_team 为 "0" 时应返回 "0"，而不是 default。"""
+        req = _make_request(api_current_team="0")
+        assert get_current_team(req, "fallback") == "0"
+
+    def test_cookie_zero_string_is_returned_not_default(self):
+        """COOKIES["current_team"] 为 "0" 时应返回 "0"，而不是 default。"""
+        req = _make_request(cookies={"current_team": "0"})
+        assert get_current_team(req, "fallback") == "0"
+
+
+# ---------------------------------------------------------------------------
+# APISecretMiddleware 注入行为测试
+# ---------------------------------------------------------------------------
+
+class TestAPISecretMiddlewareTeamInjection:
+    """验证中间件使用 request._api_current_team 而非写 request.COOKIES。"""
+
+    def _make_middleware(self):
+        from apps.core.middlewares.api_middleware import APISecretMiddleware
+        mw = APISecretMiddleware(get_response=lambda r: None)
+        return mw
+
+    def _make_auth_request(self, has_cookie=False):
+        """构造模拟认证请求，模拟 auth.login 后的状态。"""
+        req = SimpleNamespace(
+            COOKIES={"current_team": "99"} if has_cookie else {},
+            META={},
+            session=SimpleNamespace(session_key="fake-session"),
+            user=SimpleNamespace(
+                group_list=[7, 8],
+                locale="zh-cn",
+            ),
+        )
+        setattr(req, "api_pass", False)
+        return req
+
+    def test_middleware_sets_api_attr_not_cookies(self):
+        """
+        当请求不携带 current_team cookie 时，中间件应设置
+        request._api_current_team，而不是直接写 request.COOKIES。
+
+        revert-fail：若改回 request.COOKIES[...] = ...，
+        断言 "_api_current_team" in req.__dict__ 将失败。
+        """
+        mw = self._make_middleware()
+        req = self._make_auth_request(has_cookie=False)
+        user = req.user
+
+        with patch("apps.core.middlewares.api_middleware.auth") as mock_auth:
+            mock_auth.login.return_value = None
+            mw._handle_successful_auth(req, user)
+
+        # 关键断言：_api_current_team 必须被设置
+        assert hasattr(req, "_api_current_team"), (
+            "中间件应设置 request._api_current_team，而非写 request.COOKIES"
+        )
+        assert req._api_current_team == "7"
+
+    def test_middleware_does_not_mutate_cookies_dict(self):
+        """
+        中间件不应向 request.COOKIES 写入 current_team。
+
+        revert-fail：若改回 request.COOKIES[...] = ...，
+        断言 cookies_before == cookies_after 将失败。
+        """
+        mw = self._make_middleware()
+        req = self._make_auth_request(has_cookie=False)
+        user = req.user
+        cookies_before = dict(req.COOKIES)
+
+        with patch("apps.core.middlewares.api_middleware.auth") as mock_auth:
+            mock_auth.login.return_value = None
+            mw._handle_successful_auth(req, user)
+
+        assert req.COOKIES == cookies_before, (
+            "中间件不应修改 request.COOKIES（只读 dict），应使用 request._api_current_team"
+        )
+
+    def test_middleware_skips_injection_when_cookie_present(self):
+        """当浏览器已携带 current_team cookie 时，不注入 _api_current_team。"""
+        mw = self._make_middleware()
+        req = self._make_auth_request(has_cookie=True)
+        user = req.user
+
+        with patch("apps.core.middlewares.api_middleware.auth") as mock_auth:
+            mock_auth.login.return_value = None
+            mw._handle_successful_auth(req, user)
+
+        assert not hasattr(req, "_api_current_team"), (
+            "浏览器已有 cookie 时不应注入 _api_current_team"
+        )
+
+    def test_get_current_team_reads_injected_attr(self):
+        """
+        端到端：中间件注入 + get_current_team 读取，结果符合预期。
+
+        revert-fail：若中间件改回写 COOKIES，get_current_team 仍能通过 COOKIES 读到值，
+        但 test_middleware_does_not_mutate_cookies_dict 会失败，保证整体检测有效。
+        """
+        mw = self._make_middleware()
+        req = self._make_auth_request(has_cookie=False)
+        user = req.user
+
+        with patch("apps.core.middlewares.api_middleware.auth") as mock_auth:
+            mock_auth.login.return_value = None
+            mw._handle_successful_auth(req, user)
+
+        assert get_current_team(req) == "7"
+
+    def test_empty_group_list_does_not_inject(self):
+        """group_list 为空时，不设置 _api_current_team。"""
+        mw = self._make_middleware()
+        req = self._make_auth_request(has_cookie=False)
+        req.user.group_list = []
+
+        with patch("apps.core.middlewares.api_middleware.auth") as mock_auth:
+            mock_auth.login.return_value = None
+            mw._handle_successful_auth(req, req.user)
+
+        assert not hasattr(req, "_api_current_team")
+        assert get_current_team(req) is None

--- a/server/apps/core/utils/group_query_mixin.py
+++ b/server/apps/core/utils/group_query_mixin.py
@@ -4,6 +4,7 @@
 """
 
 from apps.core.logger import logger
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.user_group import normalize_user_group_ids
 from apps.system_mgmt.utils.group_utils import GroupUtils
 
@@ -41,8 +42,8 @@ class GroupQueryMixin:
         :param include_children: 是否包含子组织，如果为None则从请求参数中获取
         :return: 组织ID列表
         """
-        # 1. 获取当前选中的组织ID（从cookies中获取）
-        current_team = request.COOKIES.get("current_team")
+        # 1. 获取当前选中的组织ID（优先读 API Key 注入属性，回退到 cookie）
+        current_team = get_current_team(request)
         if not current_team:
             logger.warning("未找到current_team参数，返回空组织列表")
             return []

--- a/server/apps/core/utils/serializers.py
+++ b/server/apps/core/utils/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 from rest_framework.fields import empty
 
 from apps.core.utils.permission_utils import get_permission_rules
+from apps.core.utils.team_utils import get_current_team
 from apps.system_mgmt.models import User
 
 
@@ -44,7 +45,7 @@ class AuthSerializer(UsernameSerializer):
         super().__init__(instance=instance, data=data, **kwargs)
         request = self.context["request"]
         self.rule_map = {}
-        current_team = request.COOKIES.get("current_team", "0")
+        current_team = get_current_team(request, "0")
         include_children = request.COOKIES.get("include_children", "0") == "1"
         app_name = self.get_app_name()
         permission_rules = get_permission_rules(request.user, current_team, app_name, self.permission_key, include_children)

--- a/server/apps/core/utils/team_utils.py
+++ b/server/apps/core/utils/team_utils.py
@@ -1,0 +1,41 @@
+"""
+team_utils — 当前组织上下文读取工具
+
+统一的 current_team 读取入口，屏蔽「browser cookie」与「API Key 注入属性」两种来源的差异。
+
+使用方式：
+    from apps.core.utils.team_utils import get_current_team
+
+    # 返回字符串或 default；调用方自行 int() 转换
+    team_str = get_current_team(request)          # -> "7" | None
+    team_id  = get_current_team(request, "0")     # -> "7" | "0"
+
+来源优先级：
+  1. request._api_current_team  —— APISecretMiddleware 在无浏览器 cookie 时注入的组织 ID
+  2. request.COOKIES["current_team"] —— 浏览器正常登录时携带的 cookie
+  3. default（默认 None）
+
+这样可以保证 API Key 调用和浏览器调用在下游代码中使用同一读取路径，
+同时不再污染 request.COOKIES 只读 dict（违反 Django 约定）。
+"""
+
+
+def get_current_team(request, default=None):
+    """
+    获取当前请求的组织上下文字符串。
+
+    :param request: Django HttpRequest 对象
+    :param default: 找不到时的返回值（str | None）
+    :return: 组织 ID 字符串，或 default
+    """
+    # 优先使用 API Key 中间件注入的属性（仅在无浏览器 cookie 时设置）
+    api_team = getattr(request, "_api_current_team", None)
+    if api_team is not None:
+        return str(api_team)
+
+    # 其次使用浏览器 cookie
+    cookie_team = request.COOKIES.get("current_team")
+    if cookie_team is not None:
+        return str(cookie_team)
+
+    return default

--- a/server/apps/core/utils/viewset_utils.py
+++ b/server/apps/core/utils/viewset_utils.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from apps.core.logger import logger
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.permission_utils import delete_instance_rules, get_permission_rules
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.user_group import normalize_user_group_ids
 from apps.system_mgmt.models import Group
 
@@ -14,7 +15,7 @@ from apps.system_mgmt.models import Group
 class GenericViewSetFun(object):
     @staticmethod
     def _parse_current_team_cookie(request, default=0):
-        current_team = request.COOKIES.get("current_team", str(default))
+        current_team = get_current_team(request, str(default))
         try:
             return int(current_team)
         except (TypeError, ValueError):

--- a/server/apps/job_mgmt/views/dangerous_path.py
+++ b/server/apps/job_mgmt/views/dangerous_path.py
@@ -9,6 +9,7 @@ from apps.job_mgmt.filters.dangerous_path import DangerousPathFilter
 from apps.job_mgmt.models import DangerousPath
 from apps.job_mgmt.serializers.dangerous_path import DangerousPathCreateSerializer, DangerousPathSerializer, DangerousPathUpdateSerializer
 from apps.job_mgmt.views.dangerous_base import BaseDangerousItemViewSet
+from apps.core.utils.team_utils import get_current_team
 
 
 class DangerousPathViewSet(BaseDangerousItemViewSet):
@@ -47,7 +48,7 @@ class DangerousPathViewSet(BaseDangerousItemViewSet):
     @action(detail=False, methods=["GET"])
     def enabled_paths(self, request):
         """获取当前组启用的所有高危路径规则"""
-        current_team = int(request.COOKIES.get("current_team", 0))
+        current_team = int(get_current_team(request, 0))
         paths = DangerousPath.objects.filter(is_enabled=True, team__contains=current_team)
 
         result = {

--- a/server/apps/job_mgmt/views/dangerous_rule.py
+++ b/server/apps/job_mgmt/views/dangerous_rule.py
@@ -9,6 +9,7 @@ from apps.job_mgmt.filters.dangerous_rule import DangerousRuleFilter
 from apps.job_mgmt.models import DangerousRule
 from apps.job_mgmt.serializers.dangerous_rule import DangerousRuleCreateSerializer, DangerousRuleSerializer, DangerousRuleUpdateSerializer
 from apps.job_mgmt.views.dangerous_base import BaseDangerousItemViewSet
+from apps.core.utils.team_utils import get_current_team
 
 
 class DangerousRuleViewSet(BaseDangerousItemViewSet):
@@ -46,7 +47,7 @@ class DangerousRuleViewSet(BaseDangerousItemViewSet):
 
     @action(detail=False, methods=["GET"])
     def enabled_rules(self, request):
-        current_team = int(request.COOKIES.get("current_team", 0))
+        current_team = int(get_current_team(request, 0))
         rules = DangerousRule.objects.filter(is_enabled=True, team__contains=current_team)
         result = {DangerousLevel.CONFIRM: [], DangerousLevel.FORBIDDEN: []}
         for rule in rules:

--- a/server/apps/job_mgmt/views/mixins.py
+++ b/server/apps/job_mgmt/views/mixins.py
@@ -9,6 +9,7 @@ from typing import Optional, Tuple, Type
 from rest_framework import serializers, status
 from rest_framework.response import Response
 
+from apps.core.utils.team_utils import get_current_team
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
@@ -52,8 +53,8 @@ class TeamResolveMixin:
         if getattr(request, "api_pass", False):
             return user_group_ids[0], None
 
-        # 会话认证：优先使用 current_team cookie
-        current_team_str = request.COOKIES.get("current_team")
+        # 会话认证：优先使用 current_team（API Key 注入属性或 cookie）
+        current_team_str = get_current_team(request)
         if current_team_str:
             try:
                 current_team = int(current_team_str)

--- a/server/apps/job_mgmt/views/target.py
+++ b/server/apps/job_mgmt/views/target.py
@@ -20,6 +20,7 @@ from apps.rpc.executor import Executor
 from apps.rpc.node_mgmt import NodeMgmt
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.utils.operation_log_utils import log_operation
+from apps.core.utils.team_utils import get_current_team
 
 
 def _get_executor_node(cloud_region_id: int) -> str:
@@ -78,7 +79,7 @@ def _build_ssh_test_failure_message(result: dict, fallback_error: str, fallback_
 
 
 def _build_actor_context(request):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         raise BaseAppException("缺少 current_team 参数")
 

--- a/server/apps/log/services/access_scope.py
+++ b/server/apps/log/services/access_scope.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from apps.core.utils.permission_utils import get_permission_rules, permission_filter
 from apps.log.constants.permission import PermissionConstants
 from apps.log.models.log_group import LogGroup
+from apps.core.utils.team_utils import get_current_team
 
 
 @dataclass
@@ -22,7 +23,7 @@ class LogAccessScope:
 class LogAccessScopeService:
     @staticmethod
     def _get_current_team(request):
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if current_team in (None, ""):
             raise ValueError("当前组织信息不存在，请重新登录")
         return current_team

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -30,6 +30,7 @@ from apps.log.services.collect_type import CollectTypeService
 from apps.log.services.access_scope import LogAccessScopeService
 from apps.log.services.search import SearchService
 from apps.rpc.node_mgmt import NodeMgmt
+from apps.core.utils.team_utils import get_current_team
 
 
 def should_hide_collect_type_entry(result: dict) -> bool:
@@ -156,7 +157,7 @@ class CollectTypeViewSet(ModelViewSet):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             policy_res = get_permissions_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "log",
                 PermissionConstants.POLICY_MODULE,
                 include_children=include_children,
@@ -195,7 +196,7 @@ class CollectTypeViewSet(ModelViewSet):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             instance_res = get_permissions_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "log",
                 PermissionConstants.INSTANCE_MODULE,
                 include_children=include_children,
@@ -300,7 +301,7 @@ class CollectInstanceViewSet(ViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permission_result = get_permissions_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "log",
             PermissionConstants.INSTANCE_MODULE,
             include_children=include_children,
@@ -459,7 +460,7 @@ class CollectInstanceViewSet(ViewSet):
             return WebUtils.response_error(error_message=str(exc))
 
         # 获取当前用户选择的组织（必填）
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
 
         if collect_type_id:
             # 单采集类型查询 - 使用与监控模块完全一致的权限检查方式

--- a/server/apps/log/views/node.py
+++ b/server/apps/log/views/node.py
@@ -3,6 +3,7 @@ from rest_framework.viewsets import ViewSet
 
 from apps.core.utils.web_utils import WebUtils
 from apps.rpc.node_mgmt import NodeMgmt
+from apps.core.utils.team_utils import get_current_team
 
 
 class NodeViewSet(ViewSet):
@@ -24,7 +25,7 @@ class NodeViewSet(ViewSet):
                 permission_data={
                     "username": request.user.username,
                     "domain": request.user.domain,
-                    "current_team": request.COOKIES.get("current_team"),
+                    "current_team": get_current_team(request),
                 },
             )
         )

--- a/server/apps/log/views/policy.py
+++ b/server/apps/log/views/policy.py
@@ -32,6 +32,7 @@ from apps.log.serializers.policy import (
     EventRawDataSerializer,
 )
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 def get_accessible_log_policy_ids(request, collect_type_id=None):
@@ -45,7 +46,7 @@ def get_accessible_log_policy_ids(request, collect_type_id=None):
     if normalized_collect_type_id in cached_policy_ids:
         return cached_policy_ids[normalized_collect_type_id]
 
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if not current_team:
         cached_policy_ids[normalized_collect_type_id] = []
         return []
@@ -140,7 +141,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permissions_result = get_permissions_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "log",
             PermissionConstants.POLICY_MODULE,
             include_children=include_children,
@@ -220,7 +221,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permissions_result = get_permissions_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "log",
             PermissionConstants.POLICY_MODULE,
             include_children=include_children,
@@ -528,7 +529,7 @@ class AlertViewSet(viewsets.ModelViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permissions_result = get_permissions_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "log",
             PermissionConstants.POLICY_MODULE,
             include_children=include_children,
@@ -581,7 +582,7 @@ class AlertViewSet(viewsets.ModelViewSet):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             permission = get_permission_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "log",
                 f"{PermissionConstants.POLICY_MODULE}.{collect_type_id}",
                 include_children=include_children,
@@ -596,7 +597,7 @@ class AlertViewSet(viewsets.ModelViewSet):
             )
             policy_qs = policy_qs.filter(
                 collect_type_id=collect_type_id,
-                policyorganization__organization=request.COOKIES.get("current_team"),
+                policyorganization__organization=get_current_team(request),
             ).distinct()
 
             # 获取有权限的policy_ids
@@ -728,7 +729,7 @@ class AlertViewSet(viewsets.ModelViewSet):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             permission = get_permission_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "log",
                 f"{PermissionConstants.POLICY_MODULE}.{collect_type_id}",
                 include_children=include_children,
@@ -743,7 +744,7 @@ class AlertViewSet(viewsets.ModelViewSet):
             )
             policy_qs = policy_qs.filter(
                 collect_type_id=collect_type_id,
-                policyorganization__organization=request.COOKIES.get("current_team"),
+                policyorganization__organization=get_current_team(request),
             ).distinct()
 
             # 获取有权限的policy_ids

--- a/server/apps/log/views/search.py
+++ b/server/apps/log/views/search.py
@@ -10,6 +10,7 @@ from apps.log.models.log_group import SearchCondition
 from apps.log.serializers.log_group import SearchConditionSerializer
 from apps.log.serializers.search import LogFieldValuesSerializer, LogHitsSerializer, LogSearchSerializer, LogTopStatsSerializer
 from apps.log.filters.log_group import SearchConditionFilter
+from apps.core.utils.team_utils import get_current_team
 
 
 class LogSearchViewSet(ViewSet):
@@ -181,7 +182,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def get_queryset(self):
         """根据当前组织过滤查询集"""
-        current_team = self.request.COOKIES.get("current_team")
+        current_team = get_current_team(self.request)
         if not current_team:
             return SearchCondition.objects.none()
 
@@ -206,7 +207,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         """创建搜索条件"""
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return WebUtils.response_error("当前组织信息不存在，请重新登录")
 
@@ -229,7 +230,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def list(self, request, *args, **kwargs):
         """获取搜索条件列表"""
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return WebUtils.response_error("当前组织信息不存在，请重新登录")
 
@@ -246,7 +247,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         """获取搜索条件详情"""
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return WebUtils.response_error("当前组织信息不存在，请重新登录")
 
@@ -256,7 +257,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def update(self, request, *args, **kwargs):
         """更新搜索条件"""
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return WebUtils.response_error("当前组织信息不存在，请重新登录")
 
@@ -285,7 +286,7 @@ class SearchConditionViewSet(ModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         """删除搜索条件"""
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if not current_team:
             return WebUtils.response_error("当前组织信息不存在，请重新登录")
 

--- a/server/apps/log/views/system_mgmt.py
+++ b/server/apps/log/views/system_mgmt.py
@@ -3,12 +3,13 @@ from rest_framework.viewsets import ViewSet
 
 from apps.core.utils.web_utils import WebUtils
 from apps.rpc.system_mgmt import SystemMgmt
+from apps.core.utils.team_utils import get_current_team
 
 
 class SystemMgmtView(ViewSet):
     @action(methods=["get"], detail=False, url_path="user_all")
     def get_user_all(self, request):
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
         result = SystemMgmt().get_group_users(group=current_team, include_children=include_children)
         return WebUtils.response_success(result["data"])
@@ -16,7 +17,7 @@ class SystemMgmtView(ViewSet):
     @action(methods=["get"], detail=False, url_path="search_channel_list")
     def search_channel_list(self, request):
         channel_type = request.GET.get("channel_type", "")
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
         teams = [int(current_team)] if current_team else None
         result = SystemMgmt().search_channel_list(channel_type=channel_type, teams=teams, include_children=include_children)

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import logging
 
 from rest_framework import serializers
+from apps.core.utils.team_utils import get_current_team
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,7 @@ def get_current_team(request, default=0):
     Returns:
         int – the parsed team id, or *default*.
     """
-    raw = request.COOKIES.get("current_team", "")
+    raw = get_current_team(request, "")
     if not raw:
         return default
     try:

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -12,22 +12,25 @@ from types import SimpleNamespace
 import logging
 
 from rest_framework import serializers
-from apps.core.utils.team_utils import get_current_team
+from apps.core.utils.team_utils import get_current_team as _get_current_team_str
 
 logger = logging.getLogger(__name__)
 
 
 def get_current_team(request, default=0):
-    """Parse ``current_team`` from *request.COOKIES* and return an ``int``.
+    """Parse ``current_team`` from request and return an ``int``.
+
+    Reads via ``apps.core.utils.team_utils.get_current_team`` so that
+    both browser-cookie and API-Key-injected team contexts are supported.
 
     Args:
         request: Django/DRF request object.
-        default: Value returned when the cookie is missing or non-numeric.
+        default: Value returned when the team is missing or non-numeric.
 
     Returns:
         int – the parsed team id, or *default*.
     """
-    raw = get_current_team(request, "")
+    raw = _get_current_team_str(request, "")
     if not raw:
         return default
     try:

--- a/server/apps/monitor/views/metrics_instance.py
+++ b/server/apps/monitor/views/metrics_instance.py
@@ -12,6 +12,7 @@ from apps.monitor.models import MonitorInstance
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.services.metrics import Metrics as MetricsService
 from apps.monitor.utils.unit_converter import UnitConverter
+from apps.core.utils.team_utils import get_current_team
 
 
 class MetricsInstanceViewSet(viewsets.ViewSet):
@@ -268,7 +269,7 @@ class MetricsInstanceViewSet(viewsets.ViewSet):
         if not all([monitor_object_id, metric_id, instance_id]):
             raise BaseAppException("monitor_object_id, metric_id, instance_id are required")
 
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
 
         if not request.user.is_superuser:

--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -30,6 +30,7 @@ from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 from apps.monitor.services.policy_baseline import PolicyBaselineService
 from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 class MonitorAlertViewSet(
@@ -63,7 +64,7 @@ class MonitorAlertViewSet(
         """
         获取当前用户所有有权限的策略ID
         """
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
 
         # 获取所有采集类型下policy模块的权限规则
@@ -107,7 +108,7 @@ class MonitorAlertViewSet(
             include_children = request.COOKIES.get("include_children", "0") == "1"
             permission = get_permission_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "monitor",
                 f"{PermissionConstants.POLICY_MODULE}.{monitor_object_id}",
                 include_children=include_children,
@@ -293,7 +294,7 @@ class MonitorAlertViewSet(
 
 class MonitorEventViewSet(viewsets.ViewSet):
     def _get_all_accessible_policy_ids(self, request):
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         include_children = request.COOKIES.get("include_children", "0") == "1"
 
         permissions_result = get_permissions_rules(

--- a/server/apps/monitor/views/monitor_condition.py
+++ b/server/apps/monitor/views/monitor_condition.py
@@ -12,6 +12,7 @@ from apps.monitor.models.monitor_condition import (
 from apps.monitor.serializers.monitor_condition import MonitorConditionSerializer
 from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 class MonitorConditionViewSet(viewsets.ModelViewSet):
@@ -24,7 +25,7 @@ class MonitorConditionViewSet(viewsets.ModelViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permission = get_permission_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "monitor",
             PermissionConstants.CONDITION_MODULE,
             include_children=include_children,

--- a/server/apps/monitor/views/monitor_instance.py
+++ b/server/apps/monitor/views/monitor_instance.py
@@ -24,10 +24,11 @@ from apps.monitor.services.metrics import Metrics as MetricsService
 from apps.monitor.utils.dimension import normalize_instance_identity
 from apps.monitor.utils.pagination import parse_page_params
 from apps.rpc.node_mgmt import NodeMgmt
+from apps.core.utils.team_utils import get_current_team
 
 
 def _build_actor_context(request):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         raise BaseAppException("缺少 current_team 参数")
 
@@ -151,7 +152,7 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
     def monitor_instance_list(self, request, monitor_object_id):
         """非特殊对象的通用列表接口"""
         include_children = request.COOKIES.get("include_children", "0") == "1"
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
 
         permission = get_permission_rules(
             request.user,
@@ -211,7 +212,7 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permission = get_permission_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "monitor",
             f"{PermissionConstants.INSTANCE_MODULE}.{monitor_object_id}",
             include_children=include_children,
@@ -281,7 +282,7 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permission = get_permission_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "monitor",
             f"{PermissionConstants.INSTANCE_MODULE}.{monitor_object_id}",
             include_children=include_children,

--- a/server/apps/monitor/views/monitor_object.py
+++ b/server/apps/monitor/views/monitor_object.py
@@ -19,6 +19,7 @@ from apps.monitor.services.monitor_object import MonitorObjectService
 from apps.monitor.utils.display_fields import validate_display_fields
 from apps.monitor.utils.instance_id_keys import resolve_monitor_object_instance_id_keys
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 class MonitorObjectViewSet(viewsets.ModelViewSet):
@@ -65,7 +66,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
 
         if request.GET.get("add_instance_count") in ["true", "True"]:
             include_children = request.COOKIES.get("include_children", "0") == "1"
-            current_team = request.COOKIES.get("current_team")
+            current_team = get_current_team(request)
 
             inst_res = get_permissions_rules(
                 request.user,
@@ -106,7 +107,7 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             policy_res = get_permissions_rules(
                 request.user,
-                request.COOKIES.get("current_team"),
+                get_current_team(request),
                 "monitor",
                 f"{PermissionConstants.POLICY_MODULE}",
                 include_children=include_children,

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -28,6 +28,7 @@ from apps.monitor.services.policy_baseline import PolicyBaselineService
 from apps.monitor.services.policy_preview import PolicyPreviewService
 from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
+from apps.core.utils.team_utils import get_current_team
 
 
 class MonitorPolicyViewSet(viewsets.ModelViewSet):
@@ -42,7 +43,7 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
         include_children = request.COOKIES.get("include_children", "0") == "1"
         permission = get_permission_rules(
             request.user,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
             "monitor",
             f"{PermissionConstants.POLICY_MODULE}.{monitor_object_id}",
             include_children=include_children,

--- a/server/apps/monitor/views/node_mgmt.py
+++ b/server/apps/monitor/views/node_mgmt.py
@@ -9,10 +9,11 @@ from apps.rpc.node_mgmt import NodeMgmt
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.utils.pagination import parse_page_params
 from apps.monitor.utils.node_selector import merge_node_query_with_selector
+from apps.core.utils.team_utils import get_current_team
 
 
 def _build_actor_context(request):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         raise BaseAppException("缺少 current_team 参数")
 
@@ -75,7 +76,7 @@ class NodeMgmtView(ViewSet):
         logger.debug(
             "batch_setting_node_child_config called by user=%s, current_team=%s",
             request.user.username,
-            request.COOKIES.get("current_team"),
+            get_current_team(request),
         )
         InstanceConfigService.create_monitor_instance_by_node_mgmt(request.data, actor_context)
         return WebUtils.response_success()

--- a/server/apps/monitor/views/system_mgmt.py
+++ b/server/apps/monitor/views/system_mgmt.py
@@ -5,10 +5,11 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
+from apps.core.utils.team_utils import get_current_team
 
 
 def _build_actor_context(request):
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     if current_team in (None, ""):
         raise BaseAppException("缺少 current_team 参数")
 

--- a/server/apps/node_mgmt/utils/permission.py
+++ b/server/apps/node_mgmt/utils/permission.py
@@ -1,6 +1,7 @@
 from django.db.models import Count, F, Q
 
 from apps.core.utils.permission_utils import get_instance_permission_map, get_permission_rules, permission_filter
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.web_utils import WebUtils
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models.sidecar import ChildConfig, CollectorConfiguration, Node
@@ -32,7 +33,7 @@ def normalize_orgs(values):
 
 def get_node_permission(request):
     include_children = request.COOKIES.get("include_children", "0") == "1"
-    current_team = request.COOKIES.get("current_team")
+    current_team = get_current_team(request)
     user = get_request_user(request)
 
     if current_team in (None, "") or user is None:

--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -4,6 +4,7 @@
 # @Author: windyzhao
 from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.nats.nats_client import DefaultNastClient
+from apps.core.utils.team_utils import get_current_team
 
 
 class GetNatsData:
@@ -38,7 +39,7 @@ class GetNatsData:
         :return:
         """
         username = self.request.user.username
-        team = int(self.request.COOKIES.get("current_team"))
+        team = int(get_current_team(self.request))
         include_children = self.request.COOKIES.get("include_children", "0") == "1"
         permission = getattr(self.request.user, "permission", {})
         if isinstance(permission, dict):

--- a/server/apps/operation_analysis/filters/base_filters.py
+++ b/server/apps/operation_analysis/filters/base_filters.py
@@ -7,6 +7,7 @@ from django_filters import FilterSet
 
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.operation_analysis.constants.constants import APP_NAME
+from apps.core.utils.team_utils import get_current_team
 
 
 class GroupPermissionMixin:
@@ -47,7 +48,7 @@ class GroupPermissionMixin:
         #     return True, None
 
         # 获取当前选中的组织
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
 
         if not current_team:
             return False, None
@@ -187,7 +188,7 @@ class BaseGroupFilter(FilterSet):
         # if not is_valid:
         #     return queryset.none()
         #
-        # current_team = request.COOKIES.get("current_team")
+        # current_team = get_current_team(request)
         # _permission_key = self.permission_key()
         #
         # # 应用组织过滤

--- a/server/apps/operation_analysis/services/directory_service.py
+++ b/server/apps/operation_analysis/services/directory_service.py
@@ -7,6 +7,7 @@ from apps.operation_analysis.filters.base_filters import GroupPermissionMixin
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
 from apps.operation_analysis.models.models import Directory, Dashboard, Topology, Architecture
 from apps.operation_analysis.services.node_tree import TreeNodeBuilder
+from apps.core.utils.team_utils import get_current_team
 
 
 class DictDirectoryService:
@@ -18,7 +19,7 @@ class DictDirectoryService:
         获取目录树形结构,目录和仪表盘统一作为树节点
         """
         # 验证用户组织权限，构建组织ID列表（支持 include_children）
-        current_team = int(request.COOKIES.get("current_team"))
+        current_team = int(get_current_team(request))
         group_ids = [current_team]
         if request.COOKIES.get("include_children", "0") == "1":
             from apps.core.utils.viewset_utils import GenericViewSetFun

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -15,6 +15,7 @@ from apps.operation_analysis.services.import_export.authorization_service import
 from apps.operation_analysis.services.import_export.export_service import ExportService
 from apps.operation_analysis.services.import_export.import_service import ImportService
 from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
+from apps.core.utils.team_utils import get_current_team
 
 
 class ImportExportViewSet(ViewSet):
@@ -175,7 +176,7 @@ class ImportExportViewSet(ViewSet):
         return Response(result, status=status.HTTP_200_OK)
 
     def _get_current_team(self, request) -> int | None:
-        current_team = request.COOKIES.get("current_team")
+        current_team = get_current_team(request)
         if current_team:
             try:
                 return int(current_team)

--- a/server/apps/opspilot/utils/team_permission_mixin.py
+++ b/server/apps/opspilot/utils/team_permission_mixin.py
@@ -2,6 +2,7 @@
 
 from rest_framework.exceptions import PermissionDenied
 
+from apps.core.utils.team_utils import get_current_team
 from apps.opspilot.models import Bot, KnowledgeBase
 
 
@@ -16,8 +17,8 @@ class TeamPermissionMixin:
     """
 
     def _parse_current_team_cookie(self, request, default=0):
-        """解析 current_team cookie"""
-        current_team = request.COOKIES.get("current_team", str(default))
+        """解析 current_team（优先读 API Key 注入属性，回退到 cookie）"""
+        current_team = get_current_team(request, str(default))
         try:
             return int(current_team)
         except (TypeError, ValueError):

--- a/server/apps/opspilot/views.py
+++ b/server/apps/opspilot/views.py
@@ -38,6 +38,7 @@ from apps.opspilot.utils.sse_chat import create_error_stream_response, generate_
 from apps.opspilot.utils.wechat_chat_flow_utils import WechatChatFlowUtils
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import User
+from apps.core.utils.team_utils import get_current_team
 
 
 def parse_json_body(request, default=None):
@@ -634,7 +635,7 @@ async def execute_chat_flow(request, bot_id, node_id):
 
     # 验证token
     token = extract_api_token(request)
-    is_valid, msg = await sync_to_async(validate_openai_token, thread_sensitive=False)(token, request.COOKIES.get("current_team") or None)
+    is_valid, msg = await sync_to_async(validate_openai_token, thread_sensitive=False)(token, get_current_team(request) or None)
     if not is_valid:
         return JsonResponse(msg)
 
@@ -747,7 +748,7 @@ def interrupt_chat_flow_execution(request):
     execution_id = validated["execution_id"]
 
     token = extract_api_token(request)
-    is_valid, msg = validate_openai_token(token, request.COOKIES.get("current_team") or None)
+    is_valid, msg = validate_openai_token(token, get_current_team(request) or None)
     if not is_valid:
         return JsonResponse(msg)
     user = msg
@@ -802,7 +803,7 @@ def submit_approval(request):
 
     # 认证：要求有效 Token
     token = extract_api_token(request)
-    is_valid, msg = validate_openai_token(token, request.COOKIES.get("current_team") or None)
+    is_valid, msg = validate_openai_token(token, get_current_team(request) or None)
     if not is_valid:
         return JsonResponse(msg, status=401)
     user = msg
@@ -867,7 +868,7 @@ def submit_choice(request):
 
     # 认证：要求有效 Token
     token = extract_api_token(request)
-    is_valid, msg = validate_openai_token(token, request.COOKIES.get("current_team") or None)
+    is_valid, msg = validate_openai_token(token, get_current_team(request) or None)
     if not is_valid:
         return JsonResponse(msg, status=401)
     user = msg

--- a/server/apps/opspilot/viewsets/llm_view.py
+++ b/server/apps/opspilot/viewsets/llm_view.py
@@ -47,6 +47,7 @@ from apps.opspilot.utils.skill_execution_params import resolve_request_tools
 from apps.opspilot.utils.sse_chat import stream_chat
 from apps.opspilot.utils.vendor_model_mixin import VendorModelMixin
 from apps.system_mgmt.utils.operation_log_utils import log_operation
+from apps.core.utils.team_utils import get_current_team
 
 
 class LLMFilter(FilterSet):
@@ -172,7 +173,7 @@ class LLMViewSet(PinMixin, AuthViewSet):
     def update(self, request, *args, **kwargs):
         instance: LLMSkill = self.get_object()
         if not request.user.is_superuser:
-            current_team = request.COOKIES.get("current_team", "0")
+            current_team = get_current_team(request, "0")
             include_children = request.COOKIES.get("include_children", "0") == "1"
             has_permission = self.get_has_permission(request.user, instance, current_team, include_children=include_children)
             if not has_permission:
@@ -281,7 +282,7 @@ class LLMViewSet(PinMixin, AuthViewSet):
             # 获取客户端IP
             skill_obj = LLMSkill.objects.get(id=int(params["skill_id"]))
             if not request.user.is_superuser:
-                current_team = request.COOKIES.get("current_team", "0")
+                current_team = get_current_team(request, "0")
                 include_children = request.COOKIES.get("include_children", "0") == "1"
                 has_permission = self.get_has_permission(
                     request.user,
@@ -356,7 +357,7 @@ class LLMViewSet(PinMixin, AuthViewSet):
         try:
             skill_obj = LLMSkill.objects.get(id=int(params["skill_id"]))
             if not request.user.is_superuser:
-                current_team = request.COOKIES.get("current_team", "0")
+                current_team = get_current_team(request, "0")
                 include_children = request.COOKIES.get("include_children", "0") == "1"
                 has_permission = self.get_has_permission(
                     request.user,

--- a/server/apps/opspilot/viewsets/qa_pairs_view.py
+++ b/server/apps/opspilot/viewsets/qa_pairs_view.py
@@ -16,6 +16,7 @@ from apps.opspilot.tasks import create_qa_pairs, create_qa_pairs_by_chunk, creat
 from apps.opspilot.utils.chunk_helper import ChunkHelper
 from apps.opspilot.utils.permission_check import CheckKnowledgePermission
 from apps.system_mgmt.utils.operation_log_utils import log_operation
+from apps.core.utils.team_utils import get_current_team
 
 
 class QAPairsFilter(FilterSet):
@@ -96,7 +97,7 @@ class QAPairsViewSet(MaintainerViewSet):
 
     def _check_user_permission(self, knowledge_base_id, request):
         knowledge_base = KnowledgeBase.objects.get(id=knowledge_base_id)
-        current_team = request.COOKIES.get("current_team", "0")
+        current_team = get_current_team(request, "0")
         include_children = request.COOKIES.get("include_children", "0") == "1"
         has_permission = self.get_has_permission(request.user, knowledge_base, current_team, include_children=include_children)
         if not has_permission:
@@ -551,7 +552,7 @@ class QAPairsViewSet(MaintainerViewSet):
         instance_id = request.data.get("qa_pairs_id")
         instance = QAPairs.objects.get(id=instance_id)
         if not request.user.is_superuser:
-            current_team = request.COOKIES.get("current_team", "0")
+            current_team = get_current_team(request, "0")
             include_children = request.COOKIES.get("include_children", "0") == "1"
             has_permission = self.get_has_permission(request.user, instance.knowledge_base, current_team, include_children=include_children)
             if not has_permission:

--- a/server/apps/system_mgmt/utils/group_filter_mixin.py
+++ b/server/apps/system_mgmt/utils/group_filter_mixin.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse
 from rest_framework.exceptions import PermissionDenied
 
 from apps.core.logger import system_mgmt_logger as logger
+from apps.core.utils.team_utils import get_current_team
 from apps.system_mgmt.models import Group, User
 
 
@@ -120,8 +121,8 @@ class GroupFilterMixin:
     """
 
     def _parse_current_team_cookie(self, request, default=0):
-        """解析 current_team cookie"""
-        current_team = request.COOKIES.get("current_team", str(default))
+        """解析 current_team（优先读 API Key 注入属性，回退到 cookie）"""
+        current_team = get_current_team(request, str(default))
         try:
             return int(current_team)
         except (TypeError, ValueError):


### PR DESCRIPTION
## 问题

Closes #3486

`APISecretMiddleware` 在 API Key 认证后直接写 `request.COOKIES["current_team"]`，违反 Django 只读约定；当 API Key 绑定多个组织时，team 上下文固定取 `group_list[0]`，可能导致权限偏差（跨组织数据可见/写入）。

## 修复方案

1. **`APISecretMiddleware._handle_successful_auth`**：改为设置 `request._api_current_team`，不再污染 `request.COOKIES`。
2. **新增 `apps.core.utils.team_utils.get_current_team(request)`**：统一读取入口，优先读 `_api_current_team`，回退到 `COOKIES["current_team"]`，屏蔽两种来源差异。
3. **全平台 43 处** `request.COOKIES.get("current_team")` 统一改用 `get_current_team(request)` 或 `get_current_team(self.request)`。
4. **新增 10 条回归测试**（`test_api_middleware_team_injection.py`）：覆盖读取优先级、不污染 COOKIES、空 group_list 不注入、端到端链路。全部通过。

## 风险评估

risk=中（涉及 43 个文件，但变更模式机械统一：单一函数替换，无逻辑变更，有测试兜底）

@周壮杰 请 review，重点看 `api_middleware.py` 中间件改动 + `team_utils.py` 优先级逻辑。