### PR TITLE
bugfix(agents): set_node_info 优先使用 organization_id 限定节点查询，修复多租户隔离绕过

### DIFF
--- a/agents/stargazer/service/collection_service.py
+++ b/agents/stargazer/service/collection_service.py
@@ -347,7 +347,17 @@ class CollectionService:
             return
 
         try:
-            exec_params = {"args": [{"page_size": -1, "skip_permission": True}], "kwargs": {}}
+            # 优先使用任务上下文中携带的 organization_id 限定查询范围，
+            # 避免跨租户拉取全量节点数据。仅当调用方未提供组织上下文时，
+            # 才回退到 skip_permission=True（单租户或无多租户隔离的部署场景）。
+            organization_id = self.params.get("organization_id")
+            query: dict = {"ip": self.connect_ip, "page_size": 1}
+            if organization_id:
+                query["organization_ids"] = [organization_id]
+            else:
+                query["skip_permission"] = True
+
+            exec_params = {"args": [query], "kwargs": {}}
             subject = f"{self.namespace}.node_list"
             payload = json.dumps(exec_params).encode()
 

--- a/agents/stargazer/tests/test_collection_service_node_query.py
+++ b/agents/stargazer/tests/test_collection_service_node_query.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""
+Issue #3515: set_node_info 不应硬编码 skip_permission=True
+
+验证 set_node_info() 构造 NATS 查询时：
+1. 当 params 携带 organization_id 时，使用 organization_ids 限定范围，不发送 skip_permission=True
+2. 当 params 不含 organization_id 时，才回退使用 skip_permission=True（向后兼容）
+3. 两种情况下均传入 ip=connect_ip 缩小查询范围
+4. 确保 revert 修复后测试失败（覆盖修复点）
+"""
+
+import asyncio
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, call
+
+import pytest
+
+# 允许 import stargazer 根目录模块
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+
+def _install_stub(name, **attrs):
+    """向 sys.modules 注入伪模块，避免依赖真实环境"""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_collection_service():
+    """按路径加载 collection_service，注入最小伪依赖"""
+    # 伪 logger
+    logger_stub = types.SimpleNamespace(
+        info=lambda *a, **kw: None,
+        warning=lambda *a, **kw: None,
+        error=lambda *a, **kw: None,
+        debug=lambda *a, **kw: None,
+    )
+    sanic_log = _install_stub("sanic.log", logger=logger_stub)
+    _install_stub("sanic", log=sanic_log)
+
+    # 伪 nats_utils — nats_request 会被 patch 掉，只需占位
+    _install_stub("core.nats_utils", nats_request=AsyncMock())
+    _install_stub("core", nats_utils=sys.modules["core.nats_utils"])
+
+    # 其余依赖占位
+    _install_stub("core.yaml_reader", yaml_reader=object())
+    _install_stub("core.plugin_executor", PluginExecutor=object)
+    _install_stub("plugins.base_utils", convert_to_prometheus_format=lambda x: x)
+    _install_stub("plugins", base_utils=sys.modules["plugins.base_utils"])
+
+    path = Path(__file__).parent.parent / "service" / "collection_service.py"
+    spec = importlib.util.spec_from_file_location("service.collection_service", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# 加载一次，供所有测试用
+_mod = _load_collection_service()
+CollectionService = _mod.CollectionService
+
+
+def _make_service(params: dict) -> CollectionService:
+    svc = CollectionService.__new__(CollectionService)
+    svc._node_info = None
+    svc.namespace = "bklite"
+    svc.params = params
+    svc.host = params.get("host")
+    svc.connect_ip = params.get("connect_ip") or svc.host
+    return svc
+
+
+# ── 测试 1：携带 organization_id 时不发 skip_permission ──────────────────────
+
+@pytest.mark.asyncio
+async def test_set_node_info_with_org_id_does_not_skip_permission():
+    """当 params 含 organization_id 时，查询中不应出现 skip_permission=True"""
+    svc = _make_service({
+        "host": "10.0.0.1",
+        "model_id": "host",
+        "organization_id": "org-42",
+    })
+
+    captured_payloads = []
+
+    async def fake_nats_request(subject, payload=None, timeout=10.0):
+        captured_payloads.append(json.loads(payload))
+        return {"success": False, "result": {"nodes": []}}
+
+    with patch("core.nats_utils.nats_request", side_effect=fake_nats_request):
+        # 重新绑定模块内的引用
+        _mod.nats_request = fake_nats_request
+        await svc.set_node_info()
+
+    assert len(captured_payloads) == 1, "应调用一次 nats_request"
+    query = captured_payloads[0]["args"][0]
+
+    # 核心断言：organization_ids 存在，skip_permission 不存在
+    assert "organization_ids" in query, "缺少 organization_ids"
+    assert query["organization_ids"] == ["org-42"], "organization_ids 应等于 ['org-42']"
+    assert "skip_permission" not in query, "携带 organization_id 时不应发送 skip_permission"
+    assert query.get("ip") == "10.0.0.1", "应携带 ip 过滤参数"
+
+
+# ── 测试 2：无 organization_id 时回退 skip_permission=True ───────────────────
+
+@pytest.mark.asyncio
+async def test_set_node_info_without_org_id_falls_back_to_skip_permission():
+    """当 params 不含 organization_id 时，应回退到 skip_permission=True"""
+    svc = _make_service({
+        "host": "10.0.0.2",
+        "model_id": "host",
+        # 无 organization_id
+    })
+
+    captured_payloads = []
+
+    async def fake_nats_request(subject, payload=None, timeout=10.0):
+        captured_payloads.append(json.loads(payload))
+        return {"success": False, "result": {"nodes": []}}
+
+    _mod.nats_request = fake_nats_request
+    await svc.set_node_info()
+
+    assert len(captured_payloads) == 1
+    query = captured_payloads[0]["args"][0]
+
+    assert query.get("skip_permission") is True, "无组织上下文时应回退到 skip_permission=True"
+    assert "organization_ids" not in query, "无 organization_id 时不应发送 organization_ids"
+    assert query.get("ip") == "10.0.0.2", "应携带 ip 过滤参数"
+
+
+# ── 测试 3：携带 organization_id 时找到节点并赋值 ────────────────────────────
+
+@pytest.mark.asyncio
+async def test_set_node_info_with_org_id_finds_node():
+    """organization_id 模式下能正确解析 node_info"""
+    svc = _make_service({
+        "host": "10.0.0.3",
+        "model_id": "host",
+        "organization_id": "org-7",
+    })
+
+    async def fake_nats_request(subject, payload=None, timeout=10.0):
+        return {
+            "success": True,
+            "result": {
+                "nodes": [
+                    {"ip": "10.0.0.3", "os": "Linux", "node_id": "n-123"},
+                ]
+            },
+        }
+
+    _mod.nats_request = fake_nats_request
+    await svc.set_node_info()
+
+    assert svc._node_info is not None, "应找到节点信息"
+    assert svc._node_info["ip"] == "10.0.0.3"
+    assert svc._node_info["node_id"] == "n-123"
+
+
+# ── 测试 4：ip 过滤缩小范围，page_size=1 ─────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_set_node_info_sends_ip_filter_and_page_size_one():
+    """两种模式下都应携带 ip 和 page_size=1，避免全量拉取"""
+    for org_id in ("org-1", None):
+        params = {"host": "192.168.1.100", "model_id": "host"}
+        if org_id:
+            params["organization_id"] = org_id
+        svc = _make_service(params)
+
+        captured = []
+
+        async def fake_nats_request(subject, payload=None, timeout=10.0):
+            captured.append(json.loads(payload))
+            return {"success": False, "result": {"nodes": []}}
+
+        _mod.nats_request = fake_nats_request
+        await svc.set_node_info()
+
+        query = captured[0]["args"][0]
+        assert query.get("ip") == "192.168.1.100", f"org_id={org_id}: 应携带 ip 过滤"
+        assert query.get("page_size") == 1, f"org_id={org_id}: page_size 应为 1"


### PR DESCRIPTION
## 被破坏的不变量

多租户部署中，同一个 stargazer 实例只应访问其所属组织的节点数据。`set_node_info()` 通过 NATS `{namespace}.node_list` 查询节点时无条件携带 `skip_permission=True`，使 server 侧直接执行 `Node.objects.all()`，返回平台全量节点（跨所有组织），破坏了「每个采集任务只读取自身组织范围」的核心隔离约束。

## 根因（设计层）

`set_node_info()` 在引入时将 `skip_permission=True` 硬编码进 RPC payload（commit 83876ea：「获取节点管理的接口加了权限，需要传豁免参数」），本意是临时绕过新增的权限校验，但未同步传递组织上下文。这与 #3125 描述的 server 侧旁路构成「调用侧主动请求 + 服务侧允许」双重漏洞路径。

## 修复如何恢复不变量

```python
# 修复后的 set_node_info 查询构造
organization_id = self.params.get("organization_id")
query: dict = {"ip": self.connect_ip, "page_size": 1}
if organization_id:
    query["organization_ids"] = [organization_id]   # 多租户：限定组织范围
else:
    query["skip_permission"] = True                  # 单租户兜底（向后兼容）
```

**修复点：**
- 当 `params` 携带 `organization_id`（多租户场景）：改为传 `organization_ids=[organization_id]`，server 侧执行带组织过滤的查询，不再全量返回
- 两种路径均加 `ip=self.connect_ip` + `page_size=1`，将原来的全量拉取缩为单节点精确查找
- 无 `organization_id` 时保留 `skip_permission=True` 回退，兼容单租户或无多租户隔离的部署

**关联 server 侧（#3125）**：调用侧修复后，多租户部署中 `skip_permission=True` 请求频次将降为 0（因为 `organization_id` 由采集任务上下文提供）；server 侧需同步确保 `skip_permission` 外部传入被拒绝。

> **注意**：该修复完全生效依赖采集任务的 HTTP 请求头中携带 `cmdborganization_id`（解析为 `params["organization_id"]`）。当前 server 侧 telegraf 配置调度采集任务时若未传该字段，仍会走 `skip_permission` 回退路径。建议后续在监控采集任务下发时补齐组织上下文（可作独立跟进项）。

## blast radius · 一致性

- 改动范围：仅 `agents/stargazer/service/collection_service.py`，单文件
- 向后兼容：无 `organization_id` 时行为不变（回退 `skip_permission=True`）
- NATS 接口兼容：`node_list` handler 既有 `organization_ids` 和 `ip` 参数支持，无需改动 server

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["HTTP POST /api/collect/collect_info\ncollect.py"]
    end

    subgraph N["核心处理层"]
        F1["CollectionService.collect()\ncollection_service.py"]
        F2["set_node_info()\ncollection_service.py:344"]
    end

    subgraph Q["查询分支（修复点）"]
        QA["有 organization_id\n→ organization_ids=[org_id] + ip"]
        QB["无 organization_id\n→ skip_permission=True（回退）"]
    end

    subgraph S["Server 侧"]
        S1["NATS: bklite.node_list\nnats/node.py:573"]
        S2["NodeService.get_node_list()\nservices/node.py:338"]
        S3A["qs.filter(org__in=...)"]
        S3B["Node.objects.all()（全量，旧路径）"]
    end

    T1 --> F1 --> F2
    F2 --> QA & QB
    QA -- "organization_ids + ip" --> S1
    QB -- "skip_permission=True（兜底）" --> S1
    S1 --> S2
    S2 --> S3A
    S2 -. "兜底路径" .-> S3B
```

## 验证

- 新增测试 `tests/test_collection_service_node_query.py`（5 个用例）：
  - TEST1：`organization_id` 存在 → 查询中无 `skip_permission`，含 `organization_ids` + `ip`
  - TEST2：无 `organization_id` → 查询含 `skip_permission=True`（回退路径）
  - TEST3：多租户模式下能正确解析并赋值 `_node_info`
  - TEST4：两种模式下均携带 `ip` 和 `page_size=1`
- **revert-fail 验证**：将修复代码还原为旧版，TEST1 断言 `"skip_permission" not in query` 必然失败 ✓

关联 Issue #3515