### PR TITLE
bugfix: 脱敏 Tauri 代理请求头日志

### DIFF
--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -56,6 +56,33 @@ fn is_allowed_host(url: &str) -> bool {
     false
 }
 
+fn is_sensitive_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization"
+            | "proxy-authorization"
+            | "cookie"
+            | "set-cookie"
+            | "api-authorization"
+            | "x-api-key"
+            | "api-key"
+    )
+}
+
+fn redact_headers_for_log(headers: &HashMap<String, String>) -> HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(key, value)| {
+            let value = if is_sensitive_header(key) {
+                "<redacted>".to_string()
+            } else {
+                value.clone()
+            };
+            (key.clone(), value)
+        })
+        .collect()
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ApiRequest {
     pub url: String,
@@ -140,7 +167,11 @@ pub async fn api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError> {
 
     // 添加请求头
     if let Some(headers) = &request.headers {
-        log::info!("📨 [Tauri-API-{}] Headers: {:?}", request_id, headers);
+        log::info!(
+            "📨 [Tauri-API-{}] Headers: {:?}",
+            request_id,
+            redact_headers_for_log(headers)
+        );
         for (key, value) in headers {
             req_builder = req_builder.header(key, value);
         }
@@ -533,8 +564,8 @@ pub async fn cancel_stream(
 
 #[cfg(test)]
 mod tests {
-    use super::is_allowed_host;
-    use std::env;
+    use super::{is_allowed_host, redact_headers_for_log};
+    use std::{collections::HashMap, env};
 
     /// 辅助：在测试中临时设置 / 清除环境变量（串行执行，避免并发干扰）
     fn with_env<F: FnOnce()>(key: &str, val: Option<&str>, f: F) {
@@ -620,5 +651,28 @@ mod tests {
             assert!(!is_allowed_host("not-a-url"));
             assert!(!is_allowed_host(""));
         });
+    }
+
+    #[test]
+    fn test_redact_headers_for_log_masks_sensitive_headers_case_insensitively() {
+        let mut headers = HashMap::new();
+        headers.insert("Authorization".to_string(), "Bearer secret-token".to_string());
+        headers.insert("cookie".to_string(), "sessionid=secret".to_string());
+        headers.insert("Set-Cookie".to_string(), "refresh=secret".to_string());
+        headers.insert("X-Api-Key".to_string(), "api-key-secret".to_string());
+        headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+        let redacted = redact_headers_for_log(&headers);
+
+        assert_eq!(redacted.get("Authorization").map(String::as_str), Some("<redacted>"));
+        assert_eq!(redacted.get("cookie").map(String::as_str), Some("<redacted>"));
+        assert_eq!(redacted.get("Set-Cookie").map(String::as_str), Some("<redacted>"));
+        assert_eq!(redacted.get("X-Api-Key").map(String::as_str), Some("<redacted>"));
+        assert_eq!(
+            redacted.get("Content-Type").map(String::as_str),
+            Some("application/json")
+        );
+
+        assert_eq!(headers.get("Authorization").map(String::as_str), Some("Bearer secret-token"));
     }
 }


### PR DESCRIPTION
## 问题

移动端统一 API 客户端会把登录态 token 放进 Authorization header，然后通过 Tauri Rust 代理转发请求。代理原来在 info 级别直接打印完整 headers，开发包、调试包或启用日志插件时，本地日志、终端输出、adb logcat 里都可能出现可复用凭据。

## 根因

代理层把“转发所需的原始请求头”和“排障日志里可展示的请求头”当成同一份数据使用。请求转发确实需要原始 header 值，但日志只需要定位请求结构；敏感 header 没有先经过脱敏边界就进入了 info 日志。

## 怎么修的

在打印前新增敏感 header 识别和脱敏函数，Authorization、Cookie、Set-Cookie、Proxy-Authorization、Api-Authorization、X-Api-Key、Api-Key 会统一显示为 `<redacted>`。转发请求时仍使用原始 headers，不改变后端请求行为。

```rust
log::info!(
    "📨 [Tauri-API-{}] Headers: {:?}",
    request_id,
    redact_headers_for_log(headers)
);
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["apiRequest\nmobile/src/api/request.ts"]
        T2["tauriFetch\nmobile/src/utils/tauriFetch.ts"]
    end

    BU["Authorization header\n由前端请求组装"]

    subgraph N["核心处理层"]
        F1["api_proxy\nmobile/src-tauri/src/api_proxy.rs"]
        F2["redact_headers_for_log\nmobile/src-tauri/src/api_proxy.rs"]
    end

    subgraph C["转发层"]
        C1["reqwest request builder\n继续使用原始 headers"]
    end

    T1 --> BU --> T2 --> F1 --> F2
    F1 --> C1
```

## 影响范围

只改 `mobile/src-tauri/src/api_proxy.rs`。影响范围限定在 Tauri API 代理的日志输出：敏感请求头在日志中不再露出原值，非敏感请求头仍保留原值用于排障；实际 HTTP 转发、响应处理、鉴权和前端调用方式不变。该修复涉及认证凭据日志泄漏，按中风险提交并加 `⚠️ review`。

## 验证

- 已在当前 `weops/master` 基线确认缺陷仍存在：`api_proxy.rs` 原先直接 `log::info!(Headers: {:?}, headers)`，`request.ts` 会注入 `Authorization: Bearer ...`。
- 新增 Rust 单测 `test_redact_headers_for_log_masks_sensitive_headers_case_insensitively`：覆盖 Authorization、Cookie、Set-Cookie、X-Api-Key 大小写不敏感脱敏，并确认原始 headers 不被修改。
- 已运行 `git diff --check` 通过。
- 当前执行环境缺少 `cargo`/`rustc`，且默认 Node 为 14.18.2 不满足 mobile pnpm 要求，因此未能在本机执行 `cargo test` 或 `pnpm lint && pnpm type-check`。