### PR TITLE
fix(job_mgmt): 收口 NATS 模块数据团队鉴权

### DIFF
--- a/server/apps/alerts/tests/test_job_script_rpc_service.py
+++ b/server/apps/alerts/tests/test_job_script_rpc_service.py
@@ -21,7 +21,7 @@ def test_list_scripts_returns_team_scripts_via_local_rpc():
     # 另一团队的脚本不应出现
     Script.objects.create(name="别人家的脚本", script_type="shell", content="echo no", params=[], timeout=60, team=[99])
 
-    result = JobMgmt(is_local_client=True).list_scripts(group_id=7)
+    result = JobMgmt(is_local_client=True).list_scripts(group_id=7, team=[7])
 
     names = [it["name"] for it in result["items"]]
     assert "重启nginx" in names

--- a/server/apps/alerts/views/action.py
+++ b/server/apps/alerts/views/action.py
@@ -231,10 +231,13 @@ class ActionJobScriptListView(APIView):
     """代理 job_mgmt 脚本列表，供告警动作规则编辑器使用。"""
 
     def get(self, request):
-        from apps.alerts.utils.permission_scope import get_current_team_from_request
+        from apps.alerts.utils.permission_scope import get_authorized_group_ids, get_current_team_from_request
 
         group_id = get_current_team_from_request(request, required=True)
-        data = JobMgmt().list_scripts(group_id=group_id)
+        if not group_id:
+            return Response({"result": False, "message": "缺少团队上下文"}, status=status.HTTP_400_BAD_REQUEST)
+
+        data = JobMgmt().list_scripts(group_id=group_id, team=get_authorized_group_ids(request))
         return Response(data)
 
 

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -2,6 +2,7 @@
 
 from asgiref.sync import async_to_sync
 from celery import current_app
+from django.db import connection
 from django.utils import timezone
 
 import nats_client
@@ -66,7 +67,7 @@ def get_job_mgmt_module_list():
 
 
 @nats_client.register
-def get_job_mgmt_module_data(module, child_module, page, page_size, group_id):
+def get_job_mgmt_module_data(module, child_module, page, page_size, group_id, *, team=None):
     """获取作业管理模块数据"""
     model_map = {
         "script": Script,
@@ -81,11 +82,33 @@ def get_job_mgmt_module_data(module, child_module, page, page_size, group_id):
     }
 
     if module != "system":
-        model = model_map[module]
+        model = model_map.get(module)
+        if model is None:
+            return {"result": False, "message": f"未知 module: {module}"}
     else:
-        model = system_model_map[child_module]
+        model = system_model_map.get(child_module)
+        if model is None:
+            return {"result": False, "message": f"未知 child_module: {child_module}"}
 
-    queryset = model.objects.filter(team__contains=int(group_id))
+    requested_teams = normalize_team(group_id)
+    if len(requested_teams) != 1:
+        return {"result": False, "message": "group_id 参数非法"}
+
+    authorized_team_ids = normalize_team(team)
+    if not authorized_team_ids:
+        return {"result": False, "message": "team 不能为空"}
+
+    group_id = next(iter(requested_teams))
+    if not is_team_authorized(group_id, authorized_team_ids):
+        return {"result": False, "message": "无权访问该团队数据"}
+
+    try:
+        page = max(1, int(page))
+        page_size = max(1, int(page_size))
+    except (TypeError, ValueError):
+        return {"result": False, "message": "page/page_size 参数非法"}
+
+    queryset = _filter_module_data_by_team(model.objects.all(), group_id)
 
     # 计算总数
     total_count = queryset.count()
@@ -101,6 +124,18 @@ def get_job_mgmt_module_data(module, child_module, page, page_size, group_id):
         "count": total_count,
         "items": list(data_list),
     }
+
+
+def _filter_module_data_by_team(queryset, group_id):
+    if connection.features.supports_json_field_contains:
+        return queryset.filter(team__contains=group_id)
+
+    matched_ids = [
+        item.id
+        for item in queryset.only("id", "team")
+        if group_id in normalize_team(getattr(item, "team", None))
+    ]
+    return queryset.filter(id__in=matched_ids)
 
 
 @nats_client.register

--- a/server/apps/job_mgmt/tests/test_nats_api_extra.py
+++ b/server/apps/job_mgmt/tests/test_nats_api_extra.py
@@ -20,13 +20,39 @@ class TestModuleData:
 
     def test_module_data_script(self):
         Script.objects.create(name="s1", content="echo", script_type="shell", team=[1])
-        out = nats_api.get_job_mgmt_module_data("script", None, 1, 10, 1)
+        out = nats_api.get_job_mgmt_module_data("script", None, 1, 10, 1, team=[1])
         assert out["count"] == 1 and out["items"][0]["name"] == "s1"
 
     def test_module_data_system_child(self):
         DangerousRule.objects.create(name="r1", pattern="rm", level=DangerousLevel.CONFIRM, team=[1])
-        out = nats_api.get_job_mgmt_module_data("system", "dangerous_rule", 1, 10, 1)
+        out = nats_api.get_job_mgmt_module_data("system", "dangerous_rule", 1, 10, 1, team=[1])
         assert out["count"] == 1
+
+    def test_module_data_rejects_unknown_module(self):
+        out = nats_api.get_job_mgmt_module_data("unknown", None, 1, 10, 1, team=[1])
+        assert out["result"] is False
+        assert "module" in out["message"]
+
+    def test_module_data_rejects_unknown_system_child(self):
+        out = nats_api.get_job_mgmt_module_data("system", "unknown", 1, 10, 1, team=[1])
+        assert out["result"] is False
+        assert "child_module" in out["message"]
+
+    def test_module_data_requires_authorized_team(self):
+        out = nats_api.get_job_mgmt_module_data("script", None, 1, 10, 1)
+        assert out["result"] is False
+        assert "team" in out["message"]
+
+    def test_module_data_rejects_cross_team_group_id(self):
+        Script.objects.create(name="s2", content="echo", script_type="shell", team=[2])
+        out = nats_api.get_job_mgmt_module_data("script", None, 1, 10, 2, team=[1])
+        assert out["result"] is False
+        assert "无权" in out["message"]
+
+    def test_module_data_rejects_invalid_group_id(self):
+        out = nats_api.get_job_mgmt_module_data("script", None, 1, 10, "bad", team=[1])
+        assert out["result"] is False
+        assert "group_id" in out["message"]
 
 
 def _exec(**over):

--- a/server/apps/rpc/job_mgmt.py
+++ b/server/apps/rpc/job_mgmt.py
@@ -42,10 +42,11 @@ class JobMgmt:
             return None
         return resp.get("data")
 
-    def list_scripts(self, group_id, page=1, page_size=1000):
+    def list_scripts(self, group_id, page=1, page_size=1000, team=None):
         """脚本列表（供告警动作选择作业）。按团队(group_id)过滤，返回 {count, items:[{id,name}]}。
 
         get_job_mgmt_module_data 需要 module/child_module/page/page_size/group_id 五个独立参数，必须按关键字传（参见 get_module_data）。
+        team 为当前调用方已授权团队 ID 列表，用于避免直接信任 group_id。
         """
         return self.client.run(
             "get_job_mgmt_module_data",
@@ -54,4 +55,5 @@ class JobMgmt:
             page=page,
             page_size=page_size,
             group_id=group_id,
+            team=team,
         )

--- a/server/apps/system_mgmt/tests/test_org_scope_permissions.py
+++ b/server/apps/system_mgmt/tests/test_org_scope_permissions.py
@@ -112,6 +112,72 @@ def test_group_data_rule_cmdb_get_app_data_rejects_invalid_current_team(monkeypa
     assert payload == {"result": False, "message": "current_team 参数非法"}
 
 
+def test_group_data_rule_job_get_app_data_injects_authorized_team(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def get_module_data(self, **kwargs):
+            captured.update(kwargs)
+            return {"count": 0, "items": []}
+
+    def fake_get_client(params):
+        params.pop("app")
+        return FakeClient()
+
+    monkeypatch.setattr(GroupDataRuleViewSet, "get_client", staticmethod(fake_get_client))
+
+    request = APIRequestFactory().get(
+        "/system_mgmt/api/group_data_rule/get_app_data/",
+        {
+            "app": "job",
+            "module": "script",
+            "child_module": "",
+            "page": "1",
+            "page_size": "10",
+            "group_id": "7",
+        },
+    )
+    force_authenticate(request, user=_request_user([7], {"data_permission-View"}))
+
+    response = GroupDataRuleViewSet.as_view({"get": "get_app_data"})(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 200
+    assert payload == {"result": True, "data": {"count": 0, "items": []}}
+    assert captured["team"] == [7]
+
+
+def test_group_data_rule_job_get_app_data_rejects_unauthorized_group(monkeypatch):
+    class FakeClient:
+        def get_module_data(self, **kwargs):
+            return {"count": 0, "items": []}
+
+    def fake_get_client(params):
+        params.pop("app")
+        return FakeClient()
+
+    monkeypatch.setattr(GroupDataRuleViewSet, "get_client", staticmethod(fake_get_client))
+
+    request = APIRequestFactory().get(
+        "/system_mgmt/api/group_data_rule/get_app_data/",
+        {
+            "app": "job",
+            "module": "script",
+            "child_module": "",
+            "page": "1",
+            "page_size": "10",
+            "group_id": "8",
+        },
+    )
+    force_authenticate(request, user=_request_user([7], {"data_permission-View"}))
+
+    response = GroupDataRuleViewSet.as_view({"get": "get_app_data"})(request)
+    payload = _json_payload(response)
+
+    assert response.status_code == 403
+    assert payload == {"result": False, "message": "无权访问该组织"}
+
+
 @pytest.mark.django_db
 def test_search_user_list_filters_to_accessible_groups():
     allowed = Group.objects.create(name="scope-search-allowed", parent_id=0, is_virtual=False)

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -86,7 +86,7 @@ class GroupDataRuleViewSet(LanguageViewSet):
 
         user_group_ids = self._get_user_group_ids(request.user)
         if group_id not in user_group_ids:
-            message = self.loader.get("error.no_permission_access_group") if self.loader else "无权访问该组织"
+            message = (self.loader.get("error.no_permission_access_group") if self.loader else None) or "无权访问该组织"
             return False, JsonResponse({"result": False, "message": message}, status=403)
         return True, None
 
@@ -209,7 +209,7 @@ class GroupDataRuleViewSet(LanguageViewSet):
         params = request.GET.dict()
         # 记录 app 值（get_client 会从 params 中弹出），用于后续判断是否注入上下文
         app = params.get("app", "")
-        if params.get("app") == "mlops":
+        if app in {"job", "mlops"}:
             try:
                 group_id = int(params.get("group_id"))
             except (TypeError, ValueError):
@@ -219,10 +219,14 @@ class GroupDataRuleViewSet(LanguageViewSet):
             if not is_valid:
                 return error_response
 
-            actor_context, error_response = _build_actor_context(request, self.loader)
-            if error_response:
-                return error_response
-            params["actor_context"] = actor_context
+            if app == "mlops":
+                actor_context, error_response = _build_actor_context(request, self.loader)
+                if error_response:
+                    return error_response
+                params["actor_context"] = actor_context
+            else:
+                user_group_ids = self._get_user_group_ids(request.user)
+                params["team"] = [group_id] if user_group_ids is None else sorted(user_group_ids)
 
         client = self.get_client(params)
         fun = getattr(client, "get_module_data", None)


### PR DESCRIPTION
## 背景

再次按 issue-to-pr 流程处理 #3430，作为和既有 PR #3870 的另一套客户端产物对比。

Fixes #3430

## 变更

- `get_job_mgmt_module_data` 不再直接通过裸字典下标取 `module/child_module`，未知模块返回结构化错误。
- `group_id` 必须是单个合法团队 ID，且必须落在调用方传入的 `team` 授权团队集合内，否则失败关闭。
- 数据权限页面的 `job` 模块入口先校验 group 权限，再把授权团队传给 Job RPC。
- 告警动作脚本列表通过请求权限上下文传递授权团队，避免下游继续只信任 `group_id`。
- 增补回归测试覆盖未知模块、缺授权团队、跨团队、非法 group_id、系统入口注入 team。

## 验证

```bash
INSTALL_APPS=job_mgmt,system_mgmt,node_mgmt ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=test-issue-3430-full.sqlite3 MINIO_ENDPOINT=127.0.0.1:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=False uv run --extra dev pytest -o addopts='' apps/job_mgmt/tests/test_nats_api_extra.py apps/job_mgmt/tests/test_team_authz.py apps/system_mgmt/tests/test_org_scope_permissions.py::test_group_data_rule_job_get_app_data_injects_authorized_team apps/system_mgmt/tests/test_org_scope_permissions.py::test_group_data_rule_job_get_app_data_rejects_unauthorized_group apps/alerts/tests/test_job_script_rpc_service.py::test_list_scripts_returns_team_scripts_via_local_rpc -q
# 50 passed

uv run python -m py_compile apps/job_mgmt/nats_api.py apps/system_mgmt/viewset/group_data_rule_viewset.py apps/rpc/job_mgmt.py apps/alerts/views/action.py apps/job_mgmt/tests/test_nats_api_extra.py apps/system_mgmt/tests/test_org_scope_permissions.py apps/alerts/tests/test_job_script_rpc_service.py
```

## 对比说明

- #3870 偏向在 job_mgmt NATS handler 内补 `team` 鉴权。
- 本 PR 在 handler 修复基础上同步收口了系统数据权限入口和告警脚本列表调用链，避免真实页面/包装器仍只传不可信 `group_id`。