### PR TITLE
bugfix(monitor): 修复 get_monitor_statistics 用 naive datetime 与 tz-aware created_at 比较导致今日计数偏差

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Optional
 
 from django.db.models import Count, Q
+from django.utils import timezone
 from rest_framework import serializers
 
 import nats_client
@@ -1136,7 +1137,7 @@ def get_monitor_statistics(user_info=None, **kwargs):
     alert_recovered = alert_qs.filter(status="recovered").count()
     alert_closed = alert_qs.filter(status="closed").count()
 
-    today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
     alert_today = alert_qs.filter(created_at__gte=today_start).count()
 
     event_qs = MonitorEvent.objects.filter(policy_id__in=policy_qs.values_list("id", flat=True)) if not is_superuser else MonitorEvent.objects.all()

--- a/server/apps/monitor/tests/test_nats_create_handlers.py
+++ b/server/apps/monitor/tests/test_nats_create_handlers.py
@@ -605,3 +605,58 @@ def test_get_monitor_statistics_superuser_returns_full_counts(monkeypatch):
 
     for key in _ORG_SCOPED_KEYS + _CATALOG_KEYS:
         assert data[key] == 100, f"{key} 超管应为全量 100，实际 {data[key]}"
+
+
+# ============ 今日计数时区一致性（Issue #3607）============
+
+
+def test_get_monitor_statistics_today_start_is_tz_aware(monkeypatch):
+    """today_start 必须来自 timezone.now()（tz-aware），而非 datetime.now()（naive）。
+
+    验证方式：拦截 timezone.now 记录调用，同时拦截 MonitorAlert.objects.filter 捕获
+    created_at__gte 参数，断言它带有 tzinfo。revert 修复（改回 datetime.now()）后，
+    today_start 为 naive datetime，tzinfo 为 None，本断言将失败。
+    """
+    import sys
+    from datetime import datetime, timezone as _stdlib_tz
+
+    module = _load_monitor_nats_module(monkeypatch, "monitor_nats_stats_tz_test_module")
+    _install_stats_models(monkeypatch, module)
+
+    # 注入一个固定的 tz-aware 时间，并记录 timezone.now 是否被调用
+    fixed_aware = datetime(2024, 6, 15, 16, 30, 0, tzinfo=_stdlib_tz.utc)
+    timezone_calls = []
+
+    def fake_timezone_now():
+        timezone_calls.append(True)
+        return fixed_aware
+
+    monkeypatch.setattr(module.timezone, "now", fake_timezone_now)
+
+    # 拦截 MonitorAlert（超管路径，全量 alert_qs）的 filter 来捕获 today_start
+    captured_filter_kwargs = {}
+
+    class _TodayCapturingQS(_StatsFakeQS):
+        def filter(self, **kwargs):
+            if "created_at__gte" in kwargs:
+                captured_filter_kwargs.update(kwargs)
+            return super().filter(**kwargs)
+
+    class _TodayCapturingModel:
+        objects = _TodayCapturingQS("full")
+
+    monkeypatch.setattr(module, "MonitorAlert", _TodayCapturingModel)
+
+    module.get_monitor_statistics(user_info={"is_superuser": True})
+
+    # 1. timezone.now() 必须被调用过（修复点：如果改回 datetime.now()，不会调用 timezone.now）
+    assert timezone_calls, "timezone.now() 未被调用——today_start 未使用 tz-aware 时间源"
+
+    # 2. 传入 filter 的 today_start 必须带时区信息
+    assert "created_at__gte" in captured_filter_kwargs, "alert_qs.filter(created_at__gte=...) 未被调用"
+    today_start = captured_filter_kwargs["created_at__gte"]
+    assert today_start.tzinfo is not None, (
+        f"today_start 是 naive datetime（tzinfo=None），"
+        f"Django USE_TZ=True 环境下与 tz-aware created_at 比较会产生偏差；"
+        f"应使用 timezone.now() 替代 datetime.now()"
+    )


### PR DESCRIPTION
## 问题

监控大盘统计接口（`get_monitor_statistics`）中，「今日告警数」和「今日事件数」在非 UTC 时区部署的环境下（如中国区标准配置 Asia/Shanghai，UTC+8）每天必然出现最多 8 小时的边界偏差窗口：UTC 午夜（即北京时间 08:00）前后，「今日」的起始时间戳算错，导致告警数虚增或漏计。

Django 对这种 naive/aware 混用还会持续产生 `RuntimeWarning: DateTimeField received a naive datetime`，掩盖真正的异常日志。

## 根因

`datetime.now()` 返回的是不带时区信息的 naive datetime。Django `USE_TZ=True`（默认开启）时，所有 `DateTimeField`（如 `MonitorAlert.created_at`、`MonitorEvent.created_at`）存储的是 tz-aware UTC 时间。两者用 `__gte` 比较时，Django 以本地时区做隐式转换，非 UTC 环境下「今日 0 点」的实际边界偏移了整个时区偏移量。

## 怎么修的

将 `today_start` 的时间来源从 `datetime.now()` 换成 `django.utils.timezone.now()`，后者返回当前 UTC 时刻的 tz-aware datetime，与 `DateTimeField` 的存储格式完全一致：

```python
# 修复前（有问题）
from datetime import datetime
today_start = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)

# 修复后
from django.utils import timezone
today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
```

改动 2 行（加 1 行 import）：`server/apps/monitor/nats/monitor.py`。

## 影响范围

- 仅涉及 `server/apps/monitor/nats/monitor.py` 中的 `get_monitor_statistics` 函数
- 不改查询逻辑、不改模型、不改接口协议，无需数据迁移
- `alert_today` 和 `event_today` 两个字段的含义（今日 UTC 自然日起始）与 `DateTimeField` 存储语义对齐，其他调用方不受影响

## 验证

新增测试 `test_get_monitor_statistics_today_start_is_tz_aware`（`test_nats_create_handlers.py`）：

1. 拦截 `module.timezone.now` 记录调用次数
2. 拦截 `MonitorAlert.objects.filter` 捕获 `created_at__gte` 参数
3. 断言 `timezone.now()` 被调用过（revert 后不调用 → 失败）
4. 断言 `today_start.tzinfo is not None`（revert 后 naive datetime → 失败）

使用已有的 Django-free 注入式测试框架，无需 Django settings 或数据库。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NATS subject: get_monitor_statistics\nnats/monitor.py:1058"]
    end

    subgraph N["核心处理层"]
        F1["get_monitor_statistics()\nnats/monitor.py:1110"]
        F2["timezone.now().replace(...)\nnats/monitor.py:1140\n✅ tz-aware UTC"]
    end

    subgraph Q["查询层"]
        Q1["alert_qs.filter(created_at__gte=today_start)\nnats/monitor.py:1141"]
        Q2["event_qs.filter(created_at__gte=today_start)\nnats/monitor.py:1145"]
    end

    T1 --> F1 --> F2
    F2 --> Q1
    F2 --> Q2
```

关联 Issue #3607