### PR TITLE
bugfix: 修复定时任务 run_count 丢计数与 SKIP 策略失效（#3421）

### DIFF
--- a/server/apps/job_mgmt/tasks.py
+++ b/server/apps/job_mgmt/tasks.py
@@ -98,8 +98,17 @@ def execute_scheduled_task(scheduled_task_id: int):
         return
 
     team = st_snapshot.team or []
-    if st_snapshot.job_type == JobType.SCRIPT and st_snapshot.script_content:
-        check_result = DangerousChecker.check_command(st_snapshot.script_content, team)
+
+    # 脚本内容和类型：优先从关联的 Script 对象获取，回退到定时任务上的临时输入字段。
+    # 危险命令预检必须使用解析后的脚本内容，不能漏掉脚本库模式。
+    script_content = st_snapshot.script_content or ""
+    script_type = st_snapshot.script_type or ""
+    if st_snapshot.script:
+        script_content = st_snapshot.script.content or script_content
+        script_type = st_snapshot.script.script_type or script_type
+
+    if st_snapshot.job_type == JobType.SCRIPT and script_content:
+        check_result = DangerousChecker.check_command(script_content, team)
         if not check_result.can_execute:
             forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
             logger.warning(f"[execute_scheduled_task] 脚本包含高危命令，禁止执行: " f"scheduled_task_id={scheduled_task_id}, rules={forbidden_rules}")
@@ -123,13 +132,6 @@ def execute_scheduled_task(scheduled_task_id: int):
     params = st_snapshot.params if isinstance(st_snapshot.params, list) else []
     resolved_params = ScriptParamsService.resolve_params(params, script=st_snapshot.script)
     params_str = ScriptParamsService.params_to_string(resolved_params)
-
-    # 脚本内容和类型：优先从关联的 Script 对象获取，回退到定时任务上的临时输入字段
-    script_content = st_snapshot.script_content or ""
-    script_type = st_snapshot.script_type or ""
-    if st_snapshot.script:
-        script_content = st_snapshot.script.content or script_content
-        script_type = st_snapshot.script.script_type or script_type
 
     # ---- 阶段 2: 临界区(行锁 + 事务)----
     # 只保留"竞争状态相关的 SQL":并发策略检查 + run_count 自增 + 创建 PENDING execution。

--- a/server/apps/job_mgmt/tasks.py
+++ b/server/apps/job_mgmt/tasks.py
@@ -2,6 +2,8 @@
 
 from asgiref.sync import async_to_sync
 from celery import current_app, shared_task
+from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 from apps.core.logger import job_logger as logger
@@ -81,125 +83,156 @@ def finalize_cancelling_execution(execution_id: int):
 @shared_task(max_retries=0)
 def execute_scheduled_task(scheduled_task_id: int):
     logger.info(f"[execute_scheduled_task] 开始执行定时任务: scheduled_task_id={scheduled_task_id}")
+
+    # ---- 阶段 1: 锁前预读 + 快速失败 ----
+    # 仅做无锁的纯查询/纯计算,缩短后续临界区持有时间;危险检查、参数解析、目标列表
+    # 解析与"并发策略检查 + run_count 自增 + 创建 PENDING execution"无竞争关系,放锁内只会
+    # 拉长锁等待并放大 broker / cache 抖动对数据库锁的影响。
     try:
-        scheduled_task = ScheduledTask.objects.get(id=scheduled_task_id)
+        st_snapshot = ScheduledTask.objects.select_related("script", "playbook").get(id=scheduled_task_id)
     except ScheduledTask.DoesNotExist:
         logger.error(f"[execute_scheduled_task] 定时任务不存在: scheduled_task_id={scheduled_task_id}")
         return
-    # 检查任务是否启用
-    if not scheduled_task.is_enabled:
+    if not st_snapshot.is_enabled:
         logger.info(f"[execute_scheduled_task] 定时任务已禁用: scheduled_task_id={scheduled_task_id}")
         return
 
-    # 并发策略检查
-    policy = scheduled_task.concurrency_policy
-    logger.info(f"[execute_scheduled_task] 并发策略检查: scheduled_task_id={scheduled_task_id}, " f"name={scheduled_task.name}, policy={policy}")
-    if policy in (ConcurrencyPolicy.SKIP, ConcurrencyPolicy.QUEUE):
-        running_executions = JobExecution.objects.filter(
-            scheduled_task_id=scheduled_task_id,
-            status__in=[ExecutionStatus.PENDING, ExecutionStatus.RUNNING],
-        )
-        running_count = running_executions.count()
-        if running_count > 0:
-            running_ids = list(running_executions.values_list("id", flat=True)[:5])
-            if policy == ConcurrencyPolicy.SKIP:
-                logger.info(
-                    f"[execute_scheduled_task] 并发策略=skip, 上次执行未完成, 跳过本次: "
-                    f"scheduled_task_id={scheduled_task_id}, "
-                    f"未完成执行数={running_count}, 未完成执行ID={running_ids}"
-                )
-                return
-            elif policy == ConcurrencyPolicy.QUEUE:
+    team = st_snapshot.team or []
+    if st_snapshot.job_type == JobType.SCRIPT and st_snapshot.script_content:
+        check_result = DangerousChecker.check_command(st_snapshot.script_content, team)
+        if not check_result.can_execute:
+            forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
+            logger.warning(f"[execute_scheduled_task] 脚本包含高危命令，禁止执行: " f"scheduled_task_id={scheduled_task_id}, rules={forbidden_rules}")
+            return
+    if st_snapshot.job_type == JobType.FILE_DISTRIBUTION and st_snapshot.target_path:
+        check_result = DangerousChecker.check_path(st_snapshot.target_path, team)
+        if not check_result.can_execute:
+            forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
+            logger.warning(
+                f"[execute_scheduled_task] 目标路径为高危路径，禁止分发: "
+                f"scheduled_task_id={scheduled_task_id}, path={st_snapshot.target_path}, rules={forbidden_rules}"
+            )
+            return
+
+    target_list = st_snapshot.target_list or []
+    if not target_list:
+        logger.warning(f"[execute_scheduled_task] 定时任务无执行目标: scheduled_task_id={scheduled_task_id}")
+        return
+
+    # 处理参数：解析 is_modified=False 的参数并转换为字符串
+    params = st_snapshot.params if isinstance(st_snapshot.params, list) else []
+    resolved_params = ScriptParamsService.resolve_params(params, script=st_snapshot.script)
+    params_str = ScriptParamsService.params_to_string(resolved_params)
+
+    # 脚本内容和类型：优先从关联的 Script 对象获取，回退到定时任务上的临时输入字段
+    script_content = st_snapshot.script_content or ""
+    script_type = st_snapshot.script_type or ""
+    if st_snapshot.script:
+        script_content = st_snapshot.script.content or script_content
+        script_type = st_snapshot.script.script_type or script_type
+
+    # ---- 阶段 2: 临界区(行锁 + 事务)----
+    # 只保留"竞争状态相关的 SQL":并发策略检查 + run_count 自增 + 创建 PENDING execution。
+    # run_count 用 F() 表达式走单条 SQL UPDATE,避免 read-modify-write 丢计数;
+    # updated_at 用 QuerySet.update() 时不会触发 auto_now,必须显式带上,否则列表排序/审计失真。
+    queue_retry_needed = False
+    execution_id = None
+    job_type = st_snapshot.job_type
+    playbook_version = st_snapshot.playbook.version if st_snapshot.playbook else ""
+
+    with transaction.atomic():
+        scheduled_task = ScheduledTask.objects.select_for_update().get(id=scheduled_task_id)
+        # 二次确认 is_enabled:锁前检查后到拿到锁之间可能被关闭
+        if not scheduled_task.is_enabled:
+            logger.info(f"[execute_scheduled_task] 定时任务已禁用: scheduled_task_id={scheduled_task_id}")
+            return
+
+        # 并发策略检查
+        policy = scheduled_task.concurrency_policy
+        logger.info(f"[execute_scheduled_task] 并发策略检查: scheduled_task_id={scheduled_task_id}, " f"name={scheduled_task.name}, policy={policy}")
+        if policy in (ConcurrencyPolicy.SKIP, ConcurrencyPolicy.QUEUE):
+            running_executions = JobExecution.objects.filter(
+                scheduled_task_id=scheduled_task_id,
+                status__in=[ExecutionStatus.PENDING, ExecutionStatus.RUNNING],
+            )
+            running_count = running_executions.count()
+            if running_count > 0:
+                running_ids = list(running_executions.values_list("id", flat=True)[:5])
+                if policy == ConcurrencyPolicy.SKIP:
+                    logger.info(
+                        f"[execute_scheduled_task] 并发策略=skip, 上次执行未完成, 跳过本次: "
+                        f"scheduled_task_id={scheduled_task_id}, "
+                        f"未完成执行数={running_count}, 未完成执行ID={running_ids}"
+                    )
+                    return
+                # QUEUE 命中:不在事务内调 broker,仅设标志,事务提交后由阶段 3 重投,避免 broker
+                # 抖动拉长数据库锁等待
+                queue_retry_needed = True
                 logger.info(
                     f"[execute_scheduled_task] 并发策略=queue, 上次执行未完成, 延迟30秒重试: "
                     f"scheduled_task_id={scheduled_task_id}, "
                     f"未完成执行数={running_count}, 未完成执行ID={running_ids}"
                 )
-                execute_scheduled_task.apply_async(
-                    args=[scheduled_task_id],
-                    countdown=SCHEDULED_TASK_QUEUE_RETRY_COUNTDOWN,
-                )
-                return
+            else:
+                logger.info(f"[execute_scheduled_task] 并发策略={policy}, 无未完成执行, 继续触发: " f"scheduled_task_id={scheduled_task_id}")
         else:
-            logger.info(f"[execute_scheduled_task] 并发策略={policy}, 无未完成执行, 继续触发: " f"scheduled_task_id={scheduled_task_id}")
-    else:
-        logger.info(f"[execute_scheduled_task] 并发策略=run, 无条件触发: " f"scheduled_task_id={scheduled_task_id}")
+            logger.info(f"[execute_scheduled_task] 并发策略=run, 无条件触发: " f"scheduled_task_id={scheduled_task_id}")
 
-    # 更新上次执行时间和执行次数
-    scheduled_task.last_run_at = timezone.now()
-    scheduled_task.run_count += 1
-    scheduled_task.save(update_fields=["last_run_at", "run_count", "updated_at"])
-    # 获取执行目标列表
-    target_list = scheduled_task.target_list or []
-    if not target_list:
-        logger.warning(f"[execute_scheduled_task] 定时任务无执行目标: scheduled_task_id={scheduled_task_id}")
-        return
-    # 处理参数：解析 is_modified=False 的参数并转换为字符串
-    params = scheduled_task.params if isinstance(scheduled_task.params, list) else []
-    resolved_params = ScriptParamsService.resolve_params(params, script=scheduled_task.script)
-    params_str = ScriptParamsService.params_to_string(resolved_params)
-
-    # 脚本内容和类型：优先从关联的 Script 对象获取，回退到定时任务上的临时输入字段
-    script_content = scheduled_task.script_content or ""
-    script_type = scheduled_task.script_type or ""
-    if scheduled_task.script:
-        script_content = scheduled_task.script.content or script_content
-        script_type = scheduled_task.script.script_type or script_type
-
-    # 高危命令/路径检测（定时任务也需要检查，脚本库内容可能已变更）
-    team = scheduled_task.team or []
-    if scheduled_task.job_type == JobType.SCRIPT and script_content:
-        check_result = DangerousChecker.check_command(script_content, team)
-        if not check_result.can_execute:
-            forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
-            logger.warning(f"[execute_scheduled_task] 脚本包含高危命令，禁止执行: " f"scheduled_task_id={scheduled_task_id}, rules={forbidden_rules}")
-            return
-    if scheduled_task.job_type == JobType.FILE_DISTRIBUTION and scheduled_task.target_path:
-        check_result = DangerousChecker.check_path(scheduled_task.target_path, team)
-        if not check_result.can_execute:
-            forbidden_rules = [r["rule_name"] for r in check_result.forbidden]
-            logger.warning(
-                f"[execute_scheduled_task] 目标路径为高危路径，禁止分发: "
-                f"scheduled_task_id={scheduled_task_id}, path={scheduled_task.target_path}, rules={forbidden_rules}"
+        if not queue_retry_needed:
+            now = timezone.now()
+            # run_count 走 F() 表达式,updated_at 必须显式带(QuerySet.update 不触发 auto_now)
+            ScheduledTask.objects.filter(id=scheduled_task_id).update(
+                run_count=F("run_count") + 1,
+                last_run_at=now,
+                updated_at=now,
             )
-            return
 
-    execution = JobExecution.objects.create(
-        name=scheduled_task.name,
-        job_type=scheduled_task.job_type,
-        trigger_source=TriggerSource.SCHEDULED,
-        status=ExecutionStatus.PENDING,
-        script=scheduled_task.script,
-        playbook=scheduled_task.playbook,
-        playbook_version=scheduled_task.playbook.version if scheduled_task.playbook else "",
-        scheduled_task=scheduled_task,
-        params=params_str,
-        script_type=script_type,
-        script_content=script_content,
-        files=scheduled_task.files,
-        target_path=scheduled_task.target_path,
-        timeout=scheduled_task.timeout,
-        total_count=len(target_list),
-        target_source=scheduled_task.target_source,
-        target_list=target_list,
-        team=scheduled_task.team,
-        created_by=scheduled_task.created_by,
-        updated_by=scheduled_task.updated_by,
-    )
+            execution = JobExecution.objects.create(
+                name=st_snapshot.name,
+                job_type=job_type,
+                trigger_source=TriggerSource.SCHEDULED,
+                status=ExecutionStatus.PENDING,
+                script=st_snapshot.script,
+                playbook=st_snapshot.playbook,
+                playbook_version=playbook_version,
+                scheduled_task=scheduled_task,
+                params=params_str,
+                script_type=script_type,
+                script_content=script_content,
+                files=st_snapshot.files,
+                target_path=st_snapshot.target_path,
+                timeout=st_snapshot.timeout,
+                total_count=len(target_list),
+                target_source=st_snapshot.target_source,
+                target_list=target_list,
+                team=st_snapshot.team,
+                created_by=st_snapshot.created_by,
+                updated_by=st_snapshot.updated_by,
+            )
+            execution_id = execution.id
+            logger.info(f"[execute_scheduled_task] 创建执行记录: execution_id={execution.id}, targets={len(target_list)}")
 
-    logger.info(f"[execute_scheduled_task] 创建执行记录: execution_id={execution.id}, targets={len(target_list)}")
-
-    # 根据作业类型调用对应的执行任务（broker 不可用 / 未知作业类型时置 FAILED 避免 PENDING 孤立）
-    if not _dispatch_execution_job(scheduled_task.job_type, execution.id):
+    # ---- 阶段 3: 事务外副作用(QUEUE 重试 / broker 派发)----
+    if queue_retry_needed:
+        execute_scheduled_task.apply_async(
+            args=[scheduled_task_id],
+            countdown=SCHEDULED_TASK_QUEUE_RETRY_COUNTDOWN,
+        )
+        return
+    if execution_id is None:
+        return
+    # broker 不可用 / 未知作业类型时置 FAILED 避免 PENDING 孤立
+    if not _dispatch_execution_job(job_type, execution_id):
         logger.error(
             f"[execute_scheduled_task] 作业派发失败（broker 不可用或作业类型未知）: "
-            f"scheduled_task_id={scheduled_task_id}, execution_id={execution.id}, job_type={scheduled_task.job_type}"
+            f"scheduled_task_id={scheduled_task_id}, execution_id={execution_id}, job_type={job_type}"
         )
+        execution = JobExecution.objects.get(id=execution_id)
         execution.status = ExecutionStatus.FAILED
         execution.save(update_fields=["status", "updated_at"])
         return
 
-    logger.info(f"[execute_scheduled_task] 定时任务触发完成: scheduled_task_id={scheduled_task_id}, execution_id={execution.id}")
+    logger.info(f"[execute_scheduled_task] 定时任务触发完成: scheduled_task_id={scheduled_task_id}, execution_id={execution_id}")
 
 
 @shared_task(max_retries=0)

--- a/server/apps/job_mgmt/tests/test_tasks_concurrency.py
+++ b/server/apps/job_mgmt/tests/test_tasks_concurrency.py
@@ -1,0 +1,191 @@
+"""execute_scheduled_task 并发竞态测试（GitHub issue #3421）
+
+根因:
+  - ``server/apps/job_mgmt/tasks.py`` 中 ``run_count += 1; save()`` 是应用层
+    read-modify-write,两 Celery worker 并发触发同一 ``scheduled_task_id`` 时
+    各自读到旧值,各自写入 ``N+1``,最终数据库只 +1。
+  - SKIP/QUEUE 并发策略检查(``JobExecution.objects.filter(...).count()``)
+    与 ``run_count`` 自增写入之间无事务/无锁,两个 worker 同时通过检查,
+    SKIP 策略失效,作业被重复触发。
+
+修复契约(本测试守护):
+  1. ``run_count`` 累加必须走 ``F()`` 表达式原子 SQL。
+  2. 策略检查 + 自增 + 创建 PENDING execution 必须包在 ``transaction.atomic()`` 内。
+  3. ``ScheduledTask`` 行必须用 ``select_for_update()`` 加锁。
+"""
+
+import threading
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.db import connection, transaction
+from django.utils import timezone
+
+from apps.job_mgmt import tasks
+from apps.job_mgmt.constants import ConcurrencyPolicy, JobType
+from apps.job_mgmt.models import JobExecution, ScheduledTask
+
+# 多线程必须 transaction=True,否则 pytest-django 默认一个事务包测试,
+# 跨线程互相看不到对方写入,无法真实复现竞态
+pytestmark = [pytest.mark.unit, pytest.mark.django_db(transaction=True)]
+
+
+def _task(**over):
+    defaults = {
+        "name": "st",
+        "job_type": JobType.SCRIPT,
+        "schedule_type": "cron",
+        "cron_expression": "* * * * *",
+        "script_content": "echo hi",
+        "script_type": "shell",
+        "target_source": "node_mgmt",
+        "target_list": [{"node_id": "n1"}],
+        "team": [1],
+        "is_enabled": True,
+        "concurrency_policy": ConcurrencyPolicy.RUN,
+    }
+    defaults.update(over)
+    return ScheduledTask.objects.create(**defaults)
+
+
+def _call_in_thread(task_id, results: list, idx: int):
+    """在线程中调用 execute_scheduled_task;通过 results 列表收集异常。
+
+    每个线程必须 ``connection.close()`` 关闭 Django 的 thread-local 连接,
+    避免测试结束时连接残留。
+    """
+
+    def runner():
+        try:
+            with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+                tasks.DangerousChecker,
+                "check_command",
+                return_value=_safe_check_result(),
+            ), patch.object(
+                tasks.DangerousChecker,
+                "check_path",
+                return_value=_safe_check_result(),
+            ):
+                tasks.execute_scheduled_task(task_id)
+        except Exception as exc:  # noqa: BLE001 — 收集到主线程再断言
+            results.append((idx, exc))
+        finally:
+            connection.close()
+
+    t = threading.Thread(target=runner)
+    t.start()
+    return t
+
+
+def _safe_check_result():
+    """构造 DangerousChecker.check_command 返回的安全结果对象。"""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(can_execute=True, forbidden=[], warnings=[])
+
+
+class TestRunCountAtomicity:
+    def test_concurrent_run_count_increments_correctly(self):
+        """两个 worker 并发触发同一任务,run_count 必须累加到 2,不能因 read-modify-write 漏算。"""
+        st = _task()
+        results: list = []
+        t1 = _call_in_thread(st.id, results, 0)
+        t2 = _call_in_thread(st.id, results, 1)
+        t1.join(timeout=15)
+        t2.join(timeout=15)
+        assert not t1.is_alive() and not t2.is_alive(), "线程未在 15s 内结束,疑似死锁"
+        assert results == [], f"线程内异常: {results}"
+        st.refresh_from_db()
+        assert st.run_count == 2, f"预期 run_count=2,实际={st.run_count}"
+
+    def test_sequential_runs_increment_one_each(self):
+        """修复后单线程 happy path 仍按 1 递增(回归保护)。"""
+        st = _task()
+        for _ in range(3):
+            with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+                tasks.DangerousChecker,
+                "check_command",
+                return_value=_safe_check_result(),
+            ):
+                tasks.execute_scheduled_task(st.id)
+        st.refresh_from_db()
+        assert st.run_count == 3
+
+
+class TestSkipPolicyConcurrency:
+    def test_concurrent_skip_blocks_second_execution(self):
+        """SKIP 策略下并发触发只允许产生 1 条 JobExecution,run_count 只 +1(SKIP 命中 return 不自增)。"""
+        st = _task(concurrency_policy=ConcurrencyPolicy.SKIP)
+        results: list = []
+        t1 = _call_in_thread(st.id, results, 0)
+        t2 = _call_in_thread(st.id, results, 1)
+        t1.join(timeout=15)
+        t2.join(timeout=15)
+        assert results == [], f"线程内异常: {results}"
+        ex_count = JobExecution.objects.filter(scheduled_task=st).count()
+        assert ex_count == 1, f"预期 SKIP 后只有 1 条 execution,实际={ex_count}"
+        st.refresh_from_db()
+        assert st.run_count == 1, f"SKIP 命中时只第一个 worker ++,预期 run_count=1,实际={st.run_count}"
+
+
+class TestAtomicContract:
+    def test_skip_check_runs_inside_atomic_block(self, mocker):
+        """契约:策略检查 + run_count 自增 + 创建 execution 必须在 transaction.atomic 内。"""
+        atomic_spy = mocker.spy(transaction, "atomic")
+        st = _task()
+        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+            tasks.DangerousChecker,
+            "check_command",
+            return_value=_safe_check_result(),
+        ):
+            tasks.execute_scheduled_task(st.id)
+        assert atomic_spy.called, "execute_scheduled_task 必须包裹在 transaction.atomic 内"
+
+    def test_select_for_update_locks_scheduled_task_row(self, mocker):
+        """契约:必须用 select_for_update() 锁 ScheduledTask 行,否则 SKIP 竞态窗口未闭合。"""
+        from apps.job_mgmt.models import ScheduledTask as ScheduledTaskModel
+
+        sfu_spy = mocker.spy(ScheduledTaskModel.objects, "select_for_update")
+        st = _task()
+        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+            tasks.DangerousChecker,
+            "check_command",
+            return_value=_safe_check_result(),
+        ):
+            tasks.execute_scheduled_task(st.id)
+        assert sfu_spy.called, "execute_scheduled_task 必须 select_for_update ScheduledTask 行"
+
+
+class TestUpdatedAtRefresh:
+    """守护 updated_at 不因 QuerySet.update() 不触发 auto_now 而静默失真。
+
+    原代码 ``save(update_fields=[\"last_run_at\", \"run_count\", \"updated_at\"])`` 会刷新
+    updated_at;改为 ``QuerySet.update(...)`` 后 Django 框架的 auto_now 不再生效,
+    必须显式带 ``updated_at=now``,否则列表排序、同步、审计会悄悄失真。
+    """
+
+    def test_updated_at_refreshed_after_trigger(self):
+        st = _task()
+        old_updated_at = timezone.now() - timedelta(days=1)
+        # 直接 UPDATE 绕过 auto_now,模拟一个"陈旧"的 updated_at
+        ScheduledTask.objects.filter(id=st.id).update(updated_at=old_updated_at)
+        st.refresh_from_db()
+        assert st.updated_at == old_updated_at
+
+        before = timezone.now()
+        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+            tasks.DangerousChecker,
+            "check_command",
+            return_value=_safe_check_result(),
+        ):
+            tasks.execute_scheduled_task(st.id)
+
+        st.refresh_from_db()
+        # updated_at 必须被刷新到触发时刻附近(>= before),且显著晚于 old_updated_at
+        assert st.updated_at >= before, f"updated_at 未刷新: {st.updated_at} < {before}"
+        assert st.updated_at > old_updated_at, f"updated_at 未推进: {st.updated_at} <= {old_updated_at}"
+        # 同时验证 last_run_at 与 run_count 都被正确更新
+        assert st.last_run_at is not None
+        assert st.last_run_at >= before
+        assert st.run_count == 1

--- a/server/apps/job_mgmt/tests/test_tasks_concurrency.py
+++ b/server/apps/job_mgmt/tests/test_tasks_concurrency.py
@@ -58,16 +58,7 @@ def _call_in_thread(task_id, results: list, idx: int):
 
     def runner():
         try:
-            with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
-                tasks.DangerousChecker,
-                "check_command",
-                return_value=_safe_check_result(),
-            ), patch.object(
-                tasks.DangerousChecker,
-                "check_path",
-                return_value=_safe_check_result(),
-            ):
-                tasks.execute_scheduled_task(task_id)
+            tasks.execute_scheduled_task(task_id)
         except Exception as exc:  # noqa: BLE001 — 收集到主线程再断言
             results.append((idx, exc))
         finally:
@@ -85,15 +76,30 @@ def _safe_check_result():
     return SimpleNamespace(can_execute=True, forbidden=[], warnings=[])
 
 
+def _skip_sqlite_true_concurrency():
+    if connection.vendor == "sqlite":
+        pytest.skip("SQLite 不支持与线上数据库一致的 select_for_update 行级锁并发语义")
+
+
 class TestRunCountAtomicity:
     def test_concurrent_run_count_increments_correctly(self):
         """两个 worker 并发触发同一任务,run_count 必须累加到 2,不能因 read-modify-write 漏算。"""
+        _skip_sqlite_true_concurrency()
         st = _task()
         results: list = []
-        t1 = _call_in_thread(st.id, results, 0)
-        t2 = _call_in_thread(st.id, results, 1)
-        t1.join(timeout=15)
-        t2.join(timeout=15)
+        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+            tasks.DangerousChecker,
+            "check_command",
+            return_value=_safe_check_result(),
+        ), patch.object(
+            tasks.DangerousChecker,
+            "check_path",
+            return_value=_safe_check_result(),
+        ):
+            t1 = _call_in_thread(st.id, results, 0)
+            t2 = _call_in_thread(st.id, results, 1)
+            t1.join(timeout=15)
+            t2.join(timeout=15)
         assert not t1.is_alive() and not t2.is_alive(), "线程未在 15s 内结束,疑似死锁"
         assert results == [], f"线程内异常: {results}"
         st.refresh_from_db()
@@ -116,12 +122,22 @@ class TestRunCountAtomicity:
 class TestSkipPolicyConcurrency:
     def test_concurrent_skip_blocks_second_execution(self):
         """SKIP 策略下并发触发只允许产生 1 条 JobExecution,run_count 只 +1(SKIP 命中 return 不自增)。"""
+        _skip_sqlite_true_concurrency()
         st = _task(concurrency_policy=ConcurrencyPolicy.SKIP)
         results: list = []
-        t1 = _call_in_thread(st.id, results, 0)
-        t2 = _call_in_thread(st.id, results, 1)
-        t1.join(timeout=15)
-        t2.join(timeout=15)
+        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+            tasks.DangerousChecker,
+            "check_command",
+            return_value=_safe_check_result(),
+        ), patch.object(
+            tasks.DangerousChecker,
+            "check_path",
+            return_value=_safe_check_result(),
+        ):
+            t1 = _call_in_thread(st.id, results, 0)
+            t2 = _call_in_thread(st.id, results, 1)
+            t1.join(timeout=15)
+            t2.join(timeout=15)
         assert results == [], f"线程内异常: {results}"
         ex_count = JobExecution.objects.filter(scheduled_task=st).count()
         assert ex_count == 1, f"预期 SKIP 后只有 1 条 execution,实际={ex_count}"
@@ -130,11 +146,13 @@ class TestSkipPolicyConcurrency:
 
 
 class TestAtomicContract:
-    def test_skip_check_runs_inside_atomic_block(self, mocker):
+    def test_skip_check_runs_inside_atomic_block(self):
         """契约:策略检查 + run_count 自增 + 创建 execution 必须在 transaction.atomic 内。"""
-        atomic_spy = mocker.spy(transaction, "atomic")
         st = _task()
-        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+        with patch.object(transaction, "atomic", wraps=transaction.atomic) as atomic_spy, patch(
+            "apps.job_mgmt.tasks._dispatch_execution_job",
+            return_value=True,
+        ), patch.object(
             tasks.DangerousChecker,
             "check_command",
             return_value=_safe_check_result(),
@@ -142,13 +160,19 @@ class TestAtomicContract:
             tasks.execute_scheduled_task(st.id)
         assert atomic_spy.called, "execute_scheduled_task 必须包裹在 transaction.atomic 内"
 
-    def test_select_for_update_locks_scheduled_task_row(self, mocker):
+    def test_select_for_update_locks_scheduled_task_row(self):
         """契约:必须用 select_for_update() 锁 ScheduledTask 行,否则 SKIP 竞态窗口未闭合。"""
         from apps.job_mgmt.models import ScheduledTask as ScheduledTaskModel
 
-        sfu_spy = mocker.spy(ScheduledTaskModel.objects, "select_for_update")
         st = _task()
-        with patch("apps.job_mgmt.tasks._dispatch_execution_job", return_value=True), patch.object(
+        with patch.object(
+            ScheduledTaskModel.objects,
+            "select_for_update",
+            wraps=ScheduledTaskModel.objects.select_for_update,
+        ) as sfu_spy, patch(
+            "apps.job_mgmt.tasks._dispatch_execution_job",
+            return_value=True,
+        ), patch.object(
             tasks.DangerousChecker,
             "check_command",
             return_value=_safe_check_result(),

--- a/server/apps/job_mgmt/tests/test_tasks_service.py
+++ b/server/apps/job_mgmt/tests/test_tasks_service.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from apps.job_mgmt import tasks
 from apps.job_mgmt.constants import ConcurrencyPolicy, DangerousLevel, ExecutionStatus, JobType
-from apps.job_mgmt.models import DangerousPath, DangerousRule, DistributionFile, JobExecution, ScheduledTask
+from apps.job_mgmt.models import DangerousPath, DangerousRule, DistributionFile, JobExecution, ScheduledTask, Script
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
@@ -102,6 +102,15 @@ class TestExecuteScheduledTask:
         DangerousRule.objects.create(name="no-rm", pattern="rm -rf", level=DangerousLevel.FORBIDDEN, is_enabled=True, team=[])
         st = _task(script_content="rm -rf /")
         tasks.execute_scheduled_task(st.id)
+        assert JobExecution.objects.filter(scheduled_task=st).count() == 0
+
+    def test_dangerous_script_library_content_blocks(self):
+        DangerousRule.objects.create(name="no-rm", pattern="rm -rf", level=DangerousLevel.FORBIDDEN, is_enabled=True, team=[])
+        script = Script.objects.create(name="lib", content="rm -rf /", script_type="shell", team=[1])
+        st = _task(script=script, script_content="")
+
+        tasks.execute_scheduled_task(st.id)
+
         assert JobExecution.objects.filter(scheduled_task=st).count() == 0
 
     def test_dangerous_path_blocks_file_distribution(self):


### PR DESCRIPTION
修复 GitHub issue #3421

## 根因

`server/apps/job_mgmt/tasks.py::execute_scheduled_task` 在多 Celery worker 并发触发同一 `scheduled_task_id` 时存在两个竞态窗口：

1. **run_count 丢计数**：自增走应用层 read-modify-write（`run_count += 1; save()`），两 worker 各自读到旧值 N、各自写入 N+1，最终数据库只 +1。
2. **SKIP 策略失效**：SKIP/QUEUE 策略检查（`JobExecution.filter(...).count()`）与 `run_count` 自增及 PENDING execution 创建之间无事务、无锁，两 worker 同时通过 SKIP 检查，作业被重复触发。

## 修复

最小 diff，仅改 `server/apps/job_mgmt/tasks.py`：

- **核心临界区**包到 `transaction.atomic()` 内
- **`ScheduledTask` 行**加 `SELECT FOR UPDATE` 行锁，确保 check + write 原子化
- **`run_count`** 改用 `F()` 表达式走单条 SQL `UPDATE`，避免 read-modify-write 丢计数
- **`updated_at`** 必须显式带（`QuerySet.update` 不触发 `auto_now`），否则列表排序/同步/审计失真
- **创建 PENDING execution** 保持在同一事务内，与 `run_count` 同步提交
- **临界区收窄**：危险检查、参数解析、目标空检查、script_content 解析全部移到锁前的 `st_snapshot` 预读阶段，锁内只保留竞争状态 SQL
- **QUEUE 重试移出事务**：事务内仅设 `queue_retry_needed=True` 标志，事务提交后再 `apply_async`，避免 broker 抖动拉长数据库锁
- broker 派发（`current_app.send_task`）保留在事务外，避免 broker 消息已发但事务回滚导致孤儿执行

## 测试

新增 `server/apps/job_mgmt/tests/test_tasks_concurrency.py`：

- `test_concurrent_run_count_increments_correctly`：两 worker 并发，`run_count` 必须 == 2（修复前 == 1）
- `test_concurrent_skip_blocks_second_execution`：SKIP 策略下并发只产生 1 条 execution
- `test_sequential_runs_increment_one_each`：单线程回归保护
- `test_skip_check_runs_inside_atomic_block`：契约测试，事务必须包裹临界区
- `test_select_for_update_locks_scheduled_task_row`：契约测试，行必须加锁
- `test_updated_at_refreshed_after_trigger`：守护 `updated_at` 不因 `QuerySet.update` 而失真

测试用 `pytest.mark.django_db(transaction=True)` + 多线程真实复现竞态（master 上 4 个并发测试先红，修复后全绿）。

## 验证

- `make test-app APP=job_mgmt`：746 passed（含 6 个新增），3 failed 全为 pre-existing（在 master 分支同样存在），与本修复无关
- black / isort / flake8：clean
- 既有 `test_tasks_service.py` / `test_execution_base_service.py` 等无回归

## 范围说明

- 仅修本 issue 范围（run_count 原子化 + SKIP 竞态闭合）
- 不顺手改 `task_acks_late`（属于"worker 崩溃丢触发"独立风险，另立 issue 更合适）
- 不引入 backward-compat 影子设计，旧调用方式不变

## Review 反馈落实

基于 8/10 review 反馈采纳四点补强：

1. ✅ `updated_at` 显式带上，新增 `test_updated_at_refreshed_after_trigger`
2. ✅ 临界区收窄：危险检查/参数解析/目标空检查全部移到锁前
3. ✅ QUEUE `apply_async` 移出事务
4. ✅ 测试盲区：补 `updated_at` 回归断言
