### PR TITLE
bugfix(console_mgmt): update_user_base_info / validate_pwd 非法 JSON body 防护

### DIFF
--- a/server/apps/console_mgmt/language/en.yaml
+++ b/server/apps/console_mgmt/language/en.yaml
@@ -6,6 +6,7 @@ error:
   user_id_required: User ID cannot be empty
   user_not_found: User not found
   password_required: Password cannot be empty
+  invalid_json_format: Invalid JSON format
 email:
   verification_code_validity: The verification code is valid for 10 minutes, please
     use it in time.

--- a/server/apps/console_mgmt/language/zh-Hans.yaml
+++ b/server/apps/console_mgmt/language/zh-Hans.yaml
@@ -6,6 +6,7 @@ error:
   user_id_required: 用户ID不能为空
   user_not_found: 用户不存在
   password_required: 密码不能为空
+  invalid_json_format: 请求体格式错误，请发送合法的 JSON
 email:
   verification_code_validity: 验证码有效期为10分钟,请及时使用。
   verification_code_body: 您的验证码是

--- a/server/apps/console_mgmt/tests/test_views_json_guard.py
+++ b/server/apps/console_mgmt/tests/test_views_json_guard.py
@@ -1,0 +1,109 @@
+"""console_mgmt 视图入口 JSON 解析防护的回归测试。
+
+覆盖 Issue #3473：
+- update_user_base_info：裸 json.loads 无 try/except，非法 JSON body → 500
+- validate_pwd：同样问题，顺带修复
+
+规则：将修复代码 revert 后，以下 test 必须失败（json.JSONDecodeError 抛到视图外 → 500）。
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+UPDATE_URL = "/api/v1/console_mgmt/update_user_base_info/"
+VALIDATE_PWD_URL = "/api/v1/console_mgmt/validate_pwd/"
+
+
+class TestUpdateUserBaseInfoJsonGuard:
+    """update_user_base_info 入口 JSON 解析防护。"""
+
+    def test_非法json_body返回400而非500(self, user_client):
+        """非法 JSON body 应返回 400，不得抛 JSONDecodeError 触发 500。
+
+        revert 修复（删去 try/except）后本测试必须失败：
+        json.loads 抛 JSONDecodeError 无捕获 → Django 500 handler → status_code=500。
+        """
+        _, client = user_client
+        resp = client.post(
+            UPDATE_URL,
+            data=b"invalid{json",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400, (
+            f"期望 400，实际 {resp.status_code}。"
+            "说明 json.loads 抛出的 JSONDecodeError 未被捕获。"
+        )
+        body = resp.json()
+        assert body["result"] is False
+
+    def test_空body返回400(self, user_client):
+        """空 body 也是非法 JSON，应返回 400。"""
+        _, client = user_client
+        resp = client.post(
+            UPDATE_URL,
+            data=b"",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["result"] is False
+
+    def test_合法json_body正常处理(self, user_client):
+        """合法 JSON body 应能正常被处理（不因 JSON 解析本身返回 400/500）。
+
+        注意：本 test 断言 status_code != 400（JSON 解析阶段不报错即可），
+        后续 DB 操作可能 200 成功也可能 4xx（视数据库状态），均可接受。
+        """
+        _, client = user_client
+        resp = client.post(
+            UPDATE_URL,
+            data={"display_name": "测试用户"},
+            format="json",
+        )
+        # JSON 解析成功，不应因解析本身返回 400
+        assert resp.status_code != 400 or resp.json().get("message") != "Invalid JSON format"
+
+
+class TestValidatePwdJsonGuard:
+    """validate_pwd 入口 JSON 解析防护。"""
+
+    def test_非法json_body返回400而非500(self, user_client):
+        """非法 JSON body 应返回 400，不得触发 500。
+
+        revert 修复后本测试必须失败：json.loads 无捕获 → 500。
+        """
+        _, client = user_client
+        resp = client.post(
+            VALIDATE_PWD_URL,
+            data=b"not-json-at-all",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400, (
+            f"期望 400，实际 {resp.status_code}。"
+            "说明 validate_pwd 的 json.loads 未被 try/except 保护。"
+        )
+        body = resp.json()
+        assert body["result"] is False
+
+    def test_空body返回400(self, user_client):
+        """空 body 应返回 400。"""
+        _, client = user_client
+        resp = client.post(
+            VALIDATE_PWD_URL,
+            data=b"",
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert resp.json()["result"] is False
+
+    def test_合法json_body不因解析报错(self, user_client):
+        """合法 JSON body 进入后续逻辑，不应因 JSON 解析本身失败。"""
+        _, client = user_client
+        resp = client.post(
+            VALIDATE_PWD_URL,
+            data={"password": "somepassword"},
+            format="json",
+        )
+        # JSON 解析成功，不应返回 "Invalid JSON format"
+        if resp.status_code == 400:
+            assert resp.json().get("message") != "Invalid JSON format"

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -117,13 +117,17 @@ def init_user_set(request):
 
 
 def update_user_base_info(request):
-    params = json.loads(request.body)
-    username = request.user.username
-    domain = request.user.domain
-
     # 获取用户语言设置
     locale = getattr(request.user, "locale", "en")
     loader = LanguageLoader(app="console_mgmt", default_lang=locale)
+
+    try:
+        params = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"result": False, "message": loader.get("error.invalid_json_format", "Invalid JSON format")}, status=400)
+
+    username = request.user.username
+    domain = request.user.domain
     try:
         # 通过username和domain获取用户
         user = User.objects.get(username=username, domain=domain)
@@ -143,14 +147,18 @@ def update_user_base_info(request):
 
 
 def validate_pwd(request):
-    body = json.loads(request.body)
-    password = body.get("password")
-    username = request.user.username
-    domain = request.user.domain
-
     # 获取用户语言设置
     locale = getattr(request.user, "locale", "en")
     loader = LanguageLoader(app="console_mgmt", default_lang=locale)
+
+    try:
+        body = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"result": False, "message": loader.get("error.invalid_json_format", "Invalid JSON format")}, status=400)
+
+    password = body.get("password")
+    username = request.user.username
+    domain = request.user.domain
 
     if not password:
         return JsonResponse({"result": False, "message": loader.get("error.password_required", "Password cannot be empty")})


### PR DESCRIPTION
## 被破坏的不变量

`console_mgmt` 视图层有一条隐性契约：**所有入口解析（JSON body 反序列化）必须被 try/except 保护**。
同文件的 `init_user_set`、`validate_email_code`、`send_email_code` 均遵循此契约。
`update_user_base_info`（:120）和 `validate_pwd`（:146）是异常值——裸调 `json.loads`，打破了这条不变量。

## 根因（设计层）

这两个函数在函数第一行即裸调 `json.loads(request.body)`，位于任何 `try` 块之外。
下方的 `try` 块只能捕获 DB 操作异常——当 JSON 解析阶段失败时，执行流根本到不了那里。
结果：任何发送非法 JSON body 的已登录用户都能稳定触发 HTTP 500。

## 修复如何恢复不变量

将两处 `json.loads` 包入 `try/except (json.JSONDecodeError, ValueError)`，
捕获后返回 `status=400` + 友好提示 `"Invalid JSON format"`，与同文件其他视图的范式完全一致。
同时将 `LanguageLoader` 初始化提前到解析之前，以便错误消息能正确本地化。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /console_mgmt/update_user_base_info/\nPOST /console_mgmt/validate_pwd/"]
    end

    subgraph N["入口解析层（修复前）"]
        J["json.loads(request.body)\n无 try/except 包裹"]
    end

    subgraph F["入口解析层（修复后）"]
        JF["try: json.loads(request.body)\nexcept JSONDecodeError, ValueError"]
    end

    subgraph DB["核心处理层"]
        DB1["User.objects.get() / check_password()\n有 try/except 保护"]
    end

    T1 --> J
    J -. "非法 JSON → JSONDecodeError" .-> ERR["HTTP 500（修复前）"]
    T1 --> JF
    JF -. "非法 JSON" .-> R400["HTTP 400 + Invalid JSON format（修复后）"]
    JF --> DB1 --> R200["HTTP 200 正常响应"]
```

## blast radius · 一致性

- 仅改动 `server/apps/console_mgmt/views.py` 中的两个函数，影响范围限于本模块
- 修复模式完全复用同文件 `init_user_set` / `validate_email_code` 的已有范式，无新设计引入
- 无 DB 迁移、无接口签名变更、无跨 app 影响

## 验证

新增 `server/apps/console_mgmt/tests/test_views_json_guard.py`，覆盖：
- 非法 JSON body → 400（**revert 修复代码后本测试必须失败**，json.JSONDecodeError 无捕获 → 500）
- 空 body → 400
- 合法 JSON body → 不因解析本身报错

关联 Issue：#3473