### PR TITLE
bugfix(job_mgmt): job_task_terminate 补调用方团队归属校验防跨租户取消

### DIFF
--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -549,15 +549,30 @@ def job_detail_query(data: dict):
 def job_task_terminate(data=None, task_id=None, **kwargs):
     if isinstance(data, dict):
         task_id = data.get("task_id", task_id)
+        caller_team = data.get("caller_team", [])
+    else:
+        caller_team = []
     if task_id is None:
         task_id = kwargs.get("task_id")
     if not task_id:
         return {"result": False, "message": "task_id 不能为空"}
+    if not caller_team:
+        return {"result": False, "message": "caller_team 不能为空"}
 
     try:
         execution = JobExecution.objects.get(id=task_id)
     except JobExecution.DoesNotExist:
         return {"result": False, "message": "任务不存在"}
+
+    # 归属校验：执行记录所属团队必须与调用方团队有交集
+    if not set(execution.team) & set(caller_team):
+        logger.warning(
+            "[job_task_terminate] 团队归属校验失败: task_id=%s, execution.team=%s, caller_team=%s",
+            task_id,
+            execution.team,
+            caller_team,
+        )
+        return {"result": False, "message": "无权取消该任务"}
 
     status_now = execution.status
     if status_now in ExecutionStatus.TERMINAL_STATES:

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -549,9 +549,9 @@ def job_detail_query(data: dict):
 def job_task_terminate(data=None, task_id=None, **kwargs):
     if isinstance(data, dict):
         task_id = data.get("task_id", task_id)
-        caller_team = data.get("caller_team", [])
+        caller_team = data.get("caller_team", kwargs.get("caller_team", []))
     else:
-        caller_team = []
+        caller_team = kwargs.get("caller_team", [])
     if task_id is None:
         task_id = kwargs.get("task_id")
     if not task_id:

--- a/server/apps/job_mgmt/tests/test_cancel_honest_semantics.py
+++ b/server/apps/job_mgmt/tests/test_cancel_honest_semantics.py
@@ -231,6 +231,16 @@ class TestTerminateTaskNatsAPI:
         execution.refresh_from_db()
         assert execution.status == ExecutionStatus.CANCELLED
 
+    def test_kwargs_caller_team_can_cancel(self):
+        """NATS request(..., task_id=..., caller_team=...) 的 kwargs 调用路径也必须可用。"""
+        execution = _make_execution(ExecutionStatus.PENDING, team=[1])
+
+        result = job_task_terminate(task_id=execution.id, caller_team=[1])
+
+        assert result["result"] is True
+        execution.refresh_from_db()
+        assert execution.status == ExecutionStatus.CANCELLED
+
 
 @pytest.mark.django_db
 class TestFinalizeExecutionConvergesCancelling:

--- a/server/apps/job_mgmt/tests/test_cancel_honest_semantics.py
+++ b/server/apps/job_mgmt/tests/test_cancel_honest_semantics.py
@@ -174,7 +174,7 @@ class TestTerminateTaskNatsAPI:
     def test_pending_execution_is_cancelled_directly(self):
         execution = _make_execution(ExecutionStatus.PENDING)
 
-        result = job_task_terminate({"task_id": execution.id})
+        result = job_task_terminate({"task_id": execution.id, "caller_team": [1]})
 
         assert result["result"] is True
         assert result["data"]["status"] == ExecutionStatus.CANCELLED
@@ -186,7 +186,7 @@ class TestTerminateTaskNatsAPI:
         execution = _make_execution(ExecutionStatus.RUNNING)
 
         with patch("apps.job_mgmt.nats_api.finalize_cancelling_execution") as mock_task:
-            result = job_task_terminate({"task_id": execution.id})
+            result = job_task_terminate({"task_id": execution.id, "caller_team": [1]})
 
         assert result["result"] is True
         assert result["data"]["status"] == ExecutionStatus.CANCELLING
@@ -197,6 +197,39 @@ class TestTerminateTaskNatsAPI:
         _, kwargs = mock_task.apply_async.call_args
         assert kwargs["args"] == [execution.id]
         assert kwargs["countdown"] > execution.timeout
+
+    def test_missing_caller_team_rejected(self):
+        """不传 caller_team 时拒绝取消，防止枚举 task_id 跨租户操作"""
+        execution = _make_execution(ExecutionStatus.PENDING)
+
+        result = job_task_terminate({"task_id": execution.id})
+
+        assert result["result"] is False
+        assert "caller_team" in result["message"]
+        execution.refresh_from_db()
+        assert execution.status == ExecutionStatus.PENDING  # 状态未变
+
+    def test_wrong_team_cannot_cancel(self):
+        """调用方 team 与执行记录 team 无交集时，返回无权操作"""
+        execution = _make_execution(ExecutionStatus.PENDING, team=[1])
+
+        result = job_task_terminate({"task_id": execution.id, "caller_team": [999]})
+
+        assert result["result"] is False
+        assert "无权取消" in result["message"]
+        execution.refresh_from_db()
+        assert execution.status == ExecutionStatus.PENDING  # 状态未变
+
+    def test_overlapping_team_can_cancel(self):
+        """调用方 team 与执行记录 team 有交集时，正常取消"""
+        execution = _make_execution(ExecutionStatus.PENDING, team=[1, 2])
+
+        result = job_task_terminate({"task_id": execution.id, "caller_team": [2, 3]})
+
+        assert result["result"] is True
+        assert result["data"]["status"] == ExecutionStatus.CANCELLED
+        execution.refresh_from_db()
+        assert execution.status == ExecutionStatus.CANCELLED
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

`job_task_terminate` NATS handler 无团队归属校验，任意内部调用方只要知道 `task_id` 即可跨租户取消他人的执行任务（#3711）。

## 修复

- 新增 `caller_team` 参数：调用方通过 NATS 消息体传入所属团队列表
- 归属校验：`execution.team` 与 `caller_team` 必须有交集（`set() & set()`），无交集返回 `{"result": False, "message": "无权取消该任务"}`
- 缺 `caller_team` 参数直接拒绝（向后不兼容，但原接口已是内部 NATS）

## 测试

补 3 条回归测试：
- `test_missing_caller_team_rejected`：不传 caller_team → 拒绝，执行状态不变
- `test_wrong_team_cannot_cancel`：跨团队 caller_team 无交集 → 拒绝，执行状态不变
- `test_overlapping_team_can_cancel`：caller_team 与 execution.team 有交集 → 正常取消

更新已有 2 条测试：补传 `caller_team=[1]` 与 `_make_execution` 默认 `team=[1]` 匹配。

Fixes #3711