### PR TITLE
bugfix: 修复 CMDB NATS PERMISSION_INSTANCES 分支 permission_map={} 绕过权限过滤

### DIFF
--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -261,9 +261,18 @@ def _format_asset_instances_response(model_id, instances):
 
 
 @nats_client.register
-def get_cmdb_module_data(module, child_module, page, page_size, group_id):
+def get_cmdb_module_data(module, child_module, page, page_size, group_id, user_info=None):
     """
     获取cmdb模块实例数据
+
+    Args:
+        module: 模块类型（PERMISSION_INSTANCES / PERMISSION_MODEL / PERMISSION_TASK）
+        child_module: 子模块标识（PERMISSION_INSTANCES 分支下为 model_id）
+        page: 页码
+        page_size: 每页条目数
+        group_id: 组织 ID，用于限定组织范围查询
+        user_info: 用户上下文 { user: str, team: int, domain: str }，
+                   由调用方（system_mgmt）注入；缺失时 PERMISSION_INSTANCES 分支返回空列表（安全兜底）
     """
     page = int(page)
     page_size = int(page_size)
@@ -275,14 +284,19 @@ def get_cmdb_module_data(module, child_module, page, page_size, group_id):
         count = instances.count()
         queryset = [{"id": str(i["id"]), "name": f"{i['model_id']}_{i['name']}"} for i in instances]
     elif module == PERMISSION_INSTANCES:
+        # 构建真实权限 map：根据调用方传入的 user_info 查询用户在目标模型上的权限范围
+        # 当 user_info 缺失或用户无权限时返回空列表，避免越权泄露实例名称
+        permission_map = _build_nats_permission_map(user_info, model_id=child_module)
+        if permission_map is None:
+            return {"count": 0, "items": []}
         instances, count = InstanceManage.instance_list(
-            model_id=child_module,  # 使用实际模型ID
-            params=[{"field": "organization", "type": "list[]", "value": [int(group_id)]}],  # 空查询条件（或按需添加）
+            model_id=child_module,
+            params=[{"field": "organization", "type": "list[]", "value": [int(group_id)]}],
             page=page,
             page_size=page_size,
             order="",
             creator="",
-            permission_map={},
+            permission_map=permission_map,
         )
         queryset = []
         for instance in instances:

--- a/server/apps/cmdb/tests/test_get_cmdb_module_data_permission_3662.py
+++ b/server/apps/cmdb/tests/test_get_cmdb_module_data_permission_3662.py
@@ -1,0 +1,98 @@
+"""测试 get_cmdb_module_data PERMISSION_INSTANCES 分支的权限过滤。
+
+Issue #3662: 原先 permission_map={} 硬编码绕过权限，本测试验证修复后：
+1. user_info 缺失时返回空列表（安全兜底）
+2. _build_nats_permission_map 返回 None 时返回空列表
+3. 有效 permission_map 时调用 InstanceManage.instance_list 并使用该 map
+
+revert 修复后测试必须失败（验证覆盖修复点本身）。
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from apps.cmdb.nats.nats import get_cmdb_module_data
+from apps.cmdb.constants.constants import PERMISSION_INSTANCES
+
+
+@pytest.mark.unit
+class TestGetCmdbModuleDataPermission:
+    """PERMISSION_INSTANCES 分支权限过滤测试。"""
+
+    def test_no_user_info_returns_empty(self):
+        """user_info 缺失时返回空列表（安全兜底，不泄露任何实例）。"""
+        result = get_cmdb_module_data(
+            module=PERMISSION_INSTANCES,
+            child_module="host",
+            page=1,
+            page_size=10,
+            group_id=1,
+            user_info=None,
+        )
+        assert result == {"count": 0, "items": []}, (
+            "缺少 user_info 时应返回空列表，不得泄露实例名称"
+        )
+
+    def test_permission_map_none_returns_empty(self):
+        """_build_nats_permission_map 返回 None（用户无权或信息不完整）时返回空列表。"""
+        with patch("apps.cmdb.nats.nats._build_nats_permission_map", return_value=None):
+            result = get_cmdb_module_data(
+                module=PERMISSION_INSTANCES,
+                child_module="host",
+                page=1,
+                page_size=10,
+                group_id=1,
+                user_info={"user": "alice", "team": 1},
+            )
+        assert result == {"count": 0, "items": []}, (
+            "_build_nats_permission_map 返回 None 时应返回空列表"
+        )
+
+    def test_valid_user_info_uses_real_permission_map(self):
+        """有效 user_info 时将真实 permission_map 传入 InstanceManage.instance_list。"""
+        fake_permission_map = {1: {"inst_names": ["host-001"], "permission_instances_map": {}}}
+        fake_instances = [{"inst_name": "host-001"}]
+
+        with patch("apps.cmdb.nats.nats._build_nats_permission_map", return_value=fake_permission_map) as mock_build, \
+             patch("apps.cmdb.nats.nats.InstanceManage.instance_list", return_value=(fake_instances, 1)) as mock_list:
+
+            result = get_cmdb_module_data(
+                module=PERMISSION_INSTANCES,
+                child_module="host",
+                page=1,
+                page_size=10,
+                group_id=1,
+                user_info={"user": "alice", "team": 1, "domain": "domain.com"},
+            )
+
+        # 验证 _build_nats_permission_map 用了正确参数
+        mock_build.assert_called_once_with(
+            {"user": "alice", "team": 1, "domain": "domain.com"},
+            model_id="host",
+        )
+        # 验证 instance_list 收到的 permission_map 是真实的，而非空字典
+        call_kwargs = mock_list.call_args[1]
+        assert call_kwargs["permission_map"] is fake_permission_map, (
+            "instance_list 必须使用从 user_info 构建的真实 permission_map，不得传入 {}"
+        )
+        assert call_kwargs["permission_map"] != {}, (
+            "permission_map 不得为空字典（空字典会绕过权限过滤）"
+        )
+        assert result == {"count": 1, "items": [{"name": "host-001", "id": "host-001"}]}
+
+    def test_empty_permission_map_dict_would_bypass_filter(self):
+        """回归测试：若 permission_map={} 传入 instance_list，确认可被检测。
+
+        此测试验证修复点：revert 修复（改回 permission_map={}）后，
+        test_valid_user_info_uses_real_permission_map 中的断言会失败。
+        """
+        # 使用空字典验证 _build_format_permission_dict 的语义
+        from apps.cmdb.services.instance import InstanceManage
+        # 空 permission_map 产生空 format_permission_dict → 无权限条件 → 越权
+        result = InstanceManage._build_format_permission_dict({})
+        assert result == {}, "空 permission_map 产生空过滤条件，验证旁路场景"
+
+        # 非空 permission_map 产生有效过滤条件
+        permission_map = {1: {"inst_names": ["host-001"], "permission_instances_map": {}}}
+        result = InstanceManage._build_format_permission_dict(permission_map)
+        assert 1 in result, "非空 permission_map 必须产生有效权限过滤条件"

--- a/server/apps/system_mgmt/tests/test_org_scope_permissions.py
+++ b/server/apps/system_mgmt/tests/test_org_scope_permissions.py
@@ -38,6 +38,80 @@ def test_group_data_rule_permission_accepts_integer_group_list():
     assert error_response is None
 
 
+def test_group_data_rule_cmdb_get_app_data_injects_user_info(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def get_module_data(self, **kwargs):
+            captured.update(kwargs)
+            return {"count": 0, "items": []}
+
+    def fake_get_client(params):
+        params.pop("app")
+        return FakeClient()
+
+    monkeypatch.setattr(GroupDataRuleViewSet, "get_client", staticmethod(fake_get_client))
+
+    request = APIRequestFactory().get(
+        "/system_mgmt/api/group_data_rule/get_app_data/",
+        {
+            "app": "cmdb",
+            "module": "instances",
+            "child_module": "host",
+            "page": "1",
+            "page_size": "10",
+            "group_id": "7",
+        },
+    )
+    request.COOKIES["current_team"] = "7"
+    request.COOKIES["include_children"] = "1"
+    force_authenticate(request, user=_request_user([7], {"data_permission-View"}))
+
+    response = GroupDataRuleViewSet.as_view({"get": "get_app_data"})(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 200
+    assert payload == {"result": True, "data": {"count": 0, "items": []}}
+    assert captured["user_info"] == {
+        "user": "org-scope-operator",
+        "domain": "domain.com",
+        "team": 7,
+        "include_children": True,
+    }
+
+
+def test_group_data_rule_cmdb_get_app_data_rejects_invalid_current_team(monkeypatch):
+    class FakeClient:
+        def get_module_data(self, **kwargs):
+            return {"count": 0, "items": []}
+
+    def fake_get_client(params):
+        params.pop("app")
+        return FakeClient()
+
+    monkeypatch.setattr(GroupDataRuleViewSet, "get_client", staticmethod(fake_get_client))
+
+    request = APIRequestFactory().get(
+        "/system_mgmt/api/group_data_rule/get_app_data/",
+        {
+            "app": "cmdb",
+            "module": "instances",
+            "child_module": "host",
+            "page": "1",
+            "page_size": "10",
+            "group_id": "7",
+        },
+    )
+    request.COOKIES["current_team"] = "bad"
+    force_authenticate(request, user=_request_user([7], {"data_permission-View"}))
+
+    response = GroupDataRuleViewSet.as_view({"get": "get_app_data"})(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 400
+    assert payload == {"result": False, "message": "current_team 参数非法"}
+
+
 @pytest.mark.django_db
 def test_search_user_list_filters_to_accessible_groups():
     allowed = Group.objects.create(name="scope-search-allowed", parent_id=0, is_virtual=False)

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -235,10 +235,16 @@ class GroupDataRuleViewSet(LanguageViewSet):
         if app == "cmdb":
             user = request.user
             current_team = get_current_team(request)
+            try:
+                team = int(current_team) if current_team not in (None, "") else None
+            except (TypeError, ValueError):
+                message = self.loader.get("error.invalid_current_team") if self.loader else "current_team 参数非法"
+                return JsonResponse({"result": False, "message": message}, status=400)
             params["user_info"] = {
                 "user": getattr(user, "username", ""),
                 "domain": getattr(user, "domain", "domain.com"),
-                "team": int(current_team) if current_team is not None else None,
+                "team": team,
+                "include_children": request.COOKIES.get("include_children", "0") == "1",
             }
         return_data = fun(**params)
         if isinstance(return_data, dict) and not return_data.get("result", True):

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -207,6 +207,8 @@ class GroupDataRuleViewSet(LanguageViewSet):
     @HasPermission("data_permission-View")
     def get_app_data(self, request):
         params = request.GET.dict()
+        # 记录 app 值（get_client 会从 params 中弹出），用于后续判断是否注入上下文
+        app = params.get("app", "")
         if params.get("app") == "mlops":
             try:
                 group_id = int(params.get("group_id"))
@@ -229,6 +231,15 @@ class GroupDataRuleViewSet(LanguageViewSet):
             raise AttributeError(message)
         params["page"] = int(params.get("page", "1"))
         params["page_size"] = int(params.get("page_size", "10"))
+        # 对 CMDB 权限实例查询注入调用方用户上下文，供 NATS handler 构建真实权限 map
+        if app == "cmdb":
+            user = request.user
+            current_team = get_current_team(request)
+            params["user_info"] = {
+                "user": getattr(user, "username", ""),
+                "domain": getattr(user, "domain", "domain.com"),
+                "team": int(current_team) if current_team is not None else None,
+            }
         return_data = fun(**params)
         if isinstance(return_data, dict) and not return_data.get("result", True):
             return JsonResponse({"result": False, "message": return_data.get("message", "")}, status=400)


### PR DESCRIPTION
## 关联 Issue

close #3662

## 问题描述

`get_cmdb_module_data` 处理 `PERMISSION_INSTANCES` 模块时硬编码传入 `permission_map={}`，导致 `InstanceManage.instance_list` 跳过实例级权限过滤，权限选择器向所有已登录用户展示目标模型的全量实例名称，越权泄露敏感资产名称。

## 修复内容

- `server/apps/cmdb/nats/nats.py`：为 `get_cmdb_module_data` 增加可选参数 `user_info=None`，`PERMISSION_INSTANCES` 分支改为调用 `_build_nats_permission_map(user_info, model_id)` 构建真实权限 map；`user_info` 缺失或用户无权时安全兜底返回空列表，不再泄露任何实例名称。
- `server/apps/system_mgmt/viewset/group_data_rule_viewset.py`：`get_app_data` 视图调用 CMDB 时注入 `user_info`（`username / domain / current_team`），使 NATS handler 能按调用方用户权限过滤实例。
- `server/apps/cmdb/tests/test_get_cmdb_module_data_permission_3662.py`：新增单测覆盖四个场景（缺失 user_info、permission_map=None、真实 map 传递、`_build_format_permission_dict` 语义）。

## 风险评估

risk=中（权限收口，修复已有测试覆盖，逻辑范围明确）