### PR TITLE
bugfix: 监控 NATS 写接口补身份闸，消除缺身份即用默认账号建库的鉴权旁路（#3339）

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -407,8 +407,8 @@ def _get_monitor_instance_permission(monitor_obj_id: str, user_info: dict):
 def _normalize_permission_user(user):
     if hasattr(user, "username") and hasattr(user, "domain"):
         return user
-    if isinstance(user, str) and user:
-        return SimpleNamespace(username=user, domain="domain.com")
+    if isinstance(user, str) and user.strip():
+        return SimpleNamespace(username=user.strip(), domain="domain.com")
     return user
 
 

--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -291,7 +291,23 @@ def _create_monitor_policy_payload(data: dict, operator: str = "api", domain: st
     return policy, MonitorPolicySerializer(policy).data
 
 
+def _require_authenticated_actor(user_info: Optional[dict]):
+    """写接口身份闸：必须携带可解析的已认证身份才允许写库。
+
+    缺身份时不再回退默认 api/domain.com 账号继续建库——对齐读接口
+    _get_monitor_instance_permission 的身份校验（缺用户即拒），消除"写比读松"的鉴权旁路：
+    仅凭向 NATS subject 发消息、不带任何身份即可新建监控对象/告警策略的攻击面。
+    校验失败时返回与读接口一致的失败结构。
+    """
+    if not isinstance(user_info, dict) or not _normalize_permission_user(user_info.get("user")):
+        return {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    return None
+
+
 def _execute_nats_create(create_func, data: dict, user_info: Optional[dict] = None):
+    identity_error = _require_authenticated_actor(user_info)
+    if identity_error:
+        return identity_error
     try:
         operator, domain = _resolve_nats_actor(user_info)
         _, result_data = create_func(data, operator=operator, domain=domain)

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -180,8 +180,8 @@ def test_execute_nats_create_rejects_user_info_without_user(monkeypatch):
         called["count"] += 1
         return object(), {"id": "metric"}
 
-    # user_info 是 dict 但缺 user（或 user 为空）→ 不再回退默认账号，直接拒
-    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"domain": "tenant-a.com"}):
+    # user_info 是 dict 但缺 user（或 user 为空/纯空白）→ 不再回退默认账号，直接拒
+    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"user": "  "}, {"user": "\t"}, {"domain": "tenant-a.com"}):
         result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=bad_user_info)
         assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
 

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -156,6 +156,66 @@ def test_execute_nats_create_uses_domain_from_user_info_for_string_users(monkeyp
     }
 
 
+def test_execute_nats_create_rejects_missing_user_info(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_missing_user_info_test_module")
+
+    called = {"count": 0}
+
+    def fake_create(payload, operator="api", domain="domain.com"):
+        called["count"] += 1
+        return object(), {"id": "metric"}
+
+    result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=None)
+
+    assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    assert called["count"] == 0
+
+
+def test_execute_nats_create_rejects_user_info_without_user(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_no_user_test_module")
+
+    called = {"count": 0}
+
+    def fake_create(payload, operator="api", domain="domain.com"):
+        called["count"] += 1
+        return object(), {"id": "metric"}
+
+    # user_info 是 dict 但缺 user（或 user 为空）→ 不再回退默认账号，直接拒
+    for bad_user_info in ({}, {"user": None}, {"user": ""}, {"domain": "tenant-a.com"}):
+        result = module._execute_nats_create(fake_create, {"name": "cpu_usage"}, user_info=bad_user_info)
+        assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+
+    assert called["count"] == 0
+
+
+def test_create_monitor_policy_rejects_anonymous_caller_without_side_effects(monkeypatch):
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_policy_anonymous_test_module")
+
+    view_calls = []
+
+    class ExplodingMonitorPolicySerializer:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("匿名调用不应触达序列化/写库")
+
+    class ExplodingViewSet:
+        def __getattr__(self, name):
+            def _boom(*args, **kwargs):
+                view_calls.append(name)
+                raise AssertionError("匿名调用不应触发任何写副作用")
+
+            return _boom
+
+    monkeypatch.setattr(module, "MonitorPolicySerializer", ExplodingMonitorPolicySerializer)
+    monkeypatch.setattr(module, "_get_monitor_policy_viewset", ExplodingViewSet)
+
+    result = module.create_monitor_policy(
+        {"name": "evil policy", "schedule": "*/5 * * * *", "organizations": [1]},
+    )
+
+    assert result == {"result": False, "data": [], "message": "缺少用户或组织信息"}
+    assert view_calls == []
+
+
 def test_create_monitor_policy_maps_api_create_side_effects(monkeypatch):
     module = _load_monitor_nats_module(monkeypatch, "monitor_nats_create_monitor_policy_test_module")
 


### PR DESCRIPTION
关闭并重新提交 #3343（rebase 后重建）。

## 被破坏的不变量

监控的写操作本应与读操作持有**同一条身份边界**：无可解析的已认证身份，就不得访问监控数据。读接口 `_get_monitor_instance_permission` 正是这么做的——缺用户/组织即拒。但 NATS 暴露的 `create_*` 写接口却在 `user_info` 缺失时**回退默认系统账号 `api/domain.com` 继续写库**，全程零身份、零权限校验。

## 修复

在 `_execute_nats_create` 写库前增加身份闸 `_require_authenticated_actor`，把"缺身份"重新变成一次显式拒绝，与读接口对齐。同时修复纯空白字符串用户名（`"  "`、`"\t"`）能绕过身份闸的边界情况。

## 验证

新增回归测试 3 条 + 既有 10 条测试全部通过（13/13）。

Closes #3339