### PR TITLE
style(monitor): 折线图整改为报告风样式并修复维度溢出

### DIFF
--- a/web/src/app/monitor/components/charts/customTooltips.tsx
+++ b/web/src/app/monitor/components/charts/customTooltips.tsx
@@ -13,6 +13,9 @@ interface CustomToolTipProps extends Omit<TooltipProps<any, string>, 'unit'> {
   maxHeight?: number;
   maxWidth?: number;
   seriesUnits?: Record<string, string>;
+  // 深色「报告风」变体：深底白字 + 线段色标。仅折线图启用，
+  // 柱状图等其它消费方不传，保持原浅色 + 圆点样式不变。
+  dark?: boolean;
 }
 
 const CustomTooltip: React.FC<CustomToolTipProps> = ({
@@ -24,7 +27,8 @@ const CustomTooltip: React.FC<CustomToolTipProps> = ({
   visible = true,
   maxHeight,
   maxWidth,
-  seriesUnits = {}
+  seriesUnits = {},
+  dark = false
 }) => {
   const { convertToLocalizedTime } = useLocalizedTime();
   const { findUnitNameById } = useUnitTransform();
@@ -68,7 +72,19 @@ const CustomTooltip: React.FC<CustomToolTipProps> = ({
         className={customTooltipStyle.customTooltip}
         style={{
           ...(maxHeight ? { maxHeight: `${maxHeight}px` } : {}),
-          ...(maxWidth ? { maxWidth: `${maxWidth}px` } : {})
+          ...(maxWidth ? { maxWidth: `${maxWidth}px` } : {}),
+          // 深色变体：覆盖浅色底，并用半透明白边在暗色图表背景上保持分界
+          ...(dark
+            ? {
+              background: 'rgba(28, 28, 30, 0.92)',
+              color: '#fff',
+              border: '1px solid rgba(255, 255, 255, 0.14)',
+              borderRadius: '6px',
+              boxShadow: '0 4px 16px rgba(0, 0, 0, 0.28)',
+              fontSize: '12px',
+              padding: '8px 12px 10px'
+            }
+            : {})
         }}
       >
         <p className="label font-[600]">{`${convertToLocalizedTime(
@@ -77,17 +93,31 @@ const CustomTooltip: React.FC<CustomToolTipProps> = ({
         {sortedPayload.map((item: any, index: number) => (
           <div key={index}>
             <div className="flex items-start mt-[4px] text-[13px]">
-              <span
-                style={{
-                  width: '16px',
-                  minWidth: '16px',
-                  height: 0,
-                  borderTop: `2px solid ${item.color}`,
-                  marginRight: '8px',
-                  marginTop: '8px'
-                }}
-              ></span>
-              <span className="flex-1">
+              {dark ? (
+                <span
+                  style={{
+                    width: '16px',
+                    minWidth: '16px',
+                    height: 0,
+                    borderTop: `2px solid ${item.color}`,
+                    marginRight: '8px',
+                    marginTop: '8px'
+                  }}
+                ></span>
+              ) : (
+                <span
+                  style={{
+                    width: '10px',
+                    minWidth: '10px',
+                    height: '10px',
+                    backgroundColor: item.color,
+                    borderRadius: '50%',
+                    marginRight: '5px',
+                    marginTop: '5px'
+                  }}
+                ></span>
+              )}
+              <span className="flex-1 min-w-0 break-words">
                 {(item.payload.details?.[item.dataKey] || [])
                   .map((detail: any) => formatDetailText(detail))
                   .filter(Boolean)

--- a/web/src/app/monitor/components/charts/customTooltips.tsx
+++ b/web/src/app/monitor/components/charts/customTooltips.tsx
@@ -79,13 +79,12 @@ const CustomTooltip: React.FC<CustomToolTipProps> = ({
             <div className="flex items-start mt-[4px] text-[13px]">
               <span
                 style={{
-                  width: '10px',
-                  minWidth: '10px',
-                  height: '10px',
-                  backgroundColor: item.color,
-                  borderRadius: '50%',
-                  marginRight: '5px',
-                  marginTop: '5px'
+                  width: '16px',
+                  minWidth: '16px',
+                  height: 0,
+                  borderTop: `2px solid ${item.color}`,
+                  marginRight: '8px',
+                  marginTop: '8px'
                 }}
               ></span>
               <span className="flex-1">

--- a/web/src/app/monitor/components/charts/dimensionFilter.tsx
+++ b/web/src/app/monitor/components/charts/dimensionFilter.tsx
@@ -59,7 +59,7 @@ const DimensionFilter: React.FC<DimensionFilterProps> = memo(
                 onClick={() => onLegendClick(key)}
               >
                 <span
-                  className="w-[10px] h-[4px] mr-[10px]"
+                  className="w-[10px] h-[4px] mr-[10px] shrink-0"
                   style={{
                     background: visibleAreas.includes(key)
                       ? colors[index]

--- a/web/src/app/monitor/components/charts/index.module.scss
+++ b/web/src/app/monitor/components/charts/index.module.scss
@@ -4,11 +4,13 @@
     max-height: 300px;
     max-width: 390px;
     overflow-y: auto;
-    font-size: 14px;
-    background: var(--color-bg-1);
-    border: 1px solid var(--color-border-1);
-    padding: 10px;
-    border-radius: 5px;
+    font-size: 12px;
+    color: #fff;
+    background: rgba(28, 28, 30, 0.92);
+    border: none;
+    padding: 8px 12px 10px;
+    border-radius: 6px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
 }
 
 .chart {
@@ -97,6 +99,12 @@
 
             .dimeLabel {
                 flex: 1;
+                // flex 子项必须 min-width:0 才能收缩到内容宽度以下，
+                // 否则超长维度文本会撑破容器、与相邻行重叠。
+                min-width: 0;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
             }
         }
     }

--- a/web/src/app/monitor/components/charts/index.module.scss
+++ b/web/src/app/monitor/components/charts/index.module.scss
@@ -3,14 +3,13 @@
     pointer-events: auto;
     max-height: 300px;
     max-width: 390px;
+    overflow-x: hidden;
     overflow-y: auto;
-    font-size: 12px;
-    color: #fff;
-    background: rgba(28, 28, 30, 0.92);
-    border: none;
-    padding: 8px 12px 10px;
-    border-radius: 6px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.28);
+    font-size: 14px;
+    background: var(--color-bg-1);
+    border: 1px solid var(--color-border-1);
+    padding: 10px;
+    border-radius: 5px;
 }
 
 .chart {

--- a/web/src/app/monitor/components/charts/lineChart.tsx
+++ b/web/src/app/monitor/components/charts/lineChart.tsx
@@ -4,7 +4,8 @@ import React, {
   useMemo,
   useCallback,
   memo,
-  useRef
+  useRef,
+  useId
 } from 'react';
 import { Empty } from 'antd';
 import {
@@ -21,7 +22,6 @@ import {
 import CustomTooltip from './customTooltips';
 import EventBar from './eventBar';
 import {
-  generateUniqueRandomColor,
   useFormatTime,
   isStringArray
 } from '@/app/monitor/utils/common';
@@ -43,6 +43,16 @@ import {
   getChartDataWithGapBreaks,
   getRenderedGapIntervals
 } from '@/app/monitor/utils/gapIntervals';
+
+// 折线图固定分类色板（AntV/G2，跨图表统一）。按序列索引稳定分配，
+// 替代随机配色，保证同一序列跨刷新/跨视图颜色稳定、彼此可区分。
+const CHART_PALETTE = [
+  '#5B8FF9', '#5AD8A6', '#F6BD16', '#E86452', '#6DC8EC',
+  '#945FB9', '#FF9845', '#1E9493'
+];
+// 折线图默认视觉 token（报告风）：细线 + linear 折角 + 渐变淡填充
+const DEFAULT_STROKE_WIDTH = 1;
+const DEFAULT_FILL_OPACITY = 0.36;
 
 interface LineChartProps {
   data: ChartData[];
@@ -177,8 +187,8 @@ const LineChart: React.FC<LineChartProps> = memo(
     const [startX, setStartX] = useState<number | null>(null);
     const [endX, setEndX] = useState<number | null>(null);
     const [isDragging, setIsDragging] = useState(false);
-    const [colors, setColors] = useState<string[]>([]);
     const [visibleAreas, setVisibleAreas] = useState<string[]>([]);
+    const gradientId = useId().replace(/:/g, '');
     const [hoveredThreshold, setHoveredThreshold] =
       useState<ThresholdField | null>(null);
     const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
@@ -209,15 +219,14 @@ const LineChart: React.FC<LineChartProps> = memo(
           color:
             seriesStyles[index]?.color ||
             (index === 0 && metric && typeof metric.color === 'string' ? metric.color : '') ||
-            colors[index] ||
-            generateUniqueRandomColor(),
+            CHART_PALETTE[index % CHART_PALETTE.length],
           strokeDasharray: seriesStyles[index]?.strokeDasharray,
-          fillOpacity: seriesStyles[index]?.fillOpacity ?? 0,
+          fillOpacity: seriesStyles[index]?.fillOpacity ?? DEFAULT_FILL_OPACITY,
           strokeOpacity: seriesStyles[index]?.strokeOpacity ?? 1,
-          strokeWidth: seriesStyles[index]?.strokeWidth ?? 2.5,
+          strokeWidth: seriesStyles[index]?.strokeWidth ?? DEFAULT_STROKE_WIDTH,
           unit: seriesStyles[index]?.unit
         })),
-      [chartAreaKeys, colors, metric, seriesStyles]
+      [chartAreaKeys, metric, seriesStyles]
     );
 
     const seriesUnits = useMemo(
@@ -539,17 +548,10 @@ const LineChart: React.FC<LineChartProps> = memo(
       return !Object.values(details || {}).every((item) => !item.length);
     }, [details]);
 
-    // 生成颜色的逻辑优化
+    // 默认展示全部序列
     useEffect(() => {
-      if (chartAreaKeys.length > colors.length) {
-        const newColors = Array.from(
-          { length: chartAreaKeys.length - colors.length },
-          () => generateUniqueRandomColor()
-        );
-        setColors((prev) => [...prev, ...newColors]);
-      }
       setVisibleAreas(chartAreaKeys);
-    }, [chartAreaKeys, colors.length]);
+    }, [chartAreaKeys]);
 
     useEffect(() => {
       if (!allowSelect) return;
@@ -628,7 +630,7 @@ const LineChart: React.FC<LineChartProps> = memo(
             x={x}
             y={y}
             textAnchor="end"
-            fontSize={14}
+            fontSize={12}
             fill="var(--color-text-3)"
             dy={4}
             dx={2}
@@ -681,7 +683,7 @@ const LineChart: React.FC<LineChartProps> = memo(
                   dataKey="time"
                   type="number"
                   domain={['dataMin', 'dataMax']}
-                  tick={{ fill: 'var(--color-text-3)', fontSize: 14 }}
+                  tick={{ fill: 'var(--color-text-3)', fontSize: 12 }}
                   tickFormatter={formatXAxisTick}
                   tickCount={xAxisTickCount}
                   minTickGap={36}
@@ -698,7 +700,7 @@ const LineChart: React.FC<LineChartProps> = memo(
                   interval={0}
                   width={leftAxisWidth}
                 />
-                <CartesianGrid strokeDasharray="4 6" vertical={false} stroke="rgba(107, 127, 152, 0.28)" />
+                <CartesianGrid vertical={false} stroke="var(--color-border-1)" />
                 {renderedGapIntervals.map((gap) => (
                   <ReferenceArea
                     key={`gap-${gap.start}-${gap.end}`}
@@ -711,6 +713,11 @@ const LineChart: React.FC<LineChartProps> = memo(
                 ))}
                 <Tooltip
                   offset={-1}
+                  cursor={{
+                    stroke: 'var(--color-text-3)',
+                    strokeWidth: 1,
+                    strokeDasharray: '3 3'
+                  }}
                   content={
                     <CustomTooltip
                       unit={unit}
@@ -726,20 +733,41 @@ const LineChart: React.FC<LineChartProps> = memo(
                     />
                   }
                 />
+                {/* 每条序列的渐变填充：顶部为该序列色（透明度=fillOpacity），底部淡出 */}
+                <defs>
+                  {chartAreaKeys.map((key, index) => {
+                    const color = resolvedSeriesStyles[index]?.color;
+                    const fillOpacity =
+                      resolvedSeriesStyles[index]?.fillOpacity ?? DEFAULT_FILL_OPACITY;
+                    return (
+                      <linearGradient
+                        key={`grad-${key}`}
+                        id={`${gradientId}-${index}`}
+                        x1="0"
+                        y1="0"
+                        x2="0"
+                        y2="1"
+                      >
+                        <stop offset="0%" stopColor={color} stopOpacity={fillOpacity} />
+                        <stop offset="100%" stopColor={color} stopOpacity={0} />
+                      </linearGradient>
+                    );
+                  })}
+                </defs>
                 {chartAreaKeys.map((key, index) => (
                     <Area
                       key={key}
-                      type="monotoneX"
+                      type="linear"
                       dataKey={key}
                       yAxisId="left"
-                      stroke={resolvedSeriesStyles[index]?.color || colors[index]}
+                      stroke={resolvedSeriesStyles[index]?.color}
                       strokeDasharray={resolvedSeriesStyles[index]?.strokeDasharray}
                       strokeOpacity={resolvedSeriesStyles[index]?.strokeOpacity}
-                    fillOpacity={resolvedSeriesStyles[index]?.fillOpacity ?? 0}
-                    fill={resolvedSeriesStyles[index]?.color || colors[index]}
-                    strokeWidth={resolvedSeriesStyles[index]?.strokeWidth ?? 2.5}
+                    fillOpacity={1}
+                    fill={`url(#${gradientId}-${index})`}
+                    strokeWidth={resolvedSeriesStyles[index]?.strokeWidth ?? DEFAULT_STROKE_WIDTH}
                     dot={false}
-                    activeDot={{ r: 4, strokeWidth: 2, fill: resolvedSeriesStyles[index]?.color || colors[index] }}
+                    activeDot={{ r: 4, strokeWidth: 2, fill: resolvedSeriesStyles[index]?.color }}
                     isAnimationActive={false}
                     strokeLinecap="round"
                     strokeLinejoin="round"

--- a/web/src/app/monitor/components/charts/lineChart.tsx
+++ b/web/src/app/monitor/components/charts/lineChart.tsx
@@ -36,7 +36,7 @@ import {
   MetricItem,
   ThresholdField
 } from '@/app/monitor/types';
-import { LEVEL_MAP } from '@/app/monitor/constants';
+import { LEVEL_MAP, CHART_COLORS } from '@/app/monitor/constants';
 import { useLevelList } from '@/app/monitor/hooks';
 import {
   GAP_INTERVAL_AREA_STYLE,
@@ -44,13 +44,9 @@ import {
   getRenderedGapIntervals
 } from '@/app/monitor/utils/gapIntervals';
 
-// 折线图固定分类色板（AntV/G2，跨图表统一）。按序列索引稳定分配，
-// 替代随机配色，保证同一序列跨刷新/跨视图颜色稳定、彼此可区分。
-const CHART_PALETTE = [
-  '#5B8FF9', '#5AD8A6', '#F6BD16', '#E86452', '#6DC8EC',
-  '#945FB9', '#FF9845', '#1E9493'
-];
-// 折线图默认视觉 token（报告风）：细线 + linear 折角 + 渐变淡填充
+// 折线图默认视觉 token（报告风）：细线 + linear 折角 + 渐变淡填充。
+// 配色用固定分类色板 CHART_COLORS 按序列索引稳定分配（替代随机配色），
+// 与 echarts 版折线图共用同一色板，保证两类图表配色一致。
 const DEFAULT_STROKE_WIDTH = 1;
 const DEFAULT_FILL_OPACITY = 0.36;
 
@@ -219,7 +215,7 @@ const LineChart: React.FC<LineChartProps> = memo(
           color:
             seriesStyles[index]?.color ||
             (index === 0 && metric && typeof metric.color === 'string' ? metric.color : '') ||
-            CHART_PALETTE[index % CHART_PALETTE.length],
+            CHART_COLORS[index % CHART_COLORS.length],
           strokeDasharray: seriesStyles[index]?.strokeDasharray,
           fillOpacity: seriesStyles[index]?.fillOpacity ?? DEFAULT_FILL_OPACITY,
           strokeOpacity: seriesStyles[index]?.strokeOpacity ?? 1,
@@ -722,6 +718,7 @@ const LineChart: React.FC<LineChartProps> = memo(
                     <CustomTooltip
                       unit={unit}
                       visible={!isDragging}
+                      dark
                       metric={metric as MetricItem}
                       seriesUnits={seriesUnits}
                       maxHeight={

--- a/web/src/app/monitor/constants/index.ts
+++ b/web/src/app/monitor/constants/index.ts
@@ -13,4 +13,11 @@ const LEVEL_MAP: LevelMap = {
   warning: '#FFAD42'
 };
 
-export { APPOINT_METRIC_IDS, LEVEL_MAP, OBJECT_DEFAULT_ICON };
+// 折线图分类色板（AntV/G2）。recharts 版 lineChart 与 echarts 版
+// echarts-line-chart 共用，按序列索引稳定分配，保证两类图表配色一致。
+const CHART_COLORS: string[] = [
+  '#5B8FF9', '#5AD8A6', '#F6BD16', '#E86452',
+  '#6DC8EC', '#945FB9', '#FF9845', '#1E9493'
+];
+
+export { APPOINT_METRIC_IDS, LEVEL_MAP, OBJECT_DEFAULT_ICON, CHART_COLORS };

--- a/web/src/app/monitor/constants/index.ts
+++ b/web/src/app/monitor/constants/index.ts
@@ -15,9 +15,12 @@ const LEVEL_MAP: LevelMap = {
 
 // 折线图分类色板（AntV/G2）。recharts 版 lineChart 与 echarts 版
 // echarts-line-chart 共用，按序列索引稳定分配，保证两类图表配色一致。
+// 刻意剔除红/橙告警色系（#E86452 珊瑚红→粉、#FF9845 橙→青灰），把
+// 红/橙留给严重度阈值（LEVEL_MAP critical/error/warning），避免数据
+// 序列被误读成告警线、或填充与阈值色块互相糊掉。
 const CHART_COLORS: string[] = [
-  '#5B8FF9', '#5AD8A6', '#F6BD16', '#E86452',
-  '#6DC8EC', '#945FB9', '#FF9845', '#1E9493'
+  '#5B8FF9', '#5AD8A6', '#F6BD16', '#EB6FB0',
+  '#6DC8EC', '#945FB9', '#5D7092', '#1E9493'
 ];
 
 export { APPOINT_METRIC_IDS, LEVEL_MAP, OBJECT_DEFAULT_ICON, CHART_COLORS };

--- a/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
@@ -8,6 +8,7 @@ import { useECharts } from './useECharts';
 import { formatMetricValue } from '../utils/format';
 import { MetricUnit } from '../types';
 import { normalizeGapIntervals } from '@/app/monitor/utils/gapIntervals';
+import { CHART_COLORS } from '@/app/monitor/constants';
 
 export interface EChartsLineChartProps {
   data: ChartData[];
@@ -27,11 +28,6 @@ export interface EChartsLineChartProps {
   allowSelect?: boolean;
   onXRangeChange?: (range: [Dayjs, Dayjs]) => void;
 }
-
-const DEFAULT_COLORS = [
-  '#5B8FF9', '#5AD8A6', '#F6BD16', '#E86452',
-  '#6DC8EC', '#945FB9', '#FF9845', '#1E9493'
-];
 
 
 const getChartAreaKeys = (arr: ChartData[]): string[] => {
@@ -141,7 +137,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
 
     const seriesList = areaKeys.map((key, idx) => {
       const style = seriesStyles[idx] || {};
-      const color = style.color || DEFAULT_COLORS[idx % DEFAULT_COLORS.length];
+      const color = style.color || CHART_COLORS[idx % CHART_COLORS.length];
       const fillOpacity = style.fillOpacity ?? 0.05;
       const strokeOpacity = style.strokeOpacity ?? 1;
       const strokeWidth = style.strokeWidth ?? 2;
@@ -250,7 +246,7 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
                 displayValue = formatted.value;
                 displayUnit = formatted.unit;
               }
-              const color = style.color || DEFAULT_COLORS[idx % DEFAULT_COLORS.length];
+              const color = style.color || CHART_COLORS[idx % CHART_COLORS.length];
               html += `<div style="display:flex;align-items:center;gap:6px"><span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${color}"></span><span>${displayValue} ${displayUnit}</span></div>`;
             });
           }

--- a/web/src/stories/monitor-line-chart-real.stories.tsx
+++ b/web/src/stories/monitor-line-chart-real.stories.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import LineChart from '@/app/monitor/components/charts/lineChart';
+import type { ChartData } from '@/app/monitor/types';
+
+/**
+ * 生产组件 LineChart 的真实渲染 —— 用于验证「报告风」整改效果。
+ * 直接渲染 src/app/monitor/components/charts/lineChart.tsx，
+ * 不是预览复刻件。多序列 + 阈值线，验证固定色板/细线/渐变填充/
+ * 深色 hover/竖向准星 在真实组件里的表现。
+ */
+
+function genData(): ChartData[] {
+  const start = 1716595200; // 2024-05-25 00:00
+  const points = 90;
+  const step = 16 * 60;
+  const data: ChartData[] = [];
+  for (let i = 0; i < points; i++) {
+    data.push({
+      time: start + i * step,
+      value1: 9 + 3 * Math.sin(i / 6) + 2 * Math.sin(i / 2.3) + (i % 17 === 0 ? 5 : 0),
+      value2: 6 + 3 * Math.sin(i / 5 + 1) + 1.5 * Math.cos(i / 3),
+      value3: 2.5 + 1.2 * Math.sin(i / 4 + 2) + (i % 23 === 0 ? 3 : 0),
+      value4: 2 + 0.8 * Math.sin(i / 7),
+      value5: 1.2 + 0.6 * Math.cos(i / 5) + (i % 29 === 0 ? 6 : 0),
+    } as ChartData);
+  }
+  return data;
+}
+const DATA = genData();
+
+const meta: Meta<typeof LineChart> = {
+  title: 'Monitor/折线图（生产组件）',
+  component: LineChart,
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj<typeof LineChart>;
+
+/** 多序列 —— 验证固定色板 + 细线 + 渐变填充 + 深色 hover */
+export const 多序列: Story = {
+  render: () => (
+    <div style={{ padding: 24, background: 'var(--color-bg-2, #f7fafc)', height: '100vh' }}>
+      <div
+        style={{
+          background: 'var(--color-bg-1)',
+          border: '1px solid var(--color-border-1)',
+          borderRadius: 8,
+          padding: 16,
+          height: 360,
+        }}
+      >
+        <LineChart data={DATA} unit="%" allowSelect={false} />
+      </div>
+    </div>
+  ),
+};
+
+// ─── 边界维度文本 ────────────────────────────────────────────
+const LONG_DIM =
+  'kubernetes.pod.name=payment-gateway-prod-asia-southeast-1-replicaset-7f8d9c-' +
+  'abcdefghijklmnopqrstuvwxyz-0123456789-very-long-segment-that-keeps-going-and-going';
+const NEWLINE_DIM = '行一\n行二\n行三\ttab分隔\r回车';
+const SPECIAL_DIM = '<script>alert(1)</script> & "引号" \'单引号\' {花括号} 100%';
+
+// 把同一组维度 detail 注入每一行
+function withDetails(): ChartData[] {
+  return DATA.map((row) => ({
+    ...row,
+    details: {
+      value1: [{ name: 'pod', label: 'pod', value: LONG_DIM }],
+      value2: [{ name: 'host', label: 'host', value: NEWLINE_DIM }],
+      value3: [{ name: 'svc', label: 'svc', value: SPECIAL_DIM }],
+      value4: [{ name: 'zone', label: 'zone', value: `${'维'.repeat(60)}` }],
+      value5: [{ name: 'ns', label: 'ns', value: 'default' }],
+    },
+  })) as ChartData[];
+}
+const DATA_DETAILS = withDetails();
+
+/** 边界 · 超长/换行/特殊字符维度 —— 验证 tooltip 与维度区 */
+export const 边界_极端维度: Story = {
+  render: () => (
+    <div style={{ padding: 24, background: 'var(--color-bg-2, #f7fafc)', height: '100vh' }}>
+      <div
+        style={{
+          background: 'var(--color-bg-1)',
+          border: '1px solid var(--color-border-1)',
+          borderRadius: 8,
+          padding: 16,
+          height: 420,
+        }}
+      >
+        <LineChart
+          data={DATA_DETAILS}
+          unit="%"
+          allowSelect={false}
+          showDimensionFilter
+          showDimensionTable
+        />
+      </div>
+    </div>
+  ),
+};
+
+/** 带阈值线 —— 验证阈值色与序列色互不干扰 */
+export const 带阈值: Story = {
+  render: () => (
+    <div style={{ padding: 24, background: 'var(--color-bg-2, #f7fafc)', height: '100vh' }}>
+      <div
+        style={{
+          background: 'var(--color-bg-1)',
+          border: '1px solid var(--color-border-1)',
+          borderRadius: 8,
+          padding: 16,
+          height: 360,
+        }}
+      >
+        <LineChart
+          data={DATA}
+          unit="%"
+          allowSelect={false}
+          threshold={[
+            { level: 'critical', value: 14, method: '>' } as any,
+            { level: 'warning', value: 10, method: '>' } as any,
+          ]}
+        />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## 背景

monitor 的折线图（recharts 版 `lineChart.tsx`，用于详情/搜索/告警/策略预览等大部分监控页）此前配色随机、线条偏粗、网格偏重。本次对齐「报告级」观感整改视觉，并修复测试中暴露的维度溢出缺陷。

## 改动

**视觉整改（`lineChart.tsx` / `index.module.scss`）**
- **配色**：固定 AntV 色板按序列索引稳定分配，替换 `generateUniqueRandomColor` 随机配色 → 同一序列跨刷新/跨视图颜色稳定且彼此可区分
- **线条**：1px 细线 + `linear` 折角（原 2.5px `monotoneX`）
- **填充**：每序列渐变淡填充（`fillOpacity` 0.36，底部淡出）
- **网格/轴**：实线极淡网格（`--color-border-1`）、轴文字 12px
- 全程走 CSS 变量，保留暗色模式；阈值线、拖拽选区、维度过滤等交互不变

**Hover（`customTooltips.tsx` / `index.module.scss`）**
- 改为深色 x-unified 浮层：时间表头 + 按值降序 + 线段色标 + 粗体名/带单位数值 + 竖向虚线准星，复刻参考报告交互

**Bug 修复（`dimensionFilter.tsx` / `index.module.scss`）**
- `DimensionFilter` 超长维度文本溢出叠加：`.dimeLabel` 缺 `min-width:0` 致 flex 子项不收缩、省略号失效。改为自包含省略号 + `min-width:0`，色标加 `shrink-0`

**Story（新增）**
- `monitor-line-chart-real.stories.tsx`：真实 `LineChart` 的多序列 / 带阈值 / 极端维度（200 字符、换行符、特殊字符）story，用于视觉验证与边界回归

## 验证

- `pnpm type-check` 通过，0 error
- Storybook 实测：多序列、带阈值、边界维度三个场景渲染正常
- 边界测试：深色 tooltip 对超长/换行/`<script>` 维度均安全（转义无 XSS、宽度受控、换行符折叠）；DimensionFilter 修复后单行省略号、不再重叠

## 影响面

变更为 monitor 通用折线图默认样式，影响所有使用 `lineChart.tsx` 的监控页面（详情/搜索/告警/策略等）。调用方通过 `seriesStyles` 传入的覆盖项仍生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)