### PR TITLE
fix(web): 修复 Studio 日志页时间筛选初始值与控件显示不一致

### DIFF
--- a/web/src/app/opspilot/(pages)/studio/detail/logInfo/page.tsx
+++ b/web/src/app/opspilot/(pages)/studio/detail/logInfo/page.tsx
@@ -13,6 +13,7 @@ import { LogRecord, Channel, WorkflowTaskResult, WorkflowExecutionDetailItem } f
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { fetchLogDetails, createConversation } from '@/app/opspilot/utils/logUtils';
 import { useStudioApi } from '@/app/opspilot/api/studio';
+import dayjs from 'dayjs';
 
 const { Search } = Input;
 
@@ -22,7 +23,10 @@ const StudioLogsPage: React.FC = () => {
   const { fetchLogs, fetchChannels, fetchBotDetail, fetchWorkflowTaskResult, fetchWorkflowLogs, fetchExecutionOutputData, fetchExecutionDetail } = useStudioApi();
   const { convertToLocalizedTime } = useLocalizedTime();
   const [searchText, setSearchText] = useState('');
-  const [dates, setDates] = useState<number[]>([]);
+  const [dates, setDates] = useState<number[]>([
+    dayjs().subtract(1440, 'minute').valueOf(),
+    dayjs().valueOf(),
+  ]);
   const [data, setData] = useState<LogRecord[] | WorkflowTaskResult[]>([]);
   const [loading, setLoading] = useState(false);
   const [channels, setChannels] = useState<Channel[]>([]);


### PR DESCRIPTION
时间控件默认显示「最近1天」，但 dates 状态初始化为空数组，
导致刷新时未带时间范围而加载全部数据。

将 dates 初始值对齐为当前时间前 1440 分钟至当前时间。