### PR TITLE
bugfix: S3 删除失败时跳过 DB 记录删除，防止孤儿文件累积

### DIFF
--- a/server/apps/job_mgmt/tests/test_open_upload.py
+++ b/server/apps/job_mgmt/tests/test_open_upload.py
@@ -317,6 +317,95 @@ class TestOpenFileDeleteView:
         # 文件仍然存在
         assert DistributionFile.objects.filter(id=df.id).exists()
 
+    def test_s3_failure_keeps_db_record_and_returns_failed(self):
+        """S3 删除失败时 DB 记录不被删除，且 failed 列表含该文件（#3713）
+
+        核验点：revert 修复（去掉 continue）后此测试必须失败——DB 记录会消失，
+        且 failed 字段不存在于响应中。
+        """
+        from apps.job_mgmt.models import DistributionFile
+
+        df = DistributionFile.objects.create(
+            original_name="s3-fail.rpm",
+            file_key="job-files/2026/06/01/s3fail.rpm",
+            team=self.api_secret.team,
+            expire_at=timezone.now() + timedelta(days=7),
+        )
+
+        with patch("apps.job_mgmt.views.open_api.async_to_sync") as mock_async:
+            mock_delete = MagicMock(side_effect=Exception("NATS connection timeout"))
+            mock_async.return_value = mock_delete
+
+            response = self.client.delete(
+                self.url,
+                {"files": [{"file_id": df.id, "file_key": df.file_key}]},
+                format="json",
+                HTTP_API_AUTHORIZATION=self.api_secret.api_secret,
+            )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        # S3 失败时 deleted_count 不增加
+        assert data["deleted"] == 0
+        # failed 列表包含该文件
+        assert "failed" in data
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["file_id"] == df.id
+        assert data["failed"][0]["file_key"] == df.file_key
+        # 关键：DB 记录仍然存在（无孤儿 S3 对象）
+        assert DistributionFile.objects.filter(id=df.id).exists()
+
+    def test_s3_failure_partial_batch_consistency(self):
+        """批量删除中一个 S3 失败、一个 S3 成功：各自独立处理，互不影响（#3713）"""
+        from apps.job_mgmt.models import DistributionFile
+
+        df_ok = DistributionFile.objects.create(
+            original_name="ok.rpm",
+            file_key="job-files/2026/06/01/ok.rpm",
+            team=self.api_secret.team,
+            expire_at=timezone.now() + timedelta(days=7),
+        )
+        df_fail = DistributionFile.objects.create(
+            original_name="fail.rpm",
+            file_key="job-files/2026/06/01/fail.rpm",
+            team=self.api_secret.team,
+            expire_at=timezone.now() + timedelta(days=7),
+        )
+
+        call_count = 0
+
+        def side_effect(file_key):
+            nonlocal call_count
+            call_count += 1
+            if file_key == df_fail.file_key:
+                raise Exception("S3 bucket unavailable")
+
+        with patch("apps.job_mgmt.views.open_api.async_to_sync") as mock_async:
+            mock_async.return_value = side_effect
+
+            response = self.client.delete(
+                self.url,
+                {
+                    "files": [
+                        {"file_id": df_ok.id, "file_key": df_ok.file_key},
+                        {"file_id": df_fail.id, "file_key": df_fail.file_key},
+                    ]
+                },
+                format="json",
+                HTTP_API_AUTHORIZATION=self.api_secret.api_secret,
+            )
+
+        assert response.status_code == 200
+        data = response.json()["data"]
+        assert data["deleted"] == 1
+        assert "failed" in data
+        assert len(data["failed"]) == 1
+        assert data["failed"][0]["file_id"] == df_fail.id
+        # S3 成功的文件：DB 记录已删
+        assert not DistributionFile.objects.filter(id=df_ok.id).exists()
+        # S3 失败的文件：DB 记录保留
+        assert DistributionFile.objects.filter(id=df_fail.id).exists()
+
 
 @pytest.mark.unit
 @pytest.mark.django_db

--- a/server/apps/job_mgmt/views/open_api.py
+++ b/server/apps/job_mgmt/views/open_api.py
@@ -166,7 +166,7 @@ class OpenFileDeleteView(TeamResolveMixin, APIView):
         Body: {"files": [{"file_id": 1, "file_key": "job-files/..."}]}
 
     返回:
-        {"result": true, "data": {"deleted": 1}}
+        {"result": true, "data": {"deleted": 1, "failed": [{"file_id": 2, "file_key": "...", "reason": "..."}]}}
     """
 
     def delete(self, request):
@@ -190,6 +190,7 @@ class OpenFileDeleteView(TeamResolveMixin, APIView):
         deleted_count = 0
         no_permission = []  # 无权限的文件
         not_found = []  # 不存在的文件
+        failed = []  # S3 删除失败的文件
         for item in files:
             file_id = item.get("file_id")
             file_key = item.get("file_key")
@@ -208,11 +209,13 @@ class OpenFileDeleteView(TeamResolveMixin, APIView):
                 no_permission.append({"file_id": file_id, "file_key": file_key})
                 continue
 
-            # 删除对象存储文件
+            # 删除对象存储文件；若失败则跳过 DB 删除，避免产生孤儿 S3 对象
             try:
                 async_to_sync(delete_s3_file)(df.file_key)
             except Exception as e:
                 logger.warning(f"[open_delete_file] 删除对象存储文件失败: {df.file_key}, error={e}")
+                failed.append({"file_id": df.id, "file_key": df.file_key, "reason": str(e)})
+                continue  # S3 删除失败时不删除 DB 记录，防止产生孤儿文件
 
             df.delete()
             deleted_count += 1
@@ -222,6 +225,8 @@ class OpenFileDeleteView(TeamResolveMixin, APIView):
             result["no_permission"] = no_permission
         if not_found:
             result["not_found"] = not_found
+        if failed:
+            result["failed"] = failed
 
         return Response(
             result,


### PR DESCRIPTION
Closes #3713

## 问题

批量删除文件接口（`DELETE /api/open/delete_file`）在 S3（NATS JetStream Object Store）删除对象失败时，仍会把数据库里的文件记录删掉。这会导致：文件从系统里消失了（调用方再也无法引用），但 S3 里的真实对象还在——孤儿文件就这样悄悄积累。S3 网络抖动、NATS 重启等生产常见事件均可触发，文件量越大累积越快，最终可能打满对象存储配额，影响全体用户的文件上传和分发。

## 根因

`open_api.py` 里的 `try/except` 捕获了 S3 删除异常，但只记日志就放行，没有阻断后续的 `df.delete()`。S3 删除成功才应删除 DB 记录——两步操作被错误地解耦了。

```python
# 修复前（错误）：S3 失败被吞，DB 仍删
try:
    async_to_sync(delete_s3_file)(df.file_key)
except Exception as e:
    logger.warning(...)          # 只记日志
df.delete()                      # 仍然执行 ← 问题所在
deleted_count += 1
```

## 怎么修的

在 `except` 块末尾加一个 `continue`，让 S3 失败时跳过 `df.delete()`。同时把失败的文件加入 `failed` 列表随响应返回，和已有的 `no_permission`/`not_found` 字段并排，调用方可以感知到哪些文件未能删除。

```python
# 修复后：S3 失败时中断当前文件，不删 DB 记录
try:
    async_to_sync(delete_s3_file)(df.file_key)
except Exception as e:
    logger.warning(f"[open_delete_file] 删除对象存储文件失败: {df.file_key}, error={e}")
    failed.append({"file_id": df.id, "file_key": df.file_key, "reason": str(e)})
    continue  # ← 关键：跳过 df.delete()

df.delete()
deleted_count += 1
```

响应格式新增可选字段（仅在有失败时出现）：

```json
{"deleted": 1, "failed": [{"file_id": 2, "file_key": "...", "reason": "NATS connection timeout"}]}
```

## 影响范围

- 改动仅限 `server/apps/job_mgmt/views/open_api.py`（1 个文件，5 行变动）
- 新增 `failed` 字段只在有失败项时才出现（`if failed: result["failed"] = failed`），不传此字段的老调用方完全不受影响
- 遵循文件内已有的 `no_permission`/`not_found` 模式，保持 API 风格一致

## 验证

新增两个测试（`test_open_upload.py::TestOpenFileDeleteView`）：

1. **`test_s3_failure_keeps_db_record_and_returns_failed`**：单文件 S3 失败 → `deleted=0`，`failed` 列表含该文件，DB 记录仍存在。若 revert 掉 `continue`，此测试必然失败（DB 记录被删除，`failed` 字段也不存在）。

2. **`test_s3_failure_partial_batch_consistency`**：批量两文件，一个 S3 成功、一个失败 → `deleted=1`，`failed` 含失败文件；S3 成功的 DB 记录已删，S3 失败的 DB 记录保留。

纯逻辑层也通过独立脚本验证：修复路径正确，revert 后断言失败，确认测试有效覆盖修复点。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["OpenFileDeleteView.delete\nopen_api.py"]
    end

    subgraph N["核心处理层"]
        F1["for each file_item"]
        F2["DistributionFile.objects.get\n权限校验"]
        F3["async_to_sync(delete_s3_file)\nNATS JetStream"]
    end

    subgraph C["结果收集层"]
        C1["df.delete() + deleted_count += 1"]
        C2["failed.append(...) + continue\n不删 DB 记录"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -- "成功" --> C1
    F3 -- "异常" --> C2
```