### PR TITLE
feat(monitor): add IBM MQ monitoring dashboard

### DIFF
--- a/web/src/app/monitor/dashboards/objects/ibmmq/config.ts
+++ b/web/src/app/monitor/dashboards/objects/ibmmq/config.ts
@@ -1,0 +1,356 @@
+import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+
+// IBM MQ 队列管理器状态枚举（与 metrics.json 的 ibmmq_qmgr_status_gauge 一致）。
+const IBMMQ_QMGR_STATUS_ENUM = {
+  0: { label: '已停止', color: '#ff4d4f' },
+  1: { label: '启动中', color: '#fa8c16' },
+  2: { label: '运行中', color: '#1ac44a' },
+  3: { label: '正在停止', color: '#fa8c16' },
+  4: { label: '待命', color: '#1890ff' }
+};
+
+export const IBMMQ_DASHBOARD_CONFIG: SimpleDashboardConfig = {
+  routeKey: 'ibmmq',
+  pageTitle: 'IBM MQ 监控仪表盘',
+  objectFallbackName: 'IBM MQ',
+  instanceType: 'ibmmq',
+  collectionStatusQuery:
+    "count({instance_type='ibmmq', collect_type='exporter', __$labels__}) by (instance_id)",
+  metaItems: ['IBM-MQ-Exporter', 'exporter'],
+  metrics: [
+    // ── KPI ──
+    {
+      name: 'ibmmq_qmgr_status_gauge',
+      display_name: '队列管理器状态',
+      description: '队列管理器当前运行状态。0 已停止、1 启动中、2 运行中、3 正在停止、4 待命。',
+      unit: 'none',
+      query: 'ibmmq_qmgr_status_gauge{__$labels__}',
+      color: '#1ac44a'
+    },
+    {
+      name: 'ibmmq_qmgr_uptime_gauge',
+      display_name: '运行时长',
+      description: '队列管理器自上次启动以来的持续运行时长。',
+      unit: 's',
+      query: 'ibmmq_qmgr_uptime_gauge{__$labels__}',
+      color: '#597ef7'
+    },
+    {
+      name: 'ibmmq_qmgr_connection_count_gauge',
+      display_name: '连接数',
+      description: '当前连接到队列管理器的活动连接数量。',
+      unit: 'counts',
+      query: 'ibmmq_qmgr_connection_count_gauge{__$labels__}',
+      color: '#2f6bff'
+    },
+    {
+      name: 'ibmmq_ram_used_pct',
+      display_name: '内存使用率',
+      description: '由空闲内存百分比推导的主机内存使用率（100 − 空闲%）。',
+      unit: 'percent',
+      query: '100 - ibmmq_qmgr_ram_free_percentage_gauge{__$labels__}',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'ibmmq_qmgr_log_current_primary_space_in_use_percentage_gauge',
+      display_name: '主日志空间使用率',
+      description: '当前主日志空间使用百分比，逼近 100% 会阻塞持久消息写入。',
+      unit: 'percent',
+      query: 'ibmmq_qmgr_log_current_primary_space_in_use_percentage_gauge{__$labels__}',
+      color: '#faad14'
+    },
+    {
+      name: 'ibmmq_queue_depth_gauge',
+      display_name: '队列深度',
+      description: '各队列当前消息数量，持续升高表示消费不及导致积压。',
+      unit: 'counts',
+      query: 'ibmmq_queue_depth_gauge{__$labels__}',
+      color: '#8a5cff'
+    },
+    // ── 资源 ──
+    {
+      name: 'ibmmq_qmgr_cpu_load_one_minute_average_percentage_gauge',
+      display_name: 'CPU 1m 平均负载',
+      description: '队列管理器主机最近一分钟的 CPU 平均负载百分比。',
+      unit: 'percent',
+      query: 'ibmmq_qmgr_cpu_load_one_minute_average_percentage_gauge{__$labels__}',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'ibmmq_qmgr_cpu_load_five_minute_average_percentage_gauge',
+      display_name: 'CPU 5m 平均负载',
+      description: '队列管理器主机最近五分钟的 CPU 平均负载百分比。',
+      unit: 'percent',
+      query: 'ibmmq_qmgr_cpu_load_five_minute_average_percentage_gauge{__$labels__}',
+      color: '#fa8c16'
+    },
+    {
+      name: 'ibmmq_qmgr_ram_free_percentage_gauge',
+      display_name: '空闲内存比例',
+      description: '队列管理器主机的空闲内存百分比。',
+      unit: 'percent',
+      query: 'ibmmq_qmgr_ram_free_percentage_gauge{__$labels__}',
+      color: '#27c274'
+    },
+    {
+      name: 'ibmmq_ram_used_bytes',
+      display_name: '已用内存',
+      description: '由总内存与空闲比例推导的已用内存量。',
+      unit: 'bytes',
+      query:
+        'ibmmq_qmgr_ram_total_bytes_gauge{__$labels__} * (1 - ibmmq_qmgr_ram_free_percentage_gauge{__$labels__} / 100)',
+      color: '#8a5cff'
+    },
+    {
+      name: 'ibmmq_ram_free_bytes',
+      display_name: '空闲内存',
+      description: '由总内存与空闲比例推导的空闲内存量。',
+      unit: 'bytes',
+      query:
+        'ibmmq_qmgr_ram_total_bytes_gauge{__$labels__} * ibmmq_qmgr_ram_free_percentage_gauge{__$labels__} / 100',
+      color: '#e8f0fe'
+    },
+    // ── 连接 ──
+    {
+      name: 'ibmmq_qmgr_active_listeners_gauge',
+      display_name: '活动监听器',
+      description: '队列管理器上处于活动状态的监听器数量。',
+      unit: 'counts',
+      query: 'ibmmq_qmgr_active_listeners_gauge{__$labels__}',
+      color: '#13c2c2'
+    },
+    {
+      name: 'ibmmq_qmgr_concurrent_connections_high_water_mark_gauge',
+      display_name: '并发连接高水位',
+      description: '队列管理器并发连接数的峰值（高水位标记）。',
+      unit: 'counts',
+      query: 'ibmmq_qmgr_concurrent_connections_high_water_mark_gauge{__$labels__}',
+      color: '#9254de'
+    },
+    // ── 日志 ──
+    {
+      name: 'ibmmq_qmgr_log_in_use_bytes_gauge',
+      display_name: '日志已用空间',
+      description: '当前正在使用的恢复日志空间。',
+      unit: 'bytes',
+      query: 'ibmmq_qmgr_log_in_use_bytes_gauge{__$labels__}',
+      color: '#faad14'
+    },
+    {
+      name: 'ibmmq_qmgr_log_max_bytes_gauge',
+      display_name: '日志容量上限',
+      description: '恢复日志的最大容量。',
+      unit: 'bytes',
+      query: 'ibmmq_qmgr_log_max_bytes_gauge{__$labels__}',
+      color: '#9aa9bf'
+    },
+    {
+      name: 'ibmmq_qmgr_log_write_latency_seconds_gauge',
+      display_name: '日志写入延迟',
+      description: '日志写入的平均延迟，升高说明磁盘写盘压力大。',
+      unit: 's',
+      query: 'ibmmq_qmgr_log_write_latency_seconds_gauge{__$labels__}',
+      color: '#ff7875'
+    },
+    // ── 队列 ──
+    {
+      name: 'ibmmq_queue_uncommitted_messages_gauge',
+      display_name: '未提交消息',
+      description: '队列中尚未提交的消息数量，过多通常表示存在长事务或回滚。',
+      unit: 'counts',
+      query: 'ibmmq_queue_uncommitted_messages_gauge{__$labels__}',
+      color: '#faad14'
+    },
+    {
+      name: 'ibmmq_queue_oldest_message_age_gauge',
+      display_name: '最早消息时长',
+      description: '队列中最早一条消息的滞留时长，过长说明消费停滞。',
+      unit: 's',
+      query: 'ibmmq_queue_oldest_message_age_gauge{__$labels__}',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'ibmmq_queue_qtime_short_gauge',
+      display_name: '短期排队时间',
+      description: '消息在队列中停留时间的短周期平均值。',
+      unit: 's',
+      query: 'ibmmq_queue_qtime_short_gauge{__$labels__}',
+      color: '#2f6bff'
+    },
+    {
+      name: 'ibmmq_queue_qtime_long_gauge',
+      display_name: '长期排队时间',
+      description: '消息在队列中停留时间的长周期平均值。',
+      unit: 's',
+      query: 'ibmmq_queue_qtime_long_gauge{__$labels__}',
+      color: '#13c2c2'
+    },
+    // ── 主题/订阅 ──
+    {
+      name: 'ibmmq_topic_publisher_count_gauge',
+      display_name: '发布者数量',
+      description: '主题上活动的发布者数量。',
+      unit: 'counts',
+      query: 'ibmmq_topic_publisher_count_gauge{__$labels__}',
+      color: '#27c274'
+    },
+    {
+      name: 'ibmmq_topic_subscriber_count_gauge',
+      display_name: '订阅者数量',
+      description: '主题上活动的订阅者数量。',
+      unit: 'counts',
+      query: 'ibmmq_topic_subscriber_count_gauge{__$labels__}',
+      color: '#597ef7'
+    }
+  ],
+  summaryCards: [
+    {
+      title: '运行时长',
+      metric: 'ibmmq_qmgr_uptime_gauge',
+      unit: 's',
+      formatter: 'duration',
+      isUptimeCard: true,
+      icon: 'clock',
+      color: '#597ef7',
+      guide: [{ label: '运行时长', detail: '队列管理器自上次启动后的持续运行时间；期间重启会重新计时。' }],
+      footer: [{ label: '启动', metric: 'ibmmq_qmgr_uptime_gauge', formatter: 'startedAt' }]
+    },
+    {
+      title: '队列管理器状态',
+      metric: 'ibmmq_qmgr_status_gauge',
+      color: '#1ac44a',
+      icon: 'health',
+      enumMap: IBMMQ_QMGR_STATUS_ENUM,
+      guide: [{ label: '队列管理器状态', detail: '是否运行中。非运行状态下消息无法收发，应先恢复队列管理器再看下游容量。' }],
+      footer: [
+        { label: '连接数', metric: 'ibmmq_qmgr_connection_count_gauge', unit: 'counts' },
+        { label: '监听器', metric: 'ibmmq_qmgr_active_listeners_gauge', unit: 'counts' }
+      ]
+    },
+    {
+      title: '连接数',
+      metric: 'ibmmq_qmgr_connection_count_gauge',
+      unit: 'counts',
+      color: '#2f6bff',
+      icon: 'node',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '连接数', detail: '当前活动客户端连接数。逼近并发高水位时需关注连接句柄与资源上限。' }],
+      footer: [{ label: '并发高水位', metric: 'ibmmq_qmgr_concurrent_connections_high_water_mark_gauge', unit: 'counts' }]
+    },
+    {
+      title: '内存使用率',
+      metric: 'ibmmq_ram_used_pct',
+      unit: 'percent',
+      color: '#ff8a1f',
+      icon: 'memory',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '内存使用率', detail: '主机内存已用占比。逼近 100% 会拖慢队列管理器并影响消息吞吐。' }],
+      footer: [
+        { label: '已用', metric: 'ibmmq_ram_used_bytes', unit: 'bytes' },
+        { label: '空闲', metric: 'ibmmq_qmgr_ram_free_percentage_gauge', unit: 'percent' }
+      ]
+    },
+    {
+      title: '主日志空间',
+      metric: 'ibmmq_qmgr_log_current_primary_space_in_use_percentage_gauge',
+      unit: 'percent',
+      color: '#faad14',
+      icon: 'backlog',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '主日志空间', detail: '主日志空间使用率。耗尽会阻塞持久消息写入，需检查日志配置与归档。' }],
+      footer: [
+        { label: '日志已用', metric: 'ibmmq_qmgr_log_in_use_bytes_gauge', unit: 'bytes' },
+        { label: '写入延迟', metric: 'ibmmq_qmgr_log_write_latency_seconds_gauge', unit: 's' }
+      ]
+    },
+    {
+      title: '消息积压',
+      metric: 'ibmmq_queue_depth_gauge',
+      unit: 'counts',
+      color: '#8a5cff',
+      icon: 'backlog',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '消息积压', detail: '队列当前消息数。持续上升说明生产快于消费，需扩消费端或排查阻塞。' }],
+      footer: [
+        { label: '未提交', metric: 'ibmmq_queue_uncommitted_messages_gauge', unit: 'counts' },
+        { label: '最早消息', metric: 'ibmmq_queue_oldest_message_age_gauge', unit: 's' }
+      ]
+    }
+  ],
+  charts: [
+    {
+      title: '资源压力趋势',
+      subtitle: 'CPU 负载与内存',
+      metric: 'ibmmq_qmgr_cpu_load_one_minute_average_percentage_gauge',
+      guide: [{ label: '资源压力', detail: '对比 CPU 一/五分钟负载与内存使用率，识别队列管理器主机资源瓶颈。' }],
+      series: [
+        { metric: 'ibmmq_qmgr_cpu_load_one_minute_average_percentage_gauge', label: 'CPU 1m', color: '#ff8a1f', unit: 'percent' },
+        { metric: 'ibmmq_qmgr_cpu_load_five_minute_average_percentage_gauge', label: 'CPU 5m', color: '#fa8c16', unit: 'percent' },
+        { metric: 'ibmmq_ram_used_pct', label: '内存使用率', color: '#8a5cff', unit: 'percent' }
+      ]
+    },
+    {
+      title: '连接趋势',
+      subtitle: '连接、监听器与高水位',
+      metric: 'ibmmq_qmgr_connection_count_gauge',
+      guide: [{ label: '连接趋势', detail: '对比活动连接、监听器与并发高水位，识别连接资源耗尽风险。' }],
+      series: [
+        { metric: 'ibmmq_qmgr_connection_count_gauge', label: '当前连接', color: '#2f6bff', unit: 'counts' },
+        { metric: 'ibmmq_qmgr_active_listeners_gauge', label: '活动监听器', color: '#13c2c2', unit: 'counts' },
+        { metric: 'ibmmq_qmgr_concurrent_connections_high_water_mark_gauge', label: '并发高水位', color: '#9254de', unit: 'counts' }
+      ]
+    },
+    {
+      title: '日志空间趋势',
+      subtitle: '已用 vs 容量上限',
+      metric: 'ibmmq_qmgr_log_in_use_bytes_gauge',
+      guide: [{ label: '日志空间', detail: '虚线为日志容量上限，实线为已用量。两线收敛即日志耗尽风险。' }],
+      series: [
+        { metric: 'ibmmq_qmgr_log_in_use_bytes_gauge', label: '日志已用', color: '#faad14', unit: 'bytes' },
+        { metric: 'ibmmq_qmgr_log_max_bytes_gauge', label: '容量上限', color: '#9aa9bf', unit: 'bytes', style: 'limit' }
+      ]
+    },
+    {
+      title: '队列排队趋势',
+      subtitle: '深度、未提交与排队时间',
+      metric: 'ibmmq_queue_depth_gauge',
+      guide: [{ label: '队列排队', detail: '对比队列深度、未提交消息与短/长期排队时间，定位积压是堆积还是确认滞后。' }],
+      series: [
+        { metric: 'ibmmq_queue_depth_gauge', label: '队列深度', color: '#8a5cff', unit: 'counts' },
+        { metric: 'ibmmq_queue_uncommitted_messages_gauge', label: '未提交', color: '#faad14', unit: 'counts' },
+        { metric: 'ibmmq_queue_qtime_short_gauge', label: '短期排队', color: '#2f6bff', unit: 's' },
+        { metric: 'ibmmq_queue_qtime_long_gauge', label: '长期排队', color: '#13c2c2', unit: 's' }
+      ]
+    }
+  ],
+  ringPanels: [
+    {
+      title: '主机内存分布',
+      subtitle: '已用 vs 空闲',
+      centerMetric: 'ibmmq_ram_used_pct',
+      centerCaption: '内存使用率',
+      centerUnit: 'percent',
+      guide: [{ label: '内存分布', detail: '按已用与空闲拆分主机内存，中心为使用率。' }],
+      segments: [
+        { label: '已用内存', metric: 'ibmmq_ram_used_bytes', color: '#8a5cff', unit: 'bytes' },
+        { label: '空闲内存', metric: 'ibmmq_ram_free_bytes', color: '#e8f0fe', unit: 'bytes' }
+      ]
+    }
+  ],
+  statusPanels: [],
+  details: [
+    {
+      title: '主题与订阅详情',
+      subtitle: '发布者、订阅者与日志延迟',
+      rows: [
+        { label: '发布者数量', metric: 'ibmmq_topic_publisher_count_gauge', unit: 'counts' },
+        { label: '订阅者数量', metric: 'ibmmq_topic_subscriber_count_gauge', unit: 'counts' },
+        { label: '日志写入延迟', metric: 'ibmmq_qmgr_log_write_latency_seconds_gauge', unit: 's' }
+      ]
+    }
+  ]
+};

--- a/web/src/app/monitor/dashboards/objects/ibmmq/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/ibmmq/dashboard.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import React from 'react';
+import { useSimpleDashboardData } from '../common/simple-dashboard-core';
+import {
+  DashboardShell,
+  DetailPanelCard,
+  FlexiblePanelSection,
+  KpiSection,
+  useFilteredChartPanels,
+  useFilteredDetailPanels,
+  useFilteredRingPanels,
+  useFilteredSummaryCards
+} from '../common/dashboard-components';
+import { RingChartPanel, TrendChartPanel } from '../../shared/widgets';
+import { IBMMQ_DASHBOARD_CONFIG } from './config';
+import styles from './index.module.scss';
+
+const SUMMARY_TITLES = ['运行时长', '队列管理器状态', '连接数', '内存使用率', '主日志空间', '消息积压'];
+const CHART_TITLES = ['资源压力趋势', '连接趋势', '日志空间趋势', '队列排队趋势'];
+const RING_TITLES = ['主机内存分布'];
+const DETAIL_TITLES = ['主题与订阅详情'];
+
+export default function IBMMQDashboardPage() {
+  const dashboard = useSimpleDashboardData(IBMMQ_DASHBOARD_CONFIG);
+  const summaryCards = useFilteredSummaryCards(dashboard.summaryCards, SUMMARY_TITLES);
+  const charts = useFilteredChartPanels(dashboard.chartPanels, CHART_TITLES);
+  const rings = useFilteredRingPanels(dashboard.ringPanels, RING_TITLES);
+  const details = useFilteredDetailPanels(dashboard.detailPanels, DETAIL_TITLES);
+
+  const [memoryRing] = rings;
+  const [topicDetail] = details;
+  const [resourceChart, connChart, logChart, queueChart] = charts;
+
+  const renderChart = (chart: typeof charts[number], spanClass: string) =>
+    chart ? (
+      <TrendChartPanel
+        key={chart.chart.title}
+        title={chart.chart.title}
+        subtitle={chart.chart.subtitle}
+        guide={chart.chart.guide}
+        legends={chart.legends}
+        data={chart.data}
+        metric={chart.metric}
+        unit={chart.unit}
+        loading={dashboard.loading}
+        seriesStyles={chart.seriesStyles}
+        onXRangeChange={dashboard.onXRangeChange}
+        className={`${spanClass} ${styles.compactTrend}`}
+        styles={styles}
+      />
+    ) : null;
+
+  return (
+    <DashboardShell
+      dashboard={dashboard}
+      styles={styles}
+      dashboardContent={
+        <>
+          <div className={styles.sectionLabel}>健康概览</div>
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
+
+          {/* R1: 内存分布环 span4 + 资源压力趋势 span8 = 12 */}
+          <div className={styles.sectionLabel}>内存与资源</div>
+          <FlexiblePanelSection styles={styles}>
+            {memoryRing ? (
+              <RingChartPanel
+                key={memoryRing.panel.title}
+                title={memoryRing.panel.title}
+                subtitle={memoryRing.panel.subtitle}
+                guide={memoryRing.panel.guide}
+                data={memoryRing.data}
+                centerValue={memoryRing.centerValue}
+                centerCaption={memoryRing.panel.centerCaption}
+                isEmpty={memoryRing.isEmpty}
+                className={styles.span4}
+                styles={styles}
+              />
+            ) : null}
+            {renderChart(resourceChart, styles.span8)}
+          </FlexiblePanelSection>
+
+          {/* R2: 连接趋势 span6 + 日志空间趋势 span6 = 12 */}
+          <div className={styles.sectionLabel}>连接与日志</div>
+          <FlexiblePanelSection styles={styles}>
+            {renderChart(connChart, styles.span6)}
+            {renderChart(logChart, styles.span6)}
+          </FlexiblePanelSection>
+
+          {/* R3: 队列排队趋势 span6 + 主题与订阅详情 span6 = 12 */}
+          <div className={styles.sectionLabel}>队列与主题</div>
+          <FlexiblePanelSection styles={styles}>
+            {renderChart(queueChart, styles.span6)}
+            {topicDetail ? (
+              <DetailPanelCard
+                key={topicDetail.panel.title}
+                detailPanel={topicDetail}
+                className={styles.span6}
+                styles={styles}
+              />
+            ) : null}
+          </FlexiblePanelSection>
+        </>
+      }
+    />
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/ibmmq/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/ibmmq/index.module.scss
@@ -1,0 +1,202 @@
+@use '../common/simple-dashboard.module.scss';
+
+/* 区块小标题:给分区加语义标题,提升可扫读性(与 redis/postgresql 同款) */
+.sectionLabel {
+  margin: 2px 2px 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eceff4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8c95a8;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 8px;
+}
+
+:global(html.dark) .sectionLabel {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+/* 折线图压缩高度(dashboard.tsx renderChart 引用 .compactTrend,参考 host) */
+.compactTrend {
+  .chartWrap {
+    height: 164px;
+  }
+}
+
+@media (max-width: 768px) {
+  .compactTrend {
+    .chartWrap {
+      height: 138px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   RabbitMQ high-density ops overrides
+
+   Scoped to the RabbitMQ dashboard only (these rules are inlined into this
+   module after the shared import, so they win by cascade without affecting
+   any other dashboard). Goal: compact cards, tight uniform spacing, flat
+   chrome, no dead whitespace — a long-watch ops wall, not a marketing page.
+   ────────────────────────────────────────────────────────────────────────── */
+
+/* Shell + title: tighter padding, smaller hero */
+.shell {
+  padding: 12px 16px 16px;
+}
+
+.title {
+  font-size: 22px;
+}
+
+/* Flat, dense chrome for every card/panel */
+.statCard,
+.panel {
+  border-radius: 10px;
+  box-shadow: 0 1px 2px rgba(18, 34, 66, 0.05);
+}
+
+/* ── Compact KPI cards ─────────────────────────────────────────── */
+.statCard {
+  min-height: 150px;
+  padding: 12px 14px;
+}
+
+.collectionStatusCard {
+  min-height: 150px;
+}
+
+.statHeader,
+.collectionStatusHeader {
+  min-height: 24px;
+}
+
+.statLabel {
+  font-size: 14px;
+}
+
+/* Bespoke duotone metric icons draw their own squircle + gradient + ring,
+   so neutralize the default flat tinted circle and let the SVG fill the chip.
+   The inline `color` still flows in as the SVG's currentColor. */
+.statIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 11px;
+  padding: 0;
+  overflow: visible;
+  background: transparent !important;
+  box-shadow: none;
+}
+
+.statIcon svg {
+  width: 34px;
+  height: 34px;
+  display: block;
+}
+
+.statBody {
+  margin-top: 8px;
+  gap: 6px;
+}
+
+.statValue,
+.collectionStatusValue {
+  font-size: 24px;
+  min-height: 28px;
+}
+
+.statUnit {
+  font-size: 13px;
+}
+
+.statCompare {
+  min-height: 0;
+  font-size: 13px;
+}
+
+.statMeta {
+  min-height: 0;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.miniTrend {
+  height: 40px;
+  padding-top: 6px;
+}
+
+/* Collection-status card internals shrink to match the row height */
+.collectionStatusBody {
+  row-gap: 6px;
+}
+
+.collectionStatusSegment {
+  height: 18px;
+}
+
+/* ── Compact panels (charts / ring / bar) ──────────────────────── */
+.panel {
+  padding: 12px 14px;
+}
+
+.panelTitle {
+  font-size: 15px;
+}
+
+.panelSubTitle {
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.chartWrap {
+  height: 168px;
+  margin-top: 8px;
+}
+
+/* ── Ring: tighter, fills its panel without leftover whitespace ── */
+.ringCard {
+  min-height: 0;
+  margin-top: 10px;
+  gap: 12px;
+  grid-template-columns: minmax(132px, 152px) minmax(0, 1fr);
+}
+
+.ringChartWrap,
+.ringCenterOverlay {
+  height: 152px;
+  min-height: 152px;
+}
+
+.ringChartWrap {
+  width: 152px;
+}
+
+.ringCenter {
+  min-height: 0;
+  padding-bottom: 10px;
+}
+
+.ringValue {
+  font-size: 20px;
+}
+
+/* ── Bars: snug to the panel ────────────────────────────────────── */
+.bars {
+  padding-top: 8px;
+}
+
+.barsFull {
+  padding: 8px 0 4px;
+}

--- a/web/src/app/monitor/dashboards/objects/ibmmq/index.ts
+++ b/web/src/app/monitor/dashboards/objects/ibmmq/index.ts
@@ -1,0 +1,1 @@
+export { default } from './dashboard';

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -10,6 +10,7 @@ import ActiveMQDashboard from './objects/activemq';
 import ApacheDashboard from './objects/apache';
 import ConsulDashboard from './objects/consul';
 import RabbitMQDashboard from './objects/rabbitmq';
+import IBMMQDashboard from './objects/ibmmq';
 import TomcatDashboard from './objects/tomcat';
 import ZookeeperDashboard from './objects/zookeeper';
 import PingDashboard from './objects/ping';
@@ -122,6 +123,15 @@ export const PROFESSIONAL_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
     objectDisplayName: 'RabbitMQ',
     inheritedPermissionPath: '/monitor/view',
     component: RabbitMQDashboard
+  },
+  {
+    key: 'ibmmq',
+    aliases: ['ibm_mq'],
+    groupKey: 'middleware',
+    objectName: 'IBMMQ',
+    objectDisplayName: 'IBM MQ',
+    inheritedPermissionPath: '/monitor/view',
+    component: IBMMQDashboard
   },
   {
     key: 'tomcat',


### PR DESCRIPTION
## What

Add a monitoring dashboard for the IBM MQ object (`IBMMQ`), following up on the IBM MQ plugin (#3684). Built on the shared `SimpleDashboard` template and registered under the middleware group (routeKey `ibmmq`).

## Layout

- **KPI**: queue manager status (enum), uptime, connections, memory usage, primary log space, message backlog
- **Trends**: resource pressure (CPU 1m/5m + memory), connections (active/listeners/high-water), log space (used vs capacity), queue backlog (depth/uncommitted/queue time)
- **Ring**: host memory distribution (used vs free, derived from total bytes × free %)
- **Detail**: topic/subscription panel (publishers, subscribers, log write latency)

## Notes

- All metric units come from the backend unit system; queries target the `ibmmq_*_gauge` series exposed by the IBM MQ plugin.
- Reuses shared widgets (`StatCard`, `TrendChartPanel`, `RingChartPanel`, `DetailPanelCard`) — no inline chart components.
- IBMMQ is a middleware object, so no `menu.json` route is required (same as RabbitMQ/ActiveMQ).

## Testing

Verified end-to-end on the local dev environment with mock instances: the dashboard renders the full KPI row, all four trend charts, the memory ring and the topic/subscription detail panel with live data; queue-manager status resolves to the running (green) enum state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)