### PR TITLE
bugfix: 修复 batch_init 初始化失败被吞掉

### DIFF
--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -16,9 +16,15 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("--apps", type=str, default="", help="逗号分隔的应用列表，为空则初始化所有应用")
+        parser.add_argument(
+            "--continue-on-error",
+            action="store_true",
+            help="初始化失败时继续执行后续模块，并在末尾输出失败列表",
+        )
 
     def handle(self, *args, **options):
         apps = options["apps"].strip()
+        continue_on_error = options["continue_on_error"]
 
         # 如果为空，初始化所有应用
         if not apps:
@@ -32,6 +38,7 @@ class Command(BaseCommand):
         self._preload_language_cache()
 
         # 按模块执行初始化
+        failed_apps = []
         for app in apps_list:
             try:
                 if app == "system_mgmt":
@@ -58,10 +65,15 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.WARNING(f"未知模块: {app}"))
             except Exception as e:
                 self.stdout.write(self.style.ERROR(f"初始化 {app} 失败: {str(e)}"))
-                if app == "system_mgmt":
+                if not continue_on_error:
                     raise
-                # 继续执行其他模块的初始化
+                failed_apps.append((app, str(e)))
                 continue
+
+        if failed_apps:
+            failed_summary = "; ".join(f"{app}: {error}" for app, error in failed_apps)
+            self.stdout.write(self.style.WARNING(f"批量初始化完成，失败模块: {failed_summary}"))
+            return
 
         self.stdout.write(self.style.SUCCESS("批量初始化完成"))
 

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -1,0 +1,95 @@
+import importlib.util
+import io
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def settings():
+    return types.SimpleNamespace(CACHES={}, MIDDLEWARE=())
+
+
+class _BaseCommand:
+    class _Style:
+        @staticmethod
+        def SUCCESS(message):
+            return message
+
+        @staticmethod
+        def ERROR(message):
+            return message
+
+        @staticmethod
+        def WARNING(message):
+            return message
+
+    def __init__(self):
+        self.stdout = types.SimpleNamespace(write=lambda message: None)
+        self.style = self._Style()
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _load_module(module_name, file_path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_command(monkeypatch):
+    calls = []
+
+    def call_command(name, *args, **kwargs):
+        calls.append((name, args, kwargs))
+        if name == "plugin_init":
+            raise RuntimeError("plugin init failed")
+
+    _install_module(monkeypatch, "django.core.management", call_command=call_command)
+    _install_module(monkeypatch, "django.core.management.base", BaseCommand=_BaseCommand)
+    _install_module(
+        monkeypatch,
+        "apps.core.utils.loader",
+        preload_language_cache=lambda: {"loaded": ["zh-Hans"], "skipped": [], "failed": []},
+    )
+
+    module = _load_module(
+        "batch_init_command_test_module",
+        Path(__file__).resolve().parents[1] / "management" / "commands" / "batch_init.py",
+    )
+    command = module.Command()
+    output = io.StringIO()
+    command.stdout = types.SimpleNamespace(write=lambda message: output.write(f"{message}\n"))
+    return command, output, calls
+
+
+def test_batch_init_raises_on_non_system_mgmt_failure_by_default(monkeypatch):
+    command, output, calls = _load_command(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="plugin init failed"):
+        command.handle(apps="monitor,node_mgmt", continue_on_error=False)
+
+    assert calls == [("plugin_init", (), {})]
+    assert "初始化 monitor 失败: plugin init failed" in output.getvalue()
+    assert "初始化节点管理" not in output.getvalue()
+    assert "批量初始化完成" not in output.getvalue()
+
+
+def test_batch_init_continue_on_error_runs_remaining_apps_and_reports_failures(monkeypatch):
+    command, output, calls = _load_command(monkeypatch)
+
+    command.handle(apps="monitor,node_mgmt", continue_on_error=True)
+
+    assert calls == [("plugin_init", (), {}), ("node_init", (), {})]
+    assert "初始化 monitor 失败: plugin init failed" in output.getvalue()
+    assert "批量初始化完成，失败模块: monitor: plugin init failed" in output.getvalue()

--- a/server/support-files/release/startup.sh
+++ b/server/support-files/release/startup.sh
@@ -11,7 +11,10 @@ INSTALL_APPS=$(echo "$INSTALL_APPS" | tr -d ' ')
 # 使用统一的批量初始化命令，在单个 Python 进程中完成所有初始化
 # 大幅减少启动时间（从原来的多次 Python 进程启动优化为单次启动）
 echo "开始批量初始化..."
-python3 manage.py batch_init --apps="$INSTALL_APPS"
+if ! python3 manage.py batch_init --apps="$INSTALL_APPS"; then
+    echo "批量初始化失败，停止启动"
+    exit 1
+fi
 
 # 检查是否包含 opspilot 模块
 opspilot_installed=false

--- a/server/support-files/release/startup.sh
+++ b/server/support-files/release/startup.sh
@@ -11,7 +11,7 @@ INSTALL_APPS=$(echo "$INSTALL_APPS" | tr -d ' ')
 # 使用统一的批量初始化命令，在单个 Python 进程中完成所有初始化
 # 大幅减少启动时间（从原来的多次 Python 进程启动优化为单次启动）
 echo "开始批量初始化..."
-python3 manage.py batch_init --apps="$INSTALL_APPS" || true
+python3 manage.py batch_init --apps="$INSTALL_APPS"
 
 # 检查是否包含 opspilot 模块
 opspilot_installed=false


### PR DESCRIPTION
## 问题

发布启动时会执行 `batch_init` 来初始化内置菜单、模型、监控插件、告警配置等基础数据。之前只有 `system_mgmt` 失败会让命令失败，其他模块失败只是打印一行错误后继续，最后仍输出“批量初始化完成”。release 启动脚本又对这条命令加了 `|| true`，所以容器可能在半初始化状态下继续拉起 `supervisord`。

## 根因

初始化编排没有把“默认发布链路必须成功”和“人工 best-effort 初始化”区分开。所有模块共用一个宽泛异常捕获，但失败策略只特殊照顾 `system_mgmt`，导致其他必需模块的失败被降级成普通日志。

## 怎么修的

`batch_init` 默认改为任一模块初始化失败就抛出异常，让管理命令返回非 0；同时新增显式参数保留人工排障场景：

```python
parser.add_argument("--continue-on-error", action="store_true", ...)
...
if not continue_on_error:
    raise
```

release `startup.sh` 移除了 `python3 manage.py batch_init ... || true`，让发布启动链路能感知初始化失败。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["startup.sh\nrelease 启动脚本"]
        T2["make init\nserver/Makefile"]
    end

    BU["manage.py batch_init\n管理命令入口"]

    subgraph N["核心处理层"]
        F1["Command.handle\nbatch_init.py"]
        F2["_init_monitor/_init_cmdb 等\nbatch_init.py"]
    end

    subgraph C["显式容错层"]
        C1["--continue-on-error\n继续后续模块并汇总失败"]
    end

    T1 --> BU --> F1 --> F2
    T2 --> BU
    F2 -- "默认失败" --> E["抛出异常\n命令返回非 0"]
    F2 -. "显式开启" .-> C1
```

## 影响范围

改动只涉及 core 初始化管理命令、server release 启动脚本和对应单测，不改对外 API、DB schema、NATS/RPC 协议。行为变化是发布链路会更早失败：如果某个初始化模块失败，默认不再继续启动服务；需要人工 best-effort 时可以显式使用 `--continue-on-error`。

## 验证

新增测试覆盖两条关键语义：默认情况下 `monitor` 初始化失败会立即抛出且不会继续执行 `node_mgmt`；开启 `--continue-on-error` 后会继续执行后续模块，并输出失败模块汇总。若把修复改回“失败后 continue”，默认失败测试会失败。

验证命令：

```bash
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --extra dev pytest -c /dev/null --rootdir=. --confcutdir=apps/core/tests apps/core/tests/test_batch_init_command.py -v --tb=short
uv run python -m py_compile apps/core/management/commands/batch_init.py apps/core/tests/test_batch_init_command.py
git diff --check
```

仓库原生 `uv run --extra dev pytest apps/core/tests/test_batch_init_command.py -v --tb=short` 在本地 settings 初始化阶段被 MinIO 必填配置阻塞：`MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY or MINIO_USE_HTTPS` 未配置，测试未进入 collection。

Fixes #3796