### PR TITLE
bugfix: [console_mgmt] get_user_group_paths 替换全表加载为两阶段按需查询

### DIFF
--- a/server/apps/console_mgmt/tests/test_get_user_group_paths_views.py
+++ b/server/apps/console_mgmt/tests/test_get_user_group_paths_views.py
@@ -1,0 +1,237 @@
+"""
+console_mgmt get_user_group_paths 按需加载规格测试。
+
+规格要点（Issue #3474 修复）：
+- get_user_group_paths 不得调用 Group.objects.all()（全表扫描）
+- 采用两阶段按需加载：
+  Phase 1: Group.objects.filter(id__in=...).values_list("id","parent_id") 逐层向上收集祖先 ID
+  Phase 2: Group.objects.filter(id__in=all_group_ids).prefetch_related("roles") 按需加载对象
+- 查询范围与路径深度成正比，而非系统组织总数
+"""
+
+import importlib.util
+import sys
+import types
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+pytestmark = [pytest.mark.unit]
+
+
+# --------------------------------------------------------------------------- #
+# 独立测试 harness：不依赖 Django ORM / settings，直接加载被测函数
+# --------------------------------------------------------------------------- #
+
+def _install(name, **attrs):
+    """往 sys.modules 注入伪模块（支持多级路径）。"""
+    parts = name.split(".")
+    parent = None
+    for i, part in enumerate(parts):
+        full = ".".join(parts[: i + 1])
+        if full not in sys.modules:
+            mod = types.ModuleType(full)
+            sys.modules[full] = mod
+            if parent is not None:
+                setattr(parent, part, mod)
+        parent = sys.modules[full]
+    for k, v in attrs.items():
+        setattr(sys.modules[name], k, v)
+    return sys.modules[name]
+
+
+# 构建 Group 桩（返回可链式调用的 mock）
+_MockGroupClass = MagicMock()
+
+
+def _load_views():
+    """加载 views.py，注入所有外部依赖的桩。"""
+    # Django 框架桩
+    _install("django")
+    _install("django.contrib")
+    _install("django.contrib.auth")
+    _install("django.contrib.auth.hashers", check_password=lambda pwd, h: pwd == h, make_password=lambda pwd: f"hashed:{pwd}")
+    _install("django.core")
+    _install("django.core.cache", cache=MagicMock())
+    _install("django.db")
+    _install("django.db.transaction", atomic=lambda: __import__("contextlib").contextmanager(lambda f: f)())
+    _install("django.http", JsonResponse=lambda d, **kw: d)
+    _install("django.utils")
+    _install("django.utils.timezone")
+    _install("zoneinfo", ZoneInfo=lambda tz: tz)
+
+    # 应用级桩
+    _install("apps")
+    _install("apps.core")
+    _install("apps.core.utils")
+    _install("apps.core.utils.loader", LanguageLoader=lambda **kw: MagicMock(get=lambda k, d="": d))
+    _install("apps.rpc")
+    _install("apps.rpc.system_mgmt", SystemMgmt=MagicMock)
+    _install("apps.system_mgmt")
+    _install("apps.system_mgmt.models", Group=_MockGroupClass, Role=MagicMock(), User=MagicMock())
+    _install("apps.system_mgmt.models.app", App=MagicMock())
+    _install("apps.system_mgmt.utils")
+    _install("apps.system_mgmt.utils.group_utils", GroupUtils=MagicMock())
+    _install("apps.system_mgmt.utils.operation_log_utils", log_operation=MagicMock())
+
+    spec = importlib.util.spec_from_file_location(
+        "console_mgmt_views_group_paths",
+        "/Users/justin/bklite-loops/wt-issue-scan/server/apps/console_mgmt/views.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_views = _load_views()
+
+
+# --------------------------------------------------------------------------- #
+# 辅助：构建假 Group 对象
+# --------------------------------------------------------------------------- #
+
+def _make_group(gid, parent_id=None, name=None):
+    g = MagicMock()
+    g.id = gid
+    g.parent_id = parent_id or 0
+    g.name = name or f"Group{gid}"
+    g.roles.all.return_value = []
+    return g
+
+
+# --------------------------------------------------------------------------- #
+# 核心测试：修复后不得调用 Group.objects.all()
+# --------------------------------------------------------------------------- #
+
+class TestGetUserGroupPaths:
+
+    def test_不调用全表查询(self):
+        """修复后 get_user_group_paths 不得调用 Group.objects.all()。"""
+        mock_group_qs = MagicMock()
+        # Phase 1 filter 返回轻量行
+        mock_group_qs.filter.return_value.values_list.return_value = [(1, 0)]
+        # Phase 2 filter 返回完整对象
+        mock_group_qs.filter.return_value.prefetch_related.return_value = [_make_group(1)]
+
+        mock_group_class = MagicMock()
+        mock_group_class.objects = mock_group_qs
+
+        _views.GroupUtils.build_group_paths.return_value = ["Root"]
+
+        with patch.object(_views, "Group", mock_group_class):
+            result = _views.get_user_group_paths([1])
+
+        # 核心断言：不得调用 .all()
+        mock_group_qs.all.assert_not_called(), "修复后不得使用全表 Group.objects.all()"
+
+    def test_空列表直接返回空(self):
+        """user_group_list 为空时应直接返回 []，不触发任何 DB 查询。"""
+        mock_group_class = MagicMock()
+        with patch.object(_views, "Group", mock_group_class):
+            result = _views.get_user_group_paths([])
+
+        assert result == []
+        mock_group_class.objects.filter.assert_not_called()
+        mock_group_class.objects.all.assert_not_called()
+
+    def test_phase1用filter按id集合查询(self):
+        """Phase 1 必须用 filter(id__in=...) + values_list('id','parent_id') 查询，不加载完整对象。"""
+        mock_group_qs = MagicMock()
+        # Phase 1 返回：用户在 group 2，其 parent 为 1，group 1 的 parent 为 0（根）
+        def filter_side_effect(**kwargs):
+            ids = set(kwargs.get("id__in", []))
+            qs = MagicMock()
+            if ids == {2}:
+                qs.values_list.return_value = [(2, 1)]  # group 2 的 parent 是 1
+                qs.prefetch_related.return_value = []
+            elif ids == {1}:
+                qs.values_list.return_value = [(1, 0)]  # group 1 的 parent 是 0（根）
+                qs.prefetch_related.return_value = []
+            else:
+                # Phase 2: filter(id__in={1,2})
+                qs.values_list.return_value = []
+                qs.prefetch_related.return_value = [_make_group(1), _make_group(2, parent_id=1)]
+            return qs
+
+        mock_group_qs.filter.side_effect = filter_side_effect
+
+        mock_group_class = MagicMock()
+        mock_group_class.objects = mock_group_qs
+
+        _views.GroupUtils.build_group_paths.return_value = ["Root/Group2"]
+
+        with patch.object(_views, "Group", mock_group_class):
+            result = _views.get_user_group_paths([2])
+
+        # 验证 filter 被调用（而非 all），且第一次调用包含 Phase 1 的 values_list 参数
+        assert mock_group_qs.filter.called, "应调用 filter(id__in=...) 而非 all()"
+        # 取第一次 filter 调用的参数
+        first_call_kwargs = mock_group_qs.filter.call_args_list[0][1]
+        assert "id__in" in first_call_kwargs, "Phase 1 的 filter 必须使用 id__in 参数"
+
+    def test_phase2用filter按需加载完整对象(self):
+        """Phase 2 必须用 filter(id__in=all_ids).prefetch_related('roles')，且传入的 ID 集合
+        只包含路径上的祖先组，而非系统所有组。"""
+        # 树结构：Root(id=100) -> Parent(id=200) -> UserGroup(id=300)
+        # 系统还有无关组 id=999，但不应被查询
+        call_record = []
+
+        def filter_side_effect(**kwargs):
+            ids = set(kwargs.get("id__in", []))
+            call_record.append(ids)
+            qs = MagicMock()
+            if ids == {300}:
+                # Phase 1 第一轮：user group 300 的 parent 是 200
+                qs.values_list.return_value = [(300, 200)]
+                qs.prefetch_related.return_value = []
+            elif ids == {200}:
+                # Phase 1 第二轮：group 200 的 parent 是 100
+                qs.values_list.return_value = [(200, 100)]
+                qs.prefetch_related.return_value = []
+            elif ids == {100}:
+                # Phase 1 第三轮：group 100 的 parent 是 0（根）
+                qs.values_list.return_value = [(100, 0)]
+                qs.prefetch_related.return_value = []
+            else:
+                # Phase 2：加载完整对象（id__in={100,200,300}）
+                qs.values_list.return_value = []
+                qs.prefetch_related.return_value = [
+                    _make_group(100, parent_id=0, name="Root"),
+                    _make_group(200, parent_id=100, name="Parent"),
+                    _make_group(300, parent_id=200, name="UserGroup"),
+                ]
+            return qs
+
+        mock_group_qs = MagicMock()
+        mock_group_qs.filter.side_effect = filter_side_effect
+
+        mock_group_class = MagicMock()
+        mock_group_class.objects = mock_group_qs
+
+        _views.GroupUtils.build_group_paths.return_value = ["Root/Parent/UserGroup"]
+
+        with patch.object(_views, "Group", mock_group_class):
+            _views.get_user_group_paths([300])
+
+        # Phase 2 的 filter 必须只包含路径上的 ID（100, 200, 300），不含无关的 999
+        phase2_ids = call_record[-1]  # 最后一次 filter 调用是 Phase 2
+        assert 999 not in phase2_ids, "Phase 2 不应查询无关的组 id=999（全表问题未修复）"
+        assert {100, 200, 300} == phase2_ids, f"Phase 2 应只包含路径上的组 ID，实际: {phase2_ids}"
+
+    def test_revert修复后all被调用(self):
+        """回归保护：若将修复 revert 回 Group.objects.all()，此测试应失败。
+        （本测试是元测试，用于文档目的；实际运行时修复已应用，此处验证 all 未被调用。）"""
+        mock_group_qs = MagicMock()
+        mock_group_qs.filter.return_value.values_list.return_value = [(1, 0)]
+        mock_group_qs.filter.return_value.prefetch_related.return_value = [_make_group(1)]
+
+        mock_group_class = MagicMock()
+        mock_group_class.objects = mock_group_qs
+
+        _views.GroupUtils.build_group_paths.return_value = ["Root"]
+
+        with patch.object(_views, "Group", mock_group_class):
+            _views.get_user_group_paths([1])
+
+        # 修复后 all() 不应被调用；若 revert 回旧实现，all() 会被调用，此断言失败
+        mock_group_qs.all.assert_not_called()

--- a/server/apps/console_mgmt/tests/test_get_user_group_paths_views.py
+++ b/server/apps/console_mgmt/tests/test_get_user_group_paths_views.py
@@ -10,6 +10,7 @@ console_mgmt get_user_group_paths 按需加载规格测试。
 """
 
 import importlib.util
+import pathlib
 import sys
 import types
 from unittest.mock import MagicMock, call, patch
@@ -74,9 +75,10 @@ def _load_views():
     _install("apps.system_mgmt.utils.group_utils", GroupUtils=MagicMock())
     _install("apps.system_mgmt.utils.operation_log_utils", log_operation=MagicMock())
 
+    _views_path = pathlib.Path(__file__).parent.parent / "views.py"
     spec = importlib.util.spec_from_file_location(
         "console_mgmt_views_group_paths",
-        "/Users/justin/bklite-loops/wt-issue-scan/server/apps/console_mgmt/views.py",
+        str(_views_path),
     )
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -122,7 +124,7 @@ class TestGetUserGroupPaths:
             result = _views.get_user_group_paths([1])
 
         # 核心断言：不得调用 .all()
-        mock_group_qs.all.assert_not_called(), "修复后不得使用全表 Group.objects.all()"
+        mock_group_qs.all.assert_not_called()
 
     def test_空列表直接返回空(self):
         """user_group_list 为空时应直接返回 []，不触发任何 DB 查询。"""

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -46,38 +46,36 @@ def get_user_group_paths(user_group_list):
     获取用户所在组的路径信息（包含所有父级组）
     :param user_group_list: 用户所属的组ID列表
     :return: 组路径列表
+
+    实现采用两阶段按需加载，避免全表扫描：
+    - Phase 1：仅查询 id/parent_id 轻量字段，BFS 收集从用户组到根的所有祖先 ID。
+    - Phase 2：按 ID 集合查询完整对象（含 prefetch_related("roles")），集合大小
+              与路径深度成正比（O(depth × fan-out)），而非系统组织总数 O(N)。
     """
     if not user_group_list:
         return []
 
-    # 一次性获取所有组数据（包含所有可能的父级组）
-    all_groups = Group.objects.all().prefetch_related("roles")
+    # Phase 1：轻量查询，仅取 id + parent_id，BFS 向上收集祖先 ID
+    # 从用户直属组出发，每轮查询当前层节点的 parent_id，直到到达根（parent_id=0 或 None）
+    all_group_ids: set = set(user_group_list)
+    current_ids: set = set(user_group_list)
 
-    # 构建组ID到组对象的映射
-    group_map = {group.id: group for group in all_groups}
-
-    # 收集用户所在组及其所有父级组ID
-    all_group_ids = set(user_group_list)
-
-    # 非递归方式获取所有父级组ID
-    current_ids = set(user_group_list)
     while current_ids:
-        parent_ids = set()
-        for group_id in current_ids:
-            group = group_map.get(group_id)
-            if group and hasattr(group, "parent_id") and group.parent_id:
-                parent_ids.add(group.parent_id)
+        # 仅查询当前层节点的 parent_id，不加载其余字段
+        parent_rows = Group.objects.filter(id__in=current_ids).values_list("id", "parent_id")
+        new_parent_ids = set()
+        for _gid, parent_id in parent_rows:
+            if parent_id and parent_id not in all_group_ids:
+                new_parent_ids.add(parent_id)
 
-        # 过滤出尚未处理的父级组ID
-        new_parent_ids = parent_ids - all_group_ids
         if not new_parent_ids:
             break
 
         all_group_ids.update(new_parent_ids)
         current_ids = new_parent_ids
 
-    # 获取所有相关组对象
-    related_groups = [group_map[gid] for gid in all_group_ids if gid in group_map]
+    # Phase 2：仅加载路径所需的组对象（含 roles prefetch）
+    related_groups = list(Group.objects.filter(id__in=all_group_ids).prefetch_related("roles"))
 
     return GroupUtils.build_group_paths(related_groups, user_group_list)
 


### PR DESCRIPTION
## 被破坏的不变量

`get_user_group_paths` 应守住的契约：**查询范围与结果集大小成正比**。
用户在一个深度为 D、每层平均 F 个兄弟的组织树中，其祖先链只有 D 个节点——
理论上查询量是 O(D×F) 级别，与系统组织总数 N 无关。

## 根因（设计层）

原始实现通过 `Group.objects.all().prefetch_related("roles")` 将全表拉入 Python 内存，
再在内存里做 BFS 路径拼接。随业务增长，每次打开个人信息页都触发一次 O(N) 全表扫描，
且 `prefetch_related("roles")` 进一步放大单次数据量，N×avg_roles 行全进内存。

破坏了上述不变量：查询量 = 系统总组织数，与用户路径深度无关。

## 修复如何恢复不变量

采用两阶段按需加载，将查询范围严格约束到「用户到根的路径」：

**Phase 1**（收集祖先 ID，仅查轻量字段）

```python
parent_rows = Group.objects.filter(id__in=current_ids).values_list("id", "parent_id")
```

从用户直属组出发，每轮只查当前层节点的 `parent_id`，BFS 向上直到根（`parent_id=0/None`）。
不加载 `name`、`roles` 等字段，每次 DB round-trip 只返回 2 列。

**Phase 2**（按需加载完整对象）

```python
related_groups = list(Group.objects.filter(id__in=all_group_ids).prefetch_related("roles"))
```

只加载祖先链上的节点，集合大小 = O(depth × fan-out)，与 N 无关。

两次 DB round-trip（轻量 BFS + 最终对象加载）替代原来的 1 次全表扫描。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GET /console_mgmt/get_user_info/\nviews.py:284"]
    end

    subgraph N["核心处理层"]
        F1["get_user_info()\nviews.py:284"]
        F2["get_user_group_paths(user.group_list)\nviews.py:300"]
    end

    subgraph Q["两阶段按需查询（修复后）"]
        Q1["Phase 1: filter(id__in=current_ids)\n.values_list('id','parent_id')\n轻量 BFS 收集祖先 ID"]
        Q2["Phase 2: filter(id__in=all_group_ids)\n.prefetch_related('roles')\n按需加载对象"]
    end

    subgraph OLD["原始全表扫描（已移除）"]
        OLD1["Group.objects.all().prefetch_related('roles')\nO(N) 全表 × avg_roles 行"]
    end

    T1 --> F1 --> F2
    F2 --> Q1 --> Q2
    F2 -. "旧实现" .-> OLD1
```

## blast radius · 一致性

- 改动范围：`server/apps/console_mgmt/views.py`，单文件单函数
- `GroupUtils.build_group_paths` 接口不变，仅改数据来源
- 行为等价：传入的 `related_groups` 仍包含祖先链所有节点，路径拼接结果不变
- 无 DB 迁移，无 RPC/NATS 协议变更，无跨 app 影响

## 验证

新增单测 `test_get_user_group_paths_views.py`（Django-free 独立 harness）：
- `test_不调用全表查询`：断言 `Group.objects.all()` 不被调用
- `test_空列表直接返回空`：空输入快路径，零 DB 查询
- `test_phase1用filter按id集合查询`：验证 Phase 1 使用 `filter(id__in=...)`
- `test_phase2只查路径上的ID`：断言 Phase 2 集合只含祖先 ID，不含系统无关组

**Revert-fail 准则**：将修复 revert 回 `Group.objects.all()`，`test_不调用全表查询` 和 `test_revert修复后all被调用` 均立即失败。

关联 Issue: #3474