### PR TITLE
bugfix: 缓存CMDB模型属性用户组织选项

### DIFF
--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -1,8 +1,10 @@
 import json
+import os
 import uuid
 from dataclasses import asdict
-from typing import Any
+from typing import Any, Callable
 
+from django.core.cache import cache
 from django.utils import timezone
 
 from apps.cmdb.constants.constants import (
@@ -65,9 +67,16 @@ from apps.core.services.user_group import UserGroup
 from apps.rpc.system_mgmt import SystemMgmt
 
 FIELD_GROUP_MANAGER: Any = getattr(FieldGroup, "objects")
+MODEL_ATTR_OPTION_CACHE_TTL = int(os.getenv("CMDB_MODEL_ATTR_OPTION_CACHE_TTL", "300"))
+MODEL_ATTR_ORGANIZATION_OPTION_CACHE_KEY = "cmdb:model_attr_options:organization"
+MODEL_ATTR_USER_OPTION_CACHE_KEY = "cmdb:model_attr_options:user"
 
 
 class ModelManage(object):
+    @staticmethod
+    def _clone_options(option: list[dict]) -> list[dict]:
+        return [dict(item) for item in option]
+
     @staticmethod
     def _normalize_default_value(raw_value: Any) -> list[str]:
         if raw_value in (None, ""):
@@ -1283,6 +1292,51 @@ class ModelManage(object):
                 ModelManage.get_organization_option(item["subGroups"], result, name)
 
     @staticmethod
+    def get_cached_organization_options(
+        system_mgmt_client_provider: Callable[[], SystemMgmt],
+    ) -> list[dict]:
+        option = cache.get(MODEL_ATTR_ORGANIZATION_OPTION_CACHE_KEY)
+        if option is not None:
+            return ModelManage._clone_options(option)
+
+        groups = UserGroup.get_all_groups(system_mgmt_client_provider()) or []
+        option = []
+        ModelManage.get_organization_option(groups, option)
+        cache.set(
+            MODEL_ATTR_ORGANIZATION_OPTION_CACHE_KEY,
+            option,
+            timeout=MODEL_ATTR_OPTION_CACHE_TTL,
+        )
+        return ModelManage._clone_options(option)
+
+    @staticmethod
+    def get_cached_user_options(
+        system_mgmt_client_provider: Callable[[], SystemMgmt],
+    ) -> list[dict]:
+        option = cache.get(MODEL_ATTR_USER_OPTION_CACHE_KEY)
+        if option is not None:
+            return ModelManage._clone_options(option)
+
+        users = UserGroup.get_all_users(system_mgmt_client_provider())
+        option = [
+            dict(
+                id=user["id"],
+                name=user["username"],
+                username=user.get("username"),
+                display_name=user.get("display_name"),
+                is_default=False,
+                type="str",
+            )
+            for user in users["users"]
+        ]
+        cache.set(
+            MODEL_ATTR_USER_OPTION_CACHE_KEY,
+            option,
+            timeout=MODEL_ATTR_OPTION_CACHE_TTL,
+        )
+        return ModelManage._clone_options(option)
+
+    @staticmethod
     def search_model_attr(model_id: str, language: str = "en"):
         """
         查询模型属性
@@ -1310,32 +1364,22 @@ class ModelManage(object):
         attrs = [ModelManage.sanitize_attr_default_value(attr, log_context="search_model_attr_v2") for attr in attrs]
         unique_rules = build_unique_rule_context(model_id).unique_rules
         attr_types = {attr["attr_type"] for attr in attrs}
-        system_mgmt_client = SystemMgmt()
+        system_mgmt_client = None
+
+        def get_system_mgmt_client() -> SystemMgmt:
+            nonlocal system_mgmt_client
+            if system_mgmt_client is None:
+                system_mgmt_client = SystemMgmt()
+            return system_mgmt_client
 
         if ORGANIZATION in attr_types:
-            groups = UserGroup.get_all_groups(system_mgmt_client)
-            # 获取默认的第一个根组织
-            groups = groups if groups else []
-            option = []
-            ModelManage.get_organization_option(groups, option)
+            option = ModelManage.get_cached_organization_options(get_system_mgmt_client)
             for attr in attrs:
                 if attr["attr_type"] == ORGANIZATION:
                     attr.update(option=option)
 
         if USER in attr_types:
-            users = UserGroup.get_all_users(system_mgmt_client)
-            option = [
-                dict(
-                    # id=user["username"],
-                    id=user["id"],
-                    name=user["username"],
-                    username=user.get("username"),
-                    display_name=user.get("display_name"),
-                    is_default=False,
-                    type="str",
-                )
-                for user in users["users"]
-            ]
+            option = ModelManage.get_cached_user_options(get_system_mgmt_client)
             for attr in attrs:
                 if attr["attr_type"] == USER:
                     attr.update(option=option)

--- a/server/apps/cmdb/tests/test_model_service_advanced.py
+++ b/server/apps/cmdb/tests/test_model_service_advanced.py
@@ -232,6 +232,45 @@ def test_search_model_attr_v2(fake_graph):
 
 
 @pytest.mark.django_db
+def test_search_model_attr_v2_caches_user_and_organization_options(fake_graph, monkeypatch):
+    attrs = [
+        {"attr_id": "owner", "attr_type": "user", "attr_name": "负责人"},
+        {"attr_id": "org", "attr_type": "organization", "attr_name": "组织"},
+    ]
+    fake_graph(MODULE, query_entity=([{"_id": 1, "attrs": json.dumps(attrs)}], 1))
+    monkeypatch.setattr(f"{MODULE}.cache.get", lambda key: None)
+
+    cached = {}
+
+    def fake_set(key, value, timeout=None):
+        cached[key] = value
+
+    monkeypatch.setattr(f"{MODULE}.cache.set", fake_set)
+    monkeypatch.setattr(f"{MODULE}.SystemMgmt", lambda: object())
+
+    calls = {"groups": 0, "users": 0}
+
+    def fake_get_all_groups(client):
+        calls["groups"] += 1
+        return [{"id": "root", "name": "Root", "subGroups": []}]
+
+    def fake_get_all_users(client):
+        calls["users"] += 1
+        return {"users": [{"id": 1, "username": "admin", "display_name": "Admin"}]}
+
+    monkeypatch.setattr(f"{MODULE}.UserGroup.get_all_groups", fake_get_all_groups)
+    monkeypatch.setattr(f"{MODULE}.UserGroup.get_all_users", fake_get_all_users)
+
+    first = ModelManage.search_model_attr_v2("host")
+    monkeypatch.setattr(f"{MODULE}.cache.get", lambda key: cached.get(key))
+    second = ModelManage.search_model_attr_v2("host")
+
+    assert calls == {"groups": 1, "users": 1}
+    assert first[0]["option"] == second[0]["option"]
+    assert first[1]["option"] == second[1]["option"]
+
+
+@pytest.mark.django_db
 def test_get_model_attrs_for_auto_rule_model_missing(monkeypatch):
     monkeypatch.setattr(f"{MODULE}.ModelManage.search_model_info", lambda mid: {})
     with pytest.raises(BaseAppException):


### PR DESCRIPTION
## 问题

CMDB 模型属性页在遇到「用户」或「组织」类型属性时，每次请求都会同步向 system_mgmt 拉全量用户列表和组织树。多人频繁打开模型详情或属性管理页时，请求量会被放大到 system_mgmt RPC 上，租户用户/组织越多，响应越慢。

关联 Issue #3671。中风险变更，请 @周壮杰 关注缓存 TTL 和跨 app RPC 调用频次变化。

## 根因

`search_model_attr_v2` 只判断了属性类型是否需要用户/组织 option，但没有缓存 option 结果；只要模型含这两类字段，就会在每次请求中创建 `SystemMgmt` 客户端并拉全量数据。这个路径本质上是稳定字典数据的展示辅助，不应该和页面访问频次一比一打到 system_mgmt。

## 怎么修的

给用户/组织 option 增加 Django cache 短缓存，默认 TTL 300 秒，可通过 `CMDB_MODEL_ATTR_OPTION_CACHE_TTL` 调整。缓存命中时不会创建 `SystemMgmt` 客户端；缓存未命中时仍复用原来的 `UserGroup.get_all_groups/get_all_users` 数据格式。

```python
option = cache.get(MODEL_ATTR_USER_OPTION_CACHE_KEY)
if option is not None:
    return ModelManage._clone_options(option)

users = UserGroup.get_all_users(system_mgmt_client_provider())
cache.set(MODEL_ATTR_USER_OPTION_CACHE_KEY, option, timeout=MODEL_ATTR_OPTION_CACHE_TTL)
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["模型属性/导入模板等入口\ncmdb services/views"]
    end

    BU["读取模型 attrs\nsearch_model_info"]

    subgraph N["核心处理层"]
        F1["search_model_attr_v2\nservices/model.py"]
        F2["缓存用户/组织 option\nDjango cache"]
        F3["SystemMgmt RPC\nget_all_groups/get_all_users"]
    end

    T1 --> BU --> F1 --> F2
    F2 -- "缓存未命中" --> F3
    F2 -. "缓存命中" .-> F1
```

## 影响范围

改动只在 CMDB 的 `search_model_attr_v2` 用户/组织 option 构造路径，不改 system_mgmt RPC 协议，不改返回字段结构。可见行为变化是用户/组织下拉数据最多会有 300 秒缓存延迟；这比每次请求全量拉取更适合模型属性页这种高频读场景。

## 验证

新增测试覆盖连续两次查询含 user/organization 属性的模型时，`get_all_groups` 和 `get_all_users` 都只调用一次；如果去掉缓存逻辑，该测试会失败。

本地验证：

```bash
MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=0 DB_ENGINE=sqlite DB_NAME=/tmp/bklite-issue-3671.sqlite3 INSTALL_APPS=cmdb,system_mgmt uv run pytest apps/cmdb/tests/test_model_service_advanced.py -v --tb=short -o addopts=''
```

结果：16 passed。
