### PR TITLE
bugfix: [log] NATS handler get_log_module_data 参数类型转换与范围校验

### DIFF
--- a/server/apps/log/nats/permission.py
+++ b/server/apps/log/nats/permission.py
@@ -1,6 +1,10 @@
+import os
+
 import nats_client
 from apps.log.models import LogGroup, CollectType, CollectInstance
 from apps.log.models.policy import Policy
+
+_PAGE_SIZE_MAX = int(os.getenv("LOG_MODULE_DATA_PAGE_SIZE_MAX", "500"))
 
 
 @nats_client.register
@@ -8,6 +12,13 @@ def get_log_module_data(module, child_module, page, page_size, group_id):
     """
     获取log模块数据
     """
+    try:
+        page = max(1, int(page))
+        page_size = max(1, min(int(page_size), _PAGE_SIZE_MAX))
+        group_id = int(group_id)
+    except (TypeError, ValueError) as exc:
+        return {"result": False, "message": f"参数类型错误: {exc}", "data": []}
+
     if module == "log_group":
         queryset = LogGroup.objects.filter(loggrouporganization__organization=group_id).distinct()
     elif module == "policy":

--- a/server/apps/log/tests/test_get_log_module_data_type_guard_3655.py
+++ b/server/apps/log/tests/test_get_log_module_data_type_guard_3655.py
@@ -1,0 +1,182 @@
+"""
+Issue #3655: get_log_module_data 参数无类型校验导致 NATS worker 崩溃
+
+这些测试采用 Django-free 注入方式：直接 importlib 加载被测模块，
+用 sys.modules 注入伪依赖，绕过 ORM 及 settings 加载。
+
+验证准则：revert 修复代码（去掉 int() 转换 + 范围校验），
+所有测试必须失败——否则测试未覆盖修复点。
+"""
+
+import importlib.util
+import sys
+import types
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# 注入伪依赖（nats_client + apps.log.models.*）
+# ---------------------------------------------------------------------------
+
+def _install(name, **attrs):
+    """往 sys.modules 注入一个伪模块（支持属性设置）。"""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_permission_module():
+    """
+    每次调用都重新加载 nats/permission.py，避免测试间模块缓存相互污染。
+    返回加载后的模块对象。
+    """
+    # ── nats_client ──────────────────────────────────────────────────────────
+    def _register(fn):
+        return fn
+
+    _install("nats_client", register=_register)
+
+    # ── apps.log.models（顶层包 + 子模块）─────────────────────────────────────
+    _install("apps")
+    _install("apps.log")
+    _install("apps.log.models")
+    _install("apps.log.models.policy", Policy=object)
+
+    # LogGroup / CollectType / CollectInstance 用于 from ... import 语句
+    for sym in ("LogGroup", "CollectType", "CollectInstance"):
+        setattr(sys.modules["apps.log.models"], sym, object)
+
+    # ── 加载被测文件 ───────────────────────────────────────────────────────────
+    import os
+    permission_path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "nats", "permission.py",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "apps.log.nats.permission", permission_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# 辅助：构造能被正常执行的伪 queryset
+# ---------------------------------------------------------------------------
+
+class _FakeQS:
+    """模拟 Django QuerySet 的最小接口。"""
+
+    def __init__(self, items=None):
+        self._items = items or [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+
+    def filter(self, **kwargs):
+        return self
+
+    def distinct(self):
+        return self
+
+    def count(self):
+        return len(self._items)
+
+    def values(self, *fields):
+        return self
+
+    def __getitem__(self, sl):
+        return self._items[sl]
+
+
+def _make_handler_with_queryset(qs: _FakeQS):
+    """
+    返回一个已注入 ORM 的 get_log_module_data 函数。
+    通过 monkeypatch LogGroup.objects / Policy.objects / CollectInstance.objects。
+    """
+    mod = _load_permission_module()
+
+    # patch model managers
+    class _Manager:
+        def filter(self, **kwargs):
+            return qs
+
+    for attr in ("LogGroup", "CollectType", "CollectInstance"):
+        fake_model = type(attr, (), {"objects": _Manager()})()
+        setattr(mod, attr, fake_model)
+
+    # Policy 同样需要 patch
+    fake_policy = type("Policy", (), {"objects": _Manager()})()
+    setattr(mod, "Policy", fake_policy)
+
+    return mod.get_log_module_data
+
+
+# ---------------------------------------------------------------------------
+# 测试用例
+# ---------------------------------------------------------------------------
+
+class TestGetLogModuleDataTypeGuard:
+    """修复验证：参数类型错误时返回错误响应，而非崩溃。"""
+
+    def test_string_page_returns_error_not_typeerror(self):
+        """page='2'（字符串）在修复前触发 TypeError。修复后返回 result=False 的错误响应。"""
+        handler = _make_handler_with_queryset(_FakeQS())
+        result = handler("log_group", None, "not-a-number", 10, 1)
+        assert result.get("result") is False
+        assert "参数类型错误" in result.get("message", "")
+
+    def test_string_page_size_returns_error_not_typeerror(self):
+        """page_size='abc'（字符串）在修复前触发 TypeError。修复后返回错误响应。"""
+        handler = _make_handler_with_queryset(_FakeQS())
+        result = handler("log_group", None, 1, "abc", 1)
+        assert result.get("result") is False
+        assert "参数类型错误" in result.get("message", "")
+
+    def test_string_group_id_returns_error_not_orm_crash(self):
+        """group_id='xyz'（字符串）在修复前导致 ORM TypeError。修复后返回错误响应。"""
+        handler = _make_handler_with_queryset(_FakeQS())
+        result = handler("log_group", None, 1, 10, "xyz")
+        assert result.get("result") is False
+        assert "参数类型错误" in result.get("message", "")
+
+    def test_negative_page_size_clamped_to_one(self):
+        """page_size=-1 在修复前导致负数切片，返回静默错误数据。修复后 clamp 为 1。"""
+        qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 6)])
+        handler = _make_handler_with_queryset(qs)
+        result = handler("log_group", None, 1, -1, 1)
+        # 修复后正常返回，page_size 被 clamp 为 1，start=0 end=1
+        assert "result" not in result or result.get("result") is not False
+        assert result.get("count") == 5
+        # 取第一条（切片 [0:1]），不应该从末尾反向取
+        assert result["items"] == [{"id": 1, "name": "1"}]
+
+    def test_zero_page_size_clamped_to_one(self):
+        """page_size=0 在修复前导致 ZeroDivisionError 或空结果，修复后 clamp 为 1。"""
+        qs = _FakeQS([{"id": 1, "name": "a"}])
+        handler = _make_handler_with_queryset(qs)
+        result = handler("log_group", None, 1, 0, 1)
+        assert "result" not in result or result.get("result") is not False
+        assert result.get("count") == 1
+
+    def test_page_size_exceeds_max_clamped(self):
+        """page_size 超过 _PAGE_SIZE_MAX 时被 clamp 到上限，不崩溃。"""
+        qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 3)])
+        handler = _make_handler_with_queryset(qs)
+        result = handler("log_group", None, 1, 99999, 1)
+        assert "result" not in result or result.get("result") is not False
+        assert result.get("count") == 2
+
+    def test_numeric_strings_are_accepted(self):
+        """'1'、'10'、'42' 这类数字字符串（NATS 反序列化常见）应被正常转换为 int。"""
+        qs = _FakeQS([{"id": i, "name": str(i)} for i in range(1, 11)])
+        handler = _make_handler_with_queryset(qs)
+        result = handler("policy", "ctype-1", "1", "5", "42")
+        assert result.get("count") == 10
+        assert len(result.get("items", [])) == 5
+
+    def test_none_page_returns_error(self):
+        """page=None 时返回错误响应，不崩溃。"""
+        handler = _make_handler_with_queryset(_FakeQS())
+        result = handler("log_group", None, None, 10, 1)
+        assert result.get("result") is False
+        assert "参数类型错误" in result.get("message", "")


### PR DESCRIPTION
## 问题

`get_log_module_data` 是 log 模块对外暴露的 NATS handler，供权限管理页查询日志模块可见数据。NATS 消息体经 JSON 序列化传输，接收端若出现反序列化异常（或调用方自身 bug），`page`/`page_size`/`group_id` 可能以字符串形式到达。

- `page="2"` 时，`(page - 1) * page_size` 直接抛 `TypeError`，NATS consumer 进程报错，影响整个 log 模块的消息处理；
- `page_size=-1` 时，`start = 0`、`end = -1`，Python 列表切片 `[0:-1]` 从末尾倒数，返回错误数据但不报错（静默缺陷，比崩溃更难发现）；
- `group_id="abc"` 传入 ORM `.filter(organization=group_id)` 同样触发类型错误。

## 根因

NATS 是弱类型消息总线，消息载体为 JSON，数字可能在网络传输过程中被序列化为字符串。handler 未在入口做类型防护，直接使用原始参数参与算术运算和 ORM 查询，导致运行时崩溃或静默数据错误。

## 怎么修的

在函数入口增加类型转换和范围校验，转换失败立即返回错误响应而不是抛异常：

```python
_PAGE_SIZE_MAX = int(os.getenv("LOG_MODULE_DATA_PAGE_SIZE_MAX", "500"))

@nats_client.register
def get_log_module_data(module, child_module, page, page_size, group_id):
    try:
        page = max(1, int(page))
        page_size = max(1, min(int(page_size), _PAGE_SIZE_MAX))
        group_id = int(group_id)
    except (TypeError, ValueError) as exc:
        return {"result": False, "message": f"参数类型错误: {exc}", "data": []}
    ...
```

- `page` 和 `page_size` clamp 到合法范围（最小为 1），防止负数切片；
- `page_size` 上限默认 500，通过环境变量 `LOG_MODULE_DATA_PAGE_SIZE_MAX` 可配；
- 类型错误统一返回 `result=False` 的结构体，不崩溃 NATS worker。

## 影响范围

- 仅修改 `server/apps/log/nats/permission.py` 单文件，不涉及其他 app；
- 行为变化：参数类型错误时由 `TypeError` 异常（worker crash）变为返回错误响应（优雅降级）；正常整型参数路径行为不变；
- 无 DB migration、无协议变更、无跨模块影响。

## 验证

新增 Django-free 注入式测试 `test_get_log_module_data_type_guard_3655.py`，覆盖：

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| `page="not-a-number"` | `TypeError` crash | 返回 `result=False` |
| `page_size="abc"` | `TypeError` crash | 返回 `result=False` |
| `group_id="xyz"` | `TypeError` crash | 返回 `result=False` |
| `page_size=-1` | 负数切片，静默错误数据 | clamp 为 1，返回正确首条 |
| `page="1", page_size="5"` | 按字面字符串运算 crash | 正常转换，返回正确分页 |
| `page=None` | `TypeError` crash | 返回 `result=False` |

revert 修复代码后所有测试均失败（已验证 RED/GREEN 互换）。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NATS subject: get_log_module_data\nnats/permission.py"]
    end

    subgraph G["入口校验层（新增）"]
        G1["类型转换 int(page/page_size/group_id)\n范围 clamp: page>=1, 1<=page_size<=500"]
        G2["转换失败 → 返回 result=False\n不崩溃 worker"]
    end

    subgraph N["核心处理层"]
        F1["queryset 按 module 分支过滤\nLogGroup / Policy / CollectInstance"]
        F2["分页切片 queryset[start:end]\n计算总数 count()"]
    end

    T1 --> G1
    G1 -- "转换失败" --> G2
    G1 -- "转换成功" --> F1
    F1 --> F2
```

关联 Issue #3655