### PR TITLE
bugfix: 限制实例指标数据探测范围

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -841,6 +841,11 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
         return {"result": False, "data": [], "message": "没有权限访问指定的实例"}
 
     metrics = Metric.objects.filter(monitor_object=monitor_obj).select_related("metric_group").order_by("metric_group__sort_order", "sort_order")
+    if only_with_data:
+        total_count = metrics.count()
+        start = (page - 1) * page_size
+        end = start + page_size
+        metrics = metrics[start:end]
 
     result_metrics = []
     for metric in metrics:
@@ -894,7 +899,16 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
         "data": {
             "monitor_obj_id": str(monitor_obj.id),
             "instance_id": instance_id,
-            **_paginate_items(result_metrics, page, page_size),
+            **(
+                {
+                    "count": total_count,
+                    "page": page,
+                    "page_size": page_size,
+                    "items": result_metrics,
+                }
+                if only_with_data
+                else _paginate_items(result_metrics, page, page_size)
+            ),
         },
         "message": "",
     }

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -243,6 +243,47 @@ class TestMonitorInstanceMetrics:
         assert out["data"]["count"] == 1
         assert out["data"]["items"][0]["metric"] == "cpu"
 
+    def test_only_with_data_limits_vm_queries_to_current_page(self, mocker):
+        obj = MonitorObject.objects.create(name="MIMObjPaged", level="base")
+        plugin = MonitorPlugin.objects.create(name="MIMPluginPaged")
+        group = MetricGroup.objects.create(monitor_object=obj, monitor_plugin=plugin, name="g")
+        for index, name in enumerate(["cpu", "mem", "disk"], start=1):
+            Metric.objects.create(
+                monitor_object=obj,
+                monitor_plugin=plugin,
+                metric_group=group,
+                name=name,
+                display_name=name.upper(),
+                query=f'{name}{{instance_id="$instance_id"}}',
+                sort_order=index,
+            )
+        MonitorInstance.objects.create(
+            id="('h1',)", name="h1", monitor_object=obj, is_active=True, is_deleted=False,
+        )
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
+        vm.return_value.query_range.return_value = {"status": "success", "data": {"result": [{"values": [[1, "1"]]}]}}
+
+        out = nm.monitor_instance_metrics(
+            {
+                "monitor_obj_id": obj.id,
+                "instance_id": "('h1',)",
+                "only_with_data": True,
+                "page": 1,
+                "page_size": 1,
+            },
+            user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
+        )
+
+        assert out["result"] is True
+        assert out["data"]["count"] == 3
+        assert [item["metric"] for item in out["data"]["items"]] == ["cpu"]
+        assert vm.return_value.query_range.call_count == 1
+
     def test_instance_not_authorized(self, mocker):
         obj = MonitorObject.objects.create(name="MIMObj2", level="base")
         mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})


### PR DESCRIPTION
## 问题

`monitor_instance_metrics` 支持 `only_with_data=true`，用于只返回当前实例有数据的指标。原实现会先把监控对象下所有指标都取出来，再对每个带查询语句的指标调用一次 VictoriaMetrics `query_range`，最后才按 `page/page_size` 做内存分页。

这会让一次只要第一页的请求，被放大成指标数量级的 VM 查询。监控对象指标很多时，VM、Django worker 和 NATS handler 都会被长时间占用。

## 根因

分页只作用在最终返回结果上，没有作用到需要探测数据的候选指标集。`page_size` 限制了返回条数，但没有限制 `only_with_data` 阶段的后端查询次数。

## 怎么修的

在 `only_with_data=true` 时，先按 `page/page_size` 对 Metric 查询集切片，只对当前页候选指标做 VM 探测；普通列表路径仍走原来的内存分页逻辑。

```python
if only_with_data:
    total_count = metrics.count()
    start = (page - 1) * page_size
    end = start + page_size
    metrics = metrics[start:end]
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["monitor_list_instance_metrics\nopspilot metrics.py"]
        T2["monitor_instance_metrics RPC\nrpc/monitor.py"]
    end

    subgraph N["核心处理层"]
        F1["monitor_instance_metrics\nmonitor/nats/monitor.py"]
        F2["Metric 候选分页\npage/page_size"]
        F3["VictoriaMetrics query_range\n仅当前页候选"]
    end

    R["返回分页结果\ncount/page/items"]

    T1 --> T2 --> F1 --> F2 --> F3 --> R
```

## 影响范围

改动范围仅限 `server/apps/monitor/nats/monitor.py` 的实例指标列表 handler，以及对应测试。RPC/opspilot 入参不变，`only_with_data=false` 的返回结构和分页逻辑不变。

需要注意：`only_with_data=true` 下为了避免全量 VM 探测，`count` 保留候选指标总数，不再通过扫描所有指标计算“有数据指标”的精确总数。这是本次避免 N 次后端查询的主要取舍。

## 验证

新增测试覆盖 `only_with_data=true&page_size=1` 且存在多个带 query 指标的场景，断言 VM `query_range` 只调用 1 次；如果回退修复，调用次数会变成 3，测试会失败。

已执行：

```bash
python3 -m py_compile server/apps/monitor/nats/monitor.py server/apps/monitor/tests/test_nats_monitor_handlers.py
git diff --check -- server/apps/monitor/nats/monitor.py server/apps/monitor/tests/test_nats_monitor_handlers.py
```

尝试执行：

```bash
cd server && uv run pytest apps/monitor/tests/test_nats_monitor_handlers.py -v -k "MonitorInstanceMetrics" --tb=short
cd server && uv run pytest -p no:cov apps/monitor/tests/test_nats_monitor_handlers.py -v -k "MonitorInstanceMetrics" --tb=short
```

本地 pytest 未进入业务测试，分别卡在 pytest-cov 初始化和第三方 pytest 插件自动加载阶段，已手动中断；不是新增用例断言失败。

关联 Issue #3886。