### PR TITLE
bugfix: 修复 WebChat 首次聊天状态迁移

### DIFF
--- a/webchat/package.json
+++ b/webchat/package.json
@@ -9,7 +9,7 @@
     "build:core": "cd packages/webchat-core && npm run build",
     "build:ui": "cd packages/webchat-ui && npm run build",
     "build:demo": "cd packages/webchat-demo && npm run build",
-    "test": "echo 'No tests configured yet'",
+    "test": "node tests/state-machine.issue-3882.mjs",
     "lint": "echo 'No linter configured yet'",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist packages/*/.next"

--- a/webchat/packages/webchat-core/src/stateMachine.ts
+++ b/webchat/packages/webchat-core/src/stateMachine.ts
@@ -41,6 +41,27 @@ export class StateMachine {
   }
 
   /**
+   * Move into chatting through the state machine's legal connection states.
+   */
+  public transitionToChatting(): boolean {
+    const pathByState: Partial<Record<ChatState, ChatState[]>> = {
+      idle: ['connecting', 'connected', 'chatting'],
+      connecting: ['connected', 'chatting'],
+      connected: ['chatting'],
+      chatting: [],
+      closed: ['idle', 'connecting', 'connected', 'chatting'],
+      error: ['idle', 'connecting', 'connected', 'chatting'],
+    };
+
+    const path = pathByState[this.state];
+    if (!path) {
+      return false;
+    }
+
+    return path.every((state) => this.transition(state));
+  }
+
+  /**
    * Subscribe to state changes
    */
   public on(listener: EventListener<StateChangeEvent>): () => void {

--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -168,7 +168,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
     switch (eventType) {
       case 'RUN_STARTED':
         setIsThinking(true);
-        stateMachineRef.current?.transition('chatting');
+        stateMachineRef.current?.transitionToChatting();
         
         streamingContentRef.current = '';
         currentMessageIdRef.current = null;
@@ -797,7 +797,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
     setIsLoading(true);
 
     try {
-      stateMachineRef.current?.transition('chatting');
+      stateMachineRef.current?.transitionToChatting();
 
       if (sseUrl) {
         // Get current session data

--- a/webchat/tests/state-machine.issue-3882.mjs
+++ b/webchat/tests/state-machine.issue-3882.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '..');
+const stateMachinePath = path.join(rootDir, 'packages/webchat-core/src/stateMachine.ts');
+const chatPath = path.join(rootDir, 'packages/webchat-ui/src/Chat.tsx');
+
+const source = fs.readFileSync(stateMachinePath, 'utf8');
+assert.match(source, /public transitionToChatting\(\): boolean/);
+assert.match(source, /idle:\s*\['connecting', 'connected', 'chatting'\]/);
+assert.match(source, /connecting:\s*\['connected', 'chatting'\]/);
+assert.match(source, /connected:\s*\['chatting'\]/);
+assert.match(source, /return path\.every\(\(state\) => this\.transition\(state\)\)/);
+
+const chatSource = fs.readFileSync(chatPath, 'utf8');
+assert.match(chatSource, /transitionToChatting\(\)/);
+assert.doesNotMatch(chatSource, /transition\(['"]chatting['"]\)/);


### PR DESCRIPTION
## 问题

WebChat 首次发送消息或收到 AG-UI `RUN_STARTED` 时，本应先进入连接流程，再进入聊天态。当前代码直接从 `idle` 切到 `chatting`，状态机会拒绝这次非法迁移，外部宿主通过 `onStateChange` 拿不到聊天态回调，容易导致按钮禁用、加载态、埋点或重复提交防护失真。

## 根因

`Chat` 组件把“开始发送/运行”和“已经进入可聊天态”合成了一步，但 `StateMachine` 的状态契约只允许 `idle -> connecting -> connected -> chatting`。`transition()` 遇到非法迁移只返回 `false` 并打印 warning，调用方没有检查返回值，所以失败被静默吞掉。

## 怎么修的

在 core 状态机里增加 `transitionToChatting()`，按当前状态选择合法迁移链路推进到 `chatting`。`Chat.tsx` 的 `RUN_STARTED` 和用户发送入口都改为复用这个 helper，不再直接调用非法的 `transition('chatting')`。

```ts
stateMachineRef.current?.transitionToChatting();
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["handleSendMessage / RUN_STARTED\nwebchat-ui/src/Chat.tsx"]
    end

    subgraph N["状态机层"]
        F1["transitionToChatting\nwebchat-core/src/stateMachine.ts"]
        F2["transition\nwebchat-core/src/stateMachine.ts"]
    end

    subgraph C["外部回调"]
        C1["onStateChange\nChat props"]
    end

    T1 --> F1 --> F2 --> C1
```

## 影响范围

改动集中在 `webchat`：`webchat-core` 增加一个向后兼容的公开 helper，`webchat-ui` 两个入口改用它。没有改 AG-UI 事件格式、消息请求参数、组件 props 或后端协议。`server/agents/web` 中只发现 AG-UI 事件生产或其他独立处理逻辑，不直接调用这个状态机。

## 验证

- `node webchat/tests/state-machine.issue-3882.mjs` 通过，验证 helper 包含合法迁移链，且 `Chat.tsx` 不再直接 `transition('chatting')`。
- `npm_config_userconfig=/dev/null npx --yes -p typescript@5.0.4 tsc -p webchat/packages/webchat-core/tsconfig.json --noEmit` 通过。
- `webchat-ui` 类型检查因本地未安装依赖失败，报错集中在缺少 `react`、`rxjs`、`@ag-ui/core`、`@webchat/core` 等依赖；未发现由本次改动新增的独立类型错误。

关联 Issue #3882。