### PR TITLE
Fix K8s full metrics navigation

### DIFF
--- a/server/apps/monitor/services/effective_plugins.py
+++ b/server/apps/monitor/services/effective_plugins.py
@@ -4,6 +4,7 @@ from apps.core.utils.loader import LanguageLoader
 from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.plugin import PluginConstants
 from apps.monitor.models import CollectConfig, MonitorObject, MonitorPlugin
+from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 
@@ -69,6 +70,9 @@ class MonitorEffectivePluginService:
     @staticmethod
     def _get_reported_plugin_ids(plugins: list[MonitorPlugin], instance_id: str, instance_id_keys: list[str]) -> set[int]:
         reported_plugin_ids = set()
+        parsed = parse_instance_id(instance_id)
+        primary_key = instance_id_keys[0] if instance_id_keys else "instance_id"
+        target_primary = str(parsed[0]) if parsed else None
         vm_api = VictoriaMetricsAPI()
         for plugin in plugins:
             query = (plugin.status_query or "").strip()
@@ -83,7 +87,10 @@ class MonitorEffectivePluginService:
             for metric in response.get("data", {}).get("result", []):
                 labels = metric.get("metric", {})
                 metric_instance_id = str(tuple(labels.get(key) for key in instance_id_keys))
-                if metric_instance_id == instance_id:
+                if metric_instance_id == instance_id or (
+                    target_primary is not None
+                    and str(labels.get(primary_key)) == target_primary
+                ):
                     reported_plugin_ids.add(plugin.id)
                     break
         return reported_plugin_ids

--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -205,7 +205,7 @@ class InstanceSearch:
             results = items[start:end]
 
         if self.query_data.get("add_metrics", False) and page_size != -1:
-            results = self.add_other_metrics(results)
+            MonitorObjectService._fill_display_metrics(self.monitor_obj.id, self.obj_metric_map, results)
 
         MonitorObjectService.add_attr(results)
 

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -246,33 +246,35 @@ class MonitorObjectService:
         # 也应纳入其「上报插件」的展示列取数;否则插件隔离会把它们一律判为 --。
         # 与 effective_plugins 的 reported 逻辑一致:按对象各插件 status_query 反查上报实例,
         # 以实例主键(instance_id)前缀匹配,使集群及其下 Pod/Node 都能命中所属插件。
-        plugin_status_qs = (
-            MonitorPlugin.objects.filter(monitor_object=monitor_object_id)
-            .exclude(status_query="")
-            .values_list("name", "status_query")
-            .distinct()
-        )
-        for plugin_name, status_query in plugin_status_qs:
-            query = (status_query or "").strip()
-            if not query:
-                continue
-            try:
-                resp = VictoriaMetricsAPI().query(query)
-            except Exception:
-                logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
-                continue
-            reported_primary_ids = {
-                metric["metric"].get("instance_id")
-                for metric in resp.get("data", {}).get("result", [])
-            }
-            reported_primary_ids.discard(None)
-            if not reported_primary_ids:
-                continue
-            for inst in result:
-                parsed = parse_instance_id(inst["instance_id"])
-                primary = str(parsed[0]) if parsed else None
-                if primary in reported_primary_ids:
-                    instance_plugin_map.setdefault(inst["instance_id"], set()).add(plugin_name)
+        uncovered = [inst for inst in result if inst["instance_id"] not in instance_plugin_map]
+        if uncovered:
+            plugin_status_qs = (
+                MonitorPlugin.objects.filter(monitor_object=monitor_object_id)
+                .exclude(status_query="")
+                .values_list("name", "status_query")
+                .distinct()
+            )
+            for plugin_name, status_query in plugin_status_qs:
+                query = (status_query or "").strip()
+                if not query:
+                    continue
+                try:
+                    resp = VictoriaMetricsAPI().query(query)
+                except Exception:
+                    logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
+                    continue
+                reported_primary_ids = {
+                    metric["metric"].get("instance_id")
+                    for metric in resp.get("data", {}).get("result", [])
+                }
+                reported_primary_ids.discard(None)
+                if not reported_primary_ids:
+                    continue
+                for inst in uncovered:
+                    parsed = parse_instance_id(inst["instance_id"])
+                    primary = str(parsed[0]) if parsed else None
+                    if primary in reported_primary_ids:
+                        instance_plugin_map.setdefault(inst["instance_id"], set()).add(plugin_name)
 
         # 同名指标可能分属多个插件,按 (plugin, name) 精确取;另留 name 兜底给遗留无 plugin 的绑定
         metric_by_plugin = {}

--- a/server/apps/monitor/tests/test_display_fields_reported_plugin.py
+++ b/server/apps/monitor/tests/test_display_fields_reported_plugin.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from apps.monitor.models import MonitorObject, MonitorPlugin
+from apps.monitor.models import CollectConfig, MonitorInstance, MonitorObject, MonitorPlugin
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.services import monitor_object as mo
 from apps.monitor.services.monitor_object import MonitorObjectService
@@ -76,3 +76,45 @@ def test_fill_display_metrics_reported_instance_without_collectconfig(monkeypatc
 
     # 修复前:无 CollectConfig → 不命中插件 → 列值缺失(--);修复后:按上报插件命中 → 回填 7
     assert result[0].get("K8STEST::cluster_pod_count") == "7"
+
+
+@pytest.mark.django_db
+def test_fill_display_metrics_skips_status_query_when_all_collectconfig_covered(monkeypatch):
+    obj, plugin, metric = _build_k8s_like_object()
+    instance = MonitorInstance.objects.create(id="('host1',)", name="host1", monitor_object=obj)
+    CollectConfig.objects.create(
+        id="host1-cfg",
+        monitor_instance=instance,
+        monitor_plugin=plugin,
+        collector="K8S",
+        collect_type="k8s",
+        config_type="k8stest",
+        file_type="toml",
+        is_child=True,
+    )
+
+    status_calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, **kwargs):
+            if "instance_type='k8stest'" in query and "count(" not in query:
+                status_calls.append(query)
+                return {"data": {"result": []}}
+            if "some_kube_pod_info" in query:
+                return {"data": {"result": [{"metric": {"instance_id": "host1"}, "value": [0, "5"]}]}}
+            return {"data": {"result": []}}
+
+    monkeypatch.setattr(mo, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = [{"instance_id": "('host1',)", "instance_name": "host1"}]
+    obj_metric_map = {
+        "display_fields": [
+            {"name": "Pod Count", "metrics": [{"plugin": "K8STEST", "metric": "cluster_pod_count"}]}
+        ],
+        "supplementary_indicators": [],
+    }
+
+    MonitorObjectService._fill_display_metrics(obj.id, obj_metric_map, result)
+
+    assert status_calls == []
+    assert result[0].get("K8STEST::cluster_pod_count") == "5"

--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -307,6 +307,45 @@ def test_effective_plugins_service_resolves_derived_instance_without_row(db, mon
     assert by_name["K8sPod"]["collect_mode"] == "manual"
 
 
+def test_effective_plugins_service_matches_multi_key_derived_by_primary(db, monkeypatch):
+    from apps.monitor.services import effective_plugins
+
+    monitor_object = MonitorObject.objects.create(
+        name="PodMultiKey",
+        display_name="PodMultiKey",
+        instance_id_keys=["instance_id", "pod"],
+    )
+    reported_plugin = MonitorPlugin.objects.create(
+        name="K8S",
+        display_name="K8S",
+        template_id="k8s-mk",
+        template_type="api",
+        collector="push_api",
+        collect_type="push_api",
+        status_query="any({instance_type='k8s'}) by (instance_id)",
+        is_pre=False,
+    )
+    reported_plugin.monitor_object.add(monitor_object)
+
+    multi_key_instance_id = "('mac', 'coredns-abc')"
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, step="5m", time=None):
+            return {"data": {"result": [{"metric": {"instance_id": "mac"}, "value": [100, "1"]}]}}
+
+    monkeypatch.setattr(effective_plugins, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = effective_plugins.MonitorEffectivePluginService.get_effective_plugins(
+        monitor_object.id,
+        multi_key_instance_id,
+        locale="zh-Hans",
+    )
+
+    by_name = {item["name"]: item for item in result}
+    assert "K8S" in by_name
+    assert by_name["K8S"]["status"] == "normal"
+
+
 def test_primary_object_plugin_list_keeps_builtin_plugins_distinct_by_plugin_id(db, monkeypatch):
     from apps.monitor.constants.plugin import PluginConstants
     from apps.monitor.services import monitor_instance

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "test:log-policy-form": "pnpm exec tsx scripts/log-policy-form-state-test.ts",
     "test:monitor-search-plugin-scope": "pnpm exec tsx scripts/monitor-search-plugin-scope-test.ts",
     "test:monitor-query-step": "pnpm exec tsx scripts/monitor-query-step-test.ts",
+    "test:k8s-cluster-filter": "pnpm exec tsx scripts/k8s-cluster-filter-test.ts",
     "test:monitor-gap-interval": "pnpm exec tsx scripts/monitor-gap-interval-test.ts",
     "test:monitor-promql-label-query": "pnpm exec tsx scripts/monitor-promql-label-query-test.ts",
     "test:monitor-capability-matrix": "pnpm exec tsx scripts/monitor-capability-matrix-test.ts",

--- a/web/scripts/k8s-cluster-filter-test.ts
+++ b/web/scripts/k8s-cluster-filter-test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+
+import {
+  buildClusterFilterOptions,
+  filterInstanceOptionsByCluster,
+  isInstanceOptionForIdentity,
+  selectFirstInstanceInCluster
+} from '../src/app/monitor/dashboards/shared/utils/instance.ts';
+
+const options = [
+  { label: 'pod-a', value: "('cluster-a', 'pod-a')", instanceIdValues: ['cluster-a', 'pod-a'] },
+  { label: 'pod-b', value: "('cluster-a', 'pod-b')", instanceIdValues: ['cluster-a', 'pod-b'] },
+  { label: 'pod-c', value: "('cluster-b', 'pod-c')", instanceIdValues: ['cluster-b', 'pod-c'] },
+  { label: 'orphan', value: "('orphan',)", instanceIdValues: ['orphan'] }
+];
+
+assert.deepEqual(buildClusterFilterOptions(options), [
+  { label: 'cluster-a', value: 'cluster-a', searchTokens: ['cluster-a'] },
+  { label: 'cluster-b', value: 'cluster-b', searchTokens: ['cluster-b'] },
+  { label: 'orphan', value: 'orphan', searchTokens: ['orphan'] }
+]);
+
+assert.deepEqual(
+  filterInstanceOptionsByCluster(options, 'cluster-a').map((item) => item.label),
+  ['pod-a', 'pod-b']
+);
+assert.deepEqual(
+  filterInstanceOptionsByCluster(options, undefined).map((item) => item.label),
+  ['pod-a', 'pod-b', 'pod-c', 'orphan']
+);
+
+assert.equal(selectFirstInstanceInCluster(options, 'cluster-b')?.value, "('cluster-b', 'pod-c')");
+assert.equal(selectFirstInstanceInCluster(options, 'missing'), undefined);
+
+assert.equal(
+  isInstanceOptionForIdentity(options[0], "('cluster-a', 'pod-a')", ['cluster-a', 'pod-a']),
+  true
+);
+assert.equal(
+  isInstanceOptionForIdentity(options[1], "('cluster-a', 'pod-a')", ['cluster-a', 'pod-a']),
+  false,
+  '同集群但不同 Pod/Node 不能被识别为当前实例'
+);
+
+console.log('k8s cluster filter tests passed');

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -638,6 +638,9 @@ export const DashboardShell = ({
           selectorLoading={dashboard.instanceLoading}
           selectorOptions={dashboard.instanceSelectOptions}
           onInstanceChange={dashboard.onInstanceChange}
+          clusterOptions={dashboard.clusterFilterEnabled ? dashboard.clusterFilterOptions : undefined}
+          clusterValue={dashboard.clusterFilterValue}
+          onClusterChange={dashboard.onClusterFilterChange}
           selectorPlaceholder={
             dashboard.resolvedInstanceName !== '--' ? dashboard.resolvedInstanceName : '选择实例'
           }

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -24,7 +24,12 @@ import {
   buildMetricItem,
   getCollectionStatus,
   buildCollectionStatusTimeline,
-  useLoadSequence
+  useLoadSequence,
+  buildClusterFilterOptions,
+  filterInstanceOptionsByCluster,
+  selectFirstInstanceInCluster,
+  isInstanceOptionForIdentity,
+  DashboardInstanceOption
 } from '../../shared/utils';
 import {
   CompareFavorableDirection,
@@ -56,13 +61,7 @@ export interface MetricSeries extends SimpleMetricConfig {
   loadState: 'success' | 'error';
 }
 
-interface InstanceOption {
-  label: string;
-  value: string;
-  instanceIdValues: string[];
-  searchTokens: string[];
-  interval?: number;
-}
+type InstanceOption = DashboardInstanceOption & { searchTokens: string[] };
 
 export interface SummaryFieldConfig {
   label: string;
@@ -177,6 +176,7 @@ export interface SimpleDashboardConfig {
   barPanels?: BarPanelConfig[];
   statusPanels?: StatusPanelConfig[];
   details: DetailPanelConfig[];
+  clusterFilter?: boolean;
 }
 
 export interface PreparedSummaryCard {
@@ -411,9 +411,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
 
   const idValuesKey = useMemo(() => JSON.stringify(idValues), [idValues]);
   const currentInstanceCandidates = useMemo(
-    () => instanceOptions.filter(
-      (item) => item.value === String(instanceId || '') || item.instanceIdValues.some((value) => idValues.includes(value))
-    ),
+    () => instanceOptions.filter((item) => isInstanceOptionForIdentity(item, instanceId, idValues)),
     [instanceOptions, instanceId, idValues]
   );
   const currentInstanceOption = useMemo(
@@ -427,8 +425,14 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     [currentInstanceOption, normalizedInstanceName]
   );
   const hasReadableInstanceName = Boolean(normalizedInstanceName && normalizedInstanceName !== String(instanceId || ''));
+  const clusterFilterEnabled = Boolean(config.clusterFilter);
+  const activeCluster = clusterFilterEnabled ? (idValues[0] ? String(idValues[0]) : undefined) : undefined;
+  const clusterFilterOptions = useMemo(
+    () => (clusterFilterEnabled ? buildClusterFilterOptions(instanceOptions) : []),
+    [clusterFilterEnabled, instanceOptions]
+  );
   const instanceSelectOptions = useMemo(() => {
-    const options = [...instanceOptions];
+    const options = filterInstanceOptionsByCluster(instanceOptions, activeCluster);
     const selectedValue = String(instanceId || '');
     if (selectedValue && hasReadableInstanceName && !options.some((item) => item.value === selectedValue)) {
       options.unshift({
@@ -440,7 +444,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
       });
     }
     return options;
-  }, [currentInstanceOption?.interval, hasReadableInstanceName, idValues, instanceId, instanceOptions, normalizedInstanceName]);
+  }, [activeCluster, currentInstanceOption?.interval, hasReadableInstanceName, idValues, instanceId, instanceOptions, normalizedInstanceName]);
   const instanceSelectValue = currentInstanceOption?.value || (hasReadableInstanceName && instanceId ? String(instanceId) : undefined);
   const currentInstanceInterval = currentInstanceOption?.interval;
 
@@ -821,6 +825,11 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     params.set('instance_id_values', (target?.instanceIdValues || [value]).join(','));
     router.push(`/monitor/view/dashboard/${config.routeKey}?${params.toString()}`);
   };
+  const onClusterFilterChange = (cluster: string) => {
+    if (cluster === activeCluster) return;
+    const first = selectFirstInstanceInCluster(instanceOptions, cluster);
+    if (first) onInstanceChange(first.value);
+  };
   const onRefresh = () => {
     if (displayMode === 'dashboard') {
       loadMetrics();
@@ -852,6 +861,9 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     instanceSelectValue,
     instanceLoading,
     instanceSelectOptions,
+    clusterFilterEnabled,
+    clusterFilterValue: activeCluster,
+    clusterFilterOptions,
     currentInstanceInterval,
     currentInstanceLabel: currentInstanceOption?.label || normalizedInstanceName || resolvedInstanceName,
     isDashboardMode,
@@ -865,6 +877,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     onRefresh,
     onXRangeChange,
     onBack: goBack,
-    onInstanceChange
+    onInstanceChange,
+    onClusterFilterChange
   };
 }

--- a/web/src/app/monitor/dashboards/objects/k8s-node/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/config.ts
@@ -10,6 +10,7 @@ export const NODE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: 'K8s 节点监控仪表盘',
   objectFallbackName: 'K8s 节点',
   instanceType: 'k8s',
+  clusterFilter: true,
   collectionStatusQuery:
     "count(prometheus_remote_write_kube_node_info{instance_type='k8s', __$labels__}) by (instance_id)",
   metaItems: ['Telegraf', 'k8s'],

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
@@ -10,6 +10,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: 'K8s Pod 监控仪表盘',
   objectFallbackName: 'Pod',
   instanceType: 'k8s',
+  clusterFilter: true,
   collectionStatusQuery:
     "count(prometheus_remote_write_kube_pod_info{instance_type='k8s', __$labels__}) by (instance_id)",
   metaItems: ['cAdvisor', 'k8s'],

--- a/web/src/app/monitor/dashboards/shared/utils/instance.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/instance.ts
@@ -55,6 +55,45 @@ export const buildInstanceSearchTokens = (item: any, displayName: string) =>
     )
   );
 
+export interface DashboardInstanceOption {
+  label: string;
+  value: string;
+  instanceIdValues: string[];
+  searchTokens?: string[];
+  interval?: number;
+}
+
+export const buildClusterFilterOptions = (options: readonly DashboardInstanceOption[]) => {
+  const seen = new Map<string, { label: string; value: string; searchTokens: string[] }>();
+  options.forEach((item) => {
+    const cluster = item.instanceIdValues[0];
+    if (cluster && !seen.has(cluster)) {
+      seen.set(cluster, { label: cluster, value: cluster, searchTokens: [cluster] });
+    }
+  });
+  return Array.from(seen.values());
+};
+
+export const filterInstanceOptionsByCluster = (
+  options: readonly DashboardInstanceOption[],
+  cluster?: string
+) => (cluster ? options.filter((item) => item.instanceIdValues[0] === cluster) : [...options]);
+
+export const selectFirstInstanceInCluster = (
+  options: readonly DashboardInstanceOption[],
+  cluster: string
+) => options.find((item) => item.instanceIdValues[0] === cluster);
+
+export const isInstanceOptionForIdentity = (
+  option: DashboardInstanceOption,
+  instanceId: string | number,
+  idValues: readonly string[]
+) => {
+  if (option.value === String(instanceId || '')) return true;
+  if (option.instanceIdValues.length !== idValues.length) return false;
+  return option.instanceIdValues.every((value, index) => value === idValues[index]);
+};
+
 export const parseLegacyParamList = (value?: string | null) => {
   if (!value) return [] as string[];
   const normalized = value

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
@@ -28,6 +28,9 @@ export interface DashboardInstanceCardProps {
   onInstanceChange: (value: string) => void;
   selectorPlaceholder?: string;
   selectorTitle?: string;
+  clusterOptions?: readonly { label: string; value: string; searchTokens?: string[] }[];
+  clusterValue?: string;
+  onClusterChange?: (value: string) => void;
   isDashboardMode?: boolean;
   /** 传入时在实例选择器右侧内联渲染时间选择器 + 刷新组（统一布局，单一来源）。 */
   timeSelectorProps?: DashboardInstanceCardTimeSelectorProps;
@@ -45,6 +48,9 @@ export function DashboardInstanceCard({
   onInstanceChange,
   selectorPlaceholder = '选择实例',
   selectorTitle,
+  clusterOptions,
+  clusterValue,
+  onClusterChange,
   isDashboardMode = true,
   timeSelectorProps,
   styles
@@ -70,6 +76,18 @@ export function DashboardInstanceCard({
         </div>
       </div>
       <div className={styles.instanceActions}>
+        {clusterOptions && clusterOptions.length > 0 && onClusterChange ? (
+          <InstanceSelector
+            styles={styles}
+            label="集群"
+            value={clusterValue}
+            options={clusterOptions}
+            onChange={onClusterChange}
+            placeholder="选择集群"
+            title={clusterValue}
+            popupWidth={220}
+          />
+        ) : null}
         <InstanceSelector
           styles={styles}
           value={selectorValue}


### PR DESCRIPTION
## 变更说明
- 修复 K8s Pod/Node 多维实例切换到全量指标时生效插件为空的问题。
- 补回 Pod/Node 仪表盘的集群级联过滤，避免跨集群实例混在一个列表里。
- 修复同集群下实例匹配过宽导致 Node/Pod 选中串到其他实例的问题。
- 实例列表 add_metrics 统一走 display_fields 回填，并避免已有 CollectConfig 覆盖实例重复反查 status_query。

## 验证
- 后端目标回归：2 passed
- 后端相关回归：6 passed
- 前端脚本：pnpm exec tsx scripts/k8s-cluster-filter-test.ts
- Chrome 本地验证：127.0.0.1:3000 上 Pod/Node 全量指标有内容、无 instance_id is required、集群过滤和实例选中正常

## 已知情况
- NEXTAPI_INSTALL_APP=monitor pnpm type-check 仍失败在既有 networkDevice 文件语法错误：networkService.tsx、wireless.tsx，本 PR 未触碰。