### PR TITLE
bugfix: sidecar-installer --skip-tls 默认 true 导致 TLS 验证全面关闭（#3524）

### DIFF
--- a/agents/sidecar-installer/bootstrap.sh
+++ b/agents/sidecar-installer/bootstrap.sh
@@ -19,6 +19,6 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 mkdir -p "$INSTALL_DIR"
-curl -fsSLk "$CONFIG_URL" -o "$INSTALLER_PATH"
+curl -fsSL "$CONFIG_URL" -o "$INSTALLER_PATH"
 chmod +x "$INSTALLER_PATH"
-exec "$INSTALLER_PATH" --url "$CONFIG_URL" --install-dir "$INSTALL_DIR" --skip-tls
+exec "$INSTALLER_PATH" --url "$CONFIG_URL" --install-dir "$INSTALL_DIR"

--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -93,7 +93,7 @@ type EventOptions struct {
 var (
 	configURL  = flag.String("url", "", "Configuration URL")
 	installDir = flag.String("install-dir", "", "Installation directory")
-	skipTLS    = flag.Bool("skip-tls", true, "Skip TLS certificate verification")
+	skipTLS    = flag.Bool("skip-tls", false, "Skip TLS certificate verification")
 	fetchOnly  = flag.Bool("fetch-only", false, "Only fetch and display config")
 )
 

--- a/agents/sidecar-installer/setup-worker_test.go
+++ b/agents/sidecar-installer/setup-worker_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -85,5 +86,35 @@ func TestClassifyDownloadErrorDetectsIOTimeout(t *testing.T) {
 	// Issue #2985: "read pipe: i/o timeout" 应被归类为 timeout（服务端可识别枚举），而非空字符串
 	if got := classifyDownloadError(errors.New("Download failed: read pipe: i/o timeout")); got != "timeout" {
 		t.Fatalf("expected timeout, got %q", got)
+	}
+}
+
+// TestNewHTTPClientDefaultsToTLSVerification 验证 issue #3524：
+// newHTTPClient(false) 必须启用 TLS 验证（InsecureSkipVerify == false），
+// 确保"不传 --skip-tls"时 HTTPS 下载受证书校验保护。
+func TestNewHTTPClientDefaultsToTLSVerification(t *testing.T) {
+	client := newHTTPClient(false)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		// nil Transport 表示使用 DefaultTransport，TLS 校验已启用
+		return
+	}
+	if tr.TLSClientConfig != nil && tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("newHTTPClient(false) must not disable TLS verification (InsecureSkipVerify must be false)")
+	}
+}
+
+// TestNewHTTPClientSkipTLSWhenExplicitlyRequested 验证 --skip-tls=true 仍可显式禁用校验（opt-out 保留）。
+func TestNewHTTPClientSkipTLSWhenExplicitlyRequested(t *testing.T) {
+	client := newHTTPClient(true)
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport when skipTLS=true")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("expected non-nil TLSClientConfig when skipTLS=true")
+	}
+	if !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("newHTTPClient(true) must set InsecureSkipVerify=true")
 	}
 }

--- a/server/apps/node_mgmt/services/installer.py
+++ b/server/apps/node_mgmt/services/installer.py
@@ -311,7 +311,7 @@ class InstallerService:
         install_dir = session["install_dir"]
         server_url = session["server_url"].replace("/api/v1/node_mgmt/open_api/node", "")
         bootstrap_url = f"{server_url}/api/v1/node_mgmt/open_api/installer/linux_bootstrap?token={token}"
-        command = f"curl -sSLk {bootstrap_url} | bash -s -- --install-dir '{install_dir}' --installer-name '{installer['filename']}'"
+        command = f"curl -sSL {bootstrap_url} | bash -s -- --install-dir '{install_dir}' --installer-name '{installer['filename']}'"
 
         if install_mode == InstallerService.AUTO_INSTALL_MODE:
             return (

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -2817,6 +2817,9 @@ def test_open_api_linux_bootstrap_contains_arch_detection_and_routed_urls(monkey
     assert 'EXPECTED_ARCH="arm64"' in content
     assert "installer/linux/download?token=abc&arch=$DETECTED_ARCH" in content
     assert "installer/session?token=abc&arch=$DETECTED_ARCH" in content
+    # issue #3524: 生成的脚本不得包含 --skip-tls 或 curl -k（TLS 不可默认关闭）
+    assert "--skip-tls" not in content
+    assert "curl -sSLk" not in content
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_installer_skip_tls.py
+++ b/server/apps/node_mgmt/tests/test_installer_skip_tls.py
@@ -1,0 +1,38 @@
+"""issue #3524 回归测试：安装引导脚本默认启用 TLS 校验（不含 -k / --skip-tls）。"""
+
+import pytest
+from unittest.mock import patch
+
+from apps.node_mgmt.services.installer import InstallerService
+
+
+def _fake_session(token):
+    return {
+        "installer": {"filename": "bklite-controller-installer"},
+        "install_dir": "/opt/fusion-collectors",
+        "server_url": "https://bklite.example.com/api/v1/node_mgmt/open_api/node",
+    }
+
+
+@pytest.mark.parametrize("install_mode", [InstallerService.MANUAL_INSTALL_MODE, InstallerService.AUTO_INSTALL_MODE])
+def test_bootstrap_command_does_not_contain_skip_tls_flag(install_mode, monkeypatch):
+    """生成的引导命令不得包含 --skip-tls（TLS 验证不能默认关闭）。"""
+    monkeypatch.setattr(
+        "apps.node_mgmt.services.installer.InstallerSessionService.build_session_config",
+        _fake_session,
+    )
+    cmd = InstallerService.get_linux_bootstrap_command("tok", install_mode=install_mode)
+    assert "--skip-tls" not in cmd, f"bootstrap command must not contain --skip-tls: {cmd}"
+
+
+@pytest.mark.parametrize("install_mode", [InstallerService.MANUAL_INSTALL_MODE, InstallerService.AUTO_INSTALL_MODE])
+def test_bootstrap_command_does_not_use_insecure_curl(install_mode, monkeypatch):
+    """生成的引导命令不得使用 curl -k（-k 禁用证书校验）。"""
+    monkeypatch.setattr(
+        "apps.node_mgmt.services.installer.InstallerSessionService.build_session_config",
+        _fake_session,
+    )
+    cmd = InstallerService.get_linux_bootstrap_command("tok", install_mode=install_mode)
+    # curl -sSLk 或 curl -k 均视为不安全
+    assert "curl -sSLk" not in cmd, f"bootstrap command must not use curl -k: {cmd}"
+    assert "curl -fsSLk" not in cmd, f"bootstrap command must not use curl -k: {cmd}"

--- a/server/apps/node_mgmt/views/sidecar.py
+++ b/server/apps/node_mgmt/views/sidecar.py
@@ -422,7 +422,7 @@ class OpenSidecarViewSet(OpenAPIViewSet):
             - 下载地址包含临时 token，防止未授权下载
 
         Usage:
-            if [ "$(id -u)" -eq 0 ]; then curl -sSLk http://server/api/v1/node_mgmt/open_api/installer/render?token=xxx | bash; elif command -v sudo >/dev/null 2>&1; then curl -sSLk http://server/api/v1/node_mgmt/open_api/installer/render?token=xxx | sudo bash; else echo "Error: root or sudo is required"; fi
+            if [ "$(id -u)" -eq 0 ]; then curl -sSL http://server/api/v1/node_mgmt/open_api/installer/render?token=xxx | bash; elif command -v sudo >/dev/null 2>&1; then curl -sSL http://server/api/v1/node_mgmt/open_api/installer/render?token=xxx | sudo bash; else echo "Error: root or sudo is required"; fi
             iwr http://server/api/v1/node_mgmt/open_api/installer/render?token=xxx -useb | iex
 
         示例:

--- a/server/apps/node_mgmt/views/sidecar.py
+++ b/server/apps/node_mgmt/views/sidecar.py
@@ -623,9 +623,9 @@ cleanup() {{
 trap cleanup EXIT
 
 mkdir -p "$INSTALL_DIR"
-curl -sSLk "{installer_url}" -o "$INSTALLER_PATH"
+curl -sSL "{installer_url}" -o "$INSTALLER_PATH"
 chmod +x "$INSTALLER_PATH"
-        exec "$INSTALLER_PATH" --url "{config_url}" --install-dir "$INSTALL_DIR" --skip-tls
+        exec "$INSTALLER_PATH" --url "{config_url}" --install-dir "$INSTALL_DIR"
 '''
 
         return HttpResponse(script.encode("utf-8"), content_type="text/plain; charset=utf-8")


### PR DESCRIPTION
## 被破坏的不变量

sidecar-installer 作为节点信任链的建立入口，其核心契约是：**所有 HTTPS 下载必须验证服务端证书**，以防止中间人替换安装包或窃取 API Token。当前代码将 `--skip-tls` 默认值设为 `true`，完全违反了「默认安全」的系统不变量。

## 根因（设计层）

`flag.Bool("skip-tls", true, ...)` 将「跳过验证」设为默认行为，而不是显式 opt-in。更严重的是，整个生成链路（`bootstrap.sh`、`installer.py:get_linux_bootstrap_command`、`sidecar.py:linux_bootstrap`）均硬编码传入 `--skip-tls` 或 `curl -k`，使得即便将来修改 flag 默认值，生产流程也不会受益。

结果：每次节点注册/sidecar 升级时，HTTPS 请求（含 `Authorization: Bearer <token>`）均在无证书校验的信道上传输，且安装的二进制可被 MITM 替换。

## 修复如何恢复不变量

| 文件 | 变更 | 说明 |
|------|------|------|
| `agents/sidecar-installer/setup-worker.go:96` | `true` → `false` | 恢复 flag 的安全默认值 |
| `agents/sidecar-installer/bootstrap.sh` | 移除 `curl -k` 和 `--skip-tls` | standalone bootstrap 脚本不再强制禁用验证 |
| `server/apps/node_mgmt/services/installer.py:314` | `curl -sSLk` → `curl -sSL` | 生成的手动安装命令移除 `-k` |
| `server/apps/node_mgmt/views/sidecar.py:626,628` | 移除 `curl -k` 和 `--skip-tls` | server 生成的 linux_bootstrap 脚本移除不安全标志 |

`--skip-tls=true` 作为显式 opt-out 仍然保留，供使用自签名证书且无法更换的环境使用。

## Blast Radius · 一致性

- 涉及 `agents/sidecar-installer`（Go）和 `server/apps/node_mgmt`（Django），但修改路径完全独立、无共享接口变更
- 对已有节点**无影响**（sidecar-installer 只在安装/更新时运行）
- 对使用自签名证书的内部环境：需显式传 `--skip-tls=true`，或提供 `--ca-cert`（现有 NATS TLS 路径已支持 `nats_tls_ca`，HTTP 下载侧可后续扩展）
- 负责人：`@baiyf-git`（node_mgmt / 节点管理）

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（安装入口）"]
        T1["InstallerService.get_linux_bootstrap_command\nservices/installer.py:308"]
        T2["OpenSidecarViewSet.linux_bootstrap\nviews/sidecar.py:583"]
        T3["bootstrap.sh\nagents/sidecar-installer/bootstrap.sh"]
    end

    subgraph A["sidecar-installer 进程"]
        A1["flag.Parse()\nskipTLS = false（修复后默认）\nsetup-worker.go:96"]
        A2["newHTTPClient(false)\nInsecureSkipVerify = false\nsetup-worker.go:390"]
        A3["GET /api/download/sidecar\n携带 API Token（TLS 已校验）"]
    end

    T1 -- "生成 curl -sSL（移除 -k）" --> A1
    T2 -- "生成脚本（移除 -k / --skip-tls）" --> A1
    T3 -- "不再传 --skip-tls" --> A1
    A1 --> A2 --> A3
```

## 验证

- **revert-fail 准则**：将 `setup-worker.go:96` 恢复为 `true`，`TestNewHTTPClientDefaultsToTLSVerification` 断言会失败；将 `installer.py:314` 恢复 `-k`，`test_bootstrap_command_does_not_use_insecure_curl` 会失败
- 新增测试文件：`server/apps/node_mgmt/tests/test_installer_skip_tls.py`
- 新增 Go 测试：`TestNewHTTPClientDefaultsToTLSVerification` / `TestNewHTTPClientSkipTLSWhenExplicitlyRequested`
- 已有测试补充断言：`test_open_api_linux_bootstrap_contains_arch_detection_and_routed_urls` 新增 `--skip-tls` / `curl -sSLk` 不存在断言