### PR TITLE
feat(monitor): add DragonWave transmission SNMP plugin

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -4517,6 +4517,9 @@ monitor_object_plugin:
   Transmission Redline SNMP:
     name: Redline (Telegraf)
     desc: Redline broadband wireless transmission SNMP baseline child template for devices under Redline PEN 10728. The shared Transmission SNMP floor supplies MIB-II uptime and IF-MIB 64-bit HC interface traffic. Current MIB facts prove the public enterprise root and private subtrees, but stable private CPU, memory, temperature, fan and power health scalars are not proven, so they are not promoted into shared device-health metrics.
+  Transmission DragonWave SNMP:
+    name: DragonWave (Telegraf)
+    desc: DragonWave microwave transmission SNMP baseline child template for devices under DragonWave PEN 7262. The shared Transmission SNMP floor supplies MIB-II uptime and IF-MIB 64-bit HC interface traffic. Current MIB facts prove the public enterprise root and airPair/horizon product subtrees, but no verified vendor MIB package or device walk proves stable private CPU, memory, temperature, fan or power health scalars, so this brand metrics.json declares no vendor-specific deltas and the private enterprise tree is not collected.
   Transmission Ekinops SNMP:
     name: Ekinops (Telegraf)
     desc: Ekinops WDM, CWDM and DWDM transmission SNMP baseline child template for devices under Ekinops PEN 20044. The shared Transmission SNMP floor supplies MIB-II uptime and IF-MIB 64-bit HC interface traffic. Stable private CPU, memory, temperature, fan and power health scalars are not proven in the current MIB facts, so they are not promoted into shared device-health metrics.

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -4154,6 +4154,9 @@ monitor_object_plugin:
   Transmission Redline SNMP:
     name: Redline（Telegraf）
     desc: Redline 宽带无线传输设备 SNMP 基线子模板（企业号 PEN 10728）。通用 Transmission SNMP 底座提供 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量；当前 MIB 事实只证明公开企业根与私有子树，未证明稳定的私有 CPU、内存、温度、风扇、电源共享健康标量，因此不提升为共享设备健康指标。
+  Transmission DragonWave SNMP:
+    name: DragonWave（Telegraf）
+    desc: DragonWave 微波传输设备 SNMP 基线子模板（企业号 PEN 7262）。通用 Transmission SNMP 底座提供 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量；当前 MIB 事实只证明公开企业根与 airPair/horizon 产品子树，未取得可验证厂商 MIB 包或设备 walk，未证明稳定的私有 CPU、内存、温度、风扇、电源共享健康标量，因此本品牌 metrics.json 不声明厂商增量指标，也不采私有企业树。
   Transmission Ekinops SNMP:
     name: Ekinops（Telegraf）
     desc: Ekinops WDM/CWDM/DWDM 光传输设备 SNMP 基线子模板（企业号 PEN 20044）。通用 Transmission SNMP 底座提供 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量；当前 MIB 事实未证明稳定的私有 CPU、内存、温度、风扇、电源共享健康标量，因此不提升为共享设备健康指标。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
@@ -1,0 +1,28 @@
+{
+  "object_name": "Transmission",
+  "instance_type": "transmission",
+  "collect_type": "snmp_dragonwave",
+  "config_type": ["dragonwave"],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_dragonwave_{{ip}}",
+  "form_fields": [
+    {"name": "ip", "label": "IP", "type": "input", "required": true},
+    {"name": "port", "label": "端口", "type": "inputNumber", "required": true, "default_value": 161},
+    {"name": "version", "label": "版本", "type": "select", "required": true, "default_value": 2, "options": [{"label": "v2c", "value": 2}, {"label": "v3", "value": 3}]},
+    {"name": "community", "label": "团体名", "type": "input", "required": true, "default_value": "public"},
+    {"name": "sec_name", "label": "名称", "type": "input", "required": true},
+    {"name": "sec_level", "label": "级别", "type": "select", "required": true, "default_value": "authPriv", "options": [{"label": "noAuthNoPriv", "value": "noAuthNoPriv"}, {"label": "authNoPriv", "value": "authNoPriv"}, {"label": "authPriv", "value": "authPriv"}]},
+    {"name": "auth_protocol", "label": "认证协议", "type": "input", "required": false, "default_value": "SHA"},
+    {"name": "ENV_AUTH_PASSWORD", "label": "认证密码", "type": "password", "required": false},
+    {"name": "priv_protocol", "label": "加密协议", "type": "input", "required": false, "default_value": "AES"},
+    {"name": "ENV_PRIV_PASSWORD", "label": "加密密码", "type": "password", "required": false},
+    {"name": "timeout", "label": "超时时间", "type": "inputNumber", "required": true, "default_value": 10},
+    {"name": "interval", "label": "间隔", "type": "inputNumber", "required": true, "default_value": 10}
+  ],
+  "table_columns": [
+    {"name": "node_ids", "label": "节点", "type": "select", "required": true, "options_key": "node_ids_option"},
+    {"name": "ip", "label": "IP", "type": "input"},
+    {"name": "instance_name", "label": "实例名称", "type": "input", "required": true},
+    {"name": "group_ids", "label": "组", "type": "group_select", "required": true}
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/dragonwave.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/dragonwave.child.toml.j2
@@ -1,0 +1,49 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_dragonwave"
+        config_type = "dragonwave"
+        brand = "dragonwave"
+
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.31.1.1"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.1"
+        name = "ifDescr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.6"
+        name = "ifHCInOctets"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.10"
+        name = "ifHCOutOctets"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/metrics.json
@@ -1,0 +1,15 @@
+{
+  "collector": "Telegraf",
+  "collect_type": "snmp_dragonwave",
+  "plugin": "Transmission DragonWave SNMP",
+  "plugin_desc": "DragonWave microwave transmission SNMP baseline child template for devices under DragonWave PEN 7262. The available state confirms public enterprise roots and product subtrees, but no verified vendor MIB package or device walk confirms row-filter-free scalar CPU, memory, temperature, fan or power health OIDs. This child declares no vendor-specific metric deltas; uptime, IF-MIB 64-bit interface traffic and aggregate device traffic are supplied by the shared Transmission SNMP floor.",
+  "status_query": "any({instance_type='transmission', collect_type='snmp_dragonwave'}) by (instance_id)",
+  "name": "Transmission",
+  "icon": "mm-dragonwave_dragonwave",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='transmission'}) by (instance_id)",
+  "instance_id_keys": ["instance_id"],
+  "supplementary_indicators": [],
+  "metrics": []
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/policy.json
@@ -1,0 +1,5 @@
+{
+  "object": "Transmission",
+  "plugin": "Transmission DragonWave SNMP",
+  "templates": []
+}

--- a/server/apps/monitor/tests/test_dragonwave_transmission_plugin.py
+++ b/server/apps/monitor/tests/test_dragonwave_transmission_plugin.py
@@ -1,0 +1,224 @@
+"""Contract tests for the DragonWave transmission SNMP plugin."""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+PLUGINS = SERVER_ROOT / "apps" / "monitor" / "support-files" / "plugins" / "Telegraf"
+BRAND_DIR = PLUGINS / "snmp" / "transmission_dragonwave"
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+WEB_ROOT = SERVER_ROOT.parents[0] / "web"
+
+BRAND = "dragonwave"
+COLLECT_TYPE = "snmp_dragonwave"
+CONFIG_TYPE = "dragonwave"
+INSTANCE_TYPE = "transmission"
+PLUGIN_NAME = "Transmission DragonWave SNMP"
+OBJECT_NAME = "Transmission"
+PEN_ROOT = "1.3.6.1.4.1.7262"
+
+BASE_METRICS = (
+    "snmp_uptime",
+    "interface_ifHCInOctets",
+    "interface_ifHCOutOctets",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic",
+)
+UNSUPPORTED_HEALTH_METRICS = (
+    "device_cpu_usage",
+    "device_memory_usage",
+    "device_memory_used",
+    "device_memory_free",
+    "device_temperature_celsius",
+    "device_fan_state",
+    "device_psu_state",
+)
+
+
+def _read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return _read_json(BRAND_DIR / "metrics.json")
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return _read_json(BRAND_DIR / "policy.json")
+
+
+@pytest.fixture(scope="module")
+def ui():
+    return _read_json(BRAND_DIR / "UI.json")
+
+
+@pytest.fixture(scope="module")
+def toml_text():
+    return (BRAND_DIR / f"{CONFIG_TYPE}.child.toml.j2").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_plugin_lives_under_snmp_dir(metrics):
+    assert metrics["collect_type"] == COLLECT_TYPE
+    assert BRAND_DIR.parent.name == "snmp"
+
+
+@pytest.mark.unit
+def test_toml_filename_follows_convention():
+    assert (BRAND_DIR / f"{CONFIG_TYPE}.child.toml.j2").exists()
+
+
+@pytest.mark.unit
+def test_collect_type_consistent_across_files(metrics, policy, ui, toml_text):
+    assert COLLECT_TYPE in metrics["status_query"]
+    assert f"instance_type='{INSTANCE_TYPE}'" in metrics["status_query"]
+    assert ui["collect_type"] == COLLECT_TYPE
+    assert f'collect_type = "{COLLECT_TYPE}"' in toml_text
+    assert metrics["plugin"] == PLUGIN_NAME
+    assert policy["plugin"] == PLUGIN_NAME
+    assert metrics["name"] == OBJECT_NAME
+    assert ui["object_name"] == OBJECT_NAME
+    assert policy["object"] == OBJECT_NAME
+
+
+@pytest.mark.unit
+def test_config_type_consistent(ui, toml_text):
+    assert ui["config_type"] == [CONFIG_TYPE]
+    assert f'config_type = "{CONFIG_TYPE}"' in toml_text
+    assert f'brand = "{BRAND}"' in toml_text
+
+
+@pytest.mark.unit
+def test_ui_is_pure_snmp_form_with_sidecar_secret_fields(ui):
+    fields = {field["name"] for field in ui["form_fields"]}
+    assert "brand" not in fields
+    assert "ENV_AUTH_PASSWORD" in fields
+    assert "ENV_PRIV_PASSWORD" in fields
+    assert "auth_password" not in fields
+    assert "priv_password" not in fields
+
+
+@pytest.mark.unit
+def test_snmpv3_passwords_use_runtime_env_placeholders(toml_text):
+    assert "${AUTH_PASSWORD__{{ config_id }}}" in toml_text
+    assert "${PRIV_PASSWORD__{{ config_id }}}" in toml_text
+    assert "{{ auth_password }}" not in toml_text
+    assert "{{ priv_password }}" not in toml_text
+
+
+@pytest.mark.unit
+def test_private_health_oids_are_not_guessed(metrics, policy, toml_text):
+    names = {m["name"] for m in metrics["metrics"]}
+    for absent in UNSUPPORTED_HEALTH_METRICS:
+        assert absent not in names
+        assert absent not in toml_text
+    assert PEN_ROOT not in toml_text
+    assert policy["templates"] == []
+
+
+@pytest.mark.unit
+def test_metrics_json_is_zero_delta_child(metrics):
+    assert metrics["metrics"] == []
+    assert metrics.get("supplementary_indicators", []) == []
+    names = {m["name"] for m in metrics["metrics"]}
+    assert [name for name in BASE_METRICS if name in names] == []
+
+
+@pytest.mark.unit
+def test_policy_templates_reference_existing_metrics(metrics, policy):
+    known = {m["name"] for m in metrics["metrics"]}
+    bad = [t["metric_name"] for t in policy["templates"] if t["metric_name"] not in known]
+    assert bad == []
+
+
+@pytest.mark.unit
+def test_toml_collects_uptime_and_64bit_ifhc_counters(toml_text):
+    assert "1.3.6.1.2.1.1.3.0" in toml_text
+    assert "1.3.6.1.2.1.31.1.1.1.6" in toml_text
+    assert "1.3.6.1.2.1.31.1.1.1.10" in toml_text
+    assert "1.3.6.1.2.1.2.2.1.10" not in toml_text
+    assert "1.3.6.1.2.1.2.2.1.16" not in toml_text
+
+
+@pytest.mark.unit
+def test_no_enum_block_without_status_health_metrics(toml_text):
+    assert "processors.enum" not in toml_text
+
+
+@pytest.mark.unit
+def test_plugin_has_bilingual_name_and_desc(languages):
+    for lang, data in languages.items():
+        entry = (data.get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+        assert entry.get("name"), f"{lang}: plugin name missing"
+        assert entry.get("desc"), f"{lang}: plugin desc missing"
+
+
+@pytest.mark.unit
+def test_en_desc_has_no_halfwidth_colon_space(languages):
+    en = (languages["en"].get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+    assert ": " not in en.get("desc", "")
+
+
+@pytest.mark.unit
+def test_frontend_collecttype_wired_to_transmission_object():
+    tsx = (
+        WEB_ROOT / "src" / "app" / "monitor" / "hooks" / "integration"
+        / "objects" / "networkDevice" / "transmission.tsx"
+    )
+    text = tsx.read_text(encoding="utf-8")
+    assert f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'" in text
+    assert text.count(f"'{PLUGIN_NAME}':") == 1
+    assert text.count(f"'{COLLECT_TYPE}'") == 1
+
+
+@pytest.mark.unit
+def test_brand_label_present_in_common_without_generic_terms():
+    common = WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx"
+    text = common.read_text(encoding="utf-8")
+    assert "DragonWave" in text
+    assert "mm-dragonwave_dragonwave" in text
+    assert text.count("label: 'DragonWave'") == 1
+    assert text.count("mm-dragonwave_dragonwave") == 1
+    assert "horizon" not in text.lower()
+
+
+@pytest.mark.unit
+def test_brand_svg_exists():
+    assert (WEB_ROOT / "public" / "assets" / "icons" / "mm-dragonwave_dragonwave.svg").exists()
+
+
+@pytest.mark.unit
+def test_brand_files_have_no_external_source_residue():
+    forbidden = [
+        "Data" + "dog",
+        "Libre" + "NMS",
+        "Zab" + "bix",
+        "Check" + "mk",
+        "Open" + "NMS",
+        "snmp_" + "exporter",
+        "Observ" + "ium",
+        "Solar" + "Winds",
+        "Manage" + "Engine",
+    ]
+    paths = list(BRAND_DIR.glob("*")) + [
+        WEB_ROOT / "public" / "assets" / "icons" / "mm-dragonwave_dragonwave.svg"
+    ]
+    offenders = {
+        path.name: [word for word in forbidden if word in path.read_text(encoding="utf-8")]
+        for path in paths
+        if path.is_file()
+    }
+    offenders = {name: words for name, words in offenders.items() if words}
+    assert offenders == {}

--- a/web/public/assets/icons/mm-dragonwave_dragonwave.svg
+++ b/web/public/assets/icons/mm-dragonwave_dragonwave.svg
@@ -1,0 +1,7 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="14" fill="#0E2A47"/>
+  <path d="M13 39C20 27 28 27 35 39C40 47 47 46 52 35" stroke="#4FD6FF" stroke-width="5" stroke-linecap="round"/>
+  <path d="M13 28C20 16 28 16 35 28C40 36 47 35 52 24" stroke="#FFB84D" stroke-width="5" stroke-linecap="round"/>
+  <circle cx="18" cy="47" r="3" fill="#4FD6FF"/>
+  <circle cx="46" cy="17" r="3" fill="#FFB84D"/>
+</svg>

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/transmission.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/transmission.tsx
@@ -71,6 +71,7 @@ export const useTransmissionConfig = () => {
       'Transmission Viavi SNMP': 'snmp_viavi',
       'Transmission Sycamore SNMP': 'snmp_sycamore',
       'Transmission Redline SNMP': 'snmp_redline',
+      'Transmission DragonWave SNMP': 'snmp_dragonwave',
       'Transmission Ekinops SNMP': 'snmp_ekinops',
       'Transmission Infinera SNMP': 'snmp_infinera',
       'Transmission BridgeWave SNMP': 'snmp_bridgewave',

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -764,6 +764,7 @@ const BRANDS: { match: RegExp; label: string; icon?: string }[] = [
   { match: /viavi|jdsu|acterna/i, label: 'Viavi', icon: 'mm-viavi_viavi' },
   { match: /sycamore/i, label: 'Sycamore', icon: 'mm-sycamore_sycamore' },
   { match: /\bredline\b/i, label: 'Redline', icon: 'mm-redline_redline' },
+  { match: /dragon\s*wave|dragonwave|airpair/i, label: 'DragonWave', icon: 'mm-dragonwave_dragonwave' },
   { match: /ekinops/i, label: 'Ekinops', icon: 'mm-ekinops_ekinops' },
   { match: /infinera|coriant|groove/i, label: 'Infinera', icon: 'mm-infinera_infinera' },
   { match: /bridgewave|flexport|fe80/i, label: 'BridgeWave', icon: 'mm-bridgewave_bridgewave' },


### PR DESCRIPTION
## Summary
- add the DragonWave transmission SNMP baseline plugin
- wire the Transmission collect type, brand mapping, bilingual plugin text, and brand icon
- add DragonWave contract tests covering SNMPv3 secret envs, zero-delta metrics, 64-bit ifHC counters, and frontend wiring

## Testing
- /Users/fanzhongming/workspace/Weops/lite/bk-lite-snmp/server/.venv/bin/python -m pytest /private/tmp/bk-lite-snmp-dragonwave-release/server/apps/monitor/tests/test_dragonwave_transmission_plugin.py --noconftest -o addopts='' -q
- /Users/fanzhongming/workspace/Weops/lite/bk-lite-snmp/server/.venv/bin/python -m pytest /private/tmp/bk-lite-snmp-dragonwave-release/server/apps/monitor/tests/test_dragonwave_transmission_plugin.py --noconftest --collect-only -o addopts='' -q
- git -C /private/tmp/bk-lite-snmp-dragonwave-release diff --check HEAD^ HEAD --