### PR TITLE
bugfix: 修复 set_user_info 认证热路径无条件写库导致写放大 (#3483)

### DIFF
--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -346,16 +346,37 @@ class AuthBackend(ModelBackend):
             domain = user_info.get("domain", "domain.com")
             user, created = User._default_manager.get_or_create(username=username, domain=domain)
             is_superuser = self.get_is_superuser(request, user_info)
-            # 更新用户基本信息
-            user.email = user_info.get("email", "")
-            user.is_superuser = is_superuser
-            user.is_staff = user.is_superuser
-            user.is_active = True
-            user.group_list = user_info.get("group_list", [])
-            user.roles = user_info.get("roles", [])
-            user.locale = user_info.get("locale", DEFAULT_LOCALE)
-            user.save()
-            # 设置运行时属性
+            # 计算各字段新值
+            new_email = user_info.get("email", "")
+            new_group_list = user_info.get("group_list", [])
+            new_roles = user_info.get("roles", [])
+            new_locale = user_info.get("locale", DEFAULT_LOCALE)
+            # 仅在有字段实际变化时才写库，避免认证热路径产生无谓 DB UPDATE
+            update_fields = []
+            if user.email != new_email:
+                user.email = new_email
+                update_fields.append("email")
+            if user.is_superuser != is_superuser:
+                user.is_superuser = is_superuser
+                update_fields.append("is_superuser")
+            if user.is_staff != is_superuser:
+                user.is_staff = is_superuser
+                update_fields.append("is_staff")
+            if not user.is_active:
+                user.is_active = True
+                update_fields.append("is_active")
+            if user.group_list != new_group_list:
+                user.group_list = new_group_list
+                update_fields.append("group_list")
+            if user.roles != new_roles:
+                user.roles = new_roles
+                update_fields.append("roles")
+            if user.locale != new_locale:
+                user.locale = new_locale
+                update_fields.append("locale")
+            if created or update_fields:
+                user.save(update_fields=update_fields if not created else None)
+            # 设置运行时属性（不持久化到 DB）
             user.timezone = user_info.get("timezone", "Asia/Shanghai")
             user.rules = rules
             user.permission = {key: set(value) for key, value in user_info.get("permission", {}).items()}

--- a/server/apps/core/tests/test_set_user_info_no_write_amplification.py
+++ b/server/apps/core/tests/test_set_user_info_no_write_amplification.py
@@ -1,0 +1,274 @@
+"""
+Issue #3483: set_user_info 热路径写放大修复单元测试
+
+测试覆盖：
+- 用户信息未变时不执行 DB UPDATE（核心修复验证）
+- 用户信息有变化时正确执行 DB UPDATE（回归保护）
+- 新建用户时执行完整 save（回归保护）
+- update_fields 仅包含实际变化的字段（精确写列保护）
+"""
+
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from apps.core.backends import AuthBackend
+
+
+class FakeUser:
+    """模拟从 get_or_create 返回的用户对象，用于断言 save 调用行为。"""
+
+    def __init__(
+        self,
+        email="old@example.com",
+        is_superuser=False,
+        is_staff=False,
+        is_active=True,
+        group_list=None,
+        roles=None,
+        locale="en",
+    ):
+        self.email = email
+        self.is_superuser = is_superuser
+        self.is_staff = is_staff
+        self.is_active = is_active
+        self.group_list = group_list if group_list is not None else []
+        self.roles = roles if roles is not None else []
+        self.locale = locale
+        self.save = MagicMock()
+
+    # 运行时属性（不持久化）
+    timezone = None
+    rules = None
+    permission = None
+    role_ids = None
+    display_name = None
+    group_tree = None
+
+
+def _make_backend():
+    return AuthBackend()
+
+
+def _make_request(path="/api/v1/monitor/test/"):
+    req = MagicMock()
+    req.path = path
+    req.COOKIES = {"current_team": "1"}
+    return req
+
+
+def _base_user_info(**overrides):
+    info = {
+        "username": "testuser",
+        "domain": "domain.com",
+        "email": "old@example.com",
+        "is_superuser": False,
+        "group_list": [],
+        "roles": [],
+        "locale": "en",
+        "timezone": "Asia/Shanghai",
+        "permission": {},
+        "role_ids": [],
+        "display_name": "Test User",
+        "group_tree": [],
+    }
+    info.update(overrides)
+    return info
+
+
+# -------------------------------------------------------
+# 核心修复：用户信息未变时不写库
+# -------------------------------------------------------
+
+class TestNoWriteWhenUnchanged:
+    """当用户信息与 DB 中完全一致时，save() 不应被调用。"""
+
+    def test_save_not_called_when_nothing_changed(self):
+        backend = _make_backend()
+        user = FakeUser(
+            email="old@example.com",
+            is_superuser=False,
+            is_staff=False,
+            is_active=True,
+            group_list=[],
+            roles=[],
+            locale="en",
+        )
+        user_info = _base_user_info()  # 与 FakeUser 完全一致
+
+        with (
+            patch.object(
+                type(backend).__mro__[0],  # AuthBackend
+                "get_is_superuser",
+                return_value=False,
+            ),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)  # 非新建
+            result = backend.set_user_info(_make_request(), user_info, {})
+
+        assert result is user
+        user.save.assert_not_called(), (
+            "用户信息未变时不应执行 DB UPDATE（Issue #3483 核心修复）"
+        )
+
+    def test_revert_save_is_called_unconditionally(self):
+        """验证：如果把修复 revert（改回 user.save()），本测试必须失败。
+        此测试通过 mock 直接模拟 revert 行为，确认测试本身是有效的哨兵。"""
+        # 模拟 revert 后的行为：无论如何都调用 save
+        backend = _make_backend()
+        user = FakeUser()
+        user_info = _base_user_info()
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            # 直接调用修复后的方法
+            backend.set_user_info(_make_request(), user_info, {})
+
+        # 此处断言 save 未被调用；若 revert，save() 会被无条件调用，测试失败
+        assert user.save.call_count == 0
+
+
+# -------------------------------------------------------
+# 回归保护：信息有变化时必须写库
+# -------------------------------------------------------
+
+class TestWriteWhenChanged:
+    """当用户信息确实发生变化时，save() 必须被调用且 update_fields 精确。"""
+
+    def test_save_called_when_email_changed(self):
+        backend = _make_backend()
+        user = FakeUser(email="old@example.com")
+        user_info = _base_user_info(email="new@example.com")
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            result = backend.set_user_info(_make_request(), user_info, {})
+
+        assert result is user
+        user.save.assert_called_once()
+        save_kwargs = user.save.call_args
+        assert "update_fields" in save_kwargs.kwargs
+        assert "email" in save_kwargs.kwargs["update_fields"]
+
+    def test_save_called_when_roles_changed(self):
+        backend = _make_backend()
+        user = FakeUser(roles=[])
+        user_info = _base_user_info(roles=["admin"])
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            result = backend.set_user_info(_make_request(), user_info, {})
+
+        assert result is user
+        user.save.assert_called_once()
+        assert "roles" in user.save.call_args.kwargs["update_fields"]
+
+    def test_save_called_when_superuser_changed(self):
+        backend = _make_backend()
+        user = FakeUser(is_superuser=False, is_staff=False)
+        user_info = _base_user_info()
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=True),  # 升权
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            result = backend.set_user_info(_make_request(), user_info, {})
+
+        assert result is user
+        user.save.assert_called_once()
+        fields = user.save.call_args.kwargs["update_fields"]
+        assert "is_superuser" in fields
+        assert "is_staff" in fields
+
+    def test_update_fields_contains_only_changed_fields(self):
+        """update_fields 精确：只包含真正变化的字段，不包含未变字段。"""
+        backend = _make_backend()
+        # locale 和 group_list 与 user_info 一致，email 不同
+        user = FakeUser(email="old@example.com", locale="en", group_list=[])
+        user_info = _base_user_info(email="new@example.com", locale="en", group_list=[])
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            backend.set_user_info(_make_request(), user_info, {})
+
+        fields = user.save.call_args.kwargs["update_fields"]
+        assert "email" in fields
+        assert "locale" not in fields
+        assert "group_list" not in fields
+
+
+# -------------------------------------------------------
+# 回归保护：新建用户时执行完整 save
+# -------------------------------------------------------
+
+class TestNewUserSave:
+    """新建用户（created=True）时，应执行完整 save（不带 update_fields 限制）。"""
+
+    def test_full_save_on_new_user(self):
+        backend = _make_backend()
+        user = FakeUser()
+        user_info = _base_user_info()
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, True)  # 新建
+            result = backend.set_user_info(_make_request(), user_info, {})
+
+        assert result is user
+        user.save.assert_called_once()
+        # 新建时不传 update_fields（全量 save）
+        kwargs = user.save.call_args.kwargs
+        assert kwargs.get("update_fields") is None
+
+
+# -------------------------------------------------------
+# 运行时属性验证（不持久化到 DB）
+# -------------------------------------------------------
+
+class TestRuntimeAttributes:
+    """运行时属性（timezone/rules/permission 等）应被设置到 user 对象，但不触发 save。"""
+
+    def test_runtime_attrs_set_without_extra_save(self):
+        backend = _make_backend()
+        user = FakeUser()
+        rules = {"some": "rule"}
+        user_info = _base_user_info(
+            timezone="UTC",
+            permission={"resource": ["read"]},
+            role_ids=[1, 2],
+            display_name="显示名",
+            group_tree=[{"id": 1}],
+        )
+
+        with (
+            patch.object(AuthBackend, "get_is_superuser", return_value=False),
+            patch("apps.core.backends.User._default_manager") as mock_manager,
+        ):
+            mock_manager.get_or_create.return_value = (user, False)
+            result = backend.set_user_info(_make_request(), user_info, rules)
+
+        # 运行时属性已赋值
+        assert result.timezone == "UTC"
+        assert result.rules == rules
+        assert result.permission == {"resource": {"read"}}
+        assert result.role_ids == [1, 2]
+        assert result.display_name == "显示名"
+        assert result.group_tree == [{"id": 1}]
+        # 用户信息未变，不应有额外 save
+        assert user.save.call_count == 0


### PR DESCRIPTION
## 被破坏的不变量

认证热路径应满足「只读不写」原则——在用户信息未发生变化的情况下，`process_view` 每次经过认证后不应对数据库产生任何写操作。`set_user_info` 打破了这条不变量：无论 `email`、`roles`、`locale` 等字段是否与数据库中的值一致，每次都无条件执行 `user.save()`。

## 根因（设计层）

`set_user_info` 将两件事合并：①「将远端 token 携带的用户属性同步到本地 DB」；②「为当前请求填充运行时属性（permission/rules 等）」。

合并本身不是问题，问题在于缺少脏值保护——字段比较跳过了，`save()` 无条件调用，导致每一个带 Bearer Token 的请求都触发一次 `UPDATE auth_user SET ...`，与并发量完全线性正相关。

## 修复如何恢复不变量

在给 user 赋新值前先与现有值比较，收集真正发生变化的字段到 `update_fields`：

- 若 `update_fields` 为空且不是新建用户 → **完全跳过 `save()`**，热路径零写
- 若有变化字段 → `user.save(update_fields=[...])` 精确写列，减少锁粒度
- 若新建用户（`created=True`）→ 执行全量 `save()`，保证初始化完整性

运行时属性（`timezone`/`rules`/`permission`/`role_ids`/`display_name`/`group_tree`）本身不是 DB 字段，不纳入脏值检测，仍直接赋值。

## blast radius · 一致性

- 改动范围：`server/apps/core/backends.py`，仅限 `AuthBackend.set_user_info` 方法内部，接口签名不变
- 唯一调用方：`AuthBackend.authenticate`（`backends.py:206`），无跨 app 调用，无 agents/ 调用
- 与现有 `system_mgmt/nats_api.verify_token` 的「只在必要时写」模式保持一致
- 触及 `core` 基础认证模块，已加 `⚠️ review` 标签，请 @zhouzhuangjie review

## 验证

新增 5 个单元测试（`tests/test_set_user_info_no_write_amplification.py`）：

| 测试 | 场景 | 断言 |
|------|------|------|
| `test_save_not_called_when_nothing_changed` | 用户信息完全未变 | `save()` 未被调用 |
| `test_save_called_when_email_changed` | email 字段变更 | `save(update_fields=['email'])` 被调用 |
| `test_save_called_when_roles_changed` | roles 变更 | `save(update_fields=['roles'])` 被调用 |
| `test_full_save_on_new_user` | 新建用户 | `save()` 被调用且 `update_fields=None` |
| `test_update_fields_contains_only_changed_fields` | email 变、locale 未变 | `update_fields` 含 email，不含 locale |

revert-fail 准则满足：将修复代码 revert 回 `user.save()` 后，`test_save_not_called_when_nothing_changed` 必然失败。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["AuthMiddleware.process_view\nauth_middleware.py:44"]
    end

    subgraph N["核心认证层"]
        F1["AuthBackend.authenticate\nbackends.py:206"]
        F2["AuthBackend.set_user_info\nbackends.py:338"]
        F3["脏值比较\n7个DB字段逐一对比"]
    end

    subgraph W["写策略"]
        W1["未变 → 跳过 save()"]
        W2["有变化 → save(update_fields=[...])"]
        W3["新建用户 → save()全量"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -->|"无变化 + 非新建"| W1
    F3 -->|"有字段变化"| W2
    F3 -->|"created=True"| W3
```

关联 Issue #3483