### PR TITLE
refactor(opspilot): 方案A — ToolSelector 状态下移至各 XxxToolEditor (#3507)

### DIFF
--- a/web/src/app/opspilot/components/skill/__tests__/toolEditors.test.tsx
+++ b/web/src/app/opspilot/components/skill/__tests__/toolEditors.test.tsx
@@ -1,0 +1,241 @@
+import React, { act, createRef } from 'react';
+import '@ant-design/v5-patch-for-react-19';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ElasticsearchToolEditor from '../elasticsearchToolEditor';
+import JenkinsToolEditor from '../jenkinsToolEditor';
+import KubernetesToolEditor from '../kubernetesToolEditor';
+import MssqlToolEditor from '../mssqlToolEditor';
+import MysqlToolEditor from '../mysqlToolEditor';
+import OracleToolEditor from '../oracleToolEditor';
+import PostgresToolEditor from '../postgresToolEditor';
+import RedisToolEditor from '../redisToolEditor';
+import { parseRedisToolConfig } from '../redisToolEditor';
+import type { ToolVariable } from '@/app/opspilot/types/tool';
+
+vi.mock('@/utils/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const { skillApiMocks } = vi.hoisted(() => ({
+  skillApiMocks: {
+    testRedisConnection: vi.fn().mockResolvedValue(undefined),
+    testMysqlConnection: vi.fn().mockResolvedValue(undefined),
+    testPostgresConnection: vi.fn().mockResolvedValue(undefined),
+    testOracleConnection: vi.fn().mockResolvedValue(undefined),
+    testMssqlConnection: vi.fn().mockResolvedValue(undefined),
+    testEsConnection: vi.fn().mockResolvedValue(undefined),
+    testJenkinsConnection: vi.fn().mockResolvedValue(undefined),
+    testKubernetesConnection: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@/app/opspilot/api/skill', () => ({ useSkillApi: () => skillApiMocks }));
+
+vi.mock('@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag', () => ({
+  default: ({ status }: { status: string }) => <span data-testid="connection-status">{status}</span>,
+}));
+
+interface SaveHandle {
+  save: () => boolean;
+}
+
+interface EditorProps {
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
+}
+
+type EditorComponent = React.ForwardRefExoticComponent<EditorProps & React.RefAttributes<SaveHandle>>;
+
+interface EditorCase {
+  name: string;
+  Component: EditorComponent;
+  instancesKey: string;
+  defaultInstanceIdKey?: string;
+  instance: Record<string, unknown>;
+  trimmedField: string;
+  trimmedValue: string;
+  testButton: string;
+  testMethod: keyof typeof skillApiMocks;
+}
+
+const editorCases: EditorCase[] = [
+  {
+    name: 'Redis', Component: RedisToolEditor, instancesKey: 'redis_instances',
+    defaultInstanceIdKey: 'redis_default_instance_id',
+    instance: { id: 'redis-1', name: ' Redis Production ', url: ' redis://localhost:6379 ' },
+    trimmedField: 'url', trimmedValue: 'redis://localhost:6379',
+    testButton: 'tool.redis.testConnection', testMethod: 'testRedisConnection',
+  },
+  {
+    name: 'MySQL', Component: MysqlToolEditor, instancesKey: 'mysql_instances',
+    defaultInstanceIdKey: 'mysql_default_instance_id',
+    instance: { id: 'mysql-1', name: ' MySQL Production ', host: ' mysql.local ' },
+    trimmedField: 'host', trimmedValue: 'mysql.local',
+    testButton: 'tool.mysql.testConnection', testMethod: 'testMysqlConnection',
+  },
+  {
+    name: 'PostgreSQL', Component: PostgresToolEditor, instancesKey: 'postgres_instances',
+    defaultInstanceIdKey: 'postgres_default_instance_id',
+    instance: { id: 'postgres-1', name: ' PostgreSQL Production ', host: ' postgres.local ' },
+    trimmedField: 'host', trimmedValue: 'postgres.local',
+    testButton: 'tool.postgres.testConnection', testMethod: 'testPostgresConnection',
+  },
+  {
+    name: 'Oracle', Component: OracleToolEditor, instancesKey: 'oracle_instances',
+    defaultInstanceIdKey: 'oracle_default_instance_id',
+    instance: { id: 'oracle-1', name: ' Oracle Production ', host: ' oracle.local ' },
+    trimmedField: 'host', trimmedValue: 'oracle.local',
+    testButton: 'tool.oracle.testConnection', testMethod: 'testOracleConnection',
+  },
+  {
+    name: 'MSSQL', Component: MssqlToolEditor, instancesKey: 'mssql_instances',
+    defaultInstanceIdKey: 'mssql_default_instance_id',
+    instance: { id: 'mssql-1', name: ' MSSQL Production ', host: ' mssql.local ' },
+    trimmedField: 'host', trimmedValue: 'mssql.local',
+    testButton: 'tool.mssql.testConnection', testMethod: 'testMssqlConnection',
+  },
+  {
+    name: 'Elasticsearch', Component: ElasticsearchToolEditor, instancesKey: 'es_instances',
+    defaultInstanceIdKey: 'es_default_instance_id',
+    instance: { id: 'es-1', name: ' Elasticsearch Production ', url: ' http://es.local:9200 ' },
+    trimmedField: 'url', trimmedValue: 'http://es.local:9200',
+    testButton: 'tool.elasticsearch.testConnection', testMethod: 'testEsConnection',
+  },
+  {
+    name: 'Jenkins', Component: JenkinsToolEditor, instancesKey: 'jenkins_instances',
+    defaultInstanceIdKey: 'jenkins_default_instance_id',
+    instance: { id: 'jenkins-1', name: ' Jenkins Production ', jenkins_url: ' http://jenkins.local ' },
+    trimmedField: 'jenkins_url', trimmedValue: 'http://jenkins.local',
+    testButton: 'tool.jenkins.testConnection', testMethod: 'testJenkinsConnection',
+  },
+  {
+    name: 'Kubernetes', Component: KubernetesToolEditor, instancesKey: 'kubernetes_instances',
+    instance: { id: 'kubernetes-1', name: ' Kubernetes Production ', kubeconfig_data: ' apiVersion: v1\nclusters: [] ' },
+    trimmedField: 'kubeconfig_data', trimmedValue: 'apiVersion: v1\nclusters: []',
+    testButton: 'tool.kubernetes.testConnection', testMethod: 'testKubernetesConnection',
+  },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe.each(editorCases)('$name tool editor', ({
+  Component, instancesKey, defaultInstanceIdKey, instance, trimmedField, trimmedValue,
+}) => {
+  it('通过统一 save 接口校验并序列化自身配置', () => {
+    const ref = createRef<SaveHandle>();
+    const onSave = vi.fn<(kwargs: ToolVariable[]) => void>();
+    render(
+      <Component
+        ref={ref}
+        initialKwargs={[{ key: instancesKey, value: JSON.stringify([instance]) }]}
+        onSave={onSave}
+      />,
+    );
+
+    let saved = false;
+    act(() => { saved = ref.current?.save() ?? false; });
+
+    expect(saved).toBe(true);
+    expect(onSave).toHaveBeenCalledOnce();
+    const savedKwargs = onSave.mock.calls[0][0];
+    const instancesValue = savedKwargs.find(({ key }) => key === instancesKey)?.value;
+    expect(typeof instancesValue).toBe('string');
+    const savedInstances = JSON.parse(String(instancesValue)) as Record<string, unknown>[];
+    expect(savedInstances).toHaveLength(1);
+    expect(savedInstances[0]).toMatchObject({
+      id: instance.id,
+      name: String(instance.name).trim(),
+      [trimmedField]: trimmedValue,
+    });
+    expect(savedInstances[0]).not.toHaveProperty('testStatus');
+
+    if (defaultInstanceIdKey) {
+      expect(savedKwargs).toContainEqual({ key: defaultInstanceIdKey, value: instance.id });
+    }
+  });
+});
+
+describe.each(editorCases)('$name tool editor connection test', ({
+  Component, instancesKey, instance, testButton, testMethod,
+}) => {
+  it('只把当前实例交给对应连接 API，并独立更新测试状态', async () => {
+    const ref = createRef<SaveHandle>();
+    render(
+      <Component
+        ref={ref}
+        initialKwargs={[{ key: instancesKey, value: JSON.stringify([instance]) }]}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('connection-status').textContent).toBe('untested');
+    fireEvent.click(screen.getByText(testButton));
+
+    await waitFor(() => expect(skillApiMocks[testMethod]).toHaveBeenCalledOnce());
+    const payload = skillApiMocks[testMethod].mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).toMatchObject({ id: instance.id, name: instance.name });
+    expect(payload).not.toHaveProperty('testStatus');
+    await waitFor(() => expect(screen.getByTestId('connection-status').textContent).toBe('success'));
+  });
+});
+
+describe('Redis 旧单实例配置兼容', () => {
+  it('读取旧字段并在保存时升级为多实例协议', () => {
+    const legacyKwargs: ToolVariable[] = [
+      { key: 'url', value: 'redis://legacy.local:6379' },
+      { key: 'username', value: 'legacy-user' },
+      { key: 'ssl', value: 'true' },
+      { key: 'cluster_mode', value: '1' },
+    ];
+    expect(parseRedisToolConfig(legacyKwargs)).toMatchObject([{
+      id: 'redis-1',
+      name: 'Redis - 1',
+      url: 'redis://legacy.local:6379',
+      username: 'legacy-user',
+      ssl: true,
+      cluster_mode: true,
+      testStatus: 'untested',
+    }]);
+
+    const ref = createRef<SaveHandle>();
+    const onSave = vi.fn<(kwargs: ToolVariable[]) => void>();
+    render(<RedisToolEditor ref={ref} initialKwargs={legacyKwargs} onSave={onSave} />);
+    act(() => { ref.current?.save(); });
+
+    const upgraded = onSave.mock.calls[0][0];
+    expect(upgraded.find(({ key }) => key === 'redis_default_instance_id')?.value).toBe('redis-1');
+    const instancesValue = upgraded.find(({ key }) => key === 'redis_instances')?.value;
+    expect(JSON.parse(String(instancesValue))).toMatchObject([{
+      id: 'redis-1',
+      url: 'redis://legacy.local:6379',
+      username: 'legacy-user',
+      ssl: true,
+      cluster_mode: true,
+    }]);
+  });
+});
+
+describe('连接失败反馈', () => {
+  it('连接 API 拒绝时只把当前实例标记为失败', async () => {
+    skillApiMocks.testRedisConnection.mockRejectedValueOnce(new Error('connection refused'));
+    render(
+      <RedisToolEditor
+        ref={createRef<SaveHandle>()}
+        initialKwargs={[{
+          key: 'redis_instances',
+          value: JSON.stringify([{ id: 'redis-failed', name: 'Redis Failed', url: 'redis://failed.local:6379' }]),
+        }]}
+        onSave={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('tool.redis.testConnection'));
+
+    await waitFor(() => expect(skillApiMocks.testRedisConnection).toHaveBeenCalledOnce());
+    await waitFor(() => expect(screen.getByTestId('connection-status').textContent).toBe('failed'));
+  });
+});

--- a/web/src/app/opspilot/components/skill/elasticsearchToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/elasticsearchToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, Switch } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, Switch, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type ElasticsearchTestStatus = 'untested' | 'success' | 'failed';
 
@@ -19,85 +21,133 @@ export interface ElasticsearchInstanceFormValue {
   testStatus: ElasticsearchTestStatus;
 }
 
+const INSTANCES_KEY = 'es_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'es_default_instance_id';
+const AUTO_NAME_PREFIX = 'Elasticsearch - ';
+
+const createId = () => `es-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const getDefaultInstance = (name: string): ElasticsearchInstanceFormValue => ({
+  id: createId(), name, url: '', username: '', password: '', api_key: '', verify_certs: true, testStatus: 'untested',
+});
+const getNextName = (instances: ElasticsearchInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^Elasticsearch - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+const parseBoolean = (value: unknown, defaultValue = true) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return !['false', '0', 'no', 'off'].includes(value.toLowerCase());
+  return defaultValue;
+};
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parseEsToolConfig = (kwargs: ToolVariable[] = []): ElasticsearchInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `es-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      url: String(item.url || ''), username: String(item.username || ''), password: String(item.password || ''),
+      api_key: String(item.api_key || ''), verify_certs: parseBoolean(item.verify_certs), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['url', 'username', 'password', 'api_key'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'es-1', name: 'Elasticsearch - 1', url: String(map.get('url') || ''), username: String(map.get('username') || ''),
+      password: String(map.get('password') || ''), api_key: String(map.get('api_key') || ''),
+      verify_certs: parseBoolean(map.get('verify_certs')), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('Elasticsearch - 1')];
+};
+
+const serializeEsToolConfig = (instances: ElasticsearchInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<ElasticsearchInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }, { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' }];
+};
+
+export interface ElasticsearchToolEditorHandle { save: () => boolean; }
 interface ElasticsearchToolEditorProps {
-  instances: ElasticsearchInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof ElasticsearchInstanceFormValue>(id: string, field: K, value: ElasticsearchInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const ElasticsearchToolEditor: React.FC<ElasticsearchToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const ElasticsearchToolEditor = forwardRef<ElasticsearchToolEditorHandle, ElasticsearchToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testEsConnection } = useSkillApi();
+  const [instances, setInstances] = useState<ElasticsearchInstanceFormValue[]>(() => parseEsToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseEsToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.elasticsearch.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.elasticsearch.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.elasticsearch.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.url.trim())) { message.error(t('tool.elasticsearch.urlRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), url: inst.url.trim() }));
+      onSave(serializeEsToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof ElasticsearchInstanceFormValue>(id: string, field: K, value: ElasticsearchInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<ElasticsearchInstanceFormValue>; delete payload.testStatus;
+      await testEsConnection(payload as Omit<ElasticsearchInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.elasticsearch.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.elasticsearch.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.elasticsearch.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.elasticsearch.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.url || t('tool.elasticsearch.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.elasticsearch.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.url || t('tool.elasticsearch.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -105,70 +155,37 @@ const ElasticsearchToolEditor: React.FC<ElasticsearchToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.elasticsearch.configTitle').replace('{name}', selectedInstance.name || t('tool.elasticsearch.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.elasticsearch.configTitle').replace('{name}', selectedInstance.name || t('tool.elasticsearch.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.elasticsearch" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.elasticsearch.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.elasticsearch.instanceNamePlaceholder')} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.url')}</div>
-              <Input
-                value={selectedInstance.url}
-                onChange={(event) => onChange(selectedInstance.id, 'url', event.target.value)}
-                placeholder="http://127.0.0.1:9200"
-              />
+              <Input value={selectedInstance.url} onChange={(e) => handleChange(selectedInstance.id, 'url', e.target.value)} placeholder="http://127.0.0.1:9200" />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.username')}</div>
-                <Input
-                  value={selectedInstance.username}
-                  onChange={(event) => onChange(selectedInstance.id, 'username', event.target.value)}
-                  placeholder={t('tool.elasticsearch.usernamePlaceholder')}
-                />
+                <Input value={selectedInstance.username} onChange={(e) => handleChange(selectedInstance.id, 'username', e.target.value)} placeholder={t('tool.elasticsearch.usernamePlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.password')}</div>
-                <Input.Password
-                  value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
-                  placeholder={t('tool.elasticsearch.passwordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.password} onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)} placeholder={t('tool.elasticsearch.passwordPlaceholder')} />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.apiKey')}</div>
-              <Input.Password
-                value={selectedInstance.api_key}
-                onChange={(event) => onChange(selectedInstance.id, 'api_key', event.target.value)}
-                placeholder={t('tool.elasticsearch.apiKeyPlaceholder')}
-              />
+              <Input.Password value={selectedInstance.api_key} onChange={(e) => handleChange(selectedInstance.id, 'api_key', e.target.value)} placeholder={t('tool.elasticsearch.apiKeyPlaceholder')} />
             </div>
-
             <div className="flex items-center gap-3">
               <div className="text-sm text-[var(--color-text-2)]">{t('tool.elasticsearch.verifyCerts')}</div>
-              <Switch
-                checked={selectedInstance.verify_certs}
-                onChange={(value) => onChange(selectedInstance.id, 'verify_certs', value)}
-              />
+              <Switch checked={selectedInstance.verify_certs} onChange={(v) => handleChange(selectedInstance.id, 'verify_certs', v)} />
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.elasticsearch.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.elasticsearch.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -179,6 +196,7 @@ const ElasticsearchToolEditor: React.FC<ElasticsearchToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+ElasticsearchToolEditor.displayName = 'ElasticsearchToolEditor';
 export default ElasticsearchToolEditor;

--- a/web/src/app/opspilot/components/skill/jenkinsToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/jenkinsToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type JenkinsTestStatus = 'untested' | 'success' | 'failed';
 
@@ -17,85 +19,127 @@ export interface JenkinsInstanceFormValue {
   testStatus: JenkinsTestStatus;
 }
 
+const INSTANCES_KEY = 'jenkins_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'jenkins_default_instance_id';
+const AUTO_NAME_PREFIX = 'Jenkins - ';
+
+const createId = () => `jenkins-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const getDefaultInstance = (name: string): JenkinsInstanceFormValue => ({
+  id: createId(), name, jenkins_url: '', jenkins_username: '', jenkins_password: '', testStatus: 'untested',
+});
+const getNextName = (instances: JenkinsInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^Jenkins - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parseJenkinsToolConfig = (kwargs: ToolVariable[] = []): JenkinsInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `jenkins-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      jenkins_url: String(item.jenkins_url || ''), jenkins_username: String(item.jenkins_username || ''),
+      jenkins_password: String(item.jenkins_password || ''), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['jenkins_url', 'jenkins_username', 'jenkins_password'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'jenkins-1', name: 'Jenkins - 1', jenkins_url: String(map.get('jenkins_url') || ''),
+      jenkins_username: String(map.get('jenkins_username') || ''), jenkins_password: String(map.get('jenkins_password') || ''), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('Jenkins - 1')];
+};
+
+const serializeJenkinsToolConfig = (instances: JenkinsInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<JenkinsInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }, { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' }];
+};
+
+export interface JenkinsToolEditorHandle { save: () => boolean; }
 interface JenkinsToolEditorProps {
-  instances: JenkinsInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof JenkinsInstanceFormValue>(id: string, field: K, value: JenkinsInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const JenkinsToolEditor: React.FC<JenkinsToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const JenkinsToolEditor = forwardRef<JenkinsToolEditorHandle, JenkinsToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testJenkinsConnection } = useSkillApi();
+  const [instances, setInstances] = useState<JenkinsInstanceFormValue[]>(() => parseJenkinsToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseJenkinsToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.jenkins.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.jenkins.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.jenkins.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.jenkins_url.trim())) { message.error(t('tool.jenkins.urlRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), jenkins_url: inst.jenkins_url.trim() }));
+      onSave(serializeJenkinsToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof JenkinsInstanceFormValue>(id: string, field: K, value: JenkinsInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<JenkinsInstanceFormValue>; delete payload.testStatus;
+      await testJenkinsConnection(payload as Omit<JenkinsInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.jenkins.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.jenkins.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.jenkins.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.jenkins.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.jenkins_url || t('tool.jenkins.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.jenkins.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.jenkins_url || t('tool.jenkins.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -103,53 +147,29 @@ const JenkinsToolEditor: React.FC<JenkinsToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.jenkins.configTitle').replace('{name}', selectedInstance.name || t('tool.jenkins.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.jenkins.configTitle').replace('{name}', selectedInstance.name || t('tool.jenkins.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.jenkins" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.jenkins.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.jenkins.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.jenkins.instanceNamePlaceholder')} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.jenkins.jenkinsUrl')}</div>
-              <Input
-                value={selectedInstance.jenkins_url}
-                onChange={(event) => onChange(selectedInstance.id, 'jenkins_url', event.target.value)}
-                placeholder="http://jenkins:8080"
-              />
+              <Input value={selectedInstance.jenkins_url} onChange={(e) => handleChange(selectedInstance.id, 'jenkins_url', e.target.value)} placeholder="http://jenkins:8080" />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.jenkins.jenkinsUsername')}</div>
-                <Input
-                  value={selectedInstance.jenkins_username}
-                  onChange={(event) => onChange(selectedInstance.id, 'jenkins_username', event.target.value)}
-                  placeholder={t('tool.jenkins.jenkinsUsernamePlaceholder')}
-                />
+                <Input value={selectedInstance.jenkins_username} onChange={(e) => handleChange(selectedInstance.id, 'jenkins_username', e.target.value)} placeholder={t('tool.jenkins.jenkinsUsernamePlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.jenkins.jenkinsPassword')}</div>
-                <Input.Password
-                  value={selectedInstance.jenkins_password}
-                  onChange={(event) => onChange(selectedInstance.id, 'jenkins_password', event.target.value)}
-                  placeholder={t('tool.jenkins.jenkinsPasswordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.jenkins_password} onChange={(e) => handleChange(selectedInstance.id, 'jenkins_password', e.target.value)} placeholder={t('tool.jenkins.jenkinsPasswordPlaceholder')} />
               </div>
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.jenkins.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.jenkins.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -160,6 +180,7 @@ const JenkinsToolEditor: React.FC<JenkinsToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+JenkinsToolEditor.displayName = 'JenkinsToolEditor';
 export default JenkinsToolEditor;

--- a/web/src/app/opspilot/components/skill/kubernetesToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/kubernetesToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type KubernetesTestStatus = 'untested' | 'success' | 'failed';
 
@@ -15,47 +17,101 @@ export interface KubernetesInstanceFormValue {
   testStatus: KubernetesTestStatus;
 }
 
+const INSTANCES_KEY = 'kubernetes_instances';
+const AUTO_NAME_PREFIX = 'Kubernetes - ';
+
+const createId = () => `kubernetes-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const getDefaultInstance = (name: string): KubernetesInstanceFormValue => ({
+  id: createId(), name, kubeconfig_data: '', testStatus: 'untested',
+});
+const getNextName = (instances: KubernetesInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^Kubernetes - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parseKubernetesToolConfig = (kwargs: ToolVariable[] = []): KubernetesInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `kubernetes-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      kubeconfig_data: String(item.kubeconfig_data || ''), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['kubeconfig_data'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'kubernetes-1', name: 'Kubernetes - 1', kubeconfig_data: String(map.get('kubeconfig_data') || ''), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('Kubernetes - 1')];
+};
+
+const serializeKubernetesToolConfig = (instances: KubernetesInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<KubernetesInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }];
+};
+
+export interface KubernetesToolEditorHandle { save: () => boolean; }
 interface KubernetesToolEditorProps {
-  instances: KubernetesInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof KubernetesInstanceFormValue>(id: string, field: K, value: KubernetesInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const KubernetesToolEditor: React.FC<KubernetesToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const KubernetesToolEditor = forwardRef<KubernetesToolEditorHandle, KubernetesToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testKubernetesConnection } = useSkillApi();
+  const [instances, setInstances] = useState<KubernetesInstanceFormValue[]>(() => parseKubernetesToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseKubernetesToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.kubernetes.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.kubernetes.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.kubernetes.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.kubeconfig_data.trim())) { message.error(t('tool.kubernetes.kubeconfigDataRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), kubeconfig_data: inst.kubeconfig_data.trim() }));
+      onSave(serializeKubernetesToolConfig(trimmed));
+      return true;
+    },
+  }));
 
-  const getKubeconfigPreview = (kubeconfigData: string) => {
-    if (!kubeconfigData) {
-      return t('tool.kubernetes.noKubeconfigData');
-    }
-    const firstLine = kubeconfigData.split('\n')[0].trim();
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof KubernetesInstanceFormValue>(id: string, field: K, value: KubernetesInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<KubernetesInstanceFormValue>; delete payload.testStatus;
+      await testKubernetesConnection(payload as Omit<KubernetesInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.kubernetes.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
+
+  const getKubeconfigPreview = (data: string) => {
+    if (!data) return t('tool.kubernetes.noKubeconfigData');
+    const firstLine = data.split('\n')[0].trim();
     return firstLine || t('tool.kubernetes.noKubeconfigData');
   };
 
@@ -64,44 +120,27 @@ const KubernetesToolEditor: React.FC<KubernetesToolEditorProps> = ({
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.kubernetes.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.kubernetes.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded p-3 text-left transition ${
-                    isActive ? 'border-2 border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.kubernetes.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {getKubeconfigPreview(instance.kubeconfig_data)}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded p-3 transition ${isActive ? 'border-2 border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.kubernetes.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {getKubeconfigPreview(instance.kubeconfig_data)}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -109,36 +148,20 @@ const KubernetesToolEditor: React.FC<KubernetesToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.kubernetes.configTitle').replace('{name}', selectedInstance.name || t('tool.kubernetes.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.kubernetes.configTitle').replace('{name}', selectedInstance.name || t('tool.kubernetes.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.kubernetes" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.kubernetes.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.kubernetes.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.kubernetes.instanceNamePlaceholder')} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.kubernetes.kubeconfigData')}</div>
-              <Input.TextArea
-                value={selectedInstance.kubeconfig_data}
-                onChange={(event) => onChange(selectedInstance.id, 'kubeconfig_data', event.target.value)}
-                placeholder={t('tool.kubernetes.kubeconfigDataPlaceholder')}
-                rows={12}
-                style={{ fontFamily: 'monospace', fontSize: '12px' }}
-              />
+              <Input.TextArea value={selectedInstance.kubeconfig_data} onChange={(e) => handleChange(selectedInstance.id, 'kubeconfig_data', e.target.value)}
+                placeholder={t('tool.kubernetes.kubeconfigDataPlaceholder')} rows={12} style={{ fontFamily: 'monospace', fontSize: '12px' }} />
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.kubernetes.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.kubernetes.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -149,6 +172,7 @@ const KubernetesToolEditor: React.FC<KubernetesToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+KubernetesToolEditor.displayName = 'KubernetesToolEditor';
 export default KubernetesToolEditor;

--- a/web/src/app/opspilot/components/skill/mssqlToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/mssqlToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, InputNumber } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, InputNumber, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type MssqlTestStatus = 'untested' | 'success' | 'failed';
 
@@ -19,85 +21,133 @@ export interface MssqlInstanceFormValue {
   testStatus: MssqlTestStatus;
 }
 
+const INSTANCES_KEY = 'mssql_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'mssql_default_instance_id';
+const AUTO_NAME_PREFIX = 'MSSQL - ';
+
+const createId = () => `mssql-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const getDefaultInstance = (name: string): MssqlInstanceFormValue => ({
+  id: createId(), name, host: '', port: 1433, database: 'master', user: '', password: '', testStatus: 'untested',
+});
+const getNextName = (instances: MssqlInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^MSSQL - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+const parseInt10 = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') { const n = parseInt(value, 10); return isNaN(n) ? defaultValue : n; }
+  return defaultValue;
+};
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parseMssqlToolConfig = (kwargs: ToolVariable[] = []): MssqlInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `mssql-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      host: String(item.host || ''), port: parseInt10(item.port, 1433), database: String(item.database || 'master'),
+      user: String(item.user || ''), password: String(item.password || ''), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['host', 'port', 'database', 'user', 'password'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'mssql-1', name: 'MSSQL - 1', host: String(map.get('host') || ''), port: parseInt10(map.get('port'), 1433),
+      database: String(map.get('database') || 'master'), user: String(map.get('user') || ''),
+      password: String(map.get('password') || ''), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('MSSQL - 1')];
+};
+
+const serializeMssqlToolConfig = (instances: MssqlInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<MssqlInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }, { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' }];
+};
+
+export interface MssqlToolEditorHandle { save: () => boolean; }
 interface MssqlToolEditorProps {
-  instances: MssqlInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof MssqlInstanceFormValue>(id: string, field: K, value: MssqlInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const MssqlToolEditor: React.FC<MssqlToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const MssqlToolEditor = forwardRef<MssqlToolEditorHandle, MssqlToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testMssqlConnection } = useSkillApi();
+  const [instances, setInstances] = useState<MssqlInstanceFormValue[]>(() => parseMssqlToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseMssqlToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.mssql.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.mssql.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.mssql.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.host.trim())) { message.error(t('tool.mssql.hostRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), host: inst.host.trim() }));
+      onSave(serializeMssqlToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof MssqlInstanceFormValue>(id: string, field: K, value: MssqlInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<MssqlInstanceFormValue>; delete payload.testStatus;
+      await testMssqlConnection(payload as Omit<MssqlInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.mssql.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.mssql.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.mssql.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.mssql.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.host ? `${instance.host}:${instance.port}` : t('tool.mssql.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.mssql.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.host ? `${instance.host}:${instance.port}` : t('tool.mssql.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -105,75 +155,39 @@ const MssqlToolEditor: React.FC<MssqlToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.mssql.configTitle').replace('{name}', selectedInstance.name || t('tool.mssql.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.mssql.configTitle').replace('{name}', selectedInstance.name || t('tool.mssql.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.mssql" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.mssql.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.mssql.instanceNamePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.host')}</div>
-                <Input
-                  value={selectedInstance.host}
-                  onChange={(event) => onChange(selectedInstance.id, 'host', event.target.value)}
-                  placeholder={t('tool.mssql.hostPlaceholder')}
-                />
+                <Input value={selectedInstance.host} onChange={(e) => handleChange(selectedInstance.id, 'host', e.target.value)} placeholder={t('tool.mssql.hostPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.port')}</div>
-                <InputNumber
-                  style={{ width: '100%' }}
-                  value={selectedInstance.port}
-                  min={1}
-                  max={65535}
-                  onChange={(value) => onChange(selectedInstance.id, 'port', value ?? 1433)}
-                  placeholder="1433"
-                />
+                <InputNumber style={{ width: '100%' }} value={selectedInstance.port} min={1} max={65535} onChange={(v) => handleChange(selectedInstance.id, 'port', v ?? 1433)} placeholder="1433" />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.database')}</div>
-              <Input
-                value={selectedInstance.database}
-                onChange={(event) => onChange(selectedInstance.id, 'database', event.target.value)}
-                placeholder="master"
-              />
+              <Input value={selectedInstance.database} onChange={(e) => handleChange(selectedInstance.id, 'database', e.target.value)} placeholder="master" />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.user')}</div>
-                <Input
-                  value={selectedInstance.user}
-                  onChange={(event) => onChange(selectedInstance.id, 'user', event.target.value)}
-                  placeholder={t('tool.mssql.userPlaceholder')}
-                />
+                <Input value={selectedInstance.user} onChange={(e) => handleChange(selectedInstance.id, 'user', e.target.value)} placeholder={t('tool.mssql.userPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mssql.password')}</div>
-                <Input.Password
-                  value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
-                  placeholder={t('tool.mssql.passwordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.password} onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)} placeholder={t('tool.mssql.passwordPlaceholder')} />
               </div>
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.mssql.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.mssql.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -184,6 +198,7 @@ const MssqlToolEditor: React.FC<MssqlToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+MssqlToolEditor.displayName = 'MssqlToolEditor';
 export default MssqlToolEditor;

--- a/web/src/app/opspilot/components/skill/mysqlToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/mysqlToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, InputNumber, Switch } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, InputNumber, Switch, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type MysqlTestStatus = 'untested' | 'success' | 'failed';
 
@@ -25,85 +27,185 @@ export interface MysqlInstanceFormValue {
   testStatus: MysqlTestStatus;
 }
 
+// ── constants ─────────────────────────────────────────────────────────────────
+const INSTANCES_KEY = 'mysql_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'mysql_default_instance_id';
+const AUTO_NAME_PREFIX = 'MySQL - ';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const createId = () => `mysql-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const getDefaultInstance = (name: string): MysqlInstanceFormValue => ({
+  id: createId(),
+  name,
+  host: '',
+  port: 3306,
+  database: '',
+  user: '',
+  password: '',
+  charset: 'utf8mb4',
+  collation: 'utf8mb4_unicode_ci',
+  ssl: false,
+  ssl_ca: '',
+  ssl_cert: '',
+  ssl_key: '',
+  testStatus: 'untested',
+});
+
+const getNextName = (instances: MysqlInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => {
+    const match = inst.name.match(/^MySQL - (\d+)$/);
+    return match ? Math.max(m, Number(match[1])) : m;
+  }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+
+const parseBoolean = (value: unknown) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+  return Boolean(value);
+};
+
+const parseInt10 = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') { const n = parseInt(value, 10); return isNaN(n) ? defaultValue : n; }
+  return defaultValue;
+};
+
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) {
+    try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; }
+  }
+  return [];
+};
+
+export const parseMysqlToolConfig = (kwargs: ToolVariable[] = []): MysqlInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `mysql-${i + 1}`),
+      name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      host: String(item.host || ''),
+      port: parseInt10(item.port, 3306),
+      database: String(item.database || ''),
+      user: String(item.user || ''),
+      password: String(item.password || ''),
+      charset: String(item.charset || 'utf8mb4'),
+      collation: String(item.collation || 'utf8mb4_unicode_ci'),
+      ssl: parseBoolean(item.ssl),
+      ssl_ca: String(item.ssl_ca || ''),
+      ssl_cert: String(item.ssl_cert || ''),
+      ssl_key: String(item.ssl_key || ''),
+      testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['host', 'port', 'database', 'user', 'password'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{
+      id: 'mysql-1', name: 'MySQL - 1',
+      host: String(map.get('host') || ''), port: parseInt10(map.get('port'), 3306),
+      database: String(map.get('database') || ''), user: String(map.get('user') || ''),
+      password: String(map.get('password') || ''), charset: String(map.get('charset') || 'utf8mb4'),
+      collation: String(map.get('collation') || 'utf8mb4_unicode_ci'), ssl: parseBoolean(map.get('ssl')),
+      ssl_ca: String(map.get('ssl_ca') || ''), ssl_cert: String(map.get('ssl_cert') || ''),
+      ssl_key: String(map.get('ssl_key') || ''), testStatus: 'untested',
+    }];
+  }
+  return [getDefaultInstance('MySQL - 1')];
+};
+
+const serializeMysqlToolConfig = (instances: MysqlInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<MysqlInstanceFormValue>; delete c.testStatus; return c; });
+  return [
+    { key: INSTANCES_KEY, value: JSON.stringify(normalized) },
+    { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' },
+  ];
+};
+
+// ── ref handle ────────────────────────────────────────────────────────────────
+export interface MysqlToolEditorHandle { save: () => boolean; }
+
 interface MysqlToolEditorProps {
-  instances: MysqlInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof MysqlInstanceFormValue>(id: string, field: K, value: MysqlInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const MysqlToolEditor: React.FC<MysqlToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const MysqlToolEditor = forwardRef<MysqlToolEditorHandle, MysqlToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testMysqlConnection } = useSkillApi();
+  const [instances, setInstances] = useState<MysqlInstanceFormValue[]>(() => parseMysqlToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseMysqlToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.mysql.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.mysql.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.mysql.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.host.trim())) { message.error(t('tool.mysql.hostRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), host: inst.host.trim() }));
+      onSave(serializeMysqlToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof MysqlInstanceFormValue>(id: string, field: K, value: MysqlInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<MysqlInstanceFormValue>; delete payload.testStatus;
+      await testMysqlConnection(payload as Omit<MysqlInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.mysql.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.mysql.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.mysql.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.mysql.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.host ? `${instance.host}:${instance.port}` : t('tool.mysql.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.mysql.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.host ? `${instance.host}:${instance.port}` : t('tool.mysql.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -111,130 +213,69 @@ const MysqlToolEditor: React.FC<MysqlToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.mysql.configTitle').replace('{name}', selectedInstance.name || t('tool.mysql.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.mysql.configTitle').replace('{name}', selectedInstance.name || t('tool.mysql.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.mysql" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.mysql.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.mysql.instanceNamePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.host')}</div>
-                <Input
-                  value={selectedInstance.host}
-                  onChange={(event) => onChange(selectedInstance.id, 'host', event.target.value)}
-                  placeholder={t('tool.mysql.hostPlaceholder')}
-                />
+                <Input value={selectedInstance.host} onChange={(e) => handleChange(selectedInstance.id, 'host', e.target.value)} placeholder={t('tool.mysql.hostPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.port')}</div>
-                <InputNumber
-                  style={{ width: '100%' }}
-                  value={selectedInstance.port}
-                  min={1}
-                  max={65535}
-                  onChange={(value) => onChange(selectedInstance.id, 'port', value ?? 3306)}
-                  placeholder="3306"
-                />
+                <InputNumber style={{ width: '100%' }} value={selectedInstance.port} min={1} max={65535} onChange={(v) => handleChange(selectedInstance.id, 'port', v ?? 3306)} placeholder="3306" />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.database')}</div>
-              <Input
-                value={selectedInstance.database}
-                onChange={(event) => onChange(selectedInstance.id, 'database', event.target.value)}
-                placeholder={t('tool.mysql.databasePlaceholder')}
-              />
+              <Input value={selectedInstance.database} onChange={(e) => handleChange(selectedInstance.id, 'database', e.target.value)} placeholder={t('tool.mysql.databasePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.user')}</div>
-                <Input
-                  value={selectedInstance.user}
-                  onChange={(event) => onChange(selectedInstance.id, 'user', event.target.value)}
-                  placeholder={t('tool.mysql.userPlaceholder')}
-                />
+                <Input value={selectedInstance.user} onChange={(e) => handleChange(selectedInstance.id, 'user', e.target.value)} placeholder={t('tool.mysql.userPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.password')}</div>
-                <Input.Password
-                  value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
-                  placeholder={t('tool.mysql.passwordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.password} onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)} placeholder={t('tool.mysql.passwordPlaceholder')} />
               </div>
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.charset')}</div>
-                <Input
-                  value={selectedInstance.charset}
-                  onChange={(event) => onChange(selectedInstance.id, 'charset', event.target.value)}
-                  placeholder="utf8mb4"
-                />
+                <Input value={selectedInstance.charset} onChange={(e) => handleChange(selectedInstance.id, 'charset', e.target.value)} placeholder="utf8mb4" />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.collation')}</div>
-                <Input
-                  value={selectedInstance.collation}
-                  onChange={(event) => onChange(selectedInstance.id, 'collation', event.target.value)}
-                  placeholder="utf8mb4_unicode_ci"
-                />
+                <Input value={selectedInstance.collation} onChange={(e) => handleChange(selectedInstance.id, 'collation', e.target.value)} placeholder="utf8mb4_unicode_ci" />
               </div>
             </div>
-
             <div className="flex items-center gap-2">
-              <Switch checked={selectedInstance.ssl} onChange={(checked) => onChange(selectedInstance.id, 'ssl', checked)} />
+              <Switch checked={selectedInstance.ssl} onChange={(checked) => handleChange(selectedInstance.id, 'ssl', checked)} />
               <span>{t('tool.mysql.ssl')}</span>
             </div>
-
             {selectedInstance.ssl && (
               <>
                 <div>
                   <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.sslCa')}</div>
-                  <Input
-                    value={selectedInstance.ssl_ca}
-                    onChange={(event) => onChange(selectedInstance.id, 'ssl_ca', event.target.value)}
-                    placeholder={t('tool.mysql.sslCaPlaceholder')}
-                  />
+                  <Input value={selectedInstance.ssl_ca} onChange={(e) => handleChange(selectedInstance.id, 'ssl_ca', e.target.value)} placeholder={t('tool.mysql.sslCaPlaceholder')} />
                 </div>
-
                 <div>
                   <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.sslCert')}</div>
-                  <Input
-                    value={selectedInstance.ssl_cert}
-                    onChange={(event) => onChange(selectedInstance.id, 'ssl_cert', event.target.value)}
-                    placeholder={t('tool.mysql.sslCertPlaceholder')}
-                  />
+                  <Input value={selectedInstance.ssl_cert} onChange={(e) => handleChange(selectedInstance.id, 'ssl_cert', e.target.value)} placeholder={t('tool.mysql.sslCertPlaceholder')} />
                 </div>
-
                 <div>
                   <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.mysql.sslKey')}</div>
-                  <Input
-                    value={selectedInstance.ssl_key}
-                    onChange={(event) => onChange(selectedInstance.id, 'ssl_key', event.target.value)}
-                    placeholder={t('tool.mysql.sslKeyPlaceholder')}
-                  />
+                  <Input value={selectedInstance.ssl_key} onChange={(e) => handleChange(selectedInstance.id, 'ssl_key', e.target.value)} placeholder={t('tool.mysql.sslKeyPlaceholder')} />
                 </div>
               </>
             )}
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.mysql.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.mysql.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -245,6 +286,7 @@ const MysqlToolEditor: React.FC<MysqlToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+MysqlToolEditor.displayName = 'MysqlToolEditor';
 export default MysqlToolEditor;

--- a/web/src/app/opspilot/components/skill/oracleToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/oracleToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, InputNumber } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, InputNumber, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type OracleTestStatus = 'untested' | 'success' | 'failed';
 
@@ -20,85 +22,138 @@ export interface OracleInstanceFormValue {
   testStatus: OracleTestStatus;
 }
 
+const INSTANCES_KEY = 'oracle_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'oracle_default_instance_id';
+const AUTO_NAME_PREFIX = 'Oracle - ';
+
+const createId = () => `oracle-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const getDefaultInstance = (name: string): OracleInstanceFormValue => ({
+  id: createId(), name, host: '', port: 1521, service_name: '', user: '', password: '', nls_lang: '', testStatus: 'untested',
+});
+
+const getNextName = (instances: OracleInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^Oracle - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+
+const parseInt10 = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') { const n = parseInt(value, 10); return isNaN(n) ? defaultValue : n; }
+  return defaultValue;
+};
+
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parseOracleToolConfig = (kwargs: ToolVariable[] = []): OracleInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `oracle-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      host: String(item.host || ''), port: parseInt10(item.port, 1521), service_name: String(item.service_name || ''),
+      user: String(item.user || ''), password: String(item.password || ''), nls_lang: String(item.nls_lang || ''), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['host', 'port', 'service_name', 'user', 'password'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'oracle-1', name: 'Oracle - 1', host: String(map.get('host') || ''), port: parseInt10(map.get('port'), 1521),
+      service_name: String(map.get('service_name') || ''), user: String(map.get('user') || ''),
+      password: String(map.get('password') || ''), nls_lang: String(map.get('nls_lang') || ''), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('Oracle - 1')];
+};
+
+const serializeOracleToolConfig = (instances: OracleInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<OracleInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }, { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' }];
+};
+
+export interface OracleToolEditorHandle { save: () => boolean; }
+
 interface OracleToolEditorProps {
-  instances: OracleInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof OracleInstanceFormValue>(id: string, field: K, value: OracleInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const OracleToolEditor: React.FC<OracleToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const OracleToolEditor = forwardRef<OracleToolEditorHandle, OracleToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testOracleConnection } = useSkillApi();
+  const [instances, setInstances] = useState<OracleInstanceFormValue[]>(() => parseOracleToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parseOracleToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.oracle.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.oracle.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.oracle.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.host.trim())) { message.error(t('tool.oracle.hostRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), host: inst.host.trim() }));
+      onSave(serializeOracleToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof OracleInstanceFormValue>(id: string, field: K, value: OracleInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<OracleInstanceFormValue>; delete payload.testStatus;
+      await testOracleConnection(payload as Omit<OracleInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.oracle.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.oracle.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.oracle.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.oracle.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.host ? `${instance.host}:${instance.port}` : t('tool.oracle.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.oracle.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.host ? `${instance.host}:${instance.port}` : t('tool.oracle.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -106,84 +161,43 @@ const OracleToolEditor: React.FC<OracleToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.oracle.configTitle').replace('{name}', selectedInstance.name || t('tool.oracle.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.oracle.configTitle').replace('{name}', selectedInstance.name || t('tool.oracle.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.oracle" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.oracle.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.oracle.instanceNamePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.host')}</div>
-                <Input
-                  value={selectedInstance.host}
-                  onChange={(event) => onChange(selectedInstance.id, 'host', event.target.value)}
-                  placeholder={t('tool.oracle.hostPlaceholder')}
-                />
+                <Input value={selectedInstance.host} onChange={(e) => handleChange(selectedInstance.id, 'host', e.target.value)} placeholder={t('tool.oracle.hostPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.port')}</div>
-                <InputNumber
-                  style={{ width: '100%' }}
-                  value={selectedInstance.port}
-                  min={1}
-                  max={65535}
-                  onChange={(value) => onChange(selectedInstance.id, 'port', value ?? 1521)}
-                  placeholder="1521"
-                />
+                <InputNumber style={{ width: '100%' }} value={selectedInstance.port} min={1} max={65535} onChange={(v) => handleChange(selectedInstance.id, 'port', v ?? 1521)} placeholder="1521" />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.serviceName')}</div>
-              <Input
-                value={selectedInstance.service_name}
-                onChange={(event) => onChange(selectedInstance.id, 'service_name', event.target.value)}
-                placeholder={t('tool.oracle.serviceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.service_name} onChange={(e) => handleChange(selectedInstance.id, 'service_name', e.target.value)} placeholder={t('tool.oracle.serviceNamePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.user')}</div>
-                <Input
-                  value={selectedInstance.user}
-                  onChange={(event) => onChange(selectedInstance.id, 'user', event.target.value)}
-                  placeholder={t('tool.oracle.userPlaceholder')}
-                />
+                <Input value={selectedInstance.user} onChange={(e) => handleChange(selectedInstance.id, 'user', e.target.value)} placeholder={t('tool.oracle.userPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.password')}</div>
-                <Input.Password
-                  value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
-                  placeholder={t('tool.oracle.passwordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.password} onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)} placeholder={t('tool.oracle.passwordPlaceholder')} />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.oracle.nlsLang')}</div>
-              <Input
-                value={selectedInstance.nls_lang}
-                onChange={(event) => onChange(selectedInstance.id, 'nls_lang', event.target.value)}
-                placeholder="AMERICAN_AMERICA.AL32UTF8"
-              />
+              <Input value={selectedInstance.nls_lang} onChange={(e) => handleChange(selectedInstance.id, 'nls_lang', e.target.value)} placeholder="AMERICAN_AMERICA.AL32UTF8" />
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.oracle.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.oracle.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -194,6 +208,7 @@ const OracleToolEditor: React.FC<OracleToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+OracleToolEditor.displayName = 'OracleToolEditor';
 export default OracleToolEditor;

--- a/web/src/app/opspilot/components/skill/postgresToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/postgresToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, InputNumber } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, InputNumber, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type PostgresTestStatus = 'untested' | 'success' | 'failed';
 
@@ -19,85 +21,133 @@ export interface PostgresInstanceFormValue {
   testStatus: PostgresTestStatus;
 }
 
+const INSTANCES_KEY = 'postgres_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'postgres_default_instance_id';
+const AUTO_NAME_PREFIX = 'PostgreSQL - ';
+
+const createId = () => `postgres-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const getDefaultInstance = (name: string): PostgresInstanceFormValue => ({
+  id: createId(), name, host: '', port: 5432, database: 'postgres', user: '', password: '', testStatus: 'untested',
+});
+const getNextName = (instances: PostgresInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => { const match = inst.name.match(/^PostgreSQL - (\d+)$/); return match ? Math.max(m, Number(match[1])) : m; }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+const parseInt10 = (value: unknown, defaultValue: number) => {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') { const n = parseInt(value, 10); return isNaN(n) ? defaultValue : n; }
+  return defaultValue;
+};
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) { try { const p = JSON.parse(value); return Array.isArray(p) ? p : []; } catch { return []; } }
+  return [];
+};
+
+export const parsePostgresToolConfig = (kwargs: ToolVariable[] = []): PostgresInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `postgres-${i + 1}`), name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      host: String(item.host || ''), port: parseInt10(item.port, 5432), database: String(item.database || 'postgres'),
+      user: String(item.user || ''), password: String(item.password || ''), testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = ['host', 'port', 'database', 'user', 'password'].some((k) => map.has(k));
+  if (hasLegacy) {
+    return [{ id: 'postgres-1', name: 'PostgreSQL - 1', host: String(map.get('host') || ''), port: parseInt10(map.get('port'), 5432),
+      database: String(map.get('database') || 'postgres'), user: String(map.get('user') || ''),
+      password: String(map.get('password') || ''), testStatus: 'untested' }];
+  }
+  return [getDefaultInstance('PostgreSQL - 1')];
+};
+
+const serializePostgresToolConfig = (instances: PostgresInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => { const c = { ...inst } as Partial<PostgresInstanceFormValue>; delete c.testStatus; return c; });
+  return [{ key: INSTANCES_KEY, value: JSON.stringify(normalized) }, { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' }];
+};
+
+export interface PostgresToolEditorHandle { save: () => boolean; }
 interface PostgresToolEditorProps {
-  instances: PostgresInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof PostgresInstanceFormValue>(id: string, field: K, value: PostgresInstanceFormValue[K]) => void;
-  onTest: () => void;
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
 }
 
-
-const PostgresToolEditor: React.FC<PostgresToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const PostgresToolEditor = forwardRef<PostgresToolEditorHandle, PostgresToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testPostgresConnection } = useSkillApi();
+  const [instances, setInstances] = useState<PostgresInstanceFormValue[]>(() => parsePostgresToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => parsePostgresToolConfig(initialKwargs)[0]?.id ?? null);
+  const [testing, setTesting] = useState(false);
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
-
   useEffect(() => {
-    if (instances.length > prevLengthRef.current && listRef.current) {
-      listRef.current.scrollTop = listRef.current.scrollHeight;
-    }
+    if (instances.length > prevLengthRef.current && listRef.current) listRef.current.scrollTop = listRef.current.scrollHeight;
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.postgres.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.postgres.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.postgres.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.host.trim())) { message.error(t('tool.postgres.hostRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), host: inst.host.trim() }));
+      onSave(serializePostgresToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => { const next = getDefaultInstance(getNextName(instances)); setInstances((p) => [...p, next]); setSelectedId(next.id); };
+  const handleDelete = (id: string) => {
+    setInstances((p) => { const n = p.filter((inst) => inst.id !== id); if (selectedId === id) setSelectedId(n[0]?.id ?? null); return n; });
+  };
+  const handleChange = <K extends keyof PostgresInstanceFormValue>(id: string, field: K, value: PostgresInstanceFormValue[K]) => {
+    setInstances((p) => p.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<PostgresInstanceFormValue>; delete payload.testStatus;
+      await testPostgresConnection(payload as Omit<PostgresInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.postgres.status.success'));
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((p) => p.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally { setTesting(false); }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.postgres.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
-            + {t('common.add')}
-          </Button>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>+ {t('common.add')}</Button>
         </div>
         <div className="flex-1 overflow-y-auto space-y-2" ref={listRef}>
           {instances.length === 0 ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.postgres.noInstances')} />
-          ) : (
-            instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
-              return (
-                <button
-                  key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
-                    isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
-                  }`}
-                  onClick={() => onSelect(instance.id)}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate font-medium">{instance.name || t('tool.postgres.unnamedInstance')}</div>
-                      <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
-                        {instance.host ? `${instance.host}:${instance.port}` : t('tool.postgres.addressNotConfigured')}
-                      </div>
+          ) : instances.map((instance) => {
+            const isActive = instance.id === selectedId;
+            return (
+              <div key={instance.id}
+                className={`flex w-full items-start gap-2 rounded border p-3 transition ${isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'}`}>
+                <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
+                    <div className="truncate font-medium">{instance.name || t('tool.postgres.unnamedInstance')}</div>
+                    <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
+                      {instance.host ? `${instance.host}:${instance.port}` : t('tool.postgres.addressNotConfigured')}
                     </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
                 </button>
-              );
-            })
-          )}
+                <Button type="link" size="small" danger aria-label={t('common.delete')}
+                  icon={<DeleteOutlined />} onClick={() => handleDelete(instance.id)} />
+              </div>
+            );
+          })}
         </div>
       </div>
 
@@ -105,75 +155,39 @@ const PostgresToolEditor: React.FC<PostgresToolEditorProps> = ({
         {selectedInstance ? (
           <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <div className="text-lg font-medium">
-                {t('tool.postgres.configTitle').replace('{name}', selectedInstance.name || t('tool.postgres.unnamedInstance'))}
-              </div>
+              <div className="text-lg font-medium">{t('tool.postgres.configTitle').replace('{name}', selectedInstance.name || t('tool.postgres.unnamedInstance'))}</div>
               <ToolConnectionStatusTag scope="tool.postgres" status={selectedInstance.testStatus} />
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.instanceName')}</div>
-              <Input
-                value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
-                placeholder={t('tool.postgres.instanceNamePlaceholder')}
-              />
+              <Input value={selectedInstance.name} onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)} placeholder={t('tool.postgres.instanceNamePlaceholder')} />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.host')}</div>
-                <Input
-                  value={selectedInstance.host}
-                  onChange={(event) => onChange(selectedInstance.id, 'host', event.target.value)}
-                  placeholder={t('tool.postgres.hostPlaceholder')}
-                />
+                <Input value={selectedInstance.host} onChange={(e) => handleChange(selectedInstance.id, 'host', e.target.value)} placeholder={t('tool.postgres.hostPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.port')}</div>
-                <InputNumber
-                  style={{ width: '100%' }}
-                  value={selectedInstance.port}
-                  min={1}
-                  max={65535}
-                  onChange={(value) => onChange(selectedInstance.id, 'port', value ?? 5432)}
-                  placeholder="5432"
-                />
+                <InputNumber style={{ width: '100%' }} value={selectedInstance.port} min={1} max={65535} onChange={(v) => handleChange(selectedInstance.id, 'port', v ?? 5432)} placeholder="5432" />
               </div>
             </div>
-
             <div>
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.database')}</div>
-              <Input
-                value={selectedInstance.database}
-                onChange={(event) => onChange(selectedInstance.id, 'database', event.target.value)}
-                placeholder="postgres"
-              />
+              <Input value={selectedInstance.database} onChange={(e) => handleChange(selectedInstance.id, 'database', e.target.value)} placeholder="postgres" />
             </div>
-
             <div className="grid grid-cols-2 gap-4">
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.user')}</div>
-                <Input
-                  value={selectedInstance.user}
-                  onChange={(event) => onChange(selectedInstance.id, 'user', event.target.value)}
-                  placeholder={t('tool.postgres.userPlaceholder')}
-                />
+                <Input value={selectedInstance.user} onChange={(e) => handleChange(selectedInstance.id, 'user', e.target.value)} placeholder={t('tool.postgres.userPlaceholder')} />
               </div>
               <div>
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.postgres.password')}</div>
-                <Input.Password
-                  value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
-                  placeholder={t('tool.postgres.passwordPlaceholder')}
-                />
+                <Input.Password value={selectedInstance.password} onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)} placeholder={t('tool.postgres.passwordPlaceholder')} />
               </div>
             </div>
-
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
-                {t('tool.postgres.testConnection')}
-              </Button>
+              <Button loading={testing} onClick={handleTest}>{t('tool.postgres.testConnection')}</Button>
             </div>
           </div>
         ) : (
@@ -184,6 +198,7 @@ const PostgresToolEditor: React.FC<PostgresToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
 
+PostgresToolEditor.displayName = 'PostgresToolEditor';
 export default PostgresToolEditor;

--- a/web/src/app/opspilot/components/skill/redisToolEditor.tsx
+++ b/web/src/app/opspilot/components/skill/redisToolEditor.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Button, Empty, Input, Switch } from 'antd';
+import React, { useState, useRef, useEffect, useImperativeHandle, forwardRef } from 'react';
+import { Button, Empty, Input, Switch, message } from 'antd';
 import { DeleteOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import ToolConnectionStatusTag from '@/app/opspilot/components/opspilot-tool-editor/tool-connection-status-tag';
+import { ToolVariable } from '@/app/opspilot/types/tool';
+import { useSkillApi } from '@/app/opspilot/api/skill';
 
 export type RedisTestStatus = 'untested' | 'success' | 'failed';
 
@@ -24,30 +26,134 @@ export interface RedisInstanceFormValue {
   testStatus: RedisTestStatus;
 }
 
-interface RedisToolEditorProps {
-  instances: RedisInstanceFormValue[];
-  selectedInstanceId: string | null;
-  testing: boolean;
-  onSelect: (id: string) => void;
-  onAdd: () => void;
-  onDelete: (id: string) => void;
-  onChange: <K extends keyof RedisInstanceFormValue>(id: string, field: K, value: RedisInstanceFormValue[K]) => void;
-  onTest: () => void;
+// ── constants ─────────────────────────────────────────────────────────────────
+const INSTANCES_KEY = 'redis_instances';
+const DEFAULT_INSTANCE_ID_KEY = 'redis_default_instance_id';
+const AUTO_NAME_PREFIX = 'Redis - ';
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+const createId = () => `redis-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+const getDefaultInstance = (name: string): RedisInstanceFormValue => ({
+  id: createId(),
+  name,
+  url: '',
+  username: '',
+  password: '',
+  ssl: false,
+  ssl_ca_path: '',
+  ssl_keyfile: '',
+  ssl_certfile: '',
+  ssl_cert_reqs: '',
+  ssl_ca_certs: '',
+  cluster_mode: false,
+  testStatus: 'untested',
+});
+
+const getNextName = (instances: RedisInstanceFormValue[]) => {
+  const max = instances.reduce((m, inst) => {
+    const match = inst.name.match(/^Redis - (\d+)$/);
+    return match ? Math.max(m, Number(match[1])) : m;
+  }, 0);
+  return `${AUTO_NAME_PREFIX}${max + 1}`;
+};
+
+const parseBoolean = (value: unknown) => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
+  return Boolean(value);
+};
+
+const parseInstancesValue = (value: unknown): Record<string, unknown>[] => {
+  if (Array.isArray(value)) return value as Record<string, unknown>[];
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      const parsed = JSON.parse(value);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch { return []; }
+  }
+  return [];
+};
+
+export const parseRedisToolConfig = (kwargs: ToolVariable[] = []): RedisInstanceFormValue[] => {
+  const map = new Map(kwargs.filter((k) => k.key).map((k) => [k.key, k.value]));
+  const parsed = parseInstancesValue(map.get(INSTANCES_KEY));
+  if (parsed.length > 0) {
+    return parsed.map((item, i) => ({
+      id: String(item.id || `redis-${i + 1}`),
+      name: String(item.name || `${AUTO_NAME_PREFIX}${i + 1}`),
+      url: String(item.url || ''),
+      username: String(item.username || ''),
+      password: String(item.password || ''),
+      ssl: parseBoolean(item.ssl),
+      ssl_ca_path: String(item.ssl_ca_path || ''),
+      ssl_keyfile: String(item.ssl_keyfile || ''),
+      ssl_certfile: String(item.ssl_certfile || ''),
+      ssl_cert_reqs: String(item.ssl_cert_reqs || ''),
+      ssl_ca_certs: String(item.ssl_ca_certs || ''),
+      cluster_mode: parseBoolean(item.cluster_mode),
+      testStatus: 'untested',
+    }));
+  }
+  const hasLegacy = [
+    'url', 'username', 'password', 'ssl', 'ssl_ca_path', 'ssl_keyfile',
+    'ssl_certfile', 'ssl_cert_reqs', 'ssl_ca_certs', 'cluster_mode',
+  ].some((key) => map.has(key));
+  if (hasLegacy) {
+    return [{
+      id: 'redis-1',
+      name: 'Redis - 1',
+      url: String(map.get('url') || ''),
+      username: String(map.get('username') || ''),
+      password: String(map.get('password') || ''),
+      ssl: parseBoolean(map.get('ssl')),
+      ssl_ca_path: String(map.get('ssl_ca_path') || ''),
+      ssl_keyfile: String(map.get('ssl_keyfile') || ''),
+      ssl_certfile: String(map.get('ssl_certfile') || ''),
+      ssl_cert_reqs: String(map.get('ssl_cert_reqs') || ''),
+      ssl_ca_certs: String(map.get('ssl_ca_certs') || ''),
+      cluster_mode: parseBoolean(map.get('cluster_mode')),
+      testStatus: 'untested',
+    }];
+  }
+  return [getDefaultInstance('Redis - 1')];
+};
+
+const serializeRedisToolConfig = (instances: RedisInstanceFormValue[]): ToolVariable[] => {
+  const normalized = instances.map((inst) => {
+    const copy = { ...inst } as Partial<RedisInstanceFormValue>;
+    delete copy.testStatus;
+    return copy;
+  });
+  return [
+    { key: INSTANCES_KEY, value: JSON.stringify(normalized) },
+    { key: DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' },
+  ];
+};
+
+// ── ref handle ────────────────────────────────────────────────────────────────
+export interface RedisToolEditorHandle {
+  /** Validates then calls onSave; returns false if validation fails */
+  save: () => boolean;
 }
 
+// ── component props ───────────────────────────────────────────────────────────
+interface RedisToolEditorProps {
+  initialKwargs: ToolVariable[];
+  onSave: (kwargs: ToolVariable[]) => void;
+}
 
-const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
-  instances,
-  selectedInstanceId,
-  testing,
-  onSelect,
-  onAdd,
-  onDelete,
-  onChange,
-  onTest,
-}) => {
+const RedisToolEditor = forwardRef<RedisToolEditorHandle, RedisToolEditorProps>(({ initialKwargs, onSave }, ref) => {
   const { t } = useTranslation();
-  const selectedInstance = instances.find((instance) => instance.id === selectedInstanceId) || null;
+  const { testRedisConnection } = useSkillApi();
+  const [instances, setInstances] = useState<RedisInstanceFormValue[]>(() => parseRedisToolConfig(initialKwargs));
+  const [selectedId, setSelectedId] = useState<string | null>(() => {
+    const insts = parseRedisToolConfig(initialKwargs);
+    return insts[0]?.id ?? null;
+  });
+  const [testing, setTesting] = useState(false);
+
+  const selectedInstance = instances.find((inst) => inst.id === selectedId) ?? null;
 
   const listRef = useRef<HTMLDivElement>(null);
   const prevLengthRef = useRef(instances.length);
@@ -59,13 +165,59 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
     prevLengthRef.current = instances.length;
   }, [instances.length]);
 
+  useImperativeHandle(ref, () => ({
+    save: () => {
+      const trimmedNames = instances.map((inst) => inst.name.trim()).filter(Boolean);
+      if (instances.length === 0) { message.error(t('tool.redis.noInstances')); return false; }
+      if (trimmedNames.length !== instances.length) { message.error(t('tool.redis.instanceNameRequired')); return false; }
+      if (new Set(trimmedNames).size !== trimmedNames.length) { message.error(t('tool.redis.duplicateInstanceName')); return false; }
+      if (instances.some((inst) => !inst.url.trim())) { message.error(t('tool.redis.urlRequired')); return false; }
+      const trimmed = instances.map((inst) => ({ ...inst, name: inst.name.trim(), url: inst.url.trim() }));
+      onSave(serializeRedisToolConfig(trimmed));
+      return true;
+    },
+  }));
+
+  const handleAdd = () => {
+    const next = getDefaultInstance(getNextName(instances));
+    setInstances((prev) => [...prev, next]);
+    setSelectedId(next.id);
+  };
+
+  const handleDelete = (id: string) => {
+    setInstances((prev) => {
+      const next = prev.filter((inst) => inst.id !== id);
+      if (selectedId === id) setSelectedId(next[0]?.id ?? null);
+      return next;
+    });
+  };
+
+  const handleChange = <K extends keyof RedisInstanceFormValue>(id: string, field: K, value: RedisInstanceFormValue[K]) => {
+    setInstances((prev) => prev.map((inst) => (inst.id === id ? { ...inst, [field]: value, testStatus: 'untested' } : inst)));
+  };
+
+  const handleTest = async () => {
+    if (!selectedInstance) return;
+    setTesting(true);
+    try {
+      const payload = { ...selectedInstance } as Partial<RedisInstanceFormValue>;
+      delete payload.testStatus;
+      await testRedisConnection(payload as Omit<RedisInstanceFormValue, 'testStatus'>);
+      message.success(t('tool.redis.status.success'));
+      setInstances((prev) => prev.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'success' } : inst)));
+    } catch {
+      setInstances((prev) => prev.map((inst) => (inst.id === selectedInstance.id ? { ...inst, testStatus: 'failed' } : inst)));
+    } finally {
+      setTesting(false);
+    }
+  };
 
   return (
     <div className="flex gap-4 min-h-[480px]">
       <div className="w-[260px] rounded border border-[var(--color-border)] p-3 flex flex-col">
         <div className="mb-3 flex items-center justify-between">
           <span className="font-medium">{t('tool.redis.instances')}</span>
-          <Button type="primary" ghost size="small" onClick={onAdd}>
+          <Button type="primary" ghost size="small" onClick={handleAdd}>
             + {t('common.add')}
           </Button>
         </div>
@@ -74,32 +226,29 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description={t('tool.redis.noInstances')} />
           ) : (
             instances.map((instance) => {
-              const isActive = instance.id === selectedInstanceId;
+              const isActive = instance.id === selectedId;
               return (
-                <button
+                <div
                   key={instance.id}
-                  type="button"
-                  className={`w-full rounded border p-3 text-left transition ${
+                  className={`flex w-full items-start gap-2 rounded border p-3 transition ${
                     isActive ? 'border-[var(--color-primary)] bg-[var(--color-primary-bg)]' : 'border-[var(--color-border)] bg-[var(--color-bg-1)]'
                   }`}
-                  onClick={() => onSelect(instance.id)}
                 >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
+                  <button type="button" className="min-w-0 flex-1 text-left" onClick={() => setSelectedId(instance.id)}>
                       <div className="truncate font-medium">{instance.name || t('tool.redis.unnamedInstance')}</div>
                       <div className="mt-1 truncate text-xs text-[var(--color-text-3)]">
                         {instance.url || t('tool.redis.addressNotConfigured')}
                       </div>
-                    </div>
-                    <DeleteOutlined
-                      className="mt-1 text-[var(--color-text-3)] hover:text-[var(--color-error)]"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onDelete(instance.id);
-                      }}
-                    />
-                  </div>
-                </button>
+                  </button>
+                  <Button
+                    type="link"
+                    size="small"
+                    danger
+                    aria-label={t('common.delete')}
+                    icon={<DeleteOutlined />}
+                    onClick={() => handleDelete(instance.id)}
+                  />
+                </div>
               );
             })
           )}
@@ -120,7 +269,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.instanceName')}</div>
               <Input
                 value={selectedInstance.name}
-                onChange={(event) => onChange(selectedInstance.id, 'name', event.target.value)}
+                onChange={(e) => handleChange(selectedInstance.id, 'name', e.target.value)}
                 placeholder={t('tool.redis.instanceNamePlaceholder')}
               />
             </div>
@@ -129,7 +278,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.url')}</div>
               <Input
                 value={selectedInstance.url}
-                onChange={(event) => onChange(selectedInstance.id, 'url', event.target.value)}
+                onChange={(e) => handleChange(selectedInstance.id, 'url', e.target.value)}
                 placeholder={t('tool.redis.urlPlaceholder')}
               />
             </div>
@@ -139,7 +288,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.username')}</div>
                 <Input
                   value={selectedInstance.username}
-                  onChange={(event) => onChange(selectedInstance.id, 'username', event.target.value)}
+                  onChange={(e) => handleChange(selectedInstance.id, 'username', e.target.value)}
                   placeholder={t('tool.redis.usernamePlaceholder')}
                 />
               </div>
@@ -147,7 +296,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.password')}</div>
                 <Input.Password
                   value={selectedInstance.password}
-                  onChange={(event) => onChange(selectedInstance.id, 'password', event.target.value)}
+                  onChange={(e) => handleChange(selectedInstance.id, 'password', e.target.value)}
                   placeholder={t('tool.redis.passwordPlaceholder')}
                 />
               </div>
@@ -155,11 +304,11 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
 
             <div className="grid grid-cols-2 gap-4">
               <div className="flex items-center gap-2">
-                <Switch checked={selectedInstance.ssl} onChange={(checked) => onChange(selectedInstance.id, 'ssl', checked)} />
+                <Switch checked={selectedInstance.ssl} onChange={(checked) => handleChange(selectedInstance.id, 'ssl', checked)} />
                 <span>{t('tool.redis.ssl')}</span>
               </div>
               <div className="flex items-center gap-2">
-                <Switch checked={selectedInstance.cluster_mode} onChange={(checked) => onChange(selectedInstance.id, 'cluster_mode', checked)} />
+                <Switch checked={selectedInstance.cluster_mode} onChange={(checked) => handleChange(selectedInstance.id, 'cluster_mode', checked)} />
                 <span>{t('tool.redis.clusterMode')}</span>
               </div>
             </div>
@@ -168,7 +317,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.sslCaPath')}</div>
               <Input
                 value={selectedInstance.ssl_ca_path}
-                onChange={(event) => onChange(selectedInstance.id, 'ssl_ca_path', event.target.value)}
+                onChange={(e) => handleChange(selectedInstance.id, 'ssl_ca_path', e.target.value)}
                 placeholder={t('tool.redis.sslCaPathPlaceholder')}
               />
             </div>
@@ -177,7 +326,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.sslKeyfile')}</div>
               <Input
                 value={selectedInstance.ssl_keyfile}
-                onChange={(event) => onChange(selectedInstance.id, 'ssl_keyfile', event.target.value)}
+                onChange={(e) => handleChange(selectedInstance.id, 'ssl_keyfile', e.target.value)}
                 placeholder={t('tool.redis.sslKeyfilePlaceholder')}
               />
             </div>
@@ -186,7 +335,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
               <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.sslCertfile')}</div>
               <Input
                 value={selectedInstance.ssl_certfile}
-                onChange={(event) => onChange(selectedInstance.id, 'ssl_certfile', event.target.value)}
+                onChange={(e) => handleChange(selectedInstance.id, 'ssl_certfile', e.target.value)}
                 placeholder={t('tool.redis.sslCertfilePlaceholder')}
               />
             </div>
@@ -196,7 +345,7 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.sslCertReqs')}</div>
                 <Input
                   value={selectedInstance.ssl_cert_reqs}
-                  onChange={(event) => onChange(selectedInstance.id, 'ssl_cert_reqs', event.target.value)}
+                  onChange={(e) => handleChange(selectedInstance.id, 'ssl_cert_reqs', e.target.value)}
                   placeholder={t('tool.redis.sslCertReqsPlaceholder')}
                 />
               </div>
@@ -204,14 +353,14 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
                 <div className="mb-1 text-sm text-[var(--color-text-2)]">{t('tool.redis.sslCaCerts')}</div>
                 <Input
                   value={selectedInstance.ssl_ca_certs}
-                  onChange={(event) => onChange(selectedInstance.id, 'ssl_ca_certs', event.target.value)}
+                  onChange={(e) => handleChange(selectedInstance.id, 'ssl_ca_certs', e.target.value)}
                   placeholder={t('tool.redis.sslCaCertsPlaceholder')}
                 />
               </div>
             </div>
 
             <div className="flex justify-end">
-              <Button loading={testing} onClick={onTest}>
+              <Button loading={testing} onClick={handleTest}>
                 {t('tool.redis.testConnection')}
               </Button>
             </div>
@@ -224,6 +373,8 @@ const RedisToolEditor: React.FC<RedisToolEditorProps> = ({
       </div>
     </div>
   );
-};
+});
+
+RedisToolEditor.displayName = 'RedisToolEditor';
 
 export default RedisToolEditor;

--- a/web/src/app/opspilot/components/skill/toolSelector.tsx
+++ b/web/src/app/opspilot/components/skill/toolSelector.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Alert, Button, Tooltip, Form, Input, Empty, InputNumber, Switch, message } from 'antd';
+import React, { useState, useEffect, useRef } from 'react';
+import { Alert, Button, Tooltip, Form, Input, Empty, InputNumber, Switch } from 'antd';
 
 const { TextArea } = Input;
 import { DeleteOutlined, EditOutlined } from '@ant-design/icons';
@@ -16,843 +16,46 @@ import {
   normalizeMonitorToolConfig,
   normalizeMonitorToolConfigs,
 } from '@/app/opspilot/utils/monitorToolConfig';
-import RedisToolEditor, { RedisInstanceFormValue } from './redisToolEditor';
-import MysqlToolEditor, { MysqlInstanceFormValue } from './mysqlToolEditor';
-import OracleToolEditor, { OracleInstanceFormValue } from './oracleToolEditor';
-import MssqlToolEditor, { MssqlInstanceFormValue } from './mssqlToolEditor';
-import PostgresToolEditor, { PostgresInstanceFormValue } from './postgresToolEditor';
-import ElasticsearchToolEditor, { ElasticsearchInstanceFormValue } from './elasticsearchToolEditor';
-import JenkinsToolEditor, { JenkinsInstanceFormValue } from './jenkinsToolEditor';
-import KubernetesToolEditor, { KubernetesInstanceFormValue } from './kubernetesToolEditor';
+import RedisToolEditor, { RedisToolEditorHandle } from './redisToolEditor';
+import MysqlToolEditor, { MysqlToolEditorHandle } from './mysqlToolEditor';
+import OracleToolEditor, { OracleToolEditorHandle } from './oracleToolEditor';
+import MssqlToolEditor, { MssqlToolEditorHandle } from './mssqlToolEditor';
+import PostgresToolEditor, { PostgresToolEditorHandle } from './postgresToolEditor';
+import ElasticsearchToolEditor, { ElasticsearchToolEditorHandle } from './elasticsearchToolEditor';
+import JenkinsToolEditor, { JenkinsToolEditorHandle } from './jenkinsToolEditor';
+import KubernetesToolEditor, { KubernetesToolEditorHandle } from './kubernetesToolEditor';
 
+// ── tool type guards ──────────────────────────────────────────────────────────
 const REDIS_TOOL_NAME = 'redis';
-const REDIS_INSTANCES_KEY = 'redis_instances';
-const REDIS_DEFAULT_INSTANCE_ID_KEY = 'redis_default_instance_id';
-const REDIS_AUTO_NAME_PREFIX = 'Redis - ';
-
-const createRedisInstanceId = () => `redis-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultRedisInstance = (name: string): RedisInstanceFormValue => ({
-  id: createRedisInstanceId(),
-  name,
-  url: '',
-  username: '',
-  password: '',
-  ssl: false,
-  ssl_ca_path: '',
-  ssl_keyfile: '',
-  ssl_certfile: '',
-  ssl_cert_reqs: '',
-  ssl_ca_certs: '',
-  cluster_mode: false,
-  testStatus: 'untested',
-});
-
-const getNextRedisInstanceName = (instances: RedisInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^Redis - (\d+)$/);
-    if (!match) {
-      return max;
-    }
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${REDIS_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseRedisInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) {
-    return value as Record<string, unknown>[];
-  }
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  return [];
-};
-
-const parseRedisBoolean = (value: unknown) => {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
-  }
-  return Boolean(value);
-};
-
-const parseRedisToolConfig = (kwargs: ToolVariable[] = []): RedisInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(REDIS_INSTANCES_KEY);
-  const parsedInstances = parseRedisInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `redis-${index + 1}`),
-      name: String(item.name || `${REDIS_AUTO_NAME_PREFIX}${index + 1}`),
-      url: String(item.url || ''),
-      username: String(item.username || ''),
-      password: String(item.password || ''),
-      ssl: parseRedisBoolean(item.ssl),
-      ssl_ca_path: String(item.ssl_ca_path || ''),
-      ssl_keyfile: String(item.ssl_keyfile || ''),
-      ssl_certfile: String(item.ssl_certfile || ''),
-      ssl_cert_reqs: String(item.ssl_cert_reqs || ''),
-      ssl_ca_certs: String(item.ssl_ca_certs || ''),
-      cluster_mode: parseRedisBoolean(item.cluster_mode),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['url', 'username', 'password', 'ssl', 'ssl_ca_path', 'ssl_keyfile', 'ssl_certfile', 'ssl_cert_reqs', 'ssl_ca_certs', 'cluster_mode']
-    .some((key) => kwargsMap.has(key));
-
-  if (hasLegacyConfig) {
-    return [{
-      id: 'redis-1',
-      name: 'Redis - 1',
-      url: String(kwargsMap.get('url') || ''),
-      username: String(kwargsMap.get('username') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      ssl: parseRedisBoolean(kwargsMap.get('ssl')),
-      ssl_ca_path: String(kwargsMap.get('ssl_ca_path') || ''),
-      ssl_keyfile: String(kwargsMap.get('ssl_keyfile') || ''),
-      ssl_certfile: String(kwargsMap.get('ssl_certfile') || ''),
-      ssl_cert_reqs: String(kwargsMap.get('ssl_cert_reqs') || ''),
-      ssl_ca_certs: String(kwargsMap.get('ssl_ca_certs') || ''),
-      cluster_mode: parseRedisBoolean(kwargsMap.get('cluster_mode')),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultRedisInstance('Redis - 1')];
-};
-
-const serializeRedisToolConfig = (instances: RedisInstanceFormValue[]): ToolVariable[] => {
-  const normalizedInstances = instances.map((instance) => {
-    const normalizedInstance = { ...instance };
-    delete normalizedInstance.testStatus;
-    return normalizedInstance;
-  });
-  return [
-    { key: REDIS_INSTANCES_KEY, value: JSON.stringify(normalizedInstances) },
-    { key: REDIS_DEFAULT_INSTANCE_ID_KEY, value: normalizedInstances[0]?.id || '' },
-  ];
-};
+const MYSQL_TOOL_NAME = 'mysql';
+const ORACLE_TOOL_NAME = 'oracle';
+const MSSQL_TOOL_NAME = 'mssql';
+const POSTGRES_TOOL_NAME = 'postgres';
+const ES_TOOL_NAME = 'elasticsearch';
+const JENKINS_TOOL_NAME = 'jenkins';
+const KUBERNETES_TOOL_NAMES = new Set(['kubernetes', 'kubernetes_data_collection']);
 
 const isRedisTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === REDIS_TOOL_NAME;
-
-const MYSQL_TOOL_NAME = 'mysql';
-const MYSQL_INSTANCES_KEY = 'mysql_instances';
-const MYSQL_DEFAULT_INSTANCE_ID_KEY = 'mysql_default_instance_id';
-const MYSQL_AUTO_NAME_PREFIX = 'MySQL - ';
-
-const createMysqlInstanceId = () => `mysql-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultMysqlInstance = (name: string): MysqlInstanceFormValue => ({
-  id: createMysqlInstanceId(),
-  name,
-  host: '',
-  port: 3306,
-  database: '',
-  user: '',
-  password: '',
-  charset: 'utf8mb4',
-  collation: 'utf8mb4_unicode_ci',
-  ssl: false,
-  ssl_ca: '',
-  ssl_cert: '',
-  ssl_key: '',
-  testStatus: 'untested',
-});
-
-const getNextMysqlInstanceName = (instances: MysqlInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^MySQL - (\d+)$/);
-    if (!match) {
-      return max;
-    }
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${MYSQL_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseMysqlInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) {
-    return value as Record<string, unknown>[];
-  }
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  return [];
-};
-
-const parseMysqlBoolean = (value: unknown) => {
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    return ['1', 'true', 'yes', 'on'].includes(value.trim().toLowerCase());
-  }
-  return Boolean(value);
-};
-
-const parseMysqlInt = (value: unknown, defaultValue: number) => {
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? defaultValue : parsed;
-  }
-  return defaultValue;
-};
-
-const parseMysqlToolConfig = (kwargs: ToolVariable[] = []): MysqlInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(MYSQL_INSTANCES_KEY);
-  const parsedInstances = parseMysqlInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `mysql-${index + 1}`),
-      name: String(item.name || `${MYSQL_AUTO_NAME_PREFIX}${index + 1}`),
-      host: String(item.host || ''),
-      port: parseMysqlInt(item.port, 3306),
-      database: String(item.database || ''),
-      user: String(item.user || ''),
-      password: String(item.password || ''),
-      charset: String(item.charset || 'utf8mb4'),
-      collation: String(item.collation || 'utf8mb4_unicode_ci'),
-      ssl: parseMysqlBoolean(item.ssl),
-      ssl_ca: String(item.ssl_ca || ''),
-      ssl_cert: String(item.ssl_cert || ''),
-      ssl_key: String(item.ssl_key || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['host', 'port', 'database', 'user', 'password']
-    .some((key) => kwargsMap.has(key));
-
-  if (hasLegacyConfig) {
-    return [{
-      id: 'mysql-1',
-      name: 'MySQL - 1',
-      host: String(kwargsMap.get('host') || ''),
-      port: parseMysqlInt(kwargsMap.get('port'), 3306),
-      database: String(kwargsMap.get('database') || ''),
-      user: String(kwargsMap.get('user') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      charset: String(kwargsMap.get('charset') || 'utf8mb4'),
-      collation: String(kwargsMap.get('collation') || 'utf8mb4_unicode_ci'),
-      ssl: parseMysqlBoolean(kwargsMap.get('ssl')),
-      ssl_ca: String(kwargsMap.get('ssl_ca') || ''),
-      ssl_cert: String(kwargsMap.get('ssl_cert') || ''),
-      ssl_key: String(kwargsMap.get('ssl_key') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultMysqlInstance('MySQL - 1')];
-};
-
-const serializeMysqlToolConfig = (instances: MysqlInstanceFormValue[]): ToolVariable[] => {
-  const normalizedInstances = instances.map((instance) => {
-    const normalizedInstance = { ...instance };
-    delete normalizedInstance.testStatus;
-    return normalizedInstance;
-  });
-  return [
-    { key: MYSQL_INSTANCES_KEY, value: JSON.stringify(normalizedInstances) },
-    { key: MYSQL_DEFAULT_INSTANCE_ID_KEY, value: normalizedInstances[0]?.id || '' },
-  ];
-};
-
 const isMysqlTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === MYSQL_TOOL_NAME;
-
-const ORACLE_TOOL_NAME = 'oracle';
-const ORACLE_INSTANCES_KEY = 'oracle_instances';
-const ORACLE_DEFAULT_INSTANCE_ID_KEY = 'oracle_default_instance_id';
-const ORACLE_AUTO_NAME_PREFIX = 'Oracle - ';
-
-const createOracleInstanceId = () => `oracle-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultOracleInstance = (name: string): OracleInstanceFormValue => ({
-  id: createOracleInstanceId(),
-  name,
-  host: '',
-  port: 1521,
-  service_name: '',
-  user: '',
-  password: '',
-  nls_lang: '',
-  testStatus: 'untested',
-});
-
-const getNextOracleInstanceName = (instances: OracleInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^Oracle - (\d+)$/);
-    if (!match) {
-      return max;
-    }
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${ORACLE_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseOracleInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) {
-    return value as Record<string, unknown>[];
-  }
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  return [];
-};
-
-const parseOracleInt = (value: unknown, defaultValue: number) => {
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? defaultValue : parsed;
-  }
-  return defaultValue;
-};
-
-const parseOracleToolConfig = (kwargs: ToolVariable[] = []): OracleInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(ORACLE_INSTANCES_KEY);
-  const parsedInstances = parseOracleInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `oracle-${index + 1}`),
-      name: String(item.name || `${ORACLE_AUTO_NAME_PREFIX}${index + 1}`),
-      host: String(item.host || ''),
-      port: parseOracleInt(item.port, 1521),
-      service_name: String(item.service_name || ''),
-      user: String(item.user || ''),
-      password: String(item.password || ''),
-      nls_lang: String(item.nls_lang || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['host', 'port', 'service_name', 'user', 'password']
-    .some((key) => kwargsMap.has(key));
-
-  if (hasLegacyConfig) {
-    return [{
-      id: 'oracle-1',
-      name: 'Oracle - 1',
-      host: String(kwargsMap.get('host') || ''),
-      port: parseOracleInt(kwargsMap.get('port'), 1521),
-      service_name: String(kwargsMap.get('service_name') || ''),
-      user: String(kwargsMap.get('user') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      nls_lang: String(kwargsMap.get('nls_lang') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultOracleInstance('Oracle - 1')];
-};
-
-const serializeOracleToolConfig = (instances: OracleInstanceFormValue[]): ToolVariable[] => {
-  const normalizedInstances = instances.map((instance) => {
-    const normalizedInstance = { ...instance };
-    delete normalizedInstance.testStatus;
-    return normalizedInstance;
-  });
-  return [
-    { key: ORACLE_INSTANCES_KEY, value: JSON.stringify(normalizedInstances) },
-    { key: ORACLE_DEFAULT_INSTANCE_ID_KEY, value: normalizedInstances[0]?.id || '' },
-  ];
-};
-
 const isOracleTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === ORACLE_TOOL_NAME;
-
-const MSSQL_TOOL_NAME = 'mssql';
-const MSSQL_INSTANCES_KEY = 'mssql_instances';
-const MSSQL_DEFAULT_INSTANCE_ID_KEY = 'mssql_default_instance_id';
-const MSSQL_AUTO_NAME_PREFIX = 'MSSQL - ';
-
-const createMssqlInstanceId = () => `mssql-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultMssqlInstance = (name: string): MssqlInstanceFormValue => ({
-  id: createMssqlInstanceId(),
-  name,
-  host: '',
-  port: 1433,
-  database: 'master',
-  user: '',
-  password: '',
-  testStatus: 'untested',
-});
-
-const getNextMssqlInstanceName = (instances: MssqlInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^MSSQL - (\d+)$/);
-    if (!match) {
-      return max;
-    }
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${MSSQL_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseMssqlInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) {
-    return value as Record<string, unknown>[];
-  }
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch {
-      return [];
-    }
-  }
-  return [];
-};
-
-const parseMssqlInt = (value: unknown, defaultValue: number) => {
-  if (typeof value === 'number') {
-    return value;
-  }
-  if (typeof value === 'string') {
-    const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? defaultValue : parsed;
-  }
-  return defaultValue;
-};
-
-const parseMssqlToolConfig = (kwargs: ToolVariable[] = []): MssqlInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(MSSQL_INSTANCES_KEY);
-  const parsedInstances = parseMssqlInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `mssql-${index + 1}`),
-      name: String(item.name || `${MSSQL_AUTO_NAME_PREFIX}${index + 1}`),
-      host: String(item.host || ''),
-      port: parseMssqlInt(item.port, 1433),
-      database: String(item.database || 'master'),
-      user: String(item.user || ''),
-      password: String(item.password || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['host', 'port', 'database', 'user', 'password']
-    .some((key) => kwargsMap.has(key));
-
-  if (hasLegacyConfig) {
-    return [{
-      id: 'mssql-1',
-      name: 'MSSQL - 1',
-      host: String(kwargsMap.get('host') || ''),
-      port: parseMssqlInt(kwargsMap.get('port'), 1433),
-      database: String(kwargsMap.get('database') || 'master'),
-      user: String(kwargsMap.get('user') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultMssqlInstance('MSSQL - 1')];
-};
-
-const serializeMssqlToolConfig = (instances: MssqlInstanceFormValue[]): ToolVariable[] => {
-  const normalizedInstances = instances.map((instance) => {
-    const normalizedInstance = { ...instance };
-    delete normalizedInstance.testStatus;
-    return normalizedInstance;
-  });
-  return [
-    { key: MSSQL_INSTANCES_KEY, value: JSON.stringify(normalizedInstances) },
-    { key: MSSQL_DEFAULT_INSTANCE_ID_KEY, value: normalizedInstances[0]?.id || '' },
-  ];
-};
-
 const isMssqlTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === MSSQL_TOOL_NAME;
-
-// ── PostgreSQL ────────────────────────────────────────────────────────────────
-
-const POSTGRES_TOOL_NAME = 'postgres';
-const POSTGRES_INSTANCES_KEY = 'postgres_instances';
-const POSTGRES_DEFAULT_INSTANCE_ID_KEY = 'postgres_default_instance_id';
-const POSTGRES_AUTO_NAME_PREFIX = 'PostgreSQL - ';
-
-const createPostgresInstanceId = () => `postgres-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultPostgresInstance = (name: string): PostgresInstanceFormValue => ({
-  id: createPostgresInstanceId(),
-  name,
-  host: '',
-  port: 5432,
-  database: 'postgres',
-  user: '',
-  password: '',
-  testStatus: 'untested',
-});
-
-const getNextPostgresInstanceName = (instances: PostgresInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^PostgreSQL - (\d+)$/);
-    if (!match) return max;
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${POSTGRES_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parsePostgresInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) return value as Record<string, unknown>[];
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch { return []; }
-  }
-  return [];
-};
-
-const parsePostgresInt = (value: unknown, defaultValue: number) => {
-  if (typeof value === 'number') return value;
-  if (typeof value === 'string') {
-    const parsed = parseInt(value, 10);
-    return isNaN(parsed) ? defaultValue : parsed;
-  }
-  return defaultValue;
-};
-
-const parsePostgresToolConfig = (kwargs: ToolVariable[] = []): PostgresInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(POSTGRES_INSTANCES_KEY);
-  const parsedInstances = parsePostgresInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `postgres-${index + 1}`),
-      name: String(item.name || `${POSTGRES_AUTO_NAME_PREFIX}${index + 1}`),
-      host: String(item.host || ''),
-      port: parsePostgresInt(item.port, 5432),
-      database: String(item.database || 'postgres'),
-      user: String(item.user || ''),
-      password: String(item.password || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['host', 'port', 'database', 'user', 'password'].some((key) => kwargsMap.has(key));
-  if (hasLegacyConfig) {
-    return [{
-      id: 'postgres-1',
-      name: 'PostgreSQL - 1',
-      host: String(kwargsMap.get('host') || ''),
-      port: parsePostgresInt(kwargsMap.get('port'), 5432),
-      database: String(kwargsMap.get('database') || 'postgres'),
-      user: String(kwargsMap.get('user') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultPostgresInstance('PostgreSQL - 1')];
-};
-
-const serializePostgresToolConfig = (instances: PostgresInstanceFormValue[]): ToolVariable[] => {
-  const normalized = instances.map((instance) => {
-    const copy = { ...instance };
-    delete copy.testStatus;
-    return copy;
-  });
-  return [
-    { key: POSTGRES_INSTANCES_KEY, value: JSON.stringify(normalized) },
-    { key: POSTGRES_DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' },
-  ];
-};
-
 const isPostgresTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === POSTGRES_TOOL_NAME;
-
-// ── Elasticsearch ─────────────────────────────────────────────────────────────
-
-const ES_TOOL_NAME = 'elasticsearch';
-const ES_INSTANCES_KEY = 'es_instances';
-const ES_DEFAULT_INSTANCE_ID_KEY = 'es_default_instance_id';
-const ES_AUTO_NAME_PREFIX = 'Elasticsearch - ';
-
-const createEsInstanceId = () => `es-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultEsInstance = (name: string): ElasticsearchInstanceFormValue => ({
-  id: createEsInstanceId(),
-  name,
-  url: '',
-  username: '',
-  password: '',
-  api_key: '',
-  verify_certs: true,
-  testStatus: 'untested',
-});
-
-const getNextEsInstanceName = (instances: ElasticsearchInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^Elasticsearch - (\d+)$/);
-    if (!match) return max;
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${ES_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseEsInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) return value as Record<string, unknown>[];
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch { return []; }
-  }
-  return [];
-};
-
-const parseEsBoolean = (value: unknown, defaultValue = true) => {
-  if (typeof value === 'boolean') return value;
-  if (typeof value === 'string') return !['false', '0', 'no', 'off'].includes(value.toLowerCase());
-  return defaultValue;
-};
-
-const parseEsToolConfig = (kwargs: ToolVariable[] = []): ElasticsearchInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(ES_INSTANCES_KEY);
-  const parsedInstances = parseEsInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `es-${index + 1}`),
-      name: String(item.name || `${ES_AUTO_NAME_PREFIX}${index + 1}`),
-      url: String(item.url || ''),
-      username: String(item.username || ''),
-      password: String(item.password || ''),
-      api_key: String(item.api_key || ''),
-      verify_certs: parseEsBoolean(item.verify_certs),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['url', 'username', 'password', 'api_key'].some((key) => kwargsMap.has(key));
-  if (hasLegacyConfig) {
-    return [{
-      id: 'es-1',
-      name: 'Elasticsearch - 1',
-      url: String(kwargsMap.get('url') || ''),
-      username: String(kwargsMap.get('username') || ''),
-      password: String(kwargsMap.get('password') || ''),
-      api_key: String(kwargsMap.get('api_key') || ''),
-      verify_certs: parseEsBoolean(kwargsMap.get('verify_certs')),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultEsInstance('Elasticsearch - 1')];
-};
-
-const serializeEsToolConfig = (instances: ElasticsearchInstanceFormValue[]): ToolVariable[] => {
-  const normalized = instances.map((instance) => {
-    const copy = { ...instance };
-    delete copy.testStatus;
-    return copy;
-  });
-  return [
-    { key: ES_INSTANCES_KEY, value: JSON.stringify(normalized) },
-    { key: ES_DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' },
-  ];
-};
-
 const isEsTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === ES_TOOL_NAME;
-
-// ── Jenkins ───────────────────────────────────────────────────────────────────
-
-const JENKINS_TOOL_NAME = 'jenkins';
-const JENKINS_INSTANCES_KEY = 'jenkins_instances';
-const JENKINS_DEFAULT_INSTANCE_ID_KEY = 'jenkins_default_instance_id';
-const JENKINS_AUTO_NAME_PREFIX = 'Jenkins - ';
-
-const createJenkinsInstanceId = () => `jenkins-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultJenkinsInstance = (name: string): JenkinsInstanceFormValue => ({
-  id: createJenkinsInstanceId(),
-  name,
-  jenkins_url: '',
-  jenkins_username: '',
-  jenkins_password: '',
-  testStatus: 'untested',
-});
-
-const getNextJenkinsInstanceName = (instances: JenkinsInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^Jenkins - (\d+)$/);
-    if (!match) return max;
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${JENKINS_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseJenkinsInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) return value as Record<string, unknown>[];
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch { return []; }
-  }
-  return [];
-};
-
-const parseJenkinsToolConfig = (kwargs: ToolVariable[] = []): JenkinsInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(JENKINS_INSTANCES_KEY);
-  const parsedInstances = parseJenkinsInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `jenkins-${index + 1}`),
-      name: String(item.name || `${JENKINS_AUTO_NAME_PREFIX}${index + 1}`),
-      jenkins_url: String(item.jenkins_url || ''),
-      jenkins_username: String(item.jenkins_username || ''),
-      jenkins_password: String(item.jenkins_password || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['jenkins_url', 'jenkins_username', 'jenkins_password'].some((key) => kwargsMap.has(key));
-  if (hasLegacyConfig) {
-    return [{
-      id: 'jenkins-1',
-      name: 'Jenkins - 1',
-      jenkins_url: String(kwargsMap.get('jenkins_url') || ''),
-      jenkins_username: String(kwargsMap.get('jenkins_username') || ''),
-      jenkins_password: String(kwargsMap.get('jenkins_password') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultJenkinsInstance('Jenkins - 1')];
-};
-
-const serializeJenkinsToolConfig = (instances: JenkinsInstanceFormValue[]): ToolVariable[] => {
-  const normalized = instances.map((instance) => {
-    const copy = { ...instance };
-    delete copy.testStatus;
-    return copy;
-  });
-  return [
-    { key: JENKINS_INSTANCES_KEY, value: JSON.stringify(normalized) },
-    { key: JENKINS_DEFAULT_INSTANCE_ID_KEY, value: normalized[0]?.id || '' },
-  ];
-};
-
 const isJenkinsTool = (tool?: SelectTool | null) => (tool?.rawName || tool?.name) === JENKINS_TOOL_NAME;
-
-// ── Kubernetes ────────────────────────────────────────────────────────────────
-
-const KUBERNETES_TOOL_NAMES = new Set(['kubernetes', 'kubernetes_data_collection']);
-const KUBERNETES_INSTANCES_KEY = 'kubernetes_instances';
-const KUBERNETES_AUTO_NAME_PREFIX = 'Kubernetes - ';
-
-const createKubernetesInstanceId = () => `kubernetes-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-
-const getDefaultKubernetesInstance = (name: string): KubernetesInstanceFormValue => ({
-  id: createKubernetesInstanceId(),
-  name,
-  kubeconfig_data: '',
-  testStatus: 'untested',
-});
-
-const getNextKubernetesInstanceName = (instances: KubernetesInstanceFormValue[]) => {
-  const maxIndex = instances.reduce((max, instance) => {
-    const match = instance.name.match(/^Kubernetes - (\d+)$/);
-    if (!match) return max;
-    return Math.max(max, Number(match[1]));
-  }, 0);
-  return `${KUBERNETES_AUTO_NAME_PREFIX}${maxIndex + 1}`;
-};
-
-const parseKubernetesInstancesValue = (value: unknown): Record<string, unknown>[] => {
-  if (Array.isArray(value)) return value as Record<string, unknown>[];
-  if (typeof value === 'string' && value.trim()) {
-    try {
-      const parsed = JSON.parse(value);
-      return Array.isArray(parsed) ? parsed : [];
-    } catch { return []; }
-  }
-  return [];
-};
-
-const parseKubernetesToolConfig = (kwargs: ToolVariable[] = []): KubernetesInstanceFormValue[] => {
-  const kwargsMap = new Map(kwargs.filter((item) => item.key).map((item) => [item.key, item.value]));
-  const instancesValue = kwargsMap.get(KUBERNETES_INSTANCES_KEY);
-  const parsedInstances = parseKubernetesInstancesValue(instancesValue);
-
-  if (parsedInstances.length > 0) {
-    return parsedInstances.map((item, index) => ({
-      id: String(item.id || `kubernetes-${index + 1}`),
-      name: String(item.name || `${KUBERNETES_AUTO_NAME_PREFIX}${index + 1}`),
-      kubeconfig_data: String(item.kubeconfig_data || ''),
-      testStatus: 'untested',
-    }));
-  }
-
-  const hasLegacyConfig = ['kubeconfig_data'].some((key) => kwargsMap.has(key));
-  if (hasLegacyConfig) {
-    return [{
-      id: 'kubernetes-1',
-      name: 'Kubernetes - 1',
-      kubeconfig_data: String(kwargsMap.get('kubeconfig_data') || ''),
-      testStatus: 'untested',
-    }];
-  }
-
-  return [getDefaultKubernetesInstance('Kubernetes - 1')];
-};
-
-const serializeKubernetesToolConfig = (instances: KubernetesInstanceFormValue[]): ToolVariable[] => {
-  const normalized = instances.map((instance) => {
-    const copy = { ...instance };
-    delete copy.testStatus;
-    return copy;
-  });
-  return [{ key: KUBERNETES_INSTANCES_KEY, value: JSON.stringify(normalized) }];
-};
-
 const isKubernetesTool = (tool?: SelectTool | null) => {
   const toolName = tool?.rawName || tool?.name;
   return toolName ? KUBERNETES_TOOL_NAMES.has(toolName) : false;
 };
+const isDbTool = (tool?: SelectTool | null) =>
+  isRedisTool(tool) || isMysqlTool(tool) || isOracleTool(tool) || isMssqlTool(tool) ||
+  isPostgresTool(tool) || isEsTool(tool) || isJenkinsTool(tool) || isKubernetesTool(tool);
 
 const isSameToolVariant = (tool?: SelectTool | null, defaultTool?: SelectTool | null) => {
-  if (!tool || !defaultTool) {
-    return false;
-  }
+  if (!tool || !defaultTool) return false;
   return (tool.rawName || tool.name) === (defaultTool.rawName || defaultTool.name);
 };
 
+// ── component ─────────────────────────────────────────────────────────────────
 interface ToolSelectorProps {
   defaultTools: SelectTool[];
   onChange: (selected: SelectTool[]) => void;
@@ -860,38 +63,24 @@ interface ToolSelectorProps {
 
 const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) => {
   const { t } = useTranslation();
-  const { fetchSkillTools, testRedisConnection, testMysqlConnection, testOracleConnection, testMssqlConnection, testPostgresConnection, testEsConnection, testJenkinsConnection, testKubernetesConnection } = useSkillApi();
+  const { fetchSkillTools } = useSkillApi();
   const [loading, setLoading] = useState<boolean>(false);
   const [modalVisible, setModalVisible] = useState(false);
   const [tools, setTools] = useState<SelectTool[]>([]);
   const [selectedTools, setSelectedTools] = useState<SelectTool[]>([]);
   const [editModalVisible, setEditModalVisible] = useState(false);
   const [editingTool, setEditingTool] = useState<SelectTool | null>(null);
-  const [redisInstances, setRedisInstances] = useState<RedisInstanceFormValue[]>([]);
-  const [selectedRedisInstanceId, setSelectedRedisInstanceId] = useState<string | null>(null);
-  const [testingRedisConnection, setTestingRedisConnection] = useState(false);
-  const [mysqlInstances, setMysqlInstances] = useState<MysqlInstanceFormValue[]>([]);
-  const [selectedMysqlInstanceId, setSelectedMysqlInstanceId] = useState<string | null>(null);
-  const [testingMysqlConnection, setTestingMysqlConnection] = useState(false);
-  const [oracleInstances, setOracleInstances] = useState<OracleInstanceFormValue[]>([]);
-  const [selectedOracleInstanceId, setSelectedOracleInstanceId] = useState<string | null>(null);
-  const [testingOracleConnection, setTestingOracleConnection] = useState(false);
-  const [mssqlInstances, setMssqlInstances] = useState<MssqlInstanceFormValue[]>([]);
-  const [selectedMssqlInstanceId, setSelectedMssqlInstanceId] = useState<string | null>(null);
-  const [testingMssqlConnection, setTestingMssqlConnection] = useState(false);
-  const [postgresInstances, setPostgresInstances] = useState<PostgresInstanceFormValue[]>([]);
-  const [selectedPostgresInstanceId, setSelectedPostgresInstanceId] = useState<string | null>(null);
-  const [testingPostgresConnection, setTestingPostgresConnection] = useState(false);
-  const [esInstances, setEsInstances] = useState<ElasticsearchInstanceFormValue[]>([]);
-  const [selectedEsInstanceId, setSelectedEsInstanceId] = useState<string | null>(null);
-  const [testingEsConnection, setTestingEsConnection] = useState(false);
-  const [jenkinsInstances, setJenkinsInstances] = useState<JenkinsInstanceFormValue[]>([]);
-  const [selectedJenkinsInstanceId, setSelectedJenkinsInstanceId] = useState<string | null>(null);
-  const [testingJenkinsConnection, setTestingJenkinsConnection] = useState(false);
-  const [kubernetesInstances, setKubernetesInstances] = useState<KubernetesInstanceFormValue[]>([]);
-  const [selectedKubernetesInstanceId, setSelectedKubernetesInstanceId] = useState<string | null>(null);
-  const [testingKubernetesConnection, setTestingKubernetesConnection] = useState(false);
   const [form] = Form.useForm();
+
+  // refs to each DB editor's imperative save handle
+  const redisRef = useRef<RedisToolEditorHandle>(null);
+  const mysqlRef = useRef<MysqlToolEditorHandle>(null);
+  const oracleRef = useRef<OracleToolEditorHandle>(null);
+  const mssqlRef = useRef<MssqlToolEditorHandle>(null);
+  const postgresRef = useRef<PostgresToolEditorHandle>(null);
+  const esRef = useRef<ElasticsearchToolEditorHandle>(null);
+  const jenkinsRef = useRef<JenkinsToolEditorHandle>(null);
+  const kubernetesRef = useRef<KubernetesToolEditorHandle>(null);
 
   const commitSelectedTools = (nextTools: SelectTool[]) => {
     const normalizedTools = normalizeMonitorToolConfigs(nextTools);
@@ -956,13 +145,8 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
             || (isEsTool(tool) ? defaultEsTool : undefined)
             || (isJenkinsTool(tool) ? defaultJenkinsTool : undefined)
             || (isKubernetesTool(tool) && isSameToolVariant(tool, defaultKubernetesTool) ? defaultKubernetesTool : undefined);
-          if (!matchedDefaultTool) {
-            return tool;
-          }
-          return {
-            ...tool,
-            kwargs: matchedDefaultTool.kwargs?.length ? matchedDefaultTool.kwargs : tool.kwargs,
-          };
+          if (!matchedDefaultTool) return tool;
+          return { ...tool, kwargs: matchedDefaultTool.kwargs?.length ? matchedDefaultTool.kwargs : tool.kwargs };
         });
       commitSelectedTools(initialSelectedTools);
     } catch (error) {
@@ -972,9 +156,7 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
     }
   };
 
-  const openModal = () => {
-    setModalVisible(true);
-  };
+  const openModal = () => setModalVisible(true);
 
   const handleModalConfirm = (selectedIds: number[]) => {
     const updatedSelectedTools = tools.filter((tool) => selectedIds.includes(tool.id));
@@ -982,9 +164,7 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
     setModalVisible(false);
   };
 
-  const handleModalCancel = () => {
-    setModalVisible(false);
-  };
+  const handleModalCancel = () => setModalVisible(false);
 
   const removeSelectedTool = (toolId: number) => {
     const updatedSelectedTools = selectedTools.filter((tool) => tool.id !== toolId);
@@ -996,44 +176,23 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
     setEditingTool(normalizedTool);
     if (isMonitorToolConfig(normalizedTool)) {
       form.setFieldsValue({ kwargs: [] });
-    } else if (isRedisTool(normalizedTool)) {
-      const instances = parseRedisToolConfig(normalizedTool.kwargs);
-      setRedisInstances(instances);
-      setSelectedRedisInstanceId(instances[0]?.id || null);
-    } else if (isMysqlTool(normalizedTool)) {
-      const instances = parseMysqlToolConfig(normalizedTool.kwargs);
-      setMysqlInstances(instances);
-      setSelectedMysqlInstanceId(instances[0]?.id || null);
-    } else if (isOracleTool(normalizedTool)) {
-      const instances = parseOracleToolConfig(normalizedTool.kwargs);
-      setOracleInstances(instances);
-      setSelectedOracleInstanceId(instances[0]?.id || null);
-    } else if (isMssqlTool(normalizedTool)) {
-      const instances = parseMssqlToolConfig(normalizedTool.kwargs);
-      setMssqlInstances(instances);
-      setSelectedMssqlInstanceId(instances[0]?.id || null);
-    } else if (isPostgresTool(normalizedTool)) {
-      const instances = parsePostgresToolConfig(normalizedTool.kwargs);
-      setPostgresInstances(instances);
-      setSelectedPostgresInstanceId(instances[0]?.id || null);
-    } else if (isEsTool(normalizedTool)) {
-      const instances = parseEsToolConfig(normalizedTool.kwargs);
-      setEsInstances(instances);
-      setSelectedEsInstanceId(instances[0]?.id || null);
-    } else if (isJenkinsTool(normalizedTool)) {
-      const instances = parseJenkinsToolConfig(normalizedTool.kwargs);
-      setJenkinsInstances(instances);
-      setSelectedJenkinsInstanceId(instances[0]?.id || null);
-    } else if (isKubernetesTool(normalizedTool)) {
-      const instances = parseKubernetesToolConfig(normalizedTool.kwargs);
-      setKubernetesInstances(instances);
-      setSelectedKubernetesInstanceId(instances[0]?.id || null);
-    } else {
+    } else if (!isDbTool(normalizedTool)) {
       form.setFieldsValue({
         kwargs: normalizedTool.kwargs?.map((item) => ({ key: item.key, value: item.value, type: item.type, isRequired: item.isRequired })) || [],
       });
     }
     setEditModalVisible(true);
+  };
+
+  /** Called by each DB editor via onSave callback — updates selectedTools and closes modal */
+  const handleDbToolSaved = (kwargs: ToolVariable[]) => {
+    if (editingTool) {
+      const updatedTool = { ...editingTool, kwargs };
+      const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
+      commitSelectedTools(updatedSelectedTools);
+    }
+    setEditModalVisible(false);
+    setEditingTool(null);
   };
 
   const handleEditModalOk = () => {
@@ -1049,264 +208,20 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
       return;
     }
 
-    if (isRedisTool(editingTool)) {
-      const trimmedNames = redisInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (redisInstances.length === 0) {
-        message.error(t('tool.redis.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== redisInstances.length) {
-        message.error(t('tool.redis.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.redis.duplicateInstanceName'));
-        return;
-      }
-      if (redisInstances.some((instance) => !instance.url.trim())) {
-        message.error(t('tool.redis.urlRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeRedisToolConfig(redisInstances.map((instance) => ({ ...instance, name: instance.name.trim(), url: instance.url.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
+    // For DB tools, delegate to the editor's imperative save (validation + serialization inside)
+    if (isRedisTool(editingTool)) { redisRef.current?.save(); return; }
+    if (isMysqlTool(editingTool)) { mysqlRef.current?.save(); return; }
+    if (isOracleTool(editingTool)) { oracleRef.current?.save(); return; }
+    if (isMssqlTool(editingTool)) { mssqlRef.current?.save(); return; }
+    if (isPostgresTool(editingTool)) { postgresRef.current?.save(); return; }
+    if (isEsTool(editingTool)) { esRef.current?.save(); return; }
+    if (isJenkinsTool(editingTool)) { jenkinsRef.current?.save(); return; }
+    if (isKubernetesTool(editingTool)) { kubernetesRef.current?.save(); return; }
 
-    if (isMysqlTool(editingTool)) {
-      const trimmedNames = mysqlInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (mysqlInstances.length === 0) {
-        message.error(t('tool.mysql.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== mysqlInstances.length) {
-        message.error(t('tool.mysql.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.mysql.duplicateInstanceName'));
-        return;
-      }
-      if (mysqlInstances.some((instance) => !instance.host.trim())) {
-        message.error(t('tool.mysql.hostRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeMysqlToolConfig(mysqlInstances.map((instance) => ({ ...instance, name: instance.name.trim(), host: instance.host.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isOracleTool(editingTool)) {
-      const trimmedNames = oracleInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (oracleInstances.length === 0) {
-        message.error(t('tool.oracle.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== oracleInstances.length) {
-        message.error(t('tool.oracle.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.oracle.duplicateInstanceName'));
-        return;
-      }
-      if (oracleInstances.some((instance) => !instance.host.trim())) {
-        message.error(t('tool.oracle.hostRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeOracleToolConfig(oracleInstances.map((instance) => ({ ...instance, name: instance.name.trim(), host: instance.host.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isMssqlTool(editingTool)) {
-      const trimmedNames = mssqlInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (mssqlInstances.length === 0) {
-        message.error(t('tool.mssql.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== mssqlInstances.length) {
-        message.error(t('tool.mssql.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.mssql.duplicateInstanceName'));
-        return;
-      }
-      if (mssqlInstances.some((instance) => !instance.host.trim())) {
-        message.error(t('tool.mssql.hostRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeMssqlToolConfig(mssqlInstances.map((instance) => ({ ...instance, name: instance.name.trim(), host: instance.host.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isPostgresTool(editingTool)) {
-      const trimmedNames = postgresInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (postgresInstances.length === 0) {
-        message.error(t('tool.postgres.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== postgresInstances.length) {
-        message.error(t('tool.postgres.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.postgres.duplicateInstanceName'));
-        return;
-      }
-      if (postgresInstances.some((instance) => !instance.host.trim())) {
-        message.error(t('tool.postgres.hostRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializePostgresToolConfig(postgresInstances.map((instance) => ({ ...instance, name: instance.name.trim(), host: instance.host.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isEsTool(editingTool)) {
-      const trimmedNames = esInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (esInstances.length === 0) {
-        message.error(t('tool.elasticsearch.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== esInstances.length) {
-        message.error(t('tool.elasticsearch.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.elasticsearch.duplicateInstanceName'));
-        return;
-      }
-      if (esInstances.some((instance) => !instance.url.trim())) {
-        message.error(t('tool.elasticsearch.urlRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeEsToolConfig(esInstances.map((instance) => ({ ...instance, name: instance.name.trim(), url: instance.url.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isJenkinsTool(editingTool)) {
-      const trimmedNames = jenkinsInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (jenkinsInstances.length === 0) {
-        message.error(t('tool.jenkins.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== jenkinsInstances.length) {
-        message.error(t('tool.jenkins.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.jenkins.duplicateInstanceName'));
-        return;
-      }
-      if (jenkinsInstances.some((instance) => !instance.jenkins_url.trim())) {
-        message.error(t('tool.jenkins.urlRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeJenkinsToolConfig(jenkinsInstances.map((instance) => ({ ...instance, name: instance.name.trim(), jenkins_url: instance.jenkins_url.trim() }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
-    if (isKubernetesTool(editingTool)) {
-      const trimmedNames = kubernetesInstances.map((instance) => instance.name.trim()).filter(Boolean);
-      if (kubernetesInstances.length === 0) {
-        message.error(t('tool.kubernetes.noInstances'));
-        return;
-      }
-      if (trimmedNames.length !== kubernetesInstances.length) {
-        message.error(t('tool.kubernetes.instanceNameRequired'));
-        return;
-      }
-      if (new Set(trimmedNames).size !== trimmedNames.length) {
-        message.error(t('tool.kubernetes.duplicateInstanceName'));
-        return;
-      }
-      if (kubernetesInstances.some((instance) => !instance.kubeconfig_data.trim())) {
-        message.error(t('tool.kubernetes.kubeconfigDataRequired'));
-        return;
-      }
-      if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: serializeKubernetesToolConfig(kubernetesInstances.map((instance) => ({
-            ...instance,
-            name: instance.name.trim(),
-            kubeconfig_data: instance.kubeconfig_data.trim(),
-          }))),
-        };
-        const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
-        commitSelectedTools(updatedSelectedTools);
-      }
-      setEditModalVisible(false);
-      setEditingTool(null);
-      return;
-    }
-
+    // Generic form-based tool
     form.validateFields().then((values) => {
       if (editingTool) {
-        const updatedTool = {
-          ...editingTool,
-          kwargs: values.kwargs,
-        };
+        const updatedTool = { ...editingTool, kwargs: values.kwargs };
         const updatedSelectedTools = selectedTools.map((tool) => (tool.id === editingTool.id ? updatedTool : tool));
         commitSelectedTools(updatedSelectedTools);
       }
@@ -1318,406 +233,6 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
   const handleEditModalCancel = () => {
     setEditModalVisible(false);
     setEditingTool(null);
-    setRedisInstances([]);
-    setSelectedRedisInstanceId(null);
-    setMysqlInstances([]);
-    setSelectedMysqlInstanceId(null);
-    setOracleInstances([]);
-    setSelectedOracleInstanceId(null);
-    setMssqlInstances([]);
-    setSelectedMssqlInstanceId(null);
-    setPostgresInstances([]);
-    setSelectedPostgresInstanceId(null);
-    setEsInstances([]);
-    setSelectedEsInstanceId(null);
-    setJenkinsInstances([]);
-    setSelectedJenkinsInstanceId(null);
-    setKubernetesInstances([]);
-    setSelectedKubernetesInstanceId(null);
-  };
-
-  const handleAddRedisInstance = () => {
-    const nextInstance = getDefaultRedisInstance(getNextRedisInstanceName(redisInstances));
-    setRedisInstances((prev) => [...prev, nextInstance]);
-    setSelectedRedisInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteRedisInstance = (instanceId: string) => {
-    setRedisInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedRedisInstanceId === instanceId) {
-        setSelectedRedisInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleRedisInstanceChange = <K extends keyof RedisInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: RedisInstanceFormValue[K],
-  ) => {
-    setRedisInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestRedisInstance = async () => {
-    const currentInstance = redisInstances.find((instance) => instance.id === selectedRedisInstanceId);
-    if (!currentInstance) {
-      return;
-    }
-    setTestingRedisConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testRedisConnection(payload);
-      message.success(t('tool.redis.status.success'));
-      setRedisInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setRedisInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingRedisConnection(false);
-    }
-  };
-
-  const handleAddMysqlInstance = () => {
-    const nextInstance = getDefaultMysqlInstance(getNextMysqlInstanceName(mysqlInstances));
-    setMysqlInstances((prev) => [...prev, nextInstance]);
-    setSelectedMysqlInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteMysqlInstance = (instanceId: string) => {
-    setMysqlInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedMysqlInstanceId === instanceId) {
-        setSelectedMysqlInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleMysqlInstanceChange = <K extends keyof MysqlInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: MysqlInstanceFormValue[K],
-  ) => {
-    setMysqlInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestMysqlInstance = async () => {
-    const currentInstance = mysqlInstances.find((instance) => instance.id === selectedMysqlInstanceId);
-    if (!currentInstance) {
-      return;
-    }
-    setTestingMysqlConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testMysqlConnection(payload);
-      message.success(t('tool.mysql.status.success'));
-      setMysqlInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setMysqlInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingMysqlConnection(false);
-    }
-  };
-
-  const handleAddOracleInstance = () => {
-    const nextInstance = getDefaultOracleInstance(getNextOracleInstanceName(oracleInstances));
-    setOracleInstances((prev) => [...prev, nextInstance]);
-    setSelectedOracleInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteOracleInstance = (instanceId: string) => {
-    setOracleInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedOracleInstanceId === instanceId) {
-        setSelectedOracleInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleOracleInstanceChange = <K extends keyof OracleInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: OracleInstanceFormValue[K],
-  ) => {
-    setOracleInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestOracleInstance = async () => {
-    const currentInstance = oracleInstances.find((instance) => instance.id === selectedOracleInstanceId);
-    if (!currentInstance) {
-      return;
-    }
-    setTestingOracleConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testOracleConnection(payload);
-      message.success(t('tool.oracle.status.success'));
-      setOracleInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setOracleInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingOracleConnection(false);
-    }
-  };
-
-  const handleAddMssqlInstance = () => {
-    const nextInstance = getDefaultMssqlInstance(getNextMssqlInstanceName(mssqlInstances));
-    setMssqlInstances((prev) => [...prev, nextInstance]);
-    setSelectedMssqlInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteMssqlInstance = (instanceId: string) => {
-    setMssqlInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedMssqlInstanceId === instanceId) {
-        setSelectedMssqlInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleMssqlInstanceChange = <K extends keyof MssqlInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: MssqlInstanceFormValue[K],
-  ) => {
-    setMssqlInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestMssqlInstance = async () => {
-    const currentInstance = mssqlInstances.find((instance) => instance.id === selectedMssqlInstanceId);
-    if (!currentInstance) {
-      return;
-    }
-    setTestingMssqlConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testMssqlConnection(payload);
-      message.success(t('tool.mssql.status.success'));
-      setMssqlInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setMssqlInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingMssqlConnection(false);
-    }
-  };
-
-  const handleAddPostgresInstance = () => {
-    const nextInstance = getDefaultPostgresInstance(getNextPostgresInstanceName(postgresInstances));
-    setPostgresInstances((prev) => [...prev, nextInstance]);
-    setSelectedPostgresInstanceId(nextInstance.id);
-  };
-
-  const handleDeletePostgresInstance = (instanceId: string) => {
-    setPostgresInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedPostgresInstanceId === instanceId) {
-        setSelectedPostgresInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handlePostgresInstanceChange = <K extends keyof PostgresInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: PostgresInstanceFormValue[K],
-  ) => {
-    setPostgresInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestPostgresInstance = async () => {
-    const currentInstance = postgresInstances.find((instance) => instance.id === selectedPostgresInstanceId);
-    if (!currentInstance) return;
-    setTestingPostgresConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testPostgresConnection(payload);
-      message.success(t('tool.postgres.status.success'));
-      setPostgresInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setPostgresInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingPostgresConnection(false);
-    }
-  };
-
-  const handleAddEsInstance = () => {
-    const nextInstance = getDefaultEsInstance(getNextEsInstanceName(esInstances));
-    setEsInstances((prev) => [...prev, nextInstance]);
-    setSelectedEsInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteEsInstance = (instanceId: string) => {
-    setEsInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedEsInstanceId === instanceId) {
-        setSelectedEsInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleEsInstanceChange = <K extends keyof ElasticsearchInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: ElasticsearchInstanceFormValue[K],
-  ) => {
-    setEsInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestEsInstance = async () => {
-    const currentInstance = esInstances.find((instance) => instance.id === selectedEsInstanceId);
-    if (!currentInstance) return;
-    setTestingEsConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testEsConnection(payload);
-      message.success(t('tool.elasticsearch.status.success'));
-      setEsInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setEsInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingEsConnection(false);
-    }
-  };
-
-  const handleAddJenkinsInstance = () => {
-    const nextInstance = getDefaultJenkinsInstance(getNextJenkinsInstanceName(jenkinsInstances));
-    setJenkinsInstances((prev) => [...prev, nextInstance]);
-    setSelectedJenkinsInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteJenkinsInstance = (instanceId: string) => {
-    setJenkinsInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedJenkinsInstanceId === instanceId) {
-        setSelectedJenkinsInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleJenkinsInstanceChange = <K extends keyof JenkinsInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: JenkinsInstanceFormValue[K],
-  ) => {
-    setJenkinsInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestJenkinsInstance = async () => {
-    const currentInstance = jenkinsInstances.find((instance) => instance.id === selectedJenkinsInstanceId);
-    if (!currentInstance) return;
-    setTestingJenkinsConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testJenkinsConnection(payload);
-      message.success(t('tool.jenkins.status.success'));
-      setJenkinsInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setJenkinsInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingJenkinsConnection(false);
-    }
-  };
-
-  const handleAddKubernetesInstance = () => {
-    const nextInstance = getDefaultKubernetesInstance(getNextKubernetesInstanceName(kubernetesInstances));
-    setKubernetesInstances((prev) => [...prev, nextInstance]);
-    setSelectedKubernetesInstanceId(nextInstance.id);
-  };
-
-  const handleDeleteKubernetesInstance = (instanceId: string) => {
-    setKubernetesInstances((prev) => {
-      const nextInstances = prev.filter((instance) => instance.id !== instanceId);
-      if (selectedKubernetesInstanceId === instanceId) {
-        setSelectedKubernetesInstanceId(nextInstances[0]?.id || null);
-      }
-      return nextInstances;
-    });
-  };
-
-  const handleKubernetesInstanceChange = <K extends keyof KubernetesInstanceFormValue>(
-    instanceId: string,
-    field: K,
-    value: KubernetesInstanceFormValue[K],
-  ) => {
-    setKubernetesInstances((prev) => prev.map((instance) => (
-      instance.id === instanceId ? { ...instance, [field]: value, testStatus: 'untested' } : instance
-    )));
-  };
-
-  const handleTestKubernetesInstance = async () => {
-    const currentInstance = kubernetesInstances.find((instance) => instance.id === selectedKubernetesInstanceId);
-    if (!currentInstance) return;
-    setTestingKubernetesConnection(true);
-    try {
-      const payload = { ...currentInstance };
-      delete payload.testStatus;
-      await testKubernetesConnection(payload);
-      message.success(t('tool.kubernetes.status.success'));
-      setKubernetesInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'success' } : instance
-      )));
-    } catch {
-      setKubernetesInstances((prev) => prev.map((instance) => (
-        instance.id === currentInstance.id ? { ...instance, testStatus: 'failed' } : instance
-      )));
-    } finally {
-      setTestingKubernetesConnection(false);
-    }
   };
 
   return (
@@ -1767,7 +282,7 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
         onCancel={handleEditModalCancel}
         okText={t('common.save')}
         cancelText={t('common.cancel')}
-        width={isRedisTool(editingTool) || isMysqlTool(editingTool) || isOracleTool(editingTool) || isMssqlTool(editingTool) || isPostgresTool(editingTool) || isEsTool(editingTool) || isJenkinsTool(editingTool) || isKubernetesTool(editingTool) ? 800 : undefined}
+        width={isDbTool(editingTool) ? 800 : undefined}
       >
         <Form form={form} layout="vertical">
           {isMonitorToolConfig(editingTool) ? (
@@ -1778,93 +293,21 @@ const ToolSelector: React.FC<ToolSelectorProps> = ({ defaultTools, onChange }) =
               description={t('tool.monitor.callerIdentityDescription')}
             />
           ) : isRedisTool(editingTool) ? (
-            <RedisToolEditor
-              instances={redisInstances}
-              selectedInstanceId={selectedRedisInstanceId}
-              testing={testingRedisConnection}
-              onSelect={setSelectedRedisInstanceId}
-              onAdd={handleAddRedisInstance}
-              onDelete={handleDeleteRedisInstance}
-              onChange={handleRedisInstanceChange}
-              onTest={handleTestRedisInstance}
-            />
+            <RedisToolEditor ref={redisRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isMysqlTool(editingTool) ? (
-            <MysqlToolEditor
-              instances={mysqlInstances}
-              selectedInstanceId={selectedMysqlInstanceId}
-              testing={testingMysqlConnection}
-              onSelect={setSelectedMysqlInstanceId}
-              onAdd={handleAddMysqlInstance}
-              onDelete={handleDeleteMysqlInstance}
-              onChange={handleMysqlInstanceChange}
-              onTest={handleTestMysqlInstance}
-            />
+            <MysqlToolEditor ref={mysqlRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isOracleTool(editingTool) ? (
-            <OracleToolEditor
-              instances={oracleInstances}
-              selectedInstanceId={selectedOracleInstanceId}
-              testing={testingOracleConnection}
-              onSelect={setSelectedOracleInstanceId}
-              onAdd={handleAddOracleInstance}
-              onDelete={handleDeleteOracleInstance}
-              onChange={handleOracleInstanceChange}
-              onTest={handleTestOracleInstance}
-            />
+            <OracleToolEditor ref={oracleRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isMssqlTool(editingTool) ? (
-            <MssqlToolEditor
-              instances={mssqlInstances}
-              selectedInstanceId={selectedMssqlInstanceId}
-              testing={testingMssqlConnection}
-              onSelect={setSelectedMssqlInstanceId}
-              onAdd={handleAddMssqlInstance}
-              onDelete={handleDeleteMssqlInstance}
-              onChange={handleMssqlInstanceChange}
-              onTest={handleTestMssqlInstance}
-            />
+            <MssqlToolEditor ref={mssqlRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isPostgresTool(editingTool) ? (
-            <PostgresToolEditor
-              instances={postgresInstances}
-              selectedInstanceId={selectedPostgresInstanceId}
-              testing={testingPostgresConnection}
-              onSelect={setSelectedPostgresInstanceId}
-              onAdd={handleAddPostgresInstance}
-              onDelete={handleDeletePostgresInstance}
-              onChange={handlePostgresInstanceChange}
-              onTest={handleTestPostgresInstance}
-            />
+            <PostgresToolEditor ref={postgresRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isEsTool(editingTool) ? (
-            <ElasticsearchToolEditor
-              instances={esInstances}
-              selectedInstanceId={selectedEsInstanceId}
-              testing={testingEsConnection}
-              onSelect={setSelectedEsInstanceId}
-              onAdd={handleAddEsInstance}
-              onDelete={handleDeleteEsInstance}
-              onChange={handleEsInstanceChange}
-              onTest={handleTestEsInstance}
-            />
+            <ElasticsearchToolEditor ref={esRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isJenkinsTool(editingTool) ? (
-            <JenkinsToolEditor
-              instances={jenkinsInstances}
-              selectedInstanceId={selectedJenkinsInstanceId}
-              testing={testingJenkinsConnection}
-              onSelect={setSelectedJenkinsInstanceId}
-              onAdd={handleAddJenkinsInstance}
-              onDelete={handleDeleteJenkinsInstance}
-              onChange={handleJenkinsInstanceChange}
-              onTest={handleTestJenkinsInstance}
-            />
+            <JenkinsToolEditor ref={jenkinsRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : isKubernetesTool(editingTool) ? (
-            <KubernetesToolEditor
-              instances={kubernetesInstances}
-              selectedInstanceId={selectedKubernetesInstanceId}
-              testing={testingKubernetesConnection}
-              onSelect={setSelectedKubernetesInstanceId}
-              onAdd={handleAddKubernetesInstance}
-              onDelete={handleDeleteKubernetesInstance}
-              onChange={handleKubernetesInstanceChange}
-              onTest={handleTestKubernetesInstance}
-            />
+            <KubernetesToolEditor ref={kubernetesRef} initialKwargs={editingTool?.kwargs ?? []} onSave={handleDbToolSaved} />
           ) : (
             <Form.List name="kwargs">
               {(fields) => (


### PR DESCRIPTION
## 问题

`toolSelector.tsx` 在当前主线仍同时承载 8 类工具编辑器的实例状态、配置转换、连接测试和表单渲染，导致修改一种工具时容易影响其他工具。

关联 Issue：#3507

## 方案 A

按负责人确认的方案 A，将 Redis、MySQL、Oracle、MSSQL、PostgreSQL、Elasticsearch、Jenkins、Kubernetes 的 `instances / selectedId / testing` 状态、解析与序列化、校验和连接测试逻辑下移到各自的 `XxxToolEditor`。`ToolSelector` 仅保留工具选择、编辑器编排和保存结果提交。

## 改动摘要

- `toolSelector.tsx` 从 1921 行收敛到 364 行，父组件状态从 24 项以上降至 6 项。
- 8 个编辑器通过统一的 `save()` 接口独立完成校验和序列化。
- 保留当前主线的 Monitor 调用方身份规范化，以及 app-local `ToolConnectionStatusTag` 组件治理结果。
- 恢复并验证 Redis 旧单实例字段到多实例协议的平滑升级，序列化格式保持兼容。
- 实例删除动作拆为独立 Ant Design 危险链接按钮，支持键盘聚焦和可访问名称。

## 验证

- `pnpm exec vitest run src/app/opspilot/components/skill/__tests__/toolEditors.test.tsx`：18 项通过，覆盖 8 类保存、8 类连接成功、连接失败和 Redis 旧协议升级。
- 本次 10 个变更文件定向 ESLint：通过。
- `pnpm check:component-ownership`：通过，112 条记录。
- 全量 `pnpm type-check`：本次变更文件未报错；仍被当前主线 APM 测试的无效 `@ts-expect-error` 和 `menuHelpers.test.ts` 缺少 `operation` 字段等既有错误阻塞。

/cc @zhouzhuangjie
