### PR TITLE
bugfix: RpcClient.request() 补充超时保护，修复 NATS 不可达时 worker 永久阻塞

### DIFF
--- a/server/apps/rpc/base.py
+++ b/server/apps/rpc/base.py
@@ -28,8 +28,15 @@ class RpcClient(object):
             raise TimeoutError(f"RPC request timeout: namespace={self.namespace}, method={method_name}, timeout={effective_timeout}s")
 
     def request(self, method_name, **kwargs):
-        return_data = asyncio.run(nats_client.nat_request(self.namespace, method_name, **kwargs))
-        return return_data
+        timeout = kwargs.get("_timeout")
+        effective_timeout = timeout if timeout is not None else getattr(settings, "NATS_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)
+        try:
+            request_coro = nats_client.nat_request(self.namespace, method_name, **kwargs)
+            if effective_timeout and effective_timeout > 0:
+                request_coro = asyncio.wait_for(request_coro, timeout=effective_timeout)
+            return asyncio.run(request_coro)
+        except TimeoutError:
+            raise TimeoutError(f"RPC request timeout: namespace={self.namespace}, method={method_name}, timeout={effective_timeout}s")
 
 
 class AppClient(object):

--- a/server/apps/rpc/tests/test_base.py
+++ b/server/apps/rpc/tests/test_base.py
@@ -2,16 +2,18 @@
 
 规格：
 - RpcClient.namespace 默认取环境变量 NATS_NAMESPACE，缺省为 "bklite"，显式传参优先；
-- AppClient.run 按 path 动态导入模块并调用其同名函数；函数不存在抛 ValueError。
+- AppClient.run 按 path 动态导入模块并调用其同名函数；函数不存在抛 ValueError；
+- RpcClient.request() 必须有超时保护，遵循 NATS_REQUEST_TIMEOUT 设置，并在超时时抛出 TimeoutError。
 不触达真实 NATS（测试只覆盖不依赖网络的分发/命名空间逻辑）。
 """
 
+import asyncio
 import os
 from unittest import mock
 
 import pytest
 
-from apps.rpc.base import AppClient, RpcClient
+from apps.rpc.base import AppClient, DEFAULT_REQUEST_TIMEOUT, RpcClient
 
 pytestmark = pytest.mark.unit
 
@@ -41,3 +43,70 @@ class TestAppClientDispatch:
         client = AppClient("math")
         with pytest.raises(ValueError, match="not found"):
             client.run("no_such_function")
+
+
+class TestRpcClientRequestTimeout:
+    """验证 request() 有超时保护，修复 Issue #3485。"""
+
+    def _make_mock_coro(self, return_value):
+        """返回一个可以被 asyncio.run / asyncio.wait_for 使用的真实协程。"""
+        async def _coro(*args, **kwargs):
+            return return_value
+        return _coro
+
+    def test_request_使用_wait_for_包裹_nat_request(self):
+        """asyncio.wait_for 必须被调用——revert 修复后此测试应失败。"""
+        client = RpcClient(namespace="test_ns")
+        expected = {"result": True, "data": {}}
+
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
+             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
+             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
+            mock_nc.nat_request = self._make_mock_coro(expected)
+            client.request("some_method", key="val")
+
+        mock_wait_for.assert_called_once()
+
+    def test_request_使用默认超时(self):
+        """未传 _timeout 时使用 NATS_REQUEST_TIMEOUT 设置值。"""
+        client = RpcClient(namespace="test_ns")
+        expected = {"result": True, "data": {}}
+
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
+             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
+             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run), \
+             mock.patch("apps.rpc.base.settings") as mock_settings:
+            mock_settings.NATS_REQUEST_TIMEOUT = 30
+            mock_nc.nat_request = self._make_mock_coro(expected)
+            client.request("some_method")
+
+        _, call_kwargs = mock_wait_for.call_args
+        assert call_kwargs.get("timeout") == 30
+
+    def test_request_尊重调用方传入的_timeout(self):
+        """调用方通过 _timeout 传入的值必须生效（如 stargazer.collection_tool_debug）。"""
+        client = RpcClient(namespace="test_ns")
+        expected = {"result": True, "data": {}}
+
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
+             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
+             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
+            mock_nc.nat_request = self._make_mock_coro(expected)
+            client.request("some_method", _timeout=15)
+
+        _, call_kwargs = mock_wait_for.call_args
+        assert call_kwargs.get("timeout") == 15
+
+    def test_request_超时时抛出_TimeoutError(self):
+        """NATS 不可达时 request() 必须抛出 TimeoutError，不得永久挂起。"""
+        client = RpcClient(namespace="test_ns")
+
+        async def _never_return(*args, **kwargs):
+            await asyncio.sleep(9999)
+
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
+             mock.patch("apps.rpc.base.settings") as mock_settings:
+            mock_settings.NATS_REQUEST_TIMEOUT = 0.01
+            mock_nc.nat_request = _never_return
+            with pytest.raises(TimeoutError):
+                client.request("some_method")


### PR DESCRIPTION
## 被破坏的不变量

`RpcClient` 有两个 NATS 调用方法：`run()` 和 `request()`。`run()` 正确地用 `asyncio.wait_for` 包裹了 NATS 请求，守住了「外部 I/O 必须有超时边界」的契约。而 `request()` 直接 `asyncio.run(nat_request(…))`，完全没有超时保护——一旦下游 NATS 节点不可达，调用永久挂起，worker 进程无法释放。

## 根因（设计层）

`request()` 是 `run()` 的简化副本，但抄写时遗漏了超时逻辑。两方法并存导致调用者行为不一致：使用 `run()` 的路径（如 `health_check`）有保护，使用 `request()` 的路径（`list_regions`、`collection_tool_debug`、`bk_lite_login`、Celery `sync_data` 任务）无保护。`stargazer.py:35` 甚至已经传入了 `_timeout=nats_timeout`，但该参数被 `request()` 完全忽略。

## 修复如何恢复不变量

在 `request()` 中复用与 `run()` 完全相同的超时逻辑：
- 读取 `_timeout` kwarg，回退到 `settings.NATS_REQUEST_TIMEOUT`（默认 `DEFAULT_REQUEST_TIMEOUT = 60s`）
- 用 `asyncio.wait_for` 包裹 `nat_request` 协程
- 超时时抛出带上下文信息的 `TimeoutError`

修复后 `stargazer.collection_tool_debug` 已传入的 `_timeout` 参数也会正确生效。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["bk_lite_login\nindex_view.py:776"]
        T2["sync_user_and_group_by_login_module\nsystem_mgmt/tasks.py:50"]
        T3["Stargazer.list_regions / collection_tool_debug\nstargazer.py:18,35"]
    end

    subgraph C["RpcClient.request()（修复前无超时）"]
        REQ["request(method_name, **kwargs)\nbase.py:30"]
        BEFORE["asyncio.run(nat_request(…))\n❌ 无 wait_for — 永久阻塞"]
        AFTER["asyncio.wait_for(nat_request(…), timeout)\n✅ 超时抛 TimeoutError"]
    end

    subgraph E["故障路径（修复前）"]
        HANG["Worker 进程卡死"]
        EXHAUST["Worker 池耗尽 → 服务不可用"]
    end

    T1 & T2 & T3 --> REQ
    REQ --> BEFORE
    BEFORE -. "NATS 不可达" .-> HANG
    HANG -. "多并发" .-> EXHAUST

    REQ --> AFTER
    AFTER -. "超时" .-> TE["TimeoutError → 上层可处理/重试"]
```

## blast radius · 一致性

- 涉及文件：`server/apps/rpc/base.py`（核心共享模块）
- 所有 `RpcClient.request()` 调用方均受益：`bk_lite_login`、`sync_data` Celery 任务、`Stargazer.list_regions`、`Stargazer.collection_tool_debug`
- **向后兼容**：原本无超时（语义等价于超时=∞），现在有默认 60s 超时——这是有意的行为收紧，不影响正常响应的调用
- 与 `run()` 的现有模式完全一致，复用相同常量和逻辑，无新增抽象

触及 `core/rpc/base`，cc @zhouzhuangjie review。

## 验证

新增 `TestRpcClientRequestTimeout`（4 个测试，`server/apps/rpc/tests/test_base.py`）：
1. `wait_for` 被调用——revert 修复后此测试失败（验证修复覆盖真实路径）
2. 无 `_timeout` 时使用 `NATS_REQUEST_TIMEOUT` 设置值
3. `_timeout` kwarg 优先于默认值（覆盖 `stargazer.collection_tool_debug` 场景）
4. NATS 不可达时抛出 `TimeoutError`（永久挂起问题不再存在）

本地独立 harness 验证全 pass（绕过 license_mgmt Django settings 限制）。

关联 Issue #3485