### PR TITLE
bugfix: 消除 apply_precheck_permissions / validate_import_submit_permissions N+1 DB 查询

### DIFF
--- a/server/apps/operation_analysis/services/import_export/authorization_service.py
+++ b/server/apps/operation_analysis/services/import_export/authorization_service.py
@@ -104,8 +104,10 @@ class ImportExportAuthorizationService:
             overwrite_allowed = cls.has_permission(request, permission_config["overwrite"])
             view_allowed = cls.has_permission(request, cls.EXPORT_PERMISSION_MAP[object_type]["permission"])
 
+            existing_map = cls.get_existing_objects_batch(object_type, items)
+
             for item in items:
-                existing = cls.get_existing_object(object_type, item)
+                existing = existing_map.get(cls._item_lookup_key(object_type, item))
                 if not existing:
                     if not create_allowed:
                         permission_errors.append(
@@ -193,8 +195,10 @@ class ImportExportAuthorizationService:
         for object_type, items in cls.iter_import_items(doc):
             permission_config = cls.IMPORT_ACTION_PERMISSION_MAP[object_type]
 
+            existing_map = cls.get_existing_objects_batch(object_type, items)
+
             for item in items:
-                existing = cls.get_existing_object(object_type, item)
+                existing = existing_map.get(cls._item_lookup_key(object_type, item))
                 conflict = conflict_map.get(item.key)
                 action = conflict_decisions.get(item.key, ConflictAction.RENAME.value)
 
@@ -271,6 +275,41 @@ class ImportExportAuthorizationService:
         if object_type == ObjectType.NAMESPACE:
             return NameSpace.objects.filter(name=item.name).first()
         return None
+
+    @classmethod
+    def get_existing_objects_batch(cls, object_type: ObjectType, items) -> dict:
+        """批量查询一组 items 对应的已存在对象，返回 {lookup_key: object} 字典，消除 N+1 查询。"""
+        from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+        from apps.operation_analysis.models.models import Architecture, Dashboard, Topology
+
+        if not items:
+            return {}
+
+        if object_type == ObjectType.DATASOURCE:
+            # DataSourceAPIModel 以 (name, rest_api) 为唯一键
+            lookup_pairs = [(item.name, item.rest_api) for item in items]
+            names = [p[0] for p in lookup_pairs]
+            qs = DataSourceAPIModel.objects.filter(name__in=names)
+            return {(obj.name, obj.rest_api): obj for obj in qs if (obj.name, obj.rest_api) in set(lookup_pairs)}
+
+        name_set = [item.name for item in items]
+        model_map = {
+            ObjectType.DASHBOARD: Dashboard,
+            ObjectType.TOPOLOGY: Topology,
+            ObjectType.ARCHITECTURE: Architecture,
+            ObjectType.NAMESPACE: NameSpace,
+        }
+        model = model_map.get(object_type)
+        if model is None:
+            return {}
+        return {obj.name: obj for obj in model.objects.filter(name__in=name_set)}
+
+    @staticmethod
+    def _item_lookup_key(object_type: ObjectType, item):
+        """返回用于 get_existing_objects_batch 结果字典的查找键。"""
+        if object_type == ObjectType.DATASOURCE:
+            return (item.name, item.rest_api)
+        return item.name
 
     @classmethod
     def can_access_existing_object(cls, request, object_type: ObjectType, existing, current_team: int | None) -> bool:

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -1,5 +1,6 @@
 import json
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import yaml
@@ -140,8 +141,8 @@ def test_precheck_drops_overwrite_when_user_lacks_overwrite_permission(authentic
 
     monkeypatch.setattr(
         ImportExportAuthorizationService,
-        "get_existing_object",
-        classmethod(lambda cls, object_type, current_item: SimpleNamespace(id=1, groups=[1])),
+        "get_existing_objects_batch",
+        classmethod(lambda cls, object_type, items: {item.name: SimpleNamespace(id=1, groups=[1]) for item in items}),
     )
     monkeypatch.setattr(
         ImportExportAuthorizationService,
@@ -174,8 +175,8 @@ def test_import_submit_rejects_overwrite_without_overwrite_permission(authentica
 
     monkeypatch.setattr(
         ImportExportAuthorizationService,
-        "get_existing_object",
-        classmethod(lambda cls, object_type, current_item: SimpleNamespace(id=1, groups=[1])),
+        "get_existing_objects_batch",
+        classmethod(lambda cls, object_type, items: {item.name: SimpleNamespace(id=1, groups=[1]) for item in items}),
     )
 
     with pytest.raises(PermissionDenied):
@@ -521,3 +522,83 @@ def test_openapi_submit_rejects_overwrite_when_rpc_scope_denies_existing_dashboa
     assert payload["result"] is False
     assert response_data["errors"][0]["object_key"] == "dashboard::demo-dashboard-submit"
     assert response_data["errors"][0]["allowed_actions"] == ["rename"]
+
+
+@pytest.mark.django_db
+def test_get_existing_objects_batch_issues_single_query_for_multiple_dashboards(authenticated_user):
+    """批量查询 N 个同类对象应只发出 1 次 DB 查询，而非逐 item N 次。
+
+    若将实现回退为逐 item 调用 get_existing_object()，该测试因 get_existing_objects_batch
+    不被调用（或被调用次数 > 1）而失败，从而守住本次 N+1 修复。
+    """
+    dashboard_a = Dashboard.objects.create(name="batch-dash-a", groups=[1], view_sets=[])
+    dashboard_b = Dashboard.objects.create(name="batch-dash-b", groups=[1], view_sets=[])
+
+    items = [
+        SimpleNamespace(name="batch-dash-a", key="dashboard::batch-dash-a"),
+        SimpleNamespace(name="batch-dash-b", key="dashboard::batch-dash-b"),
+        SimpleNamespace(name="nonexistent-dash", key="dashboard::nonexistent-dash"),
+    ]
+
+    with patch.object(
+        Dashboard.objects.__class__,
+        "filter",
+        wraps=Dashboard.objects.filter,
+    ) as mock_filter:
+        result = ImportExportAuthorizationService.get_existing_objects_batch(ObjectType.DASHBOARD, items)
+
+    # 只调用了一次 filter（批量 name__in=...），而非三次逐 item filter
+    assert mock_filter.call_count == 1, (
+        f"预期批量查询只调用 1 次 filter，实际调用了 {mock_filter.call_count} 次（存在 N+1）"
+    )
+    assert result["batch-dash-a"].id == dashboard_a.id
+    assert result["batch-dash-b"].id == dashboard_b.id
+    assert "nonexistent-dash" not in result
+
+
+@pytest.mark.django_db
+def test_apply_precheck_permissions_uses_batch_lookup_not_per_item(authenticated_user, monkeypatch):
+    """apply_precheck_permissions 对多个相同 object_type 的 item 应调用 get_existing_objects_batch
+    而非每个 item 单独调用 get_existing_object。
+
+    若回退到旧的 N+1 循环，get_existing_objects_batch 调用次数会为 0，断言失败。
+    """
+    authenticated_user.permission = {"ops-analysis": {"view-View", "view-AddChart", "view-EditChart"}}
+    request = _build_request(
+        "/operation_analysis/api/import_export/import/precheck",
+        authenticated_user,
+    )
+
+    items = [
+        SimpleNamespace(key=f"dashboard::dash-{i}", name=f"dash-{i}")
+        for i in range(5)
+    ]
+    doc = SimpleNamespace(
+        namespaces=[],
+        datasources=[],
+        dashboards=items,
+        topologies=[],
+        architectures=[],
+    )
+    result = {"valid": True, "conflicts": [], "warnings": [], "errors": []}
+
+    batch_call_count = []
+
+    original_batch = ImportExportAuthorizationService.get_existing_objects_batch.__func__
+
+    def counting_batch(cls, object_type, batch_items):
+        batch_call_count.append(object_type)
+        return original_batch(cls, object_type, batch_items)
+
+    monkeypatch.setattr(
+        ImportExportAuthorizationService,
+        "get_existing_objects_batch",
+        classmethod(counting_batch),
+    )
+
+    ImportExportAuthorizationService.apply_precheck_permissions(request, doc, result, current_team=1)
+
+    dashboard_calls = [t for t in batch_call_count if t == ObjectType.DASHBOARD]
+    assert len(dashboard_calls) == 1, (
+        f"预期对 DASHBOARD 批量查询 1 次，实际 {len(dashboard_calls)} 次"
+    )


### PR DESCRIPTION
## 问题

批量导入时，权限校验层对每个待导入对象（dashboard / topology / architecture / datasource / namespace）单独执行一次 `SELECT … WHERE name='X' LIMIT 1`。
在 `precheck` 端点和 `submit` 端点各跑一轮，100 个 dashboard 意味着 200 次只为"这个名字存不存在"的冗余查询，200 个对象则逼近 400 次。
叠加已报的 `identify_conflicts`（#3399）和 `import_datasource`（#3400）两段 N+1，单次 import/submit 累计可破千次 DB 往返，引发接口超时。

## 根因

`get_existing_object()` 封装的是单条 `filter(name=...).first()`，设计上没有批量入口。`apply_precheck_permissions` 和 `validate_import_submit_permissions` 在逐 item 循环内每次都调用它，未做名字集合的预取。

## 怎么修的

新增 `get_existing_objects_batch(object_type, items) → dict` 方法，在进入 per-item 循环之前，按 object_type 一次性发出 `filter(name__in=[...])` 批量查询，结果存为字典供内层循环 O(1) 查找：

- Dashboard / Topology / Architecture / Namespace：`{obj.name: obj}`
- DataSourceAPIModel（唯一键为 `(name, rest_api)`）：`{(obj.name, obj.rest_api): obj}`

新增 `_item_lookup_key(object_type, item)` 计算字典查找键，使 DataSourceAPIModel 的复合键处理封装在一处。

两个权限方法均改为：在外层 per-type 循环里先调用 `get_existing_objects_batch`，内层 per-item 循环改为字典 `.get()`。`get_existing_object()` 保留原实现，不影响其他调用方。

```python
# 修复前（N+1）
for item in items:
    existing = cls.get_existing_object(object_type, item)  # 每次 1 SQL

# 修复后（批量）
existing_map = cls.get_existing_objects_batch(object_type, items)  # 1 SQL
for item in items:
    existing = existing_map.get(cls._item_lookup_key(object_type, item))  # O(1)
```

## 影响范围

改动仅在 `authorization_service.py`（单文件，`operation_analysis` 模块内）。`get_existing_object()` 原方法保留，其他调用方不受影响。不涉及 Model 定义、接口签名、权限逻辑语义变更。

## 验证

- 新增测试 `test_get_existing_objects_batch_issues_single_query_for_multiple_dashboards`：断言对 5 个 dashboard items 只触发 1 次 `filter` 调用；revert 修复则断言失败。
- 新增测试 `test_apply_precheck_permissions_uses_batch_lookup_not_per_item`：monkeypatch `get_existing_objects_batch` 并计数，断言每个 object_type 只调用 1 次（不是 N 次）。
- 两处现有测试同步将 monkeypatch 目标从 `get_existing_object` 改为 `get_existing_objects_batch`，保持测试契约与实现一致。
- 独立 harness（无 Django settings）验证 4 个场景全部通过，包括 DataSourceAPIModel 复合键场景。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["import/precheck\nimport_export_view.py"]
        T2["import/submit\nimport_export_view.py"]
    end

    subgraph A["权限校验层（本次修复）"]
        A1["apply_precheck_permissions\nauthorization_service.py:88"]
        A2["validate_import_submit_permissions\nauthorization_service.py:179"]
        A3["get_existing_objects_batch\nauthorization_service.py:279\n1 SQL per object_type"]
    end

    subgraph O["旧路径（N+1，已移除）"]
        O1["get_existing_object\nauthorization_service.py:262\n1 SQL per item"]
    end

    T1 --> A1
    T2 --> A2
    A1 --> A3
    A2 --> A3
    A1 -. "旧实现" .-> O1
    A2 -. "旧实现" .-> O1
```

关联 Issue：#3703