### PR TITLE
bugfix: 收口 MLOps 模块数据 NATS 组织范围

### DIFF
--- a/server/apps/mlops/nats_api.py
+++ b/server/apps/mlops/nats_api.py
@@ -168,6 +168,35 @@ def _get_module_registry():
     return registry
 
 
+def _normalize_actor_group_ids(actor_context):
+    group_ids = set()
+    for group in (actor_context or {}).get("group_list") or []:
+        group_id = group.get("id") if isinstance(group, dict) else group
+        try:
+            group_ids.add(int(group_id))
+        except (TypeError, ValueError):
+            continue
+    return group_ids
+
+
+def _validate_actor_group(actor_context, group_id):
+    if not isinstance(actor_context, dict):
+        return False, None, "缺少调用方上下文"
+
+    try:
+        group_id = int(group_id)
+    except (TypeError, ValueError):
+        return False, None, "group_id 参数非法"
+
+    if actor_context.get("is_superuser"):
+        return True, group_id, ""
+
+    if group_id not in _normalize_actor_group_ids(actor_context):
+        return False, group_id, "无权访问该组织"
+
+    return True, group_id, ""
+
+
 @nats_client.register
 def get_mlops_module_list():
     registry = _get_module_registry()
@@ -188,7 +217,7 @@ def get_mlops_module_list():
 
 
 @nats_client.register
-def get_mlops_module_data(module, child_module, page, page_size, group_id):
+def get_mlops_module_data(module, child_module, page, page_size, group_id, actor_context=None):
     registry = _get_module_registry()
 
     module_map = registry.get(module)
@@ -199,10 +228,14 @@ def get_mlops_module_data(module, child_module, page, page_size, group_id):
     if entry is None:
         return {"result": False, "message": f"未知子模块：{module}/{child_module}"}
 
+    is_valid, group_id, message = _validate_actor_group(actor_context, group_id)
+    if not is_valid:
+        return {"result": False, "message": message}
+
     page_size = max(1, min(int(page_size), MAX_PAGE_SIZE))
 
     model, team_lookup = entry
-    queryset = model.objects.filter(**{f"{team_lookup}__contains": int(group_id)})
+    queryset = model.objects.filter(**{f"{team_lookup}__contains": group_id})
 
     total_count = queryset.count()
     start = (page - 1) * page_size

--- a/server/apps/mlops/tests/test_get_mlops_module_data_nats.py
+++ b/server/apps/mlops/tests/test_get_mlops_module_data_nats.py
@@ -186,6 +186,7 @@ class TestGetMlopsModuleDataValidation(unittest.TestCase):
                 page=1,
                 page_size=999999,
                 group_id=1,
+                actor_context={"is_superuser": True},
             )
 
         # Verify the queryset was sliced with a capped end index
@@ -225,6 +226,7 @@ class TestGetMlopsModuleDataValidation(unittest.TestCase):
                 page=1,
                 page_size=-1,
                 group_id=1,
+                actor_context={"is_superuser": True},
             )
 
         # Must succeed (not raise AssertionError from Django negative slice)
@@ -262,11 +264,81 @@ class TestGetMlopsModuleDataValidation(unittest.TestCase):
                 page=1,
                 page_size=10,
                 group_id=42,
+                actor_context={"is_superuser": True},
             )
 
         self.assertTrue(result["result"])
         self.assertEqual(result["count"], 2)
         self.assertEqual(len(result["items"]), 2)
+
+    def test_missing_actor_context_is_rejected(self):
+        """Calls without trusted user context must not choose an arbitrary group_id."""
+        result = _get_mlops_module_data(
+            module="dataset",
+            child_module="anomaly_detection_dataset",
+            page=1,
+            page_size=10,
+            group_id=42,
+        )
+
+        self.assertFalse(result["result"])
+        self.assertIn("调用方上下文", result["message"])
+
+    def test_unauthorized_group_id_is_rejected_before_query(self):
+        """Non-superusers may only query MLOps data for groups in actor_context.group_list."""
+        fake_model = MagicMock()
+
+        original_registry = _nats_api._get_module_registry
+
+        def patched_registry():
+            reg = original_registry()
+            reg["dataset"]["anomaly_detection_dataset"] = (fake_model, "team")
+            return reg
+
+        with patch.object(_nats_api, "_get_module_registry", patched_registry):
+            result = _get_mlops_module_data(
+                module="dataset",
+                child_module="anomaly_detection_dataset",
+                page=1,
+                page_size=10,
+                group_id=42,
+                actor_context={"is_superuser": False, "group_list": [1, 2]},
+            )
+
+        self.assertFalse(result["result"])
+        self.assertIn("无权访问该组织", result["message"])
+        fake_model.objects.filter.assert_not_called()
+
+    def test_authorized_group_id_filters_queryset(self):
+        """Authorized non-superuser requests should still return the selected group's data."""
+        fake_qs = MagicMock()
+        fake_qs.count.return_value = 1
+        values_mock = MagicMock()
+        values_mock.__getitem__ = lambda self, sl: [{"id": 1, "name": "foo"}]
+        fake_qs.values.return_value = values_mock
+
+        fake_model = MagicMock()
+        fake_model.objects.filter.return_value = fake_qs
+
+        original_registry = _nats_api._get_module_registry
+
+        def patched_registry():
+            reg = original_registry()
+            reg["dataset"]["anomaly_detection_dataset"] = (fake_model, "team")
+            return reg
+
+        with patch.object(_nats_api, "_get_module_registry", patched_registry):
+            result = _get_mlops_module_data(
+                module="dataset",
+                child_module="anomaly_detection_dataset",
+                page=1,
+                page_size=10,
+                group_id=42,
+                actor_context={"is_superuser": False, "group_list": [1, "42"]},
+            )
+
+        self.assertTrue(result["result"])
+        fake_model.objects.filter.assert_called_once_with(team__contains=42)
 
 
 if __name__ == "__main__":

--- a/server/apps/system_mgmt/tests/test_org_scope_permissions.py
+++ b/server/apps/system_mgmt/tests/test_org_scope_permissions.py
@@ -6,6 +6,7 @@ from django.contrib.auth.hashers import make_password
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.system_mgmt.models import Group, Role, User
+from apps.system_mgmt.viewset.group_data_rule_viewset import GroupDataRuleViewSet
 from apps.system_mgmt.viewset.role_viewset import RoleViewSet
 from apps.system_mgmt.viewset.user_viewset import UserViewSet
 
@@ -24,6 +25,17 @@ def _request_user(group_ids, permission, *, is_superuser=False):
 
 def _json_payload(response):
     return json.loads(response.content)
+
+
+def test_group_data_rule_permission_accepts_integer_group_list():
+    request = types.SimpleNamespace(
+        user=types.SimpleNamespace(is_superuser=False, group_list=[7]),
+    )
+
+    is_valid, error_response = GroupDataRuleViewSet()._validate_group_permission(request, 7)
+
+    assert is_valid is True
+    assert error_response is None
 
 
 @pytest.mark.django_db

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -4,7 +4,9 @@ from django_filters.rest_framework import FilterSet
 from rest_framework.decorators import action
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.permission_cache import clear_users_permission_cache
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.viewset_utils import LanguageViewSet
 from apps.rpc.cmdb import CMDB
 from apps.rpc.job_mgmt import JobMgmt
@@ -18,6 +20,28 @@ from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import GroupDataRule, UserRule
 from apps.system_mgmt.serializers import GroupDataRuleSerializer
 from apps.system_mgmt.utils.operation_log_utils import log_operation
+
+
+def _build_actor_context(request, loader=None):
+    current_team = get_current_team(request)
+    if current_team in (None, ""):
+        message = loader.get("error.current_team_required") if loader else "缺少 current_team 参数"
+        return None, JsonResponse({"result": False, "message": message}, status=400)
+
+    try:
+        current_team = int(current_team)
+    except (TypeError, ValueError):
+        message = loader.get("error.invalid_current_team") if loader else "current_team 参数非法"
+        return None, JsonResponse({"result": False, "message": message}, status=400)
+
+    return {
+        "username": request.user.username,
+        "domain": request.user.domain,
+        "current_team": current_team,
+        "include_children": request.COOKIES.get("include_children", "0") == "1",
+        "is_superuser": request.user.is_superuser,
+        "group_list": normalize_user_group_ids(getattr(request.user, "group_list", [])),
+    }, None
 
 
 class GroupDataRuleFilter(FilterSet):
@@ -184,6 +208,21 @@ class GroupDataRuleViewSet(LanguageViewSet):
     @HasPermission("data_permission-View")
     def get_app_data(self, request):
         params = request.GET.dict()
+        if params.get("app") == "mlops":
+            try:
+                group_id = int(params.get("group_id"))
+            except (TypeError, ValueError):
+                return JsonResponse({"result": False, "message": "group_id 参数非法"}, status=400)
+
+            is_valid, error_response = self._validate_group_permission(request, group_id)
+            if not is_valid:
+                return error_response
+
+            actor_context, error_response = _build_actor_context(request, self.loader)
+            if error_response:
+                return error_response
+            params["actor_context"] = actor_context
+
         client = self.get_client(params)
         fun = getattr(client, "get_module_data", None)
         if fun is None:

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -19,6 +19,7 @@ from apps.rpc.opspilot import OpsPilot
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import GroupDataRule, UserRule
 from apps.system_mgmt.serializers import GroupDataRuleSerializer
+from apps.system_mgmt.utils.group_filter_mixin import get_user_group_ids
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
@@ -68,9 +69,7 @@ class GroupDataRuleViewSet(LanguageViewSet):
 
     def _get_user_group_ids(self, user):
         """获取用户有权限的组ID集合"""
-        if getattr(user, "is_superuser", False):
-            return None  # superuser 返回 None 表示有权限访问所有组
-        return {g["id"] for g in getattr(user, "group_list", [])}
+        return get_user_group_ids(user)
 
     def _validate_group_permission(self, request, group_id):
         """校验用户是否有权限访问指定组


### PR DESCRIPTION
## 问题

系统管理的数据权限页面会通过 MLOps 的 NATS 接口查询数据集、训练任务、能力发布等可选资源。这个接口原来只看调用方传来的 `group_id`，不看是谁在调用，所以只要能触达这个 NATS subject，就可以把 `group_id` 换成其他组织，拿到该组织下资源的 `id/name`。

关联 Issue #3802。

## 根因

MLOps 的 `get_mlops_module_data` 把“要查哪个组织”当成普通参数信任了，但这个参数跨过了模块边界。可信边界应该是登录用户或服务账号上下文，而不是调用方自己填的组织 ID。

## 怎么修的

系统管理入口在调用 MLOps RPC 前构造可信 `actor_context`，包含当前用户、域、当前组织、是否超管和用户可访问组织列表。MLOps NATS handler 在真正查表前先校验 `group_id` 是否属于 `actor_context.group_list`，超管保留原有跨组织查询能力；缺少上下文、非法 `group_id` 或越权组织都会直接返回错误。

```python
def get_mlops_module_data(..., group_id, actor_context=None):
    is_valid, group_id, message = _validate_actor_group(actor_context, group_id)
    if not is_valid:
        return {"result": False, "message": message}
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_app_data\ngroup_data_rule_viewset.py"]
    end

    RPC["MLOps.get_module_data\nrpc/mlops.py"]

    subgraph N["MLOps NATS 处理层"]
        F1["get_mlops_module_data\nmlops/nats_api.py"]
        F2["_validate_actor_group\nmlops/nats_api.py"]
    end

    DB["model.objects.filter\nteam__contains=group_id"]

    T1 --> RPC --> F1 --> F2 --> DB
    F2 -. "缺少上下文或越权" .-> DENY["返回 result=false"]
```

## 影响范围

改动范围是 MLOps 模块数据 NATS 查询和系统管理的数据权限入口。仓库内扫描到的入口只有 `GroupDataRuleViewSet.get_app_data -> apps.rpc.mlops.MLOps.get_module_data`，agents/web 没有直接调用这个 subject。由于这是权限收口，直接 NATS 调用方需要传可信 `actor_context`，因此按中风险处理，@zhouzhuangjie 请重点看调用兼容性。

## 验证

新增的测试覆盖三条关键路径：缺少 `actor_context` 被拒绝、非超管伪造未授权 `group_id` 被拒绝且不会查表、合法组织和超管路径仍可正常返回数据。去掉 handler 中的授权校验后，这些测试会失败。

本地验证：

```bash
cd server && .venv/bin/python apps/mlops/tests/test_get_mlops_module_data_nats.py -v
cd server && .venv/bin/python -m py_compile apps/mlops/nats_api.py apps/system_mgmt/viewset/group_data_rule_viewset.py apps/mlops/tests/test_get_mlops_module_data_nats.py
git diff --check
```