### PR TITLE
fix(opspilot): 移除 DOMPurify 白名单中的 <style> 标签，防止 CSS 注入

### DIFF
--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -108,12 +108,16 @@ const md = new MarkdownIt({
   },
 });
 
-// Sanitize HTML to prevent XSS
+// Sanitize HTML to prevent XSS and CSS injection.
+// SECURITY: 'style' tag (block CSS) is intentionally excluded — allowing it enables CSS injection
+// via LLM prompt injection (e.g. `<style>*{background:url(//attacker.com)}</style>`).
+// Inline 'style' attribute is kept in ALLOWED_ATTR as it is used by guide/reference link renderers.
+// ALLOW_DATA_ATTR is false; all required data-* attributes are listed explicitly in ALLOWED_ATTR.
 const sanitizeHtml = (html: string): string => {
   return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'span', 'div', 'a', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img', 'svg', 'use', 'button', 'style'],
+    ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'code', 'pre', 'span', 'div', 'a', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img', 'svg', 'use', 'button'],
     ALLOWED_ATTR: ['class', 'style', 'href', 'target', 'rel', 'data-ref-number', 'data-chunk-id', 'data-knowledge-id', 'data-chunk-type', 'data-content', 'data-suggestion', 'data-expanded', 'data-tool-id', 'src', 'alt', 'width', 'height', 'aria-hidden'],
-    ALLOW_DATA_ATTR: true,
+    ALLOW_DATA_ATTR: false,
   });
 };
 


### PR DESCRIPTION
## 被破坏的不变量

`sanitizeHtml` 的设计契约是：LLM 输出经过过滤后，进入 `dangerouslySetInnerHTML` 的内容**不得执行任何主动资源请求或改变页面视觉结构**。允许 `<style>` 块级标签打破了这条契约——CSS 规则可触发浏览器外联（`url()`、`@import`），与 HTML 注入防护的目标相悖。

## 根因（设计层）

`ALLOWED_TAGS` 包含 `'style'` 使 DOMPurify 在过滤 XSS 的同时，放行了块级 CSS 注入。DOMPurify 官方文档明确指出允许 `<style>` 会绕过基于 HTML 的 XSS 防护，但开放 CSS 注入面。在 AI 助手场景下，攻击者可通过 prompt injection 让 LLM 输出 `<style>*{background:url(//attacker.com)}</style>`，经 `sanitizeHtml` 后原样进入 DOM，浏览器发起外联请求，可用于 CSS selector timing attack 或视觉劫持。

`ALLOW_DATA_ATTR: true` 同样多余——所有业务需要的 `data-*` 属性已在 `ALLOWED_ATTR` 中显式列出，全量开放反而扩大了攻击面。

## 修复如何恢复不变量

| 改动 | 说明 |
|------|------|
| 从 `ALLOWED_TAGS` 移除 `'style'` | Markdown 渲染（highlight.js + markdown-it）不产生 `<style>` 块，移除不影响正常功能 |
| 保留 `ALLOWED_ATTR` 中的 `'style'` | 行内 style 属性由 guide/reference link 渲染器（lines 308, 350）注入，为内部生成内容，不受 LLM 控制 |
| `ALLOW_DATA_ATTR: false` | 所有 data-* 属性已在 `ALLOWED_ATTR` 显式列出，关闭全量开放 |

## blast radius · 一致性

- 影响范围：仅 `web/src/app/opspilot/components/custom-chat-sse/index.tsx`，单文件
- 对比：`custom-chat/index.tsx` 和 `components/markdown/index.tsx` 的 `sanitizeHtml` 均未包含 `'style'`，本次修复与两者保持一致
- 向后兼容：Markdown 渲染不依赖 `<style>` 标签，行内 style 属性保留，功能无变化

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（LLM SSE 输出）"]
        T1["md.render(content)\nMarkdown → HTML"]
    end

    subgraph S["sanitizeHtml（修复点）"]
        S1["DOMPurify.sanitize\ncustom-chat-sse/index.tsx:116"]
        S2["ALLOWED_TAGS 不含 style\n块级 CSS 被剥离"]
    end

    subgraph R["渲染层"]
        R1["dangerouslySetInnerHTML\n:578 / :664"]
    end

    T1 --> S1 --> S2 --> R1

    style S2 fill:#d4edda,stroke:#28a745
```

## 验证

- revert-fail 准则：若将 `'style'` 加回 `ALLOWED_TAGS`，含 `<style>*{background:url(...)}</style>` 的输入将通过 `sanitizeHtml` 原样进入 DOM
- 本地验证：在 `sanitizeHtml` 调用处传入 `<style>body{background:red}</style>`，修复后输出应为空字符串
- 对比验证：`custom-chat/index.tsx` 和 `components/markdown/index.tsx` 中已无 `style` in ALLOWED_TAGS，与本次修复行为一致

---

关联 Issue #3506

@周壮杰 安全修复，请 review。