### PR TITLE
bugfix: 校验 MLOps 资源归属组织

### DIFF
--- a/server/apps/mlops/tests/test_group_scope.py
+++ b/server/apps/mlops/tests/test_group_scope.py
@@ -1,0 +1,33 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework import serializers
+
+from apps.mlops.utils.group_scope import validate_requested_teams
+
+pytestmark = pytest.mark.unit
+
+
+def _request(group_list, is_superuser=False):
+    return SimpleNamespace(user=SimpleNamespace(group_list=group_list, is_superuser=is_superuser))
+
+
+def test_validate_requested_teams_accepts_owned_teams():
+    request = _request([{"id": 1}, {"id": "2"}])
+
+    assert validate_requested_teams(request, ["1", 2]) == [1, 2]
+
+
+def test_validate_requested_teams_rejects_unowned_team():
+    request = _request([{"id": 1}])
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        validate_requested_teams(request, [1, 3])
+
+    assert exc.value.detail == {"team": ["只能选择当前用户所属组织"]}
+
+
+def test_validate_requested_teams_allows_superuser_to_assign_any_team():
+    request = _request([], is_superuser=True)
+
+    assert validate_requested_teams(request, [99]) == [99]

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -75,6 +75,10 @@ def validate_requested_teams(request, team_ids, field_name="team"):
         except (TypeError, ValueError):
             raise serializers.ValidationError({field_name: "组织ID必须为整数"})
 
+    allowed_team_ids = get_allowed_team_ids(request)
+    if allowed_team_ids is not None and not set(normalized).issubset(allowed_team_ids):
+        raise serializers.ValidationError({field_name: "只能选择当前用户所属组织"})
+
     return normalized
 
 


### PR DESCRIPTION
## 问题

MLOps 的数据集、训练任务、Serving 这类 root 资源都允许请求体提交 `team`。这些资源保存后，后续列表、详情、子资源都会把 `team` 当作组织边界来判断可见范围。

当前 `team` 写入只检查“必须是非空列表、元素能转成整数”，没有确认普通用户是否真的属于这些组织。普通用户可以提交其他组织 ID，把资源写进自己无权访问的组织，形成持久化的跨组织污染。

## 根因

MLOps 已经有 `get_allowed_team_ids(request)` 用来从当前用户的 `group_list` 计算可写组织集合，但 root 资源 serializer 共用的 `validate_requested_teams` 没有使用它。六类算法资源的 `validate_team` 都直接信任这个函数的返回值，所以边界在统一入口退化成了类型归一化。

## 怎么修的

在 `validate_requested_teams` 完成整数归一化后，对普通用户增加所属组织子集校验：

```python
allowed_team_ids = get_allowed_team_ids(request)
if allowed_team_ids is not None and not set(normalized).issubset(allowed_team_ids):
    raise serializers.ValidationError({field_name: "只能选择当前用户所属组织"})
```

`get_allowed_team_ids` 对 superuser 返回 `None`，所以管理员/服务账号的跨组织写入能力保持不变；普通用户只能选择自己所属组织。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MLOps root 资源 POST/PATCH\nserializers/* validate_team"]
    end

    BU["team JSONField 保存\nmodels/*"]

    subgraph N["核心处理层"]
        F1["validate_requested_teams\nutils/group_scope.py"]
        F2["get_allowed_team_ids\nutils/group_scope.py"]
    end

    subgraph C["后续读取层"]
        C1["TeamModelViewSet / filters / NATS 查询\n按 team 过滤"]
    end

    T1 --> F1 --> F2 --> BU --> C1
    F1 -- "非法组织" --> E["400 ValidationError"]
```

## 影响范围

改动集中在 `server/apps/mlops/utils/group_scope.py`，所有复用 `validate_requested_teams` 的 MLOps root 写路径都会得到同一层保护，包括 Dataset、TrainJob、Serving 等资源。

这属于权限/租户边界收紧，风险定为中：普通用户写入无所属组织会被拒绝；superuser 路径保持原样。没有改模型、迁移、RPC 协议或前端接口字段。

## 验证

新增 `server/apps/mlops/tests/test_group_scope.py`，覆盖三条关键路径：

- 普通用户提交自己所属组织，允许并完成整数归一化
- 普通用户提交非所属组织，抛出 `ValidationError`
- superuser 提交任意组织，保持允许

本地验证：

- `./.venv/bin/python -m py_compile apps/mlops/utils/group_scope.py apps/mlops/tests/test_group_scope.py` 通过
- 独立脚本直接加载 `group_scope.py` 调用 `validate_requested_teams`，输出 `verify_group_scope: ok`

完整 pytest 在当前本地环境被 settings 初始化阻塞：`uv run pytest apps/mlops/tests/test_group_scope.py -q` 首先卡在第三方 pytest 插件加载；关闭插件并设置 `DJANGO_SETTINGS_MODULE=settings` 后，collection 进入 `apps/mlops/tests/conftest.py`，继续在 Django/Celery 导入链的 `importlib.metadata` 阶段卡住，已中断。

Fixes #3801
