### PR TITLE
bugfix(log): 修复 _format_notice_content href 误含字面 f" 前缀导致告警通知链接全部失效

### DIFF
--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -914,7 +914,7 @@ class LogPolicyScan:
             f"时间：{event_obj.event_time}",
             f"告警内容：{event_obj.content}",
             f"策略名称：{self.policy.name}",
-            f'查看告警详情：<a href=f"{url}">点击查看详情</a>',
+            f'查看告警详情：<a href="{url}">点击查看详情</a>',
         ]
 
         content = "\n".join(content_parts)

--- a/server/apps/log/tests/test_format_notice_content_href_3651.py
+++ b/server/apps/log/tests/test_format_notice_content_href_3651.py
@@ -1,0 +1,142 @@
+"""Issue #3651：_format_notice_content 中 href 误含字面 f" 前缀导致链接失效。
+
+验证修复后生成的链接不再包含字面 f" 前缀，且 URL 被正确插值。
+
+沿用本目录 Django-free 注入式 harness，不依赖 Django settings / ORM。
+"""
+import importlib.util
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+SERVER_DIR = Path(__file__).resolve().parents[3]
+
+_TEST_BASE_URL = "http://test"
+_EXPECTED_HREF = f'{_TEST_BASE_URL}/log/event/alert'
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _fake_alert_constants():
+    return types.SimpleNamespace(
+        STATUS_NEW="new",
+        STATUS_CLOSED="closed",
+        LEVEL_INFO="info",
+        NOTICE_SEND_MAX_ATTEMPTS=3,
+        NOTICE_SEND_RETRY_BACKOFF_SECONDS=0,
+        NOTICE_COMPENSATE_MAX_RETRY=5,
+        NOTICE_COMPENSATE_WINDOW_SECONDS=24 * 3600,
+        NOTICE_COMPENSATE_BATCH_SIZE=200,
+        NOTICE_COMPENSATE_MIN_AGE_SECONDS=60,
+    )
+
+
+def _fake_logger():
+    return types.SimpleNamespace(
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        debug=lambda *a, **k: None,
+    )
+
+
+def _load_policy_scan(monkeypatch):
+    _install_module(monkeypatch, "django", db=types.SimpleNamespace(transaction=types.SimpleNamespace()))
+    _install_module(monkeypatch, "django.db", transaction=types.SimpleNamespace())
+    _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
+    _install_module(monkeypatch, "apps.log.constants.alert_policy", AlertConstants=_fake_alert_constants())
+    _install_module(monkeypatch, "apps.log.constants.database", DatabaseConstants=types.SimpleNamespace(DEFAULT_BATCH_SIZE=100))
+    _install_module(monkeypatch, "apps.log.constants.web", WebConstants=types.SimpleNamespace(URL=_TEST_BASE_URL))
+    _install_module(monkeypatch, "apps.log.models.policy", Alert=object, Event=object, EventRawData=object, AlertSnapshot=object)
+    _install_module(monkeypatch, "apps.log.tasks.utils.policy", period_to_seconds=lambda period: 300)
+    _install_module(monkeypatch, "apps.log.utils.query_log", VictoriaMetricsAPI=lambda: None)
+    _install_module(
+        monkeypatch,
+        "apps.log.utils.log_group",
+        LogGroupQueryBuilder=types.SimpleNamespace(build_query_with_groups=lambda query, groups: (query, [])),
+    )
+    _install_module(monkeypatch, "apps.monitor.utils.system_mgmt_api", SystemMgmtUtils=object)
+    _install_module(monkeypatch, "apps.core.logger", celery_logger=_fake_logger())
+
+    module_path = SERVER_DIR / "apps" / "log" / "tasks" / "services" / "policy_scan.py"
+    spec = importlib.util.spec_from_file_location("policy_scan_under_test_3651", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_policy(**overrides):
+    base = dict(
+        id=1,
+        name="测试策略",
+        notice=True,
+        enable=True,
+        notice_type_id=1,
+        notice_users=["u1"],
+        last_run_time=datetime(2026, 6, 23, 0, 0, tzinfo=timezone.utc),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_event(policy, **overrides):
+    base = dict(
+        id="evt-3651",
+        alert_id="alert-3651",
+        policy=policy,
+        level="error",
+        content="日志告警内容",
+        event_time=datetime(2026, 6, 23, 0, 0, tzinfo=timezone.utc),
+        created_at=datetime(2026, 6, 23, 0, 0, tzinfo=timezone.utc),
+        notice_result=[],
+        notified=False,
+        notice_retry_count=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_format_notice_content_href_no_literal_f_prefix(monkeypatch):
+    """_format_notice_content 生成的 href 不应包含字面 f" 前缀。
+
+    修复前输出: href=f"/log/event/alert"
+    修复后输出: href="http://test/log/event/alert"
+
+    若 revert 修复，href 会含字面 f" → assert 失败。
+    """
+    mod = _load_policy_scan(monkeypatch)
+    policy = _make_policy()
+    scan = mod.LogPolicyScan(policy)
+    event = _make_event(policy)
+
+    _, content = scan._format_notice_content(event)
+
+    # 不应含字面 f" 前缀
+    assert 'href=f"' not in content, (
+        f'链接含字面 f" 前缀，用户点击将得到 404。实际 content: {content!r}'
+    )
+
+
+def test_format_notice_content_href_interpolates_url(monkeypatch):
+    """_format_notice_content 生成的 href 应包含正确插值后的 URL。
+
+    若 revert 修复，URL 不会被插值进 href，此断言失败。
+    """
+    mod = _load_policy_scan(monkeypatch)
+    policy = _make_policy()
+    scan = mod.LogPolicyScan(policy)
+    event = _make_event(policy)
+
+    _, content = scan._format_notice_content(event)
+
+    assert f'href="{_EXPECTED_HREF}"' in content, (
+        f'href 未正确插值 URL。期望包含 href="{_EXPECTED_HREF}"，实际 content: {content!r}'
+    )


### PR DESCRIPTION
## 问题

日志告警通知发出后，消息中的「查看告警详情」链接**全部失效**。运维人员点击链接，浏览器跳转到 `f"/log/event/alert"` 这样的地址，直接 404。这不是偶发的——任何开启了通知的日志告警策略，每次触发都会产出坏链接。

## 根因

`_format_notice_content` 方法在构造通知 HTML 时，`href` 属性值内多写了一个 `f` 前缀：

```python
# 修复前（有缺陷）
f'查看告警详情：<a href=f"{url}">点击查看详情</a>'
#                      ^--- 这个 f 是字符串字面量，不是 f-string 前缀
```

Python 只对最外层 `f'...'` 做变量插值，`href=f"{url}"` 中的 `f` 被原样输出为字符字面量，最终渲染为 `href=f"/log/event/alert"` 而非合法的 URL。

## 怎么修的

删除 `href` 属性值中多余的 `f` 前缀（改动 1 个字符）：

```python
# 修复后
f'查看告警详情：<a href="{url}">点击查看详情</a>'
```

全仓扫描确认同类 `href=f"` 写法仅此一处。

## 影响范围

- 改动仅限 `server/apps/log/tasks/services/policy_scan.py` 第 917 行，不涉及共享 util / 公共接口 / 权限逻辑。
- 修复后通知链接恢复正常，对其他调用方无影响。

## 验证

新增回归测试 `test_format_notice_content_href_3651.py`，使用本目录 Django-free 注入式 harness：

1. 断言 `href=f"` 不存在于生成内容（revert 修复后此断言必然失败）
2. 断言 `href="http://test/log/event/alert"` 存在（验证 URL 正确插值）

本地验证输出：
```
content: '时间：...查看告警详情：<a href="http://test/log/event/alert">点击查看详情</a>'
PASS: no literal f" prefix in href
PASS: URL correctly interpolated in href
ALL TESTS PASSED
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["PolicyViewSet.enable\nviews/policy.py"]
    end

    subgraph N["核心处理层"]
        F1["LogPolicyScan.run\npolicy_scan.py"]
        F2["notice() → send_notice()"]
        F3["_format_notice_content()\npolicy_scan.py:917 ← 修复点"]
    end

    subgraph S["发送层"]
        S1["SystemMgmtUtils.send_msg_with_channel"]
    end

    T1 --> F1 --> F2 --> F3
    F3 --> S1
    F3 -. "修复前输出 href=f/url" .-> S1
```

关联 Issue：#3651