### PR TITLE
bugfix(system_mgmt): 收口组织对象级权限

### DIFF
--- a/server/apps/system_mgmt/tests/sensitive_info_management_test.py
+++ b/server/apps/system_mgmt/tests/sensitive_info_management_test.py
@@ -341,6 +341,7 @@ def test_user_viewset_search_user_list_keeps_plaintext_when_sensitive_info_prote
     from apps.system_mgmt.viewset.user_viewset import UserViewSet
 
     _set_sensitive_info_settings(enabled=False)
+    group = Group.objects.create(name="group-for-plain-list")
     target_user = User.objects.create(
         username="plain_user",
         display_name="明文用户",
@@ -348,6 +349,7 @@ def test_user_viewset_search_user_list_keeps_plaintext_when_sensitive_info_prote
         phone="13800001111",
         password=make_password("password123"),
         locale="zh-Hans",
+        group_list=[group.id],
     )
 
     factory = APIRequestFactory()
@@ -359,6 +361,7 @@ def test_user_viewset_search_user_list_keeps_plaintext_when_sensitive_info_prote
             username="viewer-plain",
             is_superuser=False,
             permission={"system-manager": {"user_group-View"}},
+            group_list=[{"id": group.id}],
         ),
     )
 

--- a/server/apps/system_mgmt/tests/test_org_scope_permissions.py
+++ b/server/apps/system_mgmt/tests/test_org_scope_permissions.py
@@ -1,0 +1,227 @@
+import json
+import types
+
+import pytest
+from django.contrib.auth.hashers import make_password
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system_mgmt.models import Group, Role, User
+from apps.system_mgmt.viewset.role_viewset import RoleViewSet
+from apps.system_mgmt.viewset.user_viewset import UserViewSet
+
+
+def _request_user(group_ids, permission, *, is_superuser=False):
+    return types.SimpleNamespace(
+        username="org-scope-operator",
+        domain="domain.com",
+        locale="en",
+        is_authenticated=True,
+        is_superuser=is_superuser,
+        permission={"system-manager": set(permission)},
+        group_list=[{"id": group_id} for group_id in group_ids],
+    )
+
+
+def _json_payload(response):
+    return json.loads(response.content)
+
+
+@pytest.mark.django_db
+def test_search_user_list_filters_to_accessible_groups():
+    allowed = Group.objects.create(name="scope-search-allowed", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="scope-search-other", parent_id=0, is_virtual=False)
+    allowed_user = User.objects.create(
+        username="scope_search_allowed",
+        display_name="Allowed User",
+        email="allowed@example.com",
+        password=make_password("password"),
+        group_list=[allowed.id],
+    )
+    User.objects.create(
+        username="scope_search_other",
+        display_name="Other User",
+        email="other@example.com",
+        password=make_password("password"),
+        group_list=[other.id],
+    )
+
+    factory = APIRequestFactory()
+    view = UserViewSet.as_view({"get": "search_user_list"})
+    request = factory.get("/system_mgmt/api/user/search_user_list/", {"search": "scope_search"})
+    force_authenticate(request, user=_request_user([allowed.id], {"user_group-View"}))
+
+    response = view(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 200
+    assert payload["data"]["count"] == 1
+    assert [user["username"] for user in payload["data"]["users"]] == [allowed_user.username]
+
+
+@pytest.mark.django_db
+def test_create_user_rejects_unauthorized_groups():
+    allowed = Group.objects.create(name="scope-create-allowed", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="scope-create-other", parent_id=0, is_virtual=False)
+    role = Role.objects.create(name="scope-create-role", app="")
+
+    factory = APIRequestFactory()
+    view = UserViewSet.as_view({"post": "create_user"})
+    request = factory.post(
+        "/system_mgmt/api/user/create_user/",
+        {
+            "username": "scope_create_user",
+            "lastName": "Scope Create User",
+            "email": "scope_create@example.com",
+            "phone": None,
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [other.id],
+            "roles": [role.id],
+            "rules": [],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_request_user([allowed.id], {"user_group-Add User"}))
+
+    response = view(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 403
+    assert payload["result"] is False
+    assert not User.objects.filter(username="scope_create_user").exists()
+
+
+@pytest.mark.django_db
+def test_create_user_allows_accessible_groups():
+    allowed = Group.objects.create(name="scope-create-allowed-ok", parent_id=0, is_virtual=False)
+    role = Role.objects.create(name="scope-create-role-ok", app="")
+
+    factory = APIRequestFactory()
+    view = UserViewSet.as_view({"post": "create_user"})
+    request = factory.post(
+        "/system_mgmt/api/user/create_user/",
+        {
+            "username": "scope_create_user_ok",
+            "lastName": "Scope Create User OK",
+            "email": "scope_create_ok@example.com",
+            "phone": None,
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [allowed.id],
+            "roles": [role.id],
+            "rules": [],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_request_user([allowed.id], {"user_group-Add User"}))
+
+    response = view(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 200
+    assert payload == {"result": True}
+    assert User.objects.get(username="scope_create_user_ok").group_list == [allowed.id]
+
+
+@pytest.mark.django_db
+def test_update_user_rejects_unauthorized_groups():
+    allowed = Group.objects.create(name="scope-update-allowed", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="scope-update-other", parent_id=0, is_virtual=False)
+    Role.objects.create(name="admin", app="")
+    role = Role.objects.create(name="scope-update-role", app="")
+    target = User.objects.create(
+        username="scope_update_user",
+        display_name="Scope Update User",
+        email="scope_update@example.com",
+        password=make_password("password"),
+        group_list=[allowed.id],
+        role_list=[role.id],
+    )
+
+    factory = APIRequestFactory()
+    view = UserViewSet.as_view({"post": "update_user"})
+    request = factory.post(
+        "/system_mgmt/api/user/update_user/",
+        {
+            "user_id": target.id,
+            "username": target.username,
+            "lastName": "Scope Update User",
+            "email": target.email,
+            "phone": None,
+            "locale": "zh-Hans",
+            "timezone": "Asia/Shanghai",
+            "groups": [other.id],
+            "roles": [role.id],
+            "rules": [],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_request_user([allowed.id], {"user_group-Edit User"}))
+
+    response = view(request)
+    payload = _json_payload(response)
+    target.refresh_from_db()
+
+    assert response.status_code == 403
+    assert payload["result"] is False
+    assert target.group_list == [allowed.id]
+
+
+@pytest.mark.django_db
+def test_batch_assign_group_roles_rejects_unauthorized_groups():
+    allowed = Group.objects.create(name="scope-role-assign-allowed", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="scope-role-assign-other", parent_id=0, is_virtual=False)
+    role = Role.objects.create(name="scope-role-assign", app="system_mgmt")
+
+    request = types.SimpleNamespace(
+        user=_request_user([allowed.id], {"application_role-Edit"}),
+        data={"group_ids": [other.id], "role_id": role.id},
+        META={},
+    )
+
+    response = RoleViewSet().batch_assign_group_roles(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 403
+    assert payload["result"] is False
+    assert not role.group_set.filter(id=other.id).exists()
+
+
+@pytest.mark.django_db
+def test_batch_assign_group_roles_allows_accessible_groups():
+    allowed = Group.objects.create(name="scope-role-assign-allowed-ok", parent_id=0, is_virtual=False)
+    role = Role.objects.create(name="scope-role-assign-ok", app="system_mgmt")
+
+    request = types.SimpleNamespace(
+        user=_request_user([allowed.id], {"application_role-Edit"}),
+        data={"group_ids": [allowed.id], "role_id": role.id},
+        META={},
+    )
+
+    response = RoleViewSet().batch_assign_group_roles(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 200
+    assert payload == {"result": True}
+    assert role.group_set.filter(id=allowed.id).exists()
+
+
+@pytest.mark.django_db
+def test_revoke_group_roles_rejects_unauthorized_groups():
+    allowed = Group.objects.create(name="scope-role-revoke-allowed", parent_id=0, is_virtual=False)
+    other = Group.objects.create(name="scope-role-revoke-other", parent_id=0, is_virtual=False)
+    role = Role.objects.create(name="scope-role-revoke", app="system_mgmt")
+    role.group_set.add(other)
+
+    request = types.SimpleNamespace(
+        user=_request_user([allowed.id], {"application_role-Edit"}),
+        data={"group_ids": [other.id], "role_id": role.id},
+        META={},
+    )
+
+    response = RoleViewSet().revoke_group_roles(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 403
+    assert payload["result"] is False
+    assert role.group_set.filter(id=other.id).exists()

--- a/server/apps/system_mgmt/utils/group_filter_mixin.py
+++ b/server/apps/system_mgmt/utils/group_filter_mixin.py
@@ -1,3 +1,4 @@
+from django.db import connection
 from django.db.models import Q
 from django.http import JsonResponse
 from rest_framework.exceptions import PermissionDenied
@@ -5,6 +6,50 @@ from rest_framework.exceptions import PermissionDenied
 from apps.core.logger import system_mgmt_logger as logger
 from apps.core.utils.team_utils import get_current_team
 from apps.system_mgmt.models import Group, User
+
+
+def normalize_group_id_set(group_list):
+    group_ids = set()
+    for group in group_list or []:
+        group_id = group.get("id") if isinstance(group, dict) else group
+        try:
+            group_ids.add(int(group_id))
+        except (TypeError, ValueError):
+            continue
+    return group_ids
+
+
+def get_user_group_ids(user):
+    """获取用户有权限的组ID集合；超管返回 None 表示全量权限。"""
+    if getattr(user, "is_superuser", False):
+        return None
+    return normalize_group_id_set(getattr(user, "group_list", []))
+
+
+def get_unauthorized_group_ids(user, group_ids):
+    accessible_group_ids = get_user_group_ids(user)
+    if accessible_group_ids is None:
+        return []
+    requested_group_ids = normalize_group_id_set(group_ids)
+    return sorted(requested_group_ids - accessible_group_ids)
+
+
+def filter_queryset_by_group_ids(queryset, group_ids, group_field="group_list"):
+    if not group_ids:
+        return queryset.none()
+
+    if connection.features.supports_json_field_contains:
+        query = Q()
+        for group_id in group_ids:
+            query |= Q(**{f"{group_field}__contains": group_id})
+        return queryset.filter(query)
+
+    matched_ids = [
+        item.id
+        for item in queryset.only("id", group_field)
+        if normalize_group_id_set(getattr(item, group_field)).intersection(group_ids)
+    ]
+    return queryset.filter(id__in=matched_ids)
 
 
 class GroupPermissionMixin:
@@ -30,9 +75,7 @@ class GroupPermissionMixin:
         Returns:
             set: 用户有权限的组ID集合
         """
-        if getattr(user, "is_superuser", False):
-            return None  # superuser 返回 None 表示有权限访问所有组
-        return {g["id"] for g in getattr(user, "group_list", [])}
+        return get_user_group_ids(user)
 
     def _validate_group_permission(self, user, group_id, loader=None):
         """校验用户是否有权限访问指定组
@@ -73,7 +116,7 @@ class GroupPermissionMixin:
             return True, None
 
         user_group_ids = self._get_user_group_ids(current_user)
-        target_group_ids = set(target_user.group_list or [])
+        target_group_ids = normalize_group_id_set(target_user.group_list)
 
         # 检查目标用户的组是否与当前用户的组有交集
         if not user_group_ids.intersection(target_group_ids):
@@ -99,11 +142,7 @@ class GroupPermissionMixin:
         if not user_group_ids:
             return queryset.none()
 
-        # 构建查询条件：group_list 与用户有权限的组有交集
-        query = Q()
-        for group_id in user_group_ids:
-            query |= Q(**{f"{group_field}__contains": group_id})
-        return queryset.filter(query)
+        return filter_queryset_by_group_ids(queryset, user_group_ids, group_field=group_field)
 
 
 class GroupFilterMixin:

--- a/server/apps/system_mgmt/viewset/group_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_viewset.py
@@ -9,6 +9,7 @@ from apps.core.utils.viewset_utils import LanguageViewSet
 from apps.rpc.cmdb import CMDB
 from apps.system_mgmt.models import Group, User
 from apps.system_mgmt.serializers.group_serializer import GroupSerializer
+from apps.system_mgmt.utils.group_filter_mixin import get_user_group_ids
 from apps.system_mgmt.utils.group_utils import GroupUtils
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 from apps.system_mgmt.utils.viewset_utils import ViewSetUtils
@@ -30,9 +31,7 @@ class GroupViewSet(LanguageViewSet, ViewSetUtils):
 
     def _get_user_group_ids(self, user):
         """获取用户有权限的组ID集合"""
-        if getattr(user, "is_superuser", False):
-            return None  # superuser 返回 None 表示有权限访问所有组
-        return {g["id"] for g in getattr(user, "group_list", [])}
+        return get_user_group_ids(user)
 
     def _validate_group_permission(self, request, group_id):
         """校验用户是否有权限访问指定组

--- a/server/apps/system_mgmt/viewset/role_viewset.py
+++ b/server/apps/system_mgmt/viewset/role_viewset.py
@@ -9,6 +9,7 @@ from apps.core.utils.viewset_utils import LanguageViewSet
 from apps.system_mgmt.models import Group, Menu, Role, User
 from apps.system_mgmt.serializers.role_serializer import RoleSerializer
 from apps.system_mgmt.services.role_manage import RoleManage
+from apps.system_mgmt.utils.group_filter_mixin import get_unauthorized_group_ids
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 from apps.system_mgmt.utils.viewset_utils import ViewSetUtils
 
@@ -16,6 +17,14 @@ from apps.system_mgmt.utils.viewset_utils import ViewSetUtils
 class RoleViewSet(LanguageViewSet, ViewSetUtils):
     queryset = Role.objects.exclude(app="")
     serializer_class = RoleSerializer
+
+    def _validate_group_scope_for_request(self, request, group_ids):
+        unauthorized_group_ids = get_unauthorized_group_ids(request.user, group_ids)
+        if unauthorized_group_ids:
+            loader = getattr(self, "loader", None)
+            message = loader.get("error.no_permission_access_group") if loader else "无权访问该组织"
+            return JsonResponse({"result": False, "message": message}, status=403)
+        return None
 
     @action(detail=False, methods=["POST"])
     @HasPermission("application_role-View")
@@ -273,6 +282,9 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                     "message": self.loader.get("error.some_groups_not_exist"),
                 }
             )
+        group_scope_error = self._validate_group_scope_for_request(request, group_ids)
+        if group_scope_error:
+            return group_scope_error
 
         # 验证角色是否存在
         try:
@@ -330,6 +342,9 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                     "message": self.loader.get("error.some_groups_not_exist"),
                 }
             )
+        group_scope_error = self._validate_group_scope_for_request(request, group_ids)
+        if group_scope_error:
+            return group_scope_error
 
         # 验证角色是否存在
         try:

--- a/server/apps/system_mgmt/viewset/user_viewset.py
+++ b/server/apps/system_mgmt/viewset/user_viewset.py
@@ -22,6 +22,12 @@ from apps.core.utils.permission_cache import clear_user_permission_cache, clear_
 from apps.rpc.cmdb import CMDB
 from apps.system_mgmt.models import Group, Role, User, UserRule
 from apps.system_mgmt.serializers.user_serializer import UserSerializer
+from apps.system_mgmt.utils.group_filter_mixin import (
+    filter_queryset_by_group_ids,
+    get_unauthorized_group_ids,
+    get_user_group_ids,
+    normalize_group_id_set,
+)
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 from apps.system_mgmt.utils.password_validator import PasswordValidator
 from apps.system_mgmt.utils.user_status import is_user_locked
@@ -80,9 +86,14 @@ class UserViewSet(ViewSetUtils):
 
     def _get_user_group_ids(self, user):
         """获取用户有权限的组ID集合"""
-        if getattr(user, "is_superuser", False):
-            return None  # superuser 返回 None 表示有权限访问所有组
-        return {g["id"] for g in getattr(user, "group_list", [])}
+        return get_user_group_ids(user)
+
+    def _validate_group_scope_for_request(self, request, group_ids, loader):
+        unauthorized_group_ids = get_unauthorized_group_ids(request.user, group_ids)
+        if unauthorized_group_ids:
+            message = loader.get("error.no_permission_access_group", "无权访问该组织")
+            return JsonResponse({"result": False, "message": message}, status=403)
+        return None
 
     def _validate_target_user_permission(self, request, target_user):
         """校验当前用户是否有权限访问目标用户
@@ -98,7 +109,7 @@ class UserViewSet(ViewSetUtils):
             return True, None
 
         user_group_ids = self._get_user_group_ids(request.user)
-        target_group_ids = set(target_user.group_list or [])
+        target_group_ids = normalize_group_id_set(target_user.group_list)
 
         # 检查目标用户的组是否与当前用户的组有交集
         if not user_group_ids.intersection(target_group_ids):
@@ -124,11 +135,7 @@ class UserViewSet(ViewSetUtils):
         if not user_group_ids:
             return queryset.none()
 
-        # 构建查询条件：group_list 与用户有权限的组有交集
-        query = Q()
-        for group_id in user_group_ids:
-            query |= Q(group_list__contains=group_id)
-        return queryset.filter(query)
+        return filter_queryset_by_group_ids(queryset, user_group_ids)
 
     def list(self, request, *args, **kwargs):
         """禁用内置 list 接口 - 使用 search_user_list action"""
@@ -222,6 +229,8 @@ class UserViewSet(ViewSetUtils):
         if is_superuser:
             super_role_id = Role.objects.get(app="", name="admin").id
             queryset = queryset.filter(role_list__contains=super_role_id)
+
+        queryset = self._filter_users_by_accessible_groups(queryset, request.user)
 
         # 如果指定了用户组ID，则过滤该组内的用户
         if group_id:
@@ -336,6 +345,9 @@ class UserViewSet(ViewSetUtils):
         if group_validation_error:
             return JsonResponse({"result": False, "message": group_validation_error})
         groups, _ = _normalize_group_ids(groups)
+        group_scope_error = self._validate_group_scope_for_request(request, groups, loader)
+        if group_scope_error:
+            return group_scope_error
 
         # 校验 roles ID 是否真实存在
         roles = kwargs.get("roles", [])
@@ -546,6 +558,9 @@ class UserViewSet(ViewSetUtils):
         if group_validation_error:
             return JsonResponse({"result": False, "message": group_validation_error})
         groups, _ = _normalize_group_ids(groups)
+        group_scope_error = self._validate_group_scope_for_request(request, groups, loader)
+        if group_scope_error:
+            return group_scope_error
         params["groups"] = groups
         is_superuser = params.pop("is_superuser", False)
         admin_role_id = Role.objects.get(name="admin", app="").id


### PR DESCRIPTION
## 变更说明

修复 system_mgmt 组织对象级权限缺口，关联：
- Fixes #3776：非超管更新用户组织归属时，禁止写入未授权组织。
- Fixes #3777：批量组织角色绑定/回收时，禁止操作未授权组织。
- Fixes #3778：用户搜索列表按当前用户可访问组织收口，避免跨组织用户泄露。

## 兼容性

- 超管仍保持全量组织权限。
- 非超管对自己已授权组织的创建用户、角色绑定等正向路径保持可用。
- PostgreSQL 继续使用 JSONField contains 过滤；sqlite 本地测试环境增加 Python 兜底，避免本地测试后端不支持 contains lookup。

## 验证

- `git diff --check` 通过。
- `uv run python -m py_compile apps/system_mgmt/utils/group_filter_mixin.py apps/system_mgmt/viewset/user_viewset.py apps/system_mgmt/viewset/role_viewset.py apps/system_mgmt/viewset/group_viewset.py apps/system_mgmt/tests/test_org_scope_permissions.py apps/system_mgmt/tests/sensitive_info_management_test.py` 通过。
- `INSTALL_APPS=system_mgmt ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=test-org-scope.sqlite3 MINIO_ENDPOINT=127.0.0.1:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=False uv run --with pytest-django --with django-extensions pytest -o addopts= apps/system_mgmt/tests/test_org_scope_permissions.py apps/system_mgmt/tests/test_group_batch_permission.py apps/system_mgmt/tests/sensitive_info_management_test.py::test_user_viewset_search_user_list_keeps_plaintext_when_sensitive_info_protection_disabled -q` 通过，10 passed。