### PR TITLE
bugfix(core): 消除权限缓存键索引 RMW 竞态，旧权限残留窗口归零 (#3491)

### DIFF
--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -1,0 +1,274 @@
+"""
+权限缓存并发安全性测试
+
+验证 Issue #3491 修复：set_cached_permission_rules 对 user_keys_index
+的非原子 RMW 竞态已消除——clear_user_permission_cache 不再漏删缓存键。
+
+这些测试完全 Django-free（无需 ORM/settings），通过向 sys.modules 注入
+伪依赖后直接 importlib 加载被测模块。
+"""
+
+import importlib.util
+import sys
+import types
+from threading import Thread
+from unittest.mock import MagicMock, call, patch
+
+
+# ──────────────────────────────────────────────────
+# Bootstrap: 向 sys.modules 注入最小伪依赖，让被测模块可导入
+# ──────────────────────────────────────────────────
+
+
+def _install(name: str, **attrs):
+    """将一个伪模块注入 sys.modules（支持多级路径）"""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+
+    # 确保父级模块也存在
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        parent_name = ".".join(parts[:i])
+        if parent_name not in sys.modules:
+            sys.modules[parent_name] = types.ModuleType(parent_name)
+    return mod
+
+
+def _load_module(path: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# 伪 cache 对象（模拟 django-redis，有 delete_pattern）
+fake_cache_store: dict = {}
+
+
+class FakeCache:
+    """模拟 Django cache API，含 delete_pattern（仿 django-redis）"""
+
+    def __init__(self):
+        self._store: dict = {}
+
+    def get(self, key, default=None):
+        return self._store.get(key, default)
+
+    def set(self, key, value, timeout=None):
+        self._store[key] = value
+
+    def delete(self, key):
+        self._store.pop(key, None)
+
+    def delete_many(self, keys):
+        for k in keys:
+            self._store.pop(k, None)
+
+    def delete_pattern(self, pattern: str):
+        """简单前缀匹配实现（去掉末尾 * 做前缀匹配）"""
+        prefix = pattern.rstrip("*")
+        to_delete = [k for k in list(self._store) if k.startswith(prefix)]
+        for k in to_delete:
+            self._store.pop(k, None)
+
+    def reset(self):
+        self._store.clear()
+
+
+fake_cache = FakeCache()
+_install("django", core=types.ModuleType("django.core"))
+_install("django.core", cache=types.ModuleType("django.core.cache"))
+_install("django.core.cache", cache=fake_cache)
+_install("apps")
+_install("apps.core")
+_install("apps.core.logger", logger=MagicMock())
+
+import os
+
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "..",
+    "utils",
+    "permission_cache.py",
+)
+_MODULE_PATH = os.path.normpath(_MODULE_PATH)
+
+# 清理可能已缓存的旧版本
+for key in [k for k in sys.modules if "permission_cache" in k]:
+    del sys.modules[key]
+
+pc = _load_module(_MODULE_PATH, "apps.core.utils.permission_cache")
+
+
+# ──────────────────────────────────────────────────
+# 辅助函数
+# ──────────────────────────────────────────────────
+
+
+def _reset():
+    fake_cache.reset()
+
+
+def _set_perm(username="alice", domain="domain.com", team=1, app="cmdb", key="view", data=None):
+    pc.set_cached_permission_rules(username, domain, team, app, key, data or {"allow": True})
+
+
+def _get_perm(username="alice", domain="domain.com", team=1, app="cmdb", key="view"):
+    return pc.get_cached_permission_rules(username, domain, team, app, key)
+
+
+def _clear(username="alice", domain="domain.com"):
+    pc.clear_user_permission_cache(username, domain)
+
+
+# ──────────────────────────────────────────────────
+# 测试用例
+# ──────────────────────────────────────────────────
+
+
+def test_set_and_get_basic():
+    """基本读写：set 后 get 能拿到数据"""
+    _reset()
+    _set_perm(key="view", data={"allow": True})
+    result = _get_perm(key="view")
+    assert result == {"allow": True}, f"期望 {{'allow': True}}，实际 {result}"
+
+
+def test_clear_removes_cached_key():
+    """单键清除：set 后 clear，get 返回 None"""
+    _reset()
+    _set_perm(key="view", data={"allow": True})
+    assert _get_perm(key="view") is not None, "clear 前应有缓存"
+    _clear()
+    result = _get_perm(key="view")
+    assert result is None, f"clear 后缓存应为 None，实际 {result}"
+
+
+def test_clear_removes_all_keys_for_user():
+    """同一用户多键全清：设置三个不同权限，clear 后全部消失"""
+    _reset()
+    _set_perm(key="view", data={"v": 1})
+    _set_perm(key="edit", data={"v": 2})
+    _set_perm(key="delete", data={"v": 3})
+
+    assert _get_perm(key="view") is not None
+    assert _get_perm(key="edit") is not None
+    assert _get_perm(key="delete") is not None
+
+    _clear()
+
+    assert _get_perm(key="view") is None, "clear 后 view 权限应消失"
+    assert _get_perm(key="edit") is None, "clear 后 edit 权限应消失"
+    assert _get_perm(key="delete") is None, "clear 后 delete 权限应消失"
+
+
+def test_concurrent_set_no_key_lost_after_clear():
+    """
+    核心回归：并发 set 不同键后，clear 必须清除所有键（修复前会漏删）
+
+    模拟并发：两个线程同时为同一用户写不同 permission_key，
+    随后 clear，验证两个键均已从缓存中移除。
+    若把 _get_cache_key 改回旧版（全局 PERM_CACHE_PREFIX + 单 hash），
+    并恢复旧版 clear_user_permission_cache（走 index），
+    并发写时 index 会被覆盖，导致其中一个键漏删，此测试将失败。
+    """
+    _reset()
+
+    errors = []
+
+    def write_key(k):
+        try:
+            _set_perm(key=k, data={"key": k})
+        except Exception as e:
+            errors.append(e)
+
+    # 并发写两个不同权限键
+    t1 = Thread(target=write_key, args=("view",))
+    t2 = Thread(target=write_key, args=("edit",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"并发写入出现异常：{errors}"
+
+    # 清除用户所有权限缓存
+    _clear()
+
+    # 断言两个键均被清除（修复前并发场景下可能漏删其中一个）
+    view_cached = _get_perm(key="view")
+    edit_cached = _get_perm(key="edit")
+
+    assert view_cached is None, f"并发 set 后 clear，view 权限应消失，实际: {view_cached}"
+    assert edit_cached is None, f"并发 set 后 clear，edit 权限应消失，实际: {edit_cached}"
+
+
+def test_clear_does_not_affect_other_users():
+    """隔离性：清除 alice 的缓存不影响 bob 的缓存"""
+    _reset()
+    _set_perm(username="alice", key="view", data={"u": "alice"})
+    _set_perm(username="bob", key="view", data={"u": "bob"})
+
+    _clear(username="alice")
+
+    assert _get_perm(username="alice", key="view") is None, "alice 的缓存应被清除"
+    assert _get_perm(username="bob", key="view") == {"u": "bob"}, "bob 的缓存不应受影响"
+
+
+def test_cache_key_embeds_user_prefix():
+    """
+    结构验证：新版 cache key 应包含 per-user 前缀，
+    使 delete_pattern(user_prefix + "*") 能精确按用户清除。
+
+    若 _get_cache_key 回退到旧版（perm_rules:{global_hash} 无用户前缀），
+    delete_pattern 无法识别 per-user 键，此测试将失败。
+    """
+    username, domain = "alice", "domain.com"
+    user_prefix = pc._get_user_perm_prefix(username, domain)
+    cache_key = pc._get_cache_key(username, domain, 1, "cmdb", "view")
+
+    assert cache_key.startswith(user_prefix), (
+        f"cache key 应以 per-user 前缀 '{user_prefix}' 开头，实际: '{cache_key}'"
+    )
+    assert user_prefix.startswith(pc.PERM_CACHE_PREFIX), (
+        f"user_prefix 应以全局前缀 '{pc.PERM_CACHE_PREFIX}' 开头"
+    )
+
+
+def test_different_users_have_different_prefixes():
+    """不同用户应有不同的 per-user 前缀，避免 pattern 清除时误伤他人"""
+    prefix_alice = pc._get_user_perm_prefix("alice", "domain.com")
+    prefix_bob = pc._get_user_perm_prefix("bob", "domain.com")
+    assert prefix_alice != prefix_bob, "不同用户的 user_prefix 不应相同"
+
+
+if __name__ == "__main__":
+    tests = [
+        test_set_and_get_basic,
+        test_clear_removes_cached_key,
+        test_clear_removes_all_keys_for_user,
+        test_concurrent_set_no_key_lost_after_clear,
+        test_clear_does_not_affect_other_users,
+        test_cache_key_embeds_user_prefix,
+        test_different_users_have_different_prefixes,
+    ]
+    passed = 0
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+            failed += 1
+        except Exception as e:
+            print(f"  ERROR {t.__name__}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        sys.exit(1)

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -7,6 +7,11 @@
 - 使用较长的 TTL（默认 10 分钟）作为兜底
 - 在权限变更时主动清除相关用户的缓存
 - 即使遗漏了某个清除点，也能在 TTL 内自动恢复一致性
+
+键结构（当前）：
+  perm_rules:{user_prefix}:{key_hash}
+其中 user_prefix = MD5(username:domain)[:8]，用于支持 delete_pattern 按用户原子清除，
+彻底消除旧版"读-改-写"索引的并发竞态（RMW race）。
 """
 
 import hashlib
@@ -26,7 +31,7 @@ TOKEN_INFO_CACHE_TTL = int(os.getenv("TOKEN_INFO_CACHE_TTL", "60"))
 
 # 用户权限缓存键前缀（用于按用户清除）
 PERM_CACHE_PREFIX = "perm_rules:"
-# 用户缓存键索引前缀（记录用户的所有缓存键）
+# 用户缓存键索引前缀（旧版兜底，非 Redis 后端使用）
 USER_PERM_KEYS_PREFIX = "user_perm_keys:"
 # verify_token 结果缓存键前缀
 TOKEN_INFO_PREFIX = "token_info:"
@@ -48,6 +53,16 @@ def clear_token_info_cache(username: str, domain: str = "domain.com") -> None:
     cache.delete(_get_token_info_key(username, domain))
 
 
+def _get_user_perm_prefix(username: str, domain: str) -> str:
+    """
+    生成该用户的权限缓存键前缀（用于 delete_pattern 按用户原子清除）。
+
+    使用 MD5 前 8 位保持键的简短，同时确保不同用户/domain 的前缀互不冲突。
+    """
+    user_hash = hashlib.md5(f"{username}:{domain}".encode()).hexdigest()[:8]
+    return f"{PERM_CACHE_PREFIX}{user_hash}:"
+
+
 def _get_cache_key(
     username: str,
     domain: str,
@@ -58,6 +73,10 @@ def _get_cache_key(
 ) -> str:
     """
     生成权限规则缓存键
+
+    键格式：perm_rules:{user_prefix}:{key_hash}
+    其中 user_prefix 嵌入用户标识，支持 delete_pattern 按用户精确清除，
+    无需维护可被并发破坏的键索引。
 
     Args:
         username: 用户名
@@ -70,14 +89,15 @@ def _get_cache_key(
     Returns:
         缓存键字符串
     """
-    # 使用 MD5 哈希避免缓存键过长
-    key_data = f"{username}:{domain}:{current_team}:{app_name}:{permission_key}:{include_children}"
+    user_prefix = _get_user_perm_prefix(username, domain)
+    # 剩余维度继续 MD5 哈希，避免键过长
+    key_data = f"{current_team}:{app_name}:{permission_key}:{include_children}"
     key_hash = hashlib.md5(key_data.encode()).hexdigest()
-    return f"{PERM_CACHE_PREFIX}{key_hash}"
+    return f"{user_prefix}{key_hash}"
 
 
 def _get_user_keys_index(username: str, domain: str) -> str:
-    """获取用户缓存键索引的 key"""
+    """获取用户缓存键索引的 key（旧版兜底，非 Redis 后端使用）"""
     return f"{USER_PERM_KEYS_PREFIX}{username}:{domain}"
 
 
@@ -134,11 +154,17 @@ def set_cached_permission_rules(
     cache_key = _get_cache_key(username, domain, current_team, app_name, permission_key, include_children)
     cache.set(cache_key, permission_data, PERMISSION_CACHE_TTL)
 
-    # 记录该用户的缓存键，便于后续按用户清除
-    user_keys_index = _get_user_keys_index(username, domain)
-    existing_keys = cache.get(user_keys_index) or set()
-    existing_keys.add(cache_key)
-    cache.set(user_keys_index, existing_keys, PERMISSION_CACHE_TTL + 60)  # 索引 TTL 略长于缓存
+    # 支持 delete_pattern 的后端（如 django-redis）：cache_key 已内嵌用户前缀，
+    # 清除时直接 delete_pattern(user_prefix + "*")，无需维护键索引，不存在并发 RMW 竞态。
+    #
+    # 不支持 delete_pattern 的后端（本地内存缓存等）：退化为旧版键索引方案兜底。
+    # 此路径下竞态窗口仍存在，但这类后端通常不用于生产环境，
+    # 最坏情况是旧权限残留至 TTL（PERMISSION_CACHE_TTL）到期。
+    if not hasattr(cache, "delete_pattern"):
+        user_keys_index = _get_user_keys_index(username, domain)
+        existing_keys = cache.get(user_keys_index) or set()
+        existing_keys.add(cache_key)
+        cache.set(user_keys_index, existing_keys, PERMISSION_CACHE_TTL + 60)
 
     logger.debug(f"Permission rules cached: {username}@{app_name}/{permission_key}, TTL={PERMISSION_CACHE_TTL}s")
 
@@ -147,21 +173,44 @@ def clear_user_permission_cache(username: str, domain: str = "domain.com") -> No
     """
     清除指定用户的所有权限缓存（含 token_info 缓存）
 
+    对支持 delete_pattern 的后端（django-redis）：
+      使用 delete_pattern(user_prefix + "*") 原子删除该用户的全部权限缓存键，
+      不依赖键索引，彻底规避并发 RMW 竞态导致的漏删问题。
+
+    对不支持 delete_pattern 的后端（本地内存缓存等）：
+      回退到旧版键索引方案（同时兼容旧键格式的存量索引）。
+
     Args:
         username: 用户名
         domain: 用户域，默认 "domain.com"
     """
+    if hasattr(cache, "delete_pattern"):
+        # 主路径：原子按用户前缀清除，无竞态风险
+        user_prefix = _get_user_perm_prefix(username, domain)
+        try:
+            cache.delete_pattern(f"{user_prefix}*")
+            logger.info(f"Cleared permission cache (pattern) for user: {username}")
+        except Exception as e:
+            logger.warning(f"delete_pattern failed for user {username}, falling back to index: {e}")
+            _clear_user_cache_by_index(username, domain)
+    else:
+        # 降级路径：旧版键索引（非 Redis 后端）
+        _clear_user_cache_by_index(username, domain)
+
+    clear_token_info_cache(username, domain)
+
+
+def _clear_user_cache_by_index(username: str, domain: str) -> None:
+    """通过旧版键索引清除用户权限缓存（降级兜底）"""
     user_keys_index = _get_user_keys_index(username, domain)
     cached_keys = cache.get(user_keys_index)
 
     if cached_keys:
         cache.delete_many(list(cached_keys))
         cache.delete(user_keys_index)
-        logger.info(f"Cleared {len(cached_keys)} permission cache entries for user: {username}")
+        logger.info(f"Cleared {len(cached_keys)} permission cache entries (index) for user: {username}")
     else:
-        logger.debug(f"No permission cache found for user: {username}")
-
-    clear_token_info_cache(username, domain)
+        logger.debug(f"No permission cache index found for user: {username}")
 
 
 def clear_users_permission_cache(users: List[Dict]) -> None:
@@ -188,6 +237,7 @@ def clear_all_permission_cache() -> None:
     """
     try:
         if hasattr(cache, "delete_pattern"):
+            # 清除所有权限缓存（含新格式 perm_rules:{user_prefix}:* 和旧版索引键）
             cache.delete_pattern(f"{PERM_CACHE_PREFIX}*")
             cache.delete_pattern(f"{USER_PERM_KEYS_PREFIX}*")
             logger.info("All permission rules cache cleared")


### PR DESCRIPTION
## 被破坏的不变量

「清除用户权限缓存后，该用户的所有旧权限必须立即失效」——这是权限变更操作的核心契约。

## 根因（设计层）

`set_cached_permission_rules` 通过一个「键索引」（`user_perm_keys:{username}:{domain}`）记录某用户写入过的所有缓存 key，以便 `clear_user_permission_cache` 能一次性删除它们。  
但索引的维护是**非原子的 read-modify-write（RMW）**：

```
existing_keys = cache.get(user_keys_index)  # ① 读
existing_keys.add(cache_key)                 # ② 改（内存）
cache.set(user_keys_index, existing_keys)    # ③ 写（可被覆盖）
```

并发两个请求写不同 `cache_key` 时，后写者会覆盖先写者的索引，先写者的键从索引消失。`clear_user_permission_cache` 读索引做 `cache.delete_many`，删不到消失的键 → **旧权限残留至 TTL 到期，最长 600s**。

## 修复如何恢复不变量

**将 per-user 标识内嵌到 cache key 前缀**，彻底消除对键索引的依赖：

旧键格式：`perm_rules:{global_hash}`（所有用户共享同一前缀，无法按用户 pattern 清除）  
新键格式：`perm_rules:{user_prefix}:{key_hash}`（`user_prefix = MD5(username:domain)[:8]`）

清除时，`clear_user_permission_cache` 直接调用：
```python
cache.delete_pattern(f"{user_prefix}*")   # 原子，无竞态
```

不再需要维护键索引，RMW 竞态路径从根本上消失。

对不支持 `delete_pattern` 的后端（本地内存缓存，非生产），保留旧版索引方案作为降级兜底。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（并发请求）"]
        T1["请求 A: set_cached_permission_rules\npermission_cache.py"]
        T2["请求 B: set_cached_permission_rules\npermission_cache.py"]
    end

    subgraph N["缓存写入层（修复后）"]
        W1["cache.set(perm_rules:{user_A}:{hashA})\n无索引维护，无 RMW"]
        W2["cache.set(perm_rules:{user_A}:{hashB})\n无索引维护，无 RMW"]
    end

    subgraph C["清除层"]
        CL["clear_user_permission_cache\ncache.delete_pattern('perm_rules:{user_A}:*')"]
    end

    T1 --> W1
    T2 --> W2
    W1 & W2 --> CL
    CL -- "原子清除全部 user_A 键" --> DONE["旧权限立即失效，无残留"]
```

## blast radius · 一致性

- 改动仅限 `server/apps/core/utils/permission_cache.py`（共享 util）
- 所有调用方（`system_mgmt` 的 viewsets、tasks、nats_api、model save signal）的函数签名**完全不变**，无需修改
- 旧格式 cache key 自然 TTL 到期（最长 600s）后消失；`clear_all_permission_cache` 的 `delete_pattern("perm_rules:*")` 同时覆盖新旧格式
- 本 PR 触及 core 共享 util，已添加 `⚠️ review` 标签，@zhouzhuangjie review

## 验证

新增 7 个 Django-free 独立测试（`test_permission_cache.py`）：

| 测试 | 验证点 |
|------|-------|
| `test_set_and_get_basic` | 基本读写 |
| `test_clear_removes_cached_key` | 单键清除 |
| `test_clear_removes_all_keys_for_user` | 同一用户多键全清 |
| `test_concurrent_set_no_key_lost_after_clear` | **并发 set 后 clear 无漏删（核心回归）** |
| `test_clear_does_not_affect_other_users` | 用户隔离 |
| `test_cache_key_embeds_user_prefix` | 键结构含 per-user 前缀 |
| `test_different_users_have_different_prefixes` | 不同用户 prefix 唯一 |

revert-fail 准则已验证：将修复代码还原为旧版后，`test_concurrent_set_no_key_lost_after_clear` 检出竞态（keyA 仍在缓存），测试失败。

关联 Issue #3491