### PR TITLE
bugfix(console_mgmt): init_user_set 校验 group_name 必填字段，缺失时返回 400

### DIFF
--- a/server/apps/console_mgmt/language/en.yaml
+++ b/server/apps/console_mgmt/language/en.yaml
@@ -5,6 +5,9 @@ error:
   verification_code_incorrect: Verification code is incorrect
   user_id_required: User ID cannot be empty
   user_not_found: User not found
+  not_first_login: User has already been initialized
+  parse_request_failed: Failed to parse request body
+  group_name_required: group_name is required
   password_required: Password cannot be empty
   invalid_json_format: Invalid JSON format
 email:

--- a/server/apps/console_mgmt/language/zh-Hans.yaml
+++ b/server/apps/console_mgmt/language/zh-Hans.yaml
@@ -5,6 +5,9 @@ error:
   verification_code_incorrect: 验证码错误
   user_id_required: 用户ID不能为空
   user_not_found: 用户不存在
+  not_first_login: 用户已完成初始化
+  parse_request_failed: 请求体解析失败
+  group_name_required: group_name 不能为空
   password_required: 密码不能为空
   invalid_json_format: 请求体格式错误，请发送合法的 JSON
 email:

--- a/server/apps/console_mgmt/tests/test_init_user_set_views.py
+++ b/server/apps/console_mgmt/tests/test_init_user_set_views.py
@@ -1,0 +1,111 @@
+"""console_mgmt init_user_set 视图的字段校验防护回归测试。
+
+覆盖 Issue #3472：
+- init_user_set：kwargs["group_name"] 裸字典访问，请求体缺少该字段时 KeyError → 500
+
+规则：将修复代码 revert（将 kwargs.get("group_name") 改回 kwargs["group_name"]）后，
+以下 test 必须失败——缺 group_name 时 KeyError 无捕获 → Django 500。
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import RequestFactory
+
+from apps.console_mgmt.views import init_user_set
+
+pytestmark = [pytest.mark.unit]
+
+INIT_URL = "/api/v1/console_mgmt/init_user_set/"
+
+
+def _make_request(body: dict, group_list=None):
+    """构造一个最小 request 对象，模拟已登录用户属于 OpsPilotGuest 组。"""
+    factory = RequestFactory()
+    req = factory.post(
+        INIT_URL,
+        data=json.dumps(body),
+        content_type="application/json",
+    )
+
+    # 构造 group_list：默认为 OpsPilotGuest（首次登录状态）
+    if group_list is None:
+        group_list = [{"id": 1, "name": "OpsPilotGuest"}]
+
+    user = MagicMock()
+    user.username = "testuser"
+    user.domain = "domain.com"
+    user.locale = "zh"
+    user.group_list = group_list
+    req.user = user
+    return req
+
+
+class TestInitUserSetGroupNameRequired:
+    """group_name 必填字段校验。"""
+
+    def test_缺少group_name返回400而非500(self):
+        """body 中没有 group_name 时应返回 400，不得抛 KeyError 触发 500。
+
+        revert 修复（还原为 kwargs["group_name"]）后本测试必须失败：
+        KeyError 无捕获 → Django 500 handler。
+        """
+        req = _make_request({})
+
+        # patch User.objects.get 让用户查找成功，排除 User.DoesNotExist 干扰
+        mock_user = MagicMock()
+        mock_user.id = 99
+        with patch("apps.console_mgmt.views.User") as MockUser:
+            MockUser.objects.get.return_value = mock_user
+            resp = init_user_set(req)
+
+        assert resp.status_code == 400, (
+            f"期望 400，实际 {resp.status_code}。"
+            "说明 kwargs['group_name'] 裸字典访问未改为 .get() 校验。"
+        )
+        body = json.loads(resp.content)
+        assert body["result"] is False
+        assert "group_name" in body.get("message", "").lower() or body["result"] is False
+
+    def test_group_name为空字符串返回400(self):
+        """group_name 存在但为空字符串，也属于无效值，应返回 400。"""
+        req = _make_request({"group_name": ""})
+
+        mock_user = MagicMock()
+        mock_user.id = 99
+        with patch("apps.console_mgmt.views.User") as MockUser:
+            MockUser.objects.get.return_value = mock_user
+            resp = init_user_set(req)
+
+        assert resp.status_code == 400
+        body = json.loads(resp.content)
+        assert body["result"] is False
+
+    def test_携带合法group_name时正常调用下游(self):
+        """group_name 存在且非空时，不应在字段校验阶段被拒，应走到下游 RPC 调用。
+
+        本测试断言：响应不是因为「group_name 缺失」返回的 400；
+        如果把修复 revert，缺 group_name 的路径会 500，与本测试无关——
+        但若此测试失败，说明修复引入了误报（把合法请求也拦截了）。
+        """
+        req = _make_request({"group_name": "DevTeam"})
+
+        mock_user = MagicMock()
+        mock_user.id = 99
+        rpc_resp = {"result": True, "data": {}}
+
+        with patch("apps.console_mgmt.views.User") as MockUser, patch(
+            "apps.console_mgmt.views.SystemMgmt"
+        ) as MockRPC, patch("apps.console_mgmt.views.log_operation"):
+            MockUser.objects.get.return_value = mock_user
+            mock_rpc_instance = MagicMock()
+            mock_rpc_instance.init_user_default_attributes.return_value = rpc_resp
+            MockRPC.return_value = mock_rpc_instance
+
+            resp = init_user_set(req)
+
+        # 断言 RPC 被调用（说明通过了字段校验）
+        mock_rpc_instance.init_user_default_attributes.assert_called_once_with(99, "DevTeam", 1)
+        body = json.loads(resp.content)
+        assert body["result"] is True

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -108,8 +108,15 @@ def init_user_set(request):
     except User.DoesNotExist:
         return JsonResponse({"result": False, "message": loader.get("error.user_not_found", "User not found")})
 
+    group_name_value = kwargs.get("group_name")
+    if not group_name_value:
+        return JsonResponse(
+            {"result": False, "message": loader.get("error.group_name_required", "group_name is required")},
+            status=400,
+        )
+
     client = SystemMgmt()
-    res = client.init_user_default_attributes(user.id, kwargs["group_name"], group_list[0]["id"])
+    res = client.init_user_default_attributes(user.id, group_name_value, group_list[0]["id"])
     if not res["result"]:
         return JsonResponse(res)
     log_operation(request, "create", "console_mgmt", f"初始化用户设置: {request.user.username}")


### PR DESCRIPTION
## 被破坏的不变量

`init_user_set` 视图在使用 `kwargs["group_name"]` 之前没有校验该字段是否存在。「外部输入在使用前必须验证」的不变量在此处被打破——JSON 解析有 try/except 防护，但字段访问没有。

## 根因（设计层）

`json.loads(request.body)` 的解析层有防护，但解析成功后的字段取用层没有边界校验：裸字典访问 `kwargs["group_name"]` 在字段缺失时抛出未捕获的 `KeyError`，直接触发 HTTP 500。这与同文件中 `validate_pwd` 用 `.get("password")` 的安全访问模式不一致。

## 修复如何恢复不变量

将裸字典访问替换为 `.get()` + 显式必填校验，缺失或为空时提前返回含 `message` 的 400 响应，与文件内其他视图的防护模式保持一致。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /console_mgmt/init_user_set/\nviews.py:init_user_set"]
    end

    subgraph N["解析层"]
        J["json.loads(request.body) :88\n有 try/except 防护"]
        V["kwargs.get('group_name') :111\n新增：缺失时返回 400"]
    end

    subgraph D["下游层"]
        RPC["SystemMgmt.init_user_default_attributes()\n正常业务路径"]
    end

    T1 --> J --> V
    V -. "group_name 缺失/空" .-> E["400 Bad Request\nresult: false"]
    V --> RPC
```

## blast radius · 一致性

- 改动仅限 `server/apps/console_mgmt/views.py` 中的 `init_user_set` 函数，单函数内部逻辑修改。
- 修复模式与同文件 `validate_pwd`（`.get("password")`）、`update_user_base_info`（`.get(...)`）保持一致。
- 无 DB migration、无接口签名变更、无跨模块影响。

## 验证

新增回归测试 `test_init_user_set_views.py`，覆盖三个场景：
1. 缺少 `group_name` → 返回 400（revert 修复后此测试必须失败：KeyError 无捕获 → 500）
2. `group_name` 为空字符串 → 返回 400
3. 合法 `group_name` → RPC 被调用，结果正确

关联 Issue: #3472