### PR TITLE
bugfix(mobile): 修复 CSP null + api_proxy 无 URL 白名单导致的 XSS→SSRF 攻击链

### DIFF
--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 tokio = { version = "1.0", features = ["full"] }
 uuid = { version = "1.0", features = ["v4"] }
 futures-util = "0.3"
+url = "2"

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -38,9 +38,9 @@ fn is_allowed_host(url: &str) -> bool {
     if allowed_hosts_env.trim().is_empty() {
         // 未配置白名单时，仅放行本地开发地址
         log::warn!(
-            "[Tauri-Proxy] TAURI_ALLOWED_HOSTS 未配置，生产环境请显式设置允许的后端域名。当前仅放行 127.0.0.1/localhost。"
+            "[Tauri-Proxy] TAURI_ALLOWED_HOSTS 未配置，生产环境请显式设置允许的后端域名。当前仅放行 127.0.0.1/::1/localhost。"
         );
-        return host == "127.0.0.1" || host == "localhost";
+        return host == "127.0.0.1" || host == "::1" || host == "localhost";
     }
 
     for entry in allowed_hosts_env.split(',') {
@@ -557,6 +557,7 @@ mod tests {
         with_env("TAURI_ALLOWED_HOSTS", None, || {
             assert!(is_allowed_host("http://127.0.0.1:8011/api"));
             assert!(is_allowed_host("http://localhost:3001/dev"));
+            assert!(is_allowed_host("http://[::1]:8011/api"));
         });
     }
 

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -8,6 +8,54 @@ use tokio::sync::oneshot;
 /// 每个活跃 SSE 流的取消发送端，keyed by stream_id
 pub struct StreamRegistry(pub Mutex<HashMap<String, oneshot::Sender<()>>>);
 
+/// 校验请求 URL 的 host 是否在环境变量 TAURI_ALLOWED_HOSTS 所配置的白名单内。
+///
+/// 白名单格式：逗号分隔的 host[:port] 列表，例如
+///   `TAURI_ALLOWED_HOSTS=bklite.example.com,api.internal.example.com:8443`
+///
+/// 若环境变量未设置，则默认只允许 127.0.0.1 和 localhost（开发模式兜底），
+/// 并在 warn 日志中提示生产环境应显式配置。
+fn is_allowed_host(url: &str) -> bool {
+    let parsed = match url::Url::parse(url) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+
+    let host = match parsed.host_str() {
+        Some(h) => h.to_lowercase(),
+        None => return false,
+    };
+    let port = parsed.port();
+
+    // 构造 host 标识：带端口时用 host:port，否则只用 host
+    let host_with_port = match port {
+        Some(p) => format!("{}:{}", host, p),
+        None => host.clone(),
+    };
+
+    let allowed_hosts_env = std::env::var("TAURI_ALLOWED_HOSTS").unwrap_or_default();
+
+    if allowed_hosts_env.trim().is_empty() {
+        // 未配置白名单时，仅放行本地开发地址
+        log::warn!(
+            "[Tauri-Proxy] TAURI_ALLOWED_HOSTS 未配置，生产环境请显式设置允许的后端域名。当前仅放行 127.0.0.1/localhost。"
+        );
+        return host == "127.0.0.1" || host == "localhost";
+    }
+
+    for entry in allowed_hosts_env.split(',') {
+        let entry = entry.trim().to_lowercase();
+        if entry.is_empty() {
+            continue;
+        }
+        if entry == host || entry == host_with_port {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiRequest {
     pub url: String,
@@ -48,9 +96,18 @@ pub struct ApiError {
 
 #[command]
 pub async fn api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError> {
+    // URL 白名单校验：防止注入脚本通过 IPC 发起任意域的 SSRF 请求
+    if !is_allowed_host(&request.url) {
+        log::warn!("[Tauri-API] 拒绝非白名单 URL: {}", request.url);
+        return Err(ApiError {
+            message: format!("URL host not in allowlist: {}", request.url),
+            status: Some(403),
+        });
+    }
+
     let start_time = std::time::Instant::now();
     let request_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
-    
+
     log::info!("🚀 [Tauri-API-{}] START: {} {}", request_id, request.method, request.url);
 
     // 创建 HTTP 客户端
@@ -174,6 +231,15 @@ pub async fn api_stream_proxy(
     registry: State<'_, StreamRegistry>,
     request: ApiRequest,
 ) -> Result<String, ApiError> {
+    // URL 白名单校验：与 api_proxy 保持一致
+    if !is_allowed_host(&request.url) {
+        log::warn!("[Tauri-Stream] 拒绝非白名单 URL: {}", request.url);
+        return Err(ApiError {
+            message: format!("URL host not in allowlist: {}", request.url),
+            status: Some(403),
+        });
+    }
+
     let stream_id = uuid::Uuid::new_v4().to_string();
     let request_id = stream_id[..8].to_string();
 
@@ -463,4 +529,95 @@ pub async fn cancel_stream(
         log::warn!("⚠️ [cancel_stream] Stream not found (already ended?): {}", &stream_id[..8.min(stream_id.len())]);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_allowed_host;
+    use std::env;
+
+    /// 辅助：在测试中临时设置 / 清除环境变量（串行执行，避免并发干扰）
+    fn with_env<F: FnOnce()>(key: &str, val: Option<&str>, f: F) {
+        let old = env::var(key).ok();
+        match val {
+            Some(v) => env::set_var(key, v),
+            None => env::remove_var(key),
+        }
+        f();
+        match old {
+            Some(v) => env::set_var(key, v),
+            None => env::remove_var(key),
+        }
+    }
+
+    // --- 未配置白名单（默认只放行 localhost/127.0.0.1）---
+
+    #[test]
+    fn test_no_env_allows_localhost() {
+        with_env("TAURI_ALLOWED_HOSTS", None, || {
+            assert!(is_allowed_host("http://127.0.0.1:8011/api"));
+            assert!(is_allowed_host("http://localhost:3001/dev"));
+        });
+    }
+
+    #[test]
+    fn test_no_env_blocks_external() {
+        with_env("TAURI_ALLOWED_HOSTS", None, || {
+            // 关键测试：revert 白名单校验逻辑后此断言应失败
+            assert!(!is_allowed_host("http://169.254.169.254/latest/meta-data/"));
+            assert!(!is_allowed_host("https://evil.example.com/exfil"));
+            assert!(!is_allowed_host("http://internal-svc/secret"));
+        });
+    }
+
+    // --- 已配置白名单 ---
+
+    #[test]
+    fn test_env_allows_listed_host() {
+        with_env(
+            "TAURI_ALLOWED_HOSTS",
+            Some("bklite.example.com,api.internal.corp:8443"),
+            || {
+                assert!(is_allowed_host("https://bklite.example.com/api/v1/"));
+                assert!(is_allowed_host("https://api.internal.corp:8443/stream"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_env_blocks_unlisted_host() {
+        with_env(
+            "TAURI_ALLOWED_HOSTS",
+            Some("bklite.example.com"),
+            || {
+                // SSRF 靶标：不在白名单内应被拒绝
+                assert!(!is_allowed_host("http://169.254.169.254/"));
+                assert!(!is_allowed_host("https://other-domain.example.com/"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_env_host_port_distinction() {
+        // host:port 条目不应放行同 host 的其它端口
+        with_env(
+            "TAURI_ALLOWED_HOSTS",
+            Some("api.corp.com:8443"),
+            || {
+                assert!(is_allowed_host("https://api.corp.com:8443/ok"));
+                // 不同端口不在白名单
+                assert!(!is_allowed_host("https://api.corp.com:9999/bad"));
+                // 纯 host（无端口）不在白名单
+                assert!(!is_allowed_host("https://api.corp.com/bad"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_invalid_url_rejected() {
+        with_env("TAURI_ALLOWED_HOSTS", Some("bklite.example.com"), || {
+            assert!(!is_allowed_host("not-a-url"));
+            assert!(!is_allowed_host(""));
+        });
+    }
 }

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -20,7 +20,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; connect-src 'self' https: http://127.0.0.1:*; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:"
     }
   },
   "bundle": {


### PR DESCRIPTION
## 修复内容

关联 Issue: #3544（替代已关闭的 PR #3551）

### 问题

Tauri WebView 安全边界由两道防线维持：
1. **CSP** — 防止注入脚本执行
2. **IPC 命令的 URL 白名单** — 防止执行脚本通过 Tauri IPC 向任意地址发请求

`tauri.conf.json` 将 `csp` 设为 `null`，第一道防线完全失效；`api_proxy` / `api_stream_proxy` 命令接受任意 `url: String`，第二道防线不存在。两者叠加形成完整攻击链：**XSS → Tauri IPC invoke → SSRF / Bearer token 外泄**。

### 修复

1. **CSP 最小安全策略**（`tauri.conf.json`）：将 `csp: null` 改为明确的最小策略
2. **api_proxy IPC 白名单**（`api_proxy.rs`）：新增 `is_allowed_host()` 函数，基于 `TAURI_ALLOWED_HOSTS` 环境变量校验目标 host
3. **P2 补充修复**：IPv6 loopback `::1` 补充到默认白名单（原代码仅覆盖 `127.0.0.1` 和 `localhost`）

### 评审结论（P0:0 P1:0 P2:2 P3:2）

**P2 修复**
1. **IPv6 本地绕过（已修复）**：`host == "localhost" || host == "127.0.0.1"` 遗漏 `::1`，已就地补充，测试中同步增加 `[::1]` 断言。
2. **CSP `connect-src https:` 宽松**：等价于放行所有 HTTPS 外站，但 Rust IPC 白名单已构成第二道防线，风险仅在纵深防御层面，可接受。

**P3 记录**
- 测试用 `env::set_var` 存在并发竞态风险（建议后续加 serial_test）
- 无端口白名单条目会放行该 host 所有端口（设计决策，建议文档说明）

攻击链切断有效：CSP + Rust IPC 白名单双重防线，XSS→SSRF 链路已封堵。