### PR TITLE
bugfix(system_mgmt): 移除无调用方鉴权的 generate_qr_code NATS handler (#3439)

### DIFF
--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -30,10 +30,6 @@ class SystemMgmt(object):
     def delete_rules(self, group_ids, instance_id, app, module, child_module=""):
         return self.client.run("delete_rules", group_ids, instance_id, app, module, child_module)
 
-    def generate_qr_code(self, username):
-        return_data = self.client.run("generate_qr_code", username=username)
-        return return_data
-
     def generate_qr_code_by_user_id(self, user_id):
         """
         Generate OTP QR code for a user by user_id.

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -1478,34 +1478,11 @@ def get_wechat_settings():
     }
 
 
-# 生成二维码
-@nats_client.register
-def generate_qr_code(username):
-    # 查找用户
-    user = User.objects.filter(username=username).first()
-    if not user:
-        return {"result": False, "message": "User not found"}
-    user.otp_secret = pyotp.random_base32()
-    user.save()
-    totp = pyotp.TOTP(user.otp_secret)
-    # 创建用于Authenticator应用的配置URL
-    provisioning_uri = totp.provisioning_uri(name=username, issuer_name="WeopsX")
-
-    qr = qrcode.QRCode(
-        version=1,
-        error_correction=qrcode.constants.ERROR_CORRECT_L,
-        box_size=10,
-        border=4,
-    )
-    qr.add_data(provisioning_uri)
-    qr.make(fit=True)
-
-    img = qr.make_image(fill_color="black", back_color="white")
-    buffer = io.BytesIO()
-    img.save(buffer, format="PNG")
-    qr_code_base64 = base64.b64encode(buffer.getvalue()).decode()
-
-    return {"result": True, "data": {"qr_code": qr_code_base64}}
+# generate_qr_code(username) 已于 #3439 废弃并移除：
+# 该 NATS handler 接受外部传入的 username，无任何调用方身份校验，
+# 任意内网服务均可通过单条消息覆盖任意用户的 OTP secret（认证凭据劫持）。
+# 安全替代接口请使用 generate_qr_code_by_user_id，
+# Web 层入口见 core/views/index_view.py::generate_qr_code。
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/tests/test_generate_qr_code_3439.py
+++ b/server/apps/system_mgmt/tests/test_generate_qr_code_3439.py
@@ -1,0 +1,76 @@
+"""
+Issue #3439: generate_qr_code NATS handler 无调用方鉴权，可对任意用户重置 OTP secret
+
+验证：
+1. 不安全的 generate_qr_code(username) NATS handler 已从注册表中移除
+2. 安全替代接口 generate_qr_code_by_user_id 仍正常注册并可用
+3. rpc/system_mgmt.SystemMgmtClient 不再暴露 generate_qr_code(username) 方法
+
+回归准则：若将修复 revert（还原已删除的 generate_qr_code handler），
+test_insecure_handler_removed 必然失败。
+"""
+
+import pytest
+
+
+class TestGenerateQrCode3439:
+    """Issue #3439 安全修复验证"""
+
+    def test_insecure_handler_removed(self):
+        """
+        generate_qr_code(username) NATS handler 必须已从注册表中移除。
+
+        该接口接受外部传入的 username，无任何调用方身份校验，
+        任意内网服务可通过单条 NATS 消息覆盖任意用户的 OTP secret。
+
+        若此测试失败，说明不安全 handler 仍在注册表中，需立即处理。
+        """
+        import nats_client as nc
+
+        registry = nc.default_registry.registry
+
+        # 所有注册的 key 中不应存在 "generate_qr_code" 但不含 "_by_user_id" 的条目
+        insecure_keys = [
+            key for key in registry
+            if "generate_qr_code" in key and "by_user_id" not in key
+        ]
+        assert insecure_keys == [], (
+            f"不安全的 generate_qr_code NATS handler 仍在注册表中: {insecure_keys}。"
+            "该接口无调用方鉴权，已于 Issue #3439 废弃，请确认修复已生效。"
+        )
+
+    def test_secure_handler_still_registered(self):
+        """
+        generate_qr_code_by_user_id NATS handler 必须仍在注册表中（安全替代接口）。
+        """
+        import nats_client as nc
+
+        registry = nc.default_registry.registry
+
+        secure_keys = [key for key in registry if "generate_qr_code_by_user_id" in key]
+        assert len(secure_keys) >= 1, (
+            "generate_qr_code_by_user_id NATS handler 未找到，安全替代接口异常缺失。"
+        )
+
+    def test_rpc_client_does_not_expose_insecure_method(self):
+        """
+        SystemMgmtClient RPC 包装类不应再暴露 generate_qr_code(username) 方法。
+
+        若 RPC 方法仍存在，调用方可能误用绕过鉴权。
+        """
+        from apps.rpc.system_mgmt import SystemMgmtClient
+
+        assert not hasattr(SystemMgmtClient, "generate_qr_code"), (
+            "SystemMgmtClient 仍暴露 generate_qr_code(username) 方法，"
+            "该方法对应已废弃的不安全 NATS handler，应随 Issue #3439 一并移除。"
+        )
+
+    def test_rpc_client_secure_method_exists(self):
+        """
+        SystemMgmtClient 必须保留 generate_qr_code_by_user_id 方法（安全替代接口）。
+        """
+        from apps.rpc.system_mgmt import SystemMgmtClient
+
+        assert hasattr(SystemMgmtClient, "generate_qr_code_by_user_id"), (
+            "SystemMgmtClient 缺少 generate_qr_code_by_user_id 方法，安全替代接口异常缺失。"
+        )


### PR DESCRIPTION
## 关联 Issue

关闭 #3439

## 问题描述

`generate_qr_code(username)` NATS handler 接受外部传入的 `username`，无任何调用方身份校验。任意能访问 NATS 总线的内网服务均可通过单条消息覆盖任意用户的 OTP secret，导致认证凭据劫持与 MFA 失效。

## 修复方案

- 移除 `system_mgmt/nats_api.py` 中的 `generate_qr_code(username)` NATS handler 注册，保留注释说明废弃原因及安全替代接口
- 移除 `rpc/system_mgmt.py` 中对应的无调用方 RPC 包装方法（web 层已统一使用 `generate_qr_code_by_user_id`）
- 新增回归测试：验证不安全 handler 不在注册表、安全替代接口仍存在、RPC 类不再暴露旧方法

## 测试

- `test_generate_qr_code_3439.py`：3 条回归测试覆盖 handler 移除确认 + 安全替代存在性 + RPC 类收紧