### PR TITLE
bugfix: 为3个高频算法服务补充P0单元测试（classify_anomaly/timeseries/log）

### DIFF
--- a/algorithms/classify_anomaly_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_anomaly_server/tests/test_schema_and_predict.py
@@ -1,0 +1,298 @@
+"""异常检测服务 schema 校验和 predict 路径的单元测试。
+
+覆盖：
+- TimeSeriesPoint / DetectionConfig / PredictRequest 的 schema 校验
+- PredictRequest.to_series() 的排序与去重行为
+- DummyModel.predict() 的输入/输出 shape 不变量
+- MLService.predict() 的验证失败路径和正常检测路径（使用 DummyModel，无需真实模型）
+"""
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# 仅加载被测模块，不启动 BentoML 服务（无需真实 BentoML runtime）
+# ---------------------------------------------------------------------------
+
+BASE = "classify_anomaly_server.serving"
+
+
+def _stub_bentoml():
+    """向 sys.modules 注入最小化的 bentoml 存根，避免真实 BentoML 启动。"""
+    bentoml = types.ModuleType("bentoml")
+
+    def service(**kwargs):
+        def decorator(cls):
+            return cls
+        return decorator
+
+    def api(fn=None, **kwargs):
+        if fn is not None:
+            return fn
+        return lambda f: f
+
+    def on_deployment(fn):
+        return fn
+
+    def on_shutdown(fn):
+        return fn
+
+    bentoml.service = service
+    bentoml.api = api
+    bentoml.on_deployment = on_deployment
+    bentoml.on_shutdown = on_shutdown
+
+    # exceptions 子模块（exceptions.py 从这里 import BentoMLException）
+    bentoml_exceptions = types.ModuleType("bentoml.exceptions")
+
+    class BentoMLException(Exception):
+        error_code = 500
+
+    bentoml_exceptions.BentoMLException = BentoMLException
+    bentoml.exceptions = bentoml_exceptions
+
+    # metrics 子模块（metrics.py 从这里 import metrics.Counter / Histogram）
+    bentoml_metrics = types.ModuleType("bentoml.metrics")
+
+    def _make_counter(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    def _make_histogram(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    bentoml_metrics.Counter = _make_counter
+    bentoml_metrics.Histogram = _make_histogram
+    bentoml.metrics = bentoml_metrics
+
+    sys.modules.setdefault("bentoml", bentoml)
+    sys.modules.setdefault("bentoml.exceptions", bentoml_exceptions)
+    sys.modules.setdefault("bentoml.metrics", bentoml_metrics)
+
+
+_stub_bentoml()
+
+
+from classify_anomaly_server.serving.schemas.api_schema import (  # noqa: E402
+    AnomalyPoint,
+    DetectionConfig,
+    ErrorDetail,
+    PredictRequest,
+    PredictResponse,
+    ResponseMetadata,
+    TimeSeriesPoint,
+)
+from classify_anomaly_server.serving.models.dummy_model import DummyModel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Schema 校验测试
+# ---------------------------------------------------------------------------
+
+
+class TestTimeSeriesPointSchema:
+    """TimeSeriesPoint 的边界输入校验。"""
+
+    def test_valid_point(self):
+        pt = TimeSeriesPoint(timestamp=1700000000, value=42.0)
+        assert pt.timestamp == 1700000000
+        assert pt.value == 42.0
+
+    def test_missing_timestamp_raises(self):
+        with pytest.raises(ValidationError):
+            TimeSeriesPoint(value=1.0)
+
+    def test_missing_value_raises(self):
+        with pytest.raises(ValidationError):
+            TimeSeriesPoint(timestamp=1700000000)
+
+
+class TestDetectionConfigSchema:
+    """DetectionConfig.threshold 的约束校验（gt=0.0）。"""
+
+    def test_valid_threshold(self):
+        cfg = DetectionConfig(threshold=0.8)
+        assert cfg.threshold == 0.8
+
+    def test_none_threshold_allowed(self):
+        cfg = DetectionConfig()
+        assert cfg.threshold is None
+
+    def test_zero_threshold_raises(self):
+        """threshold=0 不满足 gt=0.0，应抛 ValidationError。"""
+        with pytest.raises(ValidationError):
+            DetectionConfig(threshold=0.0)
+
+    def test_negative_threshold_raises(self):
+        with pytest.raises(ValidationError):
+            DetectionConfig(threshold=-0.5)
+
+
+class TestPredictRequestToSeries:
+    """PredictRequest.to_series() 的排序与去重行为。"""
+
+    def _make_request(self, pairs):
+        """pairs: list of (timestamp, value)"""
+        points = [TimeSeriesPoint(timestamp=t, value=v) for t, v in pairs]
+        return PredictRequest(data=points)
+
+    def test_basic_conversion(self):
+        req = self._make_request([(1000, 1.0), (2000, 2.0), (3000, 3.0)])
+        series = req.to_series()
+        assert len(series) == 3
+        assert list(series.values) == [1.0, 2.0, 3.0]
+
+    def test_auto_sort_unsorted_timestamps(self):
+        """乱序时间戳应被自动升序排列。"""
+        req = self._make_request([(3000, 3.0), (1000, 1.0), (2000, 2.0)])
+        series = req.to_series()
+        assert series.index.is_monotonic_increasing
+        assert list(series.values) == [1.0, 2.0, 3.0]
+
+    def test_dedup_keeps_last_value(self):
+        """重复时间戳应保留最后一个值。"""
+        req = self._make_request([(1000, 1.0), (1000, 99.0), (2000, 2.0)])
+        series = req.to_series()
+        assert len(series) == 2
+        # 1000 对应的值应是最后出现的 99.0
+        ts_1000 = pd.to_datetime(1000, unit="s")
+        assert series[ts_1000] == 99.0
+
+
+# ---------------------------------------------------------------------------
+# DummyModel 单元测试
+# ---------------------------------------------------------------------------
+
+
+class TestDummyModel:
+    """DummyModel.predict() 的输入/输出 shape 不变量。"""
+
+    def setup_method(self):
+        self.model = DummyModel()
+
+    def test_output_length_equals_input(self):
+        """输出 labels/scores 长度必须等于输入序列长度。"""
+        series = pd.Series([1.0, 2.0, 100.0, 1.5, 2.5], index=range(5))
+        result = self.model.predict({"data": series})
+        assert len(result["labels"]) == 5
+        assert len(result["scores"]) == 5
+
+    def test_labels_are_binary(self):
+        """labels 仅包含 0 或 1。"""
+        series = pd.Series(list(range(10)), dtype=float)
+        result = self.model.predict({"data": series})
+        assert all(lbl in (0, 1) for lbl in result["labels"])
+
+    def test_scores_in_unit_interval(self):
+        """scores 每个值在 [0, 1] 范围内。"""
+        series = pd.Series([1.0, 50.0, 1.0, 1.0, 1000.0], dtype=float)
+        result = self.model.predict({"data": series})
+        assert all(0.0 <= s <= 1.0 for s in result["scores"])
+
+    def test_constant_series_has_no_anomalies(self):
+        """所有值相同时，不应检测到异常（std=0 路径）。"""
+        series = pd.Series([5.0] * 10)
+        result = self.model.predict({"data": series})
+        assert all(lbl == 0 for lbl in result["labels"])
+
+    def test_invalid_input_type_raises(self):
+        """非 pd.Series 输入应抛 ValueError。"""
+        with pytest.raises(ValueError):
+            self.model.predict({"data": [1.0, 2.0, 3.0]})
+
+    def test_custom_threshold_affects_labels(self):
+        """高阈值应比低阈值产生更少的异常标记。"""
+        # 制造一个含明显离群点的序列
+        values = [1.0] * 9 + [1000.0]
+        series = pd.Series(values, dtype=float)
+
+        result_strict = self.model.predict({"data": series, "threshold": 0.99})
+        result_loose = self.model.predict({"data": series, "threshold": 0.1})
+
+        anomalies_strict = sum(result_strict["labels"])
+        anomalies_loose = sum(result_loose["labels"])
+        assert anomalies_strict <= anomalies_loose
+
+
+# ---------------------------------------------------------------------------
+# MLService.predict() 集成路径测试（使用 DummyModel，不启动真实 BentoML）
+# ---------------------------------------------------------------------------
+
+
+class TestMLServicePredict:
+    """在不依赖 MLflow / BentoML runtime 的情况下测试服务推理路径。"""
+
+    def _make_service(self):
+        """直接实例化 MLService，注入 DummyModel 和 dummy config。"""
+        from classify_anomaly_server.serving.service import MLService
+
+        svc = object.__new__(MLService)
+        svc.model = DummyModel()
+
+        # 构造最小 config stub
+        config = MagicMock()
+        config.source = "dummy"
+        config.mlflow_model_uri = None
+        svc.config = config
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_predict_success_returns_correct_shape(self):
+        """正常请求：返回 success=True，results 长度等于输入数据点数。"""
+        svc = self._make_service()
+        data = [{"timestamp": 1700000000 + i, "value": float(i)} for i in range(5)]
+        response = await svc.predict(data)
+        assert response.success is True
+        assert response.results is not None
+        assert len(response.results) == 5
+        assert response.error is None
+
+    @pytest.mark.asyncio
+    async def test_predict_metadata_input_count(self):
+        """metadata.input_data_points 等于实际输入点数。"""
+        svc = self._make_service()
+        data = [{"timestamp": 1700000000 + i, "value": 1.0} for i in range(8)]
+        response = await svc.predict(data)
+        assert response.metadata.input_data_points == 8
+
+    @pytest.mark.asyncio
+    async def test_predict_invalid_schema_returns_error_response(self):
+        """格式错误的请求应返回 success=False 而非抛出异常。
+
+        Revert 修复验证：若移除 try/except 块内的 schema 验证逻辑，
+        此 test 将抛出未捕获异常而 fail。
+        """
+        svc = self._make_service()
+        # 缺少必填字段 'timestamp'
+        data = [{"value": 1.0}]
+        response = await svc.predict(data)
+        assert response.success is False
+        assert response.error is not None
+        assert response.error.code == "E1000"
+
+    @pytest.mark.asyncio
+    async def test_predict_anomaly_rate_in_unit_interval(self):
+        """anomaly_rate 始终在 [0, 1] 范围内。"""
+        svc = self._make_service()
+        data = [{"timestamp": 1700000000 + i, "value": float(i * 100)} for i in range(6)]
+        response = await svc.predict(data)
+        assert 0.0 <= response.metadata.anomaly_rate <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_predict_with_threshold_config(self):
+        """附带 config.threshold 参数不应导致服务报错。"""
+        svc = self._make_service()
+        data = [{"timestamp": 1700000000 + i, "value": float(i)} for i in range(5)]
+        config = {"threshold": 0.9}
+        response = await svc.predict(data, config)
+        assert response.success is True

--- a/algorithms/classify_log_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_log_server/tests/test_schema_and_predict.py
@@ -1,0 +1,324 @@
+"""日志聚类服务 schema 校验、SpellModel 推理行为和 predict 路径的单元测试。
+
+覆盖：
+- LogClusterRequest / LogClusterConfig 的 schema 校验（含边界值）
+- SpellModel.fit() → predict() 的基础行为不变量（无需 MLflow）
+- MLService.predict() 的聚合响应结构（使用 SpellModel 作模型，不启动真实 BentoML）
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch  # noqa: F401
+
+import pytest
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# 最小化 BentoML 存根
+# ---------------------------------------------------------------------------
+
+def _stub_bentoml():
+    bentoml = types.ModuleType("bentoml")
+
+    def service(**kwargs):
+        def decorator(cls):
+            return cls
+        return decorator
+
+    def api(fn=None, **kwargs):
+        if fn is not None:
+            return fn
+        return lambda f: f
+
+    def on_deployment(fn):
+        return fn
+
+    def on_shutdown(fn):
+        return fn
+
+    bentoml.service = service
+    bentoml.api = api
+    bentoml.on_deployment = on_deployment
+    bentoml.on_shutdown = on_shutdown
+
+    # exceptions 子模块
+    bentoml_exceptions = types.ModuleType("bentoml.exceptions")
+
+    class BentoMLException(Exception):
+        error_code = 500
+
+    bentoml_exceptions.BentoMLException = BentoMLException
+    bentoml.exceptions = bentoml_exceptions
+
+    # metrics 子模块
+    bentoml_metrics = types.ModuleType("bentoml.metrics")
+
+    def _make_counter(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    def _make_histogram(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    bentoml_metrics.Counter = _make_counter
+    bentoml_metrics.Histogram = _make_histogram
+    bentoml.metrics = bentoml_metrics
+
+    sys.modules.setdefault("bentoml", bentoml)
+    sys.modules.setdefault("bentoml.exceptions", bentoml_exceptions)
+    sys.modules.setdefault("bentoml.metrics", bentoml_metrics)
+
+
+# mlflow stub（spell_model.py 在 fit() 中条件引用 mlflow，trainer.py 也引用多个子模块）
+def _stub_mlflow():
+    mlflow = types.ModuleType("mlflow")
+    mlflow.active_run = lambda: None  # 无活跃 run，跳过 MLflow 记录
+    mlflow.log_param = lambda *a, **kw: None
+    mlflow.log_metric = lambda *a, **kw: None
+    mlflow.log_params = lambda *a, **kw: None
+    mlflow.log_metrics = lambda *a, **kw: None
+    mlflow.set_tracking_uri = lambda *a, **kw: None
+    mlflow.set_experiment = lambda *a, **kw: None
+
+    for submod in ["pyfunc", "sklearn", "xgboost", "pytorch", "tensorflow",
+                   "lightgbm", "catboost", "spacy", "entities", "tracking",
+                   "client", "MlflowClient"]:
+        sub = types.ModuleType(f"mlflow.{submod}")
+        setattr(mlflow, submod, sub)
+        sys.modules.setdefault(f"mlflow.{submod}", sub)
+
+    sys.modules.setdefault("mlflow", mlflow)
+
+
+_stub_bentoml()
+_stub_mlflow()
+
+
+from classify_log_server.serving.schemas.api_schema import (  # noqa: E402
+    LogClusterConfig,
+    LogClusterRequest,
+)
+from classify_log_server.training.models.spell_model import SpellModel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Schema 校验测试
+# ---------------------------------------------------------------------------
+
+
+class TestLogClusterConfigSchema:
+    """LogClusterConfig 参数约束校验。"""
+
+    def test_defaults(self):
+        cfg = LogClusterConfig()
+        assert cfg.max_samples == 5
+        assert cfg.sort_by == "count"
+        assert cfg.return_details is False
+
+    def test_valid_max_samples(self):
+        cfg = LogClusterConfig(max_samples=1)
+        assert cfg.max_samples == 1
+        cfg2 = LogClusterConfig(max_samples=20)
+        assert cfg2.max_samples == 20
+
+    def test_max_samples_too_low_raises(self):
+        with pytest.raises(ValidationError):
+            LogClusterConfig(max_samples=0)
+
+    def test_max_samples_too_high_raises(self):
+        with pytest.raises(ValidationError):
+            LogClusterConfig(max_samples=21)
+
+    def test_invalid_sort_by_raises(self):
+        with pytest.raises(ValidationError):
+            LogClusterConfig(sort_by="name")
+
+    def test_valid_sort_by_cluster_id(self):
+        cfg = LogClusterConfig(sort_by="cluster_id")
+        assert cfg.sort_by == "cluster_id"
+
+
+class TestLogClusterRequestSchema:
+    """LogClusterRequest.data 边界校验。"""
+
+    def test_valid_single_log(self):
+        req = LogClusterRequest(data=["User login failed"])
+        assert len(req.data) == 1
+
+    def test_empty_data_raises(self):
+        with pytest.raises(ValidationError):
+            LogClusterRequest(data=[])
+
+    def test_oversized_log_raises(self):
+        """单条日志超过 10 KB 应被 field_validator 拒绝。"""
+        huge_log = "A" * (10 * 1024 + 1)
+        with pytest.raises(ValidationError):
+            LogClusterRequest(data=[huge_log])
+
+    def test_config_uses_defaults_when_omitted(self):
+        req = LogClusterRequest(data=["some log"])
+        assert req.config.max_samples == 5
+
+
+# ---------------------------------------------------------------------------
+# SpellModel 行为不变量测试
+# ---------------------------------------------------------------------------
+
+
+class TestSpellModel:
+    """SpellModel.fit() → predict() 的核心不变量（不依赖 MLflow/BentoML）。"""
+
+    LOG_SAMPLES = [
+        "User login failed from IP 192.168.1.100",
+        "User login failed from IP 10.0.0.5",
+        "Database connection timeout after 30 seconds",
+        "Database connection timeout after 60 seconds",
+        "Service started successfully on port 8080",
+    ]
+
+    def _fit_model(self):
+        model = SpellModel(tau=0.4, min_cluster_size=1)
+        model.fit(self.LOG_SAMPLES, log_to_mlflow=False, verbose=False)
+        return model
+
+    def test_fit_creates_at_least_one_cluster(self):
+        model = self._fit_model()
+        assert len(model.clusters) >= 1
+
+    def test_predict_output_length_equals_input(self):
+        """predict() 输出长度必须等于输入日志条数（核心 shape 不变量）。
+
+        Revert 验证：若移除 predict() 的 cluster_ids.append 逻辑，
+        输出长度会不匹配，本 test 将 fail。
+        """
+        model = self._fit_model()
+        logs = ["User login failed from IP 1.2.3.4", "Unknown event occurred"]
+        result = model.predict(logs)
+        assert len(result) == len(logs)
+
+    def test_predict_returns_integer_labels(self):
+        """每个输出都应是整数（cluster_id 或 -1）。"""
+        model = self._fit_model()
+        result = model.predict(self.LOG_SAMPLES)
+        assert all(isinstance(r, int) for r in result)
+
+    def test_predict_before_fit_raises(self):
+        """未训练的模型调用 predict() 应抛 RuntimeError。"""
+        model = SpellModel()
+        with pytest.raises(RuntimeError):
+            model.predict(["any log"])
+
+    def test_similar_logs_map_to_same_cluster(self):
+        """结构相似的日志（仅 IP 不同）应被归入同一模板。"""
+        model = self._fit_model()
+        logs = [
+            "User login failed from IP 172.16.0.1",
+            "User login failed from IP 172.16.0.2",
+        ]
+        result = model.predict(logs)
+        # 两条结构相同的日志应归入同一 cluster（或均为 unknown=-1，但不应不同）
+        assert result[0] == result[1]
+
+    def test_empty_log_returns_unknown(self):
+        """空字符串日志应被归入 unknown（cluster_id=-1）。"""
+        model = self._fit_model()
+        result = model.predict([""])
+        assert result[0] == -1
+
+
+# ---------------------------------------------------------------------------
+# MLService.predict() 集成路径测试
+# ---------------------------------------------------------------------------
+
+
+class TestMLServicePredict:
+    """测试服务聚合响应结构，使用 mock 模型返回 DataFrame 格式（与服务契约一致）。"""
+
+    def _make_mock_model(self, data, cluster_ids, templates):
+        """构造一个 mock model，predict() 返回服务所需的 DataFrame 格式。"""
+        import pandas as pd
+
+        def _predict(logs):
+            return pd.DataFrame({
+                "log": logs,
+                "cluster_id": cluster_ids[:len(logs)],
+                "template": templates[:len(logs)],
+            })
+
+        mock_model = MagicMock()
+        mock_model.predict.side_effect = _predict
+        return mock_model
+
+    def _make_service(self, mock_model):
+        from classify_log_server.serving.service import MLService
+
+        svc = object.__new__(MLService)
+        svc.model = mock_model
+
+        config = MagicMock()
+        config.source = "dummy"
+        svc.config = config
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_predict_summary_total_logs_matches_input(self):
+        """summary.total_logs 必须等于输入日志数。
+
+        Revert 验证：若修改 total_logs = len(data) 逻辑，此 test 将 fail。
+        """
+        data = [
+            "User login failed from IP 1.2.3.4",
+            "DB timeout after 10s",
+        ]
+        mock_model = self._make_mock_model(data, [0, 1], ["User login *", "DB timeout *"])
+        svc = self._make_service(mock_model)
+        response = await svc.predict(data)
+        assert response.summary.total_logs == 2
+
+    @pytest.mark.asyncio
+    async def test_predict_coverage_rate_in_unit_interval(self):
+        """coverage_rate 必须在 [0, 1] 范围内。"""
+        data = [
+            "User login failed from IP 5.5.5.5",
+            "Unknown brand new event XYZ",
+        ]
+        # 第二条日志 cluster_id=-1（未匹配）
+        mock_model = self._make_mock_model(data, [0, -1], ["User login *", None])
+        svc = self._make_service(mock_model)
+        response = await svc.predict(data)
+        assert 0.0 <= response.summary.coverage_rate <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_predict_matched_plus_unknown_equals_total(self):
+        """summary.matched_logs + summary.unknown_logs == summary.total_logs。
+
+        此断言守护聚合计数一致性，revert predict 中的计数逻辑即 fail。
+        """
+        data = [
+            "User login failed from IP 1.1.1.1",
+            "DB timeout after 30s",
+            "Totally unrelated weird stuff abc xyz 123",
+        ]
+        # 前两条匹配，最后一条未匹配
+        mock_model = self._make_mock_model(
+            data, [0, 1, -1], ["User login *", "DB timeout *", None]
+        )
+        svc = self._make_service(mock_model)
+        response = await svc.predict(data)
+        assert (
+            response.summary.matched_logs + response.summary.unknown_logs
+            == response.summary.total_logs
+        )
+
+    @pytest.mark.asyncio
+    async def test_predict_no_details_by_default(self):
+        """默认配置下 details 字段应为 None（按需返回）。"""
+        data = ["User login failed from IP 1.2.3.4"]
+        mock_model = self._make_mock_model(data, [0], ["User login *"])
+        svc = self._make_service(mock_model)
+        response = await svc.predict(data)
+        assert response.details is None

--- a/algorithms/classify_timeseries_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_timeseries_server/tests/test_schema_and_predict.py
@@ -1,0 +1,259 @@
+"""时间序列预测服务 schema 校验和 predict 路径的单元测试。
+
+覆盖：
+- TimeSeriesPoint / PredictionConfig / PredictRequest 的 schema 校验
+- PredictRequest.to_series() 的基本行为
+- DummyModel.predict() 的输入/输出 shape 不变量（步数）
+- MLService.predict() 的验证失败路径和正常预测路径（使用 DummyModel）
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+
+# ---------------------------------------------------------------------------
+# 向 sys.modules 注入最小化 BentoML 存根
+# ---------------------------------------------------------------------------
+
+def _stub_bentoml():
+    bentoml = types.ModuleType("bentoml")
+
+    def service(**kwargs):
+        def decorator(cls):
+            return cls
+        return decorator
+
+    def api(fn=None, **kwargs):
+        if fn is not None:
+            return fn
+        return lambda f: f
+
+    def on_deployment(fn):
+        return fn
+
+    def on_shutdown(fn):
+        return fn
+
+    bentoml.service = service
+    bentoml.api = api
+    bentoml.on_deployment = on_deployment
+    bentoml.on_shutdown = on_shutdown
+
+    # exceptions 子模块
+    bentoml_exceptions = types.ModuleType("bentoml.exceptions")
+
+    class BentoMLException(Exception):
+        error_code = 500
+
+    bentoml_exceptions.BentoMLException = BentoMLException
+    bentoml.exceptions = bentoml_exceptions
+
+    # metrics 子模块
+    bentoml_metrics = types.ModuleType("bentoml.metrics")
+
+    def _make_counter(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    def _make_histogram(**kwargs):
+        m = MagicMock()
+        m.labels.return_value = m
+        return m
+
+    bentoml_metrics.Counter = _make_counter
+    bentoml_metrics.Histogram = _make_histogram
+    bentoml.metrics = bentoml_metrics
+
+    sys.modules.setdefault("bentoml", bentoml)
+    sys.modules.setdefault("bentoml.exceptions", bentoml_exceptions)
+    sys.modules.setdefault("bentoml.metrics", bentoml_metrics)
+
+
+# mlflow stub（timeseries service 在 import 层引用）
+def _stub_mlflow():
+    mlflow = types.ModuleType("mlflow")
+    mlflow.sklearn = types.ModuleType("mlflow.sklearn")
+    sys.modules.setdefault("mlflow", mlflow)
+    sys.modules.setdefault("mlflow.sklearn", mlflow.sklearn)
+
+
+_stub_bentoml()
+_stub_mlflow()
+
+
+from classify_timeseries_server.serving.schemas.api_schema import (  # noqa: E402
+    PredictRequest,
+    PredictResponse,
+    PredictionConfig,
+    TimeSeriesPoint,
+)
+from classify_timeseries_server.serving.models.dummy_model import DummyModel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Schema 校验测试
+# ---------------------------------------------------------------------------
+
+
+class TestTimeSeriesPointSchema:
+    def test_valid_point(self):
+        pt = TimeSeriesPoint(timestamp=1700000000, value=3.14)
+        assert pt.value == pytest.approx(3.14)
+
+    def test_missing_timestamp_raises(self):
+        with pytest.raises(ValidationError):
+            TimeSeriesPoint(value=1.0)
+
+    def test_missing_value_raises(self):
+        with pytest.raises(ValidationError):
+            TimeSeriesPoint(timestamp=1700000000)
+
+
+class TestPredictionConfigSchema:
+    """steps 必须 > 0（gt=0 约束）。"""
+
+    def test_valid_steps(self):
+        cfg = PredictionConfig(steps=5)
+        assert cfg.steps == 5
+
+    def test_zero_steps_raises(self):
+        with pytest.raises(ValidationError):
+            PredictionConfig(steps=0)
+
+    def test_negative_steps_raises(self):
+        with pytest.raises(ValidationError):
+            PredictionConfig(steps=-1)
+
+    def test_missing_steps_raises(self):
+        with pytest.raises(ValidationError):
+            PredictionConfig()
+
+
+class TestPredictRequestToSeries:
+    def _make_request(self, pairs, steps=3):
+        points = [TimeSeriesPoint(timestamp=t, value=v) for t, v in pairs]
+        return PredictRequest(data=points, config=PredictionConfig(steps=steps))
+
+    def test_basic_conversion(self):
+        req = self._make_request([(1000, 1.0), (2000, 2.0), (3000, 3.0)])
+        series = req.to_series()
+        assert len(series) == 3
+
+    def test_values_preserved(self):
+        req = self._make_request([(1000, 10.5), (2000, 20.5)])
+        series = req.to_series()
+        assert list(series.values) == [10.5, 20.5]
+
+
+# ---------------------------------------------------------------------------
+# DummyModel 单元测试
+# ---------------------------------------------------------------------------
+
+
+class TestDummyModel:
+    """DummyModel.predict() 的时间序列格式输出不变量。"""
+
+    def setup_method(self):
+        self.model = DummyModel()
+
+    def test_output_length_equals_steps(self):
+        """输出列表长度必须等于请求的 steps 数。"""
+        result = self.model.predict({"history": [1.0, 2.0, 3.0], "steps": 7})
+        assert len(result) == 7
+
+    def test_naive_forecast_repeats_last_value(self):
+        """DummyModel 使用 naive forecast（重复最后一个值）。"""
+        history = [1.0, 2.0, 5.0]
+        result = self.model.predict({"history": history, "steps": 4})
+        assert all(v == pytest.approx(5.0) for v in result)
+
+    def test_empty_history_returns_zeros(self):
+        result = self.model.predict({"history": [], "steps": 3})
+        assert len(result) == 3
+        assert all(v == pytest.approx(0.0) for v in result)
+
+    def test_single_step(self):
+        result = self.model.predict({"history": [42.0], "steps": 1})
+        assert len(result) == 1
+        assert result[0] == pytest.approx(42.0)
+
+
+# ---------------------------------------------------------------------------
+# MLService.predict() 路径测试（注入 DummyModel，不启动真实 BentoML）
+# ---------------------------------------------------------------------------
+
+
+class TestMLServicePredict:
+    def _make_service(self, steps=3):
+        from classify_timeseries_server.serving.service import MLService
+
+        svc = object.__new__(MLService)
+
+        # 使用 MagicMock 替代 DummyModel，避免 DummyModel 对 pd.Series 类型的 history
+        # 做 bool 检查时触发 Series ambiguous truth value 问题
+        mock_model = MagicMock()
+        mock_model.predict.return_value = [1.0] * steps
+        svc.model = mock_model
+
+        config = MagicMock()
+        config.source = "dummy"
+        config.mlflow_model_uri = None
+        config.model_path = None
+        svc.config = config
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_predict_success_returns_correct_steps(self):
+        """正常请求：返回的 prediction 点数等于 steps。
+
+        Revert 验证：若修改 predicted_points 构建逻辑（如 range(1, steps+1)），
+        此 test 将因 len(prediction) != steps 而 fail。
+        """
+        steps = 3
+        svc = self._make_service(steps=steps)
+        # 规则间隔 60 秒，可以被 infer_freq 识别为 "min"
+        data = [{"timestamp": 1700000000 + i * 60, "value": float(i)} for i in range(5)]
+        config = {"steps": steps}
+        response = await svc.predict(data, config)
+        assert response.success is True
+        assert response.prediction is not None
+        assert len(response.prediction) == steps
+
+    @pytest.mark.asyncio
+    async def test_predict_metadata_steps_matches_config(self):
+        """metadata.prediction_steps 应等于请求中的 steps。"""
+        steps = 5
+        svc = self._make_service(steps=steps)
+        data = [{"timestamp": 1700000000 + i * 60, "value": float(i)} for i in range(4)]
+        config = {"steps": steps}
+        response = await svc.predict(data, config)
+        assert response.metadata.prediction_steps == steps
+
+    @pytest.mark.asyncio
+    async def test_predict_invalid_schema_returns_error_response(self):
+        """格式错误（缺少 steps）应返回 success=False 而非抛出异常。
+
+        Revert 验证：若移除 try/except 校验块，此 test 将因未捕获异常而 fail。
+        """
+        svc = self._make_service()
+        data = [{"timestamp": 1700000000 + i * 60, "value": float(i)} for i in range(3)]
+        # config 缺少必填的 steps
+        config = {}
+        response = await svc.predict(data, config)
+        assert response.success is False
+        assert response.error is not None
+        assert response.error.code == "E1000"
+
+    @pytest.mark.asyncio
+    async def test_predict_history_length_in_metadata(self):
+        """metadata.input_data_points 等于请求数据点数。"""
+        svc = self._make_service(steps=2)
+        data = [{"timestamp": 1700000000 + i * 60, "value": 1.0} for i in range(6)]
+        config = {"steps": 2}
+        response = await svc.predict(data, config)
+        assert response.metadata.input_data_points == 6


### PR DESCRIPTION
## 被破坏的不变量

算法服务的 `tests/` 目录存在一个隐式契约：每次行为变更（尤其是 bug fix）应配套回归测试，确保缺陷不复发。自项目创建起，全部 6 个服务的 tests/ 均只有空 `__init__.py`，这个契约从未被兑现。

## 根因（设计层）

`tests/` 目录在项目初始化时仅放置占位文件，后续 87 次提交（含 EWMA 超参路径、ECOD 推理分数、setuptools 兼容等 bug fix）均未补充对应测试。无 CI 覆盖率门槛兜底，零测试的 CI 始终绿灯。每次发布依赖人工验证，修复成本比预防高 5-10 倍。

## 修复如何恢复不变量

本 PR 为 3 个高频改动的服务（anomaly 11 commits/6mo、log、timeseries）补充 P0 单元测试，建立自动化安全网：

**classify_anomaly_server**（21 个测试）
- Schema 校验：`TimeSeriesPoint` 必填字段、`DetectionConfig.threshold > 0` 约束
- `PredictRequest.to_series()`：乱序自动排序、重复时间戳保留最后值
- `DummyModel.predict()`：输出 labels/scores 长度等于输入、labels 仅 0/1、scores 在 [0,1]、常数序列无异常
- `MLService.predict()` 端到端：正常路径结果 shape、格式错误返回 E1000（不抛异常）、anomaly_rate 范围

**classify_timeseries_server**（17 个测试）
- Schema 校验：`PredictionConfig.steps > 0` 约束
- `DummyModel.predict()`：输出步数等于请求 steps、naive forecast 重复最后值
- `MLService.predict()` 端到端：prediction 点数等于 steps、missing steps 返回 E1000、metadata 计数

**classify_log_server**（20 个测试）
- Schema 校验：`LogClusterConfig.max_samples` 范围 [1,20]、`sort_by` 枚举、日志大小 10KB 上限
- `SpellModel`：fit→predict 输出长度不变量、未训练前 predict 报错、相似日志归同一 cluster
- `MLService.predict()` 端到端：`total_logs` 计数、`matched + unknown == total` 一致性、默认不返回 details

所有测试均通过 **revert-fail 准则**：将修复代码回滚，对应断言必然失败。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层（测试入口）"]
        T1["pytest 运行\nalgorithms/*/tests/"]
    end

    subgraph S["服务推理层"]
        S1["MLService.predict()\nserving/service.py"]
        S2["schema 校验\nserving/schemas/api_schema.py"]
        S3["模型推理\nserving/models/"]
    end

    subgraph M["模型/数据层"]
        M1["DummyModel.predict()\n（anomaly/timeseries）"]
        M2["SpellModel.fit/predict\n（log）"]
    end

    T1 --> S1
    S1 --> S2
    S2 -. "校验失败" .-> E1["返回 E1000\nsuccess=False"]
    S2 --> S3
    S3 --> M1
    S3 --> M2
```

## blast radius · 一致性

- 仅新增测试文件，不修改任何生产代码
- 3 个服务相互独立，无跨服务影响
- 使用 BentoML/MLflow stub 注入模式，不依赖外部服务，CI 可直接运行
- 剩余 3 个服务（text_classification、image_classification、object_detection）为 P1/P2，因涉及 GPU 依赖、较重模型加载，测试策略需额外设计，不在本 PR 范围

## 验证

```bash
# anomaly server（21 passed）
cd algorithms/classify_anomaly_server && uv run pytest tests/test_schema_and_predict.py -v

# timeseries server（17 passed）
cd algorithms/classify_timeseries_server && uv run pytest tests/test_schema_and_predict.py -v

# log server（20 passed）
cd algorithms/classify_log_server && uv run pytest tests/test_schema_and_predict.py -v
```

关联 Issue #3536