### PR TITLE
test: harden Antaira switch SNMP plugin contract

### DIFF
--- a/server/apps/monitor/tests/test_antaira_switch_plugin.py
+++ b/server/apps/monitor/tests/test_antaira_switch_plugin.py
@@ -203,14 +203,19 @@ def test_frontend_collecttype_wired_to_switch_object():
     )
     text = switch_tsx.read_text(encoding="utf-8")
     assert f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'" in text
+    assert text.count(f"'{PLUGIN_NAME}':") == 1
+    assert text.count(f"'{COLLECT_TYPE}'") == 1
 
 
 @pytest.mark.unit
-def test_brand_match_and_icon_present_in_common():
+def test_brand_match_and_icon_present_once_in_common():
     common = WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx"
     text = common.read_text(encoding="utf-8")
-    assert BRAND in text
+    assert "label: 'Antaira'" in text
     assert "mm-antaira_antaira" in text
+    assert text.count("label: 'Antaira'") == 1
+    assert text.count("mm-antaira_antaira") == 1
+    assert "antaira|switch" not in text.lower()
     assert (WEB_ROOT / "public" / "assets" / "icons" / "mm-antaira_antaira.svg").exists()
 
 


### PR DESCRIPTION
## Summary
- harden the Antaira switch SNMP contract test with mapping uniqueness and false-positive guards
- keep the Antaira plugin as a conservative baseline child with zero vendor metric deltas
- re-verify the Antaira contract on the release branch before opening this PR

## Validation
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/fanzhongming/workspace/Weops/lite/bk-lite-snmp/server/.venv/bin/python -m pytest /private/tmp/bk-lite-snmp-antaira-release/server/apps/monitor/tests/test_antaira_switch_plugin.py --noconftest -o addopts= -q
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /Users/fanzhongming/workspace/Weops/lite/bk-lite-snmp/server/.venv/bin/python -m pytest /private/tmp/bk-lite-snmp-antaira-release/server/apps/monitor/tests/test_antaira_switch_plugin.py --noconftest -o addopts= --collect-only -q
- git -C /private/tmp/bk-lite-snmp-antaira-release diff --check d6074322ed4def2e6313d5f7ed51654bfb921cfa..HEAD --