### PR TITLE
fix(monitor): preserve customized display column names

### DIFF
--- a/server/apps/monitor/tests/test_display_fields_api.py
+++ b/server/apps/monitor/tests/test_display_fields_api.py
@@ -72,14 +72,30 @@ def _get_object(resp, obj_id):
 
 
 @pytest.mark.django_db
-def test_list_translates_column_to_metric_name(api_client, host_with_metric, monkeypatch):
-    """列名一律取绑定指标的当前语言译名（跟随账号语言）；即使种子名/已 customized 也照译（回归用例）。"""
+def test_list_keeps_customized_column_name(api_client, host_with_metric, monkeypatch):
+    """用户在弹窗里自定义的列名必须原样展示，不能被绑定指标译名覆盖。"""
     obj = host_with_metric
     obj.display_fields = [
-        {"name": "Service Uptime", "sort_order": 0,  # 种子标签，故意 != 指标译名
+        {"name": "新字段列", "sort_order": 0,
          "metrics": [{"plugin": "UTPlugin", "metric": "cpu_usage_total"}]}
     ]
-    obj.display_fields_customized = True  # 用户在弹窗里编辑过，仍应翻译
+    obj.display_fields_customized = True
+    obj.save(update_fields=["display_fields", "display_fields_customized"])
+
+    _patch_translations(monkeypatch, {_METRIC_KEY: "CPU使用率译"})
+    target = _get_object(api_client.get("/api/v1/monitor/api/monitor_object/"), obj.id)
+    assert target["display_fields"][0]["name"] == "新字段列"
+
+
+@pytest.mark.django_db
+def test_list_translates_default_column_to_metric_name(api_client, host_with_metric, monkeypatch):
+    """未自定义的默认展示列仍跟随账号语言展示指标译名。"""
+    obj = host_with_metric
+    obj.display_fields = [
+        {"name": "Service Uptime", "sort_order": 0,
+         "metrics": [{"plugin": "UTPlugin", "metric": "cpu_usage_total"}]}
+    ]
+    obj.display_fields_customized = False
     obj.save(update_fields=["display_fields", "display_fields_customized"])
 
     _patch_translations(monkeypatch, {_METRIC_KEY: "CPU使用率译"})

--- a/server/apps/monitor/views/monitor_object.py
+++ b/server/apps/monitor/views/monitor_object.py
@@ -38,17 +38,17 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
         return queryset
 
     @staticmethod
-    def _translate_display_fields(lan, object_name, display_fields):
-        """展示列名国际化：列名一律取绑定指标在当前账号语言下的译名，跟随 request.user.locale
-        自动中/英切换；无绑定指标或无译名时回退原列名。
+    def _translate_display_fields(lan, object_name, display_fields, customized=False):
+        """展示列名国际化。
 
-        说明：display_fields[].name 是 metrics.json 写死的英文种子（且有时是另起的精简标签，
-        不等于指标英文名），数据模型里没有可靠区分“默认名 vs 用户手打名”的信号
-        （display_fields_customized 只要在弹窗里加/删/排序就置 True），故统一按绑定指标译名展示，
-        以保证编辑后仍跟随语言、不回退英文。不就地修改入参，返回新副本。
+        未自定义的默认列取绑定指标在当前账号语言下的译名；用户通过弹窗自定义过展示列后，
+        display_fields[].name 是明确的列头配置，必须原样返回，不能再被指标译名覆盖。
+        不就地修改入参，返回新副本。
         """
         if not display_fields:
             return display_fields
+        if customized:
+            return [{**col} for col in display_fields]
         translated = []
         for col in display_fields:
             metrics = col.get("metrics") or []
@@ -86,9 +86,12 @@ class MonitorObjectViewSet(viewsets.ModelViewSet):
             result["is_builtin"] = bool(i18n_name) or not result.get("display_name")
             # 添加子对象数量
             result["children_count"] = children_count_map.get(result["id"], 0)
-            # 展示列名国际化：一律按绑定指标译名展示，跟随账号语言（编辑后也不回退英文）。
+            # 展示列名国际化：默认列跟随语言，自定义列保留用户输入。
             result["display_fields"] = self._translate_display_fields(
-                lan, result["name"], result.get("display_fields")
+                lan,
+                result["name"],
+                result.get("display_fields"),
+                result.get("display_fields_customized", False),
             )
 
         if request.GET.get("add_instance_count") in ["true", "True"]:


### PR DESCRIPTION
## 背景

展示指标配置弹窗允许用户输入展示列名，例如“新字段列”。但对象列表接口返回时会无条件把 `display_fields[].name` 覆盖成第一个绑定指标的翻译名，导致列表列头显示为指标名称而不是用户输入的列名。

## 变更

- 当 `display_fields_customized=True` 时，列表接口保留用户配置的 `display_fields[].name`。
- 未自定义的默认展示列仍按绑定指标名称进行国际化展示。
- 补充回归测试覆盖自定义列名保留和默认列翻译两个场景。

## 验证

- `uv run pytest apps/monitor/tests/test_display_fields_api.py --no-cov -q`
  - 结果：`7 passed`
