### PR TITLE
bugfix: 修复 MLOps 子资源组织校验

### DIFF
--- a/server/apps/mlops/tests_unit/test_group_scope.py
+++ b/server/apps/mlops/tests_unit/test_group_scope.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.exceptions import PermissionDenied
+
+from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
+
+
+class RecordingQuerySet:
+    def __init__(self):
+        self.filters = []
+
+    def filter(self, **kwargs):
+        self.filters.append(kwargs)
+        return self
+
+
+def make_request(current_team, group_list=None, *, is_superuser=False):
+    return SimpleNamespace(
+        COOKIES={"current_team": current_team} if current_team is not None else {},
+        user=SimpleNamespace(
+            is_superuser=is_superuser,
+            group_list=group_list if group_list is not None else [{"id": 1}, {"id": "2"}],
+        ),
+    )
+
+
+def test_filter_queryset_by_parent_team_rejects_forged_current_team():
+    queryset = RecordingQuerySet()
+    request = make_request("99", group_list=[{"id": 1}, {"id": 2}])
+
+    with pytest.raises(PermissionDenied):
+        filter_queryset_by_parent_team(queryset, request, "dataset__team")
+
+    assert queryset.filters == []
+
+
+def test_filter_queryset_by_parent_team_filters_allowed_current_team():
+    queryset = RecordingQuerySet()
+    request = make_request("2", group_list=[{"id": 1}, {"id": "2"}])
+
+    result = filter_queryset_by_parent_team(queryset, request, "dataset__team")
+
+    assert result is queryset
+    assert queryset.filters == [{"dataset__team__contains": 2}]
+
+
+def test_filter_queryset_by_parent_team_keeps_superuser_bypass():
+    queryset = RecordingQuerySet()
+    request = make_request("99", group_list=[], is_superuser=True)
+
+    result = filter_queryset_by_parent_team(queryset, request, "dataset__team")
+
+    assert result is queryset
+    assert queryset.filters == []

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import logging
 
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 from apps.core.utils.team_utils import get_current_team as _get_current_team_str
 
 logger = logging.getLogger(__name__)
@@ -101,7 +102,11 @@ def filter_queryset_by_parent_team(queryset, request, parent_team_lookup):
     if getattr(user, "is_superuser", False):
         return queryset
 
-    current_team = get_current_team(request)
+    current_team = get_current_team(request, default=None)
+    allowed_team_ids = get_allowed_team_ids(request)
+    if not current_team or current_team not in allowed_team_ids:
+        raise PermissionDenied("无权访问该团队数据")
+
     return queryset.filter(**{f"{parent_team_lookup}__contains": current_team})
 
 


### PR DESCRIPTION
## 问题
MLOps 的 TrainData、DatasetRelease 这类子资源没有自己的组织字段，列表和详情会通过父级 dataset 的 team 来做过滤。原来的过滤只读取请求里的 current_team，没有确认这个组织是否属于当前用户。这样一来，有模块权限的用户如果伪造 current_team，就可能看到或操作其他组织父资源下的子资源。

## 根因
根资源走 TeamModelViewSet 时会校验 current_team 和用户组织归属，但子资源复用了 filter_queryset_by_parent_team 这个 helper，绕过了那层校验。这个 helper 只把 current_team 拼进 dataset__team__contains 查询，缺少“current_team 必须在 request.user.group_list 内”的边界检查。

## 怎么修的
在 filter_queryset_by_parent_team 里保留 superuser 原有直通行为；非 superuser 先解析 current_team，再用已有 get_allowed_team_ids(request) 归一化用户可访问组织。current_team 缺失或不在用户组织内时直接返回 403，不再继续执行父级 team 过滤。

```python
current_team = get_current_team(request, default=None)
allowed_team_ids = get_allowed_team_ids(request)
if not current_team or current_team not in allowed_team_ids:
    raise PermissionDenied("无权访问该团队数据")
```

## 影响范围
改动集中在 server/apps/mlops/utils/group_scope.py，覆盖六类算法下复用 filter_queryset_by_parent_team 的 TrainData/DatasetRelease 子资源入口。没有改 URL、序列化字段、NATS 协议或 agents/web 调用。合法用户携带自己所属组织的 current_team 仍按原查询过滤；superuser 行为保持不变。

中风险访问控制修复，请 @周壮杰 review。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["TrainData/DatasetRelease ViewSet\nserver/apps/mlops/views/*.py"]
    end

    Q["dataset__team 过滤\nDjango QuerySet"]

    subgraph N["核心处理层"]
        F1["filter_queryset_by_parent_team\nutils/group_scope.py"]
        F2["get_allowed_team_ids\nutils/group_scope.py"]
    end

    subgraph C["拒绝层"]
        C1["PermissionDenied 403\n伪造或缺失 current_team"]
    end

    T1 --> F1 --> F2
    F2 --> Q
    F2 -. "current_team 不属于用户组织" .-> C1
```

## 验证
- `python3 -m py_compile server/apps/mlops/utils/group_scope.py server/apps/mlops/tests_unit/test_group_scope.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest --confcutdir=apps/mlops/tests_unit -c /dev/null apps/mlops/tests_unit/test_group_scope.py -q`：3 passed

补充说明：直接跑项目 pytest 时，当前本地环境在第三方包 metadata / Django settings 初始化处失败，未进入本次测试断言；因此使用上面的纯单元测试命令绕开项目级 conftest 和插件加载，专门验证该 helper 的修复逻辑。

Fixes #3800