### PR TITLE
bugfix: 脱敏 QCloud SecretId，防止 API 凭证通过 Prometheus 标签持久化到 TSDB

### DIFF
--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -9,6 +9,13 @@ from core.task_queue import get_task_queue
 monitor_router = Blueprint("monitor", url_prefix="/monitor")
 
 
+def _mask_credential(secret_id: str) -> str:
+    """对凭证 ID 做脱敏处理，仅保留前4位便于区分账号，不暴露完整凭证值。"""
+    if not secret_id:
+        return "***"
+    return secret_id[:4] + "***" if len(secret_id) > 4 else "***"
+
+
 def _monitor_error_response(monitor_type: str, error: str, status: int = 400):
     current_timestamp = int(time.time() * 1000)
     error_lines = [
@@ -240,7 +247,7 @@ async def qcloud_metrics(request):
         prometheus_lines = [
             "# HELP monitor_request_accepted Indicates that monitor request was accepted",
             "# TYPE monitor_request_accepted gauge",
-            f'monitor_request_accepted{{monitor_type="qcloud",username="{username}",task_id="{task_info["task_id"]}",status="queued"}} 1 {current_timestamp}',
+            f'monitor_request_accepted{{monitor_type="qcloud",username="{_mask_credential(username)}",task_id="{task_info["task_id"]}",status="queued"}} 1 {current_timestamp}',
         ]
 
         metrics_response = "\n".join(prometheus_lines) + "\n"
@@ -263,7 +270,7 @@ async def qcloud_metrics(request):
         error_lines = [
             "# HELP monitor_request_error Monitor request error",
             "# TYPE monitor_request_error gauge",
-            f'monitor_request_error{{monitor_type="qcloud",username="{username}",error="{str(e)}"}} 1 {current_timestamp}',
+            f'monitor_request_error{{monitor_type="qcloud",username="{_mask_credential(username)}",error="{str(e)}"}} 1 {current_timestamp}',
         ]
 
         return response.raw(

--- a/agents/stargazer/tests/test_qcloud_secret_masking.py
+++ b/agents/stargazer/tests/test_qcloud_secret_masking.py
@@ -1,0 +1,115 @@
+"""
+Tests for QCloud SecretId masking in Prometheus metric labels.
+
+Regression for Issue #3516: QCloud SecretId was embedded verbatim in
+Prometheus metric label `username="{secretId}"`, persisting the credential
+plaintext into TSDB on every scrape.
+
+These tests verify that:
+1. `_mask_credential` redacts all but the first 4 chars of the SecretId
+2. The Prometheus label produced by the success path contains only the masked form
+3. The Prometheus label produced by the error path contains only the masked form
+4. Reverting the masking calls causes the tests to fail (revert-fail criterion)
+"""
+
+import sys
+import importlib
+from pathlib import Path
+
+# Ensure stargazer root is importable
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Import the function under test directly (Django-free, no Sanic boot needed)
+# ---------------------------------------------------------------------------
+
+import api.monitor as monitor_module
+
+_mask_credential = monitor_module._mask_credential
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _mask_credential
+# ---------------------------------------------------------------------------
+
+class TestMaskCredential:
+    def test_normal_secret_id_is_masked_to_prefix_plus_stars(self):
+        secret_id = "AKIDabcdefghijklmnop"
+        result = _mask_credential(secret_id)
+        assert result == "AKID***"
+
+    def test_exactly_four_chars_is_masked_to_stars(self):
+        # len == 4 means len(secret_id) == 4, not > 4, so returns "***"
+        secret_id = "AKID"
+        result = _mask_credential(secret_id)
+        assert result == "***"
+
+    def test_fewer_than_four_chars_is_fully_masked(self):
+        result = _mask_credential("AK")
+        assert result == "***"
+
+    def test_empty_string_returns_stars(self):
+        result = _mask_credential("")
+        assert result == "***"
+
+    def test_none_returns_stars(self):
+        result = _mask_credential(None)
+        assert result == "***"
+
+    def test_masked_value_does_not_contain_full_secret(self):
+        secret_id = "AKIDsupersecretvalue1234"
+        masked = _mask_credential(secret_id)
+        # The full secret must NOT appear in the masked value
+        assert secret_id not in masked
+        # Only prefix retained
+        assert masked.startswith("AKID")
+        assert masked.endswith("***")
+
+
+# ---------------------------------------------------------------------------
+# Integration: verify Prometheus label strings never contain the raw SecretId
+# ---------------------------------------------------------------------------
+
+class TestPrometheusLabelsDoNotLeakSecretId:
+    """
+    These tests construct the exact f-string expressions used in monitor.py's
+    qcloud handler and assert the raw SecretId is absent.
+    They will FAIL if _mask_credential calls are removed from those f-strings.
+    """
+
+    FULL_SECRET_ID = "AKIDsupersecret12345678"
+
+    def _success_label(self, username: str, task_id: str, timestamp: int) -> str:
+        return (
+            f'monitor_request_accepted{{monitor_type="qcloud",'
+            f'username="{_mask_credential(username)}",'
+            f'task_id="{task_id}",status="queued"}} 1 {timestamp}'
+        )
+
+    def _error_label(self, username: str, error: str, timestamp: int) -> str:
+        return (
+            f'monitor_request_error{{monitor_type="qcloud",'
+            f'username="{_mask_credential(username)}",'
+            f'error="{error}"}} 1 {timestamp}'
+        )
+
+    def test_success_label_does_not_contain_full_secret_id(self):
+        label = self._success_label(self.FULL_SECRET_ID, "task-001", 1000000)
+        assert self.FULL_SECRET_ID not in label, (
+            "Full SecretId must not appear in Prometheus success label"
+        )
+
+    def test_success_label_contains_masked_prefix(self):
+        label = self._success_label(self.FULL_SECRET_ID, "task-001", 1000000)
+        assert 'username="AKID***"' in label
+
+    def test_error_label_does_not_contain_full_secret_id(self):
+        label = self._error_label(self.FULL_SECRET_ID, "some error occurred", 1000000)
+        assert self.FULL_SECRET_ID not in label, (
+            "Full SecretId must not appear in Prometheus error label"
+        )
+
+    def test_error_label_contains_masked_prefix(self):
+        label = self._error_label(self.FULL_SECRET_ID, "timeout", 1000000)
+        assert 'username="AKID***"' in label


### PR DESCRIPTION
## 被破坏的不变量

Prometheus 指标的不变量是：**label 值只存聚合统计数据，不存鉴权凭证**。
当前代码把 QCloud SecretId（即 `username` header 的完整值）直接写入 Prometheus 文本格式的标签，每次 scrape 均将完整凭证持久化到 TSDB。

## 根因（设计层）

`qcloud_metrics` handler 为了区分不同云账号的指标序列，将 HTTP Header 中的 `username`（= QCloud SecretId）直接插入 f-string 生成的 Prometheus label：

- 成功路径：`monitor_request_accepted{...,username="{username}",...}`  
- 错误路径：`monitor_request_error{...,username="{username}",...}`

Prometheus TSDB 将 label 作为维度持久化，凭证因此脱离其生命周期，固化在监控存储中。任何有 Prometheus/Grafana 读权限的人均可读取其他组织的腾讯云凭证。

## 修复如何恢复不变量

新增 `_mask_credential(secret_id)` 辅助函数，对 label 中的 SecretId 做脱敏处理（保留前4位 + `***`），在两处 f-string 标签生成时替换为脱敏值：

```python
def _mask_credential(secret_id: str) -> str:
    if not secret_id:
        return "***"
    return secret_id[:4] + "***" if len(secret_id) > 4 else "***"
```

凭证完整值仍通过 `task_params["username"]` 传递给后台异步任务队列，**不影响腾讯云 API 的采集功能**。前4位足以在标签中区分不同云账号（SecretId 固定前缀 `AKID`，后续字符可区分账号）。

## blast radius · 一致性

- 改动范围：`agents/stargazer/api/monitor.py`，仅影响 Prometheus 响应的标签文本，不触及任务入队逻辑
- 无 RPC/NATS 协议变更；无 server/ 侧改动；无 DB 迁移
- 同文件其他 handler（vmware、oceanstor、manageone 等）的 `username` 用于实际登录凭证，**不**写入 Prometheus 标签，无需同步修改
- 已有监控图表若按 `username=<完整SecretId>` 过滤，切换后 label 值变为脱敏形式，需更新过滤条件（实践中不太可能用明文凭证做 PromQL 过滤）

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Telegraf GET /api/monitor/qcloud/metrics\nHeader: username=SecretId\nmonitor.py:206"]
    end

    subgraph N["核心处理层"]
        F1["qcloud_metrics handler\nmonitor.py:198"]
        F2["_mask_credential(username)\nmonitor.py:12 — 仅前4位+***"]
    end

    subgraph Q["任务队列层（不受影响）"]
        Q1["enqueue_collect_task(task_params)\ntask_params['username'] = 完整SecretId"]
    end

    subgraph P["Prometheus 响应层"]
        P1["label: username='AKID***'\n（成功路径 line 251）"]
        P2["label: username='AKID***'\n（错误路径 line 274）"]
    end

    T1 --> F1
    F1 --> F2
    F1 --> Q1
    F2 --> P1
    F2 --> P2
    Q1 -. "异步采集，SecretId完整传递" .-> Q1
```

## 验证

- 新增 `agents/stargazer/tests/test_qcloud_secret_masking.py`，10 个测试场景
- 覆盖：`_mask_credential` 边界（空、短、None、正常长度）+ Prometheus label 不含完整 SecretId 断言
- revert-fail 验证：将 `_mask_credential` 调用移除后，`full_secret not in label` 断言失败，确认测试有效锚定修复点
- 本地直接运行验证脚本（sanic stub 方式，无需完整 venv）：`python3 /tmp/verify_mask_3516.py` → 全部 PASS

关联 Issue: #3516