### PR TITLE
feat(monitor): add Network TCP port monitoring via Telegraf net_response

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -2712,6 +2712,16 @@ monitor_object_metric:
     ping_ttl:
       name: Time To Live
       desc: Time To Live value of received ICMP response packets, reflecting number of network hops
+  TCPPort:
+    net_response_response_time:
+      name: Response Time
+      desc: TCP connection round-trip time in milliseconds. net_response emits seconds; the query multiplies by 1000 for display. Higher values indicate slower connections or higher network latency.
+    net_response_result_code:
+      name: Result Code
+      desc: TCP probe result code. 0 success, 1 connection timeout, 2 connection failed, 3 read failed, 4 response string mismatch. Any non-zero value indicates a probe failure.
+    net_response_string_found:
+      name: String Found
+      desc: Whether the expected string was matched in the response. Reported only when an expect string is configured; 1 means found, 0 means not found.
   Nginx:
     nginx_active:
       name: Active Connections
@@ -4077,6 +4087,8 @@ monitor_object_metric_group:
     Service: Service
   Ping:
     Ping: Ping
+  TCPPort:
+    TCPPort: TCP
   SNMP Trap: None
   Website:
     HTTP: HTTP
@@ -5089,6 +5101,9 @@ monitor_object_plugin:
     desc: Through the Telegraf collector, regularly send ICMP Echo Requests (ECHO_REQUEST)
       to check the connectivity and response time of target hosts or network devices.
     name: Ping(Telegraf)
+  TCPPort:
+    name: TCP(Telegraf)
+    desc: Probe TCP port reachability of a target host through the Telegraf net_response plugin, supporting IPv4 and IPv6, with optional send payload and expected response matching.
   MongoDB:
     name: MongoDB(Telegraf)
     desc: Through the Telegraf collector, regularly collect MongoDB metrics including
@@ -5149,6 +5164,7 @@ monitor_object:
   Minio: Minio
   Postgres: Postgres
   Ping: Ping
+  TCPPort: TCP
   vCenter: vCenter
   Switch: Switch
   WebLogic: WebLogic

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -2438,6 +2438,16 @@ monitor_object_metric:
     ping_ttl:
       name: 生存时间(TTL)
       desc: 接收到的ICMP响应包的生存时间值，反映数据包经过的网络跳数
+  TCPPort:
+    net_response_response_time:
+      name: 响应时间
+      desc: TCP建立连接的往返耗时（毫秒）。net_response原始输出为秒，查询时乘以1000换算为毫秒展示，数值越大表示连接越慢或网络延迟越高。
+    net_response_result_code:
+      name: 探测结果码
+      desc: TCP探测的结果码。0表示成功，1表示连接超时，2表示连接失败，3表示读取失败，4表示返回内容与期望串不匹配。非0均代表探测异常。
+    net_response_string_found:
+      name: 返回匹配
+      desc: 是否在响应内容中匹配到期望字符串。仅在配置了期望返回串时上报，1表示命中，0表示未命中。
   Nginx:
     nginx_active:
       name: 活跃连接数
@@ -3735,6 +3745,8 @@ monitor_object_metric_group:
     Service: 服务状态
   Ping:
     Ping: Ping
+  TCPPort:
+    TCPPort: TCP
   SNMP Trap: None
   Website:
     HTTP: HTTP
@@ -4338,6 +4350,9 @@ monitor_object_plugin:
   Ping:
     desc: 通过Telegraf采集器定期发送ICMP回显请求（ECHO_REQUEST）来检查目标主机或网络设备的连通性和响应时间。
     name: Ping（Telegraf）
+  TCPPort:
+    name: TCP（Telegraf）
+    desc: 通过Telegraf net_response插件对目标主机的TCP端口进行连通性探测，支持IPv4和IPv6，可选发送内容并匹配期望返回串。
   MongoDB:
     name: MongoDB（Telegraf）
     desc: 通过Telegraf采集器定期收集MongoDB的基础信息、性能指标、操作统计和资源使用情况，帮助优化性能，保障数据库高效稳定运行。
@@ -4383,6 +4398,7 @@ monitor_object:
   Minio: Minio
   Postgres: Postgres
   Ping: Ping
+  TCPPort: TCP
   vCenter: vCenter
   Switch: 交换机
   WebLogic: WebLogic

--- a/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/UI.json
@@ -1,0 +1,197 @@
+{
+  "object_name": "TCPPort",
+  "instance_type": "tcp",
+  "collect_type": "tcp",
+  "config_type": ["net_response"],
+  "collector": "Telegraf",
+  "instance_id": "{{instance_type}}_{{host}}_{{port}}",
+  "form_fields": [
+    {
+      "name": "host",
+      "label": "主机",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "TCP 探测目标主机，支持域名、IPv4 或 IPv6（无需手动加方括号）。",
+      "widget_props": {
+        "placeholder": "example.com / 192.168.1.1 / 2001:db8::1"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.address",
+        "to_form": {
+          "regex": "^\\[?([^\\]]+?)\\]?:\\d+$"
+        }
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "TCP 探测目标端口。",
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "端口"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.address",
+        "to_form": {
+          "regex": ":(\\d+)$"
+        }
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "timeout",
+      "label": "超时",
+      "type": "inputNumber",
+      "required": false,
+      "default_value": 5,
+      "description": "单次 TCP 连接的超时时间（单位：秒）。",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "超时",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.timeout",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "send",
+      "label": "发送内容",
+      "type": "input",
+      "required": false,
+      "description": "建连后发送的字符串，留空表示仅做端口连通性探测。",
+      "widget_props": {
+        "placeholder": "可选，如 PING\\r\\n"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.send"
+      }
+    },
+    {
+      "name": "expect",
+      "label": "期望返回",
+      "type": "input",
+      "required": false,
+      "description": "期望在响应中匹配到的字符串，需与发送内容配合使用。",
+      "widget_props": {
+        "placeholder": "可选，如 PONG"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.expect"
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点",
+        "width": 200
+      },
+      "enable_row_filter": false
+    },
+    {
+      "name": "host",
+      "label": "主机",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "example.com / 192.168.1.1 / 2001:db8::1",
+        "width": 260
+      },
+      "rules": [
+        {
+          "type": "pattern",
+          "pattern": "^([a-zA-Z0-9]([a-zA-Z0-9\\-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,}$|^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$|^([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4}$",
+          "message": "请输入有效的域名、IPv4或IPv6地址（IPv6无需方括号）"
+        }
+      ],
+      "change_handler": {
+        "type": "combine",
+        "source_fields": ["host", "port"],
+        "target_field": "instance_name",
+        "separator": ":"
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "端口",
+        "width": 120
+      },
+      "change_handler": {
+        "type": "combine",
+        "source_fields": ["host", "port"],
+        "target_field": "instance_name",
+        "separator": ":"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false,
+        "width": 200
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": false,
+      "widget_props": {
+        "placeholder": "请选择组",
+        "width": 200
+      }
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/metrics.json
@@ -1,0 +1,66 @@
+{
+  "plugin": "TCPPort",
+  "plugin_desc": "The TCP plugin uses Telegraf net_response to probe TCP port reachability for a target host:port, supporting IPv4 and IPv6, with optional send/expect string matching.",
+  "status_query": "any({instance_type='tcp', collect_type='tcp'}) by (instance_id)",
+  "name": "TCPPort",
+  "icon": "mm-website_网站",
+  "type": "Web",
+  "description": "",
+  "default_metric": "any({instance_type='tcp'}) by (instance_id)",
+  "instance_id_keys": ["instance_id"],
+  "supplementary_indicators": ["net_response_response_time", "net_response_result_code"],
+  "display_fields": [
+    {"name": "Response Time", "sort_order": 0, "metrics": [{"plugin": "TCPPort", "metric": "net_response_response_time"}]},
+    {"name": "Result Code", "sort_order": 1, "metrics": [{"plugin": "TCPPort", "metric": "net_response_result_code"}]}
+  ],
+  "metrics": [
+    {
+      "metric_group": "TCPPort",
+      "name": "net_response_response_time",
+      "query": "net_response_response_time{__$labels__} * 1000",
+      "display_name": "Response Time",
+      "data_type": "Number",
+      "unit": "ms",
+      "dimensions": [
+        {
+          "name": "agent_id",
+          "description": "agent_id"
+        }
+      ],
+      "instance_id_keys": ["instance_id"],
+      "description": "TCP connection round-trip time. net_response emits seconds; the query multiplies by 1000 to display milliseconds."
+    },
+    {
+      "metric_group": "TCPPort",
+      "name": "net_response_result_code",
+      "query": "net_response_result_code{__$labels__}",
+      "display_name": "Result Code",
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"成功\",\"id\":0,\"color\":\"#1ac44a\"},{\"name\":\"超时\",\"id\":1,\"color\":\"#ff4d4f\"},{\"name\":\"连接失败\",\"id\":2,\"color\":\"#ff4d4f\"},{\"name\":\"读取失败\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"返回不匹配\",\"id\":4,\"color\":\"#faad14\"}]",
+      "dimensions": [
+        {
+          "name": "agent_id",
+          "description": "agent_id"
+        }
+      ],
+      "instance_id_keys": ["instance_id"],
+      "description": "TCP probe result code: 0 success, 1 timeout, 2 connection failed, 3 read failed, 4 response string mismatch."
+    },
+    {
+      "metric_group": "TCPPort",
+      "name": "net_response_string_found",
+      "query": "net_response_string_found{__$labels__}",
+      "display_name": "String Found",
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"未命中\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"命中\",\"id\":1,\"color\":\"#1ac44a\"}]",
+      "dimensions": [
+        {
+          "name": "agent_id",
+          "description": "agent_id"
+        }
+      ],
+      "instance_id_keys": ["instance_id"],
+      "description": "Whether the expected response string was matched. Only reported when an expect string is configured."
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/net_response.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/net_response.child.toml.j2
@@ -1,0 +1,13 @@
+[[inputs.net_response]]
+    startup_error_behavior = "retry"
+    protocol = "tcp"
+    address = "{% if ':' in host %}[{{ host }}]{% else %}{{ host }}{% endif %}:{{ port }}"
+    timeout = "{{ timeout | default(5) }}s"
+    interval = "{{ interval }}s"
+    {% if send %}send = "{{ send | replace('\\', '\\\\') | replace('"', '\\"') }}"
+    {% endif %}{% if expect %}expect = "{{ expect | replace('\\', '\\\\') | replace('"', '\\"') }}"
+    {% endif %}[inputs.net_response.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "tcp"
+        config_type = "net_response"

--- a/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/policy.json
@@ -1,0 +1,44 @@
+{
+  "object": "TCPPort",
+  "plugin": "TCPPort",
+  "templates": [
+    {
+      "name": "TCP 探测失败",
+      "alert_name": "目标${resource_name} 节点${metric_agent_id} TCP探测失败",
+      "description": "监控TCP探测结果码，当连接超时、连接失败、读取失败或返回不匹配（结果码非0）时触发告警。注意结果码4为返回内容不匹配，此时端口可达但响应不符合期望。",
+      "metric_name": "net_response_result_code",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 1,
+          "method": ">="
+        }
+      ]
+    },
+    {
+      "name": "TCP 响应时间过高",
+      "alert_name": "目标${resource_name} 节点${metric_agent_id} TCP响应时间过高",
+      "description": "评估TCP建连耗时（毫秒），当连接延迟超过阈值时分级告警，提示用户检查目标服务的网络性能或负载情况。",
+      "metric_name": "net_response_response_time",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 500,
+          "method": ">="
+        },
+        {
+          "level": "error",
+          "value": 300,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 200,
+          "method": ">="
+        }
+      ]
+    }
+  ]
+}

--- a/web/src/app/monitor/constants/menu.json
+++ b/web/src/app/monitor/constants/menu.json
@@ -60,6 +60,11 @@
           "url": "/monitor/view/dashboard/ping",
           "name": "ping_dashboard",
           "isNotMenuItem": true
+        },
+        {
+          "url": "/monitor/view/dashboard/tcp",
+          "name": "tcp_dashboard",
+          "isNotMenuItem": true
         }
       ]
     },
@@ -216,6 +221,11 @@
         {
           "url": "/monitor/view/dashboard/ping",
           "name": "ping_dashboard",
+          "isNotMenuItem": true
+        },
+        {
+          "url": "/monitor/view/dashboard/tcp",
+          "name": "tcp_dashboard",
           "isNotMenuItem": true
         }
       ]

--- a/web/src/app/monitor/dashboards/objects/tcp/config.ts
+++ b/web/src/app/monitor/dashboards/objects/tcp/config.ts
@@ -1,0 +1,170 @@
+import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+import type { MetricEnumMap } from '../../shared/types';
+
+const TCP_RESULT_CODE_ENUM: MetricEnumMap = {
+  0: { label: '成功', color: '#27c274' },
+  1: { label: '超时', color: '#ff4d4f' },
+  2: { label: '连接失败', color: '#ff4d4f' },
+  3: { label: '读取失败', color: '#ff4d4f' },
+  4: { label: '返回不匹配', color: '#faad14' }
+};
+
+export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
+  routeKey: 'tcp',
+  pageTitle: 'TCP 监控仪表盘',
+  objectFallbackName: 'TCP',
+  instanceType: 'tcp',
+  collectionStatusQuery: "count({instance_type='tcp', collect_type='tcp', __$labels__}) by (instance_id)",
+  metaItems: ['Telegraf', 'tcp'],
+  metrics: [
+    {
+      name: 'tcp_response_time_avg',
+      display_name: '平均响应时间',
+      description: 'TCP 建连的平均往返耗时（毫秒）。',
+      unit: 'ms',
+      query: 'avg(net_response_response_time{__$labels__}) * 1000',
+      color: '#2f6bff'
+    },
+    {
+      name: 'tcp_response_time_min',
+      display_name: '最小响应时间',
+      description: 'TCP 建连的最小往返耗时（毫秒）。',
+      unit: 'ms',
+      query: 'min(net_response_response_time{__$labels__}) * 1000',
+      color: '#13c2c2'
+    },
+    {
+      name: 'tcp_response_time_max',
+      display_name: '最大响应时间',
+      description: 'TCP 建连的最大往返耗时（毫秒）。',
+      unit: 'ms',
+      query: 'max(net_response_response_time{__$labels__}) * 1000',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'tcp_success_rate',
+      display_name: '连通成功率',
+      description: '结果码为 0（成功）的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} == bool 0) * 100',
+      color: '#27c274'
+    },
+    {
+      name: 'tcp_failure_rate',
+      display_name: '探测失败率',
+      description: '结果码非 0（超时/连接失败/读取失败/返回不匹配）的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} != bool 0) * 100',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'tcp_result_code_max',
+      display_name: '最差结果码',
+      description: '当前最差的 TCP 探测结果码。',
+      unit: 'none',
+      query: 'max(net_response_result_code{__$labels__})',
+      color: '#9aa9bf'
+    },
+    {
+      name: 'tcp_string_found_rate',
+      display_name: '返回匹配率',
+      description: '配置了期望返回串时，命中期望串的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_string_found{__$labels__}) * 100',
+      color: '#597ef7'
+    }
+  ],
+  summaryCards: [
+    {
+      title: '连通成功率',
+      metric: 'tcp_success_rate',
+      unit: 'percent',
+      color: '#27c274',
+      icon: 'health',
+      compare: true,
+      compareFavorableDirection: 'up',
+      guide: [{ label: '连通成功率', detail: '结果码为 0 的探测占比，反映 TCP 端口整体可达性。' }],
+      footer: [{ label: '最差结果码', metric: 'tcp_result_code_max', formatter: 'enumHealth', enumMap: TCP_RESULT_CODE_ENUM }]
+    },
+    {
+      title: '平均响应时间',
+      metric: 'tcp_response_time_avg',
+      unit: 'ms',
+      color: '#2f6bff',
+      icon: 'clock',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [],
+      footer: [{ label: '最大响应时间', metric: 'tcp_response_time_max', unit: 'ms' }]
+    },
+    {
+      title: '最大响应时间',
+      metric: 'tcp_response_time_max',
+      unit: 'ms',
+      color: '#ff8a1f',
+      icon: 'clock',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '最大响应时间', detail: '探测节点的最大建连耗时，用于捕捉延迟尖刺。' }],
+      footer: [{ label: '平均响应时间', metric: 'tcp_response_time_avg', unit: 'ms' }]
+    },
+    {
+      title: '探测失败率',
+      metric: 'tcp_failure_rate',
+      unit: 'percent',
+      color: '#ff4d4f',
+      icon: 'api',
+      compare: true,
+      compareFavorableDirection: 'down',
+      guide: [{ label: '探测失败率', detail: '结果码非 0 的探测占比，升高表示端口不可达或响应异常。' }],
+      footer: [{ label: '返回匹配率', metric: 'tcp_string_found_rate', unit: 'percent' }]
+    },
+    {
+      title: '返回匹配率',
+      metric: 'tcp_string_found_rate',
+      unit: 'percent',
+      color: '#597ef7',
+      icon: 'api',
+      compare: true,
+      compareFavorableDirection: 'up',
+      guide: [{ label: '返回匹配率', detail: '仅在配置了期望返回串时统计，命中期望串的探测占比。' }],
+      footer: [{ label: '最小响应时间', metric: 'tcp_response_time_min', unit: 'ms' }]
+    }
+  ],
+  charts: [
+    {
+      title: '响应时间趋势',
+      subtitle: '平均、最小与最大',
+      metric: 'tcp_response_time_avg',
+      guide: [{ label: '响应时间趋势', detail: '观察 TCP 建连耗时的平均、最小和最大变化。' }],
+      series: [
+        { metric: 'tcp_response_time_avg', label: '平均响应时间', color: '#2f6bff', unit: 'ms' },
+        { metric: 'tcp_response_time_min', label: '最小响应时间', color: '#13c2c2', unit: 'ms' },
+        { metric: 'tcp_response_time_max', label: '最大响应时间', color: '#ff8a1f', unit: 'ms' }
+      ]
+    },
+    {
+      title: '连通成功率趋势',
+      subtitle: '成功率变化',
+      metric: 'tcp_success_rate',
+      guide: [{ label: '连通成功率趋势', detail: '观察 TCP 探测连通成功率随时间变化。' }],
+      series: [{ metric: 'tcp_success_rate', label: '连通成功率', color: '#27c274', unit: 'percent' }]
+    }
+  ],
+  ringPanels: [
+    {
+      title: '探测结果分布',
+      subtitle: '成功与失败占比',
+      centerMetric: 'tcp_success_rate',
+      centerCaption: '连通成功率',
+      centerUnit: 'percent',
+      guide: [{ label: '探测结果分布', detail: '展示 TCP 探测成功与失败的当前结构。' }],
+      segments: [
+        { label: '成功占比', metric: 'tcp_success_rate', color: '#27c274', unit: 'percent' },
+        { label: '失败占比', metric: 'tcp_failure_rate', color: '#ffccc7', unit: 'percent' }
+      ]
+    }
+  ],
+  barPanels: [],
+  details: []
+};

--- a/web/src/app/monitor/dashboards/objects/tcp/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/tcp/dashboard.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React from 'react';
+import { useSimpleDashboardData } from '../common/simple-dashboard-core';
+import {
+  DashboardShell,
+  FlexiblePanelSection,
+  KpiSection,
+  useFilteredChartPanels,
+  useFilteredRingPanels
+} from '../common/dashboard-components';
+import { RingChartPanel, TrendChartPanel } from '../../shared/widgets';
+import { TCP_DASHBOARD_CONFIG } from './config';
+import styles from './index.module.scss';
+
+const CHART_TITLES = ['响应时间趋势', '连通成功率趋势'];
+const RING_TITLES = ['探测结果分布'];
+
+export default function TcpDashboardPage() {
+  const dashboard = useSimpleDashboardData(TCP_DASHBOARD_CONFIG);
+  const charts = useFilteredChartPanels(dashboard.chartPanels, CHART_TITLES);
+  const rings = useFilteredRingPanels(dashboard.ringPanels, RING_TITLES);
+
+  const [responseChart, successChart] = charts;
+  const [resultRing] = rings;
+
+  return (
+    <DashboardShell
+      dashboard={dashboard}
+      styles={styles}
+      dashboardContent={
+        <>
+          <div className={styles.sectionLabel}>健康概览</div>
+          <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={6} styles={styles} />
+          <div className={styles.sectionLabel}>分布与趋势</div>
+          <FlexiblePanelSection styles={styles}>
+            {resultRing ? (
+              <RingChartPanel
+                key={resultRing.panel.title}
+                title={resultRing.panel.title}
+                subtitle={resultRing.panel.subtitle}
+                guide={resultRing.panel.guide}
+                data={resultRing.data}
+                centerValue={resultRing.centerValue}
+                centerCaption={resultRing.panel.centerCaption}
+                isEmpty={resultRing.isEmpty}
+                className={styles.span4}
+                styles={styles}
+              />
+            ) : null}
+            {successChart ? (
+              <TrendChartPanel
+                key={successChart.chart.title}
+                title={successChart.chart.title}
+                subtitle={successChart.chart.subtitle}
+                guide={successChart.chart.guide}
+                legends={successChart.legends}
+                data={successChart.data}
+                metric={successChart.metric}
+                unit={successChart.unit}
+                loading={dashboard.loading}
+                seriesStyles={successChart.seriesStyles}
+                onXRangeChange={dashboard.onXRangeChange}
+                className={`${styles.span4} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null}
+            {responseChart ? (
+              <TrendChartPanel
+                key={responseChart.chart.title}
+                title={responseChart.chart.title}
+                subtitle={responseChart.chart.subtitle}
+                guide={responseChart.chart.guide}
+                legends={responseChart.legends}
+                data={responseChart.data}
+                metric={responseChart.metric}
+                unit={responseChart.unit}
+                loading={dashboard.loading}
+                seriesStyles={responseChart.seriesStyles}
+                onXRangeChange={dashboard.onXRangeChange}
+                className={`${styles.span4} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null}
+          </FlexiblePanelSection>
+        </>
+      }
+    />
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/tcp/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/tcp/index.module.scss
@@ -1,0 +1,54 @@
+@use '../common/simple-dashboard.module.scss';
+
+.sectionLabel {
+  margin: 2px 2px 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eceff4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8c95a8;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 8px;
+}
+
+:global(html.dark) .sectionLabel {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.chartLegendHeader {
+  justify-content: flex-end;
+  max-width: none;
+  white-space: nowrap;
+}
+
+.compactTrend {
+  .chartWrap {
+    height: 164px;
+  }
+}
+
+@media (max-width: 768px) {
+  .chartLegendHeader {
+    justify-content: flex-start;
+    max-width: 100%;
+    white-space: normal;
+  }
+
+  .compactTrend {
+    .chartWrap {
+      height: 138px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
+}

--- a/web/src/app/monitor/dashboards/objects/tcp/index.ts
+++ b/web/src/app/monitor/dashboards/objects/tcp/index.ts
@@ -1,0 +1,3 @@
+import TcpDashboardPage from './dashboard';
+
+export default TcpDashboardPage;

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -14,6 +14,7 @@ import IBMMQDashboard from './objects/ibmmq';
 import TomcatDashboard from './objects/tomcat';
 import ZookeeperDashboard from './objects/zookeeper';
 import PingDashboard from './objects/ping';
+import TcpDashboard from './objects/tcp';
 import PostgresqlDashboard from './objects/postgresql';
 import { ProfessionalDashboardRegistryItem } from './shared/types';
 import WebsiteDashboard from './objects/website';
@@ -192,6 +193,15 @@ export const PROFESSIONAL_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
     objectDisplayName: 'Ping',
     inheritedPermissionPath: '/monitor/view',
     component: PingDashboard
+  },
+  {
+    key: 'tcp',
+    aliases: ['TCPPort', 'TCP端口'],
+    groupKey: 'network',
+    objectName: 'TCPPort',
+    objectDisplayName: 'TCP',
+    inheritedPermissionPath: '/monitor/view',
+    component: TcpDashboard
   },
   {
     key: 'switch',

--- a/web/src/app/monitor/hooks/integration/index.tsx
+++ b/web/src/app/monitor/hooks/integration/index.tsx
@@ -41,6 +41,7 @@ import { useStorageConfig } from './objects/hardwareDevice/storage';
 import { useHostConfig } from './objects/os/host';
 import { useWebsiteConfig } from './objects/web/website';
 import { usePingConfig } from './objects/web/ping';
+import { useTcpPortConfig } from './objects/web/tcpPort';
 import { useSnmpTrapConfig } from './objects/other/snmpTrap';
 import { useJvmConfig } from './objects/other/jvm';
 import { useTcpConfig } from './objects/tencentCloud/tcp';
@@ -113,6 +114,7 @@ export const useMonitorConfig = () => {
   const hostConfig = useHostConfig();
   const websiteConfig = useWebsiteConfig();
   const pingConfig = usePingConfig();
+  const tcpPortConfig = useTcpPortConfig();
   const snmpTrapConfig = useSnmpTrapConfig();
   const jvmConfig = useJvmConfig();
   const tcpConfig = useTcpConfig();
@@ -173,6 +175,7 @@ export const useMonitorConfig = () => {
       Host: hostConfig,
       Website: websiteConfig,
       Ping: pingConfig,
+      TCPPort: tcpPortConfig,
       'SNMP Trap': snmpTrapConfig,
       JVM: jvmConfig,
       TCP: tcpConfig,

--- a/web/src/app/monitor/hooks/integration/objects/web/tcpPort.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/web/tcpPort.tsx
@@ -1,0 +1,31 @@
+export const useTcpPortConfig = () => {
+  return {
+    instance_type: 'tcp',
+    dashboardDisplay: [
+      {
+        indexId: 'net_response_response_time',
+        displayType: 'single',
+        sortIndex: 0,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%',
+        },
+      },
+      {
+        indexId: 'net_response_result_code',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%',
+        },
+      },
+    ],
+    groupIds: {},
+    collectTypes: {
+      TCPPort: 'tcp',
+    },
+  };
+};


### PR DESCRIPTION
## 背景

新增「网络-TCP 端口」监控能力，基于 Telegraf 原生 `inputs.net_response` 插件，对目标主机的 TCP 端口做连通性拨测，**同时支持 IPv4 与 IPv6**，并可选发送内容（send）+ 匹配期望返回串（expect）。

## 设计要点

- **对象身份**：对象 key=`TCPPort`（显示名「TCP」），`instance_type`/`collect_type`=`tcp`，`config_type`=`net_response`，复用 `Telegraf` 采集器（无新增采集器二进制）。
  - 之所以 key 用 `TCPPort` 而非 `TCP`：`TCP` 已被既有「腾讯云（Tencent Cloud Platform）」对象占用，避免碰撞。
- **IPv6 兼容**：表单收 host + port 两个字段，模板在渲染 `address` 时对 IPv6 自动加方括号（`[2001:db8::1]:443`），用户无需手动加。
- **指标**（telegraf 原生 `net_response`）：
  - `net_response_response_time`：建连耗时，查询内联 `* 1000` 换算为毫秒展示。
  - `net_response_result_code`：探测结果码（0 成功 / 1 超时 / 2 连接失败 / 3 读取失败 / 4 返回不匹配），枚举着色。
  - `net_response_string_found`：是否命中期望返回串（仅配置 expect 时上报）。
- **告警**：TCP 探测失败（结果码非 0）、TCP 响应时间过高（毫秒分级阈值）。
- **仪表盘**：配置驱动（参考 Ping），含连通成功率/响应时间 KPI、探测结果分布环形图、响应时间与成功率趋势图。

## 改动清单

- 插件支持文件：`Telegraf/tcp/tcp/{net_response.child.toml.j2, UI.json, metrics.json, policy.json}`
- 双语：`server/apps/monitor/language/{zh-Hans,en}.yaml` 的 `TCPPort` 块
- 前端集成对象：`hooks/integration/objects/web/tcpPort.tsx` + `index.tsx` 注册
- 监控仪表盘：`dashboards/objects/tcp/*` + `registry.ts` + `constants/menu.json` 权限路由

仅触达本能力相关文件，未改动共享 API、导航、权限、节点采集导入等无关业务。

## 测试计划

- [x] JSON/YAML 语法校验；`plugin_init` 导入幂等（重复执行无重复键）
- [x] toml 渲染：IPv4 / IPv6 / send / expect 各组合渲染为合法 TOML（IPv6 正确加括号；send/expect 含引号/反斜杠已转义，不破坏 TOML）
- [x] 双语完整（3 指标 name+desc、metric_group、plugin、object 均 zh+en）
- [x] 仪表盘 PromQL 实测返回数据；单位走后端单位体系（ms/percent/none）
- [ ] 真实采集器端到端下发与上报（需联调环境）
