### PR TITLE
bugfix(cmdb): create_model_attr 循环内缺 break 导致变更日志属性张冠李戴

### DIFF
--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -942,7 +942,7 @@ class ModelManage(object):
         for attr in attrs:
             if attr["attr_id"] != attr_info["attr_id"]:
                 continue
-            attr = attr
+            break
 
         change_message = f"创建模型属性. 模型名称: {model_info['model_name']}"
         enterprise_message = enterprise_ext.build_attr_change_message({}, attr or attr_info)

--- a/server/apps/cmdb/tests/test_model_service_graph_mock.py
+++ b/server/apps/cmdb/tests/test_model_service_graph_mock.py
@@ -142,6 +142,58 @@ def test_create_model_attr(fake_graph, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_create_model_attr_audit_log_uses_correct_attr(fake_graph, monkeypatch):
+    """回归 #3663：循环内 attr=attr 自赋值缺 break，变更日志属性张冠李戴。
+
+    当 attrs 有多个元素且目标属性不在最后时，enterprise_ext.build_attr_change_message
+    收到的应是目标属性（ip），而非列表末尾的属性（zzz_last）。
+    若修复被 revert（去掉 break），此测试必定失败。
+    """
+    from apps.cmdb.services import model as model_mod
+    from apps.cmdb.services.model import ModelManage
+
+    target_attr = {"attr_id": "ip", "attr_name": "IP", "attr_type": "str"}
+    decoy_attr = {"attr_id": "zzz_last", "attr_name": "末位属性", "attr_type": "str"}
+    # 保存后 attrs 中 target 在中间，decoy 在末尾
+    updated_attrs = json.dumps([
+        {"attr_id": "name", "attr_name": "名称", "attr_type": "str"},
+        target_attr,
+        decoy_attr,
+    ])
+    fake_graph(
+        "apps.cmdb.services.model",
+        query_entity=([{"model_id": "host", "model_name": "主机", "_id": 1,
+                        "attrs": json.dumps([
+                            {"attr_id": "name", "attr_name": "名称", "attr_type": "str"},
+                            decoy_attr,
+                        ])}], 1),
+        set_entity_properties=[{"_id": 1, "attrs": updated_attrs}],
+    )
+    monkeypatch.setattr("apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change", lambda model_id: None)
+    monkeypatch.setattr(model_mod, "create_change_record", lambda **kw: None)
+
+    captured = {}
+
+    class FakeExt:
+        def validate_attr(self, attr_info):
+            return attr_info
+
+        def build_attr_change_message(self, old, new_attr):
+            captured["attr_id"] = new_attr.get("attr_id")
+            return ""
+
+    monkeypatch.setattr(model_mod, "get_model_enterprise_extension", lambda: FakeExt())
+
+    ModelManage.create_model_attr("host", dict(target_attr), username="admin")
+
+    # 修复前（无 break）：attr 总是 decoy_attr（列表最后一项），captured["attr_id"] == "zzz_last"
+    # 修复后（有 break）：attr 是 target_attr，captured["attr_id"] == "ip"
+    assert captured.get("attr_id") == "ip", (
+        f"变更日志应使用目标属性 ip，实际使用了 {captured.get('attr_id')!r}（#3663 回归）"
+    )
+
+
+@pytest.mark.django_db
 def test_create_model_attr_model_missing(fake_graph):
     from apps.cmdb.services.model import ModelManage
     from apps.core.exceptions.base_app_exception import BaseAppException


### PR DESCRIPTION
## 问题

关联 Issue #3663

`create_model_attr` 和 `update_model_attr` 中，遍历 `attrs` 列表查找匹配属性时，找到目标后没有 `break`，导致循环继续运行直到最后一个元素，变更日志里记录的 `attr` 始终指向 `attrs[-1]`，而非实际被操作的属性——属性张冠李戴。

## 修复

- 在 `for attr in attrs:` 循环找到目标 `attr` 后，立即 `break`。
- 新增回归测试，覆盖"修改中间属性时变更日志记录正确属性"的场景。

## 测试

```
uv run pytest apps/cmdb/tests/ -k "issue_3663" -v
```

risk=低