### PR TITLE
bugfix(alerts): 分派时间过滤下推至 DB，消除 Python 层 O(N) 全量遍历

### DIFF
--- a/server/apps/alerts/common/assignment.py
+++ b/server/apps/alerts/common/assignment.py
@@ -213,19 +213,28 @@ class AlertAssignmentOperator:
         if excluded_ids:
             base_queryset = base_queryset.exclude(id__in=excluded_ids)
 
-        # 首先按照Alert的created_at时间过滤符合分派策略时间范围的告警
-        time_matched_alert_ids = []
-        for alert_pk, created_at in base_queryset.values_list("id", "created_at"):
-            checker = TimeRangeChecker(assignment.config, created_at)
-            if checker.is_in_range():
-                time_matched_alert_ids.append(alert_pk)
+        # 按分派策略的时间范围过滤告警
+        # 优先尝试将时间范围下推到数据库（利用 created_at 索引），
+        # 仅当 type 不支持 SQL 下推（day/week/month 循环型）时才退化到 Python 遍历。
+        checker_proto = TimeRangeChecker(assignment.config)
+        orm_filter = checker_proto.to_orm_filter("created_at")
+
+        if orm_filter is not None:
+            # 快速路径：一次性时段（type=one）或无配置 → 全在 DB 完成，无 Python 遍历
+            time_filtered_queryset = base_queryset.filter(orm_filter)
+            time_matched_alert_ids = list(time_filtered_queryset.values_list("id", flat=True))
+        else:
+            # 退化路径：循环型时段（day/week/month）→ Python 层逐行判断
+            time_matched_alert_ids = []
+            for alert_pk, created_at in base_queryset.values_list("id", "created_at"):
+                checker = TimeRangeChecker(assignment.config, created_at)
+                if checker.is_in_range():
+                    time_matched_alert_ids.append(alert_pk)
+            time_filtered_queryset = Alert.objects.filter(id__in=time_matched_alert_ids)
 
         if not time_matched_alert_ids:
             logger.debug("[AlertAssign] 无告警匹配分派时间范围 assignment_id=%s", assignment.id)
             return []
-
-        # 重新构建查询集，只包含时间范围匹配的告警
-        time_filtered_queryset = Alert.objects.filter(id__in=time_matched_alert_ids)
 
         if assignment.match_type == AlertAssignmentMatchType.ALL:
             # 全部匹配，返回所有时间范围匹配且未分派的告警

--- a/server/apps/alerts/tests/test_time_range_checker.py
+++ b/server/apps/alerts/tests/test_time_range_checker.py
@@ -1,13 +1,16 @@
-"""TimeRangeChecker 时区行为测试。
+"""TimeRangeChecker 测试。
 
-复现并锁定缺陷：每日/每周/每月循环屏蔽窗口必须按项目本地时区
-（settings.TIME_ZONE）解释，而不是 UTC。否则当 TIME_ZONE 非 UTC 时，
-屏蔽生效时段会整体偏移时区差（如 Asia/Shanghai 偏移 8 小时）。
+覆盖：
+1. 时区行为：每日/每周/每月循环窗口必须按项目本地时区解释（Asia/Shanghai 非 UTC）。
+2. to_orm_filter：type=one 返回可用 Q 对象；day/week/month 返回 None（退化到 Python）；
+   无配置返回空 Q（全部匹配）。
 """
 
 import datetime
 
+from django.db.models import Q
 from django.test import override_settings
+from django.utils import timezone
 
 from apps.alerts.utils.time_range_checker import TimeRangeChecker
 
@@ -59,3 +62,79 @@ def test_monthly_window_uses_local_day():
     }
 
     assert TimeRangeChecker(config, check_time).is_in_range() is True
+
+
+# ---------------------------------------------------------------------------
+# to_orm_filter 测试（验证修复 #3700 的核心路径）
+# ---------------------------------------------------------------------------
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_one_returns_q():
+    """type=one 必须返回 Q 对象，而非 None，使调用方能跳过 Python 遍历。
+    revert to_orm_filter 实现后此测试会因 q is None 而失败。"""
+    config = {
+        "type": "one",
+        "start_time": "2026-06-01 00:00:00",
+        "end_time": "2026-06-30 23:59:59",
+    }
+    q = TimeRangeChecker(config).to_orm_filter("created_at")
+    assert q is not None
+    assert isinstance(q, Q)
+    assert "created_at__range" in str(q)
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_day_returns_none():
+    """type=day 循环型时段无法下推到 SQL，必须返回 None 触发 Python 退化路径。"""
+    config = {"type": "day", "start_time": "09:00:00", "end_time": "17:00:00"}
+    q = TimeRangeChecker(config).to_orm_filter("created_at")
+    assert q is None
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_week_returns_none():
+    """type=week 必须返回 None。"""
+    config = {"type": "week", "week_month": [1], "start_time": "00:00:00", "end_time": "23:59:59"}
+    q = TimeRangeChecker(config).to_orm_filter("created_at")
+    assert q is None
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_month_returns_none():
+    """type=month 必须返回 None。"""
+    config = {"type": "month", "week_month": [1], "start_time": "00:00:00", "end_time": "23:59:59"}
+    q = TimeRangeChecker(config).to_orm_filter("created_at")
+    assert q is None
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_empty_config_returns_empty_q():
+    """无配置时返回空 Q（等同于无条件过滤，全部匹配）。"""
+    q = TimeRangeChecker({}).to_orm_filter("created_at")
+    assert q is not None
+    assert isinstance(q, Q)
+    assert len(q.children) == 0
+
+
+@override_settings(TIME_ZONE="Asia/Shanghai", USE_TZ=True)
+def test_to_orm_filter_one_range_boundaries_consistent_with_is_in_range():
+    """to_orm_filter 生成的 Q range 边界与 is_in_range 语义一致。
+    revert to_orm_filter 后 q is None，assert q is not None 先失败。"""
+    config = {
+        "type": "one",
+        "start_time": "2026-06-01 00:00:00",
+        "end_time": "2026-06-30 23:59:59",
+    }
+    q = TimeRangeChecker(config).to_orm_filter("created_at")
+    assert q is not None  # revert 修复后此断言失败
+
+    inside = timezone.make_aware(datetime.datetime(2026, 6, 15, 12, 0, 0))
+    outside = timezone.make_aware(datetime.datetime(2026, 7, 1, 0, 0, 1))
+
+    assert TimeRangeChecker(config, inside).is_in_range() is True
+    assert TimeRangeChecker(config, outside).is_in_range() is False
+
+    start, end = q.children[0][1]
+    assert start <= inside <= end
+    assert not (start <= outside <= end)

--- a/server/apps/alerts/utils/time_range_checker.py
+++ b/server/apps/alerts/utils/time_range_checker.py
@@ -16,6 +16,7 @@
 import datetime
 from typing import Dict, Any, Optional
 
+from django.db.models import Q
 from django.utils import timezone
 
 from apps.core.logger import alert_logger as logger
@@ -53,6 +54,43 @@ class TimeRangeChecker:
         if timezone.is_aware(self.check_time):
             return timezone.localtime(self.check_time)
         return self.check_time
+
+    def to_orm_filter(self, field_name: str = "created_at") -> Optional[Q]:
+        """尝试将时间范围配置转换为 Django ORM Q 表达式，下推到数据库过滤。
+
+        仅 ``type="one"``（绝对时段）支持直接翻译为 SQL range 查询；
+        其余循环型时段（day/week/month）依赖本地时区的时/分/秒或周几/月日，
+        需要数据库生成列支持，暂返回 ``None`` 退化到 Python 过滤。
+
+        Args:
+            field_name: 模型上存储时间戳的字段名，默认 ``"created_at"``。
+
+        Returns:
+            ``Q`` 对象（可直接传给 ``.filter()``），或 ``None``（表示无法下推）。
+        """
+        if not self.config:
+            return Q()  # 无配置 → 全部匹配，返回空 Q（.filter(Q()) 等同于无条件）
+
+        time_type = self.config.get("type", "one")
+        if time_type != "one":
+            return None  # 循环型时段无法用 SQL 精确下推，由调用方退化到 Python 过滤
+
+        start_time_str = self.config.get("start_time")
+        end_time_str = self.config.get("end_time")
+        if not start_time_str or not end_time_str:
+            return None  # 配置不完整，退安全，让 Python 层处理
+
+        try:
+            start_time = timezone.make_aware(
+                datetime.datetime.strptime(start_time_str, "%Y-%m-%d %H:%M:%S")
+            )
+            end_time = timezone.make_aware(
+                datetime.datetime.strptime(end_time_str, "%Y-%m-%d %H:%M:%S")
+            )
+        except ValueError:
+            return None  # 格式异常，退到 Python 过滤
+
+        return Q(**{f"{field_name}__range": (start_time, end_time)})
 
     def is_in_range(self) -> bool:
         """


### PR DESCRIPTION
## 问题

告警分派任务（`AlertAssignmentOperator._batch_find_matching_alerts`）每次执行都要先把所有候选告警的 `id + created_at` 全部拉到内存，再逐条用 Python 的 `TimeRangeChecker` 判断是否在时间范围内。数据库里 `Alert.created_at` 早已建了索引，但这套实现完全绕过了它。

**实际后果**：告警越多越慢（线性增长）；偏偏告警风暴期（最需要快速分派的时候）也是候选告警最多的时候，存在正反馈恶化——大量告警积压在 Celery worker、分派超时、漏分。

## 根因

`TimeRangeChecker` 支持四种时间类型（`one`/`day`/`week`/`month`），开发者无法直接把它翻译成 SQL，就选择了"全拉出来 Python 遍历"。但对于最常用的 `type=one`（绝对时段），实际上完全可以翻译成 `WHERE created_at BETWEEN start AND end`，下推到 DB 用索引扫描。循环型时段（day/week/month 依赖本地时区的时/分/秒或星期/月日）才是真正难以用通用 SQL 表达的。

## 怎么修的

**`TimeRangeChecker` 新增 `to_orm_filter(field_name)` 方法**：
- `type=one`：解析 `start_time/end_time` → 返回 `Q(created_at__range=(start, end))`，让调用方直接传给 `.filter()`。
- `type=day/week/month`：返回 `None`，调用方据此退化到 Python 过滤。
- 无配置（全匹配）：返回空 `Q()`。

**`_batch_find_matching_alerts` 修改**：先调 `to_orm_filter()`，有 Q 就直接 `base_queryset.filter(q)` 一条 SQL 搞定，无需把全量 id+created_at 拉入内存；返回 `None` 才退化到原来的 Python 遍历（循环型时段行为完全不变，向后兼容）。

## 影响范围

- 改动仅限 `apps/alerts`（`common/assignment.py` + `utils/time_range_checker.py`）
- `to_orm_filter` 是新增方法，不改已有接口
- 循环型时段（day/week/month）代码路径完全未动，行为不变
- 无 DB 迁移，无跨模块影响

## 验证

新增 5 个 `to_orm_filter` 测试（`test_time_range_checker.py`），revert 修复代码后测试必然失败：
- `test_to_orm_filter_one_returns_q`：revert 后 q is None，断言直接失败
- `test_to_orm_filter_day/week/month_returns_none`：验证退化路径不被破坏
- `test_to_orm_filter_empty_config_returns_empty_q`：验证全匹配语义
- `test_to_orm_filter_one_range_boundaries_consistent_with_is_in_range`：验证 Q range 边界与 is_in_range 语义一致

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["process_assignment()\nassignment.py"]
    end

    subgraph N["时间过滤层（修复点）"]
        F1["_batch_find_matching_alerts()"]
        F2["TimeRangeChecker.to_orm_filter()"]
        F3A["base_queryset.filter(Q)\n快速路径：type=one，走 DB 索引"]
        F3B["Python 遍历 values_list\n退化路径：day/week/month"]
    end

    subgraph M["内容匹配层"]
        M1["RuleMatcher.filter_queryset()"]
        M2["直接返回 time_matched_alert_ids"]
    end

    T1 --> F1
    F1 --> F2
    F2 -- "返回 Q" --> F3A
    F2 -- "返回 None" --> F3B
    F3A --> M1
    F3A --> M2
    F3B --> M1
    F3B --> M2
```

关联 Issue #3700