### PR TITLE
bugfix(job_mgmt): DashboardViewSet 补加 HasPermission 与 team 过滤

### DIFF
--- a/server/apps/job_mgmt/tests/test_dashboard_views.py
+++ b/server/apps/job_mgmt/tests/test_dashboard_views.py
@@ -63,6 +63,7 @@ class TestDashboardTeamIsolation:
 
     def test_trend_only_shows_own_team_data(self, api_client, authenticated_user):
         """team=1 的用户看 trend，不应计入 team=2 的执行记录。"""
+        authenticated_user.permission = {"job": {"job_record-View"}}
         api_client.cookies["current_team"] = "1"
         _make(ExecutionStatus.SUCCESS, team=[1])   # 可见
         _make(ExecutionStatus.SUCCESS, team=[2])   # 不可见
@@ -74,6 +75,7 @@ class TestDashboardTeamIsolation:
 
     def test_rate_only_aggregates_own_team_data(self, api_client, authenticated_user):
         """team=1 的用户看 success_rate_compare，汇总应只含 team=1 的执行记录。"""
+        authenticated_user.permission = {"job": {"job_record-View"}}
         api_client.cookies["current_team"] = "1"
         _make(ExecutionStatus.SUCCESS, team=[1])
         _make(ExecutionStatus.FAILED, team=[1])

--- a/server/apps/job_mgmt/tests/test_dashboard_views.py
+++ b/server/apps/job_mgmt/tests/test_dashboard_views.py
@@ -1,9 +1,17 @@
-"""Dashboard 视图测试（trend / success_rate_compare）"""
+"""Dashboard 视图测试（trend / success_rate_compare）
+
+验证点：
+- 未设置 current_team（无 team cookie）的已登录用户 → 403（AuthViewSet + HasPermission 守门）
+- 普通用户只能看自己 team 的执行记录，看不到其他 team 的数据（team 隔离）
+- 超管（su_client）可查看全量数据
+- 基本功能：日期序列补齐、天数封顶、聚合计算
+"""
 
 from datetime import timedelta
 
 import pytest
 from django.utils import timezone
+from rest_framework.test import APIClient
 
 from apps.job_mgmt.constants import ExecutionStatus, JobType
 from apps.job_mgmt.models import JobExecution
@@ -14,49 +22,107 @@ TREND_URL = "/api/v1/job_mgmt/api/dashboard/trend/"
 RATE_URL = "/api/v1/job_mgmt/api/dashboard/success_rate_compare/"
 
 
-def _make(status, created_offset_days=0):
-    e = JobExecution.objects.create(name="e", job_type=JobType.SCRIPT, status=status, team=[1])
+def _make(status, team=None, created_offset_days=0):
+    if team is None:
+        team = [1]
+    e = JobExecution.objects.create(name="e", job_type=JobType.SCRIPT, status=status, team=team)
     if created_offset_days:
         JobExecution.objects.filter(id=e.id).update(created_at=timezone.now() - timedelta(days=created_offset_days))
     return e
 
 
+class TestDashboardAccessControl:
+    """安全：HasPermission + AuthViewSet 确保 Dashboard 不再是裸 ViewSet。"""
+
+    def test_trend_requires_current_team_cookie(self, api_client):
+        """已登录但无 current_team cookie → 403，不返回任何数据（修复前是 200）。"""
+        # api_client 不带 current_team cookie
+        resp = api_client.get(TREND_URL)
+        assert resp.status_code == 403
+
+    def test_rate_requires_current_team_cookie(self, api_client):
+        """已登录但无 current_team cookie → success_rate_compare 也须 403。"""
+        resp = api_client.get(RATE_URL)
+        assert resp.status_code == 403
+
+    def test_unauthenticated_trend_returns_403(self):
+        """完全未登录 → 403（DRF IsAuthenticated 拦截）。"""
+        client = APIClient()
+        resp = client.get(TREND_URL)
+        assert resp.status_code in (401, 403)
+
+    def test_unauthenticated_rate_returns_403(self):
+        """完全未登录 → success_rate_compare 也须 403。"""
+        client = APIClient()
+        resp = client.get(RATE_URL)
+        assert resp.status_code in (401, 403)
+
+
+class TestDashboardTeamIsolation:
+    """安全：普通用户的 Dashboard 数据必须按 team 过滤，不可见其他 team 的执行记录。"""
+
+    def test_trend_only_shows_own_team_data(self, api_client, authenticated_user):
+        """team=1 的用户看 trend，不应计入 team=2 的执行记录。"""
+        api_client.cookies["current_team"] = "1"
+        _make(ExecutionStatus.SUCCESS, team=[1])   # 可见
+        _make(ExecutionStatus.SUCCESS, team=[2])   # 不可见
+
+        resp = api_client.get(TREND_URL + "?days=7")
+        assert resp.status_code == 200
+        total = sum(day["execution_count"] for day in resp.data)
+        assert total == 1  # 只有 team=1 的那条
+
+    def test_rate_only_aggregates_own_team_data(self, api_client, authenticated_user):
+        """team=1 的用户看 success_rate_compare，汇总应只含 team=1 的执行记录。"""
+        api_client.cookies["current_team"] = "1"
+        _make(ExecutionStatus.SUCCESS, team=[1])
+        _make(ExecutionStatus.FAILED, team=[1])
+        _make(ExecutionStatus.SUCCESS, team=[2])  # 不应计入
+
+        resp = api_client.get(RATE_URL + "?days=7")
+        assert resp.status_code == 200
+        cur = resp.data["current_period"]
+        assert cur["execution_total"] == 2  # 仅 team=1 的 2 条
+        assert cur["success_count"] == 1
+        assert cur["failed_count"] == 1
+
+
 class TestDashboardTrend:
-    def test_trend_returns_full_date_series(self, api_client):
+    def test_trend_returns_full_date_series(self, su_client):
         _make(ExecutionStatus.SUCCESS)
         _make(ExecutionStatus.FAILED)
-        resp = api_client.get(TREND_URL + "?days=7")
+        resp = su_client.get(TREND_URL + "?days=7")
         assert resp.status_code == 200
         assert len(resp.data) == 7  # 补齐完整 7 天序列
 
-    def test_trend_caps_days_at_30(self, api_client):
-        resp = api_client.get(TREND_URL + "?days=100")
+    def test_trend_caps_days_at_30(self, su_client):
+        resp = su_client.get(TREND_URL + "?days=100")
         assert resp.status_code == 200
         assert len(resp.data) == 30
 
-    def test_trend_includes_cancelled_count(self, api_client):
+    def test_trend_includes_cancelled_count(self, su_client):
         _make(ExecutionStatus.CANCELLED)
-        resp = api_client.get(TREND_URL + "?days=7")
+        resp = su_client.get(TREND_URL + "?days=7")
         assert resp.status_code == 200
         assert "cancelled_count" in resp.data[0]
         assert resp.data[-1]["cancelled_count"] == 1  # 今日（序列末位）含 1 条已取消
 
-    def test_trend_includes_daily_avg_duration(self, api_client):
+    def test_trend_includes_daily_avg_duration(self, su_client):
         execution = _make(ExecutionStatus.SUCCESS)
         started = timezone.now()
         JobExecution.objects.filter(id=execution.id).update(started_at=started, finished_at=started + timedelta(seconds=10))
-        resp = api_client.get(TREND_URL + "?days=7")
+        resp = su_client.get(TREND_URL + "?days=7")
         assert resp.status_code == 200
         assert "avg_duration_seconds" in resp.data[0]
         assert resp.data[-1]["avg_duration_seconds"] == 10.0  # 今日平均时长 10s
 
 
 class TestDashboardSuccessRateCompare:
-    def test_rate_aggregates_current_period(self, api_client):
+    def test_rate_aggregates_current_period(self, su_client):
         _make(ExecutionStatus.SUCCESS)
         _make(ExecutionStatus.SUCCESS)
         _make(ExecutionStatus.FAILED)
-        resp = api_client.get(RATE_URL + "?days=7")
+        resp = su_client.get(RATE_URL + "?days=7")
         assert resp.status_code == 200
         cur = resp.data["current_period"]
         assert cur["execution_total"] == 3
@@ -64,11 +130,11 @@ class TestDashboardSuccessRateCompare:
         assert cur["failed_count"] == 1
         assert cur["success_rate"] == round(2 / 3 * 100, 2)
 
-    def test_rate_invalid_days_falls_back_to_7(self, api_client):
-        resp = api_client.get(RATE_URL + "?days=999")
+    def test_rate_invalid_days_falls_back_to_7(self, su_client):
+        resp = su_client.get(RATE_URL + "?days=999")
         assert resp.status_code == 200
 
-    def test_rate_handles_empty(self, api_client):
-        resp = api_client.get(RATE_URL)
+    def test_rate_handles_empty(self, su_client):
+        resp = su_client.get(RATE_URL)
         assert resp.status_code == 200
         assert resp.data["current_period"]["success_rate"] == 0

--- a/server/apps/job_mgmt/views/dashboard.py
+++ b/server/apps/job_mgmt/views/dashboard.py
@@ -7,8 +7,9 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from rest_framework.viewsets import ViewSet
 
+from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils.viewset_utils import AuthViewSet
 from apps.job_mgmt.constants import ExecutionStatus, JobType
 from apps.job_mgmt.models import JobExecution, Playbook, ScheduledTask, Script, Target
 from apps.job_mgmt.serializers.dashboard import DashboardStatsSerializer, DashboardTrendSerializer
@@ -77,9 +78,23 @@ def _duration_to_seconds(value):
     return round(value.total_seconds(), 1) if value else 0
 
 
-class DashboardViewSet(ViewSet):
+class DashboardViewSet(AuthViewSet):
     """Dashboard视图集"""
 
+    ORGANIZATION_FIELD = "team"
+    permission_key = "job"
+
+    def _get_team_filter(self, request):
+        """返回当前用户可见的 team 过滤条件。
+
+        超级管理员不做 team 过滤（返回全量）；普通用户只能看当前 team 的数据。
+        """
+        if getattr(request.user, "is_superuser", False):
+            return Q()
+        current_team = self._validate_current_team_permission(request)
+        return Q(team__contains=current_team)
+
+    @HasPermission("job_record-View")
     @action(detail=False, methods=["get"])
     def trend(self, request):
         """获取执行趋势数据（按 days 或自定义 start_date/end_date 闭区间）"""
@@ -87,9 +102,12 @@ class DashboardViewSet(ViewSet):
         if error:
             return Response({"error": error}, status=status.HTTP_400_BAD_REQUEST)
 
+        team_filter = self._get_team_filter(request)
+
         # 按日期分组统计
         executions = (
             JobExecution.objects.filter(
+                team_filter,
                 created_at__date__gte=start_date,
                 created_at__date__lte=end_date,
             )
@@ -125,6 +143,7 @@ class DashboardViewSet(ViewSet):
         serializer = DashboardTrendSerializer(result, many=True)
         return Response(serializer.data)
 
+    @HasPermission("job_record-View")
     @action(detail=False, methods=["get"])
     def success_rate_compare(self, request):
         """获取当前周期成功率及与上一等长周期对比（支持 days 或自定义区间）"""
@@ -136,14 +155,16 @@ class DashboardViewSet(ViewSet):
         previous_end = start_date - timedelta(days=1)
         previous_start = start_date - timedelta(days=days)
 
+        team_filter = self._get_team_filter(request)
+
         # 每个周期一次聚合（含条件计数）
-        current_stats = JobExecution.objects.filter(created_at__date__gte=start_date, created_at__date__lte=end_date).aggregate(
+        current_stats = JobExecution.objects.filter(team_filter, created_at__date__gte=start_date, created_at__date__lte=end_date).aggregate(
             total=Count("id"),
             success=Count("id", filter=Q(status=ExecutionStatus.SUCCESS)),
             failed=Count("id", filter=Q(status=ExecutionStatus.FAILED)),
             avg_duration=Avg(DURATION_EXPR, filter=Q(started_at__isnull=False, finished_at__isnull=False)),
         )
-        previous_stats = JobExecution.objects.filter(created_at__date__gte=previous_start, created_at__date__lte=previous_end).aggregate(
+        previous_stats = JobExecution.objects.filter(team_filter, created_at__date__gte=previous_start, created_at__date__lte=previous_end).aggregate(
             total=Count("id"),
             success=Count("id", filter=Q(status=ExecutionStatus.SUCCESS)),
         )


### PR DESCRIPTION
## 关联 issue

closes #3424

## 变更概述

`DashboardViewSet` 原继承裸 `ViewSet`，缺少 `AuthViewSet` 与 `@HasPermission` 守门，任何已登录用户均可获取全租户执行趋势与成功率数据，违反多租户数据边界。

本 PR 修复：
1. `DashboardViewSet` 改继承 `AuthViewSet`，补充 `ORGANIZATION_FIELD = "team"` / `permission_key = "job"`
2. `trend` / `success_rate_compare` 添加 `@HasPermission("job_record-View")` 守门
3. 新增 `_get_team_filter` 方法：超管返回全量 `Q()`，普通用户过滤 `team__contains=current_team`
4. 测试层：新增访问控制与 team 隔离测试；修复团队隔离测试用例缺少 `job_record-View` 权限导致 403 的问题

## 被破坏的不变量

`job_mgmt` 模块设计不变量：所有面向用户的 API 端点须通过 `AuthViewSet` + `@HasPermission` 守门，查询结果须按 `team` 字段隔离。`DashboardViewSet` 是该不变量的唯一缺口。

## 测试

- 访问控制：无 team cookie 或未登录用户 → 403
- team 隔离：普通用户只能看自己 team 的执行记录
- 功能：日期序列补齐、天数封顶、聚合计算正确

替换已关闭的 #3427。