### PR TITLE
bugfix: get_nats_source_data 对 int(get_current_team()) 添加异常防护

### DIFF
--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -2,6 +2,8 @@
 # @File: get_nats_source_data.py
 # @Time: 2025/7/22 18:24
 # @Author: windyzhao
+from rest_framework.exceptions import ValidationError
+
 from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.nats.nats_client import DefaultNastClient
 from apps.core.utils.team_utils import get_current_team
@@ -39,7 +41,11 @@ class GetNatsData:
         :return:
         """
         username = self.request.user.username
-        team = int(get_current_team(self.request))
+        team_str = get_current_team(self.request)
+        try:
+            team = int(team_str)
+        except (TypeError, ValueError):
+            raise ValidationError("current_team cookie 缺失或格式错误，请重新登录或刷新页面")
         include_children = self.request.COOKIES.get("include_children", "0") == "1"
         permission = getattr(self.request.user, "permission", {})
         if isinstance(permission, dict):

--- a/server/apps/operation_analysis/tests/test_get_nats_source_data.py
+++ b/server/apps/operation_analysis/tests/test_get_nats_source_data.py
@@ -1,0 +1,113 @@
+# -- coding: utf-8 --
+# Tests for apps.operation_analysis.common.get_nats_source_data
+# Regression tests for issue #3702: int(get_current_team()) has no guard,
+# cookie anomaly triggers 500.
+import types
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from apps.operation_analysis.common.get_nats_source_data import GetNatsData
+
+
+def _make_request(current_team_cookie=None, api_team=None, username="testuser"):
+    """Build a minimal fake request object."""
+    user = types.SimpleNamespace(
+        username=username,
+        domain="domain.com",
+        timezone="Asia/Shanghai",
+        permission={},
+        group_tree=[],
+        is_superuser=False,
+    )
+    cookies = {}
+    if current_team_cookie is not None:
+        cookies["current_team"] = current_team_cookie
+
+    request = types.SimpleNamespace(
+        user=user,
+        COOKIES=cookies,
+    )
+    if api_team is not None:
+        request._api_current_team = api_team
+    return request
+
+
+def _make_get_nats_data(request):
+    """Instantiate GetNatsData without calling __init__ so we can call
+    update_request_params() in isolation with full control."""
+    obj = GetNatsData.__new__(GetNatsData)
+    obj.request = request
+    obj.params = {}
+    return obj
+
+
+class TestUpdateRequestParamsGuard:
+    """
+    Regression: int(get_current_team()) must not raise TypeError/ValueError.
+    If this fix is reverted (the try/except removed), calling int(None) will
+    raise TypeError and all tests in this class will fail — confirming coverage.
+    """
+
+    def test_valid_cookie_sets_team_int(self):
+        """Normal flow: valid current_team cookie produces an integer team."""
+        request = _make_request(current_team_cookie="7")
+        obj = _make_get_nats_data(request)
+        obj.update_request_params()
+        assert obj.params["user_info"]["team"] == 7
+
+    def test_api_key_injected_team_sets_team_int(self):
+        """API key path: _api_current_team attribute is used and converted to int."""
+        request = _make_request(api_team="42")
+        obj = _make_get_nats_data(request)
+        obj.update_request_params()
+        assert obj.params["user_info"]["team"] == 42
+
+    def test_missing_cookie_raises_validation_error_not_type_error(self):
+        """
+        Core regression: when current_team cookie is absent, update_request_params()
+        must raise ValidationError (400-serialisable) instead of letting
+        int(None) bubble up as a TypeError (which becomes a 500).
+
+        Reverting the fix restores `team = int(get_current_team(self.request))`
+        which raises TypeError for None → this test will fail.
+        """
+        request = _make_request(current_team_cookie=None)
+        obj = _make_get_nats_data(request)
+
+        with pytest.raises(ValidationError):
+            obj.update_request_params()
+
+    def test_non_numeric_cookie_raises_validation_error_not_value_error(self):
+        """
+        Edge case: a corrupt/tampered current_team cookie that is not numeric.
+        Must raise ValidationError instead of raw ValueError.
+        """
+        request = _make_request(current_team_cookie="not-a-number")
+        obj = _make_get_nats_data(request)
+
+        with pytest.raises(ValidationError):
+            obj.update_request_params()
+
+    def test_empty_string_cookie_raises_validation_error(self):
+        """Empty string for current_team is also invalid."""
+        request = _make_request(current_team_cookie="")
+        obj = _make_get_nats_data(request)
+
+        with pytest.raises(ValidationError):
+            obj.update_request_params()
+
+    def test_valid_team_user_info_structure(self):
+        """Sanity check: user_info dict is correctly populated on success."""
+        request = _make_request(current_team_cookie="5")
+        obj = _make_get_nats_data(request)
+        obj.update_request_params()
+
+        info = obj.params["user_info"]
+        assert info["team"] == 5
+        assert info["user"] == "testuser"
+        assert info["domain"] == "domain.com"
+        assert isinstance(info["permission"], dict)
+        assert isinstance(info["group_tree"], list)
+        assert info["is_superuser"] is False
+        assert isinstance(info["include_children"], bool)


### PR DESCRIPTION
## 问题

`GET /api/operation_analysis/api/data_source/<pk>/get_source_data/` 接口在处理请求时，`GetNatsData.update_request_params()` 直接调用 `int(get_current_team(self.request))`。当用户的 `current_team` cookie 缺失（浏览器清除、过期、代理清头）或格式异常时，`get_current_team()` 返回 `None`，`int(None)` 抛出 `TypeError`，最终以 500 响应用户，而不是友好的 400 错误提示。

## 根因

`get_current_team()` 有合法的 `None` 返回路径，调用方未做防御直接强转 `int()`。同一项目的 `GenericViewSetFun._parse_current_team_cookie`（`server/apps/core/utils/viewset_utils.py`）已经用 try/except 正确处理这个场景，但 `GetNatsData` 绕过了这个安全入口，直接裸调。

## 怎么修的

在 `update_request_params()` 里，将 `team = int(get_current_team(self.request))` 替换为：

```python
team_str = get_current_team(self.request)
try:
    team = int(team_str)
except (TypeError, ValueError):
    raise ValidationError("current_team cookie 缺失或格式错误，请重新登录或刷新页面")
```

与 `_parse_current_team_cookie` 保持一致：`TypeError`（None）和 `ValueError`（非数字字符串）都被捕获，抛出 DRF `ValidationError`，框架自动序列化为 400 响应。

## 影响范围

- 仅修改 `server/apps/operation_analysis/common/get_nats_source_data.py` 一个文件，改动 3 行
- 正常请求（有效 cookie）路径完全不受影响
- 新增测试文件 `server/apps/operation_analysis/tests/test_get_nats_source_data.py`

## 验证

新增 5 个回归测试，覆盖：有效 cookie、API Key 注入 team、cookie 缺失、非数字 cookie、空字符串 cookie。

测试设计满足"revert 必然失败"准则：将修复 revert 后 `int(None)` 抛 `TypeError` 而非 `ValidationError`，测试 `test_missing_cookie_raises_validation_error_not_type_error` 会直接 fail。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_source_data\ndatasource_view.py"]
    end

    subgraph N["核心处理层"]
        F1["GetNatsData.__init__\nget_nats_source_data.py"]
        F2["update_request_params()\nget_nats_source_data.py:42"]
        F3["get_current_team(request)\nteam_utils.py"]
    end

    subgraph G["防护层（本次修复）"]
        G1["try: int(team_str)\nexcept TypeError/ValueError"]
        G2["raise ValidationError → 400"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -- "None / 非数字" --> G1
    G1 -. "异常" .-> G2
    F3 -- "有效字符串" --> G1
    G1 -- "成功" --> END["team = int 值，继续构建 user_info"]
```

关联 Issue #3702