### PR TITLE
fix(web): declare ace builds dependency

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -54,6 +54,7 @@
     "@antv/x6-react-shape": "^2.2.3",
     "@types/react-resizable": "^3.0.8",
     "@xyflow/react": "^12.8.4",
+    "ace-builds": "1.44.0",
     "aieditor": "^1.4.2",
     "antd": "^5.29.3",
     "axios": "^1.7.7",


### PR DESCRIPTION
## 背景

Web 构建在解析监控 CodeEditor 时失败：`Module not found: Can't resolve 'ace-builds/src-noconflict/mode-python'`。

## 根因

`web/src/app/monitor/components/codeEditor/index.tsx` 直接 import 了 `ace-builds` 的 mode/theme 文件，但顶层 `web/package.json` 只声明了 `react-ace`，没有声明 `ace-builds`。pnpm 依赖隔离下，业务代码不能稳定依赖 `react-ace` 的传递依赖，Turbopack 因此无法解析模块。

## 修改

- 在 `web/package.json` 顶层 dependencies 中补充 `ace-builds@1.44.0`
- lockfile 中已有 `ace-builds@1.44.0` 解析项，因此无需额外 lockfile 变更

## 验证

- `require.resolve('ace-builds/src-noconflict/mode-python')` 通过
- `require.resolve('ace-builds/src-noconflict/mode-toml')` 通过
- `require.resolve('ace-builds/src-noconflict/theme-monokai')` 通过
- `pnpm type-check` 通过
- `pnpm build` 未再出现原 Module not found 错误；本地完整 production build 长时间停在 Turbopack build 阶段，已中断以避免后台进程残留