### PR TITLE
bugfix: 替换 type AuthOptions = any 为 NextAuthOptions，恢复 NextAuth 配置编译期类型检查

### DIFF
--- a/web/src/constants/authOptions.ts
+++ b/web/src/constants/authOptions.ts
@@ -1,9 +1,9 @@
 import CredentialsProvider from "next-auth/providers/credentials";
+import type { NextAuthOptions } from "next-auth";
 import type {JWT} from "next-auth/jwt";
 import {normalizeLocale, normalizeTimezone} from "@/utils/userPreferences";
 import WeChatProvider from "../lib/wechatProvider";
 
-type AuthOptions = any;
 type ExtendedJWT = JWT & { timezone?: string };
 
 const buildAuthUser = (userData: any) => ({
@@ -92,7 +92,7 @@ async function getWeChatConfig() {
   }
 }
 
-export async function getAuthOptions(): Promise<AuthOptions> {
+export async function getAuthOptions(): Promise<NextAuthOptions> {
   const wechatConfig = await getWeChatConfig();
   
   const providers = [
@@ -179,26 +179,27 @@ export async function getAuthOptions(): Promise<AuthOptions> {
       maxAge: 60 * 60 * 24,
     },
     callbacks: {
-      async jwt({ token, user, account, trigger, session }: { token: ExtendedJWT; user: any; account: any; trigger?: string; session?: any }) {
+      async jwt({ token, user, account, trigger, session }) {
+        const extToken = token as ExtendedJWT;
         if (user) {
-          return applyUserToToken(token, user, account);
+          return applyUserToToken(extToken, user, account);
         }
 
         if (trigger === 'update' && session) {
-          return applySessionUpdateToToken(token, session);
+          return applySessionUpdateToToken(extToken, session);
         }
 
-        return token;
+        return extToken;
       },
-      async session({ session, token }: { session: any; token: ExtendedJWT }) {
-        return buildSessionFromToken(session, token);
+      async session({ session, token }) {
+        return buildSessionFromToken(session, token as ExtendedJWT);
       },
     },
   };
 }
 
 // For backward compatibility, keep a default authOptions, but only include basic CredentialsProvider
-export const authOptions: AuthOptions = {
+export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: "Credentials",
@@ -268,19 +269,20 @@ export const authOptions: AuthOptions = {
     maxAge: 60 * 60 * 24,
   },
   callbacks: {
-    async jwt({ token, user, account, trigger, session }: { token: ExtendedJWT; user: any; account: any; trigger?: string; session?: any }) {
+    async jwt({ token, user, account, trigger, session }) {
+      const extToken = token as ExtendedJWT;
       if (user) {
-        return applyUserToToken(token, user, account);
+        return applyUserToToken(extToken, user, account);
       }
 
       if (trigger === 'update' && session) {
-        return applySessionUpdateToToken(token, session);
+        return applySessionUpdateToToken(extToken, session);
       }
 
-      return token;
+      return extToken;
     },
-    async session({ session, token }: { session: any; token: ExtendedJWT }) {
-      return buildSessionFromToken(session, token);
+    async session({ session, token }) {
+      return buildSessionFromToken(session, token as ExtendedJWT);
     },
   },
 };


### PR DESCRIPTION
## 被破坏的不变量

NextAuth 配置对象（`providers`、`callbacks`、`session` 等字段）本应由 `NextAuthOptions` 类型守卫，确保编译期捕获：回调签名错误、必填字段缺失、Provider 配置不完整等。

`type AuthOptions = any` 一行将这条不变量完全击穿——任何注解了 `AuthOptions` 的变量都退化为 `any`，TypeScript 类型系统在认证配置入口完全哑火。

## 根因（设计层）

`web/src/constants/authOptions.ts:6` 处以 `type AuthOptions = any` 替代了应从 `next-auth` 导入的 `NextAuthOptions`。该类型通过 `getAuthOptions(): Promise<AuthOptions>` 和 `export const authOptions: AuthOptions` 两个出口传播至所有调用方（signin 页面、`[...nextauth]/route.ts`、`lib/auth.ts`），导致这三处的类型保护全部失效。

## 修复如何恢复不变量

删除 `type AuthOptions = any`，改为从 `next-auth` 直接导入并使用 `NextAuthOptions`：

- `getAuthOptions()` 返回类型：`Promise<any>` → `Promise<NextAuthOptions>`  
- `authOptions` 常量标注：`any` → `NextAuthOptions`  
- `jwt`/`session` 回调移除不兼容的内联类型注解（原注解与 `NextAuthOptions` 推导出的签名冲突），改用 `token as ExtendedJWT` 局部转型（`ExtendedJWT = JWT & { timezone?: string }` 用于扩展字段访问，符合 next-auth v4 module augmentation 的预期用法）  
- WeChatProvider 的 `as unknown as any` 转型保留——该 provider 为自定义实现，类型不在 next-auth 标准定义内，此转型是必要的，范围已最小化

**零运行时影响**：本次改动纯属类型层面，不改任何运行逻辑。

## blast radius · 一致性

- 影响范围：`web/src/constants/authOptions.ts`（单文件，web 模块内）
- 所有调用方（`signin/page.tsx`、`api/auth/[...nextauth]/route.ts`、`lib/auth.ts`）均通过 `getAuthOptions()` 获取配置，类型改善自动传播
- 不涉及 server/ / agents/ / 任何后端代码

## 验证

**Revert-fail 准则**：若将此 commit revert（恢复 `type AuthOptions = any`），`pnpm type-check` 将不再报错——即当前修复让配置对象在类型不匹配时报错，验证了修复点。

本地验证（CI 替代方案，因 node_modules 未安装）：
```bash
cd web
pnpm install
pnpm type-check
```

## 调用链

```mermaid
flowchart TD
    subgraph T["类型定义层"]
        T1["NextAuthOptions\nnext-auth（修复后导入）"]
    end

    subgraph C["配置层"]
        C1["getAuthOptions(): Promise<NextAuthOptions>\nauthOptions.ts（修复点）"]
        C2["authOptions: NextAuthOptions\nauthOptions.ts（修复点）"]
    end

    subgraph U["使用层"]
        U1["getServerSession(authOptions)\nsignin/page.tsx"]
        U2["NextAuth(await getAuthOptions())\napi/auth/[...nextauth]/route.ts"]
        U3["NextAuth(authOptions)\nlib/auth.ts"]
    end

    T1 --> C1
    T1 --> C2
    C1 --> U1
    C1 --> U2
    C2 --> U3
```

关联 Issue #3512