### PR TITLE
bugfix(webchat): 修复 Chat 组件 stale closure 致 onMessageReceived prop 更新失效

### DIFF
--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -77,6 +77,11 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const streamingContentRef = useRef<string>('');
   const currentMessageIdRef = useRef<string | null>(null);
+  // 保持 onMessageReceived 最新引用，避免 useEffect 空 deps 闭包固化旧 prop
+  const onMessageReceivedRef = useRef(onMessageReceived);
+  useEffect(() => {
+    onMessageReceivedRef.current = onMessageReceived;
+  }, [onMessageReceived]);
 
   // Cache avatar elements to prevent re-fetching on every render
   const botAvatar = React.useMemo(
@@ -123,6 +128,24 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
     aguiHandlerRef.current.getEventStream().subscribe((event: AGUIEvent) => {
       handleAGUIEvent(event);
     });
+  };
+
+  // 确保当前存在一条 bot 消息，若尚未创建则新建并通知外部。
+  // TEXT_MESSAGE_START 和 TOOL_CALL_START 均需此逻辑，提取以消除重复。
+  const ensureCurrentMessage = () => {
+    if (currentMessageIdRef.current) return;
+    const newAssistantMsg: Message = {
+      id: generateId(),
+      type: 'text',
+      content: '',
+      sender: 'bot',
+      timestamp: Date.now(),
+      metadata: { contentChunks: [] },
+    };
+    currentMessageIdRef.current = newAssistantMsg.id;
+    setMessages((prev) => [...prev, newAssistantMsg]);
+    sessionManagerRef.current?.addMessage(newAssistantMsg);
+    onMessageReceivedRef.current?.(newAssistantMsg);
   };
 
   // Handle AG-UI protocol events
@@ -249,26 +272,8 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         }
         
         // 如果还没有创建消息，现在创建
-        if (!currentMessageIdRef.current) {
-          const newAssistantMsg: Message = {
-            id: generateId(),
-            type: 'text',
-            content: '',
-            sender: 'bot',
-            timestamp: Date.now(),
-            metadata: {
-              contentChunks: []
-            },
-          };
-          
-          currentMessageIdRef.current = newAssistantMsg.id;
-          
-          setMessages((prev) => [...prev, newAssistantMsg]);
-          sessionManagerRef.current?.addMessage(newAssistantMsg);
-          onMessageReceived?.(newAssistantMsg);
-          
-        }
-        
+        ensureCurrentMessage();
+
         // 重置当前文本内容累加器
         streamingContentRef.current = '';
         setIsThinking(false);
@@ -383,28 +388,10 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
           name: toolStartEvent.toolCallName || toolStartEvent.name || 'Unknown Tool',
           status: 'running' as const,
         };
-        
-        // 如果还没有创建消息，现在创建
-        if (!currentMessageIdRef.current) {
-          const newAssistantMsg: Message = {
-            id: generateId(),
-            type: 'text',
-            content: '',
-            sender: 'bot',
-            timestamp: Date.now(),
-            metadata: {
-              contentChunks: []
-            },
-          };
-          
-          currentMessageIdRef.current = newAssistantMsg.id;
-          
-          setMessages((prev) => [...prev, newAssistantMsg]);
-          sessionManagerRef.current?.addMessage(newAssistantMsg);
-          onMessageReceived?.(newAssistantMsg);
-          
-        }
-        
+
+        // 如果还没有创建消息，现在创建（与 TEXT_MESSAGE_START 共用同一逻辑）
+        ensureCurrentMessage();
+
         // Add tool call as a new separate chunk
         setMessages((prev) => {
           return prev.map(msg => {
@@ -677,8 +664,9 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
       return [...prev, message];
     });
     sessionManagerRef.current?.addMessage(message);
-    onMessageReceived?.(message);
-  }, [onMessageReceived]);
+    // 通过 ref 调用，确保始终使用最新的 onMessageReceived prop
+    onMessageReceivedRef.current?.(message);
+  }, []);
 
   // Handle image upload
   const handleImageUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## 问题

`Chat` 组件的 `onMessageReceived` 是父组件传入的回调 prop，用于在消息产生时通知外部。问题在于：`setupAGUIEventHandlers` 在 `useEffect([], [])` 中**只在 mount 时执行一次**，订阅闭包在此时捕获了 `onMessageReceived` 的**初始引用**。

此后父组件即使更新了 prop（如 SPA 路由切换时换了一个新的回调函数），订阅闭包感知不到变化——**始终调用首次渲染时的旧回调**。若旧回调引用了已卸载组件的状态，还会触发"无法对已卸载组件更新状态"的 React 警告，甚至内存泄漏。

## 根因

`useEffect(callback, [])` 形成了一个**空依赖闭包**：`onMessageReceived` prop 在首次渲染时被捕获，之后 React 不会重新执行该 effect，闭包永远持有旧引用。React 标准解法是用 `useRef` 保存最新值并在同步 effect 中更新，让闭包通过 `ref.current` 访问。

## 怎么修的

**1. stale closure 修复**（核心）：

```typescript
const onMessageReceivedRef = useRef(onMessageReceived);
useEffect(() => {
  onMessageReceivedRef.current = onMessageReceived;
}, [onMessageReceived]);
```

将全部三处 `onMessageReceived?.(...)` 调用改为 `onMessageReceivedRef.current?.()` 调用。`addMessage` 的 `useCallback` deps 数组同步改为 `[]`，不再因 prop 变化触发重建。

**2. TOOL_CALL 重复逻辑消除**：提取 `ensureCurrentMessage()` 辅助函数，消除 `TEXT_MESSAGE_START` / `TOOL_CALL_START` 两处完全重复的首次建消息逻辑（约 18 行 x 2）。

## 影响范围

改动仅限 `webchat/packages/webchat-ui/src/Chat.tsx`（-44 / +32 行）。无 API/Model 变更，向后兼容。若父组件不动态更新 `onMessageReceived`，行为与修复前完全一致。

## 验证

revert 测试：将 `onMessageReceivedRef` 改回直接调用 `onMessageReceived?.()` 后，父组件更新 prop 时仍会调用旧回调——符合"revert 后必须失败"准则，说明修复有效覆盖了缺陷路径。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["mount: useEffect\nChat.tsx:93"]
    end

    subgraph N["核心处理层"]
        F1["setupAGUIEventHandlers\nChat.tsx:125"]
        F2["subscribe → handleAGUIEvent\n闭包访问 onMessageReceivedRef.current"]
        F3["ensureCurrentMessage\nChat.tsx:135（新提取）"]
    end

    subgraph R["Ref 同步层（修复）"]
        R1["useEffect([onMessageReceived])\n每次 prop 更新同步 ref.current"]
    end

    T1 --> F1 --> F2 --> F3
    R1 -. "保持最新引用" .-> F2
    F3 -- "onMessageReceivedRef.current?.()" --> EXT["外部回调（始终最新）"]
```

关联 Issue: #3601