### PR TITLE
bugfix(job_mgmt): run_now 在创建执行记录前增加高危命令/路径预检

### DIFF
--- a/server/apps/job_mgmt/tests/test_scheduled_task_views.py
+++ b/server/apps/job_mgmt/tests/test_scheduled_task_views.py
@@ -3,12 +3,14 @@
 PeriodicTask（celery-beat）相关操作统一 mock，避免依赖 django_celery_beat 表。
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from apps.job_mgmt.constants import JobType
 from apps.job_mgmt.models import ScheduledTask
+from apps.job_mgmt.services.dangerous_checker import DangerousCheckResult
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
@@ -116,6 +118,50 @@ class TestScheduledTaskActions:
         with patch("apps.job_mgmt.views.scheduled_task.dispatch_celery_task", return_value=None):
             resp = su_client.post(f"{URL}{task.id}/run_now/", {}, format="json")
         assert resp.status_code == 503
+
+    def test_run_now_dangerous_script_returns_400_without_creating_execution(self, su_client):
+        """run_now 在高危命令命中时应直接返回 400，不创建 JobExecution。"""
+        from apps.job_mgmt.models import JobExecution
+
+        task = _make_task(script_content="rm -rf /")
+        bad_result = DangerousCheckResult()
+        bad_result.add_match(
+            SimpleNamespace(id=1, name="禁止删根", pattern="rm -rf", level="forbidden"),
+            "rm -rf /",
+        )
+        before_count = JobExecution.objects.count()
+        with patch("apps.job_mgmt.views.scheduled_task.DangerousChecker.check_command", return_value=bad_result):
+            resp = su_client.post(f"{URL}{task.id}/run_now/", {}, format="json")
+        assert resp.status_code == 400
+        assert "高危" in resp.data.get("error", "")
+        assert JobExecution.objects.count() == before_count, "高危命中时不应创建执行记录"
+
+    def test_run_now_dangerous_path_returns_400_without_creating_execution(self, su_client):
+        """run_now 在高危路径命中时应直接返回 400，不创建 JobExecution。"""
+        from apps.job_mgmt.models import JobExecution
+
+        task = _make_task(job_type=JobType.FILE_DISTRIBUTION, target_path="/etc/passwd")
+        bad_result = DangerousCheckResult()
+        bad_result.add_match(
+            SimpleNamespace(id=2, name="禁止系统路径", pattern="/etc/", level="forbidden"),
+            "/etc/passwd",
+        )
+        before_count = JobExecution.objects.count()
+        with patch("apps.job_mgmt.views.scheduled_task.DangerousChecker.check_path", return_value=bad_result):
+            resp = su_client.post(f"{URL}{task.id}/run_now/", {}, format="json")
+        assert resp.status_code == 400
+        assert "高危" in resp.data.get("error", "")
+        assert JobExecution.objects.count() == before_count, "高危路径命中时不应创建执行记录"
+
+    def test_run_now_safe_script_proceeds_normally(self, su_client):
+        """run_now 在安全脚本时应正常创建执行记录并触发任务。"""
+        task = _make_task(script_content="echo hello")
+        safe_result = DangerousCheckResult()  # can_execute=True by default
+        with patch("apps.job_mgmt.views.scheduled_task.DangerousChecker.check_command", return_value=safe_result):
+            with patch("apps.job_mgmt.views.scheduled_task.dispatch_celery_task", return_value="task-ok"):
+                resp = su_client.post(f"{URL}{task.id}/run_now/", {}, format="json")
+        assert resp.status_code == 200
+        assert "execution_id" in resp.data
 
     def test_crontab_preview_ok(self, su_client):
         resp = su_client.post(f"{URL}crontab_preview/", {"cron_expression": "* * * * *"}, format="json")

--- a/server/apps/job_mgmt/views/scheduled_task.py
+++ b/server/apps/job_mgmt/views/scheduled_task.py
@@ -19,6 +19,7 @@ from apps.job_mgmt.serializers.scheduled_task import (
     ScheduledTaskUpdateSerializer,
 )
 from apps.job_mgmt.services.celery_dispatch import dispatch_celery_task
+from apps.job_mgmt.services.dangerous_checker import DangerousChecker
 from apps.job_mgmt.services.scheduled_task_service import ScheduledTaskService
 from apps.job_mgmt.services.script_params_service import ScriptParamsService
 from apps.job_mgmt.tasks import distribute_files_task, execute_playbook_task, execute_script_task
@@ -131,6 +132,30 @@ class ScheduledTaskViewSet(AuthViewSet):
         params = instance.params if isinstance(instance.params, list) else []
         resolved_params = ScriptParamsService.resolve_params(params, script=instance.script)
         params_str = ScriptParamsService.params_to_string(resolved_params)
+
+        # 脚本内容：优先从关联的 Script 对象获取，回退到定时任务上的临时输入字段
+        script_content = instance.script_content or ""
+        if instance.script:
+            script_content = instance.script.content or script_content
+
+        # 高危命令/路径预检：与 execute_scheduled_task 保持一致，命中则直接拒绝，不创建执行记录
+        team = instance.team or []
+        if instance.job_type == JobType.SCRIPT and script_content:
+            check_result = DangerousChecker.check_command(script_content, team)
+            if not check_result.can_execute:
+                forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
+                return Response(
+                    {"error": f"脚本包含高危命令，已拦截: {', '.join(forbidden_rules)}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        if instance.job_type == JobType.FILE_DISTRIBUTION and instance.target_path:
+            check_result = DangerousChecker.check_path(instance.target_path, team)
+            if not check_result.can_execute:
+                forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
+                return Response(
+                    {"error": f"目标路径为高危路径，已拦截: {', '.join(forbidden_rules)}"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
 
         # 根据作业类型创建执行记录
         execution = JobExecution.objects.create(


### PR DESCRIPTION
## 问题

用户在前端点击"立即执行"手动触发定时任务时，若脚本内容或目标路径命中了高危规则（如 `rm -rf /`、系统禁止路径等），系统会先把执行记录写入数据库（状态 PENDING），再由 Celery Worker 在执行阶段检测并拦截，最终以 FAILED 收场。

这会导致：
- 执行列表出现"幽灵"记录（PENDING → RUNNING → FAILED），用户困惑为何有无效执行历史
- 高危操作审计数据偏高：自动触发的高危被拒绝于记录之外，手动触发的却被记录为 FAILED
- 两条触发路径安全行为不一致，降低安全机制的可解释性

## 根因

`run_now`（手动触发）直接调用 `JobExecution.objects.create()` 创建记录再派发 Celery 任务，完全跳过了高危检测。而 `execute_scheduled_task`（自动触发）在创建记录**之前**先调用 `DangerousChecker.check_command` / `check_path`，命中则直接返回不创建记录。两条路径预检顺序错位导致行为不一致。

## 怎么修的

在 `run_now` 的 `JobExecution.objects.create()` 调用之前，仿照 `execute_scheduled_task` 加入高危预检：

```python
# SCRIPT 类型：检查脚本内容
if instance.job_type == JobType.SCRIPT and script_content:
    check_result = DangerousChecker.check_command(script_content, team)
    if not check_result.can_execute:
        forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
        return Response(
            {"error": f"脚本包含高危命令，已拦截: {', '.join(forbidden_rules)}"},
            status=status.HTTP_400_BAD_REQUEST,
        )

# FILE_DISTRIBUTION 类型：检查目标路径
if instance.job_type == JobType.FILE_DISTRIBUTION and instance.target_path:
    check_result = DangerousChecker.check_path(instance.target_path, team)
    if not check_result.can_execute:
        forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
        return Response(
            {"error": f"目标路径为高危路径，已拦截: {', '.join(forbidden_rules)}"},
            status=status.HTTP_400_BAD_REQUEST,
        )
```

同时修正了 `script_content` 的解析逻辑——优先取关联 Script 对象的 `content` 字段，回退到定时任务临时输入字段，与 `execute_scheduled_task` 保持一致（防止绕过：直接改 Script 库内容后通过 run_now 触发）。

## 影响范围

- 仅修改 `server/apps/job_mgmt/views/scheduled_task.py` 的 `run_now` 方法，约 +20 行
- 复用了已有的 `DangerousChecker` 服务（`services/dangerous_checker.py`），无新增依赖
- Worker 层（`ScriptExecutionRunner._handle_dangerous_command`）的兜底拦截不受影响，仍作为第二道防线
- 不涉及 DB 迁移、RPC 协议、agents/ 层

## 验证

新增 3 个测试用例（`test_scheduled_task_views.py`）：

1. `test_run_now_dangerous_script_returns_400_without_creating_execution` — 高危脚本命中时返回 400，并断言 `JobExecution` 记录数不增加（revert 修复后此断言失败）
2. `test_run_now_dangerous_path_returns_400_without_creating_execution` — 高危路径命中时返回 400，无执行记录产生
3. `test_run_now_safe_script_proceeds_normally` — 安全脚本放行，正常返回 200 含 `execution_id`

本地独立验证脚本（Django-free）验证 5 个场景全部通过；revert 修复代码后测试 2/3/4 均失败，符合"revert 后测试必须失败"准则。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST run_now\nviews/scheduled_task.py"]
    end

    subgraph N["预检层（本次新增）"]
        P1["DangerousChecker.check_command\nservices/dangerous_checker.py"]
        P2["DangerousChecker.check_path\nservices/dangerous_checker.py"]
        P3{高危命中?}
    end

    subgraph E["执行层"]
        E1["JobExecution.objects.create\nmodels/job_execution.py"]
        E2["dispatch_celery_task\nservices/celery_dispatch.py"]
    end

    subgraph F["兜底层（保留）"]
        F1["ScriptExecutionRunner._handle_dangerous_command\nservices/script_execution_runner.py"]
    end

    T1 --> P1
    T1 --> P2
    P1 --> P3
    P2 --> P3
    P3 -- 否 --> E1 --> E2
    P3 -- 是 --> R400["HTTP 400\n不创建记录"]
    E2 -. "Worker执行时" .-> F1
```

关联 Issue #3712