### PR TITLE
bugfix: 修复 Dameng bulk_create 忽略冲突退化

### DIFF
--- a/server/apps/core/db_patches/dameng.py
+++ b/server/apps/core/db_patches/dameng.py
@@ -25,7 +25,7 @@ import threading
 import time
 
 from django.db import IntegrityError
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.fields.json import JSONField
 
 logger = logging.getLogger(__name__)
@@ -412,6 +412,112 @@ def _patch_jsonfield_for_bulk_update():
     logger.debug("JSONField.get_db_prep_value patched for DamengDB bulk_update compatibility")
 
 
+def _iter_bulk_create_batches(objs, batch_size):
+    if not batch_size:
+        yield objs
+        return
+
+    for start in range(0, len(objs), batch_size):
+        yield objs[start : start + batch_size]
+
+
+def _get_bulk_create_conflict_field_sets(model):
+    opts = model._meta
+    field_sets = []
+
+    if opts.pk:
+        field_sets.append((opts.pk.attname,))
+
+    for field in opts.concrete_fields:
+        if getattr(field, "unique", False):
+            field_sets.append((field.attname,))
+
+    for unique_together in opts.unique_together:
+        field_sets.append(tuple(opts.get_field(field_name).attname for field_name in unique_together))
+
+    for constraint in opts.constraints:
+        if (
+            constraint.__class__.__name__ == "UniqueConstraint"
+            and getattr(constraint, "fields", None)
+            and getattr(constraint, "condition", None) is None
+            and not getattr(constraint, "expressions", None)
+        ):
+            field_sets.append(tuple(opts.get_field(field_name).attname for field_name in constraint.fields))
+
+    return tuple(dict.fromkeys(field_sets))
+
+
+def _get_obj_conflict_key(obj, field_names):
+    values = []
+    for field_name in field_names:
+        value = getattr(obj, field_name)
+        if value is None:
+            return None
+        values.append(value)
+    return tuple(values)
+
+
+def _get_existing_conflict_keys(queryset, objs, field_names):
+    keys = {_get_obj_conflict_key(obj, field_names) for obj in objs}
+    keys.discard(None)
+    if not keys:
+        return set()
+
+    query = Q()
+    for key in keys:
+        query |= Q(**dict(zip(field_names, key)))
+
+    return set(queryset.filter(query).values_list(*field_names))
+
+
+def _filter_bulk_create_conflicts(queryset, objs):
+    conflict_field_sets = _get_bulk_create_conflict_field_sets(queryset.model)
+    if not conflict_field_sets:
+        return objs
+
+    existing_keys = {
+        field_names: _get_existing_conflict_keys(queryset, objs, field_names) for field_names in conflict_field_sets
+    }
+    seen_keys = {field_names: set() for field_names in conflict_field_sets}
+    filtered = []
+
+    for obj in objs:
+        duplicate = False
+        obj_keys = {}
+        for field_names in conflict_field_sets:
+            key = _get_obj_conflict_key(obj, field_names)
+            if key is None:
+                continue
+            obj_keys[field_names] = key
+            if key in existing_keys[field_names] or key in seen_keys[field_names]:
+                duplicate = True
+                break
+
+        if duplicate:
+            continue
+
+        for field_names, key in obj_keys.items():
+            seen_keys[field_names].add(key)
+        filtered.append(obj)
+
+    return filtered
+
+
+def _save_ignore_conflicts_one_by_one(queryset, objs):
+    created = []
+    for obj in objs:
+        try:
+            obj.save(using=queryset.db)
+            created.append(obj)
+        except IntegrityError:
+            logger.debug(
+                "bulk_create ignore_conflicts fallback: skipped duplicate %s(pk=%s)",
+                type(obj).__name__,
+                obj.pk,
+            )
+    return created
+
+
 def _patch_bulk_create_ignore_conflicts():
     """
     修复达梦数据库不支持 bulk_create(ignore_conflicts=True) 的问题。
@@ -421,8 +527,9 @@ def _patch_bulk_create_ignore_conflicts():
     导致 Django 直接抛出 NotSupportedError。
 
     修复策略：
-    monkey-patch QuerySet.bulk_create，当 ignore_conflicts=True 时，
-    降级为逐条 save()，静默跳过已存在的记录（IntegrityError）。
+    monkey-patch QuerySet.bulk_create，当 ignore_conflicts=True 时，先按模型唯一键
+    预查并过滤已存在/本批重复对象，再调用原始 bulk_create 保持批量写入语义。
+    只有并发竞争导致批量插入仍触发 IntegrityError 时，才退回逐条 save() 兜底。
     """
     original_bulk_create = QuerySet.bulk_create
 
@@ -446,18 +553,29 @@ def _patch_bulk_create_ignore_conflicts():
                 unique_fields=unique_fields,
             )
 
-        # 达梦降级：逐条插入，遇到唯一约束冲突则跳过
+        objs = list(objs)
         created = []
-        for obj in objs:
+
+        for batch in _iter_bulk_create_batches(objs, batch_size):
+            bulk_objs = _filter_bulk_create_conflicts(self, batch)
+            if not bulk_objs:
+                continue
+
             try:
-                obj.save(using=self.db)
-                created.append(obj)
-            except IntegrityError:
-                logger.debug(
-                    "bulk_create ignore_conflicts fallback: skipped duplicate %s(pk=%s)",
-                    type(obj).__name__,
-                    obj.pk,
+                created.extend(
+                    original_bulk_create(
+                        self,
+                        bulk_objs,
+                        batch_size=batch_size,
+                        ignore_conflicts=False,
+                        update_conflicts=update_conflicts,
+                        update_fields=update_fields,
+                        unique_fields=unique_fields,
+                    )
                 )
+            except IntegrityError:
+                created.extend(_save_ignore_conflicts_one_by_one(self, bulk_objs))
+
         return created
 
     QuerySet.bulk_create = patched_bulk_create

--- a/server/apps/core/tests/test_dameng_bulk_create_patch.py
+++ b/server/apps/core/tests/test_dameng_bulk_create_patch.py
@@ -1,0 +1,100 @@
+from django.db.models import QuerySet
+
+from apps.core.db_patches import dameng
+
+
+class _Field:
+    def __init__(self, name, *, unique=False):
+        self.name = name
+        self.attname = name
+        self.unique = unique
+
+
+class _Meta:
+    pk = _Field("id")
+    concrete_fields = (pk, _Field("name", unique=True), _Field("team_id"))
+    unique_together = (("team_id", "name"),)
+    constraints = ()
+
+    def get_field(self, name):
+        return next(field for field in self.concrete_fields if field.name == name or field.attname == name)
+
+
+class _Model:
+    _meta = _Meta()
+
+
+class _Obj:
+    def __init__(self, *, id=None, name, team_id=1):
+        self.id = id
+        self.pk = id
+        self.name = name
+        self.team_id = team_id
+        self.save_calls = []
+
+    def save(self, using=None):
+        self.save_calls.append(using)
+
+
+class _ValuesQuerySet:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def values_list(self, *field_names):
+        return [tuple(row[field_name] for field_name in field_names) for row in self.rows]
+
+
+class _QuerySet:
+    model = _Model
+    db = "default"
+
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.filters = []
+
+    def filter(self, query):
+        self.filters.append(query)
+        return _ValuesQuerySet(self.rows)
+
+
+def test_filter_bulk_create_conflicts_skips_existing_and_batch_duplicates():
+    queryset = _QuerySet(rows=[{"id": 100, "name": "exists", "team_id": 1}])
+    objs = [
+        _Obj(name="exists", team_id=1),
+        _Obj(name="new", team_id=1),
+        _Obj(name="new", team_id=1),
+        _Obj(name="other", team_id=2),
+    ]
+
+    filtered = dameng._filter_bulk_create_conflicts(queryset, objs)
+
+    assert filtered == [objs[1], objs[3]]
+
+
+def test_ignore_conflicts_patch_keeps_bulk_create_path(monkeypatch):
+    bulk_create_calls = []
+
+    def original_bulk_create(self, objs, **kwargs):
+        bulk_create_calls.append({"objs": list(objs), "kwargs": kwargs})
+        return list(objs)
+
+    monkeypatch.setattr(QuerySet, "bulk_create", original_bulk_create)
+    dameng._patch_bulk_create_ignore_conflicts()
+
+    objs = [_Obj(name="a"), _Obj(name="b")]
+    created = QuerySet.bulk_create(_QuerySet(), objs, ignore_conflicts=True, batch_size=500)
+
+    assert created == objs
+    assert [obj.save_calls for obj in objs] == [[], []]
+    assert bulk_create_calls == [
+        {
+            "objs": objs,
+            "kwargs": {
+                "batch_size": 500,
+                "ignore_conflicts": False,
+                "update_conflicts": False,
+                "update_fields": None,
+                "unique_fields": None,
+            },
+        }
+    ]


### PR DESCRIPTION
## 问题
Dameng 环境里，`bulk_create(ignore_conflicts=True)` 现在会被全局补丁改成逐个对象 `save()`。alerts、log、monitor、node_mgmt 这些批量写热点一旦遇到大批量导入或同步，就会从一次批量写退化成 N 次 ORM 写，还会额外触发逐条保存的成本。

## 根因
补丁只解决了“Dameng 后端不支持 ignore_conflicts”这个兼容问题，但没有守住 Django `bulk_create` 的批处理约定。它用逐条 `save()` 模拟“冲突就跳过”，等于把所有调用方的批量写性能都降级了。

## 怎么修的
改为先按模型主键、唯一字段、`unique_together` 和普通 `UniqueConstraint` 预查已有冲突，再过滤本批重复对象，最后仍调用原始 `bulk_create` 批量插入。

```python
bulk_objs = _filter_bulk_create_conflicts(self, batch)
created.extend(original_bulk_create(self, bulk_objs, ignore_conflicts=False, ...))
```

只有在预查后仍因并发竞争触发 `IntegrityError` 时，才退回逐条 `save()` 兜底，保持兼容语义。

## 影响范围
改动位于 `server/apps/core/db_patches/dameng.py`，属于 Dameng 专用的 core/db 全局 ORM 补丁。调用方不需要改代码，现有 `bulk_create(..., ignore_conflicts=True)` 会继续可用，但正常路径会恢复批量写入。因为触及 core 共享补丁，本 PR 按中风险处理并加 `⚠️ review`。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["CoreConfig.ready\n启用 Dameng patch"]
        T2["alerts/log/monitor/node_mgmt\nbulk_create ignore_conflicts"]
    end

    P["_patch_bulk_create_ignore_conflicts\ndameng.py"]

    subgraph N["核心处理层"]
        F1["_filter_bulk_create_conflicts\n按唯一键预查/去重"]
        F2["original_bulk_create\n保留批量插入"]
    end

    subgraph C["兜底层"]
        C1["_save_ignore_conflicts_one_by_one\n并发冲突时逐条跳过"]
    end

    T1 --> P
    T2 --> P
    P --> F1 --> F2
    F2 -. "IntegrityError" .-> C1
```

## 验证
- `uv run --extra dev pytest -p no:django -o addopts='' --confcutdir=apps/core/tests apps/core/tests/test_dameng_bulk_create_patch.py -q`
- `uv run --extra dev python -m py_compile apps/core/db_patches/dameng.py apps/core/tests/test_dameng_bulk_create_patch.py`
- `uv run --with flake8 flake8 apps/core/db_patches/dameng.py apps/core/tests/test_dameng_bulk_create_patch.py`
- `git diff --check`

完整 Django pytest 在本地会被可选环境挡住：先缺 MinIO 配置，补 dummy env 后又缺可选 `mlflow` 依赖；本 PR 的新增测试已用纯单元方式验证补丁逻辑。

关联 Issue #3797