### PR TITLE
bugfix(alerts): 恢复 operator action 的 @HasPermission("Alarms-Edit") 权限校验

### DIFF
--- a/server/apps/alerts/tests/test_incident_alert_views.py
+++ b/server/apps/alerts/tests/test_incident_alert_views.py
@@ -128,6 +128,24 @@ def test_alert_operator_action_no_permission(superuser):
 
 
 @pytest.mark.django_db
+def test_alert_operator_requires_edit_permission(authenticated_user):
+    """Issue #3383: operator action 必须拦截仅持有 Alarms-View 的用户（权限旁路修复验证）。
+
+    若将 @HasPermission("Alarms-Edit") 注释掉，本测试将失败——
+    因为 view-only 用户的请求会被放行并返回 200/500，而非 403。
+    """
+    # 只授予 Alarms-View，不授予 Alarms-Edit
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"alarm": {"Alarms-View"}}
+
+    _make_alert("A1", team=[1])
+    request = _request("post", "/alerts/operator/close/", authenticated_user, data={"alert_id": ["A1"]}, team="1")
+    response = AlertModelViewSet.as_view({"post": "operator"})(request, operator_action="close")
+    # HasPermission("Alarms-Edit") 应拦截并返回 403
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
 def test_alert_operator_action_acknowledge(superuser):
     from apps.alerts.constants.constants import AlertStatus
 

--- a/server/apps/alerts/views/alert.py
+++ b/server/apps/alerts/views/alert.py
@@ -163,7 +163,7 @@ class AlertModelViewSet(AuthViewSet):
         )
         return Response(result)
 
-    # @HasPermission("Alarms-Edit")
+    @HasPermission("Alarms-Edit")
     @action(
         methods=["post"],
         detail=False,


### PR DESCRIPTION
## 问题

关联 Issue #3383：`AlertModelViewSet.operator` action（分派/认领/关闭/转派）的 `@HasPermission("Alarms-Edit")` 被注释掉，导致仅持有 `Alarms-View` 的只读用户可对其 team 范围内任意告警执行写操作，造成告警处置权限旁路。

## 修复

- `server/apps/alerts/views/alert.py`：恢复第 166 行被注释的 `@HasPermission("Alarms-Edit")`
- `server/apps/alerts/tests/test_incident_alert_views.py`：新增 `test_alert_operator_requires_edit_permission` 回归测试，验证 `Alarms-View` 用户调用 operator action 收到 403；若再次注释掉装饰器该测试将失败

## 验证

```bash
cd server && uv run pytest apps/alerts/tests/test_incident_alert_views.py -v
```

@周壮杰 ⚠️ 权限旁路修复，请 review。