### PR TITLE
bugfix: 移除 webchat/test.html 中硬编码的 API Token 与内网 SSE 地址（#3554）

### DIFF
--- a/webchat/test.html
+++ b/webchat/test.html
@@ -26,10 +26,11 @@
 
     <script>
         // 最简单的方式：一行代码初始化
+        // 注意：sseUrl / apiKey 仅为占位符，请替换为你自己的服务地址与凭据；切勿将真实凭据提交到仓库
         window.WebChat.default({
-            sseUrl: 'http://10.10.40.117:8000/api/v1/opspilot/bot_mgmt/execute_chat_flow/32/agui-1763629487486/',
+            sseUrl: 'https://<YOUR_SERVER>/api/v1/opspilot/bot_mgmt/execute_chat_flow/<BOT_ID>/<SESSION_ID>/',
             title: '智能助手',
-            apiKey: 'c96a6f28add4ecf7f59a49cc7e7af2b1ebc7444b745319ccb60a9203421da405',
+            apiKey: '<YOUR_API_TOKEN>',
             botAvatarUrl: 'https://api.dicebear.com/7.x/bottts/svg?seed=bot',
             userAvatarUrl: 'https://api.dicebear.com/7.x/avataaars/svg?seed=user',
             customData: { type: 'agui' },


### PR DESCRIPTION
## 问题

`webchat/test.html` 这个演示文件本应只承担"如何接入 WebChat"的示例职责，凭据与真实服务地址应通过占位符表达、由使用者自行注入。但当前文件直接以**真实生产 API Token** 和**内网 SSE 地址**填充并提交进了 `weops/master`，凭据与代码之间的安全边界被打破。任何有仓库读权限的人 `git clone` 后 `grep apiKey` 即可拿到长期有效的 token 并直接调用业务接口。

## 根因（设计层）

演示/测试文件被当成"能直接跑的真实配置"来写，把生产凭据硬编码进了版本库。正确的设计边界是：示例文件只放占位符，真实凭据走环境变量或 `.gitignore` 的本地配置注入，永不入库。本次破边界的具体表现：

- `apiKey` 写入了真实有效的 Bearer Token
- `sseUrl` 写入了内网 IP `10.10.40.117:8000`，暴露服务拓扑

## 怎么修的

把 `webchat/test.html` 中两处硬编码替换为占位符，并补充注释明确"占位符、请自行替换、切勿提交真实凭据"，将该文件恢复为纯示例职责：

- `apiKey: '<真实 token>'` → `apiKey: '<YOUR_API_TOKEN>'`
- `sseUrl: 'http://10.10.40.117:8000/...'` → `sseUrl: 'https://<YOUR_SERVER>/api/v1/opspilot/bot_mgmt/execute_chat_flow/<BOT_ID>/<SESSION_ID>/'`

## 影响范围

- 仅改动 `webchat/test.html` 一个纯静态演示文件，不涉及任何运行时逻辑、接口契约或鉴权代码，无回归风险。
- 不触及 `core`/共享 util，无跨模块影响。

## 验证

- `grep -niE "c96a6f28|10\.10\.40" webchat/test.html` 修复后无任何命中（revert 后该 grep 会重新命中 → 证明改动有效）。
- 占位符语义清晰，使用者按注释替换即可正常初始化 WebChat。

## ⚠️ 须人工跟进（本 PR 无法覆盖）

1. **历史泄露的 token 须由 webchat 负责人立即吊销/轮换** —— 该 token 已进入公开 git 历史，删除文件不等于失效，必须在服务端作废原 token。
2. **git 历史泄露需单独清理** —— 即便本 PR 合入，凭据仍永久留存在历史提交中，需单独 force-rewrite history（或确认仓库可见范围后评估风险）。

## 调用链

```mermaid
flowchart TD
    subgraph T["泄露路径（修复前）"]
        A["任意有仓库读权限的人"] --> B["git clone / 浏览 test.html"]
        B --> C["grep apiKey 获取真实 Token + 内网 SSE URL"]
        C --> D["POST /execute_chat_flow/32/\nAuthorization: Bearer &lt;token&gt;"]
        D --> E["LLM 配额耗尽 / 数据泄露 / 内网拓扑暴露"]
    end

    subgraph F["修复后"]
        F1["test.html 仅含占位符\n&lt;YOUR_API_TOKEN&gt; / &lt;YOUR_SERVER&gt;"]
        F2["使用者自行注入真实凭据，不入库"]
        F1 --> F2
    end
```

关联 Issue #3554，cc @QiuJia-layla（webchat 负责人）请确认并安排吊销历史泄露 token。
