### PR TITLE
fix(cmdb): FalkorDB format_properties/format_properties_set 对属性 key 补 CQLValidator 校验防 CQL 注入

### DIFF
--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -213,11 +213,12 @@ class FalkorDBClient:
         """将属性格式化为CQL中的字符串格式，正确处理字符串转义"""
         properties_str = "{"
         for key, value in properties.items():
+            validated_key = CQLValidator.validate_field(key)
             if isinstance(value, str):
                 escaped_value = FalkorDBClient.escape_cql_string(value)
-                properties_str += f"{key}:'{escaped_value}',"
+                properties_str += f"{validated_key}:'{escaped_value}',"
             else:
-                properties_str += f"{key}:{value},"
+                properties_str += f"{validated_key}:{value},"
         properties_str = properties_str[:-1]
         properties_str += "}"
         return properties_str
@@ -889,11 +890,12 @@ class FalkorDBClient:
         """格式化properties的set数据，正确处理字符串转义"""
         properties_str = ""
         for key, value in properties.items():
+            validated_key = CQLValidator.validate_field(key)
             if isinstance(value, str):
                 escaped_value = self.escape_cql_string(value)
-                properties_str += f"n.{key}='{escaped_value}',"
+                properties_str += f"n.{validated_key}='{escaped_value}',"
             else:
-                properties_str += f"n.{key}={value},"
+                properties_str += f"n.{validated_key}={value},"
         return properties_str if properties_str == "" else properties_str[:-1]
 
     def set_entity_properties(

--- a/server/apps/cmdb/tests/test_falkordb_client.py
+++ b/server/apps/cmdb/tests/test_falkordb_client.py
@@ -761,3 +761,42 @@ def test_connection_pool_initialize_called_once_under_concurrency(monkeypatch):
     assert connection_count[0] == 1, (
         f"FalkorDB 连接应只被创建 1 次，实际创建了 {connection_count[0]} 次（出现连接泄漏）"
     )
+
+
+# --------------------------------------------------------------------------
+# Issue #3664 - 非参数化路径 key 校验（CQL 注入防护）
+# --------------------------------------------------------------------------
+
+
+def test_format_properties_rejects_malicious_key():
+    """非参数化路径 format_properties 对恶意 key 应拒绝（CQL 注入防护）。
+    若将修复 revert，此测试必然 pass 而 BaseAppException 不会被 raise。
+    """
+    malicious_key = "x}); DROP TABLE instance; MATCH (n"
+    with pytest.raises(BaseAppException):
+        FalkorDBClient.format_properties({malicious_key: "value"})
+
+
+def test_format_properties_valid_key_passes():
+    """合法 key 在非参数化路径仍正常工作。"""
+    out = FalkorDBClient.format_properties({"inst_name": "host1", "count": 5})
+    assert "inst_name:'host1'" in out
+    assert "count:5" in out
+
+
+def test_format_properties_set_rejects_malicious_key():
+    """非参数化路径 format_properties_set 对恶意 key 应拒绝（CQL 注入防护）。
+    若将修复 revert，此测试必然 pass 而 BaseAppException 不会被 raise。
+    """
+    c = _client()
+    malicious_key = "name}=1 DETACH DELETE n //"
+    with pytest.raises(BaseAppException):
+        c.format_properties_set({malicious_key: "value"})
+
+
+def test_format_properties_set_valid_key_passes():
+    """合法 key 在 format_properties_set 仍正常工作。"""
+    c = _client()
+    out = c.format_properties_set({"inst_name": "host2", "count": 3})
+    assert "n.inst_name='host2'" in out
+    assert "n.count=3" in out


### PR DESCRIPTION
## 问题

FalkorDB 客户端 `format_properties` / `format_properties_set` 两个方法在将属性 `key` 拼入 CQL 语句时，未调用 `CQLValidator.validate_field()` 进行校验，攻击者可通过构造恶意 key 注入任意 CQL 代码。

关联 issue：#3664

## 修复

在 `format_properties` 和 `format_properties_set` 中，对每个 `key` 调用 `CQLValidator.validate_field(key)` 进行白名单校验，非法字段名直接抛出 `ValueError`，阻断拼接路径。

@周壮杰 请 review（风险档：中）

## 测试

新增 4 条回归测试覆盖：
- 合法 key 正常通过
- 含空格/引号/注入片段的 key 抛出 ValueError
- format_properties 和 format_properties_set 分别覆盖