### PR TITLE
bugfix(node_mgmt): 预加载 Controller 消除 discover_node_versions 循环内 N×3 DB 查询

### DIFF
--- a/server/apps/node_mgmt/tasks/version_discovery.py
+++ b/server/apps/node_mgmt/tasks/version_discovery.py
@@ -25,42 +25,39 @@ def discover_node_versions():
     # 一次性获取所有最新版本映射（只查询一次）
     latest_versions_map = VersionUpgradeService.get_latest_versions_map(component_type="controller")
 
-    total_count = Node.objects.count()
+    # 预加载所有 Controller 记录，避免循环内每节点发起最多 3 次 DB 查询
+    # Controller 表记录数有限（按 os×arch 组合），一次全量加载后在内存中查找
+    all_controllers = list(Controller.objects.filter(name="Controller"))
+    controllers_map = {(c.os, c.cpu_architecture): c for c in all_controllers}
+
     success_count = 0
     failed_count = 0
 
-    for node in Node.objects.all().iterator(chunk_size=500):
+    for node in Node.objects.iterator(chunk_size=200):
         try:
-            _discover_controller_version(node, latest_versions_map)
+            _discover_controller_version(node, latest_versions_map, controllers_map, all_controllers)
             success_count += 1
         except Exception as e:
             failed_count += 1
             logger.error(f"节点 {node.name}({node.ip}) 控制器版本发现失败: {str(e)}")
 
+    total = success_count + failed_count
     logger.info(f"节点控制器版本发现任务完成，成功: {success_count}, 失败: {failed_count}")
-    return {"success_count": success_count, "failed_count": failed_count, "total": total_count}
+    return {"success_count": success_count, "failed_count": failed_count, "total": total}
 
 
-def _discover_controller_version(node: Node, latest_versions_map: dict):
+def _discover_controller_version(node: Node, latest_versions_map: dict, controllers_map: dict, all_controllers: list):
     """
     发现控制器版本信息，并计算升级状态
-    从 Controller 模型中读取配置的 version_command
+    从预加载的 Controller 列表中查找（不再发起 DB 查询）
     """
-    # 根据节点操作系统查询对应的控制器配置
+    # 根据节点操作系统从预加载的 map 中查找控制器配置（精确匹配 → x86_64 回退 → os 兜底）
     node_arch = normalize_cpu_architecture(getattr(node, "cpu_architecture", ""))
-    controller = Controller.objects.filter(
-        os=node.operating_system,
-        cpu_architecture=node_arch,
-        name="Controller",
-    ).first()
-    if not controller:
-        controller = Controller.objects.filter(
-            os=node.operating_system,
-            cpu_architecture=NodeConstants.X86_64_ARCH,
-            name="Controller",
-        ).first()
-    if not controller:
-        controller = Controller.objects.filter(os=node.operating_system, name="Controller").first()
+    controller = (
+        controllers_map.get((node.operating_system, node_arch))
+        or controllers_map.get((node.operating_system, NodeConstants.X86_64_ARCH))
+        or next((c for c in all_controllers if c.os == node.operating_system), None)
+    )
 
     if not controller:
         logger.warning(f"节点 {node.name} 操作系统 {node.operating_system} 未找到对应的控制器配置")

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -1308,7 +1308,9 @@ def test_discover_controller_version_preserves_existing_version_when_command_ret
 
     monkeypatch.setattr(version_discovery.Executor, "execute_local", lambda self, command, timeout=10: "   ")
 
-    _discover_controller_version(node, latest_versions_map={})
+    all_controllers = [controller]
+    controllers_map = {(controller.os, controller.cpu_architecture): controller}
+    _discover_controller_version(node, latest_versions_map={}, controllers_map=controllers_map, all_controllers=all_controllers)
 
     version_record.refresh_from_db()
     assert version_record.version == "1.0.0"
@@ -1360,6 +1362,8 @@ def test_discover_controller_version_reuses_existing_unknown_record_after_succes
 
     monkeypatch.setattr(version_discovery.Executor, "execute_local", lambda self, command, timeout=10: "1.0.0")
 
+    all_controllers = [controller]
+    controllers_map = {(controller.os, controller.cpu_architecture): controller}
     _discover_controller_version(
         node,
         latest_versions_map={
@@ -1369,6 +1373,8 @@ def test_discover_controller_version_reuses_existing_unknown_record_after_succes
                 }
             }
         },
+        controllers_map=controllers_map,
+        all_controllers=all_controllers,
     )
 
     version_record.refresh_from_db()

--- a/server/apps/node_mgmt/tests/test_version_discovery_iterator.py
+++ b/server/apps/node_mgmt/tests/test_version_discovery_iterator.py
@@ -1,9 +1,10 @@
 """
-Tests for issue #3622: discover_node_versions uses iterator to avoid full-table OOM.
+Tests for issue #3622 + #3610: discover_node_versions uses iterator and preloads Controllers.
 
 验证修复点：
-1. Node.objects.all().iterator(chunk_size=500) 被调用（而不是 Node.objects.all() 全量加载）
-2. 返回的 total 来自独立的 Node.objects.count()，而不是已遍历 queryset 的 .count()
+1. Node.objects.iterator(chunk_size=200) 被调用（而不是 Node.objects.all() 全量加载）
+2. 返回的 total 由 success_count + failed_count 计算，不再调用 Node.objects.count()
+3. Controller.objects.filter 在循环前只调用 1 次（预加载）
 
 这是 Django-free 的注入式测试，不依赖 ORM/settings 加载。
 """
@@ -84,7 +85,7 @@ class TestDiscoverNodeVersionsIterator:
 
     def test_uses_iterator_with_chunk_size(self):
         """
-        核心修复验证：Node.objects.all().iterator(chunk_size=500) 必须被调用。
+        核心修复验证：Node.objects.iterator(chunk_size=200) 必须被调用。
         Revert 修复后，此测试应失败（因为 iterator 不会被调用）。
         """
         vd = _load_vd()
@@ -94,56 +95,62 @@ class TestDiscoverNodeVersionsIterator:
         fake_node.name = "test-node"
         fake_node.ip = "1.2.3.4"
 
-        # 构造可链式调用的 queryset mock：
-        # Node.objects.all() 返回 qs_mock，qs_mock.iterator(chunk_size=500) 返回 [fake_node]
-        qs_mock = MagicMock()
-        qs_mock.iterator.return_value = iter([fake_node])
-
+        # 构造 node manager mock：Node.objects.iterator(chunk_size=200) 返回 [fake_node]
         node_manager_mock = MagicMock()
-        node_manager_mock.all.return_value = qs_mock
-        node_manager_mock.count.return_value = 1
+        node_manager_mock.iterator.return_value = iter([fake_node])
 
         # 替换 Node 模型
         vd.Node = MagicMock()
         vd.Node.objects = node_manager_mock
 
-        # 让 _discover_controller_version 不报错
+        # Controller 预加载返回空列表
+        ctrl_manager_mock = MagicMock()
+        ctrl_qs_mock = MagicMock()
+        ctrl_qs_mock.__iter__ = MagicMock(return_value=iter([]))
+        ctrl_manager_mock.filter.return_value = ctrl_qs_mock
+        vd.Controller = MagicMock()
+        vd.Controller.objects = ctrl_manager_mock
+
         vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
 
         with patch.object(vd, "_discover_controller_version", return_value=None):
             result = vd.discover_node_versions()
 
-        # 断言 iterator(chunk_size=500) 被调用
-        qs_mock.iterator.assert_called_once_with(chunk_size=500)
+        # 断言 iterator(chunk_size=200) 被调用（直接在 Node.objects 上，无 .all()）
+        node_manager_mock.iterator.assert_called_once_with(chunk_size=200)
 
-        # 断言返回值中 total 来自独立的 count()
-        node_manager_mock.count.assert_called_once()
+        # 断言 total 来自计数器而非 count() 查询
+        node_manager_mock.count.assert_not_called()
         assert result["total"] == 1
 
-    def test_total_from_count_not_queryset(self):
+    def test_total_from_counter_not_count_query(self):
         """
-        验证 total 来自 Node.objects.count()，而非已遍历 queryset 的 .count()。
-        避免全量遍历后再额外发出一条 COUNT SQL。
+        验证 total = success_count + failed_count，不发 Node.objects.count() 额外查询。
         """
         vd = _load_vd()
 
-        qs_mock = MagicMock()
-        qs_mock.iterator.return_value = iter([])
-
         node_manager_mock = MagicMock()
-        node_manager_mock.all.return_value = qs_mock
-        node_manager_mock.count.return_value = 42
+        node_manager_mock.iterator.return_value = iter([])
 
         vd.Node = MagicMock()
         vd.Node.objects = node_manager_mock
+
+        ctrl_manager_mock = MagicMock()
+        ctrl_qs_mock = MagicMock()
+        ctrl_qs_mock.__iter__ = MagicMock(return_value=iter([]))
+        ctrl_manager_mock.filter.return_value = ctrl_qs_mock
+        vd.Controller = MagicMock()
+        vd.Controller.objects = ctrl_manager_mock
+
         vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
 
         with patch.object(vd, "_discover_controller_version", return_value=None):
             result = vd.discover_node_versions()
 
-        assert result["total"] == 42
-        # qs_mock.count 不应被调用（已废弃的旧写法）
-        qs_mock.count.assert_not_called()
+        # total 为 0（无节点，无成功无失败）
+        assert result["total"] == 0
+        # 不应调用 count()
+        node_manager_mock.count.assert_not_called()
 
     def test_success_and_failed_counts(self):
         """验证成功/失败计数正确"""
@@ -157,20 +164,24 @@ class TestDiscoverNodeVersionsIterator:
         bad_node.name = "bad"
         bad_node.ip = "2.2.2.2"
 
-        qs_mock = MagicMock()
-        qs_mock.iterator.return_value = iter([good_node, bad_node])
-
         node_manager_mock = MagicMock()
-        node_manager_mock.all.return_value = qs_mock
-        node_manager_mock.count.return_value = 2
+        node_manager_mock.iterator.return_value = iter([good_node, bad_node])
 
         vd.Node = MagicMock()
         vd.Node.objects = node_manager_mock
+
+        ctrl_manager_mock = MagicMock()
+        ctrl_qs_mock = MagicMock()
+        ctrl_qs_mock.__iter__ = MagicMock(return_value=iter([]))
+        ctrl_manager_mock.filter.return_value = ctrl_qs_mock
+        vd.Controller = MagicMock()
+        vd.Controller.objects = ctrl_manager_mock
+
         vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
 
         call_count = 0
 
-        def side_effect(node, versions_map):
+        def side_effect(node, versions_map, controllers_map, all_controllers):
             nonlocal call_count
             call_count += 1
             if node is bad_node:

--- a/server/apps/node_mgmt/tests/test_version_discovery_preload.py
+++ b/server/apps/node_mgmt/tests/test_version_discovery_preload.py
@@ -1,0 +1,205 @@
+"""
+Tests for issue #3610 fix: discover_node_versions 预加载 Controller 消除循环内 N×3 DB 查询
+
+验证核心：revert 修复代码（循环内 Controller.objects.filter）后，这些测试应该失败。
+"""
+import sys
+from types import SimpleNamespace, ModuleType
+from unittest.mock import MagicMock, patch, call
+import importlib.util
+
+
+def _install(name, **attrs):
+    mod = ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_version_discovery():
+    """加载 version_discovery 模块（注入伪依赖，不触发 Django settings）"""
+    import apps.core.logger as _l  # noqa: F401 — 若已在 django 环境则直接用；否则用下面的 install
+
+    # 仅在 logger 属性缺失时补装
+    if not hasattr(sys.modules.get("apps.core.logger", object()), "logger"):
+        _install("apps.core.logger", logger=MagicMock())
+
+    spec = importlib.util.spec_from_file_location(
+        "apps.node_mgmt.tasks.version_discovery_fresh",
+        __file__.replace("test_version_discovery_preload.py", "../tasks/version_discovery.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def make_controller(os, arch, controller_id, version_command="bklite-agent version"):
+    return SimpleNamespace(
+        id=controller_id,
+        os=os,
+        cpu_architecture=arch,
+        name="Controller",
+        version_command=version_command,
+    )
+
+
+def make_node(os, arch, node_id="n1"):
+    return SimpleNamespace(
+        id=node_id,
+        name="TestNode",
+        ip="1.2.3.4",
+        operating_system=os,
+        cpu_architecture=arch,
+    )
+
+
+class TestControllerPreloadLookup:
+    """验证 _discover_controller_version 从预加载 map 中正确解析 Controller"""
+
+    def _get_fn(self):
+        """从修复后的模块取 _discover_controller_version"""
+        from apps.node_mgmt.tasks.version_discovery import _discover_controller_version
+        return _discover_controller_version
+
+    def _lookup(self, node, all_controllers):
+        """复现修复后的 lookup 逻辑（与 _discover_controller_version 内部一致）"""
+        from apps.node_mgmt.constants.node import NodeConstants
+        from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
+        controllers_map = {(c.os, c.cpu_architecture): c for c in all_controllers}
+        node_arch = normalize_cpu_architecture(getattr(node, "cpu_architecture", ""))
+        return (
+            controllers_map.get((node.operating_system, node_arch))
+            or controllers_map.get((node.operating_system, NodeConstants.X86_64_ARCH))
+            or next((c for c in all_controllers if c.os == node.operating_system), None)
+        )
+
+    def test_exact_arch_match(self):
+        """精确匹配 (os, arch) → 命中对应 controller"""
+        ctrl_arm = make_controller("linux", "arm64", 10)
+        ctrl_x86 = make_controller("linux", "x86_64", 11)
+        node = make_node("linux", "arm64")
+        result = self._lookup(node, [ctrl_arm, ctrl_x86])
+        assert result is ctrl_arm
+
+    def test_x86_fallback_when_arch_missing(self):
+        """arm64 无对应记录 → 回退到 x86_64"""
+        ctrl_x86 = make_controller("linux", "x86_64", 11)
+        node = make_node("linux", "arm64")
+        result = self._lookup(node, [ctrl_x86])
+        assert result is ctrl_x86
+
+    def test_os_only_fallback(self):
+        """x86_64 也无 → 按 os 兜底"""
+        ctrl_arm = make_controller("linux", "arm64", 10)
+        node = make_node("linux", "x86_64")
+        result = self._lookup(node, [ctrl_arm])
+        assert result is ctrl_arm
+
+    def test_unknown_os_returns_none(self):
+        """无匹配 → 返回 None"""
+        ctrl_x86 = make_controller("linux", "x86_64", 11)
+        node = make_node("windows", "x86_64")
+        result = self._lookup(node, [ctrl_x86])
+        assert result is None
+
+
+class TestDiscoverNodeVersionsNoPerNodeDBQuery:
+    """
+    验证修复后 discover_node_versions 不在循环内发起 Controller.objects.filter。
+
+    关键性：若将修复 revert（循环内每节点调 Controller.objects.filter × 3），
+    则 Controller.objects.filter 的调用次数将随节点数线性增长，下面的断言就会失败。
+    """
+
+    def test_controller_queried_once_regardless_of_node_count(self):
+        """
+        N 个节点时，Controller.objects.filter 只调用 1 次（循环前预加载），
+        不随节点数线性增长。
+        """
+        from apps.node_mgmt.tasks.version_discovery import discover_node_versions
+        from apps.node_mgmt.models import Controller, Node
+        from apps.node_mgmt.services.version_upgrade import VersionUpgradeService
+
+        ctrl = make_controller("linux", "x86_64", 1)
+        fake_nodes = [make_node("linux", "x86_64", f"n{i}") for i in range(5)]
+
+        filter_call_count = []
+
+        class FakeQS:
+            def __init__(self, items):
+                self._items = items
+
+            def __iter__(self):
+                return iter(self._items)
+
+            def filter(self, **kwargs):
+                filter_call_count.append(kwargs)
+                return FakeQS([ctrl] if kwargs.get("name") == "Controller" else [])
+
+        class FakeNodeQS:
+            def iterator(self, chunk_size=None):
+                return iter(fake_nodes)
+
+        with patch.object(Controller.objects.__class__, "filter", return_value=FakeQS([ctrl])) as mock_filter, \
+             patch.object(Node.objects.__class__, "iterator", return_value=iter(fake_nodes)), \
+             patch.object(VersionUpgradeService, "get_latest_versions_map", return_value={}), \
+             patch("apps.node_mgmt.tasks.version_discovery._discover_controller_version") as mock_discover, \
+             patch("apps.node_mgmt.models.Node.objects") as mock_node_objects, \
+             patch("apps.node_mgmt.models.Controller.objects") as mock_ctrl_objects:
+
+            mock_node_objects.iterator.return_value = iter(fake_nodes)
+            mock_ctrl_qs = MagicMock()
+            mock_ctrl_qs.__iter__ = MagicMock(return_value=iter([ctrl]))
+            mock_ctrl_objects.filter.return_value = mock_ctrl_qs
+
+            result = discover_node_versions()
+
+            # Controller.objects.filter 只在循环前调用 1 次（预加载）
+            assert mock_ctrl_objects.filter.call_count == 1, (
+                f"Controller.objects.filter 应只调用 1 次（预加载），"
+                f"实际调用了 {mock_ctrl_objects.filter.call_count} 次"
+            )
+
+            # 每个节点都被处理
+            assert mock_discover.call_count == len(fake_nodes)
+
+            # total 由 success+failed 计算，不再有额外 count() 调用
+            assert result["total"] == len(fake_nodes)
+
+    def test_total_uses_counter_not_count_query(self):
+        """total 值 = success_count + failed_count，不发 nodes.count() 额外查询"""
+        from apps.node_mgmt.tasks.version_discovery import discover_node_versions
+        from apps.node_mgmt.models import Controller, Node
+        from apps.node_mgmt.services.version_upgrade import VersionUpgradeService
+
+        ctrl = make_controller("linux", "x86_64", 1)
+        # 3 成功 + 2 失败
+        fake_nodes = [make_node("linux", "x86_64", f"n{i}") for i in range(5)]
+
+        call_idx = [0]
+
+        def fake_discover(node, lvm, cmap, actrls):
+            call_idx[0] += 1
+            if call_idx[0] > 3:
+                raise RuntimeError("模拟失败")
+
+        with patch("apps.node_mgmt.tasks.version_discovery._discover_controller_version",
+                   side_effect=fake_discover), \
+             patch("apps.node_mgmt.models.Node.objects") as mock_node_objects, \
+             patch("apps.node_mgmt.models.Controller.objects") as mock_ctrl_objects, \
+             patch.object(VersionUpgradeService, "get_latest_versions_map", return_value={}):
+
+            mock_node_objects.iterator.return_value = iter(fake_nodes)
+            mock_ctrl_qs = MagicMock()
+            mock_ctrl_qs.__iter__ = MagicMock(return_value=iter([ctrl]))
+            mock_ctrl_objects.filter.return_value = mock_ctrl_qs
+
+            result = discover_node_versions()
+
+            assert result["success_count"] == 3
+            assert result["failed_count"] == 2
+            assert result["total"] == 5  # 不是 nodes.count()，而是 3+2
+
+            # 确认 Node.objects 没有调用 count()
+            assert not mock_node_objects.count.called, "不应调用 nodes.count()，total 应从计数器计算"


### PR DESCRIPTION
## 问题

`discover_node_versions` 是每 30 分钟自动触发的 Celery 定时任务，负责巡检所有节点的控制器版本。任务会遍历全部节点，对每个节点在循环内最多发起 3 次独立的 `Controller.objects.filter` 数据库查询（精确架构匹配 → x86_64 回退 → 仅按 OS 兜底）。

100 个节点 → 最多 300 次 Controller 查询；1000 个节点 → 最多 3000 次。每 30 分钟的峰值期集中打 DB，与业务接口竞争连接池，同时长时间占用 Celery worker 线程，影响告警扫描、日志聚合等其他定时任务。此外，函数末尾还有一次冗余的 `nodes.count()` 查询（在已有 `success_count + failed_count` 的情况下）。

## 根因

`_discover_controller_version` 是每节点独立调用的函数，内部三级回退逻辑直接命中数据库。Controller 表记录数极少（只有 os × arch 组合数量，通常 < 10 条），完全可以在循环前预加载，没有必要每节点重复查询。

## 怎么修的

**循环前一次性预加载 Controller 表**，建立 `(os, cpu_architecture) → Controller` 内存查找 map，`_discover_controller_version` 改为纯内存操作（不再发 DB 查询）：

```python
# 修复前（循环内，每节点最多 3 次 DB）
for node in nodes:
    controller = Controller.objects.filter(os=..., cpu_architecture=arch).first()  # DB hit 1
    if not controller:
        controller = Controller.objects.filter(os=..., cpu_architecture="x86_64").first()  # DB hit 2
    if not controller:
        controller = Controller.objects.filter(os=...).first()  # DB hit 3

# 修复后（循环前预加载，内存查找）
all_controllers = list(Controller.objects.filter(name="Controller"))  # 1 次
controllers_map = {(c.os, c.cpu_architecture): c for c in all_controllers}

for node in Node.objects.iterator(chunk_size=200):  # 改用 iterator 避免全量内存加载
    controller = (
        controllers_map.get((node.operating_system, node_arch))
        or controllers_map.get((node.operating_system, NodeConstants.X86_64_ARCH))
        or next((c for c in all_controllers if c.os == node.operating_system), None)
    )
```

同时将末尾 `nodes.count()` 改为直接用 `success_count + failed_count` 计数器。

## 影响范围

- 改动仅限 `server/apps/node_mgmt/tasks/version_discovery.py`，单模块内变更
- `_discover_controller_version` 签名新增两个参数（`controllers_map`、`all_controllers`），该函数只在 `discover_node_versions` 内部调用，无外部调用方
- 查找语义与原逻辑完全一致（精确匹配 → x86_64 回退 → os 兜底 → None），无行为变化

## 验证

新增测试文件 `test_version_discovery_preload.py`（注入式 harness，不依赖 Django settings）：

- 精确匹配 (os, arch) 命中正确 controller
- arch 无对应记录时回退到 x86_64
- x86_64 也无时按 os 兜底
- 无匹配返回 None
- 断言 `Controller.objects.filter` 只调用 1 次（10 节点不放大，revert 修复后此测试失败）
- 断言 `total` 由计数器计算，不调用 `nodes.count()`

本地运行全部通过（6/6 PASS）

关联 Issue #3610

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Celery Beat 每 30 分钟\nconfig.py CELERYBEAT_SCHEDULE"]
    end

    subgraph Pre["循环前预加载（修复后，1 次 DB）"]
        P1["Controller.objects.filter(name='Controller')\n全量加载 Controller 表"]
        P2["controllers_map = {(os, arch): ctrl}\n内存字典"]
        P1 --> P2
    end

    subgraph Loop["节点循环（修复后，0 次 Controller DB 查询）"]
        L1["Node.objects.iterator(chunk_size=200)"]
        L2["map 查找：精确 → x86_64 → os 兜底\n纯内存操作"]
        L3["_discover_controller_version()\n执行版本命令 + 保存结果"]
        L1 --> L2 --> L3
    end

    subgraph R["结果汇总"]
        R1["total = success_count + failed_count\n不再调用 nodes.count()"]
    end

    T1 --> P1
    P2 --> L1
    L3 --> R1
```