### PR TITLE
bugfix: create_user 新建用户时设置不可用密码标记，防止空字符串密码绕过认证

### DIFF
--- a/server/apps/system_mgmt/tests/test_create_user_password_3466.py
+++ b/server/apps/system_mgmt/tests/test_create_user_password_3466.py
@@ -1,0 +1,87 @@
+"""
+Issue #3466: create_user 未设密码初始值，新用户 password 为空字符串可能绕过 check_password
+
+修复验证：create_user 接口创建的用户 password 字段必须为 Django 不可用密码标记（!开头），
+而非空字符串；且 check_password(任意值, 该密码) 必须返回 False，禁止以任何密码登录。
+"""
+
+import json
+import types
+
+import pytest
+from django.contrib.auth.hashers import check_password, is_password_usable
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system_mgmt.models import Group, Role, User
+
+
+def _admin_user(**overrides):
+    defaults = {
+        "username": "test-admin",
+        "domain": "domain.com",
+        "locale": "en",
+        "is_superuser": True,
+        "is_authenticated": True,
+        "permission": {"system-manager": {"user_group-Add User"}},
+    }
+    defaults.update(overrides)
+    return types.SimpleNamespace(**defaults)
+
+
+@pytest.mark.django_db
+def test_create_user_password_is_not_empty_string():
+    """
+    修复验证：create_user 后新用户 password 字段不得为空字符串。
+    若将 password=make_password(None) 的修复 revert，新用户 password 将为 ""，本测试失败。
+    """
+    from apps.system_mgmt.viewset.user_viewset import UserViewSet
+
+    role = Role.objects.create(name="operator-3466", app="")
+    group = Group.objects.create(name="group-3466")
+
+    factory = APIRequestFactory()
+    view = UserViewSet.as_view({"post": "create_user"})
+
+    request = factory.post(
+        "/system_mgmt/api/user/create_user/",
+        {
+            "username": "newuser-3466",
+            "lastName": "测试用户3466",
+            "email": "newuser3466@example.com",
+            "phone": None,
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [group.id],
+            "roles": [role.id],
+            "rules": [],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_admin_user())
+
+    response = view(request)
+    payload = json.loads(response.content)
+
+    assert response.status_code == 200
+    assert payload == {"result": True}
+
+    user = User.objects.get(username="newuser-3466")
+
+    # 核心断言：password 不得为空字符串
+    assert user.password != "", "create_user 创建的用户 password 不得为空字符串（安全缺陷 #3466）"
+
+    # password 字段必须是不可用密码标记（! 开头），禁止任何字符串通过 check_password 验证
+    assert not is_password_usable(user.password), (
+        "create_user 创建的用户密码应标记为不可用（make_password(None)），"
+        "而非存储明文或空字符串（安全缺陷 #3466）"
+    )
+
+    # 空字符串不得通过密码验证
+    assert not check_password("", user.password), (
+        "以空字符串作为密码不得通过 check_password 验证（安全缺陷 #3466）"
+    )
+
+    # 任意字符串均不得通过密码验证（不可用密码标记保证）
+    assert not check_password("anypassword", user.password), (
+        "新创建用户的密码标记为不可用，check_password 对任意输入均应返回 False（安全缺陷 #3466）"
+    )

--- a/server/apps/system_mgmt/viewset/user_viewset.py
+++ b/server/apps/system_mgmt/viewset/user_viewset.py
@@ -362,6 +362,7 @@ class UserViewSet(ViewSetUtils):
                 group_list=groups,
                 role_list=roles,
                 temporary_pwd=kwargs.get("temporary_pwd", False),
+                password=make_password(None),
             )
             if rules:
                 add_rule = [UserRule(username=kwargs["username"], group_rule_id=i) for i in rules]


### PR DESCRIPTION
## 问题

管理员通过「新建用户」接口创建用户时，系统应确保每个账号都有一个安全的密码状态。但当前实现中，如果管理员没有在请求体中提供 `password` 字段，新用户的 `password` 列将存储为空字符串 `""`。

这意味着：如果有自定义认证后端或直接比对密码字段的逻辑，可能允许攻击者用空密码登录。即使是 Django 内置的 `check_password` 也无法保证对空哈希值的行为一致性——这是一个违反「数据库中任何用户密码必须是合法哈希值」框架不变量的安全隐患。

## 根因

`create_user` 视图使用 `User.objects.create(...)` 而不设置密码，且 `password` 字段的 Django 默认值为 `""`（空字符串），而非 Django 推荐的"不可用密码标记"（`!` 前缀哈希）：

```python
# 修复前：password 列存空字符串
User.objects.create(
    username=kwargs["username"],
    ...
    # ← 无 password 参数
)
```

对比：同文件 `reset_password` 接口已经正确使用 `make_password(password)`，说明项目团队认可这个模式——`create_user` 只是漏掉了初始值设置。

## 怎么修的

在 `User.objects.create(...)` 调用中添加 `password=make_password(None)`。`make_password(None)` 是 Django 的标准做法，生成以 `!` 开头的不可用密码标记，确保：
- `check_password(任意值, 不可用密码)` 始终返回 `False`
- `is_password_usable()` 返回 `False`，明确表示该账号需要先设置密码

`make_password` 已在文件头部导入（用于 `reset_password`），零额外依赖，改动仅 1 行。

```python
# 修复后：
User.objects.create(
    username=kwargs["username"],
    ...
    password=make_password(None),   # ← 新增：不可用密码标记
)
```

## 影响范围

- 只修改了 `server/apps/system_mgmt/viewset/user_viewset.py` 中的 `create_user` action
- 对已存在用户无影响
- 新建用户后，管理员需通过 `reset_password` 接口为其设置真实密码（现有流程不变）
- 无 DB migration，无 API 协议变更，无跨模块影响

## 验证

新增回归测试 `test_create_user_password_3466.py`：
- 调用 `create_user` 后断言 `user.password != ""`
- 断言 `is_password_usable(user.password) == False`
- 断言 `check_password("", user.password) == False`
- 断言 `check_password("anypassword", user.password) == False`

RED/GREEN 已验证：revert 修复后测试以 `assert '' != ''` 失败，应用修复后全部通过。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["管理员 POST /api/v1/system_mgmt/user/create_user/\nuser_viewset.py:UserViewSet.create_user"]
    end

    subgraph N["核心处理层"]
        F1["User.objects.create(...)\n+ password=make_password(None)"]
        F2["DB: password = '!<unusable_hash>'"]
    end

    subgraph V["验证层（后续）"]
        V1["login() 调用 check_password()\nnats_api.py:login"]
        V2["check_password(input, '!...')\n始终返回 False"]
    end

    T1 --> F1 --> F2
    F2 -. 登录尝试 .-> V1 --> V2
```

关联 Issue #3466