### PR TITLE
bugfix: 哈希存储 API Secret

### DIFF
--- a/server/apps/base/admin.py
+++ b/server/apps/base/admin.py
@@ -4,13 +4,19 @@ from .models import UserAPISecret, User
 
 @admin.register(UserAPISecret)
 class UserAPISecretAdmin(admin.ModelAdmin):
-    list_display = ('username', 'api_secret', 'team')
+    list_display = ("username", "api_secret_preview", "team")
     search_fields = ('username', 'team')
-    readonly_fields = ('api_secret',)
+    readonly_fields = ("api_secret_preview",)
+    exclude = ("api_secret",)
+
+    @admin.display(description="API Secret")
+    def api_secret_preview(self, obj):
+        return obj.get_api_secret_preview()
 
     def save_model(self, request, obj, form, change):
         if not obj.api_secret:
             obj.api_secret = UserAPISecret.generate_api_secret()
+        obj.api_secret = UserAPISecret.hash_api_secret(obj.api_secret)
         super().save_model(request, obj, form, change)
 
 

--- a/server/apps/base/migrations/0010_hash_user_api_secret.py
+++ b/server/apps/base/migrations/0010_hash_user_api_secret.py
@@ -1,0 +1,30 @@
+import hashlib
+
+from django.db import migrations, models
+
+
+HASH_PREFIX = "sha256$"
+
+
+def hash_existing_api_secrets(apps, schema_editor):
+    UserAPISecret = apps.get_model("base", "UserAPISecret")
+    for secret in UserAPISecret.objects.exclude(api_secret__startswith=HASH_PREFIX).iterator():
+        if not secret.api_secret:
+            continue
+        secret.api_secret = f"{HASH_PREFIX}{hashlib.sha256(secret.api_secret.encode()).hexdigest()}"
+        secret.save(update_fields=["api_secret"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0009_alter_userapisecret_unique_together"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="userapisecret",
+            name="api_secret",
+            field=models.CharField(max_length=80),
+        ),
+        migrations.RunPython(hash_existing_api_secrets, migrations.RunPython.noop),
+    ]

--- a/server/apps/base/models/user.py
+++ b/server/apps/base/models/user.py
@@ -1,4 +1,5 @@
 import binascii
+import hashlib
 import os
 
 from django.contrib.auth.models import AbstractUser
@@ -10,14 +11,46 @@ from apps.core.models.time_info import TimeInfo
 
 
 class UserAPISecret(TimeInfo):
+    HASH_PREFIX = "sha256$"
+
     username = models.CharField(max_length=255)
     domain = models.CharField(max_length=255, default="domain.com")
-    api_secret = models.CharField(max_length=64)
+    api_secret = models.CharField(max_length=80)
     team = models.IntegerField(default=0)
 
     @staticmethod
     def generate_api_secret():
         return binascii.hexlify(os.urandom(32)).decode()
+
+    @classmethod
+    def hash_api_secret(cls, api_secret: str) -> str:
+        if not api_secret:
+            return api_secret
+        if cls.is_hashed_api_secret(api_secret):
+            return api_secret
+        return f"{cls.HASH_PREFIX}{hashlib.sha256(api_secret.encode()).hexdigest()}"
+
+    @classmethod
+    def is_hashed_api_secret(cls, api_secret: str) -> bool:
+        return bool(api_secret and api_secret.startswith(cls.HASH_PREFIX))
+
+    @classmethod
+    def find_by_api_secret(cls, api_secret: str):
+        if not api_secret:
+            return None
+        if cls.is_hashed_api_secret(api_secret):
+            return None
+
+        hashed_secret = cls.hash_api_secret(api_secret)
+        user_secret = cls._default_manager.filter(api_secret=hashed_secret).first()
+        if user_secret:
+            return user_secret
+
+        # 滚动发布兼容：迁移尚未执行到的旧明文记录仍可认证。
+        return cls._default_manager.filter(api_secret=api_secret).first()
+
+    def get_api_secret_preview(self) -> str:
+        return "********" if self.api_secret else ""
 
     class Meta:
         unique_together = ("username", "domain", "team")

--- a/server/apps/base/tests/integration/test_views.py
+++ b/server/apps/base/tests/integration/test_views.py
@@ -18,7 +18,7 @@ class TestUserAPISecretList:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 1
         assert response.data[0]["username"] == user_with_permissions.username
-        assert response.data[0]["api_secret_preview"] == f"{user_api_secret.api_secret[:4]}********"
+        assert response.data[0]["api_secret_preview"] == "********"
         assert "api_secret" not in response.data[0]
 
     def test_user_cannot_see_other_users_secrets(self, api_client_with_team, user_with_permissions):
@@ -79,6 +79,9 @@ class TestUserAPISecretCreate:
         assert "api_secret_preview" not in response.data
         assert response.data["username"] == user_with_permissions.username
         assert response.data["team"] == 1
+        stored = UserAPISecret.objects.get(username=user_with_permissions.username, domain=user_with_permissions.domain, team=1)
+        assert stored.api_secret != response.data["api_secret"]
+        assert stored.api_secret == UserAPISecret.hash_api_secret(response.data["api_secret"])
 
 
 @pytest.mark.integration
@@ -90,7 +93,7 @@ class TestUserAPISecretRetrieve:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data["id"] == user_api_secret.pk
-        assert response.data["api_secret_preview"] == f"{user_api_secret.api_secret[:4]}********"
+        assert response.data["api_secret_preview"] == "********"
         assert "api_secret" not in response.data
 
     def test_duplicate_create_rejected(self, api_client_with_team, user_with_permissions, user_api_secret):

--- a/server/apps/base/tests/unit/test_models.py
+++ b/server/apps/base/tests/unit/test_models.py
@@ -17,6 +17,14 @@ class TestUserAPISecretGenerateApiSecret:
         secret2 = UserAPISecret.generate_api_secret()
         assert secret1 != secret2
 
+    def test_hash_api_secret_is_not_reusable_plaintext(self):
+        secret = "a" * 64
+        hashed = UserAPISecret.hash_api_secret(secret)
+
+        assert hashed != secret
+        assert hashed.startswith(UserAPISecret.HASH_PREFIX)
+        assert UserAPISecret.hash_api_secret(hashed) == hashed
+
 
 @pytest.mark.unit
 @pytest.mark.django_db
@@ -56,3 +64,16 @@ class TestUserAPISecretModelConstraints:
         secret = UserAPISecretFactory(username="charlie")
         assert secret.team == 0
         assert secret.domain == "domain.com"
+
+    def test_find_by_api_secret_matches_hashed_secret(self):
+        raw_secret = UserAPISecret.generate_api_secret()
+        stored = UserAPISecretFactory(api_secret=UserAPISecret.hash_api_secret(raw_secret))
+
+        assert UserAPISecret.find_by_api_secret(raw_secret) == stored
+        assert UserAPISecret.find_by_api_secret(stored.api_secret) is None
+
+    def test_find_by_api_secret_keeps_legacy_plaintext_fallback(self):
+        raw_secret = UserAPISecret.generate_api_secret()
+        stored = UserAPISecretFactory(api_secret=raw_secret)
+
+        assert UserAPISecret.find_by_api_secret(raw_secret) == stored

--- a/server/apps/base/tests/unit/test_serializers.py
+++ b/server/apps/base/tests/unit/test_serializers.py
@@ -58,20 +58,44 @@ class TestUserAPISecretSerializer:
         assert "id" in data
         assert "username" in data
         assert "api_secret_preview" in data
-        assert data["api_secret_preview"] == f"{secret.api_secret[:4]}********"
+        assert data["api_secret_preview"] == "********"
         assert "api_secret" not in data
         assert "team" in data
         assert "team_name" in data
 
-    def test_create_serializer_includes_full_api_secret(self):
+    def test_create_serializer_includes_full_api_secret_once_when_provided(self):
         user = UserFactory(
             username="erin",
             group_list=[{"id": 1, "name": "Team Alpha"}],
         )
-        secret = UserAPISecretFactory(username="erin", domain=user.domain, team=1)
+        raw_secret = UserAPISecret.generate_api_secret()
+        secret = UserAPISecretFactory(
+            username="erin",
+            domain=user.domain,
+            team=1,
+            api_secret=UserAPISecret.hash_api_secret(raw_secret),
+        )
+        secret._plain_api_secret = raw_secret
         request = self._make_request(user)
         serializer = UserAPISecretCreateSerializer(secret, context={"request": request})
         data = serializer.data
 
-        assert data["api_secret"] == secret.api_secret
+        assert data["api_secret"] == raw_secret
         assert "api_secret_preview" not in data
+
+    def test_create_serializer_does_not_echo_stored_secret_without_plaintext_context(self):
+        user = UserFactory(
+            username="frank",
+            group_list=[{"id": 1, "name": "Team Alpha"}],
+        )
+        raw_secret = UserAPISecret.generate_api_secret()
+        secret = UserAPISecretFactory(
+            username="frank",
+            domain=user.domain,
+            team=1,
+            api_secret=UserAPISecret.hash_api_secret(raw_secret),
+        )
+        request = self._make_request(user)
+        serializer = UserAPISecretCreateSerializer(secret, context={"request": request})
+
+        assert "api_secret" not in serializer.data

--- a/server/apps/base/user_api_secret_mgmt/serializers.py
+++ b/server/apps/base/user_api_secret_mgmt/serializers.py
@@ -25,10 +25,19 @@ class UserAPISecretSerializer(BaseUserAPISecretSerializer):
         fields = ("id", "username", "domain", "team", "team_name", "created_at", "updated_at", "api_secret_preview")
 
     def get_api_secret_preview(self, instance):
-        return f"{instance.api_secret[:4]}********" if instance.api_secret else ""
+        return instance.get_api_secret_preview()
 
 
 class UserAPISecretCreateSerializer(BaseUserAPISecretSerializer):
+    api_secret = serializers.CharField(write_only=True)
+
     class Meta:
         model = UserAPISecret
         fields = "__all__"
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        api_secret = getattr(instance, "_plain_api_secret", None)
+        if api_secret:
+            data["api_secret"] = api_secret
+        return data

--- a/server/apps/base/user_api_secret_mgmt/views.py
+++ b/server/apps/base/user_api_secret_mgmt/views.py
@@ -86,15 +86,17 @@ class UserAPISecretViewSet(viewsets.ModelViewSet):
                     "message": loader.get("error.api_secret_exists", "This user already has an API Secret"),
                 }
             )
+        api_secret = UserAPISecret.generate_api_secret()
         additional_data = {
             "username": username,
-            "api_secret": UserAPISecret.generate_api_secret(),
+            "api_secret": UserAPISecret.hash_api_secret(api_secret),
             "domain": request.user.domain,
             "team": current_team,
         }
         serializer = UserAPISecretCreateSerializer(data=additional_data, context=self.get_serializer_context())
         serializer.is_valid(raise_exception=True)
         self.perform_create(serializer)
+        serializer.instance._plain_api_secret = api_secret
         response_serializer = UserAPISecretCreateSerializer(serializer.instance, context=self.get_serializer_context())
         headers = self.get_success_headers(response_serializer.data)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED, headers=headers)

--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -70,7 +70,9 @@ class APISecretAuthBackend(ModelBackend):
 
         user_secret = None
         try:
-            user_secret = UserAPISecret._default_manager.get(api_secret=api_token)
+            user_secret = UserAPISecret.find_by_api_secret(api_token)
+            if user_secret is None:
+                return None
             user = User._default_manager.get(username=user_secret.username, domain=user_secret.domain)
             user.group_list = [user_secret.team]
 

--- a/server/apps/core/tests/test_api_secret_hash_auth.py
+++ b/server/apps/core/tests/test_api_secret_hash_auth.py
@@ -1,0 +1,38 @@
+import pytest
+
+from apps.base.models import User, UserAPISecret
+from apps.core.backends import APISecretAuthBackend
+
+
+@pytest.mark.django_db
+def test_api_secret_authenticates_with_raw_token_against_hashed_storage(monkeypatch):
+    raw_secret = UserAPISecret.generate_api_secret()
+    user = User.objects.create(username="alice", domain="domain.com")
+    UserAPISecret.objects.create(
+        username=user.username,
+        domain=user.domain,
+        team=7,
+        api_secret=UserAPISecret.hash_api_secret(raw_secret),
+    )
+    monkeypatch.setattr(APISecretAuthBackend, "_populate_user_permissions", lambda self, user, team: None)
+
+    authenticated = APISecretAuthBackend().authenticate(api_token=raw_secret)
+
+    assert authenticated == user
+    assert authenticated.group_list == [7]
+
+
+@pytest.mark.django_db
+def test_api_secret_auth_rejects_leaked_stored_digest(monkeypatch):
+    raw_secret = UserAPISecret.generate_api_secret()
+    stored_digest = UserAPISecret.hash_api_secret(raw_secret)
+    user = User.objects.create(username="bob", domain="domain.com")
+    UserAPISecret.objects.create(
+        username=user.username,
+        domain=user.domain,
+        team=3,
+        api_secret=stored_digest,
+    )
+    monkeypatch.setattr(APISecretAuthBackend, "_populate_user_permissions", lambda self, user, team: None)
+
+    assert APISecretAuthBackend().authenticate(api_token=stored_digest) is None

--- a/server/apps/opspilot/views.py
+++ b/server/apps/opspilot/views.py
@@ -144,7 +144,7 @@ def validate_openai_token(token, team=None, is_mobile=False):
     if not token:
         return False, {"choices": [{"message": {"role": "assistant", "content": loader.get("error.no_authorization", "No authorization")}}]}
     token = token.split("Bearer ")[-1]
-    user = UserAPISecret.objects.filter(api_secret=token).first()
+    user = UserAPISecret.find_by_api_secret(token)
     if not user:
         if team is None and not is_mobile:
             return False, {"choices": [{"message": {"role": "assistant", "content": loader.get("error.no_authorization", "No authorization")}}]}


### PR DESCRIPTION
## 问题
API Secret 是长期有效的调用凭据。创建后它本该只把完整 token 返回给用户一次，但当前代码会把完整 token 明文保存到数据库，并且 Django admin 也能直接展示。只要有人能读库、读备份或看后台列表，就能拿到可直接调用接口的完整凭据。

## 根因
存储层和认证层都把 API Secret 当成可反查的普通字符串：创建时写入明文，认证时按明文精确查库，后台展示时也直接读同一个字段。这样数据库读权限会退化成 API 调用权限。

## 怎么修的
创建 API Secret 时先保留原文用于本次响应，落库前改成不可直接复用的摘要；列表、详情和 admin 只显示掩码。认证入口统一通过原始 token 计算摘要后查找，且拒绝把已泄露的存储摘要当 token 直接使用。

```python
api_secret = UserAPISecret.generate_api_secret()
additional_data = {
    "api_secret": UserAPISecret.hash_api_secret(api_secret),
}
serializer.instance._plain_api_secret = api_secret
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["UserAPISecretViewSet.create\nbase/user_api_secret_mgmt/views.py"]
        T2["APISecretMiddleware\ncore/middlewares/api_middleware.py"]
        T3["validate_openai_token\nopspilot/views.py"]
        T4["UserAPISecretAdmin\nbase/admin.py"]
    end

    DB["UserAPISecret.api_secret\n保存 sha256 摘要"]

    subgraph C["核心处理层"]
        F1["hash_api_secret\nbase/models/user.py"]
        F2["find_by_api_secret\nbase/models/user.py"]
        F3["APISecretAuthBackend.authenticate\ncore/backends.py"]
    end

    subgraph M["迁移/兼容层"]
        M1["0010_hash_user_api_secret\n迁移旧明文记录"]
        M2["旧明文 fallback\n滚动发布兼容"]
    end

    T1 --> F1 --> DB
    T2 --> F3 --> F2 --> DB
    T3 --> F2
    T4 --> DB
    M1 --> DB
    F2 -. "未迁移旧记录" .-> M2
```

## 影响范围
改动范围在后端 `base/core/opspilot`。Web 侧已有逻辑只依赖创建响应的一次性 `api_secret` 和列表中的 `api_secret_preview`，接口形态不需要调整。迁移会把已有明文 token 改成摘要；认证保留旧明文 fallback，避免滚动发布期间迁移尚未覆盖的记录失效。

## 验证
- `SECRET_KEY=test-secret DB_ENGINE=sqlite ENABLE_CELERY=true INSTALL_APPS=system_mgmt uv run pytest apps/base/tests/unit/test_models.py apps/base/tests/unit/test_serializers.py apps/base/tests/integration/test_views.py apps/core/tests/test_api_secret_hash_auth.py --no-cov --tb=short -q`：30 passed
- `DB_ENGINE=sqlite ENABLE_CELERY=true uv run python manage.py makemigrations --check --dry-run base`：No changes detected in app 'base'
- `uv run python -m compileall -q ...`：通过