### PR TITLE
bugfix(node_mgmt): get_node_config_asso 缺少 cloud_region_id 时 KeyError → HTTP 500

### DIFF
--- a/server/apps/node_mgmt/tests/test_node_config_asso_validation.py
+++ b/server/apps/node_mgmt/tests/test_node_config_asso_validation.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+"""
+Issue #3621: get_node_config_asso 未校验 cloud_region_id 必填，缺失时 KeyError → HTTP 500
+
+验证：请求体缺少 cloud_region_id 时应返回 HTTP 400，而非 500 KeyError。
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.models import User
+from apps.node_mgmt.views import node as node_view
+
+
+def _build_admin_user():
+    return User(
+        username="test-user-3621",
+        domain="domain.com",
+        locale="en",
+        is_superuser=True,
+        roles=["admin"],
+        group_list=[{"id": 1, "name": "Team"}],
+    )
+
+
+@pytest.mark.django_db
+def test_issue_3621_missing_cloud_region_id_returns_400():
+    """
+    缺少 cloud_region_id 时，接口应返回 HTTP 400，而非因 KeyError 导致 HTTP 500。
+    验证标准：revert 修复（恢复 request.data["cloud_region_id"]）后本测试应 fail（KeyError）。
+    """
+    factory = APIRequestFactory()
+    request = factory.post(
+        "/node_config/node_config_asso/",
+        data={},
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    view = node_view.NodeViewSet.as_view({"post": "get_node_config_asso"})
+    response = view(request)
+
+    assert response.status_code == 400, (
+        f"缺少 cloud_region_id 时期望 HTTP 400，实际得到 {response.status_code}"
+    )
+    body = json.loads(response.content)
+    assert body["result"] is False
+    assert "cloud_region_id" in body["message"]
+
+
+@pytest.mark.django_db
+def test_issue_3621_null_cloud_region_id_returns_400():
+    """
+    cloud_region_id 显式为 null 时，同样应返回 HTTP 400。
+    """
+    factory = APIRequestFactory()
+    request = factory.post(
+        "/node_config/node_config_asso/",
+        data={"cloud_region_id": None},
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    view = node_view.NodeViewSet.as_view({"post": "get_node_config_asso"})
+    response = view(request)
+
+    assert response.status_code == 400
+    body = json.loads(response.content)
+    assert body["result"] is False
+
+
+@pytest.mark.django_db
+def test_issue_3621_with_cloud_region_id_proceeds_normally(monkeypatch):
+    """
+    提供合法 cloud_region_id 时，接口正常执行（返回 200 或无 KeyError）。
+    """
+    # patch get_authorized_node_queryset 返回空 queryset，避免真实 DB 依赖
+    from apps.node_mgmt.models import Node
+
+    monkeypatch.setattr(
+        node_view,
+        "get_authorized_node_queryset",
+        lambda request, *args, **kwargs: Node.objects.none(),
+    )
+
+    factory = APIRequestFactory()
+    request = factory.post(
+        "/node_config/node_config_asso/",
+        data={"cloud_region_id": 1},
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    view = node_view.NodeViewSet.as_view({"post": "get_node_config_asso"})
+    response = view(request)
+
+    # 有 cloud_region_id 时不应因 KeyError 崩溃
+    assert response.status_code == 200

--- a/server/apps/node_mgmt/views/node.py
+++ b/server/apps/node_mgmt/views/node.py
@@ -431,10 +431,13 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
 
     @action(detail=False, methods=["post"], url_path="node_config_asso")
     def get_node_config_asso(self, request):
+        cloud_region_id = request.data.get("cloud_region_id")
+        if not cloud_region_id:
+            return WebUtils.response_error(error_message="cloud_region_id is required")
         nodes = (
             get_authorized_node_queryset(request)
             .prefetch_related("collectorconfiguration_set")
-            .filter(cloud_region_id=request.data["cloud_region_id"])
+            .filter(cloud_region_id=cloud_region_id)
         )
         if request.data.get("ids"):
             nodes = nodes.filter(id__in=request.data["ids"])


### PR DESCRIPTION
关联 Issue: #3621

## 问题

运维人员调用「节点与采集配置关联」接口（POST `/node_config/node_config_asso/`）时，若请求体中遗漏 `cloud_region_id` 字段，后端直接抛出 `KeyError: 'cloud_region_id'` 未被捕获，Django 将其处理为 HTTP 500。调用方（前端 bug、移动客户端、外部 API 用户）看到服务器内部错误，而非明确的「缺少必填参数」提示，既难排查也会产生误报告警。

## 根因

`get_node_config_asso` 使用字典下标 `request.data["cloud_region_id"]` 直接取值，Python 在键不存在时抛 `KeyError`，框架层无对应 handler，最终 Django 把它当作内部错误返回 500。同文件第 214 行的 `get_node` 方法已使用 `request.data.get("cloud_region_id")` 的正确写法，本处属于写法不一致导致的漏网点。

## 怎么修的

改为先用 `.get()` 安全取值，值为空（缺失或显式 null）时提前返回 `WebUtils.response_error(400)`，否则继续原有查询逻辑：

```python
# 修复前
.filter(cloud_region_id=request.data["cloud_region_id"])   # KeyError → 500

# 修复后
cloud_region_id = request.data.get("cloud_region_id")
if not cloud_region_id:
    return WebUtils.response_error(error_message="cloud_region_id is required")
nodes = (
    get_authorized_node_queryset(request)
    .prefetch_related("collectorconfiguration_set")
    .filter(cloud_region_id=cloud_region_id)
)
```

写法与同文件第 214-216 行完全一致，无新增模式。

## 影响范围

仅改动 `server/apps/node_mgmt/views/node.py` 的 `get_node_config_asso` 方法（+3 行），不涉及 Model、serializer、NATS handler 或其他模块。新增单测文件 `test_node_config_asso_validation.py` 覆盖缺失/null/正常传值三种场景。

## 验证

新增三个测试，覆盖：

1. 请求体为空 `{}` → 400，body `result=false`，message 含 `cloud_region_id`
2. `cloud_region_id: null` → 400
3. 正常传 `cloud_region_id: 1` → 200（通过 monkeypatch 绕 DB）

revert 修复后测试 1 和 2 必然因 `KeyError` 而失败——满足「revert 后测试应 fail」准则。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST /node_config/node_config_asso/\nviews/node.py"]
    end

    subgraph N["核心处理层"]
        V1["get_node_config_asso()\nviews/node.py:433"]
        V2["request.data.get('cloud_region_id')\n修复后：安全取值"]
        V3["queryset.filter(cloud_region_id=...)"]
    end

    subgraph E["早返回（修复新增）"]
        E1["WebUtils.response_error(400)\n'cloud_region_id is required'"]
    end

    T1 --> V1 --> V2
    V2 -- "值为空" --> E1
    V2 -- "有效值" --> V3 --> R["WebUtils.response_success(result)"]
```