### PR TITLE
bugfix(web): 补全 SkillTool 接口 params 字段，消除 fetchSkillTools 映射链路中的 any

### DIFF
--- a/web/src/app/opspilot/components/skill/toolSelector.tsx
+++ b/web/src/app/opspilot/components/skill/toolSelector.tsx
@@ -908,13 +908,13 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
       const defaultEsTool = defaultTools.find((tool) => isEsTool(tool));
       const defaultJenkinsTool = defaultTools.find((tool) => isJenkinsTool(tool));
       const defaultKubernetesTool = defaultTools.find((tool) => isKubernetesTool(tool));
-      const fetchedTools = data.map((tool: any) => {
+      const fetchedTools = data.map((tool) => {
         const defaultTool = defaultToolMap.get(tool.id);
         const kwargs = (tool.params.kwargs || [])
-          .filter((kwarg: any) => kwarg.key)
-          .map((kwarg: any) => ({
+          .filter((kwarg) => kwarg.key)
+          .map((kwarg) => ({
             ...kwarg,
-            value: (defaultTool?.kwargs ?? []).find((dk: any) => dk.key === kwarg.key)?.value ?? kwarg.value,
+            value: (defaultTool?.kwargs ?? []).find((dk) => dk.key === kwarg.key)?.value ?? kwarg.value,
           }));
         return {
           id: tool.id,
@@ -1021,7 +1021,7 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
       setSelectedKubernetesInstanceId(instances[0]?.id || null);
     } else {
       form.setFieldsValue({
-        kwargs: tool.kwargs?.map((item: any) => ({ key: item.key, value: item.value, type: item.type, isRequired: item.isRequired })) || [],
+        kwargs: tool.kwargs?.map((item) => ({ key: item.key, value: item.value, type: item.type, isRequired: item.isRequired })) || [],
       });
     }
     setEditModalVisible(true);

--- a/web/src/app/opspilot/types/skill.ts
+++ b/web/src/app/opspilot/types/skill.ts
@@ -195,6 +195,22 @@ export interface SkillDetailPayload {
   [key: string]: unknown;
 }
 
+/** skill_tools API 返回的 kwarg 条目 */
+export interface SkillToolKwarg {
+  key: string;
+  value: unknown;
+  description?: string;
+  type?: string;
+  isRequired?: boolean;
+  [k: string]: unknown;
+}
+
+/** skill_tools API 返回的 params 结构 */
+export interface SkillToolParams {
+  kwargs: SkillToolKwarg[];
+  [k: string]: unknown;
+}
+
 export interface SkillTool {
   id: number;
   name: string;
@@ -204,6 +220,7 @@ export interface SkillTool {
   description_tr?: string;
   icon?: string;
   enabled: boolean;
+  params: SkillToolParams;
 }
 
 export interface SkillTemplate {


### PR DESCRIPTION
## 被破坏的不变量

`fetchSkillTools()` 的 TypeScript 返回类型 `Promise<SkillTool[]>` 与运行时实际使用形成契约：凡访问 `tool.params.kwargs` 的地方，编译器应能保证字段存在且有类型约束。但 `SkillTool` 接口缺少 `params` 字段定义，导致这条契约在入口处即告断裂。

## 根因（设计层）

`SkillTool` 接口（`types/skill.ts`）只声明了展示字段（`name`、`display_name`、`icon` 等），遗漏了 API 响应中实际携带的 `params.kwargs` 结构。消费方 `toolSelector.tsx` 为了访问 `tool.params.kwargs`，只能在 `data.map()` 入口写 `(tool: any)`，这一强转使 `any` 沿调用链向下传播（`kwarg: any` → `dk: any` → `item: any`），整条映射链路失去编译期保障。

## 修复如何恢复不变量

新增两个接口收口类型，并将 `params` 字段加回 `SkillTool`：

```typescript
// types/skill.ts（新增）
export interface SkillToolKwarg {
  key: string;
  value: unknown;
  description?: string;
  type?: string;
  isRequired?: boolean;
  [k: string]: unknown;   // 容忍后端扩展字段，不因未知字段崩溃
}

export interface SkillToolParams {
  kwargs: SkillToolKwarg[];
  [k: string]: unknown;
}

// SkillTool 新增字段
params: SkillToolParams;
```

消费侧 `toolSelector.tsx` 移除四处显式 `any` 强转，TypeScript 从 `SkillTool` 推导，编译器自动守护字段访问。

## 调用链

```mermaid
flowchart TD
    subgraph T["API 层"]
        T1["fetchSkillTools()\napi/skill.ts\nPromise<SkillTool[]>"]
    end

    subgraph N["映射层（修复点）"]
        F1["data.map((tool) =>\ntoolSelector.tsx:911\n类型推导自 SkillTool"]
        F2["tool.params.kwargs\n类型: SkillToolKwarg[]"]
        F3["kwarg.key / kwarg.value\n编译期类型检查"]
    end

    subgraph C["状态层"]
        C1["setTools(fetchedTools)\nuseState<SelectTool[]>"]
    end

    T1 --> F1 --> F2 --> F3 --> C1
    F3 -. "修复前: any 级联\n修复后: 编译期保障" .-> F3
```

## blast radius · 一致性

- 改动范围：仅 `opspilot` 模块内（`types/skill.ts` + `toolSelector.tsx`），不触 core/共享 util/公共接口
- `SkillToolKwarg` 与 `ToolVariable`（`types/tool.ts`）字段集合一致，但保留独立接口以区分 API 响应结构（skill_tools）与工具管理领域（tool manager），避免两个 API 差异造成未来耦合
- 零运行时逻辑变更，现有行为完全保留

## 验证

**revert-fail 准则**：将 `params: SkillToolParams` 从 `SkillTool` 移除，`toolSelector.tsx` 的 `tool.params.kwargs` 访问即产生 TS2339 编译错误——证明类型约束真实有效，不是装饰性注解。

本地验证方式：
```bash
cd web
pnpm type-check   # 0 errors
```

关联 Issue: #3514