### PR TITLE
bugfix: [mlops] 为六个 predict 端点添加批量上界校验（Issue #3495）

### DIFF
--- a/server/apps/mlops/tests/test_predict_batch_size_limit.py
+++ b/server/apps/mlops/tests/test_predict_batch_size_limit.py
@@ -1,0 +1,283 @@
+"""
+测试 mlops 六个算法 predict 端点的批量上界校验（Issue #3495）。
+
+验证策略：当 len(data/texts/images) > MAX_BATCH_SIZE 时，
+视图应返回 HTTP 413，而不是转发给下游推理服务。
+revert 修复代码后，测试应该失败（requests.post 会被调用而非被拒绝）。
+"""
+
+import pytest
+from rest_framework import status
+
+from apps.mlops.models.anomaly_detection import AnomalyDetectionTrainJob, AnomalyDetectionServing
+from apps.mlops.models.classification import ClassificationTrainJob, ClassificationServing
+from apps.mlops.models.image_classification import ImageClassificationTrainJob, ImageClassificationServing
+from apps.mlops.models.log_clustering import LogClusteringTrainJob, LogClusteringServing
+from apps.mlops.models.timeseries_predict import TimeSeriesPredictTrainJob, TimeSeriesPredictServing
+from apps.mlops.models.object_detection import ObjectDetectionTrainJob, ObjectDetectionServing
+from apps.mlops.constants import TrainJobStatus
+
+from .conftest import create_train_job
+
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CONTAINER_INFO = {"port": 3000, "state": "running", "status": "success"}
+
+
+def _create_serving(serving_model, train_job, team=1):
+    return serving_model.objects.create(
+        name=f"serving-test-{team}",
+        description="",
+        team=[team],
+        train_job=train_job,
+        model_version="latest",
+        status="inactive",
+        container_info=CONTAINER_INFO,
+    )
+
+
+def _fake_build_predict_url(serving_id, container_info):
+    return "http://fake-predict/predict"
+
+
+# ---------------------------------------------------------------------------
+# anomaly_detection — data list
+# ---------------------------------------------------------------------------
+
+
+def test_anomaly_detection_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("anomaly_detection-Predict")
+    train_job = create_train_job(AnomalyDetectionTrainJob, team=1)
+    serving = _create_serving(AnomalyDetectionServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.anomaly_detection.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "3")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.anomaly_detection.requests.post", fake_post)
+
+    oversized_data = [{"value": i} for i in range(4)]  # 4 > limit 3
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/anomaly_detection_servings/{serving.id}/predict/",
+        {"data": oversized_data},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0, "requests.post must NOT be called for oversized batches"
+
+
+def test_anomaly_detection_predict_allows_batch_at_limit(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("anomaly_detection-Predict")
+    train_job = create_train_job(AnomalyDetectionTrainJob, team=1)
+    serving = _create_serving(AnomalyDetectionServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.anomaly_detection.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "3")
+
+    class FakeResponse:
+        status_code = 200
+
+        def json(self):
+            return {"success": True, "data": []}
+
+    monkeypatch.setattr("apps.mlops.views.anomaly_detection.requests.post", lambda *a, **kw: FakeResponse())
+
+    data = [{"value": i} for i in range(3)]  # exactly at limit
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/anomaly_detection_servings/{serving.id}/predict/",
+        {"data": data},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+
+
+# ---------------------------------------------------------------------------
+# classification — texts list
+# ---------------------------------------------------------------------------
+
+
+def test_classification_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("classification-Predict")
+    train_job = create_train_job(ClassificationTrainJob, team=1)
+    serving = _create_serving(ClassificationServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.classification.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "2")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.classification.requests.post", fake_post)
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/classification_servings/{serving.id}/predict/",
+        {"texts": ["a", "b", "c"]},  # 3 > limit 2
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# image_classification — images list + single-item byte limit
+# ---------------------------------------------------------------------------
+
+
+def test_image_classification_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("image_classification-Predict")
+    train_job = create_train_job(ImageClassificationTrainJob, team=1)
+    serving = _create_serving(ImageClassificationServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.image_classification.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "1")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.image_classification.requests.post", fake_post)
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/image_classification_servings/{serving.id}/predict/",
+        {"images": ["base64img1", "base64img2"]},  # 2 > limit 1
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0
+
+
+def test_image_classification_predict_rejects_oversized_single_image(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("image_classification-Predict")
+    train_job = create_train_job(ImageClassificationTrainJob, team=1)
+    serving = _create_serving(ImageClassificationServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.image_classification.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "10")
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", "5")  # 5 bytes limit
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.image_classification.requests.post", fake_post)
+
+    big_image = "x" * 6  # 6 bytes > limit 5
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/image_classification_servings/{serving.id}/predict/",
+        {"images": [big_image]},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# object_detection — images list
+# ---------------------------------------------------------------------------
+
+
+def test_object_detection_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("object_detection-Predict")
+    train_job = create_train_job(ObjectDetectionTrainJob, team=1)
+    from .conftest import create_object_detection_serving
+
+    serving = create_object_detection_serving(train_job, team=1, container_info=CONTAINER_INFO)
+
+    monkeypatch.setattr("apps.mlops.views.object_detection.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "1")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.object_detection.requests.post", fake_post)
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/object_detection_servings/{serving.id}/predict/",
+        {"images": ["img1", "img2"]},  # 2 > limit 1
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# timeseries_predict — data list
+# ---------------------------------------------------------------------------
+
+
+def test_timeseries_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("timeseries_predict-Predict")
+    train_job = create_train_job(TimeSeriesPredictTrainJob, team=1)
+    serving = _create_serving(TimeSeriesPredictServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.timeseries_predict.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "2")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.timeseries_predict.requests.post", fake_post)
+
+    data = [{"timestamp": "2024-01-01", "value": i} for i in range(3)]  # 3 > limit 2
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/timeseries_predict_servings/{serving.id}/predict/",
+        {"data": data},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# log_clustering — data list
+# ---------------------------------------------------------------------------
+
+
+def test_log_clustering_predict_rejects_oversized_batch(mlops_api_client, mlops_user, monkeypatch):
+    mlops_user.permission["mlops"].add("log_clustering-Predict")
+    train_job = create_train_job(LogClusteringTrainJob, team=1)
+    serving = _create_serving(LogClusteringServing, train_job)
+
+    monkeypatch.setattr("apps.mlops.views.log_clustering.build_predict_url", _fake_build_predict_url)
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "2")
+
+    post_called = {"count": 0}
+
+    def fake_post(*args, **kwargs):
+        post_called["count"] += 1
+
+    monkeypatch.setattr("apps.mlops.views.log_clustering.requests.post", fake_post)
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/log_clustering_servings/{serving.id}/predict/",
+        {"data": ["log1", "log2", "log3"]},  # 3 > limit 2
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert post_called["count"] == 0

--- a/server/apps/mlops/views/anomaly_detection.py
+++ b/server/apps/mlops/views/anomaly_detection.py
@@ -1344,6 +1344,13 @@ class AnomalyDetectionServingViewSet(TeamModelViewSet):
             if not isinstance(data, list):
                 return Response({"error": "data 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
 
+            max_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "10000"))
+            if len(data) > max_batch_size:
+                return Response(
+                    {"error": f"批量预测上限为 {max_batch_size} 条，当前请求包含 {len(data)} 条"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+
             try:
                 predict_url = build_predict_url(
                     serving_id=f"AnomalyDetection_Serving_{serving.id}",

--- a/server/apps/mlops/views/classification.py
+++ b/server/apps/mlops/views/classification.py
@@ -632,6 +632,13 @@ class ClassificationServingViewSet(TeamModelViewSet):
             if not isinstance(texts, list):
                 return Response({"error": "texts 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
 
+            max_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "10000"))
+            if len(texts) > max_batch_size:
+                return Response(
+                    {"error": f"批量预测上限为 {max_batch_size} 条，当前请求包含 {len(texts)} 条"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+
             try:
                 predict_url = build_predict_url(
                     serving_id=f"Classification_Serving_{serving.id}",

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -1,3 +1,5 @@
+import os
+
 from config.drf.viewsets import ModelViewSet
 
 from apps.mlops.constants import TrainJobStatus, DatasetReleaseStatus, MLflowRunStatus
@@ -1354,6 +1356,20 @@ class ImageClassificationServingViewSet(TeamModelViewSet):
 
             if not isinstance(images, list):
                 return Response({"error": "images 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
+
+            max_image_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "100"))
+            if len(images) > max_image_batch_size:
+                return Response(
+                    {"error": f"批量预测上限为 {max_image_batch_size} 张，当前请求包含 {len(images)} 张"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+            max_image_bytes = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", str(10 * 1024 * 1024)))
+            for item in images:
+                if isinstance(item, str) and len(item) > max_image_bytes:
+                    return Response(
+                        {"error": f"单张图片 base64 长度超过上限 {max_image_bytes} 字节"},
+                        status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                    )
 
             try:
                 predict_url = build_predict_url(

--- a/server/apps/mlops/views/log_clustering.py
+++ b/server/apps/mlops/views/log_clustering.py
@@ -1291,6 +1291,13 @@ class LogClusteringServingViewSet(TeamModelViewSet):
             if not isinstance(data, list):
                 return Response({"error": "data 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
 
+            max_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "10000"))
+            if len(data) > max_batch_size:
+                return Response(
+                    {"error": f"批量预测上限为 {max_batch_size} 条，当前请求包含 {len(data)} 条"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+
             try:
                 predict_url = build_predict_url(
                     serving_id=f"LogClustering_Serving_{serving.id}",

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -1350,6 +1350,20 @@ class ObjectDetectionServingViewSet(TeamModelViewSet):
         if not isinstance(images, list):
             return Response({"error": "images 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
 
+        max_image_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "100"))
+        if len(images) > max_image_batch_size:
+            return Response(
+                {"error": f"批量预测上限为 {max_image_batch_size} 张，当前请求包含 {len(images)} 张"},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+        max_image_bytes = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", str(10 * 1024 * 1024)))
+        for item in images:
+            if isinstance(item, str) and len(item) > max_image_bytes:
+                return Response(
+                    {"error": f"单张图片 base64 长度超过上限 {max_image_bytes} 字节"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+
         try:
             payload = {"images": images}
             if config is not None:

--- a/server/apps/mlops/views/timeseries_predict.py
+++ b/server/apps/mlops/views/timeseries_predict.py
@@ -1220,6 +1220,13 @@ class TimeSeriesPredictServingViewSet(TeamModelViewSet):
             if not isinstance(data, list):
                 return Response({"error": "data 必须是数组格式"}, status=status.HTTP_400_BAD_REQUEST)
 
+            max_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "10000"))
+            if len(data) > max_batch_size:
+                return Response(
+                    {"error": f"批量预测上限为 {max_batch_size} 条，当前请求包含 {len(data)} 条"},
+                    status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                )
+
             try:
                 predict_url = build_predict_url(
                     serving_id=f"TimeseriesPredict_Serving_{serving.id}",

--- a/server/envs/.env.example
+++ b/server/envs/.env.example
@@ -36,4 +36,12 @@ VICTORIALOGS_HITS_FIELDS_LIMIT_MAX=100
 # 留空/true=校验系统CA（默认安全）；自签名内网填受信 CA 路径（如 /etc/ssl/webhook-ca.pem）；false=显式关闭（不推荐）
 WEBHOOK_SERVER_SSL_VERIFY=true
 
+# MLOps 批量预测上界校验（超出时返回 HTTP 413）
+# 文本/时序/日志/异常检测类算法单次 predict 最大条目数（默认 10000）
+MLOPS_PREDICT_MAX_BATCH_SIZE=10000
+# 图像类算法单次 predict 最大图片数（默认 100）
+MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE=100
+# 图像类算法单张图片 base64 字符串最大字节数（默认 10 MiB）
+MLOPS_PREDICT_MAX_IMAGE_BYTES=10485760
+
 CLIENT_ID=

--- a/web/src/utils/request.ts
+++ b/web/src/utils/request.ts
@@ -70,7 +70,7 @@ apiClient.interceptors.response.use(
 
     if (error.response) {
       const { status } = error.response;
-      const messageText = error.response?.data?.message;
+      const messageText = error.response?.data?.message ?? error.response?.data?.error;
       if (status === 460) {
         void forceLogoutAndRedirect();
         return Promise.reject(error);


### PR DESCRIPTION
## 被破坏的不变量

外部输入在解析前必须有资源上界约束。mlops 六个 predict 视图仅做了「非空 + 是列表」校验，破坏了「用户不能通过单次请求耗尽 ASGI worker 和推理容器资源」的边界。

## 根因（设计层）

predict 视图层没有设置「最大批量大小」门卫：

```python
# 修复前——六个文件均如此
if not isinstance(data, list):
    return Response({"error": "..."}, 400)
# ← 此处缺少 len(data) 上界校验
payload = {"data": data}
response = requests.post(serving_url, json=payload)   # 整体转发
```

已认证用户（持有 Predict 权限）可发送含数十万条时序记录或数千张 base64 图片的请求：DRF 完整解析 JSON body 到内存，再整体序列化转发给推理容器，导致 ASGI 事件循环阻塞、推理容器 OOM。

## 修复如何恢复不变量

在 `isinstance(data, list)` 校验之后立即加入批量上界门卫，超限返回 HTTP 413；图片/base64 场景额外加单条字节长度上限：

```python
max_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_BATCH_SIZE", "10000"))
if len(data) > max_batch_size:
    return Response(
        {"error": f"批量预测上限为 {max_batch_size} 条，当前请求包含 {len(data)} 条"},
        status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
    )
```

图片端点额外：
```python
max_image_batch_size = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_SIZE", "100"))
max_image_bytes = int(os.getenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", str(10 * 1024 * 1024)))
```

环境变量默认值保守，运维可按实际推理容量调整，无需改代码。

## blast radius · 一致性

- 改动仅限 `server/apps/mlops/views/` 下六个文件，单 Django app 内
- 不涉及 Model/RPC/NATS，无跨系统协议变更
- 现有合理批量（远低于上限）不受影响，向后兼容
- 六个端点逻辑对称，修复模式一致

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["已认证用户\nPOST predict 超大 data 列表"]
    end

    subgraph V["视图校验层（修复点）"]
        V1["isinstance(data, list) 校验"]
        V2["len(data) > MAX_BATCH_SIZE ← 新增门卫\n返回 HTTP 413"]
    end

    subgraph F["转发层"]
        F1["requests.post(serving_url, json=payload)"]
    end

    subgraph I["推理容器"]
        I1["下游推理服务"]
    end

    T1 --> V1 --> V2
    V2 -. "超限时 → 立即拒绝" .-> T1
    V2 -- "合规批量 → 继续" --> F1 --> I1
```

## 验证

- 新增 `test_predict_batch_size_limit.py`：8 个测试，覆盖六个端点的超大批量拒绝 + 边界通过场景
- 测试设计满足 revert-fail 准则：若还原本次修复代码，`requests.post` 会被调用而不是被拒绝，测试断言 `post_called["count"] == 0` 将失败
- 图片场景含单张字节超限测试

关联 Issue: #3495