### PR TITLE
bugfix: 修复 FalkorDB 连接池失效后不重连

### DIFF
--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -48,17 +48,17 @@ class FalkorDBConnectionPool:
 
     def get_connection(self):
         """获取连接，如果未初始化则初始化"""
-        if not self._initialized:
+        if not self._initialized or self._client is None or self._graph is None:
             self._initialize()
         return self._client, self._graph
 
     def _initialize(self):
         """初始化连接（双检锁保护，防止多线程并发重复创建连接）"""
-        if self._initialized:
+        if self._initialized and self._client is not None and self._graph is not None:
             return
 
         with self.__class__._lock:
-            if self._initialized:
+            if self._initialized and self._client is not None and self._graph is not None:
                 return
 
             try:
@@ -76,6 +76,24 @@ class FalkorDBConnectionPool:
 
                 logger.error(f"连接失败: {traceback.format_exc()}")
                 raise
+
+    def invalidate(self):
+        """标记当前连接已失效，下一次 get_connection 会重新初始化。"""
+        with self.__class__._lock:
+            self._client = None
+            self._graph = None
+            self._initialized = False
+
+    def close(self):
+        """关闭连接池中的连接并重置初始化状态。"""
+        client = self._client
+        self.invalidate()
+        close = getattr(client, "close", None)
+        if close:
+            try:
+                close()
+            except Exception as e:
+                logger.warning(f"关闭 FalkorDB 连接失败: {e}")
 
 
 class FalkorDBClient:
@@ -102,9 +120,9 @@ class FalkorDBClient:
 
     def close(self):
         """关闭连接"""
-        if self._client:
-            self._client = None
-            self._graph = None
+        self._pool.close()
+        self._client = None
+        self._graph = None
 
     def __enter__(self):
         """上下文管理器入口"""
@@ -144,6 +162,9 @@ class FalkorDBClient:
             logger.debug(f"[CQL Params] {safe_params}")
 
         try:
+            if self._graph is None and not self.connect():
+                raise RuntimeError("FalkorDB connection is not available")
+
             # 根据是否有参数选择调用方式
             if params:
                 result = self._graph.query(query, params=params)
@@ -155,6 +176,9 @@ class FalkorDBClient:
             return result
         except Exception as e:
             execution_time = (time.time() - start_time) * 1000
+            self._pool.invalidate()
+            self._client = None
+            self._graph = None
             logger.error(f"[CQL Error] 查询失败，耗时: {execution_time:.2f}ms，错误: {str(e)}")
             raise
 

--- a/server/apps/cmdb/tests/test_falkordb_client.py
+++ b/server/apps/cmdb/tests/test_falkordb_client.py
@@ -763,6 +763,92 @@ def test_connection_pool_initialize_called_once_under_concurrency(monkeypatch):
     )
 
 
+def test_connection_pool_reinitializes_when_handles_missing(monkeypatch):
+    """_initialized 与连接句柄不一致时，get_connection 应重新初始化。
+
+    若只检查 _initialized，本测试会返回 (None, None)，复现 issue #3672 的状态错乱。
+    """
+    from apps.cmdb.graph import falkordb as falkordb_module
+
+    pool = FalkorDBConnectionPool()
+    original_initialized = pool._initialized
+    original_client = pool._client
+    original_graph = pool._graph
+    pool._initialized = True
+    pool._client = None
+    pool._graph = None
+
+    connection_count = [0]
+
+    class FakeFalkorDB:
+        def __init__(self, host, port, password):
+            connection_count[0] += 1
+
+        def select_graph(self, name):
+            return object()
+
+    monkeypatch.setattr(falkordb_module.falkordb, "FalkorDB", FakeFalkorDB)
+
+    try:
+        client, graph = pool.get_connection()
+    finally:
+        pool._initialized = original_initialized
+        pool._client = original_client
+        pool._graph = original_graph
+
+    assert client is not None
+    assert graph is not None
+    assert connection_count[0] == 1
+
+
+def test_execute_query_invalidates_pool_after_graph_error(monkeypatch):
+    """图查询失败后连接池应失效，下一次 connect 可重新建立连接。
+
+    若失败后仍保留 _initialized=True，后续请求会继续拿到坏连接。
+    """
+    from apps.cmdb.graph import falkordb as falkordb_module
+
+    pool = FalkorDBConnectionPool()
+    original_initialized = pool._initialized
+    original_client = pool._client
+    original_graph = pool._graph
+
+    class BrokenGraph:
+        def query(self, cql, params=None):
+            raise ConnectionError("connection closed")
+
+    class FakeFalkorDB:
+        def select_graph(self, name):
+            return FakeGraph(FakeResultSet([], []))
+
+    pool._initialized = True
+    pool._client = object()
+    pool._graph = BrokenGraph()
+
+    client = FalkorDBClient()
+    client._pool = pool
+    client._client = pool._client
+    client._graph = pool._graph
+    monkeypatch.setattr(falkordb_module.falkordb, "FalkorDB", FakeFalkorDB)
+
+    try:
+        with pytest.raises(ConnectionError):
+            client._execute_query("MATCH (n) RETURN n")
+
+        assert pool._initialized is False
+        assert pool._client is None
+        assert pool._graph is None
+
+        assert client.connect() is True
+        assert pool._initialized is True
+        assert pool._client is not None
+        assert pool._graph is not None
+    finally:
+        pool._initialized = original_initialized
+        pool._client = original_client
+        pool._graph = original_graph
+
+
 # --------------------------------------------------------------------------
 # Issue #3664 - 非参数化路径 key 校验（CQL 注入防护）
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

CMDB 的 FalkorDB 连接池用 `_initialized` 判断是否已经连过库，但没有同时确认底层 client 和 graph 句柄还在。连接被清空或图查询遇到断连后，后续请求可能继续拿到坏状态，图查询会一直失败，直到进程重启。

## 根因

连接池把“初始化过”和“当前连接可用”混成了一个状态。只要 `_initialized=True`，`get_connection()` 就直接返回缓存句柄；如果句柄已经是 `None` 或查询时发现连接不可用，这个状态不会被打回未初始化，也就没有机会重新建连。

## 怎么修的

`get_connection()` 现在同时检查 `_initialized`、`_client` 和 `_graph`，三者不一致时会重新初始化。查询失败时不重试当前 CQL，避免写请求重复执行，只把连接池标记为失效，让下一次图操作重新连接。

```python
if not self._initialized or self._client is None or self._graph is None:
    self._initialize()
```

## 影响范围

改动只在 CMDB FalkorDB 驱动和对应单测内。没有改 NATS 协议、接口参数、数据模型或前端调用；对调用方来说仍然是原来的 GraphClient/FalkorDBClient 使用方式。影响的是连接失效后的恢复路径：失败中的那次查询仍抛原异常，后续请求会重新建连。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["CMDB 图查询入口\nservices/* with GraphClient"]
    end

    subgraph D["驱动层"]
        D1["GraphClient.__enter__\ngraph_client.py"]
        D2["FalkorDBClient.connect\nfalkordb.py"]
        D3["FalkorDBConnectionPool.get_connection\nfalkordb.py"]
    end

    subgraph Q["查询层"]
        Q1["FalkorDBClient._execute_query\nfalkordb.py"]
        Q2["graph.query\nFalkorDB graph"]
    end

    subgraph R["恢复层"]
        R1["invalidate/close\n重置 pool 状态"]
        R2["下一次 get_connection\n重新初始化连接"]
    end

    T1 --> D1 --> D2 --> D3 --> Q1 --> Q2
    Q2 -. "连接异常" .-> R1
    R1 -. "下一次请求" .-> R2 --> D3
```

## 验证

- `git show weops/master:server/apps/cmdb/graph/falkordb.py` + 独立 harness：确认修复前 `_initialized=True` 但 `_client/_graph=None` 时返回 `(None, None)`。
- 修改后独立 harness：确认句柄缺失时会重新初始化，查询失败后 pool 会失效，下一次 `connect()` 能重新建连。
- `cd server && uv run python -m py_compile apps/cmdb/graph/falkordb.py apps/cmdb/tests/test_falkordb_client.py` 通过。
- 目标 pytest 命令已尝试：`uv run --extra cmdb --extra dev --extra mlops pytest apps/cmdb/tests/test_falkordb_client.py -k 'connection_pool or execute_query_invalidates' -v --tb=short`，本地在 Django 初始化阶段被项目 settings 依赖拦截，未进入测试 collection（先后遇到 MinIO 必填配置、`django_celery_beat` app label 配置问题）。

关联 Issue #3672。
