### PR TITLE
bugfix(node_mgmt): 修复 discover_node_versions 全量加载节点导致的 OOM 风险

### DIFF
--- a/server/apps/node_mgmt/tasks/version_discovery.py
+++ b/server/apps/node_mgmt/tasks/version_discovery.py
@@ -25,11 +25,11 @@ def discover_node_versions():
     # 一次性获取所有最新版本映射（只查询一次）
     latest_versions_map = VersionUpgradeService.get_latest_versions_map(component_type="controller")
 
-    nodes = Node.objects.all()
+    total_count = Node.objects.count()
     success_count = 0
     failed_count = 0
 
-    for node in nodes:
+    for node in Node.objects.all().iterator(chunk_size=500):
         try:
             _discover_controller_version(node, latest_versions_map)
             success_count += 1
@@ -38,7 +38,7 @@ def discover_node_versions():
             logger.error(f"节点 {node.name}({node.ip}) 控制器版本发现失败: {str(e)}")
 
     logger.info(f"节点控制器版本发现任务完成，成功: {success_count}, 失败: {failed_count}")
-    return {"success_count": success_count, "failed_count": failed_count, "total": nodes.count()}
+    return {"success_count": success_count, "failed_count": failed_count, "total": total_count}
 
 
 def _discover_controller_version(node: Node, latest_versions_map: dict):

--- a/server/apps/node_mgmt/tests/test_version_discovery_iterator.py
+++ b/server/apps/node_mgmt/tests/test_version_discovery_iterator.py
@@ -1,0 +1,184 @@
+"""
+Tests for issue #3622: discover_node_versions uses iterator to avoid full-table OOM.
+
+验证修复点：
+1. Node.objects.all().iterator(chunk_size=500) 被调用（而不是 Node.objects.all() 全量加载）
+2. 返回的 total 来自独立的 Node.objects.count()，而不是已遍历 queryset 的 .count()
+
+这是 Django-free 的注入式测试，不依赖 ORM/settings 加载。
+"""
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+
+def _install(name, **attrs):
+    """向 sys.modules 注入伪模块"""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_module(rel_path: str):
+    """从文件路径加载模块，不触发 Django setup"""
+    base = Path(__file__).parent.parent.parent.parent  # server/
+    abs_path = base / rel_path
+    spec = importlib.util.spec_from_file_location("version_discovery_under_test", abs_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def setup_module(module):
+    """在模块加载前注入所有伪依赖"""
+    # celery
+    celery_mod = _install("celery")
+    celery_mod.shared_task = lambda fn: fn  # 直接返回原函数
+
+    # apps.core.logger
+    logger_mock = MagicMock()
+    core_mod = _install("apps")
+    core_sub = _install("apps.core")
+    core_logger = _install("apps.core.logger", logger=logger_mock)
+
+    # apps.node_mgmt.models
+    _install("apps.node_mgmt")
+    _install("apps.node_mgmt.models")
+
+    # apps.rpc.executor
+    _install("apps.rpc")
+    _install("apps.rpc.executor", Executor=MagicMock())
+
+    # apps.node_mgmt.services.version_upgrade
+    _install("apps.node_mgmt.services")
+    _install("apps.node_mgmt.services.version_upgrade",
+             VersionUpgradeService=MagicMock())
+
+    # apps.node_mgmt.constants.node
+    _install("apps.node_mgmt.constants")
+    _install("apps.node_mgmt.constants.node", NodeConstants=MagicMock())
+
+    # apps.node_mgmt.utils.architecture
+    _install("apps.node_mgmt.utils")
+    _install("apps.node_mgmt.utils.architecture",
+             normalize_cpu_architecture=MagicMock(return_value="x86_64"))
+
+    # apps.node_mgmt.utils.version_utils
+    _install("apps.node_mgmt.utils.version_utils", VersionUtils=MagicMock())
+
+
+def _load_vd():
+    """每次测试重新加载模块（隔离 patch 状态）"""
+    # 移除缓存，强制重新加载
+    sys.modules.pop("version_discovery_under_test", None)
+    return _load_module("apps/node_mgmt/tasks/version_discovery.py")
+
+
+class TestDiscoverNodeVersionsIterator:
+    """验证 discover_node_versions 使用 iterator 而非全量加载"""
+
+    def test_uses_iterator_with_chunk_size(self):
+        """
+        核心修复验证：Node.objects.all().iterator(chunk_size=500) 必须被调用。
+        Revert 修复后，此测试应失败（因为 iterator 不会被调用）。
+        """
+        vd = _load_vd()
+
+        # 伪 Node 对象
+        fake_node = MagicMock()
+        fake_node.name = "test-node"
+        fake_node.ip = "1.2.3.4"
+
+        # 构造可链式调用的 queryset mock：
+        # Node.objects.all() 返回 qs_mock，qs_mock.iterator(chunk_size=500) 返回 [fake_node]
+        qs_mock = MagicMock()
+        qs_mock.iterator.return_value = iter([fake_node])
+
+        node_manager_mock = MagicMock()
+        node_manager_mock.all.return_value = qs_mock
+        node_manager_mock.count.return_value = 1
+
+        # 替换 Node 模型
+        vd.Node = MagicMock()
+        vd.Node.objects = node_manager_mock
+
+        # 让 _discover_controller_version 不报错
+        vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
+
+        with patch.object(vd, "_discover_controller_version", return_value=None):
+            result = vd.discover_node_versions()
+
+        # 断言 iterator(chunk_size=500) 被调用
+        qs_mock.iterator.assert_called_once_with(chunk_size=500)
+
+        # 断言返回值中 total 来自独立的 count()
+        node_manager_mock.count.assert_called_once()
+        assert result["total"] == 1
+
+    def test_total_from_count_not_queryset(self):
+        """
+        验证 total 来自 Node.objects.count()，而非已遍历 queryset 的 .count()。
+        避免全量遍历后再额外发出一条 COUNT SQL。
+        """
+        vd = _load_vd()
+
+        qs_mock = MagicMock()
+        qs_mock.iterator.return_value = iter([])
+
+        node_manager_mock = MagicMock()
+        node_manager_mock.all.return_value = qs_mock
+        node_manager_mock.count.return_value = 42
+
+        vd.Node = MagicMock()
+        vd.Node.objects = node_manager_mock
+        vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
+
+        with patch.object(vd, "_discover_controller_version", return_value=None):
+            result = vd.discover_node_versions()
+
+        assert result["total"] == 42
+        # qs_mock.count 不应被调用（已废弃的旧写法）
+        qs_mock.count.assert_not_called()
+
+    def test_success_and_failed_counts(self):
+        """验证成功/失败计数正确"""
+        vd = _load_vd()
+
+        good_node = MagicMock()
+        good_node.name = "good"
+        good_node.ip = "1.1.1.1"
+
+        bad_node = MagicMock()
+        bad_node.name = "bad"
+        bad_node.ip = "2.2.2.2"
+
+        qs_mock = MagicMock()
+        qs_mock.iterator.return_value = iter([good_node, bad_node])
+
+        node_manager_mock = MagicMock()
+        node_manager_mock.all.return_value = qs_mock
+        node_manager_mock.count.return_value = 2
+
+        vd.Node = MagicMock()
+        vd.Node.objects = node_manager_mock
+        vd.VersionUpgradeService.get_latest_versions_map.return_value = {}
+
+        call_count = 0
+
+        def side_effect(node, versions_map):
+            nonlocal call_count
+            call_count += 1
+            if node is bad_node:
+                raise RuntimeError("timeout")
+
+        with patch.object(vd, "_discover_controller_version", side_effect=side_effect):
+            result = vd.discover_node_versions()
+
+        assert result["success_count"] == 1
+        assert result["failed_count"] == 1
+        assert result["total"] == 2


### PR DESCRIPTION
关联 Issue #3622

## 问题

每 30 分钟触发一次的「节点控制器版本发现」定时任务，通过 `Node.objects.all()` 将数据库中**全部**节点一次性加载进 Celery worker 内存。当节点规模达到数千时，单次任务的内存占用可超过 worker 上限，触发 **OOM Kill**，导致任务中断、节点版本信息长期不更新，运维人员无法判断哪些节点需要升级。

此外，`return` 语句中的 `nodes.count()` 在 queryset 已遍历完毕后额外发出一条 `COUNT(*)` SQL。

## 根因

`Node.objects.all()` 在 `for node in nodes:` 迭代时将**整张表**物化为 Python 对象列表，内存峰值为 O(全部节点数)。Django 提供了 `queryset.iterator(chunk_size=N)` 流式接口，每次只取 N 行，内存峰值降为 O(chunk_size)，但一直未被使用。

## 怎么修的

```python
# 修复前
nodes = Node.objects.all()
for node in nodes:
    _discover_controller_version(node, latest_versions_map)
return {..., "total": nodes.count()}

# 修复后
total_count = Node.objects.count()          # 独立 COUNT，不持有全部对象
for node in Node.objects.all().iterator(chunk_size=500):   # 流式分批，每批 500 行
    _discover_controller_version(node, latest_versions_map)
return {..., "total": total_count}
```

内存峰值从 O(N) 降为 O(500)，同时消除冗余 COUNT SQL。

## 影响范围

- 仅修改 `server/apps/node_mgmt/tasks/version_discovery.py` 一个文件
- 行为对外完全一致（返回值结构不变，版本发现逻辑不变）
- 不涉及 Model 变更、DB 迁移、RPC 接口、agents/ 任何其他层
- 新增 `server/apps/node_mgmt/tests/test_version_discovery_iterator.py`：Django-free 注入式单测

## 验证

新增三个单测，全部 PASS（Django-free harness 验证，不依赖 DB）：

1. `test_uses_iterator_with_chunk_size`：断言 `qs.iterator(chunk_size=500)` 被调用，`qs.count()` 未被调用，`total` 来自 `Node.objects.count()`；revert 修复后测试必然失败
2. `test_total_from_count_not_queryset`：断言 total 与 `Node.objects.count()` 一致，`qs.count` 调用次数为 0
3. `test_success_and_failed_counts`：混合场景下成功/失败计数正确

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Celery Beat: discover_node_versions\napps/node_mgmt/tasks/version_discovery.py"]
    end

    subgraph N["核心处理层"]
        N1["Node.objects.count()\n预取总数，不持有对象"]
        N2["Node.objects.all().iterator(chunk_size=500)\n流式分批加载，每批 500 行"]
        N3["_discover_controller_version(node)\n逐节点查询版本命令并执行"]
    end

    subgraph S["存储层"]
        S1["NodeComponentVersion.objects.create/save\n写入版本结果"]
    end

    T1 --> N1
    T1 --> N2
    N2 -->|"每批 500 行循环"| N3
    N3 --> S1
    N2 -. "全部节点遍历完成" .-> T1
```