### PR TITLE
bugfix: [monitor] 提取 AlertPermissionMixin 消除重复策略权限逻辑并缩小全量查询范围

### DIFF
--- a/server/apps/monitor/tests/test_alert_permission_mixin.py
+++ b/server/apps/monitor/tests/test_alert_permission_mixin.py
@@ -1,0 +1,315 @@
+"""
+Tests for AlertPermissionMixin — Issue #3608.
+
+验证：
+1. DRY：_get_all_accessible_policy_ids 只在 AlertPermissionMixin 中定义一处，
+   MonitorAlertViewSet / MonitorEventViewSet 均从 Mixin 继承，不再各自重复实现。
+2. 性能优化：当 policy_permissions 不包含 "all" 键时，DB 查询使用
+   monitor_object_id__in 预过滤，而非 MonitorPolicy.objects.all()。
+3. 管理员路径（"all" 键存在）：降级到全量查询，保持行为不变。
+4. 无权限时返回空列表。
+
+测试策略：Django-free，通过 sys.modules 注入伪依赖后 importlib 加载被测模块，
+直接对 AlertPermissionMixin 的方法进行单元测试，revert 修复后断言必须失败。
+"""
+import importlib.util
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+
+def _build_fake_modules():
+    """向 sys.modules 注入最小伪依赖，使 monitor_alert.py 可被 import。"""
+    mods = {}
+
+    def add(name, **attrs):
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+        mods[name] = m
+        return m
+
+    # Django stubs
+    add("django")
+    add("django.db")
+    add("django.db.models", Q=MagicMock())
+
+    # rest_framework stubs — use distinct base classes to avoid MRO "duplicate base class" error
+    class _ViewSet:
+        pass
+
+    class _GenericViewSet:
+        pass
+
+    class _RetrieveModelMixin:
+        pass
+
+    class _UpdateModelMixin:
+        pass
+
+    class _ListModelMixin:
+        pass
+
+    rf = add("rest_framework")
+    add("rest_framework.viewsets", ViewSet=_ViewSet, GenericViewSet=_GenericViewSet)
+    add("rest_framework.mixins",
+        RetrieveModelMixin=_RetrieveModelMixin,
+        UpdateModelMixin=_UpdateModelMixin,
+        ListModelMixin=_ListModelMixin)
+    add("rest_framework.decorators", action=lambda **kw: (lambda f: f))
+    add("rest_framework.response", Response=MagicMock())
+
+    # apps.core stubs
+    add("apps")
+    add("apps.core")
+    add("apps.core.logger", monitor_logger=MagicMock())
+    add("apps.core.utils")
+    add("apps.core.utils.permission_utils",
+        get_permission_rules=MagicMock(),
+        permission_filter=MagicMock(),
+        get_permissions_rules=MagicMock(),
+        check_instance_permission=MagicMock())
+    add("apps.core.utils.web_utils", WebUtils=MagicMock())
+    add("apps.core.utils.team_utils", get_current_team=MagicMock(return_value=1))
+
+    # apps.monitor stubs
+    add("apps.monitor")
+    add("apps.monitor.constants")
+    add("apps.monitor.constants.permission",
+        PermissionConstants=MagicMock(POLICY_MODULE="policy"))
+    add("apps.monitor.models",
+        MonitorAlert=MagicMock(),
+        MonitorEvent=MagicMock(),
+        MonitorPolicy=MagicMock(),
+        MonitorEventRawData=MagicMock(),
+        MonitorAlertMetricSnapshot=MagicMock(),
+        PolicyInstanceBaseline=MagicMock())
+    add("apps.monitor.filters")
+    add("apps.monitor.filters.monitor_alert", MonitorAlertFilter=MagicMock())
+    add("apps.monitor.serializers")
+    add("apps.monitor.serializers.monitor_alert", MonitorAlertSerializer=MagicMock())
+    add("apps.monitor.serializers.monitor_policy", MonitorPolicySerializer=MagicMock())
+    add("apps.monitor.services")
+    add("apps.monitor.services.alert_lifecycle_notify", AlertLifecycleNotifier=MagicMock())
+    add("apps.monitor.services.policy_baseline", PolicyBaselineService=MagicMock())
+    add("apps.monitor.utils")
+    add("apps.monitor.utils.dimension", parse_instance_id=MagicMock())
+    add("apps.monitor.utils.pagination", parse_page_params=MagicMock())
+    add("config")
+    add("config.drf")
+    add("config.drf.pagination", CustomPageNumberPagination=MagicMock())
+
+    return mods
+
+
+def _load_monitor_alert(mods):
+    """Load monitor_alert module using importlib with fake dependencies in place."""
+    spec = importlib.util.spec_from_file_location(
+        "apps.monitor.views.monitor_alert",
+        "/Users/justin/bklite-loops/wt-issue-scan/server/apps/monitor/views/monitor_alert.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["apps.monitor.views.monitor_alert"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestAlertPermissionMixin(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._mods = _build_fake_modules()
+        cls._module = _load_monitor_alert(cls._mods)
+        cls.AlertPermissionMixin = cls._module.AlertPermissionMixin
+        cls.MonitorAlertViewSet = cls._module.MonitorAlertViewSet
+        cls.MonitorEventViewSet = cls._module.MonitorEventViewSet
+
+    # -----------------------------------------------------------------
+    # 1. DRY：两个 ViewSet 都继承自 AlertPermissionMixin
+    # -----------------------------------------------------------------
+
+    def test_monitor_alert_viewset_inherits_mixin(self):
+        """MonitorAlertViewSet 必须继承 AlertPermissionMixin。"""
+        self.assertTrue(
+            issubclass(self.MonitorAlertViewSet, self.AlertPermissionMixin),
+            "MonitorAlertViewSet 未继承 AlertPermissionMixin"
+        )
+
+    def test_monitor_event_viewset_inherits_mixin(self):
+        """MonitorEventViewSet 必须继承 AlertPermissionMixin。"""
+        self.assertTrue(
+            issubclass(self.MonitorEventViewSet, self.AlertPermissionMixin),
+            "MonitorEventViewSet 未继承 AlertPermissionMixin"
+        )
+
+    def test_method_defined_only_in_mixin(self):
+        """_get_all_accessible_policy_ids 只在 Mixin 中定义，不在子类字典中单独存在。"""
+        self.assertNotIn(
+            "_get_all_accessible_policy_ids",
+            self.MonitorAlertViewSet.__dict__,
+            "_get_all_accessible_policy_ids 不应在 MonitorAlertViewSet.__dict__ 中（应由 Mixin 提供）"
+        )
+        self.assertNotIn(
+            "_get_all_accessible_policy_ids",
+            self.MonitorEventViewSet.__dict__,
+            "_get_all_accessible_policy_ids 不应在 MonitorEventViewSet.__dict__ 中（应由 Mixin 提供）"
+        )
+        self.assertIn(
+            "_get_all_accessible_policy_ids",
+            self.AlertPermissionMixin.__dict__,
+            "_get_all_accessible_policy_ids 应在 AlertPermissionMixin.__dict__ 中"
+        )
+
+    # -----------------------------------------------------------------
+    # 2. 性能优化：无 "all" 键时使用 monitor_object_id__in 预过滤
+    # -----------------------------------------------------------------
+
+    def test_db_filter_by_object_type_when_no_all_key(self):
+        """
+        当 policy_permissions 不含 "all" 键时，MonitorPolicy.objects.filter 必须被调用
+        且参数为 monitor_object_id__in，而非 MonitorPolicy.objects.all()。
+
+        revert 修复（即恢复全量查询）后此断言会失败。
+        """
+        mixin = self.AlertPermissionMixin()
+        fake_request = MagicMock()
+        fake_request.COOKIES.get.return_value = "0"
+
+        # 权限数据：有两个 object_type（1 和 2），无 "all" 键
+        fake_permissions = {
+            "1": {"instance": [{"id": 10}], "team": []},
+            "2": {"instance": [{"id": 20}], "team": []},
+        }
+        permissions_result = {"data": fake_permissions, "team": [1]}
+
+        # Mock get_permissions_rules
+        self._module.get_permissions_rules.return_value = permissions_result
+        self._module.get_current_team.return_value = 1
+
+        # Mock check_instance_permission to return False (no accessible policies)
+        self._module.check_instance_permission.return_value = False
+
+        # Mock MonitorPolicy queryset chain
+        fake_qs = MagicMock()
+        fake_qs.select_related.return_value = fake_qs
+        fake_qs.prefetch_related.return_value = fake_qs
+        fake_qs.__iter__ = MagicMock(return_value=iter([]))
+        self._module.MonitorPolicy.objects.filter.return_value = fake_qs
+        self._module.MonitorPolicy.objects.all.return_value = fake_qs
+
+        result = mixin._get_all_accessible_policy_ids(fake_request)
+
+        # Must use filter with monitor_object_id__in, not all()
+        self._module.MonitorPolicy.objects.filter.assert_called_once_with(
+            monitor_object_id__in=[1, 2]
+        )
+        self._module.MonitorPolicy.objects.all.assert_not_called()
+        self.assertEqual(result, [])
+
+    # -----------------------------------------------------------------
+    # 3. 管理员路径（"all" 键存在）：使用 all()
+    # -----------------------------------------------------------------
+
+    def test_db_uses_all_when_admin_all_key_present(self):
+        """
+        当 policy_permissions 含 "all" 键时，降级为 MonitorPolicy.objects.all()，
+        保持原有管理员权限行为不变。
+        """
+        mixin = self.AlertPermissionMixin()
+        fake_request = MagicMock()
+        fake_request.COOKIES.get.return_value = "0"
+
+        fake_permissions = {
+            "all": {"team": [1]},
+            "1": {"instance": [], "team": []},
+        }
+        permissions_result = {"data": fake_permissions, "team": [1]}
+
+        self._module.get_permissions_rules.return_value = permissions_result
+        self._module.get_current_team.return_value = 1
+        self._module.check_instance_permission.return_value = False
+
+        fake_qs = MagicMock()
+        fake_qs.select_related.return_value = fake_qs
+        fake_qs.prefetch_related.return_value = fake_qs
+        fake_qs.__iter__ = MagicMock(return_value=iter([]))
+        self._module.MonitorPolicy.objects.all.return_value = fake_qs
+        self._module.MonitorPolicy.objects.filter.reset_mock()
+
+        mixin._get_all_accessible_policy_ids(fake_request)
+
+        self._module.MonitorPolicy.objects.all.assert_called_once()
+        # filter should NOT have been called with monitor_object_id__in
+        for c in self._module.MonitorPolicy.objects.filter.call_args_list:
+            self.assertNotIn("monitor_object_id__in", c.kwargs,
+                             "admin 路径不应调用 monitor_object_id__in 过滤")
+
+    # -----------------------------------------------------------------
+    # 4. 无权限时返回空列表
+    # -----------------------------------------------------------------
+
+    def test_empty_policy_permissions_returns_empty_list(self):
+        """policy_permissions 为空时，不查 DB，直接返回 []。"""
+        mixin = self.AlertPermissionMixin()
+        fake_request = MagicMock()
+        fake_request.COOKIES.get.return_value = "0"
+
+        self._module.get_permissions_rules.return_value = {"data": {}, "team": []}
+        self._module.get_current_team.return_value = 1
+        self._module.MonitorPolicy.objects.filter.reset_mock()
+        self._module.MonitorPolicy.objects.all.reset_mock()
+
+        result = mixin._get_all_accessible_policy_ids(fake_request)
+
+        self.assertEqual(result, [])
+        self._module.MonitorPolicy.objects.filter.assert_not_called()
+        self._module.MonitorPolicy.objects.all.assert_not_called()
+
+    # -----------------------------------------------------------------
+    # 5. 有权限时返回正确 ID 列表
+    # -----------------------------------------------------------------
+
+    def test_returns_accessible_policy_ids(self):
+        """check_instance_permission 返回 True 的策略 ID 应出现在结果中。"""
+        mixin = self.AlertPermissionMixin()
+        fake_request = MagicMock()
+        fake_request.COOKIES.get.return_value = "0"
+
+        fake_permissions = {"3": {"instance": [{"id": 100}], "team": []}}
+        permissions_result = {"data": fake_permissions, "team": [1]}
+
+        self._module.get_permissions_rules.return_value = permissions_result
+        self._module.get_current_team.return_value = 1
+
+        # Two mock policies: one passes permission check, one fails
+        policy_pass = MagicMock()
+        policy_pass.monitor_object_id = 3
+        policy_pass.id = 100
+        policy_pass.policyorganization_set.all.return_value = []
+
+        policy_fail = MagicMock()
+        policy_fail.monitor_object_id = 3
+        policy_fail.id = 999
+        policy_fail.policyorganization_set.all.return_value = []
+
+        fake_qs = MagicMock()
+        fake_qs.select_related.return_value = fake_qs
+        fake_qs.prefetch_related.return_value = fake_qs
+        fake_qs.__iter__ = MagicMock(return_value=iter([policy_pass, policy_fail]))
+        self._module.MonitorPolicy.objects.filter.return_value = fake_qs
+
+        # policy_pass passes, policy_fail doesn't
+        self._module.check_instance_permission.side_effect = (
+            lambda obj_id, pol_id, teams, perms, cur_team: pol_id == 100
+        )
+
+        result = mixin._get_all_accessible_policy_ids(fake_request)
+
+        self.assertEqual(result, [100])
+        self.assertNotIn(999, result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -33,7 +33,72 @@ from config.drf.pagination import CustomPageNumberPagination
 from apps.core.utils.team_utils import get_current_team
 
 
+class AlertPermissionMixin:
+    """
+    共享的策略权限过滤逻辑。
+
+    将原先在 MonitorAlertViewSet 和 MonitorEventViewSet 中各自重复定义的
+    _get_all_accessible_policy_ids / _check_alert_permission 提取到此 Mixin，
+    同时将全量加载改为按权限数据结构预先缩小 DB 查询范围，避免 O(N) 全表扫描。
+    """
+
+    def _get_all_accessible_policy_ids(self, request):
+        """
+        返回当前用户有权限访问的所有策略 ID 列表。
+
+        优化点：根据权限规则中已知的 monitor_object_id 集合先在 DB 层过滤，
+        再在内存中做精细权限判断，避免全表加载所有策略。
+        """
+        current_team = get_current_team(request)
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+
+        permissions_result = get_permissions_rules(
+            request.user,
+            current_team,
+            "monitor",
+            PermissionConstants.POLICY_MODULE,
+            include_children=include_children,
+        )
+
+        policy_permissions = permissions_result.get("data", {})
+        cur_team = permissions_result.get("team", [])
+
+        if not policy_permissions:
+            return []
+
+        # 从权限数据中提取已知的 monitor_object_id，用于 DB 层预过滤。
+        # policy_permissions 结构：{ object_type_id: {instance: [...], team: [...]}, "all": {...} }
+        # "all" 键表示管理员级别权限（对全部对象类型生效），此时不能缩小范围。
+        if "all" not in policy_permissions:
+            known_object_type_ids = [
+                int(k) for k in policy_permissions.keys() if k != "all" and str(k).isdigit()
+            ]
+            policy_qs = MonitorPolicy.objects.filter(
+                monitor_object_id__in=known_object_type_ids
+            )
+        else:
+            policy_qs = MonitorPolicy.objects.all()
+
+        policy_qs = policy_qs.select_related("monitor_object").prefetch_related("policyorganization_set")
+
+        accessible_policy_ids = []
+        for policy_obj in policy_qs:
+            monitor_object_id = str(policy_obj.monitor_object_id)
+            policy_id = policy_obj.id
+            teams = {org.organization for org in policy_obj.policyorganization_set.all()}
+            if check_instance_permission(monitor_object_id, policy_id, teams, policy_permissions, cur_team):
+                accessible_policy_ids.append(policy_id)
+
+        return accessible_policy_ids
+
+    def _check_alert_permission(self, request, alert_obj):
+        """Check if the current user has permission to access the given alert."""
+        accessible_policy_ids = self._get_all_accessible_policy_ids(request)
+        return alert_obj.policy_id in accessible_policy_ids
+
+
 class MonitorAlertViewSet(
+    AlertPermissionMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
     mixins.ListModelMixin,
@@ -54,52 +119,6 @@ class MonitorAlertViewSet(
                 return qs.none()
             qs = qs.filter(policy_id__in=accessible_policy_ids)
         return qs
-
-    def _check_alert_permission(self, request, alert_obj):
-        """Check if the current user has permission to access the given alert."""
-        accessible_policy_ids = self._get_all_accessible_policy_ids(request)
-        return alert_obj.policy_id in accessible_policy_ids
-
-    def _get_all_accessible_policy_ids(self, request):
-        """
-        获取当前用户所有有权限的策略ID
-        """
-        current_team = get_current_team(request)
-        include_children = request.COOKIES.get("include_children", "0") == "1"
-
-        # 获取所有采集类型下policy模块的权限规则
-        permissions_result = get_permissions_rules(
-            request.user,
-            current_team,
-            "monitor",
-            PermissionConstants.POLICY_MODULE,
-            include_children=include_children,
-        )
-
-        policy_permissions = permissions_result.get("data", {})
-        cur_team = permissions_result.get("team", [])
-
-        if not policy_permissions:
-            return []
-
-        # 一次性获取所有策略及其关联组织，减少SQL查询
-        all_policies = MonitorPolicy.objects.select_related("monitor_object").prefetch_related("policyorganization_set").all()
-
-        accessible_policy_ids = []
-
-        # 遍历所有策略，在内存中进行权限检查（使用通用权限检查函数）
-        for policy_obj in all_policies:
-            monitor_object_id = str(policy_obj.monitor_object_id)
-            policy_id = policy_obj.id
-
-            # 获取策略关联的组织
-            teams = {org.organization for org in policy_obj.policyorganization_set.all()}
-
-            # 使用通用权限检查函数
-            if check_instance_permission(monitor_object_id, policy_id, teams, policy_permissions, cur_team):
-                accessible_policy_ids.append(policy_id)
-
-        return accessible_policy_ids
 
     def list(self, request, *args, **kwargs):
         monitor_object_id = request.query_params.get("monitor_object_id", None)
@@ -292,40 +311,7 @@ class MonitorAlertViewSet(
         )
 
 
-class MonitorEventViewSet(viewsets.ViewSet):
-    def _get_all_accessible_policy_ids(self, request):
-        current_team = get_current_team(request)
-        include_children = request.COOKIES.get("include_children", "0") == "1"
-
-        permissions_result = get_permissions_rules(
-            request.user,
-            current_team,
-            "monitor",
-            PermissionConstants.POLICY_MODULE,
-            include_children=include_children,
-        )
-
-        policy_permissions = permissions_result.get("data", {})
-        cur_team = permissions_result.get("team", [])
-
-        if not policy_permissions:
-            return []
-
-        all_policies = MonitorPolicy.objects.select_related("monitor_object").prefetch_related("policyorganization_set").all()
-
-        accessible_policy_ids = []
-        for policy_obj in all_policies:
-            monitor_object_id = str(policy_obj.monitor_object_id)
-            policy_id = policy_obj.id
-            teams = {org.organization for org in policy_obj.policyorganization_set.all()}
-            if check_instance_permission(monitor_object_id, policy_id, teams, policy_permissions, cur_team):
-                accessible_policy_ids.append(policy_id)
-
-        return accessible_policy_ids
-
-    def _check_alert_permission(self, request, alert_obj):
-        accessible_policy_ids = self._get_all_accessible_policy_ids(request)
-        return alert_obj.policy_id in accessible_policy_ids
+class MonitorEventViewSet(AlertPermissionMixin, viewsets.ViewSet):
 
     @action(methods=["get"], detail=False, url_path="query/(?P<alert_id>[^/.]+)")
     def get_events(self, request, alert_id):


### PR DESCRIPTION
## 问题

每次访问告警列表（`MonitorAlertViewSet.list`）或告警事件查询（`MonitorEventViewSet`）时，系统都会把数据库中**所有 MonitorPolicy 全量加载进内存**，再用 Python for 循环逐条判断当前用户有没有权限。当策略数量超过 500 条，每次请求的内存峰值和响应时延随策略规模线性增长；多用户并发时问题叠加。

同时，这段过滤逻辑在两个 ViewSet 中**各自维护一份完全相同的副本**——历史上已因此导致 bug 只修了一处、另一处漏改的问题（见 #3334）。

## 根因

权限过滤被实现为"先全查再内存筛"的模式：

```python
# 有问题：全量加载，无上界
all_policies = MonitorPolicy.objects.select_related(...).prefetch_related(...).all()
for policy_obj in all_policies:   # O(N) Python 循环
    if check_instance_permission(...):
        accessible_policy_ids.append(policy_id)
```

这段代码在 `MonitorAlertViewSet` 和 `MonitorEventViewSet` 中各写了一遍，违反 DRY 原则，且完全绕过了数据库索引。

## 怎么修的

**一、提取 `AlertPermissionMixin`**：将两处重复的 `_get_all_accessible_policy_ids` 和 `_check_alert_permission` 合并到一个 Mixin，两个 ViewSet 通过继承共用，消除代码重复。

**二、DB 层预过滤**：从权限规则数据（`policy_permissions`）中提取用户有权限的 `monitor_object_id` 集合，在 ORM 查询时先加一层 `filter(monitor_object_id__in=known_ids)`，仅加载相关对象类型下的策略，而非全表扫描。管理员路径（含 `"all"` 键）保持原有全量行为不变。

```python
# 修复后：仅查有权限的对象类型下的策略
if "all" not in policy_permissions:
    known_object_type_ids = [int(k) for k in policy_permissions.keys() if str(k).isdigit()]
    policy_qs = MonitorPolicy.objects.filter(monitor_object_id__in=known_object_type_ids)
else:
    policy_qs = MonitorPolicy.objects.all()  # 管理员：保持全量
policy_qs = policy_qs.select_related("monitor_object").prefetch_related("policyorganization_set")
```

## 影响范围

仅修改 `server/apps/monitor/views/monitor_alert.py`（单文件，单模块）。`check_instance_permission` 的精细权限判断逻辑不变，行为完全向后兼容——预过滤只是缩小了进入内存循环的候选集，不会漏判任何已有权限规则。

## 验证

新增 `server/apps/monitor/tests/test_alert_permission_mixin.py`，覆盖 5 个场景：
- DRY 约束：`_get_all_accessible_policy_ids` 只在 Mixin `__dict__` 中存在，不在子类中重复
- 无 `"all"` 键时调用 `filter(monitor_object_id__in=...)` 而非 `all()`
- 含 `"all"` 键（管理员）时降级为 `all()`
- 空权限时不查 DB，直接返回 `[]`
- 权限通过时返回正确的 policy ID 列表

将修复 revert 后上述测试均失败，符合"revert 必须失败"准则。

```
Ran 7 tests in 0.010s
OK
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MonitorAlertViewSet.list()\nmonitor_alert.py"]
        T2["MonitorEventViewSet.get_events()\nmonitor_alert.py"]
    end

    subgraph M["AlertPermissionMixin（新）"]
        M1["_get_all_accessible_policy_ids()\nmonitor_alert.py"]
        M2["_check_alert_permission()\nmonitor_alert.py"]
    end

    subgraph DB["DB 查询层"]
        DB1["MonitorPolicy.objects.filter\nmonitor_object_id__in=known_ids\n（预过滤，非全表）"]
        DB2["MonitorPolicy.objects.all()\n仅管理员路径"]
    end

    subgraph P["内存精细判断"]
        P1["check_instance_permission()\npermission_utils.py"]
    end

    T1 --> M1
    T2 --> M2
    M2 --> M1
    M1 -- 无 all 键 --> DB1
    M1 -- 含 all 键 --> DB2
    DB1 --> P1
    DB2 --> P1
    P1 -- True --> M1
```

关联 Issue #3608