### PR TITLE
bugfix: 优化历史告警分段分页

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -969,10 +969,19 @@ def query_monitor_alert_segments(query_data: dict, *args, **kwargs):
     if alert_type_values:
         queryset = queryset.filter(alert_type__in=alert_type_values)
 
-    items = [_build_monitor_alert_segment(alert) for alert in queryset.order_by("-start_event_time", "-created_at")]
+    ordered_queryset = queryset.order_by("-start_event_time", "-created_at")
+    total_count = ordered_queryset.count()
+    start = (page - 1) * page_size
+    end = start + page_size
+    items = [_build_monitor_alert_segment(alert) for alert in ordered_queryset[start:end]]
     return {
         "result": True,
-        "data": _paginate_items(items, page, page_size),
+        "data": {
+            "count": total_count,
+            "page": page,
+            "page_size": page_size,
+            "items": items,
+        },
         "message": "",
     }
 

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -305,6 +305,48 @@ class TestQueryMonitorAlertSegments:
         assert out["result"] is True
         assert out["data"]["count"] == 1
 
+    def test_paginates_before_building_segments(self, mocker):
+        from datetime import datetime, timezone
+        from apps.monitor.models import MonitorAlert
+
+        obj = MonitorObject.objects.create(name="QMASObj3", level="base")
+        MonitorInstance.objects.create(
+            id="('h1',)", name="h1", monitor_object=obj, is_active=True, is_deleted=False,
+        )
+        for idx, hour in enumerate([12, 11, 10], start=1):
+            MonitorAlert.objects.create(
+                policy_id=idx,
+                monitor_instance_id="('h1',)",
+                status="new",
+                level="critical",
+                start_event_time=datetime(2026, 1, 1, hour, tzinfo=timezone.utc),
+            )
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+        build_segment = mocker.patch(
+            "apps.monitor.nats.monitor._build_monitor_alert_segment",
+            side_effect=nm._build_monitor_alert_segment,
+        )
+
+        out = nm.query_monitor_alert_segments({
+            "monitor_obj_id": obj.id,
+            "start": "2026-01-01 00:00:00",
+            "end": "2026-01-02 00:00:00",
+            "page": 2,
+            "page_size": 1,
+        }, user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1})
+
+        assert out["result"] is True
+        assert out["data"]["count"] == 3
+        assert out["data"]["page"] == 2
+        assert out["data"]["page_size"] == 1
+        assert len(out["data"]["items"]) == 1
+        assert out["data"]["items"][0]["policy_id"] == 2
+        assert build_segment.call_count == 1
+
 
 class TestBuildMonitorAlertSegment:
     def test_computes_duration(self):


### PR DESCRIPTION
## 问题
历史告警分段查询支持 `page` 和 `page_size`，但原来是先把时间窗内所有匹配告警都转换成返回结构，再在 Python 列表里分页。用户只查一页小结果时，宽时间窗和大量授权实例仍会把全部历史告警加载到进程内，放大数据库读取、对象构造和内存占用。

## 根因
分页边界没有下推到数据库查询层。`MonitorAlert` queryset 已经完成权限、时间和状态过滤，但代码在排序后直接遍历完整 queryset，最后才调用内存分页函数，所以 `page_size` 只能限制响应结果，不能限制本次处理量。

## 怎么修的
改为先对排序后的 queryset 计算总数，再按 `page/page_size` 计算切片范围，只对当前页告警调用 `_build_monitor_alert_segment`。返回结构仍保持 `count/page/page_size/items` 不变，`count` 继续表示过滤后的总数。

```python
ordered_queryset = queryset.order_by("-start_event_time", "-created_at")
total_count = ordered_queryset.count()
start = (page - 1) * page_size
end = start + page_size
items = [_build_monitor_alert_segment(alert) for alert in ordered_queryset[start:end]]
```

## 影响范围
改动只在 `server/apps/monitor/nats/monitor.py` 的 `query_monitor_alert_segments`，RPC 和 OpsPilot 调用方不需要改参数或返回解析。行为变化是性能优化：同样的过滤条件下，总数语义保持不变，但当前页之外的告警不会再被序列化。

## 调用链
```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["monitor_query_alert_segments\nopspilot alerts.py"]
        T2["query_monitor_alert_segments\nrpc/monitor.py"]
    end

    subgraph N["NATS 处理层"]
        F1["query_monitor_alert_segments\nmonitor.py"]
        F2["权限实例过滤\nMonitorInstance queryset"]
        F3["历史告警过滤\nMonitorAlert queryset"]
    end

    subgraph P["分页/序列化层"]
        P1["count + queryset slice\n当前页边界"]
        P2["_build_monitor_alert_segment\n只处理当前页"]
    end

    T1 --> T2 --> F1 --> F2 --> F3 --> P1 --> P2
```

## 验证
新增回归测试覆盖 3 条告警、`page=2/page_size=1` 的场景，断言 `count` 仍为 3，但 `_build_monitor_alert_segment` 只调用 1 次；如果回退实现为先全量构造列表，该测试会因为调用次数变成 3 而失败。

已执行：
- `python3 -m py_compile server/apps/monitor/nats/monitor.py server/apps/monitor/tests/test_nats_monitor_handlers.py`
- `git diff --check`

本地 `uv run pytest apps/monitor/tests/test_nats_monitor_handlers.py::TestQueryMonitorAlertSegments -v --tb=short` 卡在虚拟环境/pytest 插件加载阶段，未能完成；关闭自动插件加载后 `uv run python` 也卡在导入 site-packages，已中断并记录为本地环境问题。
