### PR TITLE
fix(monitor): collapse long plugin description on integration detail

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/layout.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/layout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Tooltip } from 'antd';
+import { Typography } from 'antd';
 import WithSideMenuLayout from '@/components/sub-layout';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
@@ -28,7 +28,7 @@ const IntegrationDetailLayout = ({
   };
 
   const TopSection = () => (
-    <div className="p-4 rounded-md w-full h-[95px] flex items-center bg-[var(--color-bg-2)]">
+    <div className="p-4 rounded-md w-full min-h-[95px] flex items-start bg-[var(--color-bg-2)]">
       <div className="w-[72px] h-[72px] mr-[10px] min-w-[72px] rounded-lg flex items-center justify-center bg-[var(--color-fill-1)]">
         <img
           src={`/assets/icons/${icon}.svg`}
@@ -40,11 +40,19 @@ const IntegrationDetailLayout = ({
           }}
         />
       </div>
-      <div className="w-full">
+      <div className="w-full min-w-0">
         <h2 className="text-lg font-semibold mb-2">{pluginDisplayName}</h2>
-        <Tooltip title={desc}>
-          <p className="truncate w-[95%] text-sm hide-text">{desc}</p>
-        </Tooltip>
+        <Typography.Paragraph
+          className="!mb-0 text-sm text-[var(--color-text-3)]"
+          ellipsis={{
+            rows: 2,
+            expandable: 'collapsible',
+            symbol: (expanded: boolean) =>
+              expanded ? t('common.collapse') : t('common.expand')
+          }}
+        >
+          {desc}
+        </Typography.Paragraph>
       </div>
     </div>
   );


### PR DESCRIPTION
## 背景
集成插件详情页头部的描述过长时,原实现是`单行截断 + 必须 hover 才能看全文`(`Tooltip + truncate`)。点进详情页后仍要悬停才能阅读,既不方便也不美观。

## 改动
仅改 `web/src/app/monitor/(pages)/integration/list/detail/layout.tsx`:
- 用 antd `Typography.Paragraph` 的 `ellipsis={{ rows: 2, expandable: 'collapsible' }}` 替换 `Tooltip + truncate`:
  - 默认折叠为 2 行 + 行尾「展开」,无需 hover 直接阅读。
  - 点「展开」内联展开全文 + 「收起」。
  - 描述短(不超过 2 行)时自动不显示按钮,保持干净。
- 头部 `h-[95px] items-center` → `min-h-[95px] items-start`,展开时卡片自动撑高、图标顶对齐。
- 文案复用已有 i18n key `common.expand` / `common.collapse`(zh/en 均已存在)。

## 影响面
- 最小 diff,仅此一个文件。
- 列表页描述展示(line-clamp-3 + hover)不变。
- 无后端/接口/权限/导航改动。

## 验证
- `pnpm type-check`:该文件零报错;`eslint` 通过。
- 浏览器实测(本地 dev):
  - 短描述 → 无按钮 ✅
  - 长描述≤2行 → 无按钮 ✅
  - 长描述>2行 → 2 行截断 + 「展开」 ✅
  - 点「展开」→ 全文 + 「收起」,卡片撑高、图标顶对齐 ✅