### PR TITLE
bugfix: webchat 图片上传/粘贴缺少文件大小校验导致内存激增

### DIFF
--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -31,6 +31,12 @@ export interface ChatProps extends WebChatConfig {
   apiKey?: string;
 }
 
+// 图片大小上限（字节），默认 4MB，可通过 NEXT_PUBLIC_MAX_IMAGE_SIZE 环境变量覆盖
+const MAX_IMAGE_SIZE =
+  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_MAX_IMAGE_SIZE
+    ? parseInt(process.env.NEXT_PUBLIC_MAX_IMAGE_SIZE, 10)
+    : 0) || 4 * 1024 * 1024;
+
 const defaultBotAvatar = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSIxNiIgY3k9IjE2IiByPSIxNiIgZmlsbD0iIzgxODVmZiIvPgogIDxjaXJjbGUgY3g9IjExIiBjeT0iMTIiIHI9IjIiIGZpbGw9IndoaXRlIi8+CiAgPGNpcmNsZSBjeD0iMjEiIGN5PSIxMiIgcj0iMiIgZmlsbD0id2hpdGUiLz4KICA8cGF0aCBkPSJNIDEwIDIwIFEgMTYgMjQgMjIgMjAiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBmaWxsPSJub25lIi8+Cjwvc3ZnPg==';
 const defaultUserAvatar = 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMzIiIGhlaWdodD0iMzIiIHZpZXdCb3g9IjAgMCAzMiAzMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8Y2lyY2xlIGN4PSIxNiIgY3k9IjE2IiByPSIxNiIgZmlsbD0iIzEwYjk4MSIvPgogIDxjaXJjbGUgY3g9IjE2IiBjeT0iMTIiIHI9IjUiIGZpbGw9IndoaXRlIi8+CiAgPHBhdGggZD0iTSA2IDI4IFEgNiAyMCAxNiAyMCBRIDI2IDIwIDI2IDI4IiBmaWxsPSJ3aGl0ZSIvPgo8L3N2Zz4=';
 
@@ -690,6 +696,11 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
     for (let i = 0; i < files.length; i++) {
       const file = files[i];
       if (!file.type.startsWith('image/')) continue;
+      if (file.size > MAX_IMAGE_SIZE) {
+        const limitMB = MAX_IMAGE_SIZE / (1024 * 1024);
+        onError?.(new Error(`图片"${file.name}"超过 ${limitMB}MB 大小限制，已跳过。`));
+        continue;
+      }
 
       const reader = new FileReader();
       const promise = new Promise<string>((resolve) => {
@@ -708,7 +719,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
 
     // Reset input
     e.target.value = '';
-  }, []);
+  }, [onError]);
 
   // Remove uploaded image
   const handleRemoveImage = useCallback((index: number) => {
@@ -726,6 +737,11 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
       if (item.type.startsWith('image/')) {
         const file = item.getAsFile();
         if (file) {
+          if (file.size > MAX_IMAGE_SIZE) {
+            const limitMB = MAX_IMAGE_SIZE / (1024 * 1024);
+            onError?.(new Error(`粘贴的图片超过 ${limitMB}MB 大小限制，已跳过。`));
+            continue;
+          }
           imageFiles.push(file);
         }
       }
@@ -749,7 +765,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         setUploadedImages((prev) => [...prev, ...results]);
       });
     }
-  }, []);
+  }, [onError]);
 
   // Send message
   const handleSendMessage = useCallback(async (value: string) => {


### PR DESCRIPTION
## 问题

用户通过文件选择器上传或 Ctrl+V 粘贴图片时，`Chat` 组件会无条件把整个文件读成 base64 字符串存入 React state，再整体序列化进 POST body 发送。上传一张 20MB 的手机照片，base64 后约 27MB 直接驻留内存，多张叠加可轻易使浏览器标签页崩溃（移动端尤甚）；若超过服务端 body-size 限制，请求返回 4xx/413 但组件无任何错误提示，消息"卡住"不发送。

## 根因

`handleImageUpload` 和 `handlePaste` 的过滤逻辑只检查 `file.type`（MIME 类型），完全缺少 `file.size` 上界守卫，导致任意大小的图片都进入 `FileReader.readAsDataURL` → React state → POST body 的全量内存路径。

## 怎么修的

在模块顶层新增常量 `MAX_IMAGE_SIZE`（默认 4MB，通过 `NEXT_PUBLIC_MAX_IMAGE_SIZE` 环境变量可覆盖），并在两处入口各加一个守卫：

```ts
// 模块顶层
const MAX_IMAGE_SIZE =
  (typeof process !== 'undefined' && process.env?.NEXT_PUBLIC_MAX_IMAGE_SIZE
    ? parseInt(process.env.NEXT_PUBLIC_MAX_IMAGE_SIZE, 10)
    : 0) || 4 * 1024 * 1024;  // 默认 4MB

// handleImageUpload & handlePaste 内各加：
if (file.size > MAX_IMAGE_SIZE) {
  const limitMB = MAX_IMAGE_SIZE / (1024 * 1024);
  onError?.(new Error(`图片超过 ${limitMB}MB 大小限制，已跳过。`));
  continue;
}
```

超限文件被跳过，错误通过 `onError` 回调上报给宿主（宿主可用 `message.error` 或 Toast 显示给用户）。同时更新了两个 `useCallback` 的依赖数组（加入 `onError`）。

## 影响范围

仅改动 `webchat/packages/webchat-ui/src/Chat.tsx` 一个文件，守卫逻辑仅在图片流入 state 之前增加过滤，不影响已有的消息发送、会话管理、SSE 或任何其他路径。对不传 `onError` 的宿主无副作用（`onError?.()` 可选调用）。

## 验证

- 将修复代码 revert 后，对 `handleImageUpload` 传入 `file.size > 4MB` 的 mock File，超限文件仍会进入 `readers`，`onError` 不会被调用——即 revert 后守卫消失，验证逻辑有效
- 正常路径：`file.size ≤ MAX_IMAGE_SIZE` 的图片仍正常读取、上传、发送，无行为变化
- 环境变量路径：设置 `NEXT_PUBLIC_MAX_IMAGE_SIZE=8388608`（8MB）后阈值正确变更
- 粘贴路径：对 `handlePaste` 的 `ClipboardEvent` 传入超限图片 File，`onError` 被调用，`imageFiles` 不含该文件

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["用户选择文件\nhandleImageUpload\nChat.tsx"]
        T2["用户 Ctrl+V 粘贴\nhandlePaste\nChat.tsx"]
    end

    subgraph G["守卫层（本次新增）"]
        G1["file.size > MAX_IMAGE_SIZE?\n默认 4MB / 环境变量可配"]
    end

    subgraph P["处理层"]
        P1["FileReader.readAsDataURL\n→ base64 → React state"]
    end

    subgraph E["错误上报"]
        E1["onError callback\n→ 宿主显示错误提示"]
    end

    T1 --> G1
    T2 --> G1
    G1 -- "size ≤ 限制" --> P1
    G1 -- "size > 限制" --> E1
```

关联 Issue: #3557