### PR TITLE
bugfix: [mobile] Rust SSE 流任务引入 oneshot 取消令牌，中止对话立即停止连接

### DIFF
--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -216,7 +216,7 @@ pub async fn api_stream_proxy(
     // 创建取消通道：JS 侧调用 cancel_stream 时，通过 tx 发送取消信号
     let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
     {
-        let mut map = registry.0.lock().unwrap();
+        let mut map = registry.0.lock().unwrap_or_else(|e| e.into_inner());
         map.insert(stream_id.clone(), cancel_tx);
     }
 
@@ -238,7 +238,7 @@ pub async fn api_stream_proxy(
                     });
                     // 清理注册表后退出
                     let reg = app_clone.state::<StreamRegistry>();
-                    reg.0.lock().unwrap().remove(&stream_id_clone);
+                    reg.0.lock().unwrap_or_else(|e| e.into_inner()).remove(&stream_id_clone);
                     return;
                 }
 
@@ -253,6 +253,7 @@ pub async fn api_stream_proxy(
 
                 loop {
                     let chunk_result = tokio::select! {
+                        biased; // 优先检查取消信号，确保取消语义立即生效
                         // 收到取消信号，立即终止读循环
                         _ = &mut cancel_rx => {
                             log::info!("🛑 [Tauri-Stream-{}] Cancelled by client", request_id);
@@ -385,7 +386,7 @@ pub async fn api_stream_proxy(
                                         stream_id: stream_id_clone.clone(),
                                         error: format!("UTF-8 decode error: {}", e),
                                     });
-                                    app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
+                                    app_clone.state::<StreamRegistry>().0.lock().unwrap_or_else(|e| e.into_inner()).remove(&stream_id_clone);
                                     return;
                                 }
                             }
@@ -396,7 +397,7 @@ pub async fn api_stream_proxy(
                                 stream_id: stream_id_clone.clone(),
                                 error: format!("Stream read error: {}", e),
                             });
-                            app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
+                            app_clone.state::<StreamRegistry>().0.lock().unwrap_or_else(|e| e.into_inner()).remove(&stream_id_clone);
                             return;
                         }
                     }
@@ -421,7 +422,7 @@ pub async fn api_stream_proxy(
                 }
 
                 // 从注册表中移除
-                app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
+                app_clone.state::<StreamRegistry>().0.lock().unwrap_or_else(|e| e.into_inner()).remove(&stream_id_clone);
 
                 if cancelled {
                     log::info!("🛑 [Tauri-Stream-{}] Task exiting after cancellation", request_id);
@@ -435,7 +436,7 @@ pub async fn api_stream_proxy(
             }
             Err(err) => {
                 log::error!("❌ [Tauri-Stream-{}] HTTP request failed: {}", request_id, err);
-                app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
+                app_clone.state::<StreamRegistry>().0.lock().unwrap_or_else(|e| e.into_inner()).remove(&stream_id_clone);
                 let _ = app_clone.emit("stream-error", StreamError {
                     stream_id: stream_id_clone,
                     error: format!("HTTP request failed: {}", err),
@@ -454,7 +455,7 @@ pub async fn cancel_stream(
     registry: State<'_, StreamRegistry>,
     stream_id: String,
 ) -> Result<(), String> {
-    let mut map = registry.0.lock().unwrap();
+    let mut map = registry.0.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(tx) = map.remove(&stream_id) {
         let _ = tx.send(());
         log::info!("🛑 [cancel_stream] Cancelled stream: {}", &stream_id[..8.min(stream_id.len())]);

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -1,7 +1,12 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tauri::{command, AppHandle, Emitter};
+use std::sync::Mutex;
+use tauri::{command, AppHandle, Emitter, State};
 use futures_util::StreamExt;
+use tokio::sync::oneshot;
+
+/// 每个活跃 SSE 流的取消发送端，keyed by stream_id
+pub struct StreamRegistry(pub Mutex<HashMap<String, oneshot::Sender<()>>>);
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiRequest {
@@ -166,11 +171,12 @@ pub async fn simple_api_proxy(
 #[command]
 pub async fn api_stream_proxy(
     app: AppHandle,
+    registry: State<'_, StreamRegistry>,
     request: ApiRequest,
 ) -> Result<String, ApiError> {
     let stream_id = uuid::Uuid::new_v4().to_string();
     let request_id = stream_id[..8].to_string();
-    
+
     log::info!("🌊 [Tauri-Stream-{}] START: {} {}", request_id, request.method, request.url);
 
     // 创建 HTTP 客户端
@@ -207,9 +213,16 @@ pub async fn api_stream_proxy(
         req_builder = req_builder.body(body.clone());
     }
 
+    // 创建取消通道：JS 侧调用 cancel_stream 时，通过 tx 发送取消信号
+    let (cancel_tx, mut cancel_rx) = oneshot::channel::<()>();
+    {
+        let mut map = registry.0.lock().unwrap();
+        map.insert(stream_id.clone(), cancel_tx);
+    }
+
     let stream_id_clone = stream_id.clone();
     let app_clone = app.clone();
-    
+
     // 在后台任务中处理流式响应
     tauri::async_runtime::spawn(async move {
         match req_builder.send().await {
@@ -223,6 +236,9 @@ pub async fn api_stream_proxy(
                         stream_id: stream_id_clone.clone(),
                         error: error_msg,
                     });
+                    // 清理注册表后退出
+                    let reg = app_clone.state::<StreamRegistry>();
+                    reg.0.lock().unwrap().remove(&stream_id_clone);
                     return;
                 }
 
@@ -233,8 +249,23 @@ pub async fn api_stream_proxy(
                 let mut buffer = String::new();
                 let mut chunk_count = 0;
                 let mut pending_data_prefix = false; // 标记是否有待处理的 data: 前缀
+                let mut cancelled = false;
 
-                while let Some(chunk_result) = stream.next().await {
+                loop {
+                    let chunk_result = tokio::select! {
+                        // 收到取消信号，立即终止读循环
+                        _ = &mut cancel_rx => {
+                            log::info!("🛑 [Tauri-Stream-{}] Cancelled by client", request_id);
+                            cancelled = true;
+                            break;
+                        }
+                        item = stream.next() => {
+                            match item {
+                                Some(r) => r,
+                                None => break, // 流自然结束
+                            }
+                        }
+                    };
                     match chunk_result {
                         Ok(chunk) => {
                             chunk_count += 1;
@@ -354,6 +385,7 @@ pub async fn api_stream_proxy(
                                         stream_id: stream_id_clone.clone(),
                                         error: format!("UTF-8 decode error: {}", e),
                                     });
+                                    app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
                                     return;
                                 }
                             }
@@ -364,13 +396,14 @@ pub async fn api_stream_proxy(
                                 stream_id: stream_id_clone.clone(),
                                 error: format!("Stream read error: {}", e),
                             });
+                            app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
                             return;
                         }
                     }
                 }
 
-                // 处理剩余的 buffer
-                if !buffer.trim().is_empty() {
+                // 处理剩余的 buffer（仅在非取消情况下）
+                if !cancelled && !buffer.trim().is_empty() {
                     let trimmed = buffer.trim();
                     // 确保数据行包含 data: 前缀
                     let formatted = if trimmed.starts_with("data:") {
@@ -380,22 +413,29 @@ pub async fn api_stream_proxy(
                     } else {
                         buffer.clone()
                     };
-                    
+
                     let _ = app_clone.emit("stream-chunk", StreamChunk {
                         stream_id: stream_id_clone.clone(),
                         data: format!("{}\n", formatted),
                     });
                 }
 
-                log::info!("✅ [Tauri-Stream-{}] COMPLETED: {} chunks received", request_id, chunk_count);
-                
-                // 发送流结束事件
-                let _ = app_clone.emit("stream-end", StreamEnd {
-                    stream_id: stream_id_clone,
-                });
+                // 从注册表中移除
+                app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
+
+                if cancelled {
+                    log::info!("🛑 [Tauri-Stream-{}] Task exiting after cancellation", request_id);
+                } else {
+                    log::info!("✅ [Tauri-Stream-{}] COMPLETED: {} chunks received", request_id, chunk_count);
+                    // 发送流结束事件（仅在非取消情况下）
+                    let _ = app_clone.emit("stream-end", StreamEnd {
+                        stream_id: stream_id_clone,
+                    });
+                }
             }
             Err(err) => {
                 log::error!("❌ [Tauri-Stream-{}] HTTP request failed: {}", request_id, err);
+                app_clone.state::<StreamRegistry>().0.lock().unwrap().remove(&stream_id_clone);
                 let _ = app_clone.emit("stream-error", StreamError {
                     stream_id: stream_id_clone,
                     error: format!("HTTP request failed: {}", err),
@@ -405,4 +445,21 @@ pub async fn api_stream_proxy(
     });
 
     Ok(stream_id)
+}
+
+/// 取消一个正在进行的 SSE 流式请求
+/// JS 侧在 abortStream() 中调用此命令以通知 Rust 停止读取
+#[command]
+pub async fn cancel_stream(
+    registry: State<'_, StreamRegistry>,
+    stream_id: String,
+) -> Result<(), String> {
+    let mut map = registry.0.lock().unwrap();
+    if let Some(tx) = map.remove(&stream_id) {
+        let _ = tx.send(());
+        log::info!("🛑 [cancel_stream] Cancelled stream: {}", &stream_id[..8.min(stream_id.len())]);
+    } else {
+        log::warn!("⚠️ [cancel_stream] Stream not found (already ended?): {}", &stream_id[..8.min(stream_id.len())]);
+    }
+    Ok(())
 }

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -1,17 +1,21 @@
 mod api_proxy;
 mod permissions;
 
-use api_proxy::{api_proxy, simple_api_proxy, api_stream_proxy};
+use api_proxy::{api_proxy, simple_api_proxy, api_stream_proxy, cancel_stream, StreamRegistry};
 use permissions::{check_microphone_permission, request_microphone_permission};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .manage(StreamRegistry(Mutex::new(HashMap::new())))
     .plugin(tauri_plugin_store::Builder::new().build())
     .invoke_handler(tauri::generate_handler![
       api_proxy,
       simple_api_proxy,
       api_stream_proxy,
+      cancel_stream,
       check_microphone_permission,
       request_microphone_permission
     ])

--- a/mobile/src/utils/tauriApiProxy.ts
+++ b/mobile/src/utils/tauriApiProxy.ts
@@ -275,5 +275,12 @@ export async function* tauriApiStream(
     unlistenChunk();
     unlistenEnd();
     unlistenError();
+
+    // 通知 Rust 侧取消流（若流已自然结束则 Rust 侧会静默忽略）
+    try {
+      await invoke('cancel_stream', { streamId });
+    } catch {
+      // 忽略取消命令本身的错误（如 Rust 侧已结束）
+    }
   }
 }


### PR DESCRIPTION
## 被破坏的不变量

**流式 AI 对话的生命周期契约**：当 JS 层宣告一次流（session）结束时（无论是正常结束、用户主动中止、还是页面切换），Rust 侧对应的网络连接读循环必须同步终止。当前实现违背了这一契约——JS 侧中止后 Rust 任务不知情，HTTP 连接继续被占用直到服务器关闭，连接池线性积累泄漏。

## 根因（设计层）

`tauri::async_runtime::spawn` 产生的 JoinHandle 被立即 drop，tokio 并不因此取消任务（drop JoinHandle ≠ cancel task）。JS 层的 `abortStream` 仅设置了一个本地 `aborted` 布尔标志，这个标志通过 `isAborted()` 闭包驱动 JS 侧的 `for await` 循环退出，但对 Rust 侧完全不可见。Rust 的读循环只能等服务端自然关闭 SSE 流——在 AI Agent 慢推理场景（数十秒到数分钟）下，孤儿任务累积占用 reqwest 连接池，最终新对话无法获得连接。

## 修复如何恢复不变量

为每个 SSE 流在 Rust 侧绑定一个 `tokio::sync::oneshot` 取消通道，使 JS→Rust 的取消信号路径成为一等公民：

1. **Rust（api_proxy.rs）**：
   - 新增 `StreamRegistry`（`Mutex<HashMap<stream_id, oneshot::Sender<()>>>`），作为 Tauri managed state 存活于 App 生命周期。
   - `api_stream_proxy` 为每次调用创建 `(cancel_tx, cancel_rx)`，注册 tx 到 registry。
   - 读循环改为 `tokio::select! { _ = &mut cancel_rx => { cancelled = true; break; }, item = stream.next() => ... }`——收到取消信号立即退出，不再等服务端。
   - 新增 `cancel_stream(stream_id)` Tauri IPC 命令，从 registry 取出 tx 并 `tx.send(())` 通知对应读循环。
   - 所有退出路径（正常结束、取消、HTTP 错误、解码错误）统一从 registry 移除自身，防止 sender 泄漏；取消路径跳过 `stream-end` 事件，避免 JS 侧收到假性完成通知。

2. **TypeScript（tauriApiProxy.ts）**：
   - `tauriApiStream` 生成器的 `finally` 块新增 `await invoke('cancel_stream', { streamId })`——无论正常退出、异常退出、还是 `for await` 被 `return` 中断，取消信号都会被送达 Rust 侧。若流已自然结束，`cancel_stream` 的 warn 日志静默处理，不影响正常路径。

3. **lib.rs**：注册 `StreamRegistry` managed state 和 `cancel_stream` 命令。

## 调用链

```mermaid
flowchart TD
    subgraph JS["JS 层"]
        A["ConversationManager.abortStream\nconversation.tsx:318"]
        B["aborted = true\n布尔标志"]
        C["for await 循环退出\nhandleAGUIEventStream"]
        D["tauriApiStream finally\ntauriApiProxy.ts"]
        E["invoke('cancel_stream', streamId)"]
    end

    subgraph Rust["Rust 层"]
        F["cancel_stream IPC 命令\napi_proxy.rs"]
        G["StreamRegistry.remove(stream_id)\n取出 oneshot::Sender"]
        H["tx.send(()) 取消信号"]
        I["tokio::select! 触发 cancel_rx\n读循环 break"]
        J["HTTP 连接释放\n连接池可用"]
    end

    A --> B --> C --> D --> E
    E --> F --> G --> H --> I --> J
    I -. "cancelled=true\n跳过 stream-end" .-> J
```

## blast radius · 一致性

- **影响范围**：仅 `mobile/src-tauri/`（Rust）和 `mobile/src/utils/tauriApiProxy.ts`（TS），无 server/Django/agents 变动。
- **向后兼容**：`api_stream_proxy` 签名从调用方视角不变（仍返回 `stream_id: String`）；`cancel_stream` 是纯新增命令，不影响现有调用路径。
- **边界条件**：若流在 `cancel_stream` 被调用前已自然结束，registry 中不存在对应 sender，`cancel_stream` 打 warn 日志并正常返回 `Ok(())`，JS 侧的 try/catch 静默忽略，无副作用。
- **并发安全**：`StreamRegistry` 用标准 `std::sync::Mutex`，锁粒度为单次 insert/remove，持锁时间极短，无死锁风险。

## 验证

**revert-fail 准则**：若将 `tokio::select!` 还原为原来的 `while let Some(chunk_result) = stream.next().await`，并移除 `cancel_stream` 命令，Rust 读循环将重新在中止后持续运行——测试中可通过在 `abortStream` 后检查 `StreamRegistry` 是否为空来验证（空 = 已取消，非空 = 泄漏）。

**本地验证方式**：
1. 启动 AI 流式对话，在 Rust 日志中观察 `[Tauri-Stream-XXXXXXXX] START`
2. 点击中止或切换会话
3. 观察 Rust 日志出现 `Cancelled by client`，HTTP 连接立即释放
4. 确认 `stream-end` 事件不再被触发（JS 侧不会收到假性完成回调）

关联 Issue: #3546