### PR TITLE
fix(monitor): gate reported-plugin lookup and fix K8s dashboard display

### DIFF
--- a/server/apps/monitor/services/effective_plugins.py
+++ b/server/apps/monitor/services/effective_plugins.py
@@ -4,6 +4,7 @@ from apps.core.utils.loader import LanguageLoader
 from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.plugin import PluginConstants
 from apps.monitor.models import CollectConfig, MonitorObject, MonitorPlugin
+from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 
@@ -69,6 +70,10 @@ class MonitorEffectivePluginService:
     @staticmethod
     def _get_reported_plugin_ids(plugins: list[MonitorPlugin], instance_id: str, instance_id_keys: list[str]) -> set[int]:
         reported_plugin_ids = set()
+        # 主键(instance_id 维度的首键)值,用于多键对象的退化匹配。
+        parsed = parse_instance_id(instance_id)
+        primary_key = instance_id_keys[0] if instance_id_keys else "instance_id"
+        target_primary = str(parsed[0]) if parsed else None
         vm_api = VictoriaMetricsAPI()
         for plugin in plugins:
             query = (plugin.status_query or "").strip()
@@ -83,7 +88,13 @@ class MonitorEffectivePluginService:
             for metric in response.get("data", {}).get("result", []):
                 labels = metric.get("metric", {})
                 metric_instance_id = str(tuple(labels.get(key) for key in instance_id_keys))
-                if metric_instance_id == instance_id:
+                # 全键精确匹配;若插件 status_query 只按主键 instance_id 分组(K8s 多键对象 Pod/Node
+                # 的 K8S 插件状态查询即 `... by (instance_id)`,标签里没有 pod/node),退化为按主键匹配
+                # —— 同集群下的派生 Pod/Node 视为上报该插件,否则其生效插件/全量指标会一律为空。
+                if metric_instance_id == instance_id or (
+                    target_primary is not None
+                    and str(labels.get(primary_key)) == target_primary
+                ):
                     reported_plugin_ids.add(plugin.id)
                     break
         return reported_plugin_ids

--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -205,7 +205,11 @@ class InstanceSearch:
             results = items[start:end]
 
         if self.query_data.get("add_metrics", False) and page_size != -1:
-            results = self.add_other_metrics(results)
+            # 用 display_fields 的复合 key 回填(与前端 displayFieldKey 一致:有插件 `<plugin>::<metric>`)。
+            # 旧 add_other_metrics 用 supplementary_indicators 的裸指标名回填,对绑定了插件的对象
+            # (K8s 集群/Pod/Node 等)前端按复合 key 取值取不到 → 列显示 --。改走 _fill_display_metrics
+            # 统一 key 形态,并复用其「按上报插件纳入派生实例」的逻辑。
+            MonitorObjectService._fill_display_metrics(self.monitor_obj.id, self.obj_metric_map, results)
 
         MonitorObjectService.add_attr(results)
 

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -246,33 +246,39 @@ class MonitorObjectService:
         # 也应纳入其「上报插件」的展示列取数;否则插件隔离会把它们一律判为 --。
         # 与 effective_plugins 的 reported 逻辑一致:按对象各插件 status_query 反查上报实例,
         # 以实例主键(instance_id)前缀匹配,使集群及其下 Pod/Node 都能命中所属插件。
-        plugin_status_qs = (
-            MonitorPlugin.objects.filter(monitor_object=monitor_object_id)
-            .exclude(status_query="")
-            .values_list("name", "status_query")
-            .distinct()
-        )
-        for plugin_name, status_query in plugin_status_qs:
-            query = (status_query or "").strip()
-            if not query:
-                continue
-            try:
-                resp = VictoriaMetricsAPI().query(query)
-            except Exception:
-                logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
-                continue
-            reported_primary_ids = {
-                metric["metric"].get("instance_id")
-                for metric in resp.get("data", {}).get("result", [])
-            }
-            reported_primary_ids.discard(None)
-            if not reported_primary_ids:
-                continue
-            for inst in result:
-                parsed = parse_instance_id(inst["instance_id"])
-                primary = str(parsed[0]) if parsed else None
-                if primary in reported_primary_ids:
-                    instance_plugin_map.setdefault(inst["instance_id"], set()).add(plugin_name)
+        #
+        # 门控:仅当存在未被 CollectConfig 覆盖的实例(即派生/上报型)时才反查。常规对象实例全有
+        # CollectConfig,反查纯属浪费——本函数在实例列表热路径被调用,Switch(65)/Firewall(28) 等
+        # 多插件对象若无条件反查会每次分页串行发数十次 VM status_query。
+        uncovered = [inst for inst in result if inst["instance_id"] not in instance_plugin_map]
+        if uncovered:
+            plugin_status_qs = (
+                MonitorPlugin.objects.filter(monitor_object=monitor_object_id)
+                .exclude(status_query="")
+                .values_list("name", "status_query")
+                .distinct()
+            )
+            for plugin_name, status_query in plugin_status_qs:
+                query = (status_query or "").strip()
+                if not query:
+                    continue
+                try:
+                    resp = VictoriaMetricsAPI().query(query)
+                except Exception:
+                    logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
+                    continue
+                reported_primary_ids = {
+                    metric["metric"].get("instance_id")
+                    for metric in resp.get("data", {}).get("result", [])
+                }
+                reported_primary_ids.discard(None)
+                if not reported_primary_ids:
+                    continue
+                for inst in uncovered:
+                    parsed = parse_instance_id(inst["instance_id"])
+                    primary = str(parsed[0]) if parsed else None
+                    if primary in reported_primary_ids:
+                        instance_plugin_map.setdefault(inst["instance_id"], set()).add(plugin_name)
 
         # 同名指标可能分属多个插件,按 (plugin, name) 精确取;另留 name 兜底给遗留无 plugin 的绑定
         metric_by_plugin = {}

--- a/server/apps/monitor/tests/test_display_fields_reported_plugin.py
+++ b/server/apps/monitor/tests/test_display_fields_reported_plugin.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from apps.monitor.models import MonitorObject, MonitorPlugin
+from apps.monitor.models import CollectConfig, MonitorInstance, MonitorObject, MonitorPlugin
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.services import monitor_object as mo
 from apps.monitor.services.monitor_object import MonitorObjectService
@@ -76,3 +76,52 @@ def test_fill_display_metrics_reported_instance_without_collectconfig(monkeypatc
 
     # 修复前:无 CollectConfig → 不命中插件 → 列值缺失(--);修复后:按上报插件命中 → 回填 7
     assert result[0].get("K8STEST::cluster_pod_count") == "7"
+
+
+@pytest.mark.django_db
+def test_fill_display_metrics_skips_status_query_when_all_collectconfig_covered(monkeypatch):
+    """常规对象:实例全部有 CollectConfig 覆盖时,不应再为反查上报插件发 status_query。
+
+    回归:_fill_display_metrics 被实例列表热路径调用。若对每个 status_query 插件无条件发 VM
+    查询,Switch(65)/Firewall(28)/Router(26) 等对象会在每次分页加载串行发数十次 VM 往返。
+    仅派生(无 CollectConfig)实例才需反查上报插件。
+    """
+    obj, plugin, metric = _build_k8s_like_object()
+    instance = MonitorInstance.objects.create(id="('host1',)", name="host1", monitor_object=obj)
+    CollectConfig.objects.create(
+        id="host1-cfg",
+        monitor_instance=instance,
+        monitor_plugin=plugin,
+        collector="K8S",
+        collect_type="k8s",
+        config_type="k8stest",
+        file_type="toml",
+        is_child=True,
+    )
+
+    status_calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, **kwargs):
+            if "instance_type='k8stest'" in query and "count(" not in query:
+                status_calls.append(query)  # 不应被调用
+                return {"data": {"result": []}}
+            if "some_kube_pod_info" in query:
+                return {"data": {"result": [{"metric": {"instance_id": "host1"}, "value": [0, "5"]}]}}
+            return {"data": {"result": []}}
+
+    monkeypatch.setattr(mo, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = [{"instance_id": "('host1',)", "instance_name": "host1"}]
+    obj_metric_map = {
+        "display_fields": [
+            {"name": "Pod Count", "metrics": [{"plugin": "K8STEST", "metric": "cluster_pod_count"}]}
+        ],
+        "supplementary_indicators": [],
+    }
+
+    MonitorObjectService._fill_display_metrics(obj.id, obj_metric_map, result)
+
+    assert status_calls == [], "实例已被 CollectConfig 覆盖,不应再发插件 status_query 反查"
+    # 经 CollectConfig 命中插件,展示列仍正常回填
+    assert result[0].get("K8STEST::cluster_pod_count") == "5"

--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -307,6 +307,51 @@ def test_effective_plugins_service_resolves_derived_instance_without_row(db, mon
     assert by_name["K8sPod"]["collect_mode"] == "manual"
 
 
+def test_effective_plugins_service_matches_multi_key_derived_by_primary(db, monkeypatch):
+    # 回归：多键派生实例(K8s Pod，instance_id_keys=[instance_id, pod])的主键退化匹配。
+    # K8S 插件 status_query 仅 `... by (instance_id)`，标签里没有 pod 维度，全键精确匹配必然失败。
+    # 修复后退化为按主键 instance_id(集群)匹配，使同集群下 Pod/Node 派生实例命中其上报插件，
+    # 否则其生效插件 / 全量指标会一律为空。
+    from apps.monitor.services import effective_plugins
+
+    monitor_object = MonitorObject.objects.create(
+        name="PodMultiKey",
+        display_name="PodMultiKey",
+        instance_id_keys=["instance_id", "pod"],
+    )
+    reported_plugin = MonitorPlugin.objects.create(
+        name="K8S",
+        display_name="K8S",
+        template_id="k8s-mk",
+        template_type="api",
+        collector="push_api",
+        collect_type="push_api",
+        status_query="any({instance_type='k8s'}) by (instance_id)",
+        is_pre=False,
+    )
+    reported_plugin.monitor_object.add(monitor_object)
+
+    multi_key_instance_id = "('mac', 'coredns-abc')"
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, step="5m", time=None):
+            # status_query 仅按 instance_id 分组，标签里没有 pod —— 全键匹配会得到 ('mac', None)，
+            # 必然不等于 ('mac', 'coredns-abc')，只有按主键退化才能命中。
+            return {"data": {"result": [{"metric": {"instance_id": "mac"}, "value": [100, "1"]}]}}
+
+    monkeypatch.setattr(effective_plugins, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = effective_plugins.MonitorEffectivePluginService.get_effective_plugins(
+        monitor_object.id,
+        multi_key_instance_id,
+        locale="zh-Hans",
+    )
+
+    by_name = {item["name"]: item for item in result}
+    assert "K8S" in by_name, "多键派生实例应按主键 instance_id 退化命中上报插件"
+    assert by_name["K8S"]["status"] == "normal"
+
+
 def test_primary_object_plugin_list_keeps_builtin_plugins_distinct_by_plugin_id(db, monkeypatch):
     from apps.monitor.constants.plugin import PluginConstants
     from apps.monitor.services import monitor_instance

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "test:log-policy-form": "pnpm exec tsx scripts/log-policy-form-state-test.ts",
     "test:monitor-search-plugin-scope": "pnpm exec tsx scripts/monitor-search-plugin-scope-test.ts",
     "test:monitor-query-step": "pnpm exec tsx scripts/monitor-query-step-test.ts",
+    "test:k8s-cluster-parse": "pnpm exec tsx scripts/k8s-cluster-parse-test.ts",
     "test:monitor-gap-interval": "pnpm exec tsx scripts/monitor-gap-interval-test.ts",
     "test:monitor-promql-label-query": "pnpm exec tsx scripts/monitor-promql-label-query-test.ts",
     "test:monitor-capability-matrix": "pnpm exec tsx scripts/monitor-capability-matrix-test.ts",

--- a/web/scripts/k8s-cluster-parse-test.ts
+++ b/web/scripts/k8s-cluster-parse-test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+
+import { latestScalar, phaseCount } from '../src/app/monitor/dashboards/objects/k8s-cluster/parse';
+
+// 回归:gap 检测会在 query_range 矩阵尾部插入 null 标记点。latestScalar(经 lastValue)若直接取
+// 最后一个数组元素,会拿到 null → Number(null)=0 → K8s 集群仪表盘 KPI 卡一律显示 0。
+// 修复后跳过尾部 null,取最后一个有效采样值。
+const withTrailingGapNull = {
+  data: {
+    result: [
+      {
+        metric: {},
+        values: [
+          [1000, '1'],
+          [1009.2, null],
+          [1010, '1'],
+          [1018.2, null],
+        ] as Array<[number, string]>,
+      },
+    ],
+  },
+};
+assert.equal(latestScalar(withTrailingGapNull), 1, '尾部 gap-null 应被跳过,取最后有效值 1');
+
+// 多个尾部 null 也应一路回退到有效值
+const multipleTrailingNulls = {
+  data: { result: [{ metric: {}, values: [[1, '7'], [2, null], [3, null], [4, null]] as Array<[number, string]> }] },
+};
+assert.equal(latestScalar(multipleTrailingNulls), 7, '连续尾部 null 应回退到 7');
+
+// 正常无 null:取最后值
+const normal = {
+  data: { result: [{ metric: {}, values: [[1, '5'], [2, '6']] as Array<[number, string]> }] },
+};
+assert.equal(latestScalar(normal), 6);
+
+// 全 null → 0
+const allNull = {
+  data: { result: [{ metric: {}, values: [[1, null], [2, null]] as Array<[number, string]> }] },
+};
+assert.equal(latestScalar(allNull), 0, '全 null 序列应为 0');
+
+// 空结果 → 0
+assert.equal(latestScalar({ data: { result: [] } }), 0);
+assert.equal(latestScalar(null), 0);
+
+// phaseCount 依赖 lastValue,by(phase) 结果尾部 null 也应跳过
+const podPhase = {
+  data: {
+    result: [
+      { metric: { phase: 'Running' }, values: [[1, '7'], [2, null]] as Array<[number, string]> },
+      { metric: { phase: 'Pending' }, values: [[1, '0']] as Array<[number, string]> },
+    ],
+  },
+};
+assert.equal(phaseCount(podPhase, 'Running'), 7, 'Running 计数应跳过尾部 null 取 7');
+assert.equal(phaseCount(podPhase, 'Failed'), 0, '缺失 phase 计数为 0');
+
+console.log('k8s-cluster-parse-test: all assertions passed');

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -638,6 +638,9 @@ export const DashboardShell = ({
           selectorLoading={dashboard.instanceLoading}
           selectorOptions={dashboard.instanceSelectOptions}
           onInstanceChange={dashboard.onInstanceChange}
+          clusterOptions={dashboard.clusterFilterEnabled ? dashboard.clusterFilterOptions : undefined}
+          clusterValue={dashboard.clusterFilterValue}
+          onClusterChange={dashboard.onClusterFilterChange}
           selectorPlaceholder={
             dashboard.resolvedInstanceName !== '--' ? dashboard.resolvedInstanceName : '选择实例'
           }

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -172,6 +172,12 @@ export interface SimpleDashboardConfig {
   barPanels?: BarPanelConfig[];
   statusPanels?: StatusPanelConfig[];
   details: DetailPanelConfig[];
+  /**
+   * 开启「集群」级联过滤:实例 id 形如 (cluster, name) 的对象(如 K8s Pod/Node),
+   * 实例选择器前增加集群下拉,先按集群过滤,避免跨集群实例混在一个长列表里。
+   * 集群取 instance_id_values[0]。
+   */
+  clusterFilter?: boolean;
 }
 
 export interface PreparedSummaryCard {
@@ -415,8 +421,27 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     [currentInstanceOption, normalizedInstanceName]
   );
   const hasReadableInstanceName = Boolean(normalizedInstanceName && normalizedInstanceName !== String(instanceId || ''));
+  // ── 集群级联过滤(K8s Pod/Node 等 (cluster,name) 实例)──
+  const clusterFilterEnabled = Boolean(config.clusterFilter);
+  // 当前激活集群跟随 URL(当前实例 id 的第一维),无需独立状态,避免与导航状态失同步。
+  const activeCluster = useMemo(
+    () => (clusterFilterEnabled ? (idValues[0] ? String(idValues[0]) : undefined) : undefined),
+    [clusterFilterEnabled, idValues]
+  );
+  const clusterFilterOptions = useMemo(() => {
+    if (!clusterFilterEnabled) return [];
+    const seen = new Map<string, { label: string; value: string; searchTokens: string[] }>();
+    instanceOptions.forEach((item) => {
+      const cluster = item.instanceIdValues[0];
+      if (cluster && !seen.has(cluster)) seen.set(cluster, { label: cluster, value: cluster, searchTokens: [cluster] });
+    });
+    return Array.from(seen.values());
+  }, [clusterFilterEnabled, instanceOptions]);
   const instanceSelectOptions = useMemo(() => {
-    const options = [...instanceOptions];
+    const source = clusterFilterEnabled && activeCluster
+      ? instanceOptions.filter((item) => item.instanceIdValues[0] === activeCluster)
+      : instanceOptions;
+    const options = [...source];
     const selectedValue = String(instanceId || '');
     if (selectedValue && hasReadableInstanceName && !options.some((item) => item.value === selectedValue)) {
       options.unshift({
@@ -428,7 +453,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
       });
     }
     return options;
-  }, [currentInstanceOption?.interval, hasReadableInstanceName, idValues, instanceId, instanceOptions, normalizedInstanceName]);
+  }, [activeCluster, clusterFilterEnabled, currentInstanceOption?.interval, hasReadableInstanceName, idValues, instanceId, instanceOptions, normalizedInstanceName]);
   const instanceSelectValue = currentInstanceOption?.value || (hasReadableInstanceName && instanceId ? String(instanceId) : undefined);
   const currentInstanceInterval = currentInstanceOption?.interval;
 
@@ -809,6 +834,12 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     params.set('instance_id_values', (target?.instanceIdValues || [value]).join(','));
     router.push(`/monitor/view/dashboard/${config.routeKey}?${params.toString()}`);
   };
+  // 切换集群:跳到该集群下首个实例(立即反馈 + 实例下拉随之过滤)。
+  const onClusterFilterChange = (cluster: string) => {
+    if (cluster === activeCluster) return;
+    const first = instanceOptions.find((item) => item.instanceIdValues[0] === cluster);
+    if (first) onInstanceChange(first.value);
+  };
   const onRefresh = () => {
     if (displayMode === 'dashboard') {
       loadMetrics();
@@ -840,6 +871,10 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     instanceSelectValue,
     instanceLoading,
     instanceSelectOptions,
+    clusterFilterEnabled,
+    clusterFilterValue: activeCluster,
+    clusterFilterOptions,
+    onClusterFilterChange,
     currentInstanceInterval,
     currentInstanceLabel: currentInstanceOption?.label || normalizedInstanceName || resolvedInstanceName,
     isDashboardMode,

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -239,6 +239,10 @@
 
 .inlineInstanceSelector {
   width: 190px;
+  height: 34px;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
   padding: 0 10px;
   border-radius: 12px;
   background: #ffffff;
@@ -246,7 +250,11 @@
 }
 
 .inlineInstanceSelector :global(.ant-select-selector) {
-  min-height: 34px !important;
+  width: 100%;
+  height: 100% !important;
+  min-height: 0 !important;
+  display: flex !important;
+  align-items: center !important;
   padding: 0 24px 0 0 !important;
   border: 0 !important;
   background: transparent !important;

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { DatabaseOutlined, CloudServerOutlined, AppstoreOutlined, DeploymentUnitOutlined, PartitionOutlined, ReloadOutlined } from '@ant-design/icons';
 import useViewApi from '@/app/monitor/api/view';
 import useMonitorApi from '@/app/monitor/api';
+import MetricViews from '@/app/monitor/components/metric-views';
 import { ChartData, TimeSelectorDefaultValue, TimeValuesProps } from '@/app/monitor/types';
 import {
   buildSearchParams,
@@ -455,6 +456,21 @@ export default function K8sClusterDashboardPage() {
           />
         </div>
 
+        {displayMode === 'metrics' ? (
+          <MetricViews
+            monitorObjectId={monitorObjectId}
+            monitorObjectName={searchParams.get('name') || 'Cluster'}
+            instanceId={instanceId}
+            instanceName={resolvedInstanceName}
+            idValues={idValues}
+            externalTimeValues={timeValues}
+            externalTimeDefaultValue={timeDefaultValue}
+            externalFrequence={frequence}
+            collectionInterval={currentInstanceInterval}
+            hideTimeSelector
+          />
+        ) : (
+          <>
         {/* Tier 1 · 概览:6 张等宽卡(采集状态 + 5 KPI),全 span2(=12) */}
         <div className={styles.sectionLabel}>概览</div>
         <section className={styles.dashboardSection}>
@@ -610,6 +626,8 @@ export default function K8sClusterDashboardPage() {
             />
           </div>
         </section>
+          </>
+        )}
       </div>
     </div>
   );

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
@@ -6,8 +6,14 @@ type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; 
 
 const lastValue = (values?: Array<[number, string]>): number => {
   if (!values || values.length === 0) return 0;
-  const v = Number(values[values.length - 1][1]);
-  return Number.isFinite(v) ? v : 0;
+  // 跳过尾部 gap 检测插入的 null 标记点,取最后一个有效采样值
+  for (let i = values.length - 1; i >= 0; i -= 1) {
+    const raw = values[i][1];
+    if (raw === null || raw === undefined) continue;
+    const v = Number(raw);
+    if (Number.isFinite(v)) return v;
+  }
+  return 0;
 };
 
 /** 取单序列结果的最新标量(无数据 → 0)。 */

--- a/web/src/app/monitor/dashboards/objects/k8s-node/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/config.ts
@@ -10,6 +10,7 @@ export const NODE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: 'K8s 节点监控仪表盘',
   objectFallbackName: 'K8s 节点',
   instanceType: 'k8s',
+  clusterFilter: true,
   collectionStatusQuery:
     "count(prometheus_remote_write_kube_node_info{instance_type='k8s', __$labels__}) by (instance_id)",
   metaItems: ['Telegraf', 'k8s'],

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
@@ -10,6 +10,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: 'K8s Pod 监控仪表盘',
   objectFallbackName: 'Pod',
   instanceType: 'k8s',
+  clusterFilter: true,
   collectionStatusQuery:
     "count(prometheus_remote_write_kube_pod_info{instance_type='k8s', __$labels__}) by (instance_id)",
   metaItems: ['cAdvisor', 'k8s'],

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
@@ -28,6 +28,10 @@ export interface DashboardInstanceCardProps {
   onInstanceChange: (value: string) => void;
   selectorPlaceholder?: string;
   selectorTitle?: string;
+  /** 传入时在实例选择器左侧渲染「集群」级联过滤下拉(K8s Pod/Node 等多集群对象)。 */
+  clusterOptions?: readonly { label: string; value: string; searchTokens?: string[] }[];
+  clusterValue?: string;
+  onClusterChange?: (value: string) => void;
   isDashboardMode?: boolean;
   /** 传入时在实例选择器右侧内联渲染时间选择器 + 刷新组（统一布局，单一来源）。 */
   timeSelectorProps?: DashboardInstanceCardTimeSelectorProps;
@@ -45,6 +49,9 @@ export function DashboardInstanceCard({
   onInstanceChange,
   selectorPlaceholder = '选择实例',
   selectorTitle,
+  clusterOptions,
+  clusterValue,
+  onClusterChange,
   isDashboardMode = true,
   timeSelectorProps,
   styles
@@ -70,6 +77,18 @@ export function DashboardInstanceCard({
         </div>
       </div>
       <div className={styles.instanceActions}>
+        {clusterOptions && clusterOptions.length > 0 && onClusterChange ? (
+          <InstanceSelector
+            styles={styles}
+            label="集群"
+            value={clusterValue}
+            options={clusterOptions}
+            onChange={onClusterChange}
+            placeholder="选择集群"
+            title={clusterValue}
+            popupWidth={220}
+          />
+        ) : null}
         <InstanceSelector
           styles={styles}
           value={selectorValue}


### PR DESCRIPTION
## 背景
客户点击 K8s Pod/Node 详情曾报 500「监控实例不存在」(已由前序修复解决)。本 PR 修复其后续显示层问题,并消除一处会拖慢所有对象实例列表的性能回归。

## 后端
- **门控上报插件反查**:`_fill_display_metrics` 的「按插件 status_query 反查上报实例」现仅对**无 CollectConfig 覆盖**的派生实例(K8s 集群/Pod/Node)执行。该函数被实例列表热路径调用,此前对每个 status_query 插件**无条件**发一次 VM 查询,Switch(65)/Firewall(28)/Router(26) 等多插件对象每次分页会串行发数十次 VM 往返,纯属浪费。
- **多键派生实例主键退化匹配**:`effective_plugins` 对多键对象(K8s Pod/Node,`instance_id_keys=[instance_id, pod]`)的全键精确匹配必然失败——K8S 插件 status_query 仅 `... by (instance_id)`,标签里没有 pod 维度。退化为按主键 `instance_id`(集群)匹配,否则其生效插件 / 全量指标一律为空。
- `InstanceSearch.search` 改走 `_fill_display_metrics`,使列表列用前端读取的复合 key `<plugin>::<metric>` 回填(此前用裸指标名,绑定插件的对象列显示 `--`)。

## 前端
- K8s 集群仪表盘在 metrics 模式渲染全量指标(MetricViews)视图;此前切换按钮无效。
- `parse.lastValue` 跳过 gap 检测在序列尾部插入的 null 标记,集群 KPI 卡显示最后一个有效采样值而非 0。
- K8s Pod/Node 仪表盘新增「集群」级联过滤,实例多时先按集群收窄实例选择器。
- 修正内联实例选择器盒子的文字垂直居中。

## 测试
- 门控:实例全有 CollectConfig 覆盖时不再发 status_query。
- effective_plugins 多键派生实例按主键退化命中插件。
- `parse.latestScalar/phaseCount` 跳过尾部 gap null。

## 验证
- 后端:`test_display_fields_reported_plugin.py` + `test_monitor_instance_view.py` 全通过(含新增 3 用例,主树 40 passed)。
- 前端:`pnpm exec tsx scripts/k8s-cluster-parse-test.ts` 全断言通过;改动文件 eslint 0 错误。
- 浏览器:本地 OrbStack 真实集群 + mock 多集群下逐项核对(列表列/仪表盘/详情/全量指标/集群切换)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)