### PR TITLE
bugfix(console_mgmt): require verified email change token

### DIFF
--- a/mobile/src/app/profile/accountDetails/page.tsx
+++ b/mobile/src/app/profile/accountDetails/page.tsx
@@ -58,7 +58,6 @@ export default function AccountDetailsPage() {
         const locale = newLocale ?? currentLocale;
         const hasChanges =
             currentValues.display_name !== originalData.display_name ||
-            currentValues.email !== originalData.email ||
             tz !== originalData.timezone ||
             locale !== originalData.locale;
         setIsModified(hasChanges);
@@ -71,7 +70,6 @@ export default function AccountDetailsPage() {
             const formValues = form.getFieldsValue();
             const saveData = {
                 display_name: formValues.display_name,
-                email: formValues.email,
                 timezone: currentTimezone,
                 locale: currentLocale,
             };
@@ -182,7 +180,7 @@ export default function AccountDetailsPage() {
                             />
                         </Form.Item>
 
-                        {/* 邮箱 - 可编辑必填 */}
+                        {/* 邮箱 - 移动端暂不提供验证码闭环，避免直接提交后端被拒绝 */}
                         <Form.Item
                             name="email"
                             label={
@@ -199,6 +197,8 @@ export default function AccountDetailsPage() {
                             <Input
                                 placeholder={t('account.enterEmail')}
                                 type="email"
+                                disabled
+                                readOnly
                                 style={{
                                     '--font-size': '14px',
                                     '--text-align': 'right',

--- a/server/apps/console_mgmt/language/en.yaml
+++ b/server/apps/console_mgmt/language/en.yaml
@@ -10,6 +10,7 @@ error:
   group_name_required: group_name is required
   password_required: Password cannot be empty
   invalid_json_format: Invalid JSON format
+  email_change_verification_required: Email change requires verification
 email:
   verification_code_validity: The verification code is valid for 10 minutes, please
     use it in time.

--- a/server/apps/console_mgmt/language/zh-Hans.yaml
+++ b/server/apps/console_mgmt/language/zh-Hans.yaml
@@ -10,6 +10,7 @@ error:
   group_name_required: group_name 不能为空
   password_required: 密码不能为空
   invalid_json_format: 请求体格式错误，请发送合法的 JSON
+  email_change_verification_required: 修改邮箱需要先完成验证码校验
 email:
   verification_code_validity: 验证码有效期为10分钟,请及时使用。
   verification_code_body: 您的验证码是

--- a/server/apps/console_mgmt/tests/test_email_change_authorization.py
+++ b/server/apps/console_mgmt/tests/test_email_change_authorization.py
@@ -1,0 +1,163 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from django.test import RequestFactory
+
+from apps.console_mgmt import views
+from apps.console_mgmt.views import (
+    _email_change_verified_cache_key,
+    _email_code_cache_key,
+    update_user_base_info,
+    validate_email_code,
+)
+from apps.system_mgmt.models import User
+
+
+pytestmark = [pytest.mark.django_db]
+
+
+def _request(path, user, body):
+    request = RequestFactory().post(path, data=json.dumps(body), content_type="application/json")
+    request.user = SimpleNamespace(username=user.username, domain=user.domain, locale=user.locale)
+    return request
+
+
+def _payload(response):
+    return json.loads(response.content)
+
+
+@pytest.fixture
+def memory_cache(monkeypatch):
+    store = {}
+
+    class MemoryCache:
+        def get(self, key):
+            return store.get(key)
+
+        def set(self, key, value, timeout=None):
+            store[key] = value
+            return True
+
+        def delete(self, key):
+            store.pop(key, None)
+            return True
+
+    fake_cache = MemoryCache()
+    monkeypatch.setattr(views, "cache", fake_cache)
+    return fake_cache
+
+
+def test_update_user_base_info_rejects_email_change_without_verified_code(memory_cache):
+    user = User.objects.create(
+        username="email_auth_alice",
+        domain="domain.com",
+        display_name="Alice",
+        email="alice-old@example.com",
+        password="!",
+        locale="en",
+    )
+
+    response = update_user_base_info(
+        _request(
+            "/api/v1/console_mgmt/update_user_base_info/",
+            user,
+            {"display_name": "Alice", "email": "alice-new@example.com"},
+        )
+    )
+    user.refresh_from_db()
+
+    assert response.status_code == 403
+    assert _payload(response)["result"] is False
+    assert user.email == "alice-old@example.com"
+
+
+def test_update_user_base_info_allows_profile_update_without_email_change(memory_cache):
+    user = User.objects.create(
+        username="email_auth_profile",
+        domain="domain.com",
+        display_name="Before",
+        email="profile@example.com",
+        password="!",
+        locale="en",
+    )
+
+    response = update_user_base_info(
+        _request(
+            "/api/v1/console_mgmt/update_user_base_info/",
+            user,
+            {"display_name": "After", "email": "profile@example.com"},
+        )
+    )
+    user.refresh_from_db()
+
+    assert response.status_code == 200
+    assert _payload(response) == {"result": True}
+    assert user.display_name == "After"
+    assert user.email == "profile@example.com"
+
+
+def test_validate_email_code_authorizes_then_update_consumes_email_change(memory_cache):
+    user = User.objects.create(
+        username="email_auth_verified",
+        domain="domain.com",
+        display_name="Verified",
+        email="verified-old@example.com",
+        password="!",
+        locale="en",
+    )
+    new_email = "verified-new@example.com"
+    code_key = _email_code_cache_key(user.username, new_email)
+    verified_key = _email_change_verified_cache_key(user.username, new_email)
+    memory_cache.set(code_key, "123456", timeout=600)
+    memory_cache.delete(verified_key)
+    assert memory_cache.get(code_key) == "123456"
+
+    validate_response = validate_email_code(
+        _request(
+            "/api/v1/console_mgmt/validate_email_code/",
+            user,
+            {"email": new_email, "input_code": "123456"},
+        )
+    )
+    update_response = update_user_base_info(
+        _request(
+            "/api/v1/console_mgmt/update_user_base_info/",
+            user,
+            {"display_name": "Verified", "email": new_email},
+        )
+    )
+    user.refresh_from_db()
+    validate_payload = _payload(validate_response)
+
+    assert validate_payload["result"] is True, validate_payload
+    assert memory_cache.get(code_key) is None
+    assert update_response.status_code == 200
+    assert _payload(update_response) == {"result": True}
+    assert user.email == new_email
+    assert memory_cache.get(verified_key) is None
+
+
+def test_email_change_authorization_is_bound_to_requested_email(memory_cache):
+    user = User.objects.create(
+        username="email_auth_bound",
+        domain="domain.com",
+        display_name="Bound",
+        email="bound-old@example.com",
+        password="!",
+        locale="en",
+    )
+    memory_cache.set(_email_change_verified_cache_key(user.username, "allowed@example.com"), "1", timeout=600)
+
+    response = update_user_base_info(
+        _request(
+            "/api/v1/console_mgmt/update_user_base_info/",
+            user,
+            {"display_name": "Bound", "email": "other@example.com"},
+        )
+    )
+    user.refresh_from_db()
+
+    assert response.status_code == 403
+    assert _payload(response)["result"] is False
+    assert user.email == "bound-old@example.com"

--- a/server/apps/console_mgmt/views.py
+++ b/server/apps/console_mgmt/views.py
@@ -28,6 +28,19 @@ def _email_code_cache_key(username: str, email: str) -> str:
     return f"vc:{username}:{email}"
 
 
+def _email_change_verified_cache_key(username: str, email: str) -> str:
+    """生成邮箱变更一次性授权 cache key，按用户+邮箱隔离。"""
+    return f"email_change_verified:{username}:{email}"
+
+
+def _consume_email_change_authorization(username: str, email: str) -> bool:
+    cache_key = _email_change_verified_cache_key(username, email)
+    if cache.get(cache_key) is None:
+        return False
+    cache.delete(cache_key)
+    return True
+
+
 def _format_datetime_for_user(value, timezone_name=None):
     if not value:
         return None
@@ -138,10 +151,22 @@ def update_user_base_info(request):
     try:
         # 通过username和domain获取用户
         user = User.objects.get(username=username, domain=domain)
+        requested_email = params.get("email") or user.email
+        if requested_email != user.email and not _consume_email_change_authorization(username, requested_email):
+            return JsonResponse(
+                {
+                    "result": False,
+                    "message": loader.get(
+                        "error.email_change_verification_required",
+                        "Email change requires verification",
+                    ),
+                },
+                status=403,
+            )
 
         with transaction.atomic():
             user.display_name = params.get("display_name") or user.display_name
-            user.email = params.get("email") or user.email
+            user.email = requested_email
             user.locale = params.get("locale") or user.locale
             user.timezone = params.get("timezone") or user.timezone
             user.save()
@@ -212,6 +237,7 @@ def validate_email_code(request):
         if secrets.compare_digest(str(stored_code), str(input_code)):
             # 验证通过：立即删除（一次性使用）
             cache.delete(cache_key)
+            cache.set(_email_change_verified_cache_key(username, email), "1", timeout=_EMAIL_CODE_TTL)
             return JsonResponse({"result": True, "message": loader.get("success.verification_success", "Verification successful")})
 
         return JsonResponse({"result": False, "message": loader.get("error.verification_code_incorrect", "Verification code is incorrect")})


### PR DESCRIPTION
## 变更说明

Fixes #3781。

后端补齐邮箱变更授权闭环：
- `validate_email_code` 校验成功后，写入一次性 `email_change_verified:{user}:{email}` 授权标记。
- `update_user_base_info` 仅在邮箱未变化，或目标邮箱授权标记存在并被消费时，允许保存邮箱。
- 授权标记按用户+目标邮箱隔离，成功更新后立即消费。
- 移动端本次不改交互；后端会先拒绝未验证邮箱变更，移动端后续需补验证码流程或禁用直接改邮箱入口。

## 验证

- `git diff --check` 通过。
- `uv run python -m py_compile apps/console_mgmt/views.py apps/console_mgmt/tests/test_email_change_authorization.py apps/console_mgmt/tests/test_email_code_views.py` 通过。
- `INSTALL_APPS=console_mgmt,system_mgmt ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=test-email-auth.sqlite3 MINIO_ENDPOINT=127.0.0.1:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=False uv run --with pytest-django --with django-extensions --with factory-boy pytest -o addopts="" apps/console_mgmt/tests/test_email_change_authorization.py -q` 通过，4 passed。
- `... pytest ... apps/console_mgmt/tests/test_send_email_code_views.py -q` 通过，4 passed。
- `SECRET_KEY=test ... pytest ... apps/console_mgmt/tests/test_email_code_views.py -q` 通过，10 passed。
- `SECRET_KEY=test ... pytest ... apps/console_mgmt/tests/test_views_json_guard.py::TestUpdateUserBaseInfoJsonGuard -q` 通过，3 passed；该既有用例的合法 JSON 分支允许后续业务 500，因此日志有既有噪音。