### PR TITLE
bugfix: 修复批量通知已读 ids 校验

### DIFF
--- a/server/apps/console_mgmt/serializers/__init__.py
+++ b/server/apps/console_mgmt/serializers/__init__.py
@@ -1,4 +1,4 @@
-from .notification import NotificationSerializer
+from .notification import MarkBatchAsReadSerializer, NotificationSerializer
 from .user_app_set import UserAppSetSerializer
 
-__all__ = ["NotificationSerializer", "UserAppSetSerializer"]
+__all__ = ["MarkBatchAsReadSerializer", "NotificationSerializer", "UserAppSetSerializer"]

--- a/server/apps/console_mgmt/serializers/notification.py
+++ b/server/apps/console_mgmt/serializers/notification.py
@@ -2,6 +2,8 @@ from rest_framework import serializers
 
 from apps.console_mgmt.models import Notification
 
+MARK_BATCH_READ_MAX_IDS = 1000
+
 
 class NotificationSerializer(serializers.ModelSerializer):
     """通知消息序列化器"""
@@ -18,3 +20,11 @@ class NotificationSerializer(serializers.ModelSerializer):
         if hasattr(obj, "user_is_read"):
             return obj.user_is_read
         return False
+
+
+class MarkBatchAsReadSerializer(serializers.Serializer):
+    ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=False,
+        max_length=MARK_BATCH_READ_MAX_IDS,
+    )

--- a/server/apps/console_mgmt/tests/test_notification_views.py
+++ b/server/apps/console_mgmt/tests/test_notification_views.py
@@ -140,6 +140,34 @@ class TestMarkActions:
         assert resp.json()["result"] is True
         assert "已标记 0 条" in resp.json()["message"]
 
+    def test_mark_batch_as_read_拒绝非整数数组(self, user_client):
+        """revert-fail：若去掉 serializer 校验，字符串会被 set(ids) 拆成字符集合继续写库。"""
+        _, client = user_client
+
+        for payload in ({"ids": "123"}, {"ids": [1, "x"]}, {"ids": []}):
+            resp = client.post(f"{BASE}mark_batch_as_read/", data=payload, format="json")
+            assert resp.status_code == 400
+            assert resp.json()["result"] is False
+
+    def test_mark_batch_as_read_过滤不存在的通知ID(self, user_client):
+        """revert-fail：若直接 bulk_create 缺失 ID，数据库外键会抛 IntegrityError。"""
+        user, client = user_client
+        notification = NotificationFactory()
+        missing_id = notification.id + 10000
+
+        resp = client.post(
+            f"{BASE}mark_batch_as_read/",
+            data={"ids": [notification.id, missing_id]},
+            format="json",
+        )
+
+        data = resp.json()
+        assert resp.status_code == 200
+        assert data["result"] is True
+        assert data["data"]["skipped_ids"] == [missing_id]
+        assert NotificationRead.objects.filter(notification=notification, user=user, is_read=True).exists()
+        assert not NotificationRead.objects.filter(notification_id=missing_id, user=user).exists()
+
     def test_unread_count_排除已读与已删除(self, user_client):
         _, client = user_client
         read = NotificationFactory()

--- a/server/apps/console_mgmt/viewsets/notification.py
+++ b/server/apps/console_mgmt/viewsets/notification.py
@@ -8,7 +8,7 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from apps.console_mgmt.models import Notification, NotificationRead
-from apps.console_mgmt.serializers import NotificationSerializer
+from apps.console_mgmt.serializers import MarkBatchAsReadSerializer, NotificationSerializer
 
 MARK_ALL_READ_BATCH_SIZE = int(os.getenv("MARK_ALL_READ_BATCH_SIZE", 2000))
 
@@ -136,28 +136,41 @@ class NotificationViewSet(viewsets.ModelViewSet):
     @action(methods=["post"], detail=False)
     def mark_batch_as_read(self, request):
         """批量标记指定通知为已读（当前用户）"""
-        ids = request.data.get("ids", [])
-        if not ids:
-            return JsonResponse({"result": False, "message": "请提供通知ID列表"}, status=status.HTTP_400_BAD_REQUEST)
+        serializer = MarkBatchAsReadSerializer(data=request.data)
+        if not serializer.is_valid():
+            return JsonResponse(
+                {"result": False, "message": "通知ID列表格式不正确", "errors": serializer.errors},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
+        ids = list(dict.fromkeys(serializer.validated_data["ids"]))
         user = request.user
         now = timezone.now()
+        valid_ids = set(Notification.objects.filter(id__in=ids).values_list("id", flat=True))
+        skipped_ids = [nid for nid in ids if nid not in valid_ids]
+        if not valid_ids:
+            return JsonResponse(
+                {"result": True, "message": "已标记 0 条通知为已读", "data": {"skipped_ids": skipped_ids}}
+            )
+
         existing = set(
-            NotificationRead.objects.filter(user=user, notification_id__in=ids)
+            NotificationRead.objects.filter(user=user, notification_id__in=valid_ids)
             .values_list("notification_id", flat=True)
         )
         if existing:
             NotificationRead.objects.filter(
                 user=user, notification_id__in=existing, is_read=False,
             ).update(is_read=True, read_at=now)
-        new_ids = set(ids) - existing
+        new_ids = valid_ids - existing
         if new_ids:
             NotificationRead.objects.bulk_create([
                 NotificationRead(notification_id=nid, user=user, is_read=True, read_at=now)
                 for nid in new_ids
             ], ignore_conflicts=True)
 
-        return JsonResponse({"result": True, "message": f"已标记 {len(ids)} 条通知为已读"})
+        return JsonResponse(
+            {"result": True, "message": f"已标记 {len(valid_ids)} 条通知为已读", "data": {"skipped_ids": skipped_ids}}
+        )
 
     @action(methods=["get"], detail=False)
     def unread_count(self, request):


### PR DESCRIPTION
## 问题

批量标记通知已读接口本该只接受明确的通知 ID 数组。当前实现直接把请求体里的 `ids` 当成可信列表使用：传字符串、混合类型、空数组或不存在的 ID 时，要么可能把字符串拆成字符集合继续处理，要么把不存在的外键写进 `NotificationRead`，最终触发 500 或写入错误的已读状态。

## 根因

这个接口缺少请求边界校验，也没有在写入前确认通知 ID 是否真实存在。也就是说，接口把外部输入直接带进查询、集合运算和 `bulk_create`，数据库外键成了最后一道防线，所以非法输入会落到异常路径。

## 怎么修的

新增批量已读请求 serializer，要求 `ids` 是非空正整数数组并限制最大数量。接口通过校验后先去重，再用 `Notification.objects.filter(id__in=ids)` 取真实存在的 ID；只对这些有效 ID 更新或创建当前用户的已读状态，不存在的 ID 返回到 `skipped_ids`。

```python
serializer = MarkBatchAsReadSerializer(data=request.data)
if not serializer.is_valid():
    return JsonResponse(..., status=400)

ids = list(dict.fromkeys(serializer.validated_data["ids"]))
valid_ids = set(Notification.objects.filter(id__in=ids).values_list("id", flat=True))
skipped_ids = [nid for nid in ids if nid not in valid_ids]
```

## 影响范围

改动只在 `console_mgmt` 通知接口内：新增一个请求 serializer，调整 `mark_batch_as_read` 的写入前过滤，并补充接口测试。正常传入整数 ID 数组的调用方式不变；不存在的 ID 不再导致外键异常，而是作为跳过项返回。当前 web 通知组件没有调用这个批量 action，未发现 agents 或 NATS 调用方。

## 验证

新增测试覆盖两类会让旧实现出问题的路径：`ids` 为字符串、混合类型或空数组时返回 400；有效 ID 和不存在 ID 混合时只标记真实通知，并确认不会为不存在 ID 写入 `NotificationRead`。

本地验证：
- `uv run python -m py_compile apps/console_mgmt/serializers/notification.py apps/console_mgmt/serializers/__init__.py apps/console_mgmt/viewsets/notification.py apps/console_mgmt/tests/test_notification_views.py`
- 最小 Django harness 验证 `MarkBatchAsReadSerializer` 接受正整数数组、拒绝字符串/混合/空数组/非正整数，且错误响应可被 `JsonResponse` 序列化

说明：项目级 pytest 在当前本地环境未能跑到测试用例，阻塞于 Django 初始化：`django_celery_beat.models.SolarSchedule` 不在当前 `INSTALLED_APPS`。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST mark_batch_as_read\nnotification.py"]
    end

    V["MarkBatchAsReadSerializer\nserializers/notification.py"]
    F["Notification.objects.filter\n过滤真实 ID"]

    subgraph N["核心处理层"]
        E["查询已有 NotificationRead\nnotification.py"]
        U["update 已有未读行\nnotification.py"]
        C["bulk_create 新已读行\nnotification.py"]
    end

    S["skipped_ids\n响应给调用方"]

    T1 --> V --> F --> E
    E --> U
    E --> C
    F -. "不存在 ID" .-> S
```
