### PR TITLE
bugfix: 修复日志 Tail token 更新失效

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "test:collector-operation-architecture": "pnpm exec tsx scripts/collector-operation-architecture-test.ts",
     "test:log-alert-raw-columns": "pnpm exec tsx scripts/log-alert-raw-columns-test.ts",
     "test:log-group-field-bootstrap": "pnpm exec tsx scripts/log-group-field-bootstrap-test.ts",
+    "test:log-terminal-token": "pnpm exec tsx scripts/log-terminal-token-test.ts",
     "test:log-policy-form": "pnpm exec tsx scripts/log-policy-form-state-test.ts",
     "test:monitor-search-plugin-scope": "pnpm exec tsx scripts/monitor-search-plugin-scope-test.ts",
     "test:monitor-query-step": "pnpm exec tsx scripts/monitor-query-step-test.ts",

--- a/web/scripts/log-terminal-token-test.ts
+++ b/web/scripts/log-terminal-token-test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const source = readFileSync(
+  path.join(
+    process.cwd(),
+    'src/app/log/(pages)/search/logTerminal/index.tsx'
+  ),
+  'utf8'
+);
+
+assert(
+  !source.includes('const tokenRef = useRef(token)'),
+  'LogTerminal must not keep the initial auth token in a ref'
+);
+
+assert(
+  source.includes('if (!token) return;'),
+  'LogTerminal should wait for an available auth token before opening the tail stream'
+);
+
+assert(
+  source.includes('Authorization: `Bearer ${token}`'),
+  'LogTerminal tail requests should use the current auth token'
+);
+
+assert.match(
+  source,
+  /\}, \[query, stopLogStream, t, fetchData, token\]\);/,
+  'startLogStream dependencies should include token so auth context updates refresh the callback'
+);
+
+assert.match(
+  source,
+  /\}, \[stopLogStream, isLoading, token\]\);/,
+  'the auto-start effect should rerun when auth token becomes available without depending on unstable render-time callbacks'
+);
+
+console.log('log terminal token validation passed');

--- a/web/src/app/log/(pages)/search/logTerminal/index.tsx
+++ b/web/src/app/log/(pages)/search/logTerminal/index.tsx
@@ -28,7 +28,6 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
     const { t } = useTranslation();
     const authContext = useAuth();
     const token = authContext?.token || null;
-    const tokenRef = useRef(token);
     const isStreaming = useRef(false);
     const [isFullscreen, setIsFullscreen] = useState(false);
     const [logs, setLogs] = useState<string[]>([]);
@@ -113,6 +112,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
       // 先停止当前流和清除日志
       await stopLogStream();
       setLogs([]);
+      if (!token) return;
       if (isStreaming.current) return;
       try {
         isStreaming.current = true;
@@ -135,7 +135,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
           {
             method: 'GET',
             headers: {
-              Authorization: `Bearer ${tokenRef.current}`,
+              Authorization: `Bearer ${token}`,
             },
             signal: abortController.signal,
           }
@@ -206,7 +206,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
         }
         abortControllerRef.current = null;
       }
-    }, [query, isStreaming.current]);
+    }, [query, stopLogStream, t, fetchData, token]);
 
     // 通过 ref 暴露方法
     useImperativeHandle(
@@ -230,7 +230,7 @@ const LogTerminal = forwardRef<LogTerminalRef, LogTerminalProps>(
       return () => {
         stopLogStream();
       };
-    }, [stopLogStream, isLoading]);
+    }, [stopLogStream, isLoading, token]);
 
     // 监听全屏状态变化
     useEffect(() => {


### PR DESCRIPTION
## 问题

日志搜索页面的实时 Tail 组件会在打开流式请求时带上当前登录 token。原来组件把首次渲染时的 token 存进 `tokenRef`，后续认证上下文恢复、续期或重新登录后，这个 ref 不会同步更新。结果是用户启动或重启 Tail 时，仍可能发出 `Bearer null` 或旧 token，接口返回 401，页面表现为终端没有日志。

## 根因

Tail 请求绕过了通用请求客户端，直接调用 `fetch` 处理 SSE 流。为了避免 callback 依赖变化，代码把 token 放进 ref，但没有建立“auth token 更新后同步 ref”的契约。认证状态已经变了，流式请求头读取的还是旧状态。

## 怎么修的

修复后 Tail 启动直接读取当前 auth token，并且 token 为空时不打开流。自动启动 effect 增加 `token` 依赖，等认证上下文恢复出 token 后会重新进入启动流程，但不依赖父组件每次 render 新建的 `query` / `fetchData` callback，避免反复重启。

```tsx
if (!token) return;

const response = await fetch(`/api/proxy/log/search/tail?${queryParams.toString()}`, {
  method: 'GET',
  headers: {
    Authorization: `Bearer ${token}`,
  },
  signal: abortController.signal,
});
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["LogTerminal auto/ref start\nweb/src/app/log/(pages)/search/logTerminal/index.tsx"]
        T2["AuthProvider token update\nweb/src/context/auth.tsx"]
    end

    subgraph N["核心处理层"]
        F1["startLogStream\n读取当前 token"]
        F2["fetch log tail SSE\n/api/proxy/log/search/tail"]
    end

    subgraph B["后端接口"]
        B1["SearchView tail\nserver/apps/log/views/search.py"]
        B2["SearchService.tail\nserver/apps/log/services/search.py"]
    end

    T2 --> T1 --> F1 --> F2 --> B1 --> B2
    F1 -. "token 为空" .-> T1
```

## 影响范围

改动只在 web 日志 Tail 组件和一个聚焦脚本测试内，不改后端接口、不改代理协议、不涉及 agents/NATS。行为变化是 Tail 在没有 token 时不再发送无效请求，token 恢复或更新后使用最新 Authorization 重新启动。

## 验证

- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && pnpm test:log-terminal-token` 通过
- `source ~/.nvm/nvm.sh && nvm use 24 >/dev/null && pnpm exec eslint 'src/app/log/(pages)/search/logTerminal/index.tsx'` 通过
- `pnpm type-check` 已尝试，当前环境失败在既有 `src/context/locale.tsx` React 类型冲突和 `src/stories/ops-analysis-*` 缺失引用；这些路径不属于本次变更

关联 Issue #3806。
