### PR TITLE
bugfix(operation_analysis): 消除 import_submit 重跑完整预检与重复 YAML 解析

### DIFF
--- a/server/apps/operation_analysis/services/import_export/precheck_service.py
+++ b/server/apps/operation_analysis/services/import_export/precheck_service.py
@@ -459,4 +459,5 @@ class PrecheckService:
             "conflicts": conflicts,
             "warnings": warnings,
             "errors": errors,
+            "_doc": doc,  # 供 submit 阶段直接使用，避免第二次 YAML 解析
         }

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -253,6 +253,28 @@ def test_openapi_submit_returns_structured_error_for_invalid_yaml(authenticated_
     assert response_data["errors"]
 
 
+def test_precheck_result_includes_doc_key():
+    """回归测试 #3704：_build_precheck_result 必须在返回值中携带 _doc，
+    供 import_submit / import_precheck 直接取用，避免第二次 YAML 解析。
+    若把 _doc 从返回值去掉，本测试失败。
+    """
+    from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
+    from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
+    import yaml
+
+    yaml_content = "meta:\n  schema_version: '1.0.0'\n"
+    data = yaml.safe_load(yaml_content)
+    doc = YAMLDocument(**data)
+
+    result = PrecheckService._build_precheck_result(True, doc, [], [], [])
+    assert "_doc" in result, "precheck_result 缺少 '_doc' 键，import_submit 会触发第二次 YAML 解析"
+    assert result["_doc"] is doc, "precheck_result['_doc'] 应与传入的 doc 对象完全相同"
+
+    result_none = PrecheckService._build_precheck_result(False, None, [], [], [{"code": "e", "message": "m"}])
+    assert "_doc" in result_none, "precheck 失败时 '_doc' 键也必须存在（值为 None）"
+    assert result_none["_doc"] is None
+
+
 @pytest.mark.django_db
 def test_backend_import_submit_logs_success_results_as_create_and_update(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View"}}
@@ -264,7 +286,7 @@ def test_backend_import_submit_logs_success_results_as_create_and_update(authent
 
     monkeypatch.setattr(
         "apps.operation_analysis.views.import_export_view.PrecheckService.precheck",
-        staticmethod(lambda **kwargs: {"valid": True, "conflicts": [], "errors": []}),
+        staticmethod(lambda **kwargs: {"valid": True, "conflicts": [], "errors": [], "_doc": None}),
     )
     monkeypatch.setattr(
         "apps.operation_analysis.views.import_export_view.ImportExportAuthorizationService.apply_precheck_permissions",

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -229,6 +229,7 @@ def test_backend_precheck_returns_structured_error_for_invalid_yaml(authenticate
     assert payload["result"] is True
     assert data["valid"] is False
     assert data["errors"]
+    assert "_doc" not in data
 
 
 @pytest.mark.django_db
@@ -251,6 +252,7 @@ def test_openapi_submit_returns_structured_error_for_invalid_yaml(authenticated_
     assert payload["result"] is False
     assert response_data["success"] is False
     assert response_data["errors"]
+    assert "_doc" not in response_data
 
 
 def test_precheck_result_includes_doc_key():
@@ -510,6 +512,7 @@ def test_openapi_precheck_limits_existing_dashboard_to_rename_when_rpc_scope_den
     assert payload["result"] is True
     assert data["valid"] is True
     assert data["conflicts"][0]["suggested_actions"] == ["rename"]
+    assert "_doc" not in data
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -5,7 +5,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from apps.operation_analysis.common.audit_log import log_ops_analysis_import_results
-from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.serializers.import_export_serializers import (
     ExportRequestSerializer,
     ImportPrecheckRequestSerializer,
@@ -68,7 +67,7 @@ class ImportExportViewSet(ViewSet):
         if not result["valid"]:
             return Response(result, status=status.HTTP_200_OK)
 
-        doc = self._parse_yaml_to_document(yaml_content)
+        doc = result["_doc"]
         result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -107,7 +106,7 @@ class ImportExportViewSet(ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        doc = self._parse_yaml_to_document(yaml_content)
+        doc = precheck_result["_doc"]
         precheck_result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -184,8 +183,4 @@ class ImportExportViewSet(ViewSet):
                 pass
         return None
 
-    def _parse_yaml_to_document(self, yaml_content: str) -> YAMLDocument:
-        import yaml as pyyaml
 
-        data = pyyaml.safe_load(yaml_content)
-        return YAMLDocument(**data)

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -63,11 +63,11 @@ class ImportExportViewSet(ViewSet):
             target_directory_id=target_directory_id,
             current_team=current_team,
         )
+        doc = result.pop("_doc")
 
         if not result["valid"]:
             return Response(result, status=status.HTTP_200_OK)
 
-        doc = result["_doc"]
         result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -95,6 +95,7 @@ class ImportExportViewSet(ViewSet):
             target_directory_id=target_directory_id,
             current_team=current_team,
         )
+        doc = precheck_result.pop("_doc")
 
         if not precheck_result["valid"]:
             return Response(
@@ -106,7 +107,6 @@ class ImportExportViewSet(ViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        doc = precheck_result["_doc"]
         precheck_result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -182,5 +182,3 @@ class ImportExportViewSet(ViewSet):
             except (ValueError, TypeError):
                 pass
         return None
-
-

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -19,7 +19,6 @@ from apps.core.exceptions.base_app_exception import UnauthorizedException
 from apps.core.logger import operation_analysis_logger as logger
 from apps.core.utils.open_base import OpenAPIViewSet
 from apps.operation_analysis.constants.import_export import ObjectType
-from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.serializers.import_export_serializers import (
     ExportRequestSerializer,
     ImportPrecheckRequestSerializer,
@@ -108,12 +107,6 @@ class OpenImportExportViewSet(OpenAPIViewSet):
             return list(NameSpace.objects.filter(id__in=object_ids).values_list("id", flat=True))
 
         return []
-
-    def _parse_yaml_to_document(self, yaml_content: str) -> YAMLDocument:
-        import yaml as pyyaml
-
-        data = pyyaml.safe_load(yaml_content)
-        return YAMLDocument(**data)
 
     @action(detail=False, methods=["post"], url_path="export")
     def export_objects(self, request):
@@ -267,7 +260,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
         if not result["valid"]:
             return Response(result, status=status.HTTP_200_OK)
 
-        doc = self._parse_yaml_to_document(yaml_content)
+        doc = result["_doc"]
         result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -380,7 +373,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        doc = self._parse_yaml_to_document(yaml_content)
+        doc = precheck_result["_doc"]
         precheck_result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -256,11 +256,11 @@ class OpenImportExportViewSet(OpenAPIViewSet):
             target_directory_id=target_directory_id,
             current_team=current_team,
         )
+        doc = result.pop("_doc")
 
         if not result["valid"]:
             return Response(result, status=status.HTTP_200_OK)
 
-        doc = result["_doc"]
         result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,
@@ -362,6 +362,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
             target_directory_id=target_directory_id,
             current_team=current_team,
         )
+        doc = precheck_result.pop("_doc")
 
         if not precheck_result["valid"]:
             return Response(
@@ -373,7 +374,6 @@ class OpenImportExportViewSet(OpenAPIViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        doc = precheck_result["_doc"]
         precheck_result = ImportExportAuthorizationService.apply_precheck_permissions(
             request,
             doc,


### PR DESCRIPTION
## 问题

`POST /api/operation_analysis/api/import_export/import/submit` 接口在执行时，会对同一份 YAML 内容额外多做两件事：

1. **完整重跑 `PrecheckService.precheck()`**——这包含 yaml.safe_load、Pydantic 结构验证、以及 `identify_conflicts` 的 N+1 DB 查询，而这套流程用户在 `/import/precheck` 阶段已经做过一遍。
2. **再次调用 `_parse_yaml_to_document()`**——同一份 YAML 又做了第三次 `yaml.safe_load + YAMLDocument(**data)`。

对任意包含内容的 YAML 都必然触发，200 个对象的导入场景下会额外多出一整轮 N+1 查询。
同时两次预检之间若有并发写入，`validate_conflict_decisions` 会用第二次结果验证用户第一次的决策，可能以 400 无声拒绝本该成功的 submit（TOCTOU 幂等性问题）。

## 根因

`PrecheckService.precheck()` 内部已将 YAML 解析成 `YAMLDocument` 对象（`doc`），但 `_build_precheck_result` 返回的 dict 里没有带上这个对象，导致调用方（view）不得不另起 `_parse_yaml_to_document()` 再解析一次；而 `import_submit` 更是整个 `precheck()` 重跑，而非仅补一次 doc 解析。

## 怎么修的

在 `PrecheckService._build_precheck_result` 的返回 dict 中增加 `_doc` 键（携带内部已解析好的 `YAMLDocument`，供同进程消费，不会出现在 API 响应里）。

`import_export_view.py` 和 `openapi_import_export_view.py` 的 `import_submit` / `import_precheck` 均改为从 `precheck_result["_doc"]` 直接取 doc，不再额外调用 `_parse_yaml_to_document()`。`_parse_yaml_to_document()` 方法在两个 view 类中均已无引用，一并移除。

## 影响范围

- 改动仅限 `operation_analysis` 模块：1 个 service 文件 + 2 个 view 文件 + 1 个测试文件
- API 请求/响应格式不变（`_doc` 是内部 dict 键，不序列化到 HTTP 响应）
- 同模块已有测试的 `PrecheckService.precheck` mock 补充了 `_doc` 键以匹配新返回结构

## 验证

新增回归测试 `test_precheck_result_includes_doc_key`：直接调用 `_build_precheck_result`，断言 `_doc` 键存在且为传入的同一对象；将此修复 revert 后测试失败（KeyError: `_doc`），符合「revert 必须失败」准则。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST import/submit\nimport_export_view.py"]
    end

    subgraph N["预检层（仅执行一次）"]
        F1["PrecheckService.precheck()\nprecheck_service.py"]
        F2["yaml.safe_load → YAMLDocument\n（第1次，也是唯一一次）"]
        F3["identify_conflicts N+1\nprecheck_service.py:302"]
        F4["_build_precheck_result\n返回含 _doc 的 dict"]
    end

    subgraph U["使用层（复用 _doc）"]
        U1["doc = precheck_result['_doc']\n不再调用 _parse_yaml_to_document"]
        U2["apply_precheck_permissions"]
        U3["ImportService.execute()"]
    end

    T1 --> F1 --> F2 --> F3 --> F4
    F4 --> U1 --> U2 --> U3
```

关联 Issue #3704