### PR TITLE
bugfix: 避免文本分类调试日志输出请求原文

### DIFF
--- a/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
+++ b/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
@@ -131,7 +131,10 @@ class MLService:
 
         # 2. 文本预处理（截断处理）
         processed_texts, text_warnings = self._preprocess_texts(request.texts)
-        logger.debug(f"Preprocessed texts: {processed_texts}")
+        text_batch_summary = self._summarize_text_batch(
+            processed_texts, text_warnings
+        )
+        logger.debug(f"Preprocessed text summary: {text_batch_summary}")
         logger.debug(
             f"Processed texts type: {type(processed_texts)}, length: {len(processed_texts) if processed_texts else 0}"
         )
@@ -144,7 +147,9 @@ class MLService:
                 # 调用模型预测（MLflow PyFunc标准接口）
                 # MLflow加载后的模型使用标准接口：predict(data)
                 # MLflow内部会自动将data传递给自定义包装器的model_input参数
-                logger.debug(f"Calling model.predict with texts: {processed_texts}")
+                logger.debug(
+                    f"Calling model.predict with text summary: {text_batch_summary}"
+                )
                 model_output = self.model.predict(processed_texts)
 
                 predict_time = (time.time() - predict_start) * 1000
@@ -246,6 +251,37 @@ class MLService:
             all_warnings.append(warnings)
 
         return processed_texts, all_warnings
+
+    def _summarize_text_batch(
+        self, texts: list[str], text_warnings: list[list[TextWarning]]
+    ) -> dict[str, int | float | None]:
+        """
+        构造不含原文的文本批次摘要，避免 debug 日志泄露请求内容.
+        """
+        lengths = [len(text) for text in texts]
+        truncated_count = sum(
+            1
+            for warnings in text_warnings
+            for warning in warnings
+            if warning.type == "TEXT_TRUNCATED"
+        )
+
+        if not lengths:
+            return {
+                "count": 0,
+                "min_length": None,
+                "max_length": None,
+                "avg_length": None,
+                "truncated_count": truncated_count,
+            }
+
+        return {
+            "count": len(lengths),
+            "min_length": min(lengths),
+            "max_length": max(lengths),
+            "avg_length": round(sum(lengths) / len(lengths), 2),
+            "truncated_count": truncated_count,
+        }
 
     def _build_results(
         self,

--- a/algorithms/classify_text_classification_server/tests/test_service_logging_privacy.py
+++ b/algorithms/classify_text_classification_server/tests/test_service_logging_privacy.py
@@ -1,0 +1,59 @@
+"""Regression tests for predict debug logging privacy (Issue #3853)."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from tests.test_feature_importance import _load_service_module, _make_service
+
+
+def test_predict_debug_logs_do_not_include_request_texts():
+    """predict() should log metadata only, never raw or processed request text."""
+    service_mod = _load_service_module()
+    logger = service_mod.logger
+    logger.reset_mock()
+
+    sensitive_text = "user=jane ip=10.0.0.8 token=secret-alert-text"
+    oversized_text = "A" * (service_mod.MAX_TEXT_LENGTH + 3)
+    model = MagicMock()
+    model.predict.return_value = pd.DataFrame(
+        [
+            {
+                "prediction": "sensitive",
+                "probability": 0.95,
+                "prob_sensitive": 0.95,
+                "prob_normal": 0.05,
+            },
+            {
+                "prediction": "normal",
+                "probability": 0.75,
+                "prob_sensitive": 0.25,
+                "prob_normal": 0.75,
+            },
+        ]
+    )
+
+    svc = _make_service(model=model)
+    svc.config.source = "dummy"
+
+    response = asyncio.run(
+        svc.predict(
+            [sensitive_text, oversized_text],
+            config={"return_feature_importance": False},
+        )
+    )
+
+    assert response.success is True
+    model.predict.assert_called_once()
+    assert model.predict.call_args.args[0][0] == sensitive_text
+    assert len(model.predict.call_args.args[0][1]) == service_mod.MAX_TEXT_LENGTH
+
+    debug_output = "\n".join(str(call) for call in logger.debug.call_args_list)
+    assert sensitive_text not in debug_output
+    assert "secret-alert-text" not in debug_output
+    assert oversized_text[:120] not in debug_output
+    assert "Preprocessed text summary" in debug_output
+    assert "Calling model.predict with text summary" in debug_output
+    assert "'count': 2" in debug_output
+    assert "'truncated_count': 1" in debug_output


### PR DESCRIPTION
## 问题

文本分类服务的 `predict()` 在 debug 级别下会把预处理后的文本列表完整写进日志。这个入口处理的是用户提交的业务文本，内容可能包含告警、账号、IP、凭据片段或其他敏感上下文；一旦排障时打开 debug，原文就会进入容器日志或集中日志系统。

## 根因

这里把“可观测信息”和“业务原文”混在了一起。debug 日志可以帮助排障，但不应该成为敏感请求体的安全边界；服务只需要知道批次数量、长度和截断情况，不需要把每条文本内容打印出来。

## 怎么修的

将两处直接输出 `processed_texts` 的 debug 日志替换为不含原文的批次摘要：

```python
text_batch_summary = self._summarize_text_batch(processed_texts, text_warnings)
logger.debug(f"Preprocessed text summary: {text_batch_summary}")
logger.debug(f"Calling model.predict with text summary: {text_batch_summary}")
```

摘要只包含 `count`、`min_length`、`max_length`、`avg_length`、`truncated_count`，不会包含用户文本或截断后的文本片段。

## 影响范围

改动只在 `algorithms/classify_text_classification_server` 内部，不改变 `predict()` 请求参数、响应结构、模型调用数据或截断逻辑。模型仍然收到预处理后的文本；变化仅限 debug 日志内容从原文变为统计摘要。

## 验证

新增回归测试直接跑 `predict()`：构造包含 `token=secret-alert-text` 的敏感文本和超长文本，断言模型仍收到原始/截断后的输入，同时 debug 日志中不出现敏感原文或长文本片段，只出现批次摘要。若把修复退回到直接打印 `processed_texts`，该测试会失败。

本地验证：

```bash
cd algorithms/classify_text_classification_server && uv run pytest -q
```

结果：`6 passed`。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MLService.predict\nserving/service.py"]
    end

    V["PredictRequest 校验\nserving/schemas/api_schema.py"]

    subgraph N["核心处理层"]
        P1["_preprocess_texts\nserving/service.py"]
        S1["_summarize_text_batch\nserving/service.py"]
        M1["model.predict\nserving/service.py"]
    end

    subgraph L["日志层"]
        L1["debug 摘要日志\n不含请求原文"]
    end

    T1 --> V --> P1 --> S1 --> L1
    S1 --> M1
```