### PR TITLE
bugfix: alerts | AlertSourceModelSerializer team_secrets 未 write_only，组织密钥随 GET 响应泄露

### DIFF
--- a/server/apps/alerts/serializers/alert_source.py
+++ b/server/apps/alerts/serializers/alert_source.py
@@ -24,11 +24,11 @@ class AlertSourceModelSerializer(serializers.ModelSerializer):
         model = AlertSource
         fields = "__all__"
         extra_kwargs = {
-            # "secret": {"write_only": True},
             # "config": {"write_only": True},
             "last_active_time": {"write_only": True},
             "is_delete": {"write_only": True},
             "secret": {"write_only": True},
+            "team_secrets": {"write_only": True},
         }
 
     @staticmethod

--- a/server/apps/alerts/tests/test_serializers_and_scope.py
+++ b/server/apps/alerts/tests/test_serializers_and_scope.py
@@ -175,3 +175,26 @@ def test_alert_source_get_event_count_and_last_event_time():
 def test_alert_source_get_last_event_time_empty():
     source = AlertSource.objects.create(name="源2", source_id="s2", source_type="restful", secret="x")
     assert AlertSourceModelSerializer.get_last_event_time(source) == ""
+
+
+@pytest.mark.django_db
+def test_alert_source_serializer_team_secrets_write_only():
+    """team_secrets 必须为 write_only，GET 响应不得返回组织密钥。
+
+    验证点：revert write_only 后此测试失败（字段出现在 data 中）。
+    """
+    source = AlertSource.objects.create(
+        name="源3",
+        source_id="s3",
+        source_type="restful",
+        secret="base-secret",
+        team_secrets={1: "team-secret-abc"},
+    )
+    ser = AlertSourceModelSerializer(source)
+    data = ser.data
+    # team_secrets 不得出现在序列化输出中（write_only=True）
+    assert "team_secrets" not in data, (
+        "team_secrets 以明文出现在 GET 响应中，存在组织密钥泄露风险"
+    )
+    # secret 同理
+    assert "secret" not in data, "secret 以明文出现在 GET 响应中"


### PR DESCRIPTION
## 问题

告警源（AlertSource）提供「组织密钥」功能（`team_secrets`），用于多租户场景下各组织独立的告警推送鉴权密钥。当已登录用户调用 `GET /api/v1/alerts/alert_source/` 或 `GET /api/v1/alerts/alert_source/<id>/` 时，`team_secrets` 字段以明文 JSON 出现在响应体中，一次请求即可拿到所有组织的推送密钥，可用于伪造任意组织的告警事件推送。

## 根因

`AlertSourceModelSerializer.Meta.extra_kwargs` 中已为 `secret` 设置了 `write_only=True`，但遗漏了 `team_secrets`。`fields = "__all__"` 会默认把所有模型字段带进响应，`write_only` 是唯一屏蔽手段。

## 怎么修的

在 `extra_kwargs` 补加一行，与现有 `secret` 写法完全一致：

```python
"team_secrets": {"write_only": True},   # 新增
```

`write_only=True` 仅影响序列化输出（GET 响应），不影响反序列化写入（POST/PATCH），完全向后兼容。

## 影响范围

- 仅修改 `server/apps/alerts/serializers/alert_source.py`（1 行）和对应测试文件
- 写入接口（创建/更新告警源）行为不变，`team_secrets` 仍可正常写入
- 不涉及 core/共享 util/NATS handler，影响面仅限 alerts 模块

## 验证

新增测试 `test_alert_source_serializer_team_secrets_write_only`，revert 修复代码后测试必然失败。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GET /api/v1/alerts/alert_source/\nalerts/views/alert_source.py"]
    end

    subgraph N["序列化层（缺陷根因）"]
        S1["AlertSourceModelSerializer\nalerts/serializers/alert_source.py"]
        S2["Meta.extra_kwargs 缺少 team_secrets: write_only"]
    end

    subgraph O["响应输出（修复前）"]
        O1["team_secrets 明文出现在 JSON 响应"]
    end

    subgraph F["修复后"]
        F1["extra_kwargs 补加 team_secrets: write_only=True"]
        F2["team_secrets 从响应中排除"]
    end

    T1 --> S1 --> S2 --> O1
    S2 -. "修复" .-> F1 --> F2
```

关联 Issue #3385