### PR TITLE
Fix K8s dashboard metrics routing

### DIFF
--- a/web/scripts/dashboard-display-mode-route-test.ts
+++ b/web/scripts/dashboard-display-mode-route-test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import {
+  getDashboardDisplayModeFromParams,
+  preserveDashboardDisplayMode,
+  setDashboardDisplayModeInParams
+} from '../src/app/monitor/dashboards/shared/utils/display-mode-route.ts';
+
+const dashboardParams = new URLSearchParams('monitorObjId=6&name=Pod');
+assert.equal(getDashboardDisplayModeFromParams(dashboardParams), 'dashboard');
+
+const metricsParams = setDashboardDisplayModeInParams(dashboardParams, 'metrics');
+assert.equal(metricsParams.get('view'), 'metrics');
+assert.equal(getDashboardDisplayModeFromParams(metricsParams), 'metrics');
+assert.equal(dashboardParams.get('view'), null);
+
+const resetParams = setDashboardDisplayModeInParams(metricsParams, 'dashboard');
+assert.equal(resetParams.get('view'), null);
+assert.equal(getDashboardDisplayModeFromParams(resetParams), 'dashboard');
+
+const nextObjectParams = preserveDashboardDisplayMode(
+  new URLSearchParams('monitorObjId=7&name=Node'),
+  new URLSearchParams('monitorObjId=6&name=Pod&view=metrics')
+);
+assert.equal(nextObjectParams.get('monitorObjId'), '7');
+assert.equal(nextObjectParams.get('view'), 'metrics');
+
+const nextDashboardParams = preserveDashboardDisplayMode(
+  new URLSearchParams('monitorObjId=7&name=Node'),
+  new URLSearchParams('monitorObjId=6&name=Pod')
+);
+assert.equal(nextDashboardParams.get('view'), null);
+
+console.log('dashboard display mode route tests passed');

--- a/web/scripts/dashboard-instance-identity-test.ts
+++ b/web/scripts/dashboard-instance-identity-test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { resolveDashboardInstanceIdentity } from '../src/app/monitor/dashboards/shared/utils/instance.ts';
+
+const podMetricsParams = new URLSearchParams(
+  `monitorObjId=45&name=Pod&monitorObjDisplayName=Pod&instance_id=${encodeURIComponent("('k8s_prod','nginx_7c9f')")}&instance_id_keys=instance_id%2Cpod&instance_id_values=k8s_prod%2Cnginx_7c9f&instance_name=nginx-pod&view=metrics`
+);
+
+const podIdentity = resolveDashboardInstanceIdentity(podMetricsParams);
+assert.equal(podIdentity.instanceId, "('k8s_prod','nginx_7c9f')");
+assert.deepEqual(podIdentity.idValues, ['k8s_prod', 'nginx_7c9f']);
+
+const tupleParams = new URLSearchParams(
+  "instance_id_values=('cluster-a','pod-a')&instance_name=pod-a"
+);
+const tupleIdentity = resolveDashboardInstanceIdentity(tupleParams);
+assert.equal(tupleIdentity.instanceId, "('cluster-a', 'pod-a')");
+assert.deepEqual(tupleIdentity.idValues, ['cluster-a', 'pod-a']);
+
+const opaqueValueParams = new URLSearchParams(
+  'instance_id_values=ABCDEFGHIJKLMNOP%2Cpod-a&instance_name=pod-a'
+);
+const opaqueValueIdentity = resolveDashboardInstanceIdentity(opaqueValueParams);
+assert.equal(opaqueValueIdentity.instanceId, "('ABCDEFGHIJKLMNOP', 'pod-a')");
+assert.deepEqual(opaqueValueIdentity.idValues, ['ABCDEFGHIJKLMNOP', 'pod-a']);
+
+const legacyParams = new URLSearchParams("instance_id=('host_01',)&instance_id_values=");
+const legacyIdentity = resolveDashboardInstanceIdentity(legacyParams);
+assert.equal(legacyIdentity.instanceId, "('host_01',)");
+assert.deepEqual(legacyIdentity.idValues, ['host_01']);
+
+console.log('dashboard instance identity tests passed');

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -226,7 +226,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       return;
     }
     initPage();
-  }, [isLoading]);
+  }, [isLoading, monitorObjectId, instanceId]);
 
   useEffect(() => {
     clearTimer();
@@ -251,6 +251,15 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   }, []);
 
   const initPage = async () => {
+    if (!monitorObjectId || !instanceId) {
+      setPlugins([]);
+      setActiveTab('');
+      setMetricData([]);
+      setOriginMetricData([]);
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     const responseData = await getEffectivePlugins(monitorObjectId, {
       instance_id: instanceId

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
@@ -6,6 +6,7 @@ import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
 import { getProfessionalDashboardKey, getProfessionalDashboardUrl } from '../registry';
 import { normalizeDashboardKey } from '../shared/utils';
+import { preserveDashboardDisplayMode } from '../shared/utils/display-mode-route';
 import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import TreeSelector from '@/app/monitor/components/treeSelector';
 import { ObjectItem, TreeItem } from '@/app/monitor/types';
@@ -88,7 +89,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
     if (String(key) === String(selectedObjectId || '')) return;
 
     const monitorItem = objects.find((item) => String(item.id) === String(key));
-    const params = new URLSearchParams({
+    const params = preserveDashboardDisplayMode(new URLSearchParams({
       monitorObjId: String(monitorItem?.id || key),
       name: monitorItem?.name || '',
       monitorObjDisplayName: monitorItem?.display_name || '',
@@ -96,7 +97,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
       instance_id_keys: Array.isArray(monitorItem?.instance_id_keys)
         ? monitorItem.instance_id_keys.join(',')
         : 'instance_id'
-    });
+    }), new URLSearchParams(searchParams.toString()));
     const dashboardUrl = getProfessionalDashboardUrl(
       monitorItem?.name,
       monitorItem?.display_name,

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -8,7 +8,7 @@ import useMonitorApi from '@/app/monitor/api';
 import useViewApi from '@/app/monitor/api/view';
 import {
   normalizeDisplayText,
-  parseLegacyParamList,
+  resolveDashboardInstanceIdentity,
   buildInstanceDisplayName,
   buildInstanceSearchTokens,
   formatEnumValue,
@@ -33,6 +33,11 @@ import {
   MetricUnit,
   TrendLegendItem
 } from '../../shared/types';
+import {
+  DashboardDisplayMode,
+  getDashboardDisplayModeFromParams,
+  setDashboardDisplayModeInParams
+} from '../../shared/utils/display-mode-route';
 
 export type SimpleMetricUnit = MetricUnit;
 
@@ -319,7 +324,9 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const timerRef = useRef<NodeJS.Timeout | null>(null);
 
   const [loading, setLoading] = useState(true);
-  const [displayMode, setDisplayMode] = useState<'dashboard' | 'metrics'>('dashboard');
+  const [displayMode, setDisplayModeState] = useState<DashboardDisplayMode>(() =>
+    getDashboardDisplayModeFromParams(new URLSearchParams(searchParams.toString()))
+  );
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({ timeRange: [], originValue: 15 });
   const [timeDefaultValue, setTimeDefaultValue] = useState<TimeSelectorDefaultValue>({ selectValue: 15, rangePickerVaule: null });
   const [frequence, setFrequence] = useState<number>(0);
@@ -337,21 +344,16 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const monitorObjectId = searchParams.get('monitorObjId') || '';
   const monitorObjectName = searchParams.get('name') || config.objectFallbackName;
   const monitorObjDisplayName = searchParams.get('monitorObjDisplayName') || config.objectFallbackName;
-  const rawInstanceId = searchParams.get('instance_id') || '';
-  const rawInstanceIdValues = searchParams.get('instance_id_values') || '';
   const rawInstanceIdKeys = searchParams.get('instance_id_keys') || 'instance_id';
   const instanceName = searchParams.get('instance_name') || '--';
 
   // Stable memoized values - avoids new array references on every render
-  const parsedLegacyInstanceIds = useMemo(() => parseLegacyParamList(rawInstanceId), [rawInstanceId]);
-  const instanceId: React.Key = parsedLegacyInstanceIds[0] || rawInstanceId || '';
-  const idValues = useMemo(() => {
-    const explicitValues = parseLegacyParamList(rawInstanceIdValues);
-    if (explicitValues.length > 0) return explicitValues;
-    if (parsedLegacyInstanceIds.length > 0) return parsedLegacyInstanceIds;
-    const normalizedInstanceId = normalizeDisplayText(rawInstanceId);
-    return normalizedInstanceId ? [normalizedInstanceId] : [];
-  }, [rawInstanceIdValues, parsedLegacyInstanceIds, rawInstanceId]);
+  const instanceIdentity = useMemo(
+    () => resolveDashboardInstanceIdentity(new URLSearchParams(searchParams.toString())),
+    [searchParams]
+  );
+  const instanceId: React.Key = instanceIdentity.instanceId;
+  const idValues = instanceIdentity.idValues;
   const instanceIdKeys = useMemo(
     () => rawInstanceIdKeys.split(',').filter(Boolean),
     [rawInstanceIdKeys]
@@ -359,6 +361,16 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const objectDisplayText = normalizeDisplayText(monitorObjDisplayName) || normalizeDisplayText(monitorObjectName) || config.objectFallbackName;
   const normalizedInstanceName = normalizeDisplayText(instanceName);
   const isDashboardMode = displayMode === 'dashboard';
+
+  useEffect(() => {
+    setDisplayModeState(getDashboardDisplayModeFromParams(new URLSearchParams(searchParams.toString())));
+  }, [searchParams]);
+
+  const setDisplayMode = useCallback((mode: DashboardDisplayMode) => {
+    setDisplayModeState(mode);
+    const params = setDashboardDisplayModeInParams(new URLSearchParams(searchParams.toString()), mode);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [router, searchParams]);
 
   useEffect(() => {
     if (!monitorObjectId) {

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { Dayjs } from 'dayjs';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { DatabaseOutlined, CloudServerOutlined, AppstoreOutlined, DeploymentUnitOutlined, PartitionOutlined, ReloadOutlined } from '@ant-design/icons';
 import useViewApi from '@/app/monitor/api/view';
 import useMonitorApi from '@/app/monitor/api';
+import MetricViews from '@/app/monitor/components/metric-views';
 import { ChartData, TimeSelectorDefaultValue, TimeValuesProps } from '@/app/monitor/types';
 import {
   buildSearchParams,
@@ -18,7 +20,7 @@ import {
   buildInstanceSearchTokens,
   normalizeDisplayText,
   isOpaqueIdentifier,
-  parseLegacyParamList,
+  resolveDashboardInstanceIdentity,
   formatMetricValue,
   buildPreviousPeriodTimeValues,
   getPeriodCompare,
@@ -50,6 +52,11 @@ import {
   RING_DONE,
   NS_LABEL
 } from './queries';
+import {
+  DashboardDisplayMode,
+  getDashboardDisplayModeFromParams,
+  setDashboardDisplayModeInParams
+} from '../../shared/utils/display-mode-route';
 import {
   latestScalar,
   seriesLatestByLabel,
@@ -110,35 +117,44 @@ export default function K8sClusterDashboardPage() {
   });
 
   const monitorObjectId = searchParams.get('monitorObjId') || '';
-  const rawInstanceId = searchParams.get('instance_id') || '';
-  const parsedLegacy = parseLegacyParamList(rawInstanceId);
-  const instanceId = parsedLegacy[0] || rawInstanceId || '';
   const instanceName = searchParams.get('instance_name') || '--';
-  const idValues = useMemo(() => {
-    const explicit = parseLegacyParamList(searchParams.get('instance_id_values'));
-    if (explicit.length > 0) return explicit;
-    if (parsedLegacy.length > 0) return parsedLegacy;
-    const normalized = normalizeDisplayText(String(instanceId));
-    return normalized ? [normalized] : [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  const instanceIdentity = useMemo(
+    () => resolveDashboardInstanceIdentity(new URLSearchParams(searchParams.toString())),
+    [searchParams]
+  );
+  const instanceId = instanceIdentity.instanceId;
+  const idValues = instanceIdentity.idValues;
   const instanceIdKeys = (searchParams.get('instance_id_keys') || 'instance_id').split(',').filter(Boolean);
   const idValuesKey = idValues.join('|');
 
   const resolvedInstanceName = isOpaqueIdentifier(instanceName) ? '' : normalizeDisplayText(instanceName);
   const objectFallbackName = 'K8s 集群';
+  const monitorObjectName = searchParams.get('name') || 'Cluster';
 
-  const [displayMode, setDisplayMode] = useState<'dashboard' | 'metrics'>('dashboard');
+  const [displayMode, setDisplayModeState] = useState<DashboardDisplayMode>(() =>
+    getDashboardDisplayModeFromParams(new URLSearchParams(searchParams.toString()))
+  );
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({ timeRange: [], originValue: 15 });
-  const timeDefaultValue: TimeSelectorDefaultValue = { selectValue: 15, rangePickerVaule: null };
+  const [timeDefaultValue, setTimeDefaultValue] = useState<TimeSelectorDefaultValue>({ selectValue: 15, rangePickerVaule: null });
   const [frequence, setFrequence] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [raw, setRaw] = useState<RawMap>({});
   const [previousRaw, setPreviousRaw] = useState<RawMap>({});
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
+  const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const loadSequence = useLoadSequence();
+
+  useEffect(() => {
+    setDisplayModeState(getDashboardDisplayModeFromParams(new URLSearchParams(searchParams.toString())));
+  }, [searchParams]);
+
+  const setDisplayMode = (mode: DashboardDisplayMode) => {
+    setDisplayModeState(mode);
+    const params = setDashboardDisplayModeInParams(new URLSearchParams(searchParams.toString()), mode);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  };
 
   // 实例列表
   useEffect(() => {
@@ -210,6 +226,10 @@ export default function K8sClusterDashboardPage() {
   };
 
   useEffect(() => {
+    if (displayMode !== 'dashboard') {
+      setLoading(false);
+      return;
+    }
     if (idValues.length === 0) {
       setRaw({});
       setLoading(false);
@@ -217,7 +237,7 @@ export default function K8sClusterDashboardPage() {
     }
     loadAll();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentInstanceInterval, idValuesKey, timeValues]);
+  }, [currentInstanceInterval, idValuesKey, timeValues, displayMode]);
 
   useEffect(() => {
     if (timerRef.current) {
@@ -409,6 +429,14 @@ export default function K8sClusterDashboardPage() {
   const onTimeChange = (vals: number[], originValue: number | null) => {
     setTimeValues({ timeRange: vals, originValue: originValue ?? 0 });
   };
+  const onXRangeChange = (arr: [Dayjs, Dayjs]) => {
+    if (!arr?.[0] || !arr?.[1]) return;
+    const start = arr[0].valueOf();
+    const end = arr[1].valueOf();
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start >= end) return;
+    setTimeDefaultValue((prev) => ({ ...prev, rangePickerVaule: arr, selectValue: 0 }));
+    setTimeValues({ timeRange: [start, end], originValue: 0 });
+  };
   const onInstanceChange = (value: string) => {
     const opt = instanceOptions.find((o) => o.value === value);
     const params = new URLSearchParams(Array.from(searchParams.entries()));
@@ -418,6 +446,13 @@ export default function K8sClusterDashboardPage() {
     router.push(`?${params.toString()}`);
   };
   const goBack = () => router.back();
+  const onRefresh = () => {
+    if (displayMode === 'dashboard') {
+      loadAll();
+    } else {
+      setMetricsRefreshSignal((value) => value + 1);
+    }
+  };
 
   const guide = (label: string, detail: string) => [{ label, detail }];
 
@@ -426,13 +461,13 @@ export default function K8sClusterDashboardPage() {
       <div className={styles.shell}>
         <div className={styles.pageHeader}>
           <DashboardPageHeader
-            title="K8s 集群监控仪表盘"
+            title={displayMode === 'metrics' ? `${objectFallbackName} 全量指标` : 'K8s 集群监控仪表盘'}
             displayMode={displayMode}
             onDisplayModeChange={setDisplayMode}
             timeDefaultValue={timeDefaultValue}
             onTimeChange={onTimeChange}
             onFrequenceChange={setFrequence}
-            onRefresh={() => loadAll()}
+            onRefresh={onRefresh}
             onBack={goBack}
             showTimeSelector={false}
             styles={styles}
@@ -450,41 +485,71 @@ export default function K8sClusterDashboardPage() {
             selectorPlaceholder="选择实例"
             selectorTitle={currentOption?.label || resolvedInstanceName}
             isDashboardMode={displayMode === 'dashboard'}
-            timeSelectorProps={{ timeDefaultValue, onTimeChange, onFrequenceChange: setFrequence, onRefresh: () => loadAll() }}
+            timeSelectorProps={{ timeDefaultValue, onTimeChange, onFrequenceChange: setFrequence, onRefresh }}
             styles={styles}
           />
         </div>
 
-        {/* Tier 1 · 概览:6 张等宽卡(采集状态 + 5 KPI),全 span2(=12) */}
-        <div className={styles.sectionLabel}>概览</div>
-        <section className={styles.dashboardSection}>
-          <div className={styles.sectionGrid}>
-            <CollectionStatusCard
-              status={collectionStatus}
-              timeline={collectionTimeline}
-              guideItems={guide('采集状态', '集群监控采集是否正常。')}
-              className={styles.span2}
-              styles={styles}
-            />
-            {kpiCards.map((c) => (
-              <StatCard
-                key={c.key}
-                title={<TitleWithGuide title={c.title} items={guide(c.title, c.desc)} styles={styles} />}
-                value={num(c.value)}
-                unit=""
-                icon={c.icon}
-                iconStyle={{ color: c.color }}
-                color={c.color}
-                footer={<span>{c.footer}</span>}
-                compare={c.compare}
-                trendData={c.trendData}
-                noDataType={loading ? 'empty' : undefined}
-                className={styles.span2}
-                styles={styles}
+        {displayMode === 'metrics' ? (
+          <div className={styles.metricsMode}>
+            <div className={`${styles.panel} ${styles.fullPanel}`}>
+              <div className={styles.sectionHeading}>
+                <h3 className={styles.panelTitle}>
+                  <TitleWithGuide
+                    title="监控指标全量"
+                    items={[{ label: '监控指标全景', detail: '承载完整原始监控视图，适合在仪表盘发现异常后继续下钻排查。' }]}
+                    styles={styles}
+                  />
+                </h3>
+              </div>
+              <MetricViews
+                monitorObjectId={monitorObjectId}
+                monitorObjectName={monitorObjectName}
+                instanceId={instanceId}
+                instanceName={resolvedInstanceName}
+                idValues={idValues}
+                externalTimeValues={timeValues}
+                externalTimeDefaultValue={timeDefaultValue}
+                externalFrequence={frequence}
+                externalRefreshSignal={metricsRefreshSignal}
+                collectionInterval={currentInstanceInterval}
+                hideTimeSelector
+                onExternalXRangeChange={onXRangeChange}
               />
-            ))}
+            </div>
           </div>
-        </section>
+        ) : (
+          <>
+            {/* Tier 1 · 概览:6 张等宽卡(采集状态 + 5 KPI),全 span2(=12) */}
+            <div className={styles.sectionLabel}>概览</div>
+            <section className={styles.dashboardSection}>
+              <div className={styles.sectionGrid}>
+                <CollectionStatusCard
+                  status={collectionStatus}
+                  timeline={collectionTimeline}
+                  guideItems={guide('采集状态', '集群监控采集是否正常。')}
+                  className={styles.span2}
+                  styles={styles}
+                />
+                {kpiCards.map((c) => (
+                  <StatCard
+                    key={c.key}
+                    title={<TitleWithGuide title={c.title} items={guide(c.title, c.desc)} styles={styles} />}
+                    value={num(c.value)}
+                    unit=""
+                    icon={c.icon}
+                    iconStyle={{ color: c.color }}
+                    color={c.color}
+                    footer={<span>{c.footer}</span>}
+                    compare={c.compare}
+                    trendData={c.trendData}
+                    noDataType={loading ? 'empty' : undefined}
+                    className={styles.span2}
+                    styles={styles}
+                  />
+                ))}
+              </div>
+            </section>
 
         {/* Tier 2 · 健康构成:三环统一 span4 */}
         <div className={styles.sectionLabel}>健康构成</div>
@@ -583,33 +648,35 @@ export default function K8sClusterDashboardPage() {
             />
           </div>
         </section>
-        <section className={styles.dashboardSection}>
-          <div className={styles.sectionGrid}>
-            <HorizontalBarPanel
-              title="节点内存 Top"
-              guide={guide('节点内存 Top', '内存使用率最高的节点。')}
-              items={nodeMemBars}
-              tiered
-              className={styles.span4}
-              styles={styles}
-            />
-            <HorizontalBarPanel
-              title="Top 命名空间 · 内存"
-              guide={guide('Top 命名空间 · 内存', '内存占用最高的命名空间。')}
-              items={topNsMemBars}
-              tiered
-              className={styles.span4}
-              styles={styles}
-            />
-            <HorizontalBarPanel
-              title="工作负载可用度"
-              guide={guide('工作负载可用度', '各类工作负载可用副本占期望副本的比例。')}
-              items={workloadBars}
-              className={styles.span4}
-              styles={styles}
-            />
-          </div>
-        </section>
+            <section className={styles.dashboardSection}>
+              <div className={styles.sectionGrid}>
+                <HorizontalBarPanel
+                  title="节点内存 Top"
+                  guide={guide('节点内存 Top', '内存使用率最高的节点。')}
+                  items={nodeMemBars}
+                  tiered
+                  className={styles.span4}
+                  styles={styles}
+                />
+                <HorizontalBarPanel
+                  title="Top 命名空间 · 内存"
+                  guide={guide('Top 命名空间 · 内存', '内存占用最高的命名空间。')}
+                  items={topNsMemBars}
+                  tiered
+                  className={styles.span4}
+                  styles={styles}
+                />
+                <HorizontalBarPanel
+                  title="工作负载可用度"
+                  guide={guide('工作负载可用度', '各类工作负载可用副本占期望副本的比例。')}
+                  items={workloadBars}
+                  className={styles.span4}
+                  styles={styles}
+                />
+              </div>
+            </section>
+          </>
+        )}
       </div>
     </div>
   );

--- a/web/src/app/monitor/dashboards/shared/utils/display-mode-route.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/display-mode-route.ts
@@ -1,0 +1,30 @@
+export type DashboardDisplayMode = 'dashboard' | 'metrics';
+
+const DISPLAY_MODE_PARAM = 'view';
+
+export const getDashboardDisplayModeFromParams = (
+  params: URLSearchParams
+): DashboardDisplayMode => (
+  params.get(DISPLAY_MODE_PARAM) === 'metrics' ? 'metrics' : 'dashboard'
+);
+
+export const setDashboardDisplayModeInParams = (
+  params: URLSearchParams,
+  mode: DashboardDisplayMode
+) => {
+  const next = new URLSearchParams(params.toString());
+  if (mode === 'metrics') {
+    next.set(DISPLAY_MODE_PARAM, 'metrics');
+  } else {
+    next.delete(DISPLAY_MODE_PARAM);
+  }
+  return next;
+};
+
+export const preserveDashboardDisplayMode = (
+  nextParams: URLSearchParams,
+  currentParams: URLSearchParams
+) => setDashboardDisplayModeInParams(
+  nextParams,
+  getDashboardDisplayModeFromParams(currentParams)
+);

--- a/web/src/app/monitor/dashboards/shared/utils/instance.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/instance.ts
@@ -64,3 +64,29 @@ export const parseLegacyParamList = (value?: string | null) => {
     .filter(Boolean);
   return Array.from(new Set(normalized));
 };
+
+export const buildStorageInstanceId = (values: string[]) => {
+  const normalizedValues = values.map((value) => String(value || '').trim()).filter(Boolean);
+  if (normalizedValues.length <= 1) {
+    return normalizedValues[0] || '';
+  }
+  return `(${normalizedValues.map((value) => `'${value}'`).join(', ')})`;
+};
+
+export const resolveDashboardInstanceIdentity = (params: URLSearchParams) => {
+  const rawInstanceId = params.get('instance_id') || '';
+  const rawInstanceIdValues = params.get('instance_id_values') || '';
+  const storageInstanceId = rawInstanceId.trim() === '--' ? '' : rawInstanceId.trim();
+  const parsedLegacyInstanceIds = parseLegacyParamList(rawInstanceId);
+  const explicitValues = parseLegacyParamList(rawInstanceIdValues);
+
+  const idValues = explicitValues.length > 0
+    ? explicitValues
+    : parsedLegacyInstanceIds.length > 0
+      ? parsedLegacyInstanceIds
+      : storageInstanceId ? [storageInstanceId] : [];
+
+  const instanceId = storageInstanceId || buildStorageInstanceId(idValues);
+
+  return { instanceId, idValues };
+};


### PR DESCRIPTION
## 变更说明
- 保留仪表盘与全量指标之间的 view=metrics 路由状态，切换 K8s Cluster/Node/Pod 时不再回到错误视图。
- 修正仪表盘实例身份解析，K8s 多维实例保留完整 tuple instance_id，同时用 instance_id_values 生成指标查询标签。
- 避免 MetricViews 在 instance_id 未补齐前请求 effective_plugins，防止触发 instance_id is required。
- 为显示模式路由和实例身份解析增加回归脚本。

## 验证
- node --experimental-strip-types web/scripts/dashboard-instance-identity-test.ts
- node --experimental-strip-types web/scripts/dashboard-display-mode-route-test.ts
- pnpm type-check
- pnpm exec eslint src/app/monitor/components/metric-views/index.tsx src/app/monitor/dashboards/shared/utils/instance.ts src/app/monitor/dashboards/shared/utils/display-mode-route.ts src/app/monitor/dashboards/components/dashboard-sidebar.tsx src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
- pnpm exec eslint --no-ignore scripts/dashboard-display-mode-route-test.ts scripts/dashboard-instance-identity-test.ts

## 已知情况
- pnpm lint 全量仍有既有无关错误，涉及 alarm/cmdb/log、networkDevice/wireless 和 stories 文件；本 PR 触及文件的定向 eslint 已通过。