### PR TITLE
fix(monitor): K8s 集群列表汇总列显示 -- (展示列回填纳入上报型实例)

### DIFF
--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -4,6 +4,7 @@ import uuid
 from django.db import transaction
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.constants.monitor_object import MonitorObjConstants
 from apps.monitor.models.monitor_metrics import Metric
@@ -240,6 +241,38 @@ class MonitorObjectService:
         ).values_list("monitor_instance_id", "monitor_plugin__name")
         for inst_id, plugin_name in cc_qs:
             instance_plugin_map.setdefault(inst_id, set()).add(plugin_name)
+
+        # 派生/上报型实例(如 K8s 集群/Pod/Node 经集群内采集器上报,但 bk-lite 侧无 CollectConfig)
+        # 也应纳入其「上报插件」的展示列取数;否则插件隔离会把它们一律判为 --。
+        # 与 effective_plugins 的 reported 逻辑一致:按对象各插件 status_query 反查上报实例,
+        # 以实例主键(instance_id)前缀匹配,使集群及其下 Pod/Node 都能命中所属插件。
+        plugin_status_qs = (
+            MonitorPlugin.objects.filter(monitor_object=monitor_object_id)
+            .exclude(status_query="")
+            .values_list("name", "status_query")
+            .distinct()
+        )
+        for plugin_name, status_query in plugin_status_qs:
+            query = (status_query or "").strip()
+            if not query:
+                continue
+            try:
+                resp = VictoriaMetricsAPI().query(query)
+            except Exception:
+                logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
+                continue
+            reported_primary_ids = {
+                metric["metric"].get("instance_id")
+                for metric in resp.get("data", {}).get("result", [])
+            }
+            reported_primary_ids.discard(None)
+            if not reported_primary_ids:
+                continue
+            for inst in result:
+                parsed = parse_instance_id(inst["instance_id"])
+                primary = str(parsed[0]) if parsed else None
+                if primary in reported_primary_ids:
+                    instance_plugin_map.setdefault(inst["instance_id"], set()).add(plugin_name)
 
         # 同名指标可能分属多个插件,按 (plugin, name) 精确取;另留 name 兜底给遗留无 plugin 的绑定
         metric_by_plugin = {}

--- a/server/apps/monitor/tests/test_display_fields_reported_plugin.py
+++ b/server/apps/monitor/tests/test_display_fields_reported_plugin.py
@@ -1,0 +1,78 @@
+"""展示列回填:派生/上报型实例(无 CollectConfig)也应命中其上报插件的列值。
+
+回归场景:K8s 集群/Pod/Node 经集群内采集器上报,bk-lite 侧没有 CollectConfig。
+修复前 _fill_display_metrics 只按 CollectConfig 判定插件归属,这些实例的插件绑定列
+一律显示 --;修复后按对象各插件 status_query 反查上报实例,使其命中所属插件并回填列值。
+"""
+
+import pytest
+
+from apps.monitor.models import MonitorObject, MonitorPlugin
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
+from apps.monitor.services import monitor_object as mo
+from apps.monitor.services.monitor_object import MonitorObjectService
+
+
+def _build_k8s_like_object():
+    obj = MonitorObject.objects.create(
+        name="K8sClusterTest",
+        display_name="K8sClusterTest",
+        instance_id_keys=["instance_id"],
+    )
+    plugin = MonitorPlugin.objects.create(
+        name="K8STEST",
+        display_name="K8STEST",
+        template_id="k8stest",
+        template_type="k8s",
+        collector="K8S",
+        collect_type="k8s",
+        status_query="any({instance_type='k8stest'}) by (instance_id)",
+        is_pre=False,
+    )
+    plugin.monitor_object.add(obj)
+    group = MetricGroup.objects.create(
+        monitor_object=obj,
+        monitor_plugin=plugin,
+        name="Quantity",
+    )
+    metric = Metric.objects.create(
+        monitor_object=obj,
+        monitor_plugin=plugin,
+        metric_group=group,
+        name="cluster_pod_count",
+        display_name="Pod Count",
+        query='round(count(some_kube_pod_info{instance_type="k8stest",__$labels__}) by (instance_id))',
+        instance_id_keys=["instance_id"],
+    )
+    return obj, plugin, metric
+
+
+@pytest.mark.django_db
+def test_fill_display_metrics_reported_instance_without_collectconfig(monkeypatch):
+    obj, plugin, metric = _build_k8s_like_object()
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, **kwargs):
+            # 插件 status_query:上报实例 instance_id=mactest
+            if "instance_type='k8stest'" in query and "count(" not in query:
+                return {"data": {"result": [{"metric": {"instance_id": "mactest"}, "value": [0, "1"]}]}}
+            # 展示指标 query:mactest 集群 pod 数 = 7
+            if "some_kube_pod_info" in query:
+                return {"data": {"result": [{"metric": {"instance_id": "mactest"}, "value": [0, "7"]}]}}
+            return {"data": {"result": []}}
+
+    monkeypatch.setattr(mo, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    # 派生实例:无 CollectConfig
+    result = [{"instance_id": "('mactest',)", "instance_name": "mactest"}]
+    obj_metric_map = {
+        "display_fields": [
+            {"name": "Pod Count", "metrics": [{"plugin": "K8STEST", "metric": "cluster_pod_count"}]}
+        ],
+        "supplementary_indicators": [],
+    }
+
+    MonitorObjectService._fill_display_metrics(obj.id, obj_metric_map, result)
+
+    # 修复前:无 CollectConfig → 不命中插件 → 列值缺失(--);修复后:按上报插件命中 → 回填 7
+    assert result[0].get("K8STEST::cluster_pod_count") == "7"


### PR DESCRIPTION
## 问题

K8s 集群/Pod/Node 列表的汇总列(集群Pod总数、集群节点数、集群总内存/磁盘使用率)对**所有**集群都显示 `--`,即便仪表盘里这些指标都有数据。

## 根因

`MonitorObjectService._fill_display_metrics` 的展示列**按插件隔离**:只有"采集配置(CollectConfig)归属某插件"的实例,才会取该插件绑定的展示指标值。

但 K8s 集群/Pod/Node 由**集群内采集器经 NATS 上报**,bk-lite 侧并不存在 per-instance 的 CollectConfig。于是这些实例的 `instance_plugin_map` 为空 → 插件绑定列的 `eligible` 为空 → 该列被跳过 → 显示 `--`。

这与 `effective_plugins` 早先的"派生实例无 DB 行即 500"是同一类问题:只认"配置态(configured)",漏了"上报态(reported)"。

## 修复

在按 CollectConfig 构建 `instance_plugin_map` 之后,额外按对象各插件的 `status_query` 反查上报实例(与 `effective_plugins` 的 reported 逻辑一致),以实例主键 `instance_id` 前缀匹配,使集群及其下 Pod/Node 命中所属上报插件,从而回填 plugin 绑定的展示列。

- 配置型实例:行为不变(CollectConfig 仍生效)。
- 既无 CollectConfig 又无任何上报的实例:仍按隔离规则留空。
- 单查询去重 + 仅对象自身插件,VM 查询开销有界。

## 验证

- 新增 `test_display_fields_reported_plugin`:实例仅上报、无 CollectConfig 时展示列被正确回填(修复前因 `eligible` 为空而留空)。
- 本地实测:K8s 集群列表 5 个集群的 Pod总数/节点数/内存/磁盘列全部正常显示(修复前全 `--`)。