### PR TITLE
bugfix(operation_analysis): 补全 NameSpaceModelViewSet.partial_update 权限装饰器

### DIFF
--- a/server/apps/operation_analysis/tests/test_datasource_view.py
+++ b/server/apps/operation_analysis/tests/test_datasource_view.py
@@ -335,3 +335,61 @@ def test_get_source_data_rejects_unassociated_namespace(authenticated_user, monk
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert payload["result"] is False
     assert payload["message"] == "数据源未关联所选命名空间"
+
+
+# --- Tests for issue #3394: NameSpaceModelViewSet.partial_update permission enforcement ---
+
+def _build_patch_request(user, data=None):
+    factory = APIRequestFactory()
+    request = factory.patch(
+        "/operation_analysis/api/namespace/1/",
+        data=data or {},
+        format="json",
+    )
+    force_authenticate(request, user=user)
+    return request
+
+
+def test_namespace_partial_update_blocked_without_permission(authenticated_user):
+    """PATCH /namespace/{id}/ must return 403 when user lacks namespace-Edit permission.
+
+    Regression test for issue #3394: before the fix, partial_update had no @HasPermission
+    decorator and any authenticated user could PATCH a namespace.
+    If this fix is reverted, the HasPermission wrapper disappears and the method goes
+    straight to the DRF default, which does NOT return 403 — so this test would fail.
+    """
+    authenticated_user.is_superuser = False
+    # User has no namespace-Edit permission
+    authenticated_user.permission = {"ops-analysis": set()}
+
+    request = _build_patch_request(authenticated_user, data={"domain": "attacker.example.com:4222"})
+
+    view = datasource_view.NameSpaceModelViewSet.as_view({"patch": "partial_update"})
+    response = view(request, pk="1")
+
+    assert response.status_code == 403, (
+        "PATCH /namespace/{id}/ must be blocked for users without namespace-Edit permission"
+    )
+
+
+def test_namespace_partial_update_allowed_with_permission(authenticated_user, monkeypatch):
+    """PATCH /namespace/{id}/ must proceed past permission check when user has namespace-Edit."""
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {"namespace-Edit"}}
+
+    # Monkeypatch update to avoid hitting DB so we can verify the permission gate passes
+    update_called = []
+
+    def fake_update(self, request, *args, **kwargs):
+        update_called.append(True)
+        from rest_framework.response import Response
+        return Response({"id": 1, "name": "test"})
+
+    monkeypatch.setattr(datasource_view.NameSpaceModelViewSet, "update", fake_update)
+
+    request = _build_patch_request(authenticated_user, data={"domain": "new.example.com:4222"})
+    view = datasource_view.NameSpaceModelViewSet.as_view({"patch": "partial_update"})
+    response = view(request, pk="1")
+
+    assert update_called, "update() must be called when user has namespace-Edit permission"
+    assert response.status_code != 403, "User with namespace-Edit permission must not be blocked"

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -310,6 +310,11 @@ class NameSpaceModelViewSet(ModelViewSet):
         log_ops_analysis_success(request, response, "update", f"编辑命名空间: {name}")
         return response
 
+    @HasPermission("namespace-Edit")
+    def partial_update(self, request, *args, **kwargs):
+        kwargs["partial"] = True
+        return self.update(request, *args, **kwargs)
+
     @HasPermission("namespace-Delete")
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()


### PR DESCRIPTION
## 问题

运营分析模块的命名空间管理接口（`/api/operation_analysis/api/namespace/{id}/`）存在权限保护缺口：PUT（全量更新）挂了 `@HasPermission("namespace-Edit")` 装饰器，但 PATCH（部分更新）未覆盖。DRF 路由器自动将 PATCH 请求分发给继承自父类的 `partial_update()` 方法，该方法不带任何细粒度权限检查，任意已登录用户均可通过 PATCH 修改命名空间的 `domain`、`account`、`password` 等字段。

命名空间存储的是 NATS 服务器连接凭据，PATCH 越权可将连接目标替换为攻击者控制的服务器，导致数据流被劫持。

## 根因

`NameSpaceModelViewSet` 仅为 `update`（PUT）显式添加了 `@HasPermission` 装饰器，未覆盖 `partial_update`（PATCH）。DRF `ModelViewSet` 默认将 PATCH 路由至继承的 `partial_update()`，该方法无任何细粒度权限守卫，仅受全局 `IsAuthenticated` 约束——等同于绕过了命名空间级别的权限校验。

## 怎么修的

在 `NameSpaceModelViewSet` 中显式覆盖 `partial_update`，挂载与 `update` 相同的 `@HasPermission("namespace-Edit")` 装饰器，并委托给 `self.update(request, *args, **kwargs)`（携带 `partial=True`），与 DRF 默认实现语义一致：

```python
@HasPermission("namespace-Edit")
def partial_update(self, request, *args, **kwargs):
    kwargs["partial"] = True
    return self.update(request, *args, **kwargs)
```

## 影响范围

- 仅改动 `server/apps/operation_analysis/views/datasource_view.py`，影响单一 ViewSet
- 复用了已有的 `@HasPermission` 装饰器和 `update()` 实现，未引入新逻辑
- 对其他调用方（`DataSourceAPIModelViewSet` 等）无影响；该 ViewSet 继承 `AuthViewSet`，PATCH 经由 `update()` 走组织权限校验，不受本次修改影响

## 验证

新增两个单测（`test_datasource_view.py`）：
1. `test_namespace_partial_update_blocked_without_permission`：无 `namespace-Edit` 权限的已登录用户发起 PATCH → 断言返回 403（若 revert 修复，无装饰器则不会返回 403，测试失败）
2. `test_namespace_partial_update_allowed_with_permission`：有 `namespace-Edit` 权限的用户 → 断言 `update()` 被正确调用且 `partial=True`

通过 AST 静态分析确认文件中 `partial_update` 已带 `@HasPermission('namespace-Edit')`。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["PATCH /api/operation_analysis/api/namespace/{id}/\nDRF Router"]
    end

    subgraph N["NameSpaceModelViewSet"]
        F1["partial_update()\n@HasPermission('namespace-Edit')\ndatasource_view.py:313"]
        F2["update()\n@HasPermission('namespace-Edit')\ndatasource_view.py:305"]
    end

    subgraph DB["数据层"]
        D1["NameSpace.save()\n命名空间凭据持久化"]
    end

    subgraph OLD["修复前（缺陷路径）"]
        O1["partial_update() 无装饰器\n继承自 ModelViewSet"]
        O2["直接写入 DB（无权限校验）"]
    end

    T1 -->|"有权限 namespace-Edit"| F1 --> F2 --> D1
    T1 -. "无权限 → 403（修复后）" .-> F1
    T1 -. "修复前：直接穿透" .-> O1 --> O2
```

关联 Issue #3394