### PR TITLE
bugfix: 收紧 OpsPilot 下载链接回填

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,7 @@
     "test:monitor-gap-interval": "pnpm exec tsx scripts/monitor-gap-interval-test.ts",
     "test:monitor-promql-label-query": "pnpm exec tsx scripts/monitor-promql-label-query-test.ts",
     "test:monitor-capability-matrix": "pnpm exec tsx scripts/monitor-capability-matrix-test.ts",
+    "test:opspilot-download-url-security": "pnpm exec tsx scripts/opspilot-download-url-security-test.ts",
     "gen:capability-matrix": "pnpm exec tsx scripts/generate-capability-matrix.ts",
     "test:monitor-template-bulk": "pnpm exec tsx scripts/monitor-template-bulk-logic-test.ts",
     "test:related-alerts": "pnpm exec tsx scripts/related-alerts-validation.ts",

--- a/web/scripts/opspilot-download-url-security-test.ts
+++ b/web/scripts/opspilot-download-url-security-test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { normalizeSafeDownloadUrl } from '../src/app/opspilot/components/custom-chat-sse/downloadUrl';
+
+const currentOrigin = 'https://console.example.com';
+
+assert.equal(
+  normalizeSafeDownloadUrl('/api/v1/opspilot/bot_mgmt/workflow_attachment/download/token/', { currentOrigin }),
+  '/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/token/'
+);
+assert.equal(
+  normalizeSafeDownloadUrl('/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/token/?next=a', { currentOrigin }),
+  '/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/token/?next=a'
+);
+assert.equal(
+  normalizeSafeDownloadUrl('https://console.example.com/api/proxy/opspilot/file.docx', { currentOrigin }),
+  'https://console.example.com/api/proxy/opspilot/file.docx'
+);
+assert.equal(
+  normalizeSafeDownloadUrl('blob:https://console.example.com/attachment-id', { currentOrigin }),
+  'blob:https://console.example.com/attachment-id'
+);
+assert.equal(
+  normalizeSafeDownloadUrl('https://downloads.example.com/report.docx', {
+    currentOrigin,
+    allowedOrigins: ['https://downloads.example.com'],
+  }),
+  'https://downloads.example.com/report.docx'
+);
+
+assert.equal(normalizeSafeDownloadUrl('javascript:alert(1)', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('data:text/html,<script>alert(1)</script>', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('file:///etc/passwd', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('https://evil.example.com/report.docx', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('//evil.example.com/report.docx', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('https:evil.example.com/report.docx', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('report.docx', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('https://user:pass@console.example.com/report.docx', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('/api/proxy/opspilot/down\nload/token/', { currentOrigin }), '');
+assert.equal(normalizeSafeDownloadUrl('\\evil.example.com\\report.docx', { currentOrigin }), '');
+
+console.log('opspilot download URL security tests passed');

--- a/web/src/app/opspilot/components/custom-chat-sse/ReportDownloadCard.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/ReportDownloadCard.tsx
@@ -4,15 +4,14 @@ import React, { useCallback } from 'react';
 import { Tag } from 'antd';
 import { DownloadOutlined, FileWordOutlined } from '@ant-design/icons';
 import { ReportFileDownload } from '@/app/opspilot/types/global';
+import { normalizeSafeDownloadUrl } from './downloadUrl';
 
 interface ReportDownloadCardProps {
   download: ReportFileDownload;
 }
 
 const ReportDownloadCard: React.FC<ReportDownloadCardProps> = ({ download }) => {
-  const normalizedFileUrl = download.file_url?.startsWith('/api/v1/')
-    ? download.file_url.replace('/api/v1/', '/api/proxy/')
-    : download.file_url;
+  const normalizedFileUrl = normalizeSafeDownloadUrl(download.file_url);
 
   const handleDownload = useCallback(() => {
     if (normalizedFileUrl) {

--- a/web/src/app/opspilot/components/custom-chat-sse/downloadUrl.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/downloadUrl.ts
@@ -1,0 +1,154 @@
+import type { ReportFileDownload } from '@/app/opspilot/types/global';
+
+const API_V1_PREFIX = '/api/v1/';
+const API_PROXY_PREFIX = '/api/proxy/';
+
+interface NormalizeDownloadUrlOptions {
+  currentOrigin?: string;
+  allowedOrigins?: string[];
+}
+
+const getCurrentOrigin = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  return window.location.origin;
+};
+
+const normalizeOrigin = (origin?: string) => {
+  const value = origin?.trim();
+  if (!value) {
+    return '';
+  }
+
+  try {
+    return new URL(value).origin;
+  } catch {
+    return '';
+  }
+};
+
+const getConfiguredAllowedOrigins = () => {
+  const rawOrigins = process.env.NEXT_PUBLIC_OPSPILOT_DOWNLOAD_ORIGINS;
+  if (!rawOrigins) {
+    return [];
+  }
+
+  return rawOrigins
+    .split(',')
+    .map(normalizeOrigin)
+    .filter(Boolean);
+};
+
+const getAllowedOrigins = (options?: NormalizeDownloadUrlOptions) => {
+  return new Set([
+    normalizeOrigin(options?.currentOrigin || getCurrentOrigin()),
+    ...getConfiguredAllowedOrigins(),
+    ...(options?.allowedOrigins || []).map(normalizeOrigin),
+  ].filter(Boolean));
+};
+
+const hasUnsafeCharacters = (url: string) => /[\u0000-\u001F\u007F\\]/.test(url);
+const hasAllowedAbsoluteScheme = (url: string) => /^(https?:\/\/|blob:)/i.test(url);
+
+const normalizeApiProxyPath = (url: string) => {
+  if (url.startsWith(API_V1_PREFIX)) {
+    return `${API_PROXY_PREFIX}${url.slice(API_V1_PREFIX.length)}`;
+  }
+
+  return url;
+};
+
+const isSameOriginUrl = (url: URL, allowedOrigins: Set<string>) => {
+  return allowedOrigins.size > 0 && allowedOrigins.has(url.origin);
+};
+
+export const normalizeSafeDownloadUrl = (
+  url?: string,
+  options?: NormalizeDownloadUrlOptions
+): string => {
+  const trimmedUrl = url?.trim();
+  if (!trimmedUrl || hasUnsafeCharacters(trimmedUrl)) {
+    return '';
+  }
+
+  const normalizedUrl = normalizeApiProxyPath(trimmedUrl);
+  if (normalizedUrl.startsWith('/') && !normalizedUrl.startsWith('//')) {
+    return normalizedUrl;
+  }
+
+  const allowedOrigins = getAllowedOrigins(options);
+  try {
+    if (!hasAllowedAbsoluteScheme(normalizedUrl)) {
+      return '';
+    }
+
+    const parsedUrl = new URL(normalizedUrl, options?.currentOrigin || getCurrentOrigin() || undefined);
+    if (parsedUrl.username || parsedUrl.password) {
+      return '';
+    }
+
+    if (parsedUrl.protocol === 'blob:') {
+      return isSameOriginUrl(parsedUrl, allowedOrigins) ? normalizedUrl : '';
+    }
+
+    if (
+      (parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:')
+      && isSameOriginUrl(parsedUrl, allowedOrigins)
+    ) {
+      return normalizedUrl;
+    }
+  } catch {
+    return '';
+  }
+
+  return '';
+};
+
+export const hydrateGeneratedFileLinks = (
+  html: string,
+  downloads?: ReportFileDownload[]
+): string => {
+  if (!html || !downloads?.length || typeof window === 'undefined') {
+    return html;
+  }
+
+  const linkableDownloads = downloads
+    .map(download => ({
+      download,
+      safeUrl: normalizeSafeDownloadUrl(download.file_url),
+    }))
+    .filter(item => item.safeUrl);
+  if (linkableDownloads.length === 0 || !html.includes('<a')) {
+    return html;
+  }
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(html, 'text/html');
+  const anchors = Array.from(doc.querySelectorAll('a:not([href])'));
+  if (anchors.length === 0) {
+    return html;
+  }
+
+  const normalizeText = (value: string) => value.replace(/^下载/, '').replace(/\.[^.]+$/, '').trim().toLowerCase();
+
+  anchors.forEach(anchor => {
+    const anchorText = normalizeText(anchor.textContent || '');
+    const matchedDownload = linkableDownloads.length === 1
+      ? linkableDownloads[0]
+      : linkableDownloads.find(({ download }) => {
+        const fileName = normalizeText(download.filename);
+        return anchorText && (fileName.includes(anchorText) || anchorText.includes(fileName));
+      });
+
+    if (!matchedDownload) {
+      return;
+    }
+
+    anchor.setAttribute('href', matchedDownload.safeUrl);
+    anchor.setAttribute('target', '_blank');
+    anchor.setAttribute('rel', 'noopener noreferrer');
+  });
+
+  return doc.body.innerHTML;
+};

--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -24,7 +24,8 @@ import ConfigAnalysisReportCard from './ConfigAnalysisReportCard';
 import ReportDownloadCard from './ReportDownloadCard';
 import RepairCommandsCard from './RepairCommandsCard';
 import SkillView from './SkillView';
-import {Annotation, CustomChatMessage, ReportFileDownload} from '@/app/opspilot/types/global';
+import { hydrateGeneratedFileLinks } from './downloadUrl';
+import {Annotation, CustomChatMessage} from '@/app/opspilot/types/global';
 import {useSession} from 'next-auth/react';
 import {useAuth} from '@/context/auth';
 import {CustomChatSSEProps, GuideParseResult} from '@/app/opspilot/types/chat';
@@ -116,58 +117,6 @@ const sanitizeHtml = (html: string): string => {
     ALLOWED_ATTR: ['class', 'style', 'href', 'target', 'rel', 'data-ref-number', 'data-chunk-id', 'data-knowledge-id', 'data-chunk-type', 'data-content', 'data-suggestion', 'data-expanded', 'data-tool-id', 'src', 'alt', 'width', 'height', 'aria-hidden'],
     ALLOW_DATA_ATTR: true,
   });
-};
-
-const normalizeDownloadUrl = (url?: string): string => {
-  if (!url) {
-    return '';
-  }
-
-  if (url.startsWith('/api/v1/')) {
-    return url.replace('/api/v1/', '/api/proxy/');
-  }
-
-  return url;
-};
-
-const hydrateGeneratedFileLinks = (html: string, downloads?: ReportFileDownload[]): string => {
-  if (!html || !downloads?.length || typeof window === 'undefined') {
-    return html;
-  }
-
-  const linkableDownloads = downloads.filter(download => download.file_url);
-  if (linkableDownloads.length === 0 || !html.includes('<a')) {
-    return html;
-  }
-
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(html, 'text/html');
-  const anchors = Array.from(doc.querySelectorAll('a:not([href])'));
-  if (anchors.length === 0) {
-    return html;
-  }
-
-  const normalizeText = (value: string) => value.replace(/^下载/, '').replace(/\.[^.]+$/, '').trim().toLowerCase();
-
-  anchors.forEach(anchor => {
-    const anchorText = normalizeText(anchor.textContent || '');
-    const matchedDownload = linkableDownloads.length === 1
-      ? linkableDownloads[0]
-      : linkableDownloads.find(download => {
-        const fileName = normalizeText(download.filename);
-        return anchorText && (fileName.includes(anchorText) || anchorText.includes(fileName));
-      });
-
-    if (!matchedDownload?.file_url) {
-      return;
-    }
-
-    anchor.setAttribute('href', normalizeDownloadUrl(matchedDownload.file_url));
-    anchor.setAttribute('target', '_blank');
-    anchor.setAttribute('rel', 'noopener noreferrer');
-  });
-
-  return doc.body.innerHTML;
 };
 
 const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
@@ -572,7 +521,7 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
 
       if (!hasMarkers) {
         // No markers — render as single block with fallback positions
-        const html = hydrateGeneratedFileLinks(sanitizeHtml(md.render(replacedContent)), reportFileDownloads);
+        const html = sanitizeHtml(hydrateGeneratedFileLinks(sanitizeHtml(md.render(replacedContent)), reportFileDownloads));
         return (
           <>
             <div
@@ -658,7 +607,7 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
       for (let i = 0; i < segments.length; i++) {
         const segment = segments[i].trim();
         if (segment) {
-          const segHtml = hydrateGeneratedFileLinks(sanitizeHtml(md.render(segment)), reportFileDownloads);
+          const segHtml = sanitizeHtml(hydrateGeneratedFileLinks(sanitizeHtml(md.render(segment)), reportFileDownloads));
           elements.push(
             <div
               key={`seg-${i}`}


### PR DESCRIPTION
## 问题
OpsPilot 聊天里，报告或附件下载链接先经过 Markdown 渲染和 DOMPurify 清洗，但随后又会把工具结果里的 `file_url` 回填到无 `href` 的链接上。这样一来，不可信工具结果可以把 `javascript:`、`data:` 或非预期外链塞回页面，用户点击后可能触发 XSS 或跳到非受控下载源。

## 根因
清洗边界和下载链接回填顺序错位：HTML 已清洗完成后，前端又直接信任 `report_file_download` / `generate_attachment_file` 带回来的 `file_url`。下载卡片也使用同一字段，但没有统一的协议和来源校验。

## 怎么修的
新增统一的下载 URL 归一化函数，只保留平台受控下载形态：

```ts
normalizeSafeDownloadUrl(download.file_url)
```

它会把 `/api/v1/` 映射到 `/api/proxy/`，允许同源根路径、同源 `http(s)`、同源 `blob:`，也支持通过 `NEXT_PUBLIC_OPSPILOT_DOWNLOAD_ORIGINS` 配置可信下载域名；危险协议、外站、协议相对 URL、控制字符、反斜杠和带账号密码的 URL 都会被拒绝。聊天正文在回填 `href` 后会再次执行 DOMPurify，下载卡片复用同一校验逻辑。

## 影响范围
改动只在 Web 的 OpsPilot SSE 聊天下载链路内：`custom-chat-sse` 渲染、下载卡片和一个聚焦脚本。后端当前内置附件工具产出的是 `/api/proxy/...`，报告事件走 `content_base64`，这些合法形态保留。若现网确实有外部下载域名，需要配置 `NEXT_PUBLIC_OPSPILOT_DOWNLOAD_ORIGINS` 后再放行。中风险安全收紧，提请 @zhmf7408 review。

## 验证
- `cd web && PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH" pnpm run test:opspilot-download-url-security`：通过，覆盖合法 `/api/v1`/`/api/proxy`/同源/可信域名/同源 blob，以及 `javascript:`、`data:`、外站、协议相对 URL、控制字符、反斜杠、凭据 URL 等拒绝场景。
- `cd web && PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH" pnpm exec eslint src/app/opspilot/components/custom-chat-sse/downloadUrl.ts src/app/opspilot/components/custom-chat-sse/ReportDownloadCard.tsx src/app/opspilot/components/custom-chat-sse/index.tsx --ext .ts,.tsx`：通过。
- `cd web && PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH" pnpm exec eslint scripts/opspilot-download-url-security-test.ts --no-ignore`：通过。
- `cd web && PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH" pnpm lint`：未通过，失败点为既有跨模块 lint 问题，未指向本次改动文件。
- `cd web && PATH="$HOME/.nvm/versions/node/v24.18.0/bin:$PATH" pnpm type-check`：未通过，失败点为 `src/context/locale.tsx` 的 React 18/19 `ReactNode` 类型冲突，未指向本次改动文件。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["handleReportFileDownload / syncAttachmentDownloadFromToolResult\naguiMessageHandler.ts"]
        T2["processHistoricalMessages\nhistoryMessageProcessor.ts"]
    end

    D["reportFileDownloads\n保存 file_url"]

    subgraph N["渲染层"]
        N1["renderContent\nindex.tsx"]
        N2["hydrateGeneratedFileLinks\ndownloadUrl.ts"]
        N3["ReportDownloadCard\nReportDownloadCard.tsx"]
    end

    subgraph S["安全边界"]
        S1["normalizeSafeDownloadUrl\ndownloadUrl.ts"]
        S2["sanitizeHtml\nindex.tsx"]
    end

    T1 --> D
    T2 --> D
    D --> N1 --> N2 --> S1 --> S2
    D --> N3 --> S1
```
