### PR TITLE
bugfix: 修复记忆写入缓存处理中卡住

### DIFF
--- a/server/apps/opspilot/migrations/0061_memorywritecache_processing_started_at.py
+++ b/server/apps/opspilot/migrations/0061_memorywritecache_processing_started_at.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("opspilot", "0060_alter_skillpackage_created_at_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="memorywritecache",
+            name="processing_started_at",
+            field=models.DateTimeField(blank=True, db_index=True, null=True, verbose_name="处理开始时间"),
+        ),
+    ]

--- a/server/apps/opspilot/models/memory_mgmt.py
+++ b/server/apps/opspilot/models/memory_mgmt.py
@@ -155,6 +155,7 @@ class MemoryWriteCache(models.Model):
         db_index=True,
         verbose_name=_("状态"),
     )
+    processing_started_at = models.DateTimeField(null=True, blank=True, db_index=True, verbose_name=_("处理开始时间"))
     created_at = models.DateTimeField(auto_now_add=True, verbose_name=_("创建时间"), db_index=True)
 
     class Meta:

--- a/server/apps/opspilot/tasks.py
+++ b/server/apps/opspilot/tasks.py
@@ -4,10 +4,12 @@ import os
 import re
 import tempfile
 import time
+from datetime import timedelta
 
 from celery import shared_task
 from django.core.exceptions import SynchronousOnlyOperation
 from django.db import close_old_connections, transaction
+from django.db.models import Q
 from django.utils import timezone
 from langchain_core.messages import HumanMessage, SystemMessage
 from tqdm import tqdm
@@ -44,6 +46,8 @@ from apps.opspilot.services.workflow_attachment_service import cleanup_expired_w
 from apps.opspilot.utils.chat_flow_utils.engine.factory import create_chat_flow_engine
 from apps.opspilot.utils.chunk_helper import ChunkHelper
 from apps.opspilot.utils.graph_utils import GraphUtils
+
+MEMORY_WRITE_PROCESSING_TTL_SECONDS = int(os.getenv("MEMORY_WRITE_PROCESSING_TTL_SECONDS", "1800"))
 
 
 def _run_in_native_thread(func, *args, **kwargs):
@@ -154,6 +158,13 @@ def _resolve_org_display_name(organization_id) -> str:
     return display
 
 
+def _recover_stale_memory_write_cache():
+    cutoff = timezone.now() - timedelta(seconds=MEMORY_WRITE_PROCESSING_TTL_SECONDS)
+    return MemoryWriteCache.objects.filter(status=MemoryWriteCache.STATUS_PROCESSING).filter(
+        Q(processing_started_at__lt=cutoff) | Q(processing_started_at__isnull=True, created_at__lt=cutoff)
+    ).update(status=MemoryWriteCache.STATUS_PENDING, processing_started_at=None)
+
+
 def _flush_memory_write_cache_group(
     memory_space_id: int,
     title: str,
@@ -168,6 +179,7 @@ def _flush_memory_write_cache_group(
     normalized_batch_size = normalize_write_batch_size(batch_size)
 
     with transaction.atomic():
+        _recover_stale_memory_write_cache()
         queryset = (
             MemoryWriteCache.objects.select_for_update()
             .filter(
@@ -185,7 +197,10 @@ def _flush_memory_write_cache_group(
             return False
 
         cache_item_ids = [item.id for item in ready_items]
-        MemoryWriteCache.objects.filter(id__in=cache_item_ids).update(status=MemoryWriteCache.STATUS_PROCESSING)
+        MemoryWriteCache.objects.filter(id__in=cache_item_ids).update(
+            status=MemoryWriteCache.STATUS_PROCESSING,
+            processing_started_at=timezone.now(),
+        )
 
     try:
         cache_items = list(MemoryWriteCache.objects.filter(id__in=cache_item_ids).order_by("created_at", "id"))
@@ -201,21 +216,25 @@ def _flush_memory_write_cache_group(
         if organization_id is not None and not owner_username:
             owner_username = _resolve_org_display_name(organization_id)
 
-        process_memory_write(
-            memory_space_id=memory_space_id,
-            title=title,
-            content=summarized_content,
-            owner_username=owner_username,
-            owner_domain=owner_domain,
-            organization_id=organization_id,
-            model_id=model_id,
-            skip_write_rule=True,
-        )
-        MemoryWriteCache.objects.filter(id__in=cache_item_ids).delete()
+        with transaction.atomic():
+            process_memory_write(
+                memory_space_id=memory_space_id,
+                title=title,
+                content=summarized_content,
+                owner_username=owner_username,
+                owner_domain=owner_domain,
+                organization_id=organization_id,
+                model_id=model_id,
+                skip_write_rule=True,
+            )
+            MemoryWriteCache.objects.filter(id__in=cache_item_ids).delete()
         return True
     except Exception:
         if cache_item_ids:
-            MemoryWriteCache.objects.filter(id__in=cache_item_ids).update(status=MemoryWriteCache.STATUS_PENDING)
+            MemoryWriteCache.objects.filter(id__in=cache_item_ids).update(
+                status=MemoryWriteCache.STATUS_PENDING,
+                processing_started_at=None,
+            )
         raise
 
 
@@ -1343,6 +1362,7 @@ def process_memory_write_cache(
         close_old_connections()
 
         with transaction.atomic():
+            _recover_stale_memory_write_cache()
             MemoryWriteCache.objects.create(
                 workflow_id=workflow_id,
                 node_id=node_id,
@@ -1395,6 +1415,7 @@ def flush_memory_write_cache_for_node(
     model_id: int = None,
 ):
     close_old_connections()
+    _recover_stale_memory_write_cache()
     target_ids = list(
         MemoryWriteCache.objects.filter(
             workflow_id=workflow_id,
@@ -1421,6 +1442,7 @@ def flush_memory_write_cache_for_node(
 @shared_task
 def flush_all_pending_memory_write_cache():
     close_old_connections()
+    _recover_stale_memory_write_cache()
     pending_pairs = list(MemoryWriteCache.objects.filter(status=MemoryWriteCache.STATUS_PENDING).values("workflow_id", "node_id").distinct())
     if not pending_pairs:
         return

--- a/server/apps/opspilot/tests/workflow/cases/test_memory_workflow_nodes.py
+++ b/server/apps/opspilot/tests/workflow/cases/test_memory_workflow_nodes.py
@@ -12,6 +12,7 @@ import inspect
 import json
 import sys
 import types
+from datetime import timedelta
 from types import SimpleNamespace
 
 # ---------------------------------------------------------------------------
@@ -31,6 +32,7 @@ sys.modules.setdefault("falkordb.asyncio", _falkordb_asyncio)
 from unittest.mock import MagicMock, patch  # noqa: E402
 
 import pytest  # noqa: E402
+from django.utils import timezone  # noqa: E402
 
 from apps.opspilot.models.memory_mgmt import Memory, MemorySpace, MemoryWriteCache  # noqa: E402
 from apps.opspilot.utils.chat_flow_utils.nodes.memory.memory_read import MemoryReadNode  # noqa: E402
@@ -1601,6 +1603,103 @@ class TestProcessMemoryWriteCacheBatching:
 
         mock_write.assert_called_once()
         assert MemoryWriteCache.objects.count() == 0
+
+    def test_flush_recovers_stale_legacy_processing_cache_without_timestamp(self, memory_space_team):
+        from apps.opspilot.tasks import MEMORY_WRITE_PROCESSING_TTL_SECONDS, flush_memory_write_cache_for_node
+
+        cache = MemoryWriteCache.objects.create(
+            workflow_id=1001,
+            node_id="memory_write_node",
+            memory_target_id="1",
+            content="event-1",
+            status=MemoryWriteCache.STATUS_PROCESSING,
+        )
+        MemoryWriteCache.objects.filter(id=cache.id).update(
+            created_at=timezone.now() - timedelta(seconds=MEMORY_WRITE_PROCESSING_TTL_SECONDS + 1)
+        )
+
+        with patch("apps.opspilot.tasks.close_old_connections"):
+            with patch("apps.opspilot.tasks.process_memory_write") as mock_write:
+                flush_memory_write_cache_for_node(
+                    workflow_id=1001,
+                    node_id="memory_write_node",
+                    memory_space_id=memory_space_team.id,
+                    title="Flush Memory",
+                )
+
+        mock_write.assert_called_once()
+        assert MemoryWriteCache.objects.count() == 0
+
+    def test_flush_keeps_active_legacy_processing_cache_without_timestamp(self, memory_space_team):
+        from apps.opspilot.tasks import flush_memory_write_cache_for_node
+
+        MemoryWriteCache.objects.create(
+            workflow_id=1001,
+            node_id="memory_write_node",
+            memory_target_id="1",
+            content="event-1",
+            status=MemoryWriteCache.STATUS_PROCESSING,
+        )
+
+        with patch("apps.opspilot.tasks.close_old_connections"):
+            with patch("apps.opspilot.tasks.process_memory_write") as mock_write:
+                flush_memory_write_cache_for_node(
+                    workflow_id=1001,
+                    node_id="memory_write_node",
+                    memory_space_id=memory_space_team.id,
+                    title="Flush Memory",
+                )
+
+        mock_write.assert_not_called()
+        assert MemoryWriteCache.objects.filter(status=MemoryWriteCache.STATUS_PROCESSING).count() == 1
+
+    def test_flush_recovers_stale_processing_cache(self, memory_space_team):
+        from apps.opspilot.tasks import MEMORY_WRITE_PROCESSING_TTL_SECONDS, flush_memory_write_cache_for_node
+
+        MemoryWriteCache.objects.create(
+            workflow_id=1001,
+            node_id="memory_write_node",
+            memory_target_id="1",
+            content="event-1",
+            status=MemoryWriteCache.STATUS_PROCESSING,
+            processing_started_at=timezone.now() - timedelta(seconds=MEMORY_WRITE_PROCESSING_TTL_SECONDS + 1),
+        )
+
+        with patch("apps.opspilot.tasks.close_old_connections"):
+            with patch("apps.opspilot.tasks.process_memory_write") as mock_write:
+                flush_memory_write_cache_for_node(
+                    workflow_id=1001,
+                    node_id="memory_write_node",
+                    memory_space_id=memory_space_team.id,
+                    title="Flush Memory",
+                )
+
+        mock_write.assert_called_once()
+        assert MemoryWriteCache.objects.count() == 0
+
+    def test_flush_keeps_active_processing_cache(self, memory_space_team):
+        from apps.opspilot.tasks import flush_memory_write_cache_for_node
+
+        MemoryWriteCache.objects.create(
+            workflow_id=1001,
+            node_id="memory_write_node",
+            memory_target_id="1",
+            content="event-1",
+            status=MemoryWriteCache.STATUS_PROCESSING,
+            processing_started_at=timezone.now(),
+        )
+
+        with patch("apps.opspilot.tasks.close_old_connections"):
+            with patch("apps.opspilot.tasks.process_memory_write") as mock_write:
+                flush_memory_write_cache_for_node(
+                    workflow_id=1001,
+                    node_id="memory_write_node",
+                    memory_space_id=memory_space_team.id,
+                    title="Flush Memory",
+                )
+
+        mock_write.assert_not_called()
+        assert MemoryWriteCache.objects.filter(status=MemoryWriteCache.STATUS_PROCESSING).count() == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

工作流记忆批量写入会先把缓存行标记成 `processing`，再把内容写入长期记忆，最后删除缓存行。如果 worker 在标记完成后异常退出，缓存行会一直停在 `processing`，后续定时 flush 只扫描 `pending`，这批记忆就不会再落库；如果写库和删缓存之间断开，也存在重复写入窗口。

## 根因

`MemoryWriteCache` 原来只有 `pending` / `processing` 两个状态，没有记录“这次处理从什么时候开始”。系统无法区分“正在被活跃 worker 处理”和“worker 已经中断后遗留的 processing”，因此也没有可恢复的超时回收机制。同时，实际写入长期记忆和删除缓存行不在同一个数据库事务里，异常边界不够收敛。

## 怎么修的

新增 `processing_started_at` 字段记录进入处理中状态的时间，并在 flush 前回收超过 TTL 的遗留 `processing` 行。新选中的缓存行会同时写入状态和开始时间；失败时恢复为 `pending` 并清空开始时间；成功写入长期记忆和删除缓存行放进同一个事务。

```python
MemoryWriteCache.objects.filter(id__in=cache_item_ids).update(
    status=MemoryWriteCache.STATUS_PROCESSING,
    processing_started_at=timezone.now(),
)
```

旧版本遗留的 `processing_started_at = NULL` 行不会立刻回收，只有 `created_at` 也超过 TTL 后才回到 `pending`，避免滚动发布期间把仍在运行的旧任务重复处理。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["process_memory_write_cache\ntasks.py"]
        T2["flush_memory_write_cache_for_node\ntasks.py"]
        T3["flush_all_pending_memory_write_cache\ntasks.py"]
    end

    R["回收过期 processing\n_recover_stale_memory_write_cache"]
    BU["锁定 pending 行并标记 processing\nMemoryWriteCache"]

    subgraph N["核心处理层"]
        F1["_flush_memory_write_cache_group\ntasks.py"]
        F2["process_memory_write\ntasks.py"]
        F3["删除已写入缓存行\nMemoryWriteCache.delete"]
    end

    subgraph C["补偿层"]
        C1["异常时恢复 pending\n清空 processing_started_at"]
    end

    T1 --> R --> F1
    T2 --> R --> F1
    T3 --> R --> F1
    F1 --> BU --> F2 --> F3
    F2 -. "失败" .-> C1
```

## 影响范围

改动只在 `opspilot` 记忆批量写入链路内：模型字段、flush 任务和对应工作流测试。没有改公共 RPC、NATS 协议或前端调用。因为新增了数据库字段并改变了缓存状态恢复语义，风险按中档处理，PR 加 `⚠️ review` 等待人工 review。

## 验证

- `git show weops/master:server/apps/opspilot/tasks.py` 核对 master 仍只有 `processing` 标记，没有处理开始时间和超时回收。
- `ENABLE_CELERY=False INSTALL_APPS=opspilot DB_ENGINE=postgresql DB_NAME=bklite DB_USER=postgres DB_PASSWORD=testpass DB_HOST=localhost DB_PORT=55432 uv run pytest apps/opspilot/tests/workflow/cases/test_memory_workflow_nodes.py -k "ProcessMemoryWriteCacheBatching" -v --tb=short -o addopts=''`：7 passed。
- `ENABLE_CELERY=False INSTALL_APPS=opspilot DB_ENGINE=postgresql DB_NAME=bklite DB_USER=postgres DB_PASSWORD=testpass DB_HOST=localhost DB_PORT=55432 uv run python manage.py makemigrations opspilot --check --dry-run --skip-checks`：No changes detected。

关联 Issue #3762。
