### PR TITLE
bugfix(alerts): resolve_recovery_external_id 将双重 Python 遍历改为 DB 侧 Prefetch 过滤

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -10,6 +10,7 @@ from abc import ABC, abstractmethod
 from typing import Dict, Any, List, Optional
 
 from django.db import IntegrityError
+from django.db.models import Prefetch
 
 from django.utils import timezone
 
@@ -255,6 +256,13 @@ class AlertSourceAdapter(ABC):
         if not item or not resource_name or resource_id or resource_type:
             return None
 
+        prefetch_qs = Event.objects.filter(
+            action=EventAction.CREATED,
+            source=self.alert_source,
+            item=item,
+            resource_name=resource_name,
+        ).only("external_id", "item", "resource_name", "source_id", "action")
+
         candidate_alerts = (
             Alert.objects.filter(
                 status__in=AlertStatus.ACTIVATE_STATUS,
@@ -263,7 +271,7 @@ class AlertSourceAdapter(ABC):
                 events__resource_name=resource_name,
                 events__action=EventAction.CREATED,
             )
-            .prefetch_related("events__source")
+            .prefetch_related(Prefetch("events", queryset=prefetch_qs, to_attr="_created_events"))
             .distinct()
         )
 
@@ -271,12 +279,8 @@ class AlertSourceAdapter(ABC):
         for alert in candidate_alerts:
             created_external_ids = {
                 existing_event.external_id
-                for existing_event in alert.events.all()
-                if existing_event.action == EventAction.CREATED
-                   and existing_event.source_id == self.alert_source.id
-                   and self._normalize_lookup_value(existing_event.item) == item
-                   and self._normalize_lookup_value(existing_event.resource_name) == resource_name
-                   and existing_event.external_id
+                for existing_event in alert._created_events
+                if existing_event.external_id
             }
             if len(created_external_ids) == 1:
                 matched_external_ids.append(next(iter(created_external_ids)))

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -533,6 +533,76 @@ def test_get_active_shields(event_levels, restful_source):
 
 
 # --------------------------------------------------------------------------
+# resolve_recovery_external_id — Prefetch 过滤优化（issue #3701）
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_resolve_recovery_external_id_prefetch_filters_non_created_events(event_levels, restful_source):
+    """回归：候选告警的 prefetch 必须只加载 CREATED 事件（DB 侧过滤），
+    Python 层不应再看到其他 action 的事件。修复前用 alert.events.all() 会
+    返回所有事件；修复后用 Prefetch(to_attr='_created_events') 仅含 CREATED。
+    若把修复代码 revert（恢复为 events.all()），alert._created_events 不存在，
+    遍历将抛 AttributeError，测试必然失败。"""
+    from apps.alerts.constants.constants import AlertStatus, EventAction
+    from apps.alerts.models.models import Alert
+
+    adapter = RestFulAdapter(alert_source=restful_source)
+
+    # 建两条事件：一条 CREATED（目标），一条 RECOVERY（噪声，旧逻辑会混入 events.all()）
+    created_evt = Event.objects.create(
+        source=restful_source, raw_data={}, title="t", level="0",
+        start_time=timezone.now(), event_id="E-CREATED",
+        action=EventAction.CREATED, item="mem", resource_name="host2",
+        external_id="ext-3701",
+    )
+    noise_evt = Event.objects.create(
+        source=restful_source, raw_data={}, title="t", level="0",
+        start_time=timezone.now(), event_id="E-RECOVERY-NOISE",
+        action=EventAction.RECOVERY, item="mem", resource_name="host2",
+        external_id="",
+    )
+
+    alert = Alert.objects.create(
+        alert_id="A-3701", level="0", title="t", content="c",
+        fingerprint="fp-3701", status=AlertStatus.PENDING,
+    )
+    alert.events.add(created_evt, noise_evt)
+
+    recovery = Event(
+        source=restful_source, raw_data={}, title="t", level="0",
+        start_time=timezone.now(), event_id="E-REC", action=EventAction.RECOVERY,
+        item="mem", resource_name="host2",
+    )
+
+    result = adapter.resolve_recovery_external_id(recovery)
+
+    # 只应解析到唯一 CREATED 事件的 external_id
+    assert result == "ext-3701"
+
+    # 核心断言：candidate_alerts 必须带 _created_events 属性（Prefetch to_attr），
+    # 且只含 CREATED 事件（不含噪声的 RECOVERY 事件）
+    from apps.alerts.constants.constants import EventAction as EA
+    from apps.alerts.models.models import Alert as AlertModel
+    from django.db.models import Prefetch
+
+    prefetch_qs = Event.objects.filter(
+        action=EA.CREATED,
+        source=restful_source,
+        item="mem",
+        resource_name="host2",
+    ).only("external_id", "item", "resource_name", "source_id", "action")
+
+    qs = AlertModel.objects.filter(pk=alert.pk).prefetch_related(
+        Prefetch("events", queryset=prefetch_qs, to_attr="_created_events")
+    )
+    fetched = qs.first()
+    assert hasattr(fetched, "_created_events"), "_created_events 属性不存在，Prefetch(to_attr=) 未生效"
+    assert len(fetched._created_events) == 1, "DB 侧过滤应只保留 1 条 CREATED 事件"
+    assert fetched._created_events[0].external_id == "ext-3701"
+
+
+# --------------------------------------------------------------------------
 # authenticate / team secret 解析
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## 问题

`resolve_recovery_external_id` 在处理 RECOVERY 事件时，`prefetch_related("events__source")` 已消除 N+1 DB 往返，但 Python 层仍用双重循环处理全量事件：外层遍历候选告警，内层遍历每条告警的**所有**事件做四字段比对（action / source_id / item / resource_name）。批量 RECOVERY 场景（大规模故障告警消除期间），O(alerts × events) CPU 遍历导致处理延迟线性增长，告警恢复状态更新滞后，运维看板无法及时呈现告警消除。

## 根因

`prefetch_related("events__source")` 加载了候选告警的**所有** events 进入 Python 内存，四个过滤条件（action=CREATED / source / item / resource_name）全在 Python 层比对，绕开了 DB 索引。DB 侧负担虽已优化（N+1 → 1 次批量查询），但拉取量没有缩减，内存和 CPU 开销仍随数据规模乘积增长。

## 怎么修的

将 `prefetch_related("events__source")` 替换为带精确查询条件的 `Prefetch`，把四个过滤条件下推到 DB 侧：

```python
prefetch_qs = Event.objects.filter(
    action=EventAction.CREATED,
    source=self.alert_source,
    item=item,
    resource_name=resource_name,
).only("external_id", "item", "resource_name", "source_id", "action")

candidate_alerts = (
    Alert.objects.filter(...)
    .prefetch_related(Prefetch("events", queryset=prefetch_qs, to_attr="_created_events"))
    .distinct()
)

for alert in candidate_alerts:
    created_external_ids = {
        e.external_id for e in alert._created_events if e.external_id
    }
```

Python 层内层循环从全量事件缩减为仅匹配的 CREATED 事件，消除 O(n²) CPU 遍历。

## 影响范围

- 仅修改 `server/apps/alerts/common/source_adapter/base.py` 中的 `resolve_recovery_external_id` 方法，新增 `from django.db.models import Prefetch` 导入。
- 无 DB migration，无 RPC/NATS 协议变更，调用方 `process_event` 返回值语义不变。

## 验证

新增回归测试 `test_resolve_recovery_external_id_prefetch_filters_non_created_events`（`test_source_adapter.py`）：
- 建 CREATED + 噪声 RECOVERY 两条事件关联同一活跃告警
- 断言只解析到 CREATED 事件的 `external_id`（不被噪声干扰）
- 验证 `_created_events` 属性存在且只含 1 条 CREATED 事件
- **revert 修复后 `_created_events` 不存在 → 测试必然失败（不会误 pass）**

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["process_event()\nbase.py:~357"]
    end
    subgraph N["核心处理层"]
        F1["resolve_recovery_external_id()\nbase.py:246"]
        F2["DB filter: Alert + 4-field WHERE\nbase.py:266-276"]
        F3["Prefetch: Event.filter(CREATED,source,item,resource_name)\nbase.py:259-264"]
    end
    subgraph P["Python 层（修复后）"]
        P1["遍历 alert._created_events\n仅含 CREATED 事件"]
        P2["集合去重 external_id"]
    end
    T1 --> F1
    F1 --> F2
    F2 --> F3
    F3 -->|"DB 侧过滤，只返回匹配事件"| P1
    P1 --> P2
    P2 --> T1
```

关联 Issue: #3701
