### PR TITLE
fix(monitor): resolve effective plugins for derived instances without a row

### DIFF
--- a/server/apps/monitor/services/effective_plugins.py
+++ b/server/apps/monitor/services/effective_plugins.py
@@ -3,7 +3,7 @@ from apps.core.logger import monitor_logger as logger
 from apps.core.utils.loader import LanguageLoader
 from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.plugin import PluginConstants
-from apps.monitor.models import CollectConfig, MonitorInstance, MonitorObject, MonitorPlugin
+from apps.monitor.models import CollectConfig, MonitorObject, MonitorPlugin
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 
@@ -14,13 +14,14 @@ class MonitorEffectivePluginService:
         if not monitor_object:
             raise BaseAppException("Monitor object does not exist")
 
-        instance = MonitorInstance.objects.filter(
-            id=instance_id,
-            monitor_object_id=monitor_object_id,
-            is_deleted=False,
-        ).first()
-        if not instance:
-            raise BaseAppException("Monitor instance does not exist")
+        # Note: we intentionally do not require a MonitorInstance row here.
+        # Derived / auto-discovered instances (e.g. K8s Pod and Node) report
+        # metrics under an instance_id that has no MonitorInstance row of its
+        # own. Their effective plugins are still fully resolvable from reported
+        # metrics and collect configs (both keyed by instance_id only), so
+        # requiring a row would 500 the detail view of every derived instance.
+        # A bogus instance_id simply yields no configured/reported plugins below
+        # and returns an empty list.
 
         plugins = list(MonitorPlugin.objects.filter(monitor_object=monitor_object).distinct())
         if not plugins:

--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -262,6 +262,51 @@ def test_effective_plugins_service_deduplicates_configured_reported_plugin(db, m
     assert by_name["HostRemote"]["collect_mode"] == "auto"
 
 
+def test_effective_plugins_service_resolves_derived_instance_without_row(db, monkeypatch):
+    # 回归：K8s Pod/Node 等派生实例在指标里上报，但没有自己的 MonitorInstance 行。
+    # 修复前 get_effective_plugins 强制要求实例行，缺失即抛 "Monitor instance does not exist"（500）。
+    # 修复后无行也能基于上报指标解析有效插件，不再抛异常。
+    from apps.monitor.services import effective_plugins
+
+    monitor_object = MonitorObject.objects.create(
+        name="Pod",
+        display_name="Pod",
+        instance_id_keys=["instance_id"],
+    )
+    reported_plugin = MonitorPlugin.objects.create(
+        name="K8sPod",
+        display_name="K8s Pod",
+        template_id="k8spod",
+        template_type="api",
+        collector="push_api",
+        collect_type="push_api",
+        status_query="any({plugin_id='k8spod'}) by (instance_id)",
+        is_pre=False,
+    )
+    reported_plugin.monitor_object.add(monitor_object)
+
+    derived_instance_id = "('derived-pod-x',)"
+    # 该派生实例确实没有 MonitorInstance 行
+    assert not MonitorInstance.objects.filter(id=derived_instance_id).exists()
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, step="5m", time=None):
+            return {"data": {"result": [{"metric": {"instance_id": "derived-pod-x"}, "value": [100, "1"]}]}}
+
+    monkeypatch.setattr(effective_plugins, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = effective_plugins.MonitorEffectivePluginService.get_effective_plugins(
+        monitor_object.id,
+        derived_instance_id,
+        locale="zh-Hans",
+    )
+
+    by_name = {item["name"]: item for item in result}
+    assert "K8sPod" in by_name
+    assert by_name["K8sPod"]["status"] == "normal"
+    assert by_name["K8sPod"]["collect_mode"] == "manual"
+
+
 def test_primary_object_plugin_list_keeps_builtin_plugins_distinct_by_plugin_id(db, monkeypatch):
     from apps.monitor.constants.plugin import PluginConstants
     from apps.monitor.services import monitor_instance
@@ -580,7 +625,7 @@ def test_effective_plugins_action_returns_service_data(monkeypatch):
     monkeypatch.setattr(
         monitor_instance_view,
         "_ensure_operate_instances",
-        lambda request, instance_ids, actor_context=None: instance_ids,
+        lambda request, instance_ids, actor_context=None, allow_missing=False: instance_ids,
     )
     monkeypatch.setattr(monitor_instance_view, "MonitorEffectivePluginService", StubService)
 
@@ -665,6 +710,60 @@ def test_effective_plugins_action_normalizes_clean_instance_id(db, monkeypatch):
     assert payload["data"] == expected
 
 
+def test_effective_plugins_action_allows_derived_instance_without_row(db, monkeypatch):
+    # 回归：K8s Pod/Node 等派生实例没有 MonitorInstance 行。视图层 _ensure_operate_instances
+    # 修复前对无行实例抛 "监控实例不存在"（500，先于 service）；修复后以 allow_missing=True 放行，
+    # 详情页据上报指标解析插件并返回 200，而非 500。
+    monitor_object = MonitorObject.objects.create(
+        name="Pod",
+        display_name="Pod",
+        instance_id_keys=["instance_id"],
+    )
+    derived_instance_id = "('derived-pod-x',)"
+    assert not MonitorInstance.objects.filter(id=derived_instance_id).exists()
+
+    expected = [{"id": 7, "name": "K8sPod"}]
+
+    class StubService:
+        @staticmethod
+        def get_effective_plugins(monitor_object_id, instance_id, locale):
+            return expected
+
+    monkeypatch.setattr(monitor_instance_view, "MonitorEffectivePluginService", StubService)
+    # 超管 + 真实 _ensure_operate_instances，触发存在性查询路径（无行不再抛异常）。
+    monkeypatch.setattr(
+        monitor_instance_view,
+        "_build_actor_context",
+        lambda request: {
+            "is_superuser": True,
+            "current_team": 1,
+            "username": "tester",
+            "domain": "default",
+            "group_list": [],
+            "include_children": False,
+        },
+    )
+
+    request = types.SimpleNamespace(
+        GET={"instance_id": "derived-pod-x"},
+        COOKIES={"current_team": "1"},
+        user=types.SimpleNamespace(
+            username="tester",
+            domain="default",
+            locale="zh-Hans",
+            is_superuser=True,
+            group_list=[],
+        ),
+    )
+
+    response = monitor_instance_view.MonitorInstanceViewSet().effective_plugins(
+        request, str(monitor_object.id)
+    )
+    payload = json.loads(response.content)
+
+    assert payload["data"] == expected
+
+
 def test_effective_plugins_action_keeps_multi_dimension_instance_id(monkeypatch):
     """多维实例ID(如 VMware ESXi 的 instance_id+resource_id)不能被裁成单维。
 
@@ -684,7 +783,7 @@ def test_effective_plugins_action_keeps_multi_dimension_instance_id(monkeypatch)
     monkeypatch.setattr(
         monitor_instance_view,
         "_ensure_operate_instances",
-        lambda request, instance_ids, actor_context=None: instance_ids,
+        lambda request, instance_ids, actor_context=None, allow_missing=False: instance_ids,
     )
     monkeypatch.setattr(
         monitor_instance_view,

--- a/server/apps/monitor/views/monitor_instance.py
+++ b/server/apps/monitor/views/monitor_instance.py
@@ -104,7 +104,7 @@ def _ensure_instance_scope(instance_ids, actor_context):
     return normalized_ids
 
 
-def _ensure_operate_instances(request, instance_ids, actor_context=None):
+def _ensure_operate_instances(request, instance_ids, actor_context=None, allow_missing=False):
     normalized_ids = _normalize_id_list(instance_ids)
     if not normalized_ids:
         return []
@@ -117,7 +117,12 @@ def _ensure_operate_instances(request, instance_ids, actor_context=None):
         )
     )
     found_ids = {str(instance["id"]) for instance in instances}
-    if found_ids != set(normalized_ids):
+    # allow_missing: derived / auto-discovered instances (e.g. K8s Pod and Node)
+    # report metrics under an instance_id that has no MonitorInstance row. Read-only
+    # endpoints (e.g. effective_plugins) must tolerate their absence instead of 500-ing;
+    # only the instances that DO have a row are authorization-scoped below. Mutating
+    # callers keep allow_missing=False so a bogus instance_id still fails fast.
+    if found_ids != set(normalized_ids) and not allow_missing:
         raise BaseAppException("监控实例不存在")
 
     if not actor_context["is_superuser"]:
@@ -259,7 +264,9 @@ class MonitorInstanceViewSet(viewsets.ViewSet):
         instance_id = normalize_instance_identity(instance_id)["storage_instance_key"]
 
         actor_context = _build_actor_context(request)
-        _ensure_operate_instances(request, [instance_id], actor_context)
+        # Derived instances (K8s Pod/Node) have no MonitorInstance row; tolerate their
+        # absence so the detail view resolves plugins from reported metrics instead of 500-ing.
+        _ensure_operate_instances(request, [instance_id], actor_context, allow_missing=True)
         data = MonitorEffectivePluginService.get_effective_plugins(
             int(monitor_object_id),
             instance_id,


### PR DESCRIPTION
## Problem

Opening the detail view of a K8s **Pod** or **Node** instance returns HTTP 500 with `Monitor instance does not exist`.

Root cause is an inconsistency in how the backend decides an instance "exists":

| Path | Existence basis | Pod/Node |
|------|-----------------|----------|
| Instance **list** (`monitor_instance.py` `count(kube_pod_info)/count(kube_node_info)`) | derived from reported metrics | ✅ listed |
| Instance **detail** (`effective_plugins`) | requires a `MonitorInstance` DB row | ❌ no row → raises |

Pod/Node are auto-discovered/derived instances (dynamic, many, volatile) and intentionally have **no `MonitorInstance` row** — they exist only as metric series (`kube_pod_info` / `kube_node_info`). The list view derives them from metrics and works; the detail endpoint requires a DB row and therefore 500s for every Pod/Node.

This is purely a backend code inconsistency — not a collector or data problem (the list counting 26 pods / 17 nodes proves the metrics are present).

## Fix

Make the effective-plugins detail path tolerate derived instances that have no DB row, at **both** layers it is gated by:

1. **Service** (`effective_plugins.py`): drop the hard `MonitorInstance` existence check. The fetched `instance` object was only used for that check and never referenced afterwards; configured-plugin and reported-plugin resolution are both keyed by `instance_id` alone and need no row. A bogus `instance_id` still yields an empty list; only a missing monitor object remains fatal.
2. **View** (`monitor_instance.py`): add `allow_missing` to `_ensure_operate_instances` and pass `allow_missing=True` from the `effective_plugins` action. This view-layer existence check runs *before* the service, so it must also be relaxed — only the instances that do have a row are authorization-scoped; mutating callers keep `allow_missing=False` so a bogus id still fails fast.

After the fix, list and detail use the same metric-derived definition of "exists"; the inconsistency is gone.

## Tests

`apps/monitor/tests/test_monitor_instance_view.py`:
- New service-level test: a derived instance with no row resolves effective plugins from reported metrics.
- New action-level test: the view (real `_ensure_operate_instances`) returns 200 for a derived instance with no row instead of 500.
- Existing row-present merge/dedup/normalize tests still pass (no regression).

`7 passed` for the effective_plugins suite; `15 passed` for the full file.