### PR TITLE
bugfix: 修复微信登录 bridge 错误路径 UI 缺失，错误被静默吞掉导致用户无限等待

### DIFF
--- a/web/src/app/(core)/auth/wechat-popup/bridge/page.tsx
+++ b/web/src/app/(core)/auth/wechat-popup/bridge/page.tsx
@@ -15,6 +15,8 @@ export default function WechatPopupBridgePage() {
 
   useEffect(() => {
     if (!code) {
+      const oauthError = searchParams.get('error');
+      setLoginError(oauthError ? `微信授权失败：${oauthError}` : '未获取到微信授权码，请关闭弹窗后重试');
       return;
     }
 
@@ -87,7 +89,7 @@ export default function WechatPopupBridgePage() {
       console.error('Failed to complete wechat popup login:', error);
       setLoginError((error as Error)?.message || '微信登录失败，请关闭弹窗后重试');
     });
-  }, [callbackUrl, code, thirdLogin]);
+  }, [callbackUrl, code, searchParams, thirdLogin]);
 
   if (loginError) {
     return (

--- a/web/src/app/(core)/auth/wechat-popup/bridge/page.tsx
+++ b/web/src/app/(core)/auth/wechat-popup/bridge/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { AUTH_POPUP_SUCCESS_MESSAGE, buildThirdLoginCallbackUrl, resolveThirdLoginFlag } from '@/utils/authRedirect';
@@ -11,6 +11,7 @@ export default function WechatPopupBridgePage() {
   const callbackUrl = searchParams.get('callbackUrl') || '/';
   const thirdLogin = resolveThirdLoginFlag(searchParams.get('thirdLogin'));
   const code = searchParams.get('code') || '';
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!code) {
@@ -84,8 +85,26 @@ export default function WechatPopupBridgePage() {
 
     void completeWechatPopupLogin().catch((error) => {
       console.error('Failed to complete wechat popup login:', error);
+      setLoginError((error as Error)?.message || '微信登录失败，请关闭弹窗后重试');
     });
   }, [callbackUrl, code, thirdLogin]);
+
+  if (loginError) {
+    return (
+      <div className="flex min-h-screen items-center justify-center px-6 text-center">
+        <div>
+          <div className="text-lg font-semibold text-(--color-text-1)">微信登录失败</div>
+          <div className="mt-2 text-sm text-(--color-text-3)">{loginError}</div>
+          <button
+            className="mt-4 rounded px-4 py-2 text-sm text-(--color-primary) underline"
+            onClick={() => window.close()}
+          >
+            关闭并重试
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center px-6 text-center">


### PR DESCRIPTION
## 被破坏的不变量

微信弹窗登录 bridge 页面的不变量：**任何终态（成功或失败）都必须向用户提供明确反馈**。当前实现仅有成功路径的 UI（postMessage / 跳转），错误路径完全缺失——异常被 `.catch` 消费后 React 渲染树无感知，UI 永久停在加载状态。

## 根因（设计层）

`completeWechatPopupLogin()` 的错误通过 `void completeWechatPopupLogin().catch(e => console.error(e))` 处理，该 catch 消费了 Promise rejection 但没有触发任何 state 更新。组件没有 error state，返回的 JSX 只有一个静态加载视图，React 永远不会重渲染到错误分支。

```
fetch /api/wechat-popup-login → !ok → throw Error
signIn credentials → error → throw Error
                 ↓
          .catch(console.error)   ← 错误在此消失，UI 无感知
```

## 修复如何恢复不变量

增加 `loginError` state（`useState<string | null>(null)`），在 `.catch` 中调用 `setLoginError(msg)` 触发 React 重渲染。渲染层新增错误分支：显示失败原因 + "关闭并重试"按钮（`window.close()`）。成功路径不受影响。

## blast radius · 一致性

- 改动范围：单文件，仅加 state 和 UI 分支，不触碰登录逻辑、fetch 逻辑、postMessage 协议
- 无新增依赖，无 API 变更，无后端改动
- 对父页面（微信弹窗宿主）零影响：成功时 postMessage 契约不变，失败时父页面收不到消息（此前行为不变），仅 bridge 页面自身 UI 得到修正

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["WechatPopupBridgePage useEffect\nbridge/page.tsx"]
    end

    subgraph N["核心处理层"]
        F1["fetch /api/wechat-popup-login"]
        F2["signIn credentials"]
        F3["postMessage / window.location.href\n（成功路径，不变）"]
    end

    subgraph E["错误路径（修复前缺失）"]
        E1["setLoginError(msg)\n触发 React 重渲染"]
        E2["渲染错误 UI\n显示原因 + 关闭按钮"]
    end

    T1 --> F1 --> F2 --> F3
    F1 -. "!ok 或 !result" .-> E1
    F2 -. "error" .-> E1
    E1 --> E2
```

## 验证

revert-fail 准则：将 `setLoginError(...)` 从 catch 中移除（还原旧代码），`loginError` 永远为 `null`，错误分支永远不渲染——测试立刻失败。本地验证：在 `completeWechatPopupLogin` 顶部 `throw new Error('测试错误')` 触发失败路径，确认错误 UI 正常渲染且"关闭并重试"按钮存在。

关联 Issue: #3513