### PR TITLE
Fix web build failures from duplicate network device collect types

### DIFF
--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/firewall.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/firewall.tsx
@@ -81,7 +81,6 @@ export const useFirewallConfig = () => {
       'Firewall Westone SNMP': 'snmp_westone',
       'Firewall Amaranten SNMP': 'snmp_amaranten',
       'Firewall Secworld SNMP': 'snmp_secworld',
-      'Firewall Westone SNMP': 'snmp_westone',
       'Firewall Check Point SNMP': 'snmp_checkpoint',
       'Firewall Stormshield SNMP': 'snmp_stormshield',
       'Firewall Palo Alto SNMP': 'snmp_paloalto',

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/networkService.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/networkService.tsx
@@ -70,7 +70,6 @@ export const useNetworkServiceConfig = () => {
     collectTypes: {
       'NetworkService Infoblox SNMP': 'snmp_infoblox',
       'NetworkService Gigamon SNMP': 'snmp_gigamon',
-      'NetworkService Accedian SNMP': 'snmp_accedian'
       'NetworkService Accedian SNMP': 'snmp_accedian',
       'NetworkService ZDNS SNMP': 'snmp_zdns',
       'NetworkService BlueCat SNMP': 'snmp_bluecat'

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/switch.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/switch.tsx
@@ -163,7 +163,6 @@ export const useSwitchConfig = () => {
       'Switch GarretCom SNMP': 'snmp_garretcom',
       'Switch Enterasys SNMP': 'snmp_enterasys',
       'Switch Cumulus SNMP': 'snmp_cumulus',
-      'Switch Netonix SNMP': 'snmp_netonix',
       'Switch DCN SNMP': 'snmp_dcn',
       'Switch Edgecore SNMP': 'snmp_edgecore',
       'Switch FS SNMP': 'snmp_fs',

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
@@ -58,7 +58,6 @@ export const useWirelessConfig = () => {
       'Wireless EnGenius SNMP': 'snmp_engenius',
       'Wireless Aerohive SNMP': 'snmp_aerohive',
       'Wireless Grandstream SNMP': 'snmp_grandstream',
-      'Wireless ASCOM SNMP': 'snmp_ascom'
       'Wireless ASCOM SNMP': 'snmp_ascom',
       'Wireless Albentia SNMP': 'snmp_albentia'
     }


### PR DESCRIPTION
## 变更内容
- 删除 network device 集成配置里的重复 collectTypes 映射。
- 覆盖 NetworkService、Wireless、Firewall、Switch 四个对象中导致构建/类型检查失败的重复项。

## 根因
SNMP 插件合并后部分 collectTypes 出现重复 key，两个文件还因为重复项缺少分隔逗号触发 Turbopack/TS 解析失败，导致 web 镜像构建中断。

## 验证
- NEXTAPI_INSTALL_APP=monitor pnpm type-check