### PR TITLE
bugfix: 避免 Linux sidecar token 暴露在 argv

### DIFF
--- a/agents/fusion-collector/misc/linux/install.sh
+++ b/agents/fusion-collector/misc/linux/install.sh
@@ -10,7 +10,7 @@ show_usage() {
     echo ""
     echo "参数说明:"
     echo "  server_url       - 服务器URL"
-    echo "  server_api_token - 服务器API令牌"
+    echo "  server_api_token - 服务器API令牌；setup-worker 可通过 BK_LITE_SERVER_API_TOKEN_FILE 安全传入"
     echo "  zone             - 云区域"
     echo "  teams           - 分组信息"
     echo "  node_name        - 节点名称 (可选)"
@@ -32,6 +32,22 @@ check_args() {
     if [ $# -lt 4 ] || [ $# -gt 7 ]; then
         show_usage
     fi
+}
+
+load_server_api_token() {
+    local token_arg="$1"
+
+    if [ -n "${BK_LITE_SERVER_API_TOKEN_FILE:-}" ]; then
+        if [ ! -r "$BK_LITE_SERVER_API_TOKEN_FILE" ]; then
+            echo "错误: 无法读取 server_api_token 文件"
+            exit 1
+        fi
+        SERVER_API_TOKEN=$(cat "$BK_LITE_SERVER_API_TOKEN_FILE")
+        rm -f -- "$BK_LITE_SERVER_API_TOKEN_FILE"
+        return
+    fi
+
+    SERVER_API_TOKEN=$token_arg
 }
 
 # 安装服务
@@ -94,7 +110,7 @@ main() {
 
     # 解析参数
     SERVER_URL=$1
-    SERVER_API_TOKEN=$2
+    load_server_api_token "$2"
     ZONE=$3
     TEAMS=$4
     NODE_NAME=""

--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -439,20 +439,64 @@ func runLinuxInstaller(cfg *Config) error {
 	if err := os.Chmod(installScript, 0755); err != nil {
 		return err
 	}
+
+	apiTokenArg, apiTokenEnv, cleanup, err := linuxInstallerAPITokenInputs(cfg.InstallDir, cfg.APIToken)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
 	cmd := exec.Command(
 		installScript,
 		cfg.ServerURL,
-		cfg.APIToken,
+		apiTokenArg,
 		cfg.ZoneID,
 		cfg.GroupID,
 		cfg.NodeName,
 		cfg.NodeID,
 		cfg.Package.CPUArchitecture,
 	)
+	if apiTokenEnv != "" {
+		cmd.Env = append(os.Environ(), apiTokenEnv)
+	}
 	cmd.Dir = cfg.InstallDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+func linuxInstallerAPITokenInputs(installDir, apiToken string) (string, string, func(), error) {
+	cleanup := func() {}
+	if apiToken == "" {
+		return "", "", cleanup, nil
+	}
+
+	file, err := os.CreateTemp(installDir, ".server-api-token-*")
+	if err != nil {
+		return "", "", cleanup, fmt.Errorf("create API token file: %w", err)
+	}
+	tokenFile := file.Name()
+	cleanup = func() {
+		_ = os.Remove(tokenFile)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	if err := file.Chmod(0600); err != nil {
+		cleanup()
+		return "", "", cleanup, fmt.Errorf("restrict API token file: %w", err)
+	}
+	if _, err := file.WriteString(apiToken); err != nil {
+		cleanup()
+		return "", "", cleanup, fmt.Errorf("write API token file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", "", cleanup, fmt.Errorf("close API token file: %w", err)
+	}
+
+	return "", "BK_LITE_SERVER_API_TOKEN_FILE=" + tokenFile, cleanup, nil
 }
 
 func printConfig(cfg *Config) {

--- a/agents/sidecar-installer/setup-worker_test.go
+++ b/agents/sidecar-installer/setup-worker_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -86,4 +88,101 @@ func TestClassifyDownloadErrorDetectsIOTimeout(t *testing.T) {
 	if got := classifyDownloadError(errors.New("Download failed: read pipe: i/o timeout")); got != "timeout" {
 		t.Fatalf("expected timeout, got %q", got)
 	}
+}
+
+func TestRunLinuxInstallerDoesNotExposeAPITokenInArgv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script test is only for Unix-like systems")
+	}
+
+	installDir := t.TempDir()
+	token := "issue-3842-secret-token"
+	installScript := filepath.Join(installDir, "install.sh")
+	script := `#!/bin/sh
+set -eu
+for arg in "$@"; do
+    printf '<%s>\n' "$arg"
+done > argv.txt
+printf '%s' "$BK_LITE_SERVER_API_TOKEN_FILE" > token-file-path.txt
+stat -f '%Lp' "$BK_LITE_SERVER_API_TOKEN_FILE" > token-file-mode.txt 2>/dev/null || stat -c '%a' "$BK_LITE_SERVER_API_TOKEN_FILE" > token-file-mode.txt
+cat "$BK_LITE_SERVER_API_TOKEN_FILE" > token-value.txt
+`
+	if err := os.WriteFile(installScript, []byte(script), 0644); err != nil {
+		t.Fatalf("write install.sh: %v", err)
+	}
+
+	cfg := &Config{
+		ServerURL:  "https://bk.example",
+		APIToken:   token,
+		ZoneID:     "zone-a",
+		GroupID:    "group-a",
+		NodeName:   "node-a",
+		NodeID:     "node-1",
+		InstallDir: installDir,
+		Package: PackageConfig{
+			CPUArchitecture: "x86_64",
+		},
+	}
+
+	if err := runLinuxInstaller(cfg); err != nil {
+		t.Fatalf("runLinuxInstaller: %v", err)
+	}
+
+	argv := readTestFile(t, filepath.Join(installDir, "argv.txt"))
+	if strings.Contains(argv, token) {
+		t.Fatalf("API token leaked through argv: %q", argv)
+	}
+
+	args := strings.Split(strings.TrimSpace(argv), "\n")
+	wantArgs := []string{"<https://bk.example>", "<>", "<zone-a>", "<group-a>", "<node-a>", "<node-1>", "<x86_64>"}
+	if !equalStringSlices(args, wantArgs) {
+		t.Fatalf("unexpected argv\nwant: %#v\n got: %#v", wantArgs, args)
+	}
+
+	if got := readTestFile(t, filepath.Join(installDir, "token-value.txt")); got != token {
+		t.Fatalf("install script did not receive API token, got %q", got)
+	}
+	tokenFilePath := readTestFile(t, filepath.Join(installDir, "token-file-path.txt"))
+	if strings.Contains(tokenFilePath, token) {
+		t.Fatalf("token file path contains token: %q", tokenFilePath)
+	}
+	if _, err := os.Stat(tokenFilePath); !os.IsNotExist(err) {
+		t.Fatalf("expected token file to be cleaned up, stat error: %v", err)
+	}
+	mode := readTestFile(t, filepath.Join(installDir, "token-file-mode.txt"))
+	if mode != "600" {
+		t.Fatalf("expected token file mode 600, got %q", mode)
+	}
+}
+
+func TestLinuxInstallerAPITokenInputsKeepsEmptyTokenOnArgv(t *testing.T) {
+	arg, env, cleanup, err := linuxInstallerAPITokenInputs(t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("linuxInstallerAPITokenInputs: %v", err)
+	}
+	defer cleanup()
+	if arg != "" || env != "" {
+		t.Fatalf("empty token should not create env/file inputs, got arg=%q env=%q", arg, env)
+	}
+}
+
+func readTestFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## 问题

Linux sidecar 安装时，`setup-worker` 会再调用本地的 `install.sh`。这一步原来把 API token 当作第二个命令行参数传进去，同机用户或进程采集只要看到 argv，就可能在安装窗口内读到这个 token。

关联 Issue #3842。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["runLinuxInstaller\nsetup-worker.go"]
    end

    subgraph S["凭据传递层"]
        F1["linuxInstallerAPITokenInputs\nsetup-worker.go"]
        F2["0600 临时 token 文件\ninstall dir"]
    end

    subgraph I["安装脚本层"]
        I1["load_server_api_token\ninstall.sh"]
        I2["写入 sidecar.yml\ninstall.sh"]
    end

    T1 --> F1 --> F2
    F1 --> T1
    T1 --> I1 --> I2
    I1 -. "读取后清理" .-> F2
```

## 根因

外层安装命令已经避免把敏感信息直接暴露出来，但 worker 到 `install.sh` 的本地二段调用没有延续这个边界，仍然把 token 放进 argv。argv 不是日志问题，而是进程元数据问题，不能只靠不打印来规避。

## 怎么修的

`setup-worker` 在 Linux 安装前创建一个权限为 `0600` 的临时 token 文件，调用 `install.sh` 时第二个参数保留为空占位，只通过非敏感环境变量传 token 文件路径。

```go
apiTokenArg, apiTokenEnv, cleanup, err := linuxInstallerAPITokenInputs(cfg.InstallDir, cfg.APIToken)
defer cleanup()
cmd := exec.Command(installScript, cfg.ServerURL, apiTokenArg, cfg.ZoneID, cfg.GroupID, cfg.NodeName, cfg.NodeID, cfg.Package.CPUArchitecture)
```

`install.sh` 优先从 `BK_LITE_SERVER_API_TOKEN_FILE` 指向的文件读取 token，并在读取后清理；没有该环境变量时仍按原来的 `$2` 参数读取，保留手工执行脚本的旧入口。

## 影响范围

改动只涉及 Linux sidecar 安装链路：`agents/sidecar-installer/setup-worker.go` 和 `agents/fusion-collector/misc/linux/install.sh`。Windows 安装配置生成逻辑没有调整，server 生成外层安装命令的逻辑也没有调整。这里属于凭据传递加固，PR 已按中风险处理，等待人工 review。

## 验证

- `bash -n agents/fusion-collector/misc/linux/install.sh` 通过。
- `git diff --check` 通过。
- 新增 `TestRunLinuxInstallerDoesNotExposeAPITokenInArgv`，断言真实执行假 `install.sh` 时 token 不出现在 argv、token 文件权限为 `600`、脚本能读取到 token 且临时文件会被清理。把本次 `runLinuxInstaller` 修复回退后，该测试会因为 argv 含 token 或缺少 token 文件而失败。
- 本地 `go test ./...` 未能执行：当前机器只有 Go 1.16.3，无法解析模块中的 `go 1.23.0` 与 `toolchain` 指令。
