### PR TITLE
bugfix: log AlertViewSet 三接口裸 int() 转换分页/step 参数致 500（#3653）

### DIFF
--- a/server/apps/log/tests/test_alert_viewset_param_validation_3653.py
+++ b/server/apps/log/tests/test_alert_viewset_param_validation_3653.py
@@ -1,0 +1,82 @@
+"""
+tests for issue #3653: AlertViewSet bare int() 转换分页/step 参数触发 500
+
+直接测试 _to_positive_int 工具函数的行为契约（Django-free）。
+revert 修复代码（将 _to_positive_int 替换回 int()）后这些断言必然失败。
+"""
+import ast
+import pathlib
+
+
+# ---------------------------------------------------------------------------
+# 从 policy.py 源码中提取 _to_positive_int 函数定义，隔离执行（无 Django 依赖）
+# ---------------------------------------------------------------------------
+
+_policy_src = (
+    pathlib.Path(__file__).parent.parent / "views" / "policy.py"
+).read_text(encoding="utf-8")
+
+# 找到 _to_positive_int 函数的 AST 节点并反编译为可执行源码
+_tree = ast.parse(_policy_src)
+_func_node = next(
+    node for node in ast.walk(_tree)
+    if isinstance(node, ast.FunctionDef) and node.name == "_to_positive_int"
+)
+_func_src = ast.get_source_segment(_policy_src, _func_node)
+
+_ns: dict = {}
+exec(_func_src, _ns)  # noqa: S102  — controlled exec of our own source
+_to_positive_int = _ns["_to_positive_int"]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestToPositiveInt:
+    """直接对 _to_positive_int 工具函数的单元测试"""
+
+    def test_valid_integer_string(self):
+        assert _to_positive_int("5", 1) == 5
+
+    def test_valid_integer_zero_clipped_to_min(self):
+        # min_val 默认 1，传 0 应返回 1
+        assert _to_positive_int("0", 1) == 1
+
+    def test_negative_clipped_to_min(self):
+        assert _to_positive_int("-10", 1) == 1
+
+    def test_non_integer_returns_default(self):
+        # 这是修复的核心：非整数必须返回默认值而非抛 ValueError
+        assert _to_positive_int("abc", 1) == 1
+
+    def test_none_returns_default(self):
+        assert _to_positive_int(None, 10) == 10
+
+    def test_float_string_returns_default(self):
+        # "1.5" 不能被 int() 直接转换，应返回默认值
+        assert _to_positive_int("1.5", 10) == 10
+
+    def test_exceeds_max_val_clipped(self):
+        assert _to_positive_int("99999", 1, max_val=500) == 500
+
+    def test_step_non_integer_returns_default(self):
+        # step=1h 场景
+        assert _to_positive_int("1h", 60) == 60
+
+    def test_step_zero_clipped_to_min_val_1(self):
+        # step=0 时 min_val=1 防止除零
+        assert _to_positive_int("0", 60, min_val=1, max_val=1440) == 1
+
+    def test_step_valid(self):
+        assert _to_positive_int("30", 60, min_val=1, max_val=1440) == 30
+
+    def test_step_exceeds_max(self):
+        assert _to_positive_int("9999", 60, min_val=1, max_val=1440) == 1440
+
+    def test_page_size_default_max(self):
+        # page_size 上限 500
+        assert _to_positive_int("1000", 10, max_val=500) == 500
+
+    def test_empty_string_returns_default(self):
+        assert _to_positive_int("", 1) == 1

--- a/server/apps/log/views/policy.py
+++ b/server/apps/log/views/policy.py
@@ -35,6 +35,15 @@ from config.drf.pagination import CustomPageNumberPagination
 from apps.core.utils.team_utils import get_current_team
 
 
+def _to_positive_int(val, default: int, min_val: int = 1, max_val: int = 10000) -> int:
+    """将查询参数安全转换为正整数，非法值返回 default。"""
+    try:
+        v = int(val)
+    except (TypeError, ValueError):
+        return default
+    return max(min_val, min(v, max_val))
+
+
 def get_accessible_log_policy_ids(request, collect_type_id=None):
     cache_key = "_log_accessible_policy_ids_cache"
     cached_policy_ids = getattr(request, cache_key, None)
@@ -278,8 +287,8 @@ class PolicyViewSet(viewsets.ModelViewSet):
         queryset = queryset.distinct().select_related("collect_type").prefetch_related("policyorganization_set")
 
         # 获取分页参数
-        page = int(request.GET.get("page", 1))
-        page_size = int(request.GET.get("page_size", 10))
+        page = _to_positive_int(request.GET.get("page"), 1)
+        page_size = _to_positive_int(request.GET.get("page_size"), 10, max_val=500)
 
         # 计算分页的起始位置
         start = (page - 1) * page_size
@@ -614,8 +623,8 @@ class AlertViewSet(viewsets.ModelViewSet):
         queryset = queryset.filter(policy_id__in=policy_ids).distinct()
 
         # 获取分页参数
-        page = int(request.GET.get("page", 1))
-        page_size = int(request.GET.get("page_size", 10))
+        page = _to_positive_int(request.GET.get("page"), 1)
+        page_size = _to_positive_int(request.GET.get("page_size"), 10, max_val=500)
 
         # 计算分页
         start = (page - 1) * page_size
@@ -649,8 +658,8 @@ class AlertViewSet(viewsets.ModelViewSet):
         queryset = queryset.filter(policy_id__in=policy_ids).distinct()
 
         # 获取分页参数
-        page = int(request.GET.get("page", 1))
-        page_size = int(request.GET.get("page_size", 10))
+        page = _to_positive_int(request.GET.get("page"), 1)
+        page_size = _to_positive_int(request.GET.get("page_size"), 10, max_val=500)
 
         # 计算分页
         start = (page - 1) * page_size
@@ -759,7 +768,7 @@ class AlertViewSet(viewsets.ModelViewSet):
                         "total": 0,
                         "status": request.query_params.get("status", AlertConstants.STATUS_NEW),
                         "time_range": {"start": None, "end": None},
-                        "step_minutes": int(request.query_params.get("step", 60)),
+                        "step_minutes": _to_positive_int(request.query_params.get("step"), 60, min_val=1, max_val=1440),
                         "time_series": [],
                     }
                 )
@@ -770,7 +779,7 @@ class AlertViewSet(viewsets.ModelViewSet):
 
         # 获取参数
         status = request.query_params.get("status", AlertConstants.STATUS_NEW)
-        step_minutes = int(request.query_params.get("step", 60))
+        step_minutes = _to_positive_int(request.query_params.get("step"), 60, min_val=1, max_val=1440)
 
         # 按状态过滤
         queryset = queryset.filter(status=status)


### PR DESCRIPTION
## 问题

日志告警列表（`/api/v1/log/alert/`）、全量查询（`alert_list_all/`）、统计（`stats/`）三接口对 `page`、`page_size`、`step` 参数做裸 `int()` 转换，传入 `page=abc` / `step=1h` 等非整数值时直接抛 `ValueError`，用户侧收到 HTTP 500。任何已登录用户均可触发。

## 修复

新增 `_to_positive_int(val, default, min_val, max_val)` 工具函数，统一替换四处裸 `int()` 调用：
- `PolicyViewSet.list()` page / page_size
- `AlertViewSet.list()` page / page_size
- `AlertViewSet.alert_list_all()` page / page_size
- `AlertViewSet.stats()` / `_get_step_based_stats()` step 参数

非整数输入返回安全默认值并按 min/max 范围夹紧（page_size ≤ 500，step ∈ [1, 1440]）。

## 测试

新增 13 条 Django-free 回归测试（`test_alert_viewset_param_validation_3653.py`），覆盖：
- 合法整数字符串
- 负数 / 零截断到 min_val
- 非整数字符串（`"abc"` / `"1.5"` / `"1h"`）→ 默认值
- `None` → 默认值
- 越界值 → max_val 截断

Closes #3653