### PR TITLE
feat(monitor): add reviewed Milesight and MikroTik SNMP router plugins

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -5371,6 +5371,9 @@ monitor_object_plugin:
   Router Robustel SNMP:
     name: Robustel (Telegraf)
     desc: Robustel industrial cellular router / gateway SNMP collection template (enterprise 39699). This is a clean baseline template — it collects system uptime and IF-MIB interface metrics including 64-bit ifHCInOctets/ifHCOutOctets, admin/oper status, speed, error/discard/packet counters and aggregate device traffic. CPU, memory, temperature, fan and power-supply state are not collected (N/A) because no cross-version stable row-filter-free vendor scalar device-health gauges are currently confirmed. Cellular, WAN, VPN, SMS and trap-event tables are also not promoted to shared device-health metrics. Supported brands/models — Robustel R3000 industrial cellular routers and gateways.
+  Router Milesight SNMP:
+    name: Milesight (Telegraf)
+    desc: Milesight UR32/UR35/UR75 industrial cellular router SNMP collection template. The official manuals confirm SNMPv1/v2c/v3, SNMP Trap, MIB View, VACM and an LTE-ROUTER-MIB.txt download path. This remains a clean baseline template because no cross-model stable row-filter-free vendor scalar CPU, memory, temperature, fan or power-supply gauges are currently confirmed — it collects system uptime and IF-MIB interface metrics including 64-bit ifHCInOctets/ifHCOutOctets, admin/oper status, speed, error/discard/packet counters and aggregate device traffic.
   Router MultiTech SNMP:
     name: MultiTech (Telegraf)
     desc: MultiTech Systems cellular router / IoT gateway SNMP collection template

--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -5374,6 +5374,9 @@ monitor_object_plugin:
   Router Milesight SNMP:
     name: Milesight (Telegraf)
     desc: Milesight UR32/UR35/UR75 industrial cellular router SNMP collection template. The official manuals confirm SNMPv1/v2c/v3, SNMP Trap, MIB View, VACM and an LTE-ROUTER-MIB.txt download path. This remains a clean baseline template because no cross-model stable row-filter-free vendor scalar CPU, memory, temperature, fan or power-supply gauges are currently confirmed — it collects system uptime and IF-MIB interface metrics including 64-bit ifHCInOctets/ifHCOutOctets, admin/oper status, speed, error/discard/packet counters and aggregate device traffic.
+  Router MikroTik SNMP:
+    name: MikroTik (Telegraf)
+    desc: MikroTik RouterOS Ethernet router SNMP collection template. The official RouterOS SNMP documentation publishes the MikroTik RouterOS MIB, MIKROTIK-MIB, HOST-RESOURCES-MIB and IF-MIB, and documents the mtxrHlTemperature private temperature OID. Beyond the shared Router SNMP floor, this template collects per-core CPU utilization, system memory used/total, memory utilization and board temperature. MikroTik exposes fan as raw RPM and has no cross-model standardized power-supply state OID, so fan and power health are not collected.
   Router MultiTech SNMP:
     name: MultiTech (Telegraf)
     desc: MultiTech Systems cellular router / IoT gateway SNMP collection template

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -4654,6 +4654,9 @@ monitor_object_plugin:
   Router Robustel SNMP:
     name: Robustel（Telegraf）
     desc: Robustel 工业蜂窝路由器/网关专用 SNMP 采集模板（企业号 39699）。本模板为干净的基线——采集系统运行时长与 IF-MIB 接口指标（含 64 位 ifHCInOctets/ifHCOutOctets、admin/oper 状态、速率、错误/丢弃/包计数与整机汇总流量）。当前未确认跨版本稳定、无需行级过滤的厂商私有 CPU、内存、温度、风扇或电源状态标量，蜂窝链路、WAN、VPN、SMS 与 Trap 事件表也不提升为共享设备健康指标，故这些指标不采集（N/A）。适用品牌型号——Robustel R3000 系列工业蜂窝路由器/网关。
+  Router Milesight SNMP:
+    name: Milesight（Telegraf）
+    desc: Milesight UR32/UR35/UR75 工业蜂窝路由器专用 SNMP 采集模板。官方手册已确认 SNMPv1/v2c/v3、SNMP Trap、MIB View、VACM 与 LTE-ROUTER-MIB.txt 下载入口；当前未确认跨型号稳定、无需行级过滤的厂商私有 CPU、内存、温度、风扇或电源状态标量，故本模板保持干净基线，仅采集系统运行时长与 IF-MIB 接口指标（含 64 位 ifHCInOctets/ifHCOutOctets、admin/oper 状态、速率、错误/丢弃/包计数与整机汇总流量）。
   Router MultiTech SNMP:
     name: MultiTech（Telegraf）
     desc: MultiTech Systems 蜂窝路由器/IoT 网关专用 SNMP 采集模板（MultiConnect rCell 系列，IANA PEN 995）。rCell 平台 SNMP agent 为 RFC1213 兼容（标准 MIB-II + IF-MIB），故本模板为干净的基线——采集系统运行时长与 IF-MIB 接口指标（含 64 位 ifHCInOctets/ifHCOutOctets、admin/oper 状态、速率、错误/丢弃/包计数与整机汇总流量）。CPU、内存、温度、风扇与电源状态因 rCell agent 未以可轮询标量暴露设备健康量，故不采集（N/A）；蜂窝 RSSI/信号对象跨固件未统一以可轮询标量暴露，留待后续增量。

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -4657,6 +4657,9 @@ monitor_object_plugin:
   Router Milesight SNMP:
     name: Milesight（Telegraf）
     desc: Milesight UR32/UR35/UR75 工业蜂窝路由器专用 SNMP 采集模板。官方手册已确认 SNMPv1/v2c/v3、SNMP Trap、MIB View、VACM 与 LTE-ROUTER-MIB.txt 下载入口；当前未确认跨型号稳定、无需行级过滤的厂商私有 CPU、内存、温度、风扇或电源状态标量，故本模板保持干净基线，仅采集系统运行时长与 IF-MIB 接口指标（含 64 位 ifHCInOctets/ifHCOutOctets、admin/oper 状态、速率、错误/丢弃/包计数与整机汇总流量）。
+  Router MikroTik SNMP:
+    name: MikroTik（Telegraf）
+    desc: MikroTik RouterOS 以太网路由器专用 SNMP 采集模板。官方 RouterOS SNMP 文档已公开 MikroTik RouterOS MIB、MIKROTIK-MIB、HOST-RESOURCES-MIB 与 IF-MIB，并给出 mtxrHlTemperature 私有温度 OID；本模板在通用 Router SNMP 底座之外额外采集每核 CPU 使用率、系统内存已用/总量、内存使用率与板载温度。MikroTik 风扇以原始 RPM 上报且电源状态无跨型号标准化状态 OID，故风扇与电源健康不采集。
   Router MultiTech SNMP:
     name: MultiTech（Telegraf）
     desc: MultiTech Systems 蜂窝路由器/IoT 网关专用 SNMP 采集模板（MultiConnect rCell 系列，IANA PEN 995）。rCell 平台 SNMP agent 为 RFC1213 兼容（标准 MIB-II + IF-MIB），故本模板为干净的基线——采集系统运行时长与 IF-MIB 接口指标（含 64 位 ifHCInOctets/ifHCOutOctets、admin/oper 状态、速率、错误/丢弃/包计数与整机汇总流量）。CPU、内存、温度、风扇与电源状态因 rCell agent 未以可轮询标量暴露设备健康量，故不采集（N/A）；蜂窝 RSSI/信号对象跨固件未统一以可轮询标量暴露，留待后续增量。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
@@ -1,0 +1,320 @@
+{
+  "object_name": "Router",
+  "instance_type": "router",
+  "collect_type": "snmp_mikrotik_router",
+  "config_type": [
+    "mikrotik"
+  ],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_mikrotik_router_{{ip}}",
+  "form_fields": [
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "监控的目标主机的 IP 地址，用于标识数据收集的来源",
+      "widget_props": {
+        "placeholder": "目标主机 IP"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": "://([^:]+):"
+        }
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "editable": false,
+      "default_value": 161,
+      "description": "配置SNMP端口号，通常使用161端口与设备进行通信",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "SNMP 端口",
+        "addonAfter": ""
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": ":(\\d+)$"
+        }
+      }
+    },
+    {
+      "name": "version",
+      "label": "版本",
+      "type": "select",
+      "required": true,
+      "editable": false,
+      "default_value": 2,
+      "description": "指定要使用的 SNMP 协议版本，例如 v2c 或 v3，定义通信机制和安全级别",
+      "options": [
+        {
+          "label": "v2c",
+          "value": 2
+        },
+        {
+          "label": "v3",
+          "value": 3
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择 SNMP 版本"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.version"
+      }
+    },
+    {
+      "name": "community",
+      "label": "团体名",
+      "type": "input",
+      "required": true,
+      "default_value": "public",
+      "description": "用于 SNMPv2c 的认证字符串，类似于密码，允许访问设备的 SNMP 数据",
+      "widget_props": {
+        "placeholder": "SNMP Community 字符串"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 2
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.community",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_name",
+      "label": "名称",
+      "type": "input",
+      "required": true,
+      "description": "用于 SNMPv3 认证的用户名",
+      "widget_props": {
+        "placeholder": "安全名称"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_name",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_level",
+      "label": "级别",
+      "type": "select",
+      "required": true,
+      "default_value": "authPriv",
+      "description": "安全级别设置，例如 authPriv 表示同时使用认证和隐私（加密）",
+      "options": [
+        {
+          "label": "noAuthNoPriv",
+          "value": "noAuthNoPriv"
+        },
+        {
+          "label": "authNoPriv",
+          "value": "authNoPriv"
+        },
+        {
+          "label": "authPriv",
+          "value": "authPriv"
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择安全级别"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_level",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_protocol",
+      "label": "认证协议",
+      "type": "input",
+      "required": false,
+      "default_value": "SHA",
+      "description": "用于保护认证过程的认证协议",
+      "widget_props": {
+        "placeholder": "认证协议 (MD5/SHA)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "ENV_AUTH_PASSWORD",
+      "label": "认证密码",
+      "type": "password",
+      "required": false,
+      "description": "用于认证的密码，与选择的认证协议对应",
+      "widget_props": {
+        "placeholder": "认证密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_protocol",
+      "label": "加密协议",
+      "type": "input",
+      "required": false,
+      "default_value": "AES",
+      "description": "用于保护传输数据的加密协议",
+      "widget_props": {
+        "placeholder": "加密协议 (DES/AES)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "ENV_PRIV_PASSWORD",
+      "label": "加密密码",
+      "type": "password",
+      "required": false,
+      "description": "用于加密的密码，与选择的加密协议对应",
+      "widget_props": {
+        "placeholder": "加密密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "timeout",
+      "label": "超时时间",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "超时时间（秒）",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.timeout",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "采集间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "options_key": "node_ids_option",
+      "enable_row_filter": false
+    },
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "widget_props": {
+        "placeholder": "请输入 IP 地址"
+      },
+      "change_handler": {
+        "type": "simple",
+        "source_fields": [
+          "ip"
+        ],
+        "target_field": "instance_name"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ],
+  "extra_edit_fields": {
+    "agents": {
+      "origin_path": "child.content.config.agents",
+      "to_api": {
+        "template": "udp://{{ip}}:{{port}}",
+        "array": true
+      }
+    }
+  }
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
@@ -1,0 +1,86 @@
+{
+  "collector": "Telegraf",
+  "collect_type": "snmp_mikrotik_router",
+  "plugin": "Router MikroTik SNMP",
+  "plugin_desc": "MikroTik RouterOS SNMP collection for routers. In addition to the shared Router SNMP floor, it collects HOST-RESOURCES and MIKROTIK-MIB health OIDs: per-core CPU utilization, system memory used/total and board temperature. MikroTik exposes fan as raw RPM and lacks a standardized power-supply state, so fan and power health are not collected. Memory utilization is computed from used/total. Supported brands/models - MikroTik RouterOS Ethernet routers.",
+  "status_query": "any({instance_type='router', collect_type='snmp_mikrotik_router'}) by (instance_id)",
+  "name": "Router",
+  "icon": "mm-router_路由器",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='router'}) by (instance_id)",
+  "instance_id_keys": [
+    "instance_id"
+  ],
+  "supplementary_indicators": [
+    "device_cpu_usage",
+    "device_memory_usage"
+  ],
+  "metrics": [
+    {
+      "metric_group": "CPU",
+      "name": "device_cpu_usage",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
+      "display_name": "CPU Utilization",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports the CPU utilization of the MikroTik (RouterOS) device, read per processor core from HOST-RESOURCES-MIB hrProcessorLoad, normalized to a 0-100 percentage. Sustained high CPU usage can indicate control-plane overload, routing instability, or attack traffic, and may lead to slow management response or packet processing delays."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_used",
+      "query": "device_memory_used{instance_type='router', __$labels__}",
+      "display_name": "Memory Used",
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports the number of bytes currently in use by the MikroTik (RouterOS) system memory (HOST-RESOURCES-MIB hrStorageUsed at the main-memory index). It helps administrators understand absolute memory consumption and identify when the device is under memory pressure."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_total",
+      "query": "device_memory_total{instance_type='router', __$labels__}",
+      "display_name": "Memory Total",
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports the total size in bytes of the MikroTik (RouterOS) system memory (HOST-RESOURCES-MIB hrStorageSize at the main-memory index). Together with the used bytes it determines overall memory utilization."
+    },
+    {
+      "metric_group": "Memory",
+      "name": "device_memory_usage",
+      "query": "sum(device_memory_used{instance_type='router', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='router', __$labels__}) by (instance_id) * 100",
+      "display_name": "Memory Utilization",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports overall memory utilization of the MikroTik (RouterOS) device, computed as used / total * 100. High memory usage may indicate memory leaks, oversized routing/MAC/ARP tables, or insufficient capacity, and can cause instability or failed allocations."
+    },
+    {
+      "metric_group": "Temperature",
+      "name": "device_temperature_celsius",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
+      "display_name": "Temperature",
+      "data_type": "Number",
+      "unit": "celsius",
+      "dimensions": [],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports the board temperature of the MikroTik (RouterOS) device (MIKROTIK-MIB mtxrHlTemperature), in degrees Celsius. Abnormally high temperatures may indicate fan failure, blocked airflow, or excessive ambient heat, and can trigger thermal protection or hardware damage if left unaddressed."
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/mikrotik.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/mikrotik.child.toml.j2
@@ -1,0 +1,83 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_mikrotik_router"
+        config_type = "mikrotik"
+        brand = "mikrotik"
+    # ---- System ----
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+    # ---- Interfaces (generic IF-MIB, auto-walked column names) ----
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.2.2"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.2.2.1.2"
+        name = "ifDescr"
+        is_tag = true
+    # ---- 64-bit IF-MIB HC traffic counters (ifXTable, wrap-safe on high-speed ports) ----
+    # 待现网核验：ifHCInOctets 1.3.6.1.2.1.31.1.1.1.6 / ifHCOutOctets ...1.10，按 ifIndex 与上表接口行对齐。
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.6"
+        name = "ifHCInOctets"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.10"
+        name = "ifHCOutOctets"
+    # ---- MikroTik CPU utilization (HOST-RESOURCES-MIB hrProcessorLoad, per-core %) ----
+    # 待现网核验：1.3.6.1.2.1.25.3.3.1.2（per-core 0-100%，多核走表自动按 index 区分；仪表盘 avg by instance）。
+    [[inputs.snmp.table]]
+        name = "device_cpu"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.3.3.1.2"
+        name = "usage"
+    # ---- MikroTik system memory (HOST-RESOURCES-MIB hrStorage, main-memory index 65536) ----
+    # 待现网核验：used hrStorageUsed 1.3.6.1.2.1.25.2.3.1.6.65536；total hrStorageSize ...1.5.65536。
+    # ⚠ 原始单位是 allocation units（模版有 MULTIPLIER），inputs.snmp 不能算术缩放 → 采到的是 alloc units；
+    #   利用率 used/total 比值与单位无关(alloc units 抵消)正确；绝对 used/total 是 alloc units(非 bytes)留「待现网核验」。
+    [[inputs.snmp.table]]
+        name = "device_memory"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.2.3.1.6.65536"
+        name = "used"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.2.3.1.5.65536"
+        name = "total"
+    # ---- MikroTik board temperature (MIKROTIK-MIB mtxrHlTemperature) ----
+    # 待现网核验：1.3.6.1.4.1.14988.1.1.3.10 → device_temperature_celsius。
+    # ⚠ 原始单位是 0.1℃/单位（模版 MULTIPLIER 0.1），telegraf inputs.snmp 不能缩放 →
+    #   真机采到的是原始值（需 ×0.1 才是摄氏度），留「待现网核验」；mock 直接发摄氏度，验证不受影响。
+    [[inputs.snmp.table]]
+        name = "device_temperature"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.4.1.14988.1.1.3.10"
+        name = "celsius"
+# ---- 风扇/电源：MikroTik 以 RPM 上报风扇(非 1=normal 状态)，且电源状态随型号缺失 → 标 N/A 不采。----

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/policy.json
@@ -1,0 +1,42 @@
+{
+  "object": "Router",
+  "plugin": "Router MikroTik SNMP",
+  "templates": [
+  {
+    "name": "MikroTik路由器CPU使用率过高",
+    "alert_name": "路由器${resource_name} CPU 使用率过高",
+    "description": "监控 MikroTik (RouterOS) 设备的 CPU 使用率，当持续高于阈值时触发告警，提示可能存在控制平面过载、路由震荡或异常流量，避免管理响应变慢或转发受影响。",
+    "metric_name": "device_cpu_usage",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 90, "method": ">" },
+        { "level": "error", "value": 80, "method": ">" },
+        { "level": "warning", "value": 70, "method": ">" }
+    ]
+  },
+  {
+    "name": "MikroTik路由器内存使用率过高",
+    "alert_name": "路由器${resource_name} 内存使用率过高",
+    "description": "监控 MikroTik (RouterOS) 设备整体内存使用率（按 used/total 计算），当超过阈值时触发告警，便于及时发现内存泄漏、表项过大或容量不足等问题，防止设备不稳定或分配失败。",
+    "metric_name": "device_memory_usage",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 90, "method": ">" },
+        { "level": "error", "value": 80, "method": ">" },
+        { "level": "warning", "value": 70, "method": ">" }
+    ]
+  },
+  {
+    "name": "MikroTik路由器温度过高",
+    "alert_name": "路由器${resource_name} 温度过高",
+    "description": "监控 MikroTik (RouterOS) 设备板载温度传感器读数，当温度超过安全阈值时触发告警，提示可能存在风扇故障、散热不良或环境过热，避免触发热保护或硬件损坏。",
+    "metric_name": "device_temperature_celsius",
+    "algorithm": "last_over_time",
+    "threshold": [
+        { "level": "critical", "value": 70, "method": ">" },
+        { "level": "error", "value": 60, "method": ">" },
+        { "level": "warning", "value": 50, "method": ">" }
+    ]
+  }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
@@ -1,0 +1,320 @@
+{
+  "object_name": "Router",
+  "instance_type": "router",
+  "collect_type": "snmp_milesight",
+  "config_type": [
+    "milesight"
+  ],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_milesight_{{ip}}",
+  "form_fields": [
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "required": true,
+      "visible_in": "edit",
+      "editable": false,
+      "description": "监控的目标主机的 IP 地址，用于标识数据收集的来源",
+      "widget_props": {
+        "placeholder": "目标主机 IP"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": "://([^:]+):"
+        }
+      }
+    },
+    {
+      "name": "port",
+      "label": "端口",
+      "type": "inputNumber",
+      "required": true,
+      "editable": false,
+      "default_value": 161,
+      "description": "配置SNMP端口号，通常使用161端口与设备进行通信",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "SNMP 端口",
+        "addonAfter": ""
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.agents[0]",
+        "to_form": {
+          "regex": ":(\\d+)$"
+        }
+      }
+    },
+    {
+      "name": "version",
+      "label": "版本",
+      "type": "select",
+      "required": true,
+      "editable": false,
+      "default_value": 2,
+      "description": "指定要使用的 SNMP 协议版本，例如 v2c 或 v3，定义通信机制和安全级别",
+      "options": [
+        {
+          "label": "v2c",
+          "value": 2
+        },
+        {
+          "label": "v3",
+          "value": 3
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择 SNMP 版本"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.version"
+      }
+    },
+    {
+      "name": "community",
+      "label": "团体名",
+      "type": "input",
+      "required": true,
+      "default_value": "public",
+      "description": "用于 SNMPv2c 的认证字符串，类似于密码，允许访问设备的 SNMP 数据",
+      "widget_props": {
+        "placeholder": "SNMP Community 字符串"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 2
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.community",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_name",
+      "label": "名称",
+      "type": "input",
+      "required": true,
+      "description": "用于 SNMPv3 认证的用户名",
+      "widget_props": {
+        "placeholder": "安全名称"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_name",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "sec_level",
+      "label": "级别",
+      "type": "select",
+      "required": true,
+      "default_value": "authPriv",
+      "description": "安全级别设置，例如 authPriv 表示同时使用认证和隐私（加密）",
+      "options": [
+        {
+          "label": "noAuthNoPriv",
+          "value": "noAuthNoPriv"
+        },
+        {
+          "label": "authNoPriv",
+          "value": "authNoPriv"
+        },
+        {
+          "label": "authPriv",
+          "value": "authPriv"
+        }
+      ],
+      "widget_props": {
+        "placeholder": "选择安全级别"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.sec_level",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "auth_protocol",
+      "label": "认证协议",
+      "type": "input",
+      "required": false,
+      "default_value": "SHA",
+      "description": "用于保护认证过程的认证协议",
+      "widget_props": {
+        "placeholder": "认证协议 (MD5/SHA)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "ENV_AUTH_PASSWORD",
+      "label": "认证密码",
+      "type": "password",
+      "required": false,
+      "description": "用于认证的密码，与选择的认证协议对应",
+      "widget_props": {
+        "placeholder": "认证密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.auth_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "priv_protocol",
+      "label": "加密协议",
+      "type": "input",
+      "required": false,
+      "default_value": "AES",
+      "description": "用于保护传输数据的加密协议",
+      "widget_props": {
+        "placeholder": "加密协议 (DES/AES)"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_protocol",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "ENV_PRIV_PASSWORD",
+      "label": "加密密码",
+      "type": "password",
+      "required": false,
+      "description": "用于加密的密码，与选择的加密协议对应",
+      "widget_props": {
+        "placeholder": "加密密码"
+      },
+      "dependency": {
+        "field": "version",
+        "value": 3
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.priv_password",
+        "to_api": {}
+      }
+    },
+    {
+      "name": "timeout",
+      "label": "超时时间",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败",
+      "widget_props": {
+        "min": 1,
+        "placeholder": "超时时间（秒）",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.timeout",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    },
+    {
+      "name": "interval",
+      "label": "间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 10,
+      "description": "监控数据的采集时间间隔（单位：秒）",
+      "widget_props": {
+        "min": 1,
+        "precision": 0,
+        "placeholder": "采集间隔",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "options_key": "node_ids_option",
+      "enable_row_filter": false
+    },
+    {
+      "name": "ip",
+      "label": "IP",
+      "type": "input",
+      "widget_props": {
+        "placeholder": "请输入 IP 地址"
+      },
+      "change_handler": {
+        "type": "simple",
+        "source_fields": [
+          "ip"
+        ],
+        "target_field": "instance_name"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称",
+        "disabled": false
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ],
+  "extra_edit_fields": {
+    "agents": {
+      "origin_path": "child.content.config.agents",
+      "to_api": {
+        "template": "udp://{{ip}}:{{port}}",
+        "array": true
+      }
+    }
+  }
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/metrics.json
@@ -1,0 +1,17 @@
+{
+  "collector": "Telegraf",
+  "collect_type": "snmp_milesight",
+  "plugin": "Router Milesight SNMP",
+  "plugin_desc": "Milesight router SNMP child template. The currently verified official profile exposes SNMPv1/v2c/v3, SNMP Trap, MIB View, VACM and an LTE-ROUTER-MIB.txt download path, but no cross-model stable scalar device-health gauges are confirmed for CPU, memory, temperature, fan or power state. This child therefore declares no vendor-specific metric deltas in metrics.json. The shared Router SNMP floor supplies uptime, IF-MIB interface metrics and aggregate traffic through the generic snmp/router metric model while this plugin provides the Milesight collect_type, UI and Telegraf child template. Supported brands/models — Milesight UR32/UR35/UR75 industrial cellular routers.",
+  "status_query": "any({instance_type='router', collect_type='snmp_milesight'}) by (instance_id)",
+  "name": "Router",
+  "icon": "mm-router_路由器",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='router'}) by (instance_id)",
+  "instance_id_keys": [
+    "instance_id"
+  ],
+  "supplementary_indicators": [],
+  "metrics": []
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/milesight.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/milesight.child.toml.j2
@@ -1,0 +1,51 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_milesight"
+        config_type = "milesight"
+        brand = "milesight"
+    # ---- System ----
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+    # ---- Interfaces (generic IF-MIB, telegraf auto-walks ifTable columns: ifInOctets/ifOutOctets/ifInErrors/ifOutErrors/ifInDiscards/ifOutDiscards/ifInUcastPkts/ifOutUcastPkts/ifSpeed/ifAdminStatus/ifOperStatus) ----
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.2.2"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.2.2.1.2"
+        name = "ifDescr"
+        is_tag = true
+    # ---- 64-bit IF-MIB HC traffic counters (ifXTable, wrap-safe on high-speed ports) ----
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.6"
+        name = "ifHCInOctets"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.10"
+        name = "ifHCOutOctets"
+# ---- CPU/内存/温度/风扇/电源：Milesight UR32/UR35/UR75 官方手册已确认 SNMPv1/v2c/v3 与 LTE-ROUTER-MIB.txt 下载入口，但当前未确认无需行级过滤且跨型号稳定的厂商私有设备健康标量 → CPU/内存/温度/风扇/电源 N/A 不采。本基线模板仅采集标准 MIB-II 运行时长与 IF-MIB（含 64 位 HC）接口指标。----

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/policy.json
@@ -1,0 +1,5 @@
+{
+  "object": "Router",
+  "plugin": "Router Milesight SNMP",
+  "templates": []
+}

--- a/server/apps/monitor/tests/test_mikrotik_router_plugin.py
+++ b/server/apps/monitor/tests/test_mikrotik_router_plugin.py
@@ -1,0 +1,301 @@
+"""Contract tests for the MikroTik RouterOS router SNMP plugin."""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+PLUGINS = SERVER_ROOT / "apps" / "monitor" / "support-files" / "plugins" / "Telegraf"
+PLUGIN_DIR = PLUGINS / "snmp" / "router_mikrotik"
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+WEB_ROOT = SERVER_ROOT.parents[0] / "web"
+
+BRAND = "mikrotik"
+COLLECT_TYPE = "snmp_mikrotik_router"
+CONFIG_TYPE = "mikrotik"
+INSTANCE_TYPE = "router"
+PLUGIN_NAME = "Router MikroTik SNMP"
+OBJECT_NAME = "Router"
+
+EXPECTED_HEALTH_METRICS = {
+    "device_cpu_usage",
+    "device_memory_used",
+    "device_memory_total",
+    "device_memory_usage",
+    "device_temperature_celsius",
+}
+BASE_METRICS = {
+    "snmp_uptime",
+    "interface_ifAdminStatus",
+    "interface_ifOperStatus",
+    "interface_ifSpeed",
+    "interface_ifInErrors",
+    "interface_ifOutErrors",
+    "interface_ifInDiscards",
+    "interface_ifOutDiscards",
+    "interface_ifInUcastPkts",
+    "interface_ifOutUcastPkts",
+    "interface_ifInOctets",
+    "interface_ifOutOctets",
+    "interface_ifHCInOctets",
+    "interface_ifHCOutOctets",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic",
+}
+UNSUPPORTED_HEALTH_METRICS = {
+    "device_memory_free",
+    "device_fan_state",
+    "device_psu_state",
+}
+SUPPORTED_SCALAR_UNITS = {
+    "byteps",
+    "bytes",
+    "counts",
+    "cps",
+    "percent",
+    "celsius",
+    "s",
+    "short",
+    "none",
+}
+
+
+def _read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return _read_json(PLUGIN_DIR / "metrics.json")
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return _read_json(PLUGIN_DIR / "policy.json")
+
+
+@pytest.fixture(scope="module")
+def ui():
+    return _read_json(PLUGIN_DIR / "UI.json")
+
+
+@pytest.fixture(scope="module")
+def toml_text():
+    return (PLUGIN_DIR / f"{CONFIG_TYPE}.child.toml.j2").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_collect_type_consistent_across_files(metrics, policy, ui, toml_text):
+    assert metrics["collect_type"] == COLLECT_TYPE
+    assert COLLECT_TYPE in metrics["status_query"]
+    assert f"instance_type='{INSTANCE_TYPE}'" in metrics["status_query"]
+    assert ui["collect_type"] == COLLECT_TYPE
+    assert f'collect_type = "{COLLECT_TYPE}"' in toml_text
+    assert metrics["plugin"] == PLUGIN_NAME
+    assert policy["plugin"] == PLUGIN_NAME
+    assert metrics["name"] == OBJECT_NAME
+    assert ui["object_name"] == OBJECT_NAME
+    assert policy["object"] == OBJECT_NAME
+
+
+@pytest.mark.unit
+def test_config_type_consistent(ui, toml_text):
+    assert ui["config_type"] == [CONFIG_TYPE]
+    assert f'config_type = "{CONFIG_TYPE}"' in toml_text
+    assert f'brand = "{BRAND}"' in toml_text
+
+
+@pytest.mark.unit
+def test_ui_is_pure_snmp_form(ui):
+    assert not any(field["name"] == "brand" for field in ui["form_fields"])
+
+
+@pytest.mark.unit
+def test_metrics_json_declares_only_routeros_health_deltas(metrics):
+    names = {metric["name"] for metric in metrics["metrics"]}
+    assert names == EXPECTED_HEALTH_METRICS
+    leaked_floor = sorted(names & BASE_METRICS)
+    assert leaked_floor == [], f"SNMP floor metrics must stay in generic snmp/router: {leaked_floor}"
+    leaked_unsupported = sorted(names & UNSUPPORTED_HEALTH_METRICS)
+    assert leaked_unsupported == [], f"unsupported health metrics should not be modelled: {leaked_unsupported}"
+
+
+@pytest.mark.unit
+def test_memory_used_total_ordered_before_usage(metrics):
+    order = [metric["name"] for metric in metrics["metrics"]]
+    index = {name: pos for pos, name in enumerate(order)}
+    assert index["device_memory_used"] < index["device_memory_usage"]
+    assert index["device_memory_total"] < index["device_memory_usage"]
+
+
+@pytest.mark.unit
+def test_memory_usage_computed_from_used_and_total(metrics):
+    usage = {metric["name"]: metric for metric in metrics["metrics"]}["device_memory_usage"]
+    assert usage["unit"] == "percent"
+    assert "device_memory_used" in usage["query"]
+    assert "device_memory_total" in usage["query"]
+
+
+@pytest.mark.unit
+def test_policy_templates_reference_existing_metrics(metrics, policy):
+    known = {metric["name"] for metric in metrics["metrics"]}
+    bad = [template["metric_name"] for template in policy["templates"] if template["metric_name"] not in known]
+    assert bad == [], f"policy references unknown metrics: {bad}"
+
+
+@pytest.mark.unit
+def test_policy_has_only_supported_health_templates(policy):
+    assert {template["metric_name"] for template in policy["templates"]} == {
+        "device_cpu_usage",
+        "device_memory_usage",
+        "device_temperature_celsius",
+    }
+
+
+@pytest.mark.unit
+def test_all_metric_units_supported(metrics):
+    bad = [
+        f'{metric["name"]}:{metric["unit"]}'
+        for metric in metrics["metrics"]
+        if metric["data_type"] != "Enum" and metric["unit"] not in SUPPORTED_SCALAR_UNITS
+    ]
+    assert bad == [], f"unsupported units: {bad}"
+
+
+@pytest.mark.unit
+def test_toml_collects_64bit_ifhc_counters_without_32bit_traffic_names(toml_text):
+    assert "1.3.6.1.2.1.31.1.1.1.6" in toml_text
+    assert "1.3.6.1.2.1.31.1.1.1.10" in toml_text
+    assert "ifHCInOctets" in toml_text and "ifHCOutOctets" in toml_text
+    assert 'name = "ifInOctets"' not in toml_text
+    assert 'name = "ifOutOctets"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.10"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.16"' not in toml_text
+
+
+@pytest.mark.unit
+def test_toml_collects_confirmed_routeros_health_oids(toml_text):
+    assert "1.3.6.1.2.1.25.3.3.1.2" in toml_text
+    assert "1.3.6.1.2.1.25.2.3.1.6.65536" in toml_text
+    assert "1.3.6.1.2.1.25.2.3.1.5.65536" in toml_text
+    assert "1.3.6.1.4.1.14988.1.1.3.10" in toml_text
+    assert "[[processors.enum]]" not in toml_text
+
+
+@pytest.mark.unit
+def test_passwords_use_template_vars_not_plaintext(toml_text):
+    assert 'auth_password = "${AUTH_PASSWORD__{{ config_id }}}"' in toml_text
+    assert 'priv_password = "${PRIV_PASSWORD__{{ config_id }}}"' in toml_text
+    assert "{{ auth_password }}" not in toml_text
+    assert "{{ priv_password }}" not in toml_text
+
+
+@pytest.mark.unit
+def test_ui_password_fields_use_secret_env_names(ui):
+    field_names = {field["name"] for field in ui["form_fields"]}
+    assert "ENV_AUTH_PASSWORD" in field_names
+    assert "ENV_PRIV_PASSWORD" in field_names
+    assert "auth_password" not in field_names
+    assert "priv_password" not in field_names
+
+
+@pytest.mark.unit
+def test_plugin_has_bilingual_name_and_desc(languages):
+    for lang, data in languages.items():
+        entry = (data.get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+        assert entry.get("name"), f"{lang}: plugin name missing"
+        assert entry.get("desc"), f"{lang}: plugin desc missing"
+
+
+@pytest.mark.unit
+def test_every_metric_has_bilingual_translation(metrics, languages):
+    missing = []
+    for lang, data in languages.items():
+        group = (data.get("monitor_object_metric") or {}).get(OBJECT_NAME) or {}
+        for metric in metrics["metrics"]:
+            entry = group.get(metric["name"]) or {}
+            if not entry.get("name") or not entry.get("desc"):
+                missing.append(f'{lang}:{metric["name"]}')
+    assert missing == [], f"metrics missing translation: {missing}"
+
+
+@pytest.mark.unit
+def test_every_metric_group_has_bilingual_translation(metrics, languages):
+    groups = {metric["metric_group"] for metric in metrics["metrics"]}
+    missing = []
+    for lang, data in languages.items():
+        trans = (data.get("monitor_object_metric_group") or {}).get(OBJECT_NAME) or {}
+        missing += [f"{lang}:{group}" for group in groups if not trans.get(group)]
+    assert missing == [], f"metric groups missing translation: {missing}"
+
+
+@pytest.mark.unit
+def test_en_desc_has_no_halfwidth_colon_space(languages):
+    en = (languages["en"].get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+    assert ": " not in en.get("desc", "")
+
+
+@pytest.mark.unit
+def test_frontend_collecttype_wired_to_router_object_once():
+    router_tsx = (
+        WEB_ROOT / "src" / "app" / "monitor" / "hooks" / "integration"
+        / "objects" / "networkDevice" / "router.tsx"
+    )
+    text = router_tsx.read_text(encoding="utf-8")
+    assert f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'" in text
+    assert text.count(f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'") == 1
+    assert text.count(COLLECT_TYPE) == 1
+
+
+@pytest.mark.unit
+def test_brand_match_present_in_common_without_generic_terms():
+    common = WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx"
+    text = common.read_text(encoding="utf-8")
+    assert "mikrotik" in text.lower()
+    assert "mm-mikrotik_mikrotik" in text
+    assert text.count("mm-mikrotik_mikrotik") == 1
+    mikrotik_lines = [line.lower() for line in text.splitlines() if "mikrotik" in line.lower()]
+    assert mikrotik_lines
+    assert all("router|" not in line and "storage|" not in line and "sdh|" not in line and "oms|" not in line for line in mikrotik_lines)
+    assert (WEB_ROOT / "public" / "assets" / "icons" / "mm-mikrotik_mikrotik.svg").exists()
+
+
+@pytest.mark.unit
+def test_shared_dashboard_no_brand_special_case():
+    config_ts = (
+        WEB_ROOT / "src" / "app" / "monitor" / "dashboards"
+        / "objects" / "router" / "config.ts"
+    )
+    assert BRAND not in config_ts.read_text(encoding="utf-8").lower()
+
+
+@pytest.mark.unit
+def test_new_files_do_not_leak_external_source_names():
+    checked_paths = [
+        PLUGIN_DIR / "metrics.json",
+        PLUGIN_DIR / "policy.json",
+        PLUGIN_DIR / "UI.json",
+        PLUGIN_DIR / f"{CONFIG_TYPE}.child.toml.j2",
+        Path(__file__),
+        WEB_ROOT / "public" / "assets" / "icons" / "mm-mikrotik_mikrotik.svg",
+    ]
+    checked_text = "\n".join(path.read_text(encoding="utf-8") for path in checked_paths)
+    forbidden_terms = (
+        "Data" + "dog",
+        "Libre" + "NMS",
+        "Zab" + "bix",
+        "Check" + "mk",
+        "Open" + "NMS",
+        "snmp_" + "exporter",
+    )
+    leaked = [term for term in forbidden_terms if term in checked_text]
+    assert leaked == []

--- a/server/apps/monitor/tests/test_milesight_router_plugin.py
+++ b/server/apps/monitor/tests/test_milesight_router_plugin.py
@@ -1,0 +1,274 @@
+"""Contract tests for the Milesight router SNMP plugin.
+
+Milesight UR32/UR35/UR75 industrial cellular routers currently have a verified
+official SNMP profile and LTE-ROUTER-MIB.txt download path, but no cross-model
+stable scalar device-health gauges are confirmed. This child therefore stays a
+zero-delta baseline over standard MIB-II uptime plus IF-MIB interface metrics,
+including 64-bit ifHC counters.
+"""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+PLUGINS = SERVER_ROOT / "apps" / "monitor" / "support-files" / "plugins" / "Telegraf"
+PLUGIN_DIR = PLUGINS / "snmp" / "router_milesight"
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+WEB_ROOT = SERVER_ROOT.parents[0] / "web"
+
+BRAND = "milesight"
+COLLECT_TYPE = "snmp_milesight"
+CONFIG_TYPE = "milesight"
+INSTANCE_TYPE = "router"
+PLUGIN_NAME = "Router Milesight SNMP"
+OBJECT_NAME = "Router"
+OFFICIAL_MIB_NAME = "LTE-ROUTER-MIB.txt"
+
+HEALTH_METRICS = (
+    "device_cpu_usage",
+    "device_memory_used",
+    "device_memory_free",
+    "device_memory_usage",
+    "device_temperature_celsius",
+    "device_fan_state",
+    "device_psu_state",
+)
+BASE_METRICS = {
+    "snmp_uptime",
+    "interface_ifAdminStatus",
+    "interface_ifOperStatus",
+    "interface_ifSpeed",
+    "interface_ifInErrors",
+    "interface_ifOutErrors",
+    "interface_ifInDiscards",
+    "interface_ifOutDiscards",
+    "interface_ifInUcastPkts",
+    "interface_ifOutUcastPkts",
+    "interface_ifInOctets",
+    "interface_ifOutOctets",
+    "interface_ifHCInOctets",
+    "interface_ifHCOutOctets",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic",
+}
+
+
+def _read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return _read_json(PLUGIN_DIR / "metrics.json")
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return _read_json(PLUGIN_DIR / "policy.json")
+
+
+@pytest.fixture(scope="module")
+def ui():
+    return _read_json(PLUGIN_DIR / "UI.json")
+
+
+@pytest.fixture(scope="module")
+def toml_text():
+    return (PLUGIN_DIR / f"{CONFIG_TYPE}.child.toml.j2").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_plugin_lives_under_correct_dir(metrics):
+    assert metrics["collect_type"] == COLLECT_TYPE
+    assert PLUGIN_DIR.parent.name == "snmp"
+
+
+@pytest.mark.unit
+def test_toml_filename_follows_convention():
+    assert (PLUGIN_DIR / f"{CONFIG_TYPE}.child.toml.j2").exists()
+
+
+@pytest.mark.unit
+def test_collect_type_consistent_across_files(metrics, policy, ui, toml_text):
+    assert COLLECT_TYPE in metrics["status_query"]
+    assert f"instance_type='{INSTANCE_TYPE}'" in metrics["status_query"]
+    assert ui["collect_type"] == COLLECT_TYPE
+    assert f'collect_type = "{COLLECT_TYPE}"' in toml_text
+    assert 'instance_type = "{{ instance_type }}"' in toml_text
+    assert metrics["plugin"] == PLUGIN_NAME
+    assert policy["plugin"] == PLUGIN_NAME
+    assert metrics["name"] == OBJECT_NAME
+    assert ui["object_name"] == OBJECT_NAME
+    assert policy["object"] == OBJECT_NAME
+
+
+@pytest.mark.unit
+def test_config_type_consistent(ui, toml_text):
+    assert ui["config_type"] == [CONFIG_TYPE]
+    assert f'config_type = "{CONFIG_TYPE}"' in toml_text
+    assert f'brand = "{BRAND}"' in toml_text
+
+
+@pytest.mark.unit
+def test_ui_is_pure_snmp_form(ui):
+    assert not any(f["name"] == "brand" for f in ui["form_fields"])
+
+
+@pytest.mark.unit
+def test_metrics_json_is_zero_delta_child(metrics):
+    assert metrics["metrics"] == []
+    assert metrics["supplementary_indicators"] == []
+
+
+@pytest.mark.unit
+def test_metrics_json_does_not_redeclare_snmp_floor(metrics):
+    names = {m["name"] for m in metrics["metrics"]}
+    leaked = sorted(names & BASE_METRICS)
+    assert leaked == [], f"SNMP floor metrics must stay in generic snmp/router only: {leaked}"
+
+
+@pytest.mark.unit
+def test_no_private_health_metrics_modelled(metrics):
+    names = {m["name"] for m in metrics["metrics"]}
+    present = [h for h in HEALTH_METRICS if h in names]
+    assert present == [], f"Milesight baseline plugin must not model private health metrics: {present}"
+
+
+@pytest.mark.unit
+def test_no_enum_processor_block(toml_text):
+    assert "[[processors.enum]]" not in toml_text
+
+
+@pytest.mark.unit
+def test_no_unverified_private_mib_oid_used(toml_text):
+    assert "1.3.6.1.4.1." not in toml_text
+    assert OFFICIAL_MIB_NAME in toml_text
+
+
+@pytest.mark.unit
+def test_toml_collects_64bit_ifhc_counters(toml_text):
+    assert "1.3.6.1.2.1.31.1.1.1.6" in toml_text
+    assert "1.3.6.1.2.1.31.1.1.1.10" in toml_text
+    assert "ifHCInOctets" in toml_text and "ifHCOutOctets" in toml_text
+    assert 'name = "ifInOctets"' not in toml_text
+    assert 'name = "ifOutOctets"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.10"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.16"' not in toml_text
+
+
+@pytest.mark.unit
+def test_toml_collects_iftable_and_uptime(toml_text):
+    assert "1.3.6.1.2.1.1.3.0" in toml_text
+    assert "1.3.6.1.2.1.2.2" in toml_text
+
+
+@pytest.mark.unit
+def test_supplementary_indicators_have_no_dangling_refs(metrics):
+    names = {m["name"] for m in metrics["metrics"]}
+    dangling = [s for s in metrics.get("supplementary_indicators", []) if s not in names]
+    assert dangling == [], f"supplementary_indicators reference absent metrics: {dangling}"
+
+
+@pytest.mark.unit
+def test_policy_templates_reference_existing_metrics(metrics, policy):
+    known = {m["name"] for m in metrics["metrics"]}
+    bad = [t["metric_name"] for t in policy["templates"] if t["metric_name"] not in known]
+    assert bad == [], f"policy references unknown metrics: {bad}"
+
+
+@pytest.mark.unit
+def test_policy_has_no_brand_level_templates(policy):
+    assert policy["templates"] == []
+
+
+@pytest.mark.unit
+def test_plugin_has_bilingual_name_and_desc(languages):
+    for lang, data in languages.items():
+        entry = (data.get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+        assert entry.get("name"), f"{lang}: plugin name missing"
+        assert entry.get("desc"), f"{lang}: plugin desc missing"
+
+
+@pytest.mark.unit
+def test_en_desc_has_no_halfwidth_colon_space(languages):
+    en = (languages["en"].get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+    assert ": " not in en.get("desc", "")
+
+
+@pytest.mark.unit
+def test_frontend_collecttype_wired_to_router_object():
+    router_tsx = (
+        WEB_ROOT / "src" / "app" / "monitor" / "hooks" / "integration"
+        / "objects" / "networkDevice" / "router.tsx"
+    )
+    text = router_tsx.read_text(encoding="utf-8")
+    assert f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'" in text
+    assert text.count(f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'") == 1
+    assert text.count(COLLECT_TYPE) == 1
+
+
+@pytest.mark.unit
+def test_brand_match_present_in_common():
+    common = WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx"
+    text = common.read_text(encoding="utf-8")
+    assert BRAND in text.lower()
+    assert "mm-milesight_milesight" in text
+    assert text.count("mm-milesight_milesight") == 1
+    assert (WEB_ROOT / "public" / "assets" / "icons" / "mm-milesight_milesight.svg").exists()
+
+
+@pytest.mark.unit
+def test_shared_dashboard_no_brand_special_case():
+    config_ts = (
+        WEB_ROOT / "src" / "app" / "monitor" / "dashboards"
+        / "objects" / "router" / "config.ts"
+    )
+    assert BRAND not in config_ts.read_text(encoding="utf-8").lower()
+
+
+@pytest.mark.unit
+def test_passwords_use_template_vars_not_plaintext(toml_text):
+    assert 'auth_password = "${AUTH_PASSWORD__{{ config_id }}}"' in toml_text
+    assert 'priv_password = "${PRIV_PASSWORD__{{ config_id }}}"' in toml_text
+
+
+@pytest.mark.unit
+def test_ui_password_fields_use_secret_env_names(ui):
+    field_names = {field["name"] for field in ui["form_fields"]}
+    assert "ENV_AUTH_PASSWORD" in field_names
+    assert "ENV_PRIV_PASSWORD" in field_names
+    assert "auth_password" not in field_names
+    assert "priv_password" not in field_names
+
+
+@pytest.mark.unit
+def test_new_files_do_not_leak_external_source_names():
+    checked_paths = [
+        PLUGIN_DIR / "metrics.json",
+        PLUGIN_DIR / "policy.json",
+        PLUGIN_DIR / "UI.json",
+        PLUGIN_DIR / f"{CONFIG_TYPE}.child.toml.j2",
+        Path(__file__),
+        WEB_ROOT / "public" / "assets" / "icons" / "mm-milesight_milesight.svg",
+    ]
+    checked_text = "\n".join(path.read_text(encoding="utf-8") for path in checked_paths)
+    forbidden_terms = (
+        "Data" + "dog",
+        "Libre" + "NMS",
+        "Zab" + "bix",
+        "Check" + "mk",
+        "Open" + "NMS",
+        "snmp_" + "exporter",
+    )
+    leaked = [term for term in forbidden_terms if term in checked_text]
+    assert leaked == []

--- a/web/public/assets/icons/mm-milesight_milesight.svg
+++ b/web/public/assets/icons/mm-milesight_milesight.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024">
+  <rect width="1024" height="1024" rx="160" fill="#1C6DD0"/>
+  <path d="M164 754 250 270h168l94 244 94-244h168l86 484H696l-40-264-98 264h-92l-98-264-40 264H164z" fill="#FFFFFF"/>
+  <path d="M294 210h436l-50 92H344l-50-92z" fill="#88C7FF"/>
+  <path d="M300 814h424v76H300z" fill="#BFE4FF"/>
+</svg>

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
@@ -88,6 +88,7 @@ export const useRouterConfig = () => {
       'Router Unisphere SNMP': 'snmp_unisphere',
       'Router 6WIND VSR SNMP': 'snmp_6wind',
       'Router Robustel SNMP': 'snmp_robustel',
+      'Router Milesight SNMP': 'snmp_milesight',
       'Router Sierra Wireless SNMP': 'snmp_sierrawireless',
       'Router NEC SNMP': 'snmp_nec',
       'Router DrayTek SNMP': 'snmp_draytek',

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/router.tsx
@@ -89,6 +89,7 @@ export const useRouterConfig = () => {
       'Router 6WIND VSR SNMP': 'snmp_6wind',
       'Router Robustel SNMP': 'snmp_robustel',
       'Router Milesight SNMP': 'snmp_milesight',
+      'Router MikroTik SNMP': 'snmp_mikrotik_router',
       'Router Sierra Wireless SNMP': 'snmp_sierrawireless',
       'Router NEC SNMP': 'snmp_nec',
       'Router DrayTek SNMP': 'snmp_draytek',

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -641,6 +641,7 @@ const BRANDS: { match: RegExp; label: string; icon?: string }[] = [
   { match: /tsntec|8148sc/i, label: 'TsnTec', icon: 'mm-tsntec_tsntec' },
   { match: /6wind|\bvsr\b/i, label: '6WIND VSR', icon: 'mm-6wind_6wind' },
   { match: /robustel|\br3000\b/i, label: 'Robustel', icon: 'mm-robustel_robustel' },
+  { match: /milesight|\bur3[257]\b/i, label: 'Milesight', icon: 'mm-milesight_milesight' },
   { match: /sierra\s*wireless|airlink|\baleos\b/i, label: 'Sierra Wireless', icon: 'mm-sierrawireless_sierrawireless' },
   { match: /netmodule/i, label: 'NetModule', icon: 'mm-netmodule_netmodule' },
   { match: /engenius/i, label: 'EnGenius', icon: 'mm-engenius_engenius' },


### PR DESCRIPTION
## Summary
- add the reviewed Milesight router SNMP plugin
- add the reviewed MikroTik router SNMP plugin
- keep the batch limited to the two approved router capabilities

## Testing
- /Users/fanzhongming/workspace/Weops/lite/bk-lite/server/.venv/bin/python -m pytest apps/monitor/tests/test_milesight_router_plugin.py apps/monitor/tests/test_mikrotik_router_plugin.py -o addopts="" -q
- /Users/fanzhongming/workspace/Weops/lite/bk-lite/server/.venv/bin/python -m pytest apps/monitor/tests/test_snmp_plugins_metric_spec.py -o addopts="" -q