### PR TITLE
bugfix: FalkorDBConnectionPool 单例初始化加线程锁消除多线程竞态连接泄漏 #3661

### DIFF
--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -4,6 +4,7 @@
 # @Author: windyzhao
 import json
 import os
+import threading
 import time
 from typing import List, Union
 
@@ -36,10 +37,13 @@ class FalkorDBConnectionPool:
     _client = None
     _graph = None
     _initialized = False
+    _lock = threading.Lock()
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(FalkorDBConnectionPool, cls).__new__(cls)
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super(FalkorDBConnectionPool, cls).__new__(cls)
         return cls._instance
 
     def get_connection(self):
@@ -49,25 +53,29 @@ class FalkorDBConnectionPool:
         return self._client, self._graph
 
     def _initialize(self):
-        """初始化连接"""
+        """初始化连接（双检锁保护，防止多线程并发重复创建连接）"""
         if self._initialized:
             return
 
-        try:
-            password = os.getenv("FALKORDB_REQUIREPASS", "") or None
-            host = os.getenv("FALKORDB_HOST", "127.0.0.1")
-            port = int(os.getenv("FALKORDB_PORT", "6379"))
-            database = os.getenv("FALKORDB_DATABASE", "cmdb_graph")
+        with self.__class__._lock:
+            if self._initialized:
+                return
 
-            self._client = falkordb.FalkorDB(host=host, port=port, password=password)
-            self._graph = self._client.select_graph(database)
-            self._initialized = True
-            logger.info(f"已连接到 FalkorDB，选择Graph: {database}")
-        except Exception:
-            import traceback
+            try:
+                password = os.getenv("FALKORDB_REQUIREPASS", "") or None
+                host = os.getenv("FALKORDB_HOST", "127.0.0.1")
+                port = int(os.getenv("FALKORDB_PORT", "6379"))
+                database = os.getenv("FALKORDB_DATABASE", "cmdb_graph")
 
-            logger.error(f"连接失败: {traceback.format_exc()}")
-            raise
+                self._client = falkordb.FalkorDB(host=host, port=port, password=password)
+                self._graph = self._client.select_graph(database)
+                self._initialized = True
+                logger.info(f"已连接到 FalkorDB，选择Graph: {database}")
+            except Exception:
+                import traceback
+
+                logger.error(f"连接失败: {traceback.format_exc()}")
+                raise
 
 
 class FalkorDBClient:

--- a/server/apps/cmdb/tests/test_falkordb_client.py
+++ b/server/apps/cmdb/tests/test_falkordb_client.py
@@ -4,10 +4,11 @@
 """
 
 import json
+import threading
 
 import pytest
 
-from apps.cmdb.graph.falkordb import FalkorDBClient
+from apps.cmdb.graph.falkordb import FalkorDBClient, FalkorDBConnectionPool
 from apps.core.exceptions.base_app_exception import BaseAppException
 
 
@@ -669,3 +670,94 @@ def test_batch_save_entity_create_only():
     # 返回 (add_results, update_results)
     add_results = result[0]
     assert add_results[0]["success"] is True
+
+
+# --------------------------------------------------------------------------
+# FalkorDBConnectionPool 线程安全（issue #3661）
+# --------------------------------------------------------------------------
+
+
+def test_connection_pool_singleton_under_concurrency(monkeypatch):
+    """多线程并发构造 FalkorDBConnectionPool 只产生一个实例（__new__ 双检锁）。
+
+    revert 双检锁后此测试有概率出现多个不同实例，即验证了修复点。
+    """
+    # 重置单例状态，使本测试独立于其他测试
+    original_instance = FalkorDBConnectionPool._instance
+    FalkorDBConnectionPool._instance = None
+
+    instances = []
+    barrier = threading.Barrier(20)
+
+    def create_instance():
+        barrier.wait()  # 所有线程同时冲入 __new__
+        instances.append(FalkorDBConnectionPool())
+
+    threads = [threading.Thread(target=create_instance) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # 恢复原始状态
+    FalkorDBConnectionPool._instance = original_instance
+
+    unique_instances = set(id(i) for i in instances)
+    assert len(unique_instances) == 1, (
+        f"预期单例，但并发创建出 {len(unique_instances)} 个不同实例（连接泄漏）"
+    )
+
+
+def test_connection_pool_initialize_called_once_under_concurrency(monkeypatch):
+    """多线程并发调用 get_connection 时，FalkorDB 连接只被创建一次（无连接泄漏）。
+
+    通过 mock falkordb.FalkorDB 构造函数统计实际连接创建次数——
+    revert _initialize 双检锁后此测试将断言 connection_count > 1，即验证了修复点。
+    """
+    import time
+    from apps.cmdb.graph import falkordb as falkordb_module
+
+    pool = FalkorDBConnectionPool()
+    # 重置初始化状态
+    original_initialized = pool._initialized
+    original_client = pool._client
+    original_graph = pool._graph
+    pool._initialized = False
+    pool._client = None
+    pool._graph = None
+
+    connection_count = [0]
+    count_lock = threading.Lock()
+
+    class FakeFalkorDB:
+        def __init__(self, host, port, password):
+            time.sleep(0.01)  # 拉长窗口，使无锁版本必然出现多次并发创建
+            with count_lock:
+                connection_count[0] += 1
+
+        def select_graph(self, name):
+            return object()
+
+    # mock falkordb.FalkorDB，让真实的 _initialize 双检锁发挥作用
+    monkeypatch.setattr(falkordb_module.falkordb, "FalkorDB", FakeFalkorDB)
+
+    barrier = threading.Barrier(20)
+
+    def call_get_connection():
+        barrier.wait()
+        pool.get_connection()
+
+    threads = [threading.Thread(target=call_get_connection) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # 恢复状态
+    pool._initialized = original_initialized
+    pool._client = original_client
+    pool._graph = original_graph
+
+    assert connection_count[0] == 1, (
+        f"FalkorDB 连接应只被创建 1 次，实际创建了 {connection_count[0]} 次（出现连接泄漏）"
+    )


### PR DESCRIPTION
## 问题描述

`FalkorDBConnectionPool` 使用单例模式，但 `__new__` 和 `_initialize` 方法均未加锁。在多线程并发场景下（如 Celery worker、Django ASGI），多个线程可同时通过 `if cls._instance is None` 检查并各自创建实例，导致：
- 产生多个 `FalkorDBConnectionPool` 实例（单例失效）
- 每个实例各自建立 FalkorDB 连接（连接泄漏）

Fixes #3661

## 修复方案

在 `FalkorDBConnectionPool` 引入类级别 `threading.Lock`，对 `__new__` 和 `_initialize` 均采用**双检锁（Double-Checked Locking）**模式：

1. **`__new__`**：外层无锁检查 `_instance is None`，内层加锁后再次检查，确保单例只被创建一次。
2. **`_initialize`**：外层无锁检查 `_initialized`，内层加锁后再次检查，确保 FalkorDB 连接只被建立一次。

## 关键代码路径

- `server/apps/cmdb/graph/falkordb.py` — 添加 `_lock = threading.Lock()`，`__new__` 和 `_initialize` 双检锁

## 测试说明

新增 `server/apps/cmdb/tests/test_falkordb_client.py` 中的并发测试：

- `test_connection_pool_singleton_under_concurrency`：20 线程通过 `threading.Barrier` 同时冲入 `__new__`，断言只产生 1 个实例
- `test_connection_pool_initialize_called_once_under_concurrency`：20 线程同时调用 `get_connection()`，mock `falkordb.FalkorDB` 并加 10ms 延时拉宽竞态窗口，断言连接只被创建 1 次

## 风险评估

- **改动范围**：仅 `server/apps/cmdb/graph/falkordb.py`，局限于 cmdb 模块
- **风险等级**：低 — `threading.Lock` 为标准库，双检锁模式为成熟并发惯用法，不影响正常单线程路径性能