### PR TITLE
bugfix: 移除算法训练脚本 eval 执行

### DIFF
--- a/algorithms/classify_anomaly_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_anomaly_server/support-files/scripts/train-model.sh
@@ -88,7 +88,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -114,7 +114,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -148,13 +148,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_anomaly_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_anomaly_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码

--- a/algorithms/classify_anomaly_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_anomaly_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_anomaly_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_anomaly_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()

--- a/algorithms/classify_image_classification_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_image_classification_server/support-files/scripts/train-model.sh
@@ -92,7 +92,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -118,7 +118,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -152,13 +152,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_image_classification_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_image_classification_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码

--- a/algorithms/classify_image_classification_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_image_classification_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_image_classification_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_image_classification_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()

--- a/algorithms/classify_log_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_log_server/support-files/scripts/train-model.sh
@@ -92,7 +92,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -118,7 +118,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -152,13 +152,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_log_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_log_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码

--- a/algorithms/classify_log_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_log_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_log_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_log_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()

--- a/algorithms/classify_object_detection_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_object_detection_server/support-files/scripts/train-model.sh
@@ -92,7 +92,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -118,7 +118,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -152,13 +152,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_object_detection_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_object_detection_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码

--- a/algorithms/classify_object_detection_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_object_detection_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_object_detection_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_object_detection_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()

--- a/algorithms/classify_text_classification_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_text_classification_server/support-files/scripts/train-model.sh
@@ -92,7 +92,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -118,7 +118,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -152,13 +152,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_text_classification_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_text_classification_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码

--- a/algorithms/classify_text_classification_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_text_classification_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_text_classification_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_text_classification_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()

--- a/algorithms/classify_timeseries_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_timeseries_server/support-files/scripts/train-model.sh
@@ -94,7 +94,7 @@ mkdir -p "${CONFIG_DIR}"
 
 # ==================== 下载数据集 ====================
 log_info "从 MinIO 下载数据集: ${MINIO_BUCKET}/${DATASET_NAME}"
-DATASET_FILE="${DOWNLOAD_DIR}/$(basename ${DATASET_NAME})"
+DATASET_FILE="${DOWNLOAD_DIR}/$(basename -- "${DATASET_NAME}")"
 
 # 使用 Python 脚本下载
 if python "${DOWNLOAD_SCRIPT}" \
@@ -120,7 +120,7 @@ fi
 if [ -n "$3" ]; then
     # 用户指定了配置名称，从 MinIO 下载
     log_info "从 MinIO 下载配置文件: ${MINIO_BUCKET}/${CONFIG_NAME}"
-    CONFIG_FILE="${CONFIG_DIR}/$(basename ${CONFIG_NAME})"
+    CONFIG_FILE="${CONFIG_DIR}/$(basename -- "${CONFIG_NAME}")"
     
     if python "${DOWNLOAD_SCRIPT}" \
         --bucket "${MINIO_BUCKET}" \
@@ -154,13 +154,15 @@ log_info "MLflow Tracking URI: ${MLFLOW_TRACKING_URI}"
 export MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI}"
 
 # 构建训练命令（使用已注册的 CLI 入口点）
-TRAIN_CMD="classify_timeseries_server train \
-    --dataset-path \"${EXTRACT_DIR}\" \
-    --config \"${CONFIG_FILE}\""
+TRAIN_CMD=(
+    classify_timeseries_server train
+    --dataset-path "${EXTRACT_DIR}"
+    --config "${CONFIG_FILE}"
+)
 
 # 执行训练（捕获标准输出和标准错误）
-log_info "执行训练命令: ${TRAIN_CMD}"
-eval ${TRAIN_CMD}
+log_info "执行训练命令: ${TRAIN_CMD[*]}"
+"${TRAIN_CMD[@]}"
 EXIT_CODE=$?
 
 # 检查退出码
@@ -178,4 +180,3 @@ if [ "${CLEANUP_AFTER_TRAIN:-false}" = "true" ]; then
     log_info "清理下载的压缩包..."
     rm -f "${DATASET_FILE}"
 fi
-

--- a/algorithms/classify_timeseries_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_timeseries_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,0 +1,17 @@
+import subprocess
+from pathlib import Path
+
+
+def test_train_script_does_not_reparse_arguments_with_eval():
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    text = script.read_text()
+
+    assert "eval ${TRAIN_CMD}" not in text
+    assert 'TRAIN_CMD="' not in text
+    assert '$(basename -- "${DATASET_NAME}")' in text
+    assert '$(basename -- "${CONFIG_NAME}")' in text
+    assert f"{service_root.name} train" in text
+    assert '"${TRAIN_CMD[@]}"' in text
+
+    subprocess.run(["bash", "-n", str(script)], check=True)

--- a/algorithms/classify_timeseries_server/tests/test_issue_3851_train_script_shell_safety.py
+++ b/algorithms/classify_timeseries_server/tests/test_issue_3851_train_script_shell_safety.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 from pathlib import Path
 
@@ -15,3 +16,36 @@ def test_train_script_does_not_reparse_arguments_with_eval():
     assert '"${TRAIN_CMD[@]}"' in text
 
     subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+def test_train_script_passes_shell_fragments_as_literal_arguments(tmp_path, monkeypatch):
+    service_root = Path(__file__).resolve().parents[1]
+    script = service_root / "support-files" / "scripts" / "train-model.sh"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+
+    for name, body in {
+        "python": 'out=""; while [ "$#" -gt 0 ]; do case "$1" in --output) shift; out="$1";; esac; shift; done; mkdir -p "$(dirname "$out")"; printf stub > "$out"\n',
+        "unzip": 'dest=""; while [ "$#" -gt 0 ]; do case "$1" in -d) shift; dest="$1";; esac; shift; done; mkdir -p "$dest"\n',
+        service_root.name: 'printf "%s\\n" "$@" > "$CALLS_FILE"\n',
+    }.items():
+        path = fake_bin / name
+        path.write_text(f"#!/bin/bash\nset -e\n{body}")
+        path.chmod(0o755)
+
+    calls_file = tmp_path / "calls"
+    monkeypatch.setenv("PATH", f"{fake_bin}:{os.environ['PATH']}")
+    monkeypatch.setenv("CALLS_FILE", str(calls_file))
+    monkeypatch.setenv("DOWNLOAD_DIR", str(tmp_path / "downloads"))
+    monkeypatch.setenv("EXTRACT_DIR", str(tmp_path / "datasets"))
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "configs"))
+    monkeypatch.setenv("MINIO_ENDPOINT", "minio:9000")
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "sk")
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://mlflow")
+
+    malicious_config = "$(:>pwned).json"
+    subprocess.run(["bash", str(script), "bucket", "data.zip", malicious_config], cwd=tmp_path, check=True)
+
+    assert not (tmp_path / "pwned").exists()
+    assert malicious_config in calls_file.read_text()


### PR DESCRIPTION
## 问题

MLOps 训练任务会把 bucket、dataset、config 这些对象名传给算法容器里的 `train-model.sh`。这些值本来只应该作为普通参数参与下载和训练，但脚本把训练命令拼成字符串后再用 `eval` 执行，配置文件名里的 shell 片段可能被第二次解析，变成容器内实际执行的命令。

## 根因

训练脚本把“参数化调用”退化成了“字符串命令”。即使前面下载配置时参数还是普通字符串，到了 `eval` 这一步，shell 会重新解释整段命令，边界从“参数”变成了“可执行脚本片段”。

## 怎么修的

六个算法服务都改成 Bash 数组直接执行训练 CLI，并对 `basename` 参数使用 `--` 和引用，避免对象名被当成选项或被拆词。

```bash
TRAIN_CMD=(
    classify_image_classification_server train
    --dataset-path "${EXTRACT_DIR}"
    --config "${CONFIG_FILE}"
)
"${TRAIN_CMD[@]}"
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["训练任务 JSON\nbucket/dataset/config"]
        T2["docker/kubernetes train.sh\nagents/webhookd/mlops"]
    end

    subgraph N["算法容器"]
        F1["train-model.sh\n下载数据和配置"]
        F2["TRAIN_CMD 数组\n直接执行训练 CLI"]
    end

    subgraph C["训练入口"]
        C1["classify_*_server train\n算法服务 CLI"]
    end

    T1 --> T2 --> F1 --> F2 --> C1
```

## 影响范围

改动只覆盖六个算法服务的训练脚本和对应测试：anomaly、image classification、log、object detection、text classification、timeseries。调用入口参数不变，训练 CLI 参数不变，没有改 Docker/Kubernetes 任务协议；合法对象名和现有训练流程继续走同一路径。

这是安全相关且跨多个算法服务的修复，按中风险处理，请 @zhouzhuangjie（周壮杰）重点 review。

## 验证

新增测试会检查每个训练脚本不再使用 `eval ${TRAIN_CMD}`，不再用字符串形式的 `TRAIN_CMD="..."`，并用 `bash -n` 检查脚本语法。把修复改回旧写法时，这些测试会失败。

已执行：

```bash
cd algorithms/classify_anomaly_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
cd algorithms/classify_image_classification_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
cd algorithms/classify_log_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
cd algorithms/classify_object_detection_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
cd algorithms/classify_text_classification_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
cd algorithms/classify_timeseries_server && uv run pytest tests/test_issue_3851_train_script_shell_safety.py
```

全部通过。

关联 Issue #3851。
