### PR TITLE
bugfix(cmdb): 先写 PG 变更记录再删图节点，修复审计日志丢失问题 (#3665)

### DIFF
--- a/server/apps/cmdb/services/instance.py
+++ b/server/apps/cmdb/services/instance.py
@@ -788,12 +788,9 @@ class InstanceManage(object):
             roles=roles,
         )
 
-        with GraphClient() as ag:
-            ag.batch_delete_entity(INSTANCE, inst_ids)
-
-        # 企业版：实例删除后把其附件/图片文件标记为待回收（批量单次处理）
-        get_instance_enterprise_extension().on_instances_delete([item["_id"] for item in inst_list])
-
+        # 先写 PG 变更记录，再删图数据库节点。
+        # 若 PG 写入失败则直接抛出，图删除不执行，两侧保持一致；
+        # 反之若先删图再写 PG，图删除提交后无法回滚，PG 失败会导致审计日志丢失（#3665）。
         change_records = [
             dict(
                 inst_id=i["_id"],
@@ -805,6 +802,12 @@ class InstanceManage(object):
             for i in inst_list
         ]
         batch_create_change_record(INSTANCE, DELETE_INST, change_records, operator=operator)
+
+        with GraphClient() as ag:
+            ag.batch_delete_entity(INSTANCE, inst_ids)
+
+        # 企业版：实例删除后把其附件/图片文件标记为待回收（批量单次处理）
+        get_instance_enterprise_extension().on_instances_delete([item["_id"] for item in inst_list])
 
         from apps.cmdb.services.auto_relation_reconcile import schedule_incoming_rule_full_sync_by_model_ids
 
@@ -1051,14 +1054,25 @@ class InstanceManage(object):
             f"目标模型ID: {dst_info.get('model_id', '')} 目标模型实例: "
             f"{dst_info.get('inst_name') or dst_info.get('ip_addr', '')}"
         )
-        create_change_record_by_asso(
-            INSTANCE_ASSOCIATION,
-            CREATE_INST_ASST,
-            asso_info,
-            message=message,
-            operator=operator,
-            scenario=scenario,
-        )
+        # 关联关系需先创建图边才能取到 edge._id / asso_info，无法在图写之前先写 PG。
+        # 用 try/except 兜底：变更记录写入失败时记录错误日志但不影响关联创建结果，
+        # 避免异常向上传播让调用方误判关联创建失败而重试（可能触发"edge already exists"重复异常）。
+        # 若需更强一致性保障，可改为 Celery 异步投递（至少一次）——见 #3665。
+        try:
+            create_change_record_by_asso(
+                INSTANCE_ASSOCIATION,
+                CREATE_INST_ASST,
+                asso_info,
+                message=message,
+                operator=operator,
+                scenario=scenario,
+            )
+        except Exception as e:  # noqa: 变更记录写入失败不影响关联创建，但必须记录以便排查审计缺失
+            logger.error(
+                "[instance_association_create] 变更记录写入失败，关联已创建但审计日志可能缺失: "
+                "edge_id=%s, operator=%s, error=%s",
+                edge.get("_id"), operator, e,
+            )
 
         return edge
 

--- a/server/apps/cmdb/tests/test_instance_service_graph_mock.py
+++ b/server/apps/cmdb/tests/test_instance_service_graph_mock.py
@@ -109,3 +109,155 @@ def test_instance_batch_delete_not_found(fake_graph):
     fake_graph("apps.cmdb.services.instance", query_entity_by_ids=[])
     with pytest.raises(BaseAppException):
         InstanceManage.instance_batch_delete([], [], [1], "admin")
+
+
+@pytest.mark.django_db
+def test_instance_batch_delete_change_record_written_before_graph_delete(monkeypatch):
+    """#3665: 变更记录必须先于图删除写入 PG，若 PG 写入失败则图删除不执行。
+
+    验证手段：记录全局调用顺序，确认 batch_create_change_record 在 batch_delete_entity 之前。
+    若 revert 修复（改回先图后 PG），batch_delete_entity 会排在 batch_create_change_record 之前，测试失败。
+    """
+    call_order = []
+
+    inst_list = [{"_id": 1, "model_id": "host", "inst_name": "h1"}]
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.GraphClient",
+        lambda *a, **k: _SpyGraphClient(call_order),
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.query_entity_by_ids",
+        lambda *a, **kw: inst_list,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.ModelManage.search_model_info",
+        lambda model_id: {"model_name": "主机"},
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.check_instances_permission",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.get_instance_enterprise_extension",
+        lambda: type("Ext", (), {"on_instances_delete": lambda self, x: None})(),
+    )
+
+    def spy_batch_create_change_record(*args, **kwargs):
+        call_order.append("batch_create_change_record")
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.batch_create_change_record",
+        spy_batch_create_change_record,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.auto_relation_reconcile.schedule_incoming_rule_full_sync_by_model_ids",
+        lambda x: None,
+        raising=False,
+    )
+
+    InstanceManage.instance_batch_delete([], [], [1], "admin")
+
+    # 核心断言：PG 写入必须先于图删除
+    assert call_order.index("batch_create_change_record") < call_order.index("batch_delete_entity"), (
+        "batch_create_change_record 应在 batch_delete_entity 之前调用，"
+        "否则 PG 失败时图删除已提交、审计日志丢失（#3665）"
+    )
+
+
+class _SpyGraphClient:
+    """记录 batch_delete_entity 调用顺序的 spy graph client。"""
+
+    def __init__(self, call_order: list):
+        self._call_order = call_order
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def batch_delete_entity(self, *args, **kwargs):
+        self._call_order.append("batch_delete_entity")
+
+
+@pytest.mark.django_db
+def test_instance_batch_delete_pg_failure_prevents_graph_delete(fake_graph, monkeypatch):
+    """#3665: 若 PG 变更记录写入失败，图删除不应执行（先写 PG 保障一致性）。"""
+    inst_list = [{"_id": 1, "model_id": "host", "inst_name": "h1"}]
+
+    graph_delete_called = []
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.GraphClient",
+        lambda *a, **k: _SpyGraphClient(graph_delete_called),
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.query_entity_by_ids",
+        lambda *a, **kw: inst_list,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.ModelManage.search_model_info",
+        lambda model_id: {"model_name": "主机"},
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.check_instances_permission",
+        lambda *a, **kw: None,
+    )
+
+    def failing_batch_create_change_record(*args, **kwargs):
+        raise Exception("PG connection error")
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.batch_create_change_record",
+        failing_batch_create_change_record,
+    )
+
+    with pytest.raises(Exception, match="PG connection error"):
+        InstanceManage.instance_batch_delete([], [], [1], "admin")
+
+    # 核心断言：PG 失败后图删除不应被调用
+    assert "batch_delete_entity" not in graph_delete_called, (
+        "PG 写入失败时图删除不应执行，否则实例消失但无审计日志（#3665）"
+    )
+
+
+@pytest.mark.django_db
+def test_instance_association_create_pg_failure_does_not_propagate(fake_graph, monkeypatch):
+    """#3665: instance_association_create 中 PG 变更记录写入失败不应向上传播。
+
+    图边已创建后，PG 写入失败应仅记录日志，不影响关联创建结果（避免调用方误以为关联创建失败而重试）。
+    """
+    edge = {"_id": 99, "src_inst_id": 1, "dst_inst_id": 2, "model_asst_id": "host_run_proc"}
+    asso_info = {
+        "_id": 99,
+        "src": {"_id": 1, "model_id": "host", "inst_name": "h1"},
+        "dst": {"_id": 2, "model_id": "proc", "inst_name": "p1"},
+    }
+
+    fake_graph(
+        "apps.cmdb.services.instance",
+        create_edge=edge,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.check_asso_mapping",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.InstanceManage.instance_association_by_asso_id",
+        lambda *a, **kw: asso_info,
+    )
+
+    def failing_create_change_record_by_asso(*args, **kwargs):
+        raise Exception("PG write failure")
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.instance.create_change_record_by_asso",
+        failing_create_change_record_by_asso,
+    )
+
+    # 核心断言：即使 PG 失败，函数应正常返回 edge（不传播异常）
+    result = InstanceManage.instance_association_create(
+        {"src_inst_id": 1, "dst_inst_id": 2, "model_asst_id": "host_run_proc"}, "admin"
+    )
+    assert result == edge, "PG 变更记录失败不应影响关联创建返回值（#3665）"


### PR DESCRIPTION
## 问题

关联 issue：#3665

`instance_batch_delete` 中操作顺序为：先删 FalkorDB 图节点，再写 PG 变更记录。若 PG 写入失败，图已删除但审计日志永久丢失，两侧状态不一致。

## 修复

**先写日志模式**：将 `batch_create_change_record` 移到 `ag.batch_delete_entity` 之前。
- PG 失败 → 异常传播，图删除不执行 → 两侧一致
- PG 成功后图失败 → 有预写变更记录，实例未实际删除 → 可观察可恢复

`instance_association_create` 场景必须先建图边获取 `_id`，改用 `try/except` 捕获 PG 失败并记录 error，不向上传播避免重试死循环。

## 测试

新增 3 个 Django-free 单测：
1. `batch_create_change_record` 调用排在 `batch_delete_entity` 之前（revert 即失败）
2. PG 失败时 `batch_delete_entity` 不被调用
3. 关联创建 PG 失败不传播，函数正常返回 edge

## 风险

- 风险档：**中**（数据一致性 / 审计完整性，改动单模块 ≤2 文件）
- 无破坏性接口变更

@zhaojinmeng