### PR TITLE
bugfix: restrict ansible executor callback subjects

### DIFF
--- a/agents/ansible-executor/README.md
+++ b/agents/ansible-executor/README.md
@@ -115,6 +115,14 @@ runtime:
   work_dir: /var/lib/ansible-executor/work
   state_db_path: /var/lib/ansible-executor/task_state.db
 
+security:
+  allowed_callback_subjects:
+    - job.ansible_task_callback
+  allowed_stream_subjects:
+    - job.stream.>
+    - executor.stream.>
+    - bk.ans_exec.stream.>
+
 jetstream:
   namespace: bk.ans_exec
   max_deliver: 5
@@ -122,6 +130,9 @@ jetstream:
   backoff: [5, 15, 30, 60]
   dlq_subject: bk.ans_exec.tasks.dlq
 ```
+
+`security.allowed_callback_subjects` 和 `security.allowed_stream_subjects` 也可分别通过
+`ANSIBLE_ALLOWED_CALLBACK_SUBJECTS`、`ANSIBLE_ALLOWED_STREAM_SUBJECTS` 以逗号分隔形式注入；仅在部署确有自定义回调或流式日志 subject 时扩展。
 
 兼容的环境变量模式仍保留，便于迁移，但不再推荐作为主配置方式。
 

--- a/agents/ansible-executor/config.example.yml
+++ b/agents/ansible-executor/config.example.yml
@@ -14,6 +14,17 @@ runtime:
   work_dir: /var/lib/ansible-executor/work
   state_db_path: /var/lib/ansible-executor/task_state.db
 
+security:
+  # Callback subjects are NATS request targets used by the executor to report task results.
+  # Keep this list narrow; append deployment-specific callback prefixes only after review.
+  allowed_callback_subjects:
+    - job.ansible_task_callback
+  # Stream subjects are publish targets used for line-by-line command output.
+  allowed_stream_subjects:
+    - job.stream.>
+    - executor.stream.>
+    - bk.ans_exec.stream.>
+
 jetstream:
   namespace: bk.ans_exec
   # stream: BK_ANS_EXEC_TASKS

--- a/agents/ansible-executor/core/config.py
+++ b/agents/ansible-executor/core/config.py
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ServiceConfig:
+    DEFAULT_ALLOWED_CALLBACK_SUBJECTS = ["job.ansible_task_callback"]
+    DEFAULT_ALLOWED_STREAM_SUBJECTS = ["job.stream.>", "executor.stream.>", "bk.ans_exec.stream.>"]
+
     nats_servers: list[str]
     nats_instance_id: str
     nats_username: str = ""
@@ -33,6 +36,14 @@ class ServiceConfig:
     js_backoff: list[int] | None = None
     dlq_subject: str = "ansible.tasks.dlq"
     state_db_path: str = "/tmp/ansible-executor/task_state.db"
+    allowed_callback_subjects: list[str] | None = None
+    allowed_stream_subjects: list[str] | None = None
+
+    def __post_init__(self):
+        if self.allowed_callback_subjects is None:
+            self.allowed_callback_subjects = list(self.DEFAULT_ALLOWED_CALLBACK_SUBJECTS)
+        if self.allowed_stream_subjects is None:
+            self.allowed_stream_subjects = list(self.DEFAULT_ALLOWED_STREAM_SUBJECTS)
 
 
 def _render_env_vars(value: str) -> str:
@@ -119,6 +130,14 @@ def load_config(path: str | None = None) -> ServiceConfig:
     state_db_path_fallback = os.getenv("ANSIBLE_STATE_DB_PATH", "/tmp/ansible-executor/task_state.db")
     callback_timeout_fallback = os.getenv("ANSIBLE_CALLBACK_TIMEOUT", "10")
     ansible_work_dir_fallback = os.getenv("ANSIBLE_WORK_DIR", "/tmp/ansible-executor")
+    allowed_callback_subjects_fallback = os.getenv(
+        "ANSIBLE_ALLOWED_CALLBACK_SUBJECTS",
+        ",".join(ServiceConfig.DEFAULT_ALLOWED_CALLBACK_SUBJECTS),
+    )
+    allowed_stream_subjects_fallback = os.getenv(
+        "ANSIBLE_ALLOWED_STREAM_SUBJECTS",
+        ",".join(ServiceConfig.DEFAULT_ALLOWED_STREAM_SUBJECTS),
+    )
 
     nats_servers_raw = _pick_value(
         data,
@@ -319,6 +338,20 @@ def load_config(path: str | None = None) -> ServiceConfig:
         ).strip()
         or state_db_path_fallback
     )
+    allowed_callback_subjects = _parse_string_list(
+        _pick_value(
+            data,
+            [("allowed_callback_subjects",), ("security", "allowed_callback_subjects")],
+            allowed_callback_subjects_fallback,
+        )
+    )
+    allowed_stream_subjects = _parse_string_list(
+        _pick_value(
+            data,
+            [("allowed_stream_subjects",), ("security", "allowed_stream_subjects")],
+            allowed_stream_subjects_fallback,
+        )
+    )
 
     return ServiceConfig(
         nats_servers=nats_servers,
@@ -339,4 +372,6 @@ def load_config(path: str | None = None) -> ServiceConfig:
         js_backoff=js_backoff,
         dlq_subject=dlq_subject,
         state_db_path=state_db_path,
+        allowed_callback_subjects=allowed_callback_subjects,
+        allowed_stream_subjects=allowed_stream_subjects,
     )

--- a/agents/ansible-executor/service/nats_service.py
+++ b/agents/ansible-executor/service/nats_service.py
@@ -60,6 +60,24 @@ def _build_queue_safe_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     return sanitized or {}
 
 
+def _subject_matches(subject: str, allowed_subjects: list[str] | None) -> bool:
+    if not subject or any(char.isspace() for char in subject):
+        return False
+
+    for raw_pattern in allowed_subjects or []:
+        pattern = str(raw_pattern).strip()
+        if not pattern:
+            continue
+        if pattern.endswith(".>"):
+            prefix = pattern[:-1]
+            if subject.startswith(prefix):
+                return True
+            continue
+        if subject == pattern:
+            return True
+    return False
+
+
 class AnsibleNATSService:
     CALLBACK_PAYLOAD_MARGIN_BYTES = 4 * 1024
     CALLBACK_RESULT_TEXT_MAX_CHARS = 8 * 1024
@@ -145,6 +163,14 @@ class AnsibleNATSService:
         max_payload = int(getattr(self.nc, "max_payload", 1024 * 1024) or 1024 * 1024)
         max_bytes = max(1024, max_payload - self.CALLBACK_PAYLOAD_MARGIN_BYTES)
         return self._compact_callback_payload(payload, max_bytes)
+
+    def _validate_callback_subject(self, subject: str):
+        if not _subject_matches(subject, self.config.allowed_callback_subjects):
+            raise ValueError(f"callback subject is not allowed: {subject}")
+
+    def _validate_stream_subject(self, subject: str):
+        if not _subject_matches(subject, self.config.allowed_stream_subjects):
+            raise ValueError(f"stream subject is not allowed: {subject}")
 
     @staticmethod
     def _build_accepted(task_id: str, duplicate: bool = False) -> bytes:
@@ -382,6 +408,7 @@ class AnsibleNATSService:
             return
         if not subject:
             subject = f"{namespace}.{method_name}.{instance_id}" if instance_id else f"{namespace}.{method_name}"
+        self._validate_callback_subject(subject)
 
         timeout = int(callback.get("timeout", self.config.callback_timeout))
         request_payload = json.dumps({"args": [payload], "kwargs": {}}, ensure_ascii=False).encode("utf-8")
@@ -500,15 +527,18 @@ class AnsibleNATSService:
 
         stream_log_topic = execution_payload.get("stream_log_topic")
         execution_id = execution_payload.get("execution_id")
-        stream_kwargs: dict[str, Any] = {}
-        if stream_log_topic and execution_id:
-            stream_kwargs = {
-                "stream_publish": lambda subject, data: self.nc.publish(subject, data),
-                "stream_log_topic": str(stream_log_topic),
-                "execution_id": str(execution_id),
-            }
 
         try:
+            stream_kwargs: dict[str, Any] = {}
+            if stream_log_topic and execution_id:
+                stream_subject = str(stream_log_topic).strip()
+                self._validate_stream_subject(stream_subject)
+                stream_kwargs = {
+                    "stream_publish": lambda subject, data: self.nc.publish(subject, data),
+                    "stream_log_topic": stream_subject,
+                    "execution_id": str(execution_id),
+                }
+
             if task.task_type == "adhoc":
                 request = to_adhoc_request(execution_payload)
                 cmd, workspace = prepare_adhoc_execution(request)

--- a/agents/ansible-executor/tests/test_config.py
+++ b/agents/ansible-executor/tests/test_config.py
@@ -1,0 +1,44 @@
+from core.config import ServiceConfig, load_config
+
+
+def test_service_config_uses_default_subject_allowlists():
+    config = ServiceConfig(nats_servers=["nats://127.0.0.1:4222"], nats_instance_id="default")
+
+    assert config.allowed_callback_subjects == ["job.ansible_task_callback"]
+    assert config.allowed_stream_subjects == ["job.stream.>", "executor.stream.>", "bk.ans_exec.stream.>"]
+
+
+def test_load_config_reads_subject_allowlists_from_yaml(tmp_path):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(
+        """
+nats:
+  servers:
+    - nats://127.0.0.1:4222
+  instance_id: default
+security:
+  allowed_callback_subjects:
+    - job.ansible_task_callback
+    - bklite.safe_callback.>
+  allowed_stream_subjects:
+    - job.stream.>
+    - executor.stream.>
+""",
+        encoding="utf-8",
+    )
+
+    config = load_config(str(config_file))
+
+    assert config.allowed_callback_subjects == ["job.ansible_task_callback", "bklite.safe_callback.>"]
+    assert config.allowed_stream_subjects == ["job.stream.>", "executor.stream.>"]
+
+
+def test_load_config_reads_subject_allowlists_from_env(monkeypatch):
+    monkeypatch.setenv("NATS_SERVERS", "nats://127.0.0.1:4222")
+    monkeypatch.setenv("ANSIBLE_ALLOWED_CALLBACK_SUBJECTS", "job.ansible_task_callback,bklite.safe_callback.>")
+    monkeypatch.setenv("ANSIBLE_ALLOWED_STREAM_SUBJECTS", "job.stream.>,executor.stream.>")
+
+    config = load_config()
+
+    assert config.allowed_callback_subjects == ["job.ansible_task_callback", "bklite.safe_callback.>"]
+    assert config.allowed_stream_subjects == ["job.stream.>", "executor.stream.>"]

--- a/agents/ansible-executor/tests/test_nats_service.py
+++ b/agents/ansible-executor/tests/test_nats_service.py
@@ -43,8 +43,10 @@ class DummyNATSClient:
     def __init__(self, payload, max_payload=1024 * 1024):
         self.payload = payload
         self.max_payload = max_payload
+        self.requests = []
 
     async def request(self, subject, request_payload, timeout):
+        self.requests.append((subject, request_payload, timeout))
         return DummyNATSResponse(self.payload)
 
 
@@ -206,6 +208,46 @@ async def test_invoke_callback_rejects_non_object_response(tmp_path):
 
     with pytest.raises(ValueError, match="non-object"):
         await service._invoke_callback({"subject": "job.ansible_task_callback"}, {"task_id": "task-6"})
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_rejects_untrusted_subject_before_request(tmp_path):
+    service = AnsibleNATSService(
+        ServiceConfig(
+            nats_servers=["nats://127.0.0.1:4222"],
+            nats_instance_id="default",
+            js_stream="BK_ANS_EXEC_TASKS",
+            js_subject_prefix="bk.ans_exec.tasks",
+            js_durable="ansible-executor",
+            state_db_path=str(tmp_path / "task.db"),
+        )
+    )
+    service.nc = DummyNATSClient({"success": True})
+
+    with pytest.raises(ValueError, match="callback subject is not allowed"):
+        await service._invoke_callback({"subject": "system_mgmt.delete_user"}, {"task_id": "task-bad"})
+
+    assert service.nc.requests == []
+
+
+@pytest.mark.asyncio
+async def test_invoke_callback_allows_configured_subject_pattern(tmp_path):
+    service = AnsibleNATSService(
+        ServiceConfig(
+            nats_servers=["nats://127.0.0.1:4222"],
+            nats_instance_id="default",
+            js_stream="BK_ANS_EXEC_TASKS",
+            js_subject_prefix="bk.ans_exec.tasks",
+            js_durable="ansible-executor",
+            state_db_path=str(tmp_path / "task.db"),
+            allowed_callback_subjects=["job.ansible_task_callback", "bklite.safe_callback.>"],
+        )
+    )
+    service.nc = DummyNATSClient({"success": True})
+
+    await service._invoke_callback({"subject": "bklite.safe_callback.result"}, {"task_id": "task-safe"})
+
+    assert service.nc.requests[0][0] == "bklite.safe_callback.result"
 
 
 @pytest.mark.asyncio
@@ -470,6 +512,84 @@ async def test_run_task_forwards_stream_context_to_run_command(tmp_path, monkeyp
     assert callable(captured["stream_publish"])
     # The publisher wrapper routes to the core NATS publish on self.nc.
     assert service.nc.published == [("bk.ans_exec.stream.exec-9", b'{"line": "hi"}')]
+
+
+@pytest.mark.asyncio
+async def test_run_task_rejects_untrusted_stream_topic_before_publish(tmp_path, monkeypatch):
+    service = _make_service(tmp_path)
+    service.nc = RecordingNATSClient()
+
+    calls = {"run": 0}
+
+    monkeypatch.setattr("service.nats_service.to_adhoc_request", lambda payload: type("R", (), {"execute_timeout": 60})())
+    monkeypatch.setattr("service.nats_service.prepare_adhoc_execution", lambda request: (["echo", "hi"], None))
+    monkeypatch.setattr("service.nats_service.cleanup_workspace", lambda workspace: None)
+
+    async def fake_run_command(cmd, timeout, **kwargs):
+        calls["run"] += 1
+        return 0, "hi", {"truncated": False, "output_bytes_total": 2, "output_bytes_retained": 2, "output_max_bytes": 0}
+
+    monkeypatch.setattr("service.nats_service.run_command", fake_run_command)
+    monkeypatch.setattr(service.task_store, "update_execution_result", lambda *a, **k: True)
+    monkeypatch.setattr(service.task_store, "update_callback_status", lambda *a, **k: True)
+
+    task = QueuedTask(
+        task_id="task-stream-bad",
+        task_type="adhoc",
+        payload={
+            "task_id": "task-stream-bad",
+            "stream_log_topic": "system_mgmt.delete_user",
+            "execution_id": "exec-bad",
+        },
+        callback=None,
+        instance_id="default",
+    )
+
+    result = await service._run_task(task, "owner-a")
+
+    assert calls["run"] == 0
+    assert service.nc.published == []
+    assert result["success"] is False
+    assert "stream subject is not allowed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_run_task_allows_executor_stream_topic(tmp_path, monkeypatch):
+    service = _make_service(tmp_path)
+    service.nc = RecordingNATSClient()
+
+    captured = {}
+
+    monkeypatch.setattr("service.nats_service.to_adhoc_request", lambda payload: type("R", (), {"execute_timeout": 60})())
+    monkeypatch.setattr("service.nats_service.prepare_adhoc_execution", lambda request: (["echo", "hi"], None))
+    monkeypatch.setattr("service.nats_service.cleanup_workspace", lambda workspace: None)
+
+    async def fake_run_command(cmd, timeout, **kwargs):
+        captured.update(kwargs)
+        if kwargs.get("stream_publish") and kwargs.get("stream_log_topic"):
+            await kwargs["stream_publish"](kwargs["stream_log_topic"], b'{"line": "ok"}')
+        return 0, "ok", {"truncated": False, "output_bytes_total": 2, "output_bytes_retained": 2, "output_max_bytes": 0}
+
+    monkeypatch.setattr("service.nats_service.run_command", fake_run_command)
+    monkeypatch.setattr(service.task_store, "update_execution_result", lambda *a, **k: True)
+    monkeypatch.setattr(service.task_store, "update_callback_status", lambda *a, **k: True)
+
+    task = QueuedTask(
+        task_id="task-stream-executor",
+        task_type="adhoc",
+        payload={
+            "task_id": "task-stream-executor",
+            "stream_log_topic": "executor.stream.exec-9",
+            "execution_id": "exec-9",
+        },
+        callback=None,
+        instance_id="default",
+    )
+
+    await service._run_task(task, "owner-a")
+
+    assert captured["stream_log_topic"] == "executor.stream.exec-9"
+    assert service.nc.published == [("executor.stream.exec-9", b'{"line": "ok"}')]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

ansible-executor 接到任务后，会把执行结果回调到 payload 里的 `callback.subject`，也会把流式日志发布到 payload 里的 `stream_log_topic`。这两个 subject 本该只指向受控的 Job/执行日志通道；现在调用方只要能投递 ansible 任务，就能把结果或日志改路由到其它 NATS subject，可能造成执行输出泄露或误触其它内部处理逻辑。

## 根因

executor 之前只检查 callback 配置是否为空，没有把 callback 和 stream subject 当作信任边界处理。server 侧默认会传 `job.ansible_task_callback`、`job.stream.*` 或 `executor.stream.*` 这类受控 subject，但 executor 侧没有把这个契约固化，导致 payload 中的任意 subject 会直接进入 NATS request/publish。

## 怎么修的

在 executor 配置中增加两组 allowlist，并在真正 request/publish 前做校验：

```python
self._validate_callback_subject(subject)
self._validate_stream_subject(stream_subject)
```

默认只允许现有合法契约：`job.ansible_task_callback`、`job.stream.>`、`executor.stream.>`、`bk.ans_exec.stream.>`；部署确有自定义 subject 时，可以通过 `security.allowed_callback_subjects`、`security.allowed_stream_subjects` 或环境变量扩展。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["AnsibleRpcClient\nserver/apps/rpc/ansible.py"]
        T2["execute_ansible_*\nserver/apps/job_mgmt/services"]
    end

    subgraph N["NATS 执行层"]
        N1["_handle_adhoc/_handle_playbook\nagents/ansible-executor/service/nats_service.py"]
        N2["_run_task\nagents/ansible-executor/service/nats_service.py"]
        N3["_invoke_callback\nagents/ansible-executor/service/nats_service.py"]
    end

    C1["job.ansible_task_callback\nserver/apps/job_mgmt/nats_api.py"]
    S1["job.stream.* / executor.stream.*\n执行日志通道"]

    T2 --> T1 --> N1 --> N2
    N2 --> S1
    N2 --> N3 --> C1
```

## 影响范围

改动集中在 `agents/ansible-executor`，不改 server 调用参数和返回字段。默认 allowlist 覆盖当前扫描到的合法调用：Job 回调 `job.ansible_task_callback`、Job 流式日志 `job.stream.>`、节点安装流式日志 `executor.stream.>`，以及 executor 自身文档中的 `bk.ans_exec.stream.>`。这是内部 NATS 契约收紧，属于中风险，请 @baiyf-git 重点确认是否存在未登记的部署侧自定义 callback/stream subject。

## 验证

修复测试直接覆盖 request/publish 前的边界：非法 callback subject 不会发起 NATS request，非法 stream topic 会在执行命令前失败，合法扩展 allowlist 和默认合法 stream topic 保持可用。

本地已执行：

```bash
cd agents/ansible-executor
PYTHONPATH=. uv run --with pytest --with pytest-asyncio pytest tests/test_config.py tests/test_nats_service.py -q
PYTHONPATH=. uv run --with pytest --with pytest-asyncio pytest -q
```

结果：`22 passed`，全量 `63 passed`。

Closes #3841
