### PR TITLE
feat(monitor): add Proxim Wireless SNMP plugin

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -3940,6 +3940,9 @@ monitor_object_plugin:
   Wireless Cambium SNMP:
     name: Wireless Cambium SNMP
     desc: Baseline SNMP collection template for wireless devices (interface traffic + uptime). Collects IF-MIB 64-bit HC interface counters (ifHCInOctets/ifHCOutOctets, ifXTable) rates and device uptime (sysUpTime). Wireless health metrics (signal strength/SNR/associated clients) use Cambium private per-row indexed MIBs requiring row-level filtering not supported by telegraf inputs.snmp, so they are N/A. Applicable to Cambium Networks wireless devices (cnPilot/ePMP/PMP, enterprise OID 17713) and other IF-MIB compliant wireless AP/bridges.
+  Wireless Proxim SNMP:
+    name: Wireless Proxim SNMP
+    desc: Baseline SNMP collection template for wireless devices (interface traffic + uptime). Collects IF-MIB 64-bit HC interface counters (ifHCInOctets/ifHCOutOctets, ifXTable) rates and device uptime (sysUpTime). Wireless health metrics (signal strength/SNR/subscriber units) use Proxim ORiNOCO/Tsunami private per-row indexed MIBs requiring row-level filtering not supported by telegraf inputs.snmp, so wireless health is N/A. Applicable to Proxim Wireless devices (ORiNOCO AP access points, Tsunami MP point-to-multipoint backhaul base stations/subscriber units, enterprise OID 841) and other IF-MIB compliant wireless AP/backhaul bridges.
   Transmission Ciena SNMP:
     name: Transmission Ciena SNMP
     desc: Collects IF-MIB 64-bit HC interface traffic (ifHCInOctets/ifHCOutOctets) plus uptime. Health metrics of Ciena SAOS transmission devices (temperature/optical module power/laser bias current) use per-row indexed MIB tables with row-level filtering (skip_values); telegraf inputs.snmp cannot do row-level filtering, so they are N/A. Applicable to Ciena SAOS transmission/packet-optical devices.

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -3600,6 +3600,9 @@ monitor_object_plugin:
   Wireless Cambium SNMP:
     name: Cambium (Telegraf)
     desc: 无线设备 SNMP 采集基线模板（接口流量 + 运行时长）。采集 IF-MIB 64 位 HC 接口流量计数器（ifHCInOctets/ifHCOutOctets，ifXTable）速率与设备运行时长（sysUpTime）。无线信号强度/SNR/关联客户端数等健康指标因 Cambium 私有 MIB 采用 per-row 索引表（按射频单元/SSID/客户端逐行）并需行级过滤（skip_values），而 telegraf inputs.snmp 不支持行级过滤，故为 N/A，不伪造。适用品牌型号——Cambium Networks 无线设备（cnPilot/ePMP/PMP 系列，企业号 17713）及其他遵循 IF-MIB 标准的无线 AP/网桥。
+  Wireless Proxim SNMP:
+    name: Proxim (Telegraf)
+    desc: 无线设备 SNMP 采集基线模板（接口流量 + 运行时长）。采集 IF-MIB 64 位 HC 接口流量计数器（ifHCInOctets/ifHCOutOctets，ifXTable）速率与设备运行时长（sysUpTime）。无线信号强度/SNR/远端订户单元等健康指标因 Proxim ORiNOCO/Tsunami 私有 MIB 采用 per-row 索引表（按射频单元/订户单元逐行）并需行级过滤（skip_values），而 telegraf inputs.snmp 不支持行级过滤，故无线健康为 N/A，不伪造。适用品牌型号——Proxim Wireless 无线设备（ORiNOCO AP 系列接入点、Tsunami MP 点对多点回传基站/订户单元，企业号 841）及其他遵循 IF-MIB 标准的无线 AP/回传网桥。
   Transmission Ciena SNMP:
     name: Ciena (Telegraf)
     desc: 采 IF-MIB 64位 HC 接口流量（ifHCInOctets/ifHCOutOctets）+ 运行时长；Ciena SAOS 传输设备的温度/光模块光功率/激光偏置电流等健康指标因 MIB 为 per-row 索引表带行级过滤（skip_values），telegraf inputs.snmp 不能行级过滤，故为 N/A。适用品牌型号——Ciena SAOS 传输/分组光设备（3000/5000/6500 系列，企业号 1271）及其他 IF-MIB 标准传输设备。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/UI.json
@@ -1,0 +1,320 @@
+{
+  "object_name": "Wireless",
+  "instance_type": "wireless",
+  "collect_type": "snmp_proxim",
+  "config_type": [
+    "proxim"
+  ],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_proxim_{{ip}}",
+  "form_fields": [
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "监控的目标主机的 IP 地址，用于标识数据收集的来源",
+      "widget_props": {
+        "placeholder": "目标主机 IP"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": "://([^:]+):"
+        }
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "editable": false,
+      "default_value": 161,
+      "description": "配置SNMP端口号，通常使用161端口与设备进行通信",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "SNMP 端口",
+        "addonAfter": ""
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": ":(\\d+)$"
+        }
+      }
+    },
+    {
+      "name": "version",
+      "label": "版本",
+      "type": "select",
+      "required": true,
+      "editable": false,
+      "default_value": 2,
+      "description": "指定要使用的 SNMP 协议版本，例如 v2c 或 v3，定义通信机制和安全级别",
+      "options": [
+        {
+          "label": "v2c",
+          "value": 2
+        },
+        {
+          "label": "v3",
+          "value": 3
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择 SNMP 版本"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.version"
+      }
+    },
+    {
+      "name": "community",
+      "label": "团体名",
+      "type": "input",
+      "required": true,
+      "default_value": "public",
+      "description": "用于 SNMPv2c 的认证字符串，类似于密码，允许访问设备的 SNMP 数据",
+      "widget_props": {
+        "placeholder": "SNMP Community 字符串"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 2
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.community",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_name",
+      "label": "名称",
+      "type": "input",
+      "required": true,
+      "description": "用于 SNMPv3 认证的用户名",
+      "widget_props": {
+        "placeholder": "安全名称"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_name",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_level",
+      "label": "级别",
+      "type": "select",
+      "required": true,
+      "default_value": "authPriv",
+      "description": "安全级别设置，例如 authPriv 表示同时使用认证和隐私（加密）",
+      "options": [
+        {
+          "label": "noAuthNoPriv",
+          "value": "noAuthNoPriv"
+        },
+        {
+          "label": "authNoPriv",
+          "value": "authNoPriv"
+        },
+        {
+          "label": "authPriv",
+          "value": "authPriv"
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择安全级别"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_level",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_protocol",
+      "label": "认证协议",
+      "type": "input",
+      "required": false,
+      "default_value": "SHA",
+      "description": "用于保护认证过程的认证协议",
+      "widget_props": {
+        "placeholder": "认证协议 (MD5/SHA)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_password",
+      "label": "认证密码",
+      "type": "password",
+      "required": false,
+      "description": "用于认证的密码，与选择的认证协议对应",
+      "widget_props": {
+        "placeholder": "认证密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_protocol",
+      "label": "加密协议",
+      "type": "input",
+      "required": false,
+      "default_value": "AES",
+      "description": "用于保护传输数据的加密协议",
+      "widget_props": {
+        "placeholder": "加密协议 (DES/AES)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_password",
+      "label": "加密密码",
+      "type": "password",
+      "required": false,
+      "description": "用于加密的密码，与选择的加密协议对应",
+      "widget_props": {
+        "placeholder": "加密密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "timeout",
+      "label": "超时时间",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "超时时间（秒）",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.timeout",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "采集间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "options_key": "node_ids_option",
+      "enable_row_filter": false
+    },
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "widget_props": {
+        "placeholder": "请输入 IP 地址"
+      },
+      "change_handler": {
+        "type": "simple",
+        "source_fields": [
+          "ip"
+        ],
+        "target_field": "instance_name"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ],
+  "extra_edit_fields": {
+    "agents": {
+      "origin_path": "child.content.config.agents",
+      "to_api": {
+        "template": "udp://{{ip}}:{{port}}",
+        "array": true
+      }
+    }
+  }
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/metrics.json
@@ -1,0 +1,127 @@
+{
+  "plugin": "Wireless Proxim SNMP",
+  "plugin_desc": "无线设备 SNMP 采集基线模板（接口流量 + 运行时长）。采集 IF-MIB 64 位 HC 接口流量计数器（ifHCInOctets/ifHCOutOctets，ifXTable）速率与设备运行时长（sysUpTime）。无线信号强度/SNR/远端订户单元等健康指标因 Proxim ORiNOCO/Tsunami 私有 MIB 采用 per-row 索引表（按射频单元/订户单元逐行）并需行级过滤（skip_values），而 telegraf inputs.snmp 不支持行级过滤，故无线健康为 N/A，不伪造。适用品牌型号——Proxim Wireless 无线设备（ORiNOCO AP 系列接入点、Tsunami MP 点对多点回传基站/订户单元，企业号 841）及其他遵循 IF-MIB 标准的无线 AP/回传网桥。",
+  "status_query": "any({instance_type='wireless', collect_type='snmp_proxim'}) by (instance_id)",
+  "name": "Wireless",
+  "icon": "mm-proxim_proxim",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='wireless'}) by (instance_id)",
+  "instance_id_keys": [
+    "instance_id"
+  ],
+  "supplementary_indicators": [
+    "snmp_uptime",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic"
+  ],
+  "display_fields": [
+    {
+      "name": "System Uptime",
+      "sort_order": 0,
+      "metrics": [
+        {
+          "plugin": "Wireless Proxim SNMP",
+          "metric": "snmp_uptime"
+        }
+      ]
+    },
+    {
+      "name": "Device Total Incoming Traffic Rate",
+      "sort_order": 1,
+      "metrics": [
+        {
+          "plugin": "Wireless Proxim SNMP",
+          "metric": "device_total_incoming_traffic"
+        }
+      ]
+    },
+    {
+      "name": "Device Total Outgoing Traffic Rate",
+      "sort_order": 2,
+      "metrics": [
+        {
+          "plugin": "Wireless Proxim SNMP",
+          "metric": "device_total_outgoing_traffic"
+        }
+      ]
+    }
+  ],
+  "metrics": [
+    {
+      "metric_group": "Base",
+      "name": "snmp_uptime",
+      "query": "sum(snmp_uptime{instance_type='wireless', __$labels__}/100) by (instance_id)",
+      "display_name": "System Uptime",
+      "data_type": "Number",
+      "unit": "s",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric indicates the uptime of the wireless device since the last restart, derived from sysUpTime. Monitoring uptime helps administrators understand device stability and identify unexpected reboots."
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "interface_ifHCInOctets",
+      "query": "rate(interface_ifHCInOctets{instance_type='wireless', __$labels__}[5m])",
+      "display_name": "Interface Incoming Traffic Rate",
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [
+        {
+          "name": "ifDescr",
+          "description": "ifDescr"
+        }
+      ],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric indicates the average rate of bytes received over the past 5 minutes, measured in bytes per second, from the 64-bit IF-MIB ifHCInOctets counter (ifXTable)."
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "interface_ifHCOutOctets",
+      "query": "rate(interface_ifHCOutOctets{instance_type='wireless', __$labels__}[5m])",
+      "display_name": "Interface Outgoing Traffic Rate",
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [
+        {
+          "name": "ifDescr",
+          "description": "ifDescr"
+        }
+      ],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric calculates the average rate of bytes sent over the past 5 minutes, measured in bytes per second, from the 64-bit IF-MIB ifHCOutOctets counter (ifXTable)."
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "device_total_incoming_traffic",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='wireless', __$labels__}[5m])) by (instance_id)",
+      "display_name": "Device Total Incoming Traffic Rate",
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric indicates the average rate of total bytes received by the entire wireless device over the past 5 minutes, summed across all interfaces from the 64-bit ifHCInOctets counter."
+    },
+    {
+      "metric_group": "Traffic",
+      "name": "device_total_outgoing_traffic",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='wireless', __$labels__}[5m])) by (instance_id)",
+      "display_name": "Device Total Outgoing Traffic Rate",
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric represents the average rate of total bytes sent by the entire wireless device over the past 5 minutes, summed across all interfaces from the 64-bit ifHCOutOctets counter."
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/policy.json
@@ -1,0 +1,5 @@
+{
+  "object": "Wireless",
+  "plugin": "Wireless Proxim SNMP",
+  "templates": []
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/proxim.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp_proxim/wireless/proxim.child.toml.j2
@@ -1,0 +1,63 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "{{ auth_password }}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "{{ priv_password }}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_proxim"
+        config_type = "proxim"
+        brand = "proxim"
+    # ---- System ----
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+    # ---- Interfaces (generic IF-MIB ifTable, 用于自动展开 ifDescr/ifOperStatus 等接口属性列) ----
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.2.2"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.2.2.1.2"
+        name = "ifDescr"
+        is_tag = true
+    # ---- 64 位 IF-MIB HC 流量计数器 (ifXTable，无线回传链路高吞吐不易回绕，按 ifIndex 与上表接口行对齐) ----
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.31.1.1"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.1"
+        name = "ifDescr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.6"
+        name = "ifHCInOctets"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.10"
+        name = "ifHCOutOctets"
+    # ---- 无线健康 (信号强度/SNR/关联客户端数等) → N/A ----
+    # Proxim ORiNOCO/Tsunami 私有 MIB 的无线健康指标为 per-row 索引表（按射频单元/远端订户单元逐行），
+    # 取值需对索引行做行级过滤 (skip_values)，而 telegraf inputs.snmp 不支持行级过滤，
+    # 故本基线插件仅采集 IF-MIB 接口流量 (ifHCInOctets/ifHCOutOctets) 与运行时长 (uptime)，
+    # 无线信号/SNR/客户端数等健康指标为 N/A，不伪造。

--- a/web/public/assets/icons/mm-proxim_proxim.svg
+++ b/web/public/assets/icons/mm-proxim_proxim.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="#0a4d8c"/>
+  <text x="60" y="71" font-family="Arial, Helvetica, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">PROXIM</text>
+</svg>

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
@@ -53,7 +53,8 @@ export const useWirelessConfig = () => {
       default: ['instance_id']
     },
     collectTypes: {
-      'Wireless Cambium SNMP': 'snmp_cambium'
+      'Wireless Cambium SNMP': 'snmp_cambium',
+      'Wireless Proxim SNMP': 'snmp_proxim'
     }
   };
 };


### PR DESCRIPTION
## Summary

Adds a baseline SNMP monitoring plugin for **Proxim Wireless** devices (object type: Wireless, collect_type `snmp_proxim`).

Covers Proxim Wireless ORiNOCO AP access points and Tsunami MP point-to-multipoint backhaul base stations/subscriber units, plus other IF-MIB compliant wireless AP/backhaul bridges.

### Metrics
- `snmp_uptime` — device uptime from sysUpTime (`1.3.6.1.2.1.1.3.0`, /100 to seconds)
- Interface traffic rates from 64-bit IF-MIB HC counters `ifHCInOctets`/`ifHCOutOctets` (ifXTable: `1.3.6.1.2.1.31.1.1.1.6` / `.10`)
- Device-total incoming/outgoing traffic (summed by instance_id)

Wireless health metrics (signal/SNR/subscriber units) live in Proxim's private per-row indexed MIBs that require row-level filtering not supported by telegraf inputs.snmp, so they are intentionally omitted rather than fabricated.

### Files
- metrics.json / policy.json / UI.json / proxim.child.toml.j2 plugin definition
- en + zh-Hans plugin-level i18n (bilingual name + desc)
- Proxim icon + wireless integration registration

### OID provenance
Proxim Wireless enterprise OID **1.3.6.1.4.1.841**, verified against the IANA Private Enterprise Numbers registry (PEN 841 = Proxim Wireless, Inc). Field OIDs use only standard IF-MIB/system OIDs.

### Tests
Metric-spec regression guard (group/name bilingual translation + no dangling aggregation dimensions): **2332 passed** (15 Proxim cases green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)