### PR TITLE
fix(monitor): surface CPU/memory/temperature panels on router/firewall/loadbalance/networkService SNMP dashboards

### DIFF
--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/firewall.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/firewall.tsx
@@ -3,49 +3,60 @@ export const useFirewallConfig = () => {
     instance_type: 'firewall',
     dashboardDisplay: [
       {
-        indexId: 'device_total_outgoing_traffic',
+        indexId: 'device_cpu_usage',
         displayType: 'single',
         sortIndex: 0,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '15%'
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_memory_usage',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_incoming_traffic',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_outgoing_traffic',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
         }
       },
       {
         indexId: 'snmp_uptime',
         displayType: 'lineChart',
-        sortIndex: 1,
+        sortIndex: 4,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '40%'
-        }
-      },
-      {
-        indexId: 'device_total_incoming_traffic',
-        displayType: 'lineChart',
-        sortIndex: 2,
-        displayDimension: [],
-        style: {
-          height: '200px',
-          width: '40%'
+          width: '100%'
         }
       },
       {
         indexId: 'interfaces',
         displayType: 'multipleIndexsTable',
-        sortIndex: 3,
-        displayDimension: [
-          'ifOperStatus',
-          'ifHighSpeed',
-          'ifInErrors',
-          'ifOutErrors',
-          'ifInUcastPkts',
-          'ifOutUcastPkts',
-          'ifInOctets',
-          'ifOutOctets'
-        ],
+        sortIndex: 5,
+        displayDimension: ['ifOperStatus', 'ifHighSpeed', 'ifInErrors', 'ifOutErrors', 'ifInUcastPkts', 'ifOutUcastPkts', 'ifInOctets', 'ifOutOctets'],
         style: {
           height: '400px',
           width: '100%'

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/loadbalance.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/loadbalance.tsx
@@ -3,49 +3,60 @@ export const useLoadbalanceConfig = () => {
     instance_type: 'loadbalance',
     dashboardDisplay: [
       {
-        indexId: 'device_total_outgoing_traffic',
+        indexId: 'device_cpu_usage',
         displayType: 'single',
         sortIndex: 0,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '15%'
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_memory_usage',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_incoming_traffic',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_outgoing_traffic',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
         }
       },
       {
         indexId: 'snmp_uptime',
         displayType: 'lineChart',
-        sortIndex: 1,
+        sortIndex: 4,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '40%'
-        }
-      },
-      {
-        indexId: 'device_total_incoming_traffic',
-        displayType: 'lineChart',
-        sortIndex: 2,
-        displayDimension: [],
-        style: {
-          height: '200px',
-          width: '40%'
+          width: '100%'
         }
       },
       {
         indexId: 'interfaces',
         displayType: 'multipleIndexsTable',
-        sortIndex: 3,
-        displayDimension: [
-          'ifOperStatus',
-          'ifHighSpeed',
-          'ifInErrors',
-          'ifOutErrors',
-          'ifInUcastPkts',
-          'ifOutUcastPkts',
-          'ifInOctets',
-          'ifOutOctets'
-        ],
+        sortIndex: 5,
+        displayDimension: ['ifOperStatus', 'ifHighSpeed', 'ifInErrors', 'ifOutErrors', 'ifInUcastPkts', 'ifOutUcastPkts', 'ifInOctets', 'ifOutOctets'],
         style: {
           height: '400px',
           width: '100%'

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/networkService.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/networkService.tsx
@@ -3,45 +3,60 @@ export const useNetworkServiceConfig = () => {
     instance_type: 'network_service',
     dashboardDisplay: [
       {
-        indexId: 'device_total_outgoing_traffic',
+        indexId: 'device_cpu_usage',
         displayType: 'single',
         sortIndex: 0,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '15%'
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_memory_usage',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_incoming_traffic',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_outgoing_traffic',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
         }
       },
       {
         indexId: 'snmp_uptime',
         displayType: 'lineChart',
-        sortIndex: 1,
+        sortIndex: 4,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '40%'
-        }
-      },
-      {
-        indexId: 'device_total_incoming_traffic',
-        displayType: 'lineChart',
-        sortIndex: 2,
-        displayDimension: [],
-        style: {
-          height: '200px',
-          width: '40%'
+          width: '100%'
         }
       },
       {
         indexId: 'interfaces',
         displayType: 'multipleIndexsTable',
-        sortIndex: 3,
-        displayDimension: [
-          'ifOperStatus',
-          'ifHighSpeed',
-          'ifHCInOctets',
-          'ifHCOutOctets'
-        ],
+        sortIndex: 5,
+        displayDimension: ['ifOperStatus', 'ifHighSpeed', 'ifHCInOctets', 'ifHCOutOctets'],
         style: {
           height: '400px',
           width: '100%'

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
@@ -3,49 +3,70 @@ export const useRouterConfig = () => {
     instance_type: 'router',
     dashboardDisplay: [
       {
-        indexId: 'device_total_outgoing_traffic',
+        indexId: 'device_cpu_usage',
         displayType: 'single',
         sortIndex: 0,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '15%'
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_memory_usage',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_incoming_traffic',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
+        }
+      },
+      {
+        indexId: 'device_total_outgoing_traffic',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '24%'
         }
       },
       {
         indexId: 'snmp_uptime',
         displayType: 'lineChart',
-        sortIndex: 1,
+        sortIndex: 4,
         displayDimension: [],
         style: {
           height: '200px',
-          width: '40%'
+          width: '49%'
         }
       },
       {
-        indexId: 'device_total_incoming_traffic',
+        indexId: 'device_temperature_celsius',
         displayType: 'lineChart',
-        sortIndex: 2,
-        displayDimension: [],
+        sortIndex: 5,
+        displayDimension: ['descr'],
         style: {
           height: '200px',
-          width: '40%'
+          width: '49%'
         }
       },
       {
         indexId: 'interfaces',
         displayType: 'multipleIndexsTable',
-        sortIndex: 3,
-        displayDimension: [
-          'ifOperStatus',
-          'ifHighSpeed',
-          'ifInErrors',
-          'ifOutErrors',
-          'ifInUcastPkts',
-          'ifOutUcastPkts',
-          'ifInOctets',
-          'ifOutOctets'
-        ],
+        sortIndex: 6,
+        displayDimension: ['ifOperStatus', 'ifHighSpeed', 'ifInErrors', 'ifOutErrors', 'ifInUcastPkts', 'ifOutUcastPkts', 'ifInOctets', 'ifOutOctets'],
         style: {
           height: '400px',
           width: '100%'


### PR DESCRIPTION
## Summary

Several SNMP device brands report CPU / memory / temperature health metrics, but the shared object dashboards for **Router / Firewall / Loadbalance / NetworkService** only displayed interface traffic + uptime + the interfaces table — so those collected health metrics were never visualised. (The Switch dashboard already shows them.)

This adds the missing panels to the four object dashboards' `dashboardDisplay`, mirroring the Switch layout:
- **Router**: + `device_cpu_usage`, `device_memory_usage`, `device_temperature_celsius`
- **Firewall / Loadbalance / NetworkService**: + `device_cpu_usage`, `device_memory_usage`

Brands that report these metrics (e.g. Aethra/Harbour routers with CPU+memory, Sierra/NetModule routers with temperature, Neteye/Bluedon/Amaranten/Secworld/Westone firewalls, Superiority loadbalance) now surface them. Brands without these metrics simply render an empty panel — no breakage.

Purely additive frontend dashboard config; no backend or metric changes.

## Test plan
- [x] Panels mirror the proven Switch `dashboardDisplay` structure
- [ ] Visual check in monitor UI: open a Router/Firewall/Loadbalance instance dashboard, confirm CPU/memory (and temperature for router) panels render
