### PR TITLE
fix(monitor): load enterprise dashboard registry

### DIFF
--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -32,6 +32,20 @@ import ConsoleServerDashboard from './objects/console_server';
 import VoiceGatewayDashboard from './objects/voice_gateway';
 import { normalizeDashboardKey } from './shared/utils';
 
+const loadEnterpriseDashboards = (): ProfessionalDashboardRegistryItem[] => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('@/app/monitor/(enterprise)/dashboards/registry');
+    return Array.isArray(mod.ENTERPRISE_PROFESSIONAL_DASHBOARDS)
+      ? mod.ENTERPRISE_PROFESSIONAL_DASHBOARDS
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const ENTERPRISE_PROFESSIONAL_DASHBOARDS = loadEnterpriseDashboards();
+
 export const PROFESSIONAL_DASHBOARD_GROUPS = {
   hardware: { label: '硬件设备', order: 10 },
   container: { label: '容器', order: 15 },
@@ -309,7 +323,8 @@ export const PROFESSIONAL_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
     objectDisplayName: 'Pod',
     inheritedPermissionPath: '/monitor/view',
     component: K8sPodDashboard
-  }
+  },
+  ...ENTERPRISE_PROFESSIONAL_DASHBOARDS
 ];
 
 export const PROFESSIONAL_DASHBOARD_MAP = new Map(


### PR DESCRIPTION
## 变更说明

修复企业版启动后新增监控对象无法进入专业监控仪表盘的问题。

### 背景

企业版通过 `web/scripts/prepare-enterprise.mjs` 将企业代码挂载到社区 Web 的 `src/app/<module>/(enterprise)` 目录下。企业版 PR 中新增了 IBM MQ、WebLogic、WebSphere、JBoss、Jetty、TongWeb、BES、Nacos 等专业仪表盘，但社区 `monitor/dashboards/registry.ts` 没有加载企业版 registry 扩展，导致 `getProfessionalDashboardUrl()` 找不到企业对象对应的 dashboard key，最终回退到 `/monitor/view/detail` 全量指标页。

### 修复内容

- 在社区 dashboard registry 中增加企业版 registry 扩展加载点。
- 当企业版存在 `@/app/monitor/(enterprise)/dashboards/registry` 且导出 `ENTERPRISE_PROFESSIONAL_DASHBOARDS` 时，将其追加到 `PROFESSIONAL_DASHBOARDS`。
- 社区版未挂载企业目录时返回空数组，不影响现有社区 dashboard。

### 验证

- 已用源码级回归脚本确认 registry 会加载并追加企业 dashboard 扩展。
- 已用 TypeScript `transpileModule` 验证 `web/src/app/monitor/dashboards/registry.ts` 可解析。
- 已执行 `git diff --check`。
