### PR TITLE
bugfix(webchat): 修复 Chat useEffect 未清理 AGUIHandler/StateMachine 监听器

### DIFF
--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -100,27 +100,34 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
 
     // Initialize StateMachine
     stateMachineRef.current = new StateMachine('idle');
-    stateMachineRef.current.on((event) => {
+    const unsubscribeState = stateMachineRef.current.on((event) => {
       onStateChange?.(event.to);
     });
 
     // Initialize SSEHandler - 不再需要，我们用 fetch 直接处理
     // Initialize AGUIHandler (默认启用)
     aguiHandlerRef.current = new AGUIHandler(agui || { enabled: true, debug: true });
-    setupAGUIEventHandlers();
+    const aguiSubscription = setupAGUIEventHandlers();
 
     // Load previous session
     const session = sessionManagerRef.current.initSession();
     if (session && session.messages.length > 0) {
       setMessages(session.messages);
     }
+
+    return () => {
+      aguiSubscription?.unsubscribe();
+      aguiHandlerRef.current?.destroy();
+      unsubscribeState();
+      stateMachineRef.current?.destroy();
+    };
   }, []);
 
   // Setup AG-UI event handlers
   const setupAGUIEventHandlers = () => {
     if (!aguiHandlerRef.current) return;
 
-    aguiHandlerRef.current.getEventStream().subscribe((event: AGUIEvent) => {
+    return aguiHandlerRef.current.getEventStream().subscribe((event: AGUIEvent) => {
       handleAGUIEvent(event);
     });
   };


### PR DESCRIPTION
## 问题

`Chat` 组件挂载时，`useEffect` 订阅了 AGUIHandler 的 RxJS 事件流并注册了 StateMachine 状态监听器，但没有返回任何清理函数。当用户关闭浮动聊天窗口或路由切换导致组件卸载后，这些订阅和监听器继续存活——依然往已卸载组件的 `setMessages` 里写数据。

表现为：旧会话的 AG-UI 事件（TEXT_MESSAGE_DELTA、TOOL_CALL_END 等）出现在新会话消息列表里，React 控制台出现 "Can't perform a state update on an unmounted component" 警告，频繁打开/关闭聊天窗口后内存持续增长。

Closes #3555

## 根因

`setupAGUIEventHandlers` 内的 `subscribe()` 返回值（`Subscription` 对象）被直接丢弃，无法在 cleanup 中调用 `.unsubscribe()`；`stateMachineRef.current.on()` 的 unsubscribe 函数同样被丢弃；`AGUIHandler.destroy()` 方法虽然存在但从未被调用。`useEffect` 没有返回 cleanup 函数，React 卸载组件时无法通知这些订阅停止。

## 怎么修的

1. `setupAGUIEventHandlers` 改为 `return` 订阅对象（`Subscription`），让调用方能持有引用
2. `stateMachineRef.current.on()` 的返回值存入 `unsubscribeState` 变量
3. `useEffect` 增加 cleanup 返回函数，卸载时依次执行：
   - `aguiSubscription?.unsubscribe()` — 停止 RxJS 事件流订阅
   - `aguiHandlerRef.current?.destroy()` — 销毁 AGUIHandler 内部资源
   - `unsubscribeState()` — 移除 StateMachine 状态监听器
   - `stateMachineRef.current?.destroy()` — 销毁 StateMachine 实例

```ts
// 改动核心（Chat.tsx）
const unsubscribeState = stateMachineRef.current.on(...);
const aguiSubscription = setupAGUIEventHandlers();  // 现在返回 Subscription

return () => {                          // ← 新增 cleanup
  aguiSubscription?.unsubscribe();
  aguiHandlerRef.current?.destroy();
  unsubscribeState();
  stateMachineRef.current?.destroy();
};
```

## 影响范围

仅改动 `webchat/packages/webchat-ui/src/Chat.tsx`（+10/-3 行），不涉及任何 server/agents 代码，不改 API 契约，不影响其他调用方。`setupAGUIEventHandlers` 是组件内部函数，无外部调用方。

## 验证

- 将 cleanup 代码 revert 后，订阅泄漏路径重新出现（测试应失败）
- 手动验证：挂载 Chat → 流式回复进行中 → 关闭浮窗 → 无 React "unmounted component" 警告，新会话消息列表干净
- 多次 mount/unmount 循环后 memory profile 不再持续增长

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Chat mount\nuseEffect 执行\nChat.tsx:100"]
    end

    subgraph N["核心处理层"]
        F1["setupAGUIEventHandlers()\nChat.tsx:132"]
        F2["getEventStream().subscribe()\nagui.ts:222"]
        F3["stateMachineRef.on()\nChat.tsx:102"]
    end

    subgraph C["清理层（新增）"]
        C1["aguiSubscription.unsubscribe()\naguiHandlerRef.destroy()"]
        C2["unsubscribeState()\nstateMachineRef.destroy()"]
    end

    T1 --> F1 --> F2
    T1 --> F3
    T1 -. "组件卸载 cleanup return" .-> C1
    T1 -. "组件卸载 cleanup return" .-> C2
```