### PR TITLE
bugfix: [opspilot] consume_bot_event 缺失 bot_id 时显式拒绝，移除硬编码默认值 7

### DIFF
--- a/server/apps/opspilot/nats_api.py
+++ b/server/apps/opspilot/nats_api.py
@@ -167,6 +167,7 @@ def get_guest_provider(group_id):
 def consume_bot_event(kwargs):
     """
     kwargs 参数：
+        bot_id: （必填）目标 Bot 的 ID，缺失时拒绝处理并返回错误
         text： 对话内容
         send_id: 用户ID
         timestamp： 对话时间
@@ -181,7 +182,10 @@ def consume_bot_event(kwargs):
         sender_id = kwargs["sender_id"]
         if not sender_id.strip():
             return {"result": True}
-        bot_id = int(kwargs.get("bot_id", 7))
+        raw_bot_id = kwargs.get("bot_id")
+        if not raw_bot_id:
+            return {"result": False, "message": "bot_id is required"}
+        bot_id = int(raw_bot_id)
         created_at = datetime.datetime.fromtimestamp(kwargs["timestamp"], tz=datetime.timezone.utc)
 
         # 优化 input_channel 获取逻辑

--- a/server/apps/opspilot/tests/test_nats_api_consume_bot_event.py
+++ b/server/apps/opspilot/tests/test_nats_api_consume_bot_event.py
@@ -1,0 +1,203 @@
+"""
+Tests for consume_bot_event NATS handler — Issue #3721
+Validates that missing bot_id returns an explicit error instead of silently
+writing conversation history to the hardcoded Bot #7.
+"""
+import sys
+import importlib.util
+import types
+from pathlib import Path
+
+
+def _install(name, **attrs):
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    sys.modules[name] = mod
+    return mod
+
+
+def _load_nats_api():
+    """
+    Load server/apps/opspilot/nats_api.py in isolation via exec_module,
+    injecting all required stubs so Django settings are never touched.
+    """
+    registered_handlers = {}
+
+    def register(fn):
+        registered_handlers[fn.__name__] = fn
+        return fn
+
+    _install("nats_client", register=register)
+    _install("django")
+    _install("django.db")
+    _install("django.db.models")
+
+    # Track Bot.objects.get calls so we can assert Bot #7 is never queried
+    bot_get_calls = []
+
+    class _BotObjects:
+        def get(self, **kwargs):
+            bot_get_calls.append(kwargs)
+            raise _BotDoesNotExist(f"Bot matching query does not exist: {kwargs}")
+
+    class _BotDoesNotExist(Exception):
+        pass
+
+    class _Bot:
+        DoesNotExist = _BotDoesNotExist
+        objects = _BotObjects()
+
+    # Track BotConversationHistory.objects.create calls
+    history_create_calls = []
+
+    class _HistoryObjects:
+        def create(self, **kwargs):
+            history_create_calls.append(kwargs)
+
+    class _BotConversationHistory:
+        objects = _HistoryObjects()
+
+    class _QS:
+        def filter(self, **kwargs):
+            return self
+        def order_by(self, *a):
+            return self
+        def first(self):
+            return None
+
+    class _BotWorkFlow:
+        objects = _QS()
+
+    _install(
+        "apps.opspilot.models",
+        Bot=_Bot,
+        BotConversationHistory=_BotConversationHistory,
+        BotWorkFlow=_BotWorkFlow,
+        EmbedProvider=object,
+        KnowledgeBase=object,
+        LLMModel=object,
+        LLMSkill=object,
+        OCRProvider=object,
+        RerankProvider=object,
+        SkillTools=object,
+    )
+    _install("apps")
+    _install("apps.core")
+    _install("apps.core.logger", opspilot_logger=__import__("logging").getLogger("test"))
+    _install("apps.opspilot")
+    _install("apps.opspilot.utils")
+    _install("apps.opspilot.utils.bot_utils", get_user_info=lambda *a, **kw: (types.SimpleNamespace(id=1), None))
+    _install("apps.opspilot.utils.chat_flow_utils")
+    _install("apps.opspilot.utils.chat_flow_utils.engine")
+    _install(
+        "apps.opspilot.utils.chat_flow_utils.engine.factory",
+        create_chat_flow_engine=lambda *a, **kw: None,
+    )
+
+    src = Path(__file__).parent.parent / "nats_api.py"
+    spec = importlib.util.spec_from_file_location("opspilot_nats_api_3721", src)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    return mod, registered_handlers, bot_get_calls, history_create_calls
+
+
+class TestConsumeBotEventBotIdRequired:
+    """Issue #3721: missing bot_id must be rejected explicitly, not silently written to Bot #7."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.mod, cls.handlers, cls.bot_get_calls, cls.history_create_calls = _load_nats_api()
+
+    def _call(self, **kwargs):
+        fn = self.handlers["consume_bot_event"]
+        return fn(kwargs)
+
+    # ── Core fix: absent bot_id must return error ─────────────────────
+    def test_missing_bot_id_returns_error(self):
+        result = self._call(
+            text="hello",
+            sender_id="user_abc",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+        )
+        assert result["result"] is False, "Expected result=False when bot_id is absent"
+        assert "bot_id" in result.get("message", "").lower(), (
+            f"Error message should mention bot_id; got: {result.get('message')}"
+        )
+
+    def test_none_bot_id_returns_error(self):
+        result = self._call(
+            text="hello",
+            sender_id="user_abc",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+            bot_id=None,
+        )
+        assert result["result"] is False, "Expected result=False when bot_id is None"
+
+    def test_zero_bot_id_returns_error(self):
+        """bot_id=0 is falsy and should also be rejected (0 is not a valid Bot pk)."""
+        result = self._call(
+            text="hello",
+            sender_id="user_abc",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+            bot_id=0,
+        )
+        assert result["result"] is False, "Expected result=False when bot_id is 0"
+
+    # ── Revert guard: Bot #7 must never be queried when bot_id is absent ─
+    def test_bot7_not_queried_when_bot_id_missing(self):
+        initial_calls = len(self.bot_get_calls)
+        self._call(
+            text="hello",
+            sender_id="user_xyz",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+        )
+        new_calls = self.bot_get_calls[initial_calls:]
+        bot7_calls = [c for c in new_calls if c.get("id") == 7]
+        assert not bot7_calls, (
+            f"Bot #7 was queried despite missing bot_id — hardcoded default is back: {bot7_calls}"
+        )
+
+    # ── Regression: empty text short-circuits before bot_id check ──────
+    def test_empty_text_returns_ok_without_touching_bot(self):
+        result = self._call(
+            text="",
+            sender_id="user_abc",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+        )
+        # empty text → early return True (existing behaviour preserved)
+        assert result["result"] is True
+
+    # ── Regression: whitespace-only sender_id short-circuits ───────────
+    def test_blank_sender_id_returns_ok_without_touching_bot(self):
+        result = self._call(
+            text="hello",
+            sender_id="   ",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+        )
+        assert result["result"] is True
+
+    # ── Regression: non-integer bot_id returns structured error ────────
+    def test_non_integer_bot_id_returns_error(self):
+        result = self._call(
+            text="hello",
+            sender_id="user_abc",
+            timestamp=1700000000.0,
+            event="user",
+            input_channel="web",
+            bot_id="not_a_number",
+        )
+        assert result["result"] is False


### PR DESCRIPTION
## 问题

OpsPilot 的 NATS handler `consume_bot_event` 在处理 Rasa 对话事件时，如果消息没有携带 `bot_id` 字段，原代码会悄悄地把它当成 Bot #7 来处理——没有任何报错，也不通知调用方。

后果：任何发出不含 `bot_id` 的 NATS 消息的调用方（配置错误的 Rasa 实例、版本不兼容的客户端、测试消息），其对话历史都会被静默写入 Bot #7，导致数据归属错误且难以发现。如果 Bot #7 不存在，则调用方收到一个令人困惑的 `Bot.DoesNotExist` 错误，而真正的原因（`bot_id` 没有传）被完全掩盖。

## 根因

```python
# 修改前
bot_id = int(kwargs.get("bot_id", 7))  # bot_id 是路由键，缺失时不该有默认值
```

`bot_id` 是 `consume_bot_event` 的核心路由键——它决定对话历史写入哪个 Bot。把它设计成「可选且有默认值」违背了其语义：任何不知道目标 Bot 的调用方本就不该被允许写入数据。这个魔数 `7` 是历史遗留自旧 Rasa 接口，被保留进了新代码。

## 怎么修的

在进入任何 DB 操作之前，先检查 `bot_id` 是否存在，缺失/None/0 时立即返回明确错误：

```python
# 修改后
raw_bot_id = kwargs.get("bot_id")
if not raw_bot_id:
    return {"result": False, "message": "bot_id is required"}
bot_id = int(raw_bot_id)
```

同时在函数 docstring 中将 `bot_id` 标注为必填字段，消除歧义。

## 影响范围

- 改动仅限 `server/apps/opspilot/nats_api.py`，单文件单函数
- 无 DB 迁移，无跨模块影响
- 所有正常配置的 Rasa 实例已在消息中携带 `bot_id`，行为不变
- 之前被静默写入 Bot #7 的异常消息，现在会收到清晰的 `{"result": false, "message": "bot_id is required"}` 错误响应

## 验证

新增 Django-free 注入式测试（`test_nats_api_consume_bot_event.py`），覆盖：
- 缺失 `bot_id` → 返回 `result=False`，message 包含 "bot_id"
- `bot_id=None` → 同上
- `bot_id=0` → 同上（0 不是有效 Bot pk）
- Bot #7 在缺失 `bot_id` 时**不被查询**（revert 守护断言）
- 空 text / 空白 sender_id 的早返回行为保持不变（回归）
- 非整数 `bot_id` 返回结构化错误（通过现有 ValueError 捕获）

将修复代码 revert 后，`test_missing_bot_id_returns_error` 和 `test_bot7_not_queried_when_bot_id_missing` 会立即失败。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NATS 调用方\nRasa 实例 / 测试消息"]
    end

    subgraph N["核心处理层 — nats_api.py"]
        F1["consume_bot_event\n:167"]
        F2["bot_id 必填校验\n:185-187（新增）"]
        F3["Bot.objects.get(id=bot_id)\n:196"]
        F4["BotConversationHistory.objects.create\n:202"]
    end

    T1 -->|"NATS 消息"| F1
    F1 --> F2
    F2 -->|"bot_id 存在"| F3
    F2 -->|"bot_id 缺失/None/0"| E1["返回错误\nresult=False"]
    F3 --> F4
    F3 -. "Bot 不存在" .-> E2["DoesNotExist 异常\n→ result=False"]
```

关联 Issue #3721