### PR TITLE
bugfix(opspilot): invoke_chat future.result() 增加超时保护，修复 worker 线程永久阻塞

### DIFF
--- a/server/apps/opspilot/metis/llm/common/llm_client_factory.py
+++ b/server/apps/opspilot/metis/llm/common/llm_client_factory.py
@@ -1,5 +1,6 @@
 """LLM客户端工厂类,用于创建不同用途的LLM客户端"""
 
+import os
 from typing import Union
 
 import anthropic
@@ -63,7 +64,7 @@ class LLMClientFactory:
             api_key=request.openai_api_key,
             temperature=request.temperature,
             disable_streaming=disable_stream,
-            timeout=3000,
+            timeout=int(os.getenv("LLM_INVOKE_TIMEOUT", "60")),
         )
 
         if llm.extra_body is None:
@@ -109,7 +110,7 @@ class LLMClientFactory:
             api_key=request.openai_api_key,
             temperature=request.temperature,
             disable_streaming=disable_stream,
-            timeout=3000,
+            timeout=int(os.getenv("LLM_INVOKE_TIMEOUT", "60")),
             model_kwargs=model_kwargs if model_kwargs else None,
         )
 

--- a/server/apps/opspilot/services/chat_service.py
+++ b/server/apps/opspilot/services/chat_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import os
 import re
 import uuid
 from typing import Any, Dict, Tuple
@@ -136,9 +137,10 @@ class ChatService:
                         pass
                     loop.close()
 
+            _llm_timeout = int(os.getenv("LLM_INVOKE_TIMEOUT", "60"))
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                 future = pool.submit(_run_in_new_loop)
-                response = future.result()
+                response = future.result(timeout=_llm_timeout)
 
             # 构建返回结果
             result = {
@@ -156,6 +158,27 @@ class ChatService:
                 result["message"] = content
 
             return result, doc_map, title_map
+
+        except concurrent.futures.TimeoutError:
+            # LLM 调用超时：future.result(timeout=...) 触发，worker 线程已放弃等待
+            _llm_timeout = int(os.getenv("LLM_INVOKE_TIMEOUT", "60"))
+            logger.error(f"invoke_chat LLM 调用超时（>{_llm_timeout}s）: skill_type={skill_type}")
+            loader = LanguageLoader(app="opspilot", default_lang="en")
+            message = loader.get("error.llm_timeout") or f"LLM 调用超时（>{_llm_timeout}s），请稍后重试"
+            return (
+                {
+                    "message": message,
+                    "success": False,
+                    "error": f"LLM invoke timeout after {_llm_timeout}s",
+                    "error_type": "TimeoutError",
+                    "total_tokens": 0,
+                    "prompt_tokens": 0,
+                    "completion_tokens": 0,
+                    "browser_steps": [],
+                },
+                doc_map,
+                title_map,
+            )
 
         except Exception as e:
             # 记录详细的异常信息以便排查问题

--- a/server/apps/opspilot/tests/test_chat_service_llm_timeout.py
+++ b/server/apps/opspilot/tests/test_chat_service_llm_timeout.py
@@ -1,0 +1,161 @@
+"""
+测试 invoke_chat future.result() 超时保护（Issue #3718）
+
+验证点：
+- future.result() 携带 LLM_INVOKE_TIMEOUT 秒的超时
+- LLM 卡死时 TimeoutError 被捕获并返回结构化错误响应（不永久阻塞）
+- 超时时间可通过环境变量 LLM_INVOKE_TIMEOUT 配置
+- LLMClientFactory 不再使用 timeout=3000（50分钟无效超时）
+
+注：这些测试使用源码级别检查（Source-level verification），无需 Django 环境启动，
+    因为修复的核心逻辑（timeout 参数和 TimeoutError 处理块）直接体现在源码结构中。
+    revert 修复后，以下测试均应失败，从而证明测试覆盖了修复点。
+"""
+
+import inspect
+import os
+import re
+import concurrent.futures
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Lazy imports of the target modules to avoid Django bootstrap at collection time
+# ---------------------------------------------------------------------------
+
+def _load_chat_service_source():
+    path = os.path.join(os.path.dirname(__file__), "..", "services", "chat_service.py")
+    with open(os.path.normpath(path)) as f:
+        return f.read()
+
+
+def _load_llm_client_factory_source():
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..", "..", "opspilot", "metis", "llm", "common", "llm_client_factory.py",
+    )
+    # Resolve relative to this file
+    base = os.path.dirname(__file__)  # .../apps/opspilot/tests/
+    factory_path = os.path.normpath(
+        os.path.join(base, "..", "metis", "llm", "common", "llm_client_factory.py")
+    )
+    with open(factory_path) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatServiceFutureTimeout:
+    """
+    验证 chat_service.py 中 future.result() 的超时保护（Issue #3718）。
+
+    判断标准（revert 修复后这些测试均应失败）：
+    - revert future.result(timeout=...) → test_future_result_has_timeout 失败
+    - revert TimeoutError handler → test_timeout_error_is_explicitly_caught 失败
+    - revert LLM_INVOKE_TIMEOUT env var → test_llm_invoke_timeout_env_var_referenced 失败
+    """
+
+    @pytest.fixture(scope="class")
+    def chat_service_src(self):
+        return _load_chat_service_source()
+
+    def test_future_result_has_timeout(self, chat_service_src):
+        """
+        future.result() 必须携带 timeout 参数。
+
+        revert 修复（还原为 `future.result()`）后，此测试应失败。
+        """
+        match = re.search(r"future\.result\s*\(([^)]*)\)", chat_service_src)
+        assert match, "chat_service.py 中未找到 future.result() 调用"
+        args = match.group(1).strip()
+        assert "timeout" in args, (
+            f"future.result() 缺少 timeout 参数，当前参数为：({args})。"
+            "没有 timeout 参数时，LLM 卡死会导致 worker 线程永久阻塞（Issue #3718）。"
+        )
+
+    def test_llm_invoke_timeout_env_var_referenced(self, chat_service_src):
+        """
+        超时值应通过 LLM_INVOKE_TIMEOUT 环境变量读取，支持运维侧调整。
+
+        revert 后（移除 os.getenv("LLM_INVOKE_TIMEOUT", ...)）此测试失败。
+        """
+        assert "LLM_INVOKE_TIMEOUT" in chat_service_src, (
+            "chat_service.py 中未引用 LLM_INVOKE_TIMEOUT 环境变量。"
+            "超时值应可通过环境变量配置。"
+        )
+
+    def test_timeout_error_is_explicitly_caught(self, chat_service_src):
+        """
+        concurrent.futures.TimeoutError 应被单独捕获并返回清晰错误响应。
+
+        revert（移除 except concurrent.futures.TimeoutError 块）后此测试失败。
+        """
+        assert "except concurrent.futures.TimeoutError" in chat_service_src, (
+            "chat_service.py 未专门处理 concurrent.futures.TimeoutError。"
+            "未处理的 TimeoutError 会向上传播为 500 错误，缺少明确提示。"
+        )
+
+    def test_timeout_error_handler_returns_error_type_field(self, chat_service_src):
+        """
+        TimeoutError 处理块应返回 error_type='TimeoutError'，便于前端区分超时与其他错误。
+        """
+        # Find the TimeoutError handler block
+        idx = chat_service_src.find("except concurrent.futures.TimeoutError")
+        assert idx != -1, "未找到 TimeoutError 处理块"
+        # Check the next 500 chars for the error_type field
+        handler_snippet = chat_service_src[idx: idx + 600]
+        assert '"TimeoutError"' in handler_snippet or "'TimeoutError'" in handler_snippet, (
+            "TimeoutError 处理块应设置 error_type='TimeoutError'"
+        )
+        assert "False" in handler_snippet, (
+            "TimeoutError 处理块应设置 success=False"
+        )
+
+    def test_os_is_imported(self, chat_service_src):
+        """os 模块必须被 import，用于 os.getenv('LLM_INVOKE_TIMEOUT', ...)"""
+        assert "import os" in chat_service_src, (
+            "chat_service.py 缺少 import os，无法调用 os.getenv()"
+        )
+
+
+class TestLLMClientFactoryTimeout:
+    """
+    验证 llm_client_factory.py 中 timeout=3000（50分钟）已被替换（Issue #3718）。
+
+    revert 修复（还原为 timeout=3000）后，test_no_hardcoded_timeout_3000 失败。
+    """
+
+    @pytest.fixture(scope="class")
+    def factory_src(self):
+        return _load_llm_client_factory_source()
+
+    def test_no_hardcoded_timeout_3000(self, factory_src):
+        """
+        llm_client_factory.py 中不应再出现 timeout=3000（即 3000 秒/50分钟）。
+
+        revert 修复后，此测试应失败——证明测试覆盖了修复点。
+        """
+        count = factory_src.count("timeout=3000")
+        assert count == 0, (
+            f"llm_client_factory.py 中仍存在 {count} 处 timeout=3000（50分钟无效超时）。"
+            "应改为使用 LLM_INVOKE_TIMEOUT 环境变量。"
+        )
+
+    def test_llm_invoke_timeout_env_var_in_factory(self, factory_src):
+        """
+        llm_client_factory.py 也应通过 LLM_INVOKE_TIMEOUT 统一控制客户端超时。
+        """
+        assert "LLM_INVOKE_TIMEOUT" in factory_src, (
+            "llm_client_factory.py 未使用 LLM_INVOKE_TIMEOUT 环境变量。"
+            "client-level timeout 应与 future.result() 超时保持一致。"
+        )
+
+    def test_os_is_imported_in_factory(self, factory_src):
+        """os 模块必须被 import，用于 os.getenv()"""
+        assert "import os" in factory_src, (
+            "llm_client_factory.py 缺少 import os，无法调用 os.getenv()"
+        )


### PR DESCRIPTION
## 问题

OpsPilot 的 `skill_execute` / `lobe_skill_execute` 调用链在执行 LLM 请求时，把实际调用放到独立线程里跑，然后用 `future.result()` 等结果——但这个等待**没有任何超时限制**。一旦 LLM 服务卡住（网络抖动、模型过载、token 生成中途挂死），这个线程就永远阻塞在那里，无法释放。

每一个卡住的请求消耗一个 worker 线程；高并发下线程耗尽后，服务整体无法响应新请求。在生产环境中 LLM 间歇性超时是常态，影响面波及所有 skill_execute 用户，且无任何自愈机制。

同一问题还出现在 `LLMClientFactory` 里——OpenAI 和 Anthropic 客户端的 `timeout=3000`（3000 秒 = 50 分钟），实际上等同于没有超时。

## 根因

`future.result()` 没有传 `timeout` 参数，默认行为是无限期等待：

```python
# 修复前
with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
    future = pool.submit(_run_in_new_loop)
    response = future.result()  # 永久阻塞

# LLMClientFactory 里的无效超时
timeout=3000  # 3000 秒 = 50 分钟，等同于无超时
```

设计层面的边界失守：调用了外部 LLM，没有在"等待结果"这一层设置保护。

## 怎么修的

**1. `chat_service.py`**：`future.result()` 加 `timeout` 参数，超时值通过环境变量 `LLM_INVOKE_TIMEOUT` 读取（默认 60 秒）：

```python
_llm_timeout = int(os.getenv("LLM_INVOKE_TIMEOUT", "60"))
with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
    future = pool.submit(_run_in_new_loop)
    response = future.result(timeout=_llm_timeout)
```

**2. `chat_service.py`**：新增 `concurrent.futures.TimeoutError` 专属捕获，返回结构化错误响应而不是裸异常：

```python
except concurrent.futures.TimeoutError:
    _llm_timeout = int(os.getenv("LLM_INVOKE_TIMEOUT", "60"))
    logger.error(f"invoke_chat LLM 调用超时（>{_llm_timeout}s）: skill_type={skill_type}")
    return ({"message": "...", "success": False, "error_type": "TimeoutError", ...}, ...)
```

**3. `llm_client_factory.py`**：`ChatOpenAI` 和 `ChatAnthropic` 的 `timeout=3000` 同步替换为 `int(os.getenv("LLM_INVOKE_TIMEOUT", "60"))`，与 `future.result()` 超时保持一致。

**新增环境变量**：`LLM_INVOKE_TIMEOUT`（单位秒，默认 60）。如需调整（如部分模型需要更长生成时间），可在部署环境中覆盖。

## 影响范围

| 文件 | 改动 |
|------|------|
| `server/apps/opspilot/services/chat_service.py` | 加 `import os`；`future.result(timeout=...)`；新增 `TimeoutError` 处理块 |
| `server/apps/opspilot/metis/llm/common/llm_client_factory.py` | 加 `import os`；两处 `timeout=3000` → 读环境变量 |
| `server/apps/opspilot/tests/test_chat_service_llm_timeout.py` | 新增单测覆盖所有修复点 |

改动限于 `opspilot` 模块内，未触及 `core`/`rpc`/`base` 等共享层。行为语义对用户可见变化：LLM 卡死时由"永远等待"变为"超时后返回结构化错误"——这是收紧而非放松，建议 review 确认 60s 默认值适合生产场景。

## 验证

**revert 判断标准**：把 `future.result(timeout=_llm_timeout)` 还原为 `future.result()`，所有新增测试均应失败——确认测试覆盖了修复点。

本次验证结果：
- `future.result(timeout=_llm_timeout)` ✅
- `LLM_INVOKE_TIMEOUT` 在两个文件中均引用 ✅
- `concurrent.futures.TimeoutError` 被专属捕获 ✅
- `error_type="TimeoutError"` / `success=False` 正确设置 ✅
- `timeout=3000` 在 factory 中已清零（0 处残留） ✅

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["skill_execute / lobe_skill_execute\nviews.py"]
    end

    subgraph N["核心处理层"]
        F1["ChatService.invoke_chat\nchat_service.py"]
        F2["ThreadPoolExecutor.submit(_run_in_new_loop)\nchat_service.py"]
        F3["future.result(timeout=LLM_INVOKE_TIMEOUT)\nchat_service.py ← 修复点"]
    end

    subgraph C["超时兜底层（新增）"]
        C1["except concurrent.futures.TimeoutError\nchat_service.py"]
        C2["返回 success=False\nerror_type=TimeoutError"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -. "超时（默认60s）" .-> C1 --> C2
```

关联 Issue #3718