### PR TITLE
bugfix: 移除服务端 authOptions 中含敏感信息的 console.log（#3505）

### DIFF
--- a/web/src/constants/authOptions.ts
+++ b/web/src/constants/authOptions.ts
@@ -85,7 +85,6 @@ async function getWeChatConfig() {
       console.error("Failed to get WeChat settings:", responseData);
       return null;
     }
-    console.log("WeChat settings fetched successfully:", responseData.data);
     return responseData.data;
   } catch (error) {
     console.error("Error fetching WeChat settings:", error);
@@ -117,8 +116,7 @@ export async function getAuthOptions(): Promise<AuthOptions> {
           // This is used when the login validation has already been done in SigninClient
           if (credentials.skipValidation === 'true' && credentials.userData) {
             const userData = JSON.parse(credentials.userData);
-            console.log("Parsed userData:", userData);
-            
+
             // Ensure required fields are present
             if (!userData.id && !userData.username) {
               console.error("Invalid userData: missing id and username");
@@ -160,7 +158,6 @@ export async function getAuthOptions(): Promise<AuthOptions> {
     }),
   ];
   
-  console.log("Credentials wechatConfig", wechatConfig);
   if (wechatConfig && wechatConfig.app_id) {
     providers.push(
       WeChatProvider({
@@ -169,9 +166,6 @@ export async function getAuthOptions(): Promise<AuthOptions> {
         redirectUri: `${wechatConfig.redirect_uri}/api/auth/callback/wechat`,
       }) as unknown as any
     );
-    console.log("WeChat provider added successfully");
-  } else {
-    console.log("WeChat configuration is incomplete or unavailable. Skipping WeChat provider.");
   }
 
   return {


### PR DESCRIPTION
## 被破坏的不变量

服务端（Node.js 进程）不应将认证凭据（auth token、第三方配置）写入 stdout。Next.js API route 的 stdout 会直接流向容器日志，进而被日志采集平台索引——这条"敏感数据不出进程"的边界被调试代码打破。

## 根因（设计层）

`authOptions.ts` 的 `authorize()` 函数在 `skipValidation` 路径下，将完整的 `userData`（含 `token` 字段）通过 `console.log` 输出到 Node.js stdout：

```ts
// 修复前 — line 120（已删除）
const userData = JSON.parse(credentials.userData);
console.log("Parsed userData:", userData);  // ← userData.token 明文写入容器日志
```

同文件 `getWeChatConfig()` 和 `getAuthOptions()` 也存在将微信配置（含 `app_id`）打印到 stdout 的调试代码。这些均为"调试代码未在上线前移除"的典型债务（tech-debt）。

## 修复如何恢复不变量

删除 3 处含敏感数据的 `console.log`（服务端 stdout 路径）：

| 原位置 | 内容 | 处理 |
|--------|------|------|
| `authorize()` line 120 | `"Parsed userData:", userData`（含 token） | 删除 |
| `getWeChatConfig()` line 88 | `"WeChat settings fetched successfully:", responseData.data`（含 app_id） | 删除 |
| `getAuthOptions()` line 163 | `"Credentials wechatConfig", wechatConfig`（含 app_id） | 删除 |
| line 172/174 | WeChat provider 控制流状态 | 删除（多余调试噪音） |

保留所有 `console.error()` 调用（错误场景，不含敏感字段，用于问题诊断）。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["completeAuthentication\nSigninClient.tsx"]
    end

    subgraph N["认证处理层"]
        N1["authorize(credentials)\nauthOptions.ts"]
        N2["JSON.parse(credentials.userData)\nauthOptions.ts:119"]
        N3["buildAuthUser(userData)\nauthOptions.ts:128"]
    end

    subgraph FIXED["已修复（删除）"]
        DEL["console.log('Parsed userData:', userData)\n含 token 字段 → Node.js stdout"]
    end

    subgraph OUT["输出层"]
        OUT1["return buildAuthUser 结果\n仅内存中，不落日志"]
    end

    T1 --> N1 --> N2 --> N3
    N2 -. "修复前写入stdout" .-> DEL
    N3 --> OUT1
```

## blast radius · 一致性

- **影响范围**：仅 `web/src/constants/authOptions.ts`，1 文件，纯删代码
- **接口变更**：无——`authorize()` 返回值、函数签名、NextAuth 集成均不变
- **向后兼容**：完全兼容，零迁移成本
- **调用方**：`web/src/app/api/auth/[...nextauth]/route.ts` 引用 `getAuthOptions()`，行为不受影响

## 验证

- 修复后 `grep -n "console.log" web/src/constants/authOptions.ts` 无输出 ✓
- 登录流程：`authorize()` 仍正确解析 `userData` 并返回 `buildAuthUser` 结果，仅删除了调试日志
- revert 准则：若将删除的 `console.log` 还原，代码 review 可立即发现 token 泄漏路径重现

关联 Issue: #3505