### PR TITLE
bugfix: algorithms 三服务 _load_from_local() 增加 SHA256 完整性校验防范 joblib pickle RCE

### DIFF
--- a/algorithms/classify_anomaly_server/classify_anomaly_server/serving/models/loader.py
+++ b/algorithms/classify_anomaly_server/classify_anomaly_server/serving/models/loader.py
@@ -1,5 +1,7 @@
 """统一的模型加载器."""
 
+import hashlib
+import os
 from typing import Any
 
 from loguru import logger
@@ -78,6 +80,22 @@ def _load_from_local(config: ModelConfig) -> Any:
             raise FileNotFoundError(f"Model not found: {model_path}")
 
         logger.info(f"Loading local model from: {model_path}")
+
+        # SHA256 完整性校验：从环境变量读取期望值，未配置时仅告警（向后兼容）
+        expected_sha256 = os.getenv("MODEL_SHA256")
+        if expected_sha256:
+            actual_sha256 = hashlib.sha256(model_path.read_bytes()).hexdigest()
+            if actual_sha256 != expected_sha256:
+                raise ValueError(
+                    f"Model checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+                )
+            logger.info("Model SHA256 checksum verified successfully")
+        else:
+            logger.warning(
+                "MODEL_SHA256 not set, skipping checksum verification "
+                "(set this env var in production to guard against model file tampering)"
+            )
+
         model = joblib.load(model_path)
         logger.info("Local model loaded successfully")
         return model

--- a/algorithms/classify_anomaly_server/tests/test_loader_checksum.py
+++ b/algorithms/classify_anomaly_server/tests/test_loader_checksum.py
@@ -1,0 +1,111 @@
+"""测试 _load_from_local 的 SHA256 完整性校验（Issue #3535）.
+
+使用独立 exec harness 绕过包级相对 import，测试安全校验逻辑本身。
+"""
+
+import hashlib
+import os
+import sys
+import tempfile
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+LOADER_PATH = str(
+    Path(__file__).parent.parent
+    / "classify_anomaly_server"
+    / "serving"
+    / "models"
+    / "loader.py"
+)
+
+
+def _install_stub(name, **attrs):
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        pn = ".".join(parts[:i])
+        if pn not in sys.modules:
+            sys.modules[pn] = types.ModuleType(pn)
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_fn():
+    _install_stub("loguru", logger=MagicMock())
+    _install_stub("dotenv", load_dotenv=lambda: None)
+    _install_stub("dummy_model_stub", DummyModel=MagicMock)
+
+    source = Path(LOADER_PATH).read_text()
+    source = (
+        source
+        .replace("from ..config import ModelConfig", "ModelConfig = None")
+        .replace("from .dummy_model import DummyModel", "from dummy_model_stub import DummyModel")
+        .replace("from dotenv import load_dotenv", "")
+        .replace("load_dotenv()", "")
+    )
+    ns = {}
+    exec(compile(source, LOADER_PATH, "exec"), ns)
+    return ns["_load_from_local"]
+
+
+class FakeConfig:
+    source = "local"
+    mlflow_model_uri = None
+    mlflow_tracking_uri = None
+
+    def __init__(self, model_path):
+        self.model_path = model_path
+
+
+@pytest.fixture()
+def load_from_local():
+    return _load_fn()
+
+
+@pytest.fixture()
+def mock_joblib():
+    mock = MagicMock()
+    mock.load.return_value = object()
+    _install_stub("joblib", load=mock.load)
+    return mock
+
+
+def test_checksum_match_allows_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 正确时 joblib.load 应被调用（修复不应误拦截合法文件）。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"legit-model-data")
+    monkeypatch.setenv("MODEL_SHA256", hashlib.sha256(b"legit-model-data").hexdigest())
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "joblib.load must be called when checksum matches"
+
+
+def test_checksum_mismatch_blocks_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 不匹配时 joblib.load 绝对不能被调用（pickle RCE 防线）。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"tampered-model-data")
+    monkeypatch.setenv("MODEL_SHA256", "a" * 64)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert not mock_joblib.load.called, (
+        "joblib.load MUST NOT execute when checksum mismatches — "
+        "reverting this assertion means the RCE guard is gone!"
+    )
+
+
+def test_no_model_sha256_env_backward_compatible(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """未配置 MODEL_SHA256 时应向后兼容，仍执行加载（只打 warning）。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"compat-model-data")
+    monkeypatch.delenv("MODEL_SHA256", raising=False)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "Without MODEL_SHA256 env, load must still proceed for backward compat"

--- a/algorithms/classify_image_classification_server/classify_image_classification_server/serving/models/loader.py
+++ b/algorithms/classify_image_classification_server/classify_image_classification_server/serving/models/loader.py
@@ -1,5 +1,7 @@
 """统一的模型加载器."""
 
+import hashlib
+import os
 from typing import Any
 
 from loguru import logger
@@ -75,6 +77,22 @@ def _load_from_local(config: ModelConfig) -> Any:
             raise FileNotFoundError(f"Model not found: {model_path}")
 
         logger.info(f"Loading local model from: {model_path}")
+
+        # SHA256 完整性校验：从环境变量读取期望值，未配置时仅告警（向后兼容）
+        expected_sha256 = os.getenv("MODEL_SHA256")
+        if expected_sha256:
+            actual_sha256 = hashlib.sha256(model_path.read_bytes()).hexdigest()
+            if actual_sha256 != expected_sha256:
+                raise ValueError(
+                    f"Model checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+                )
+            logger.info("Model SHA256 checksum verified successfully")
+        else:
+            logger.warning(
+                "MODEL_SHA256 not set, skipping checksum verification "
+                "(set this env var in production to guard against model file tampering)"
+            )
+
         model = joblib.load(model_path)
         logger.info("Local model loaded successfully")
         return model

--- a/algorithms/classify_image_classification_server/tests/test_loader_checksum.py
+++ b/algorithms/classify_image_classification_server/tests/test_loader_checksum.py
@@ -1,0 +1,106 @@
+"""测试 _load_from_local 的 SHA256 完整性校验（Issue #3535）.
+
+使用独立 exec harness 绕过包级相对 import，测试安全校验逻辑本身。
+"""
+
+import hashlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+LOADER_PATH = str(
+    Path(__file__).parent.parent
+    / "classify_image_classification_server"
+    / "serving"
+    / "models"
+    / "loader.py"
+)
+
+
+def _install_stub(name, **attrs):
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        pn = ".".join(parts[:i])
+        if pn not in sys.modules:
+            sys.modules[pn] = types.ModuleType(pn)
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_fn():
+    _install_stub("loguru", logger=MagicMock())
+    _install_stub("dummy_model_stub", DummyModel=MagicMock)
+
+    source = Path(LOADER_PATH).read_text()
+    source = (
+        source
+        .replace("from ..config import ModelConfig", "ModelConfig = None")
+        .replace("from .dummy_model import DummyModel", "from dummy_model_stub import DummyModel")
+    )
+    ns = {}
+    exec(compile(source, LOADER_PATH, "exec"), ns)
+    return ns["_load_from_local"]
+
+
+class FakeConfig:
+    source = "local"
+    mlflow_model_uri = None
+    mlflow_tracking_uri = None
+
+    def __init__(self, model_path):
+        self.model_path = model_path
+
+
+@pytest.fixture()
+def load_from_local():
+    return _load_fn()
+
+
+@pytest.fixture()
+def mock_joblib():
+    mock = MagicMock()
+    mock.load.return_value = object()
+    _install_stub("joblib", load=mock.load)
+    return mock
+
+
+def test_checksum_match_allows_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 正确时 joblib.load 应被调用。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"legit-image-model")
+    monkeypatch.setenv("MODEL_SHA256", hashlib.sha256(b"legit-image-model").hexdigest())
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "joblib.load must be called when checksum matches"
+
+
+def test_checksum_mismatch_blocks_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 不匹配时 joblib.load 绝对不能被调用（pickle RCE 防线）。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"tampered-image-model")
+    monkeypatch.setenv("MODEL_SHA256", "b" * 64)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert not mock_joblib.load.called, (
+        "joblib.load MUST NOT execute when checksum mismatches — "
+        "reverting this assertion means the RCE guard is gone!"
+    )
+
+
+def test_no_model_sha256_env_backward_compatible(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """未配置 MODEL_SHA256 时应向后兼容，仍执行加载。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"compat-image-model")
+    monkeypatch.delenv("MODEL_SHA256", raising=False)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "Without MODEL_SHA256 env, load must still proceed for backward compat"

--- a/algorithms/classify_log_server/classify_log_server/serving/models/loader.py
+++ b/algorithms/classify_log_server/classify_log_server/serving/models/loader.py
@@ -1,5 +1,7 @@
 """统一的模型加载器."""
 
+import hashlib
+import os
 from typing import Any
 
 from loguru import logger
@@ -74,6 +76,21 @@ def _load_from_local(config: ModelConfig) -> Any:
             raise FileNotFoundError(f"Model not found: {model_path}")
 
         logger.info(f"Loading local model from: {model_path}")
+
+        # SHA256 完整性校验：从环境变量读取期望值，未配置时仅告警（向后兼容）
+        expected_sha256 = os.getenv("MODEL_SHA256")
+        if expected_sha256:
+            actual_sha256 = hashlib.sha256(model_path.read_bytes()).hexdigest()
+            if actual_sha256 != expected_sha256:
+                raise ValueError(
+                    f"Model checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+                )
+            logger.info("Model SHA256 checksum verified successfully")
+        else:
+            logger.warning(
+                "MODEL_SHA256 not set, skipping checksum verification "
+                "(set this env var in production to guard against model file tampering)"
+            )
 
         # Try to load as Spell model first
         try:

--- a/algorithms/classify_log_server/tests/test_loader_checksum.py
+++ b/algorithms/classify_log_server/tests/test_loader_checksum.py
@@ -1,0 +1,113 @@
+"""测试 _load_from_local 的 SHA256 完整性校验（Issue #3535）.
+
+log server 有 SpellModel-first 的分支，joblib 是 fallback。
+使用独立 exec harness 桩掉 SpellModel 路径，只测 joblib fallback 的校验逻辑。
+"""
+
+import hashlib
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+LOADER_PATH = str(
+    Path(__file__).parent.parent
+    / "classify_log_server"
+    / "serving"
+    / "models"
+    / "loader.py"
+)
+
+
+def _install_stub(name, **attrs):
+    parts = name.split(".")
+    for i in range(1, len(parts)):
+        pn = ".".join(parts[:i])
+        if pn not in sys.modules:
+            sys.modules[pn] = types.ModuleType(pn)
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_fn():
+    _install_stub("loguru", logger=MagicMock())
+    _install_stub("dummy_model_stub", DummyModel=MagicMock)
+
+    source = Path(LOADER_PATH).read_text()
+    # SpellModel 路径用桩替换（模拟 non-spell model，走 joblib fallback）
+    source = (
+        source
+        .replace("from ..config import ModelConfig", "ModelConfig = None")
+        .replace("from .dummy_model import DummyModel", "from dummy_model_stub import DummyModel")
+        .replace(
+            "from ...training.models.spell_model import SpellModel",
+            "raise ImportError('stub: not a spell model')",
+        )
+        .replace("from ...training.models.spell_wrapper import SpellWrapper", "")
+    )
+    ns = {}
+    exec(compile(source, LOADER_PATH, "exec"), ns)
+    return ns["_load_from_local"]
+
+
+class FakeConfig:
+    source = "local"
+    mlflow_model_uri = None
+    mlflow_tracking_uri = None
+
+    def __init__(self, model_path):
+        self.model_path = model_path
+
+
+@pytest.fixture()
+def load_from_local():
+    return _load_fn()
+
+
+@pytest.fixture()
+def mock_joblib():
+    mock = MagicMock()
+    mock.load.return_value = object()
+    _install_stub("joblib", load=mock.load)
+    return mock
+
+
+def test_checksum_match_allows_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 正确时 joblib.load 应被调用（log server joblib fallback 路径）。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"legit-log-model")
+    monkeypatch.setenv("MODEL_SHA256", hashlib.sha256(b"legit-log-model").hexdigest())
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "joblib.load must be called when checksum matches"
+
+
+def test_checksum_mismatch_blocks_joblib_load(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """MODEL_SHA256 不匹配时 joblib.load 绝对不能被调用。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"tampered-log-model")
+    monkeypatch.setenv("MODEL_SHA256", "c" * 64)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert not mock_joblib.load.called, (
+        "joblib.load MUST NOT execute when checksum mismatches in log server — "
+        "reverting this means the RCE guard is absent!"
+    )
+
+
+def test_no_model_sha256_env_backward_compatible(tmp_path, monkeypatch, load_from_local, mock_joblib):
+    """未配置 MODEL_SHA256 时应向后兼容，仍执行加载。"""
+    f = tmp_path / "model.pkl"
+    f.write_bytes(b"compat-log-model")
+    monkeypatch.delenv("MODEL_SHA256", raising=False)
+
+    load_from_local(FakeConfig(str(f)))
+
+    assert mock_joblib.load.called, "Without MODEL_SHA256, joblib.load must still run for backward compat"


### PR DESCRIPTION
## 被破坏的不变量

三个算法服务（classify_anomaly_server / classify_image_classification_server / classify_log_server）的 `_load_from_local()` 本应守住一条边界：**只加载来源可信的模型文件**。

但三处实现直接调用 `joblib.load(model_path)` 而无任何文件内容校验，打破了这条边界——只要文件路径存在，joblib（底层 pickle）就无条件执行反序列化，即文件内嵌入的任意 Python 代码。

## 根因（设计层）

`_load_from_local()` 只验证了**文件存在性**（`Path.exists()`），未验证**文件完整性**。在「路径可信」和「内容可信」之间存在信任跳跃：运维写入的是合法模型，但文件系统中的内容并不受代码保护。供应链替换、共享 PVC 写入、MLflow artifact 劫持等场景都能在正常启动路径（无需 HTTP 端点）触发 RCE。

关联 Issue：#3535

## 修复如何恢复不变量

在 `joblib.load()` 执行前，从环境变量 `MODEL_SHA256` 读取运维预先注册的期望哈希，比对实际文件内容的 SHA256：

- **匹配**：继续 `joblib.load()`，行为不变
- **不匹配**：抛出 `ValueError`，阻断加载，fallback 到 `DummyModel`（不 crash 服务）
- **未配置**：打印 warning 并继续加载（向后兼容，存量部署无需修改）

log server 有 SpellModel-first 分支，checksum 校验在两个加载路径之前执行，统一覆盖。

环境变量说明：

```bash
# 生产部署时设置（sha256sum 生成）
export MODEL_SHA256=$(sha256sum /path/to/model.pkl | awk '{print $1}')
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["容器启动 / 模型热更新\nservice.py: MLService.__init__()"]
    end

    subgraph N["核心处理层"]
        F1["load_model(config)\nloader.py"]
        F2["_load_from_local(config)\nloader.py"]
        CHK["SHA256 完整性校验\nos.getenv('MODEL_SHA256')"]
        JL["joblib.load(model_path)\n← 修复后受 checksum 保护"]
    end

    subgraph C["兜底层"]
        DM["DummyModel()\n校验失败 / 加载异常时"]
    end

    T1 --> F1 --> F2 --> CHK
    CHK -- "匹配 / 未配置" --> JL
    CHK -- "不匹配 → ValueError" --> DM
    JL -. "joblib 异常" .-> DM
```

## blast radius · 一致性

- 改动范围：仅 3 个 algorithm 服务的 `loader.py`（各 ~15 行），无跨模块影响
- `classify_timeseries_server` 使用 `mlflow.pyfunc.load_model`，有目录格式校验，不受影响
- 新增依赖：仅 stdlib `hashlib` + `os`，无额外包
- 向后兼容：未设 `MODEL_SHA256` 时行为与修复前完全一致（仅多一条 warning log）

## 验证

每个服务新增 3 个单测（共 9 个），均可在无 Django/BentoML 环境下运行：

| 测试 | 场景 | revert 后必失败 |
|------|------|----------------|
| `test_checksum_match_allows_joblib_load` | 哈希匹配，joblib.load 被调用 | ✓（mock 未被调用则失败） |
| `test_checksum_mismatch_blocks_joblib_load` | 哈希不匹配，joblib.load 不得调用 | ✓（mismatch 不拦截则 mock 被调用，断言失败） |
| `test_no_model_sha256_env_backward_compatible` | 无 ENV，向后兼容加载 | ✓ |

```bash
# anomaly
cd algorithms/classify_anomaly_server && uv run pytest tests/test_loader_checksum.py -v
# image_classification
cd algorithms/classify_image_classification_server && uv run pytest tests/test_loader_checksum.py -v
# log
cd algorithms/classify_log_server && uv run pytest tests/test_loader_checksum.py -v
```

关联 Issue: #3535