### PR TITLE
fix(webchat): MessageActions 支持多模态消息内容复制（修复 [object Object] 问题）

### DIFF
--- a/webchat/packages/webchat-ui/src/components/MessageActions.tsx
+++ b/webchat/packages/webchat-ui/src/components/MessageActions.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { MessageContent } from '@webchat/core';
 
 interface MessageActionsProps {
   messageId: string;
-  messageContent: string;
+  messageContent: string | MessageContent[];
   isBot: boolean;
   isLastBotMessage?: boolean;
   showActions: boolean;
@@ -51,8 +52,14 @@ export const MessageActions: React.FC<MessageActionsProps> = ({
       )}
       <button
         onClick={() => {
-          navigator.clipboard.writeText(messageContent);
-          onCopy?.(messageContent);
+          const text = Array.isArray(messageContent)
+            ? messageContent
+                .filter((item) => item.type === 'text' && item.text)
+                .map((item) => item.text)
+                .join('\n')
+            : messageContent;
+          navigator.clipboard.writeText(text);
+          onCopy?.(text);
         }}
         className="p-1 hover:bg-gray-100 rounded transition-colors"
         title="复制"


### PR DESCRIPTION
## 问题

关联 Issue #3598

MessageActionsProps.messageContent 类型声明为 string，但实际调用侧传入 string | MessageContent[]。
用户复制多模态消息时，数组被 toString() 产生垃圾字符串 [object Object]。

## 修复

- 将 MessageActionsProps.messageContent 类型改为 string | MessageContent[]
- 复制前序列化：字符串直接复制，数组则提取 type==='text' 的 text 字段后 join

## 验证

- 纯文本消息复制行为不变
- 多模态消息复制得到可读文本内容

Close #3598