### PR TITLE
bugfix: 批量查询工作流日志分页关联数据

### DIFF
--- a/server/apps/opspilot/tests/test_workflow_log_pagination.py
+++ b/server/apps/opspilot/tests/test_workflow_log_pagination.py
@@ -1,0 +1,117 @@
+from datetime import datetime, timezone
+
+from apps.opspilot.viewsets.bot_view import BotViewSet
+
+
+class _HistoryQuery:
+    def __init__(self, rows):
+        self.rows = rows
+        self.order_by_args = None
+        self.values_args = None
+
+    def order_by(self, *args):
+        self.order_by_args = args
+        return self
+
+    def values(self, *args):
+        self.values_args = args
+        return self.rows
+
+
+def test_workflow_log_pagination_batches_history_lookup(mocker):
+    day = datetime(2026, 6, 29, tzinfo=timezone.utc)
+    later = datetime(2026, 6, 29, 9, 0, tzinfo=timezone.utc)
+    earlier = datetime(2026, 6, 29, 8, 0, tzinfo=timezone.utc)
+    other = datetime(2026, 6, 29, 10, 0, tzinfo=timezone.utc)
+    entries = [
+        {
+            "day": day,
+            "bot_id": 1,
+            "user_id": "alice",
+            "entry_type": "web_chat",
+            "count": 2,
+            "earliest_created_at": earlier,
+            "last_updated_at": later,
+        },
+        {
+            "day": day,
+            "bot_id": 1,
+            "user_id": "bob",
+            "entry_type": "restful",
+            "count": 1,
+            "earliest_created_at": other,
+            "last_updated_at": other,
+        },
+    ]
+    ids_rows = [
+        {
+            "id": 2,
+            "bot_id": 1,
+            "user_id": "alice",
+            "entry_type": "web_chat",
+            "conversation_time": later,
+        },
+        {
+            "id": 1,
+            "bot_id": 1,
+            "user_id": "alice",
+            "entry_type": "web_chat",
+            "conversation_time": earlier,
+        },
+        {
+            "id": 3,
+            "bot_id": 1,
+            "user_id": "bob",
+            "entry_type": "restful",
+            "conversation_time": other,
+        },
+    ]
+    title_rows = [
+        {
+            "bot_id": 1,
+            "user_id": "alice",
+            "conversation_time": later,
+            "conversation_content": "newer alice message",
+        },
+        {
+            "bot_id": 1,
+            "user_id": "alice",
+            "conversation_time": earlier,
+            "conversation_content": "earliest alice title",
+        },
+        {
+            "bot_id": 1,
+            "user_id": "bob",
+            "conversation_time": other,
+            "conversation_content": "bob title",
+        },
+    ]
+    ids_query = _HistoryQuery(ids_rows)
+    title_query = _HistoryQuery(title_rows)
+    history_filter = mocker.patch(
+        "apps.opspilot.viewsets.bot_view.WorkFlowConversationHistory.objects.filter",
+        side_effect=[ids_query, title_query],
+    )
+
+    _, result = BotViewSet._get_workflow_log_by_page(entries, page=1, page_size=10)
+
+    assert history_filter.call_count == 2
+    history_filter.assert_any_call(
+        bot_id__in={1},
+        user_id__in={"alice", "bob"},
+        entry_type__in={"web_chat", "restful"},
+        conversation_time__date__in={day.date()},
+    )
+    history_filter.assert_any_call(
+        bot_id__in={1},
+        user_id__in={"alice", "bob"},
+        conversation_time__date__in={day.date()},
+    )
+    assert ids_query.order_by_args == ("-conversation_time",)
+    assert ids_query.values_args == ("id", "bot_id", "user_id", "entry_type", "conversation_time")
+    assert title_query.order_by_args == ("-conversation_time",)
+    assert title_query.values_args == ("bot_id", "user_id", "conversation_time", "conversation_content")
+    assert result[0]["ids"] == [2, 1]
+    assert result[0]["title"] == "earliest alice title"
+    assert result[1]["ids"] == [3]
+    assert result[1]["title"] == "bob title"

--- a/server/apps/opspilot/viewsets/bot_view.py
+++ b/server/apps/opspilot/viewsets/bot_view.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from django.core.paginator import Paginator
 from django.db import connection
 from django.db.models import Count, Max, Min
@@ -523,7 +525,59 @@ class BotViewSet(PinMixin, AuthViewSet):
         except Exception:
             page_data = paginator.page(1)
 
-        for entry in page_data:
+        page_entries = list(page_data)
+        page_keys = []
+        for entry in page_entries:
+            entry_day = entry["day"].date() if hasattr(entry["day"], "date") else entry["day"]
+            page_keys.append((entry["bot_id"], entry["user_id"], entry["entry_type"], entry_day))
+        page_key_set = set(page_keys)
+
+        ids_rows = []
+        title_rows = []
+        if page_keys:
+            bot_ids = {key[0] for key in page_keys}
+            user_ids = {key[1] for key in page_keys}
+            entry_types = {key[2] for key in page_keys}
+            entry_days = {key[3] for key in page_keys}
+            if any("ids" not in entry for entry in page_entries):
+                ids_rows = list(
+                    WorkFlowConversationHistory.objects.filter(
+                        bot_id__in=bot_ids,
+                        user_id__in=user_ids,
+                        entry_type__in=entry_types,
+                        conversation_time__date__in=entry_days,
+                    )
+                    .order_by("-conversation_time")
+                    .values("id", "bot_id", "user_id", "entry_type", "conversation_time")
+                )
+            title_rows = list(
+                WorkFlowConversationHistory.objects.filter(
+                    bot_id__in=bot_ids,
+                    user_id__in=user_ids,
+                    conversation_time__date__in=entry_days,
+                )
+                .order_by("-conversation_time")
+                .values("bot_id", "user_id", "conversation_time", "conversation_content")
+            )
+
+        ids_map = defaultdict(list)
+        for row in ids_rows:
+            row_day = row["conversation_time"].date()
+            ids_key = (row["bot_id"], row["user_id"], row["entry_type"], row_day)
+            if ids_key in page_key_set:
+                ids_map[ids_key].append(row["id"])
+
+        title_map = {}
+        title_keys = {(key[0], key[1], key[3]) for key in page_keys}
+        for row in title_rows:
+            row_day = row["conversation_time"].date()
+            title_key = (row["bot_id"], row["user_id"], row_day)
+            if title_key in title_keys and (
+                title_key not in title_map or row["conversation_time"] < title_map[title_key][0]
+            ):
+                title_map[title_key] = (row["conversation_time"], row["conversation_content"])
+
+        for entry in page_entries:
             # 将 TruncDay 返回的 datetime 转换为 date，确保跨数据库兼容性
             entry_day = entry["day"].date() if hasattr(entry["day"], "date") else entry["day"]
 
@@ -531,29 +585,10 @@ class BotViewSet(PinMixin, AuthViewSet):
             if "ids" in entry:
                 ids = entry["ids"]
             else:
-                # 回退方案：根据聚合条件查询对应的 ID 列表
-                ids = list(
-                    WorkFlowConversationHistory.objects.filter(
-                        bot_id=entry["bot_id"],
-                        user_id=entry["user_id"],
-                        entry_type=entry["entry_type"],
-                        conversation_time__date=entry_day,
-                    ).values_list("id", flat=True)
-                )
+                ids = ids_map.get((entry["bot_id"], entry["user_id"], entry["entry_type"], entry_day), [])
 
-            # 获取 title：查询当天最早的对话内容作为标题
-            # 此查询从主聚合查询中分离，避免 GROUP BY 子查询问题（达梦等数据库不支持）
-            title_record = (
-                WorkFlowConversationHistory.objects.filter(
-                    bot_id=entry["bot_id"],
-                    user_id=entry["user_id"],
-                    conversation_time__date=entry_day,
-                )
-                .order_by("conversation_time")
-                .values_list("conversation_content", flat=True)
-                .first()
-            )
-            title = title_record[:100] if title_record else ""
+            title_record = title_map.get((entry["bot_id"], entry["user_id"], entry_day))
+            title = title_record[1][:100] if title_record else ""
 
             result.append(
                 {


### PR DESCRIPTION
## 问题
工作流日志分页接口在非 PostgreSQL 数据库路径下，会先拿到当前页的聚合记录，再在循环里为每条记录分别查询一次 ids、一次 title。一页记录越多，额外数据库查询越多，页面加载和数据库压力都会随 page_size 线性放大。

## 根因
PostgreSQL 路径可以用 ArrayAgg 在聚合阶段带出 ids，但其他数据库没有走这个能力。为了兼容达梦等数据库，title 又被拆到聚合外单查，结果两个补充字段都落到了分页循环里，形成 N+1 查询。

## 怎么修的
保留现有聚合方式和响应字段不变，只把页内补充数据改为批量取数后内存映射：

```python
ids_rows = WorkFlowConversationHistory.objects.filter(...__in=...).values(...)
title_rows = WorkFlowConversationHistory.objects.filter(...__in=...).values(...)
```

循环里只按 `(bot_id, user_id, entry_type, day)` 取 ids，按 `(bot_id, user_id, day)` 取 title，避免每条记录再打数据库。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["search_workflow_log\nbot_view.py"]
        W1["工作流日志页面\nlogInfo/page.tsx"]
    end

    subgraph N["核心处理层"]
        A1["聚合当前日志\nbase_queryset.annotate"]
        P1["_get_workflow_log_by_page\nbot_view.py"]
        B1["批量查询 ids/title\nWorkFlowConversationHistory"]
    end

    subgraph R["返回层"]
        R1["内存映射组装 items\nJsonResponse"]
    end

    W1 --> T1 --> A1 --> P1 --> B1 --> R1
```

## 影响范围
只改 `server/apps/opspilot` 的工作流日志分页处理和对应单测，不改接口参数、不改返回字段、不改权限逻辑。PostgreSQL 已带 `ids` 的路径仍复用原 ids，非 PostgreSQL 路径从每条记录 2 次补查收敛为页内固定批量查询。

## 验证
- `uv run python -m py_compile apps/opspilot/viewsets/bot_view.py apps/opspilot/tests/test_workflow_log_pagination.py` 通过
- `git diff --check -- server/apps/opspilot/viewsets/bot_view.py server/apps/opspilot/tests/test_workflow_log_pagination.py` 通过
- 新增 `apps/opspilot/tests/test_workflow_log_pagination.py`，断言页内多条记录只触发 ids/title 两次批量查询，并校验 ids 顺序和 title 选择保持兼容
- 本地正式 pytest 未完成：当前测试环境 Django 初始化失败，报 `django_celery_beat.models.SolarSchedule` 未在 `INSTALLED_APPS` 中声明，测试未进入断言阶段