### PR TITLE
bugfix: 限制对话标注详情租户访问

### DIFF
--- a/server/apps/opspilot/tests/test_history_view_tenant_isolation.py
+++ b/server/apps/opspilot/tests/test_history_view_tenant_isolation.py
@@ -22,8 +22,6 @@ pytestmark = pytest.mark.django_db
 
 def _make_request(request_factory, body, current_team, user=None):
     """Build a POST request with cookies for current_team."""
-    from django.test import RequestFactory
-
     req = request_factory.post(
         "/api/v1/opspilot/bot_mgmt/history/get_log_detail/",
         data=json.dumps(body),
@@ -43,6 +41,21 @@ def _make_request(request_factory, body, current_team, user=None):
     req.user = user
     return req
 
+
+def _make_get_request(request_factory, params, current_team, user=None):
+    """Build a GET request with cookies for current_team."""
+    req = request_factory.get(
+        "/api/v1/opspilot/bot_mgmt/history/get_tag_detail/",
+        data=params,
+    )
+    req.COOKIES["current_team"] = str(current_team)
+    if user is None:
+        user = MagicMock()
+        user.is_superuser = False
+        user.group_list = [{"id": current_team}]
+        user.permission = {"opspilot": {"bot_conversation_log-View"}}
+    req.user = user
+    return req
 
 
 class TestGetLogDetailTenantIsolation:
@@ -137,3 +150,82 @@ class TestGetLogDetailTenantIsolation:
 
         with pytest.raises(PermissionDenied):
             viewset.get_log_detail(request)
+
+
+class TestGetTagDetailTenantIsolation:
+    """get_tag_detail 必须按 ConversationTag.answer.bot.team 做租户隔离（Issue #3438）。"""
+
+    def _make_bot(self, team_ids):
+        from apps.opspilot.models import Bot
+
+        return Bot.objects.create(name=f"bot-{team_ids}", team=team_ids, usage_team=team_ids)
+
+    def _make_history(self, bot, role, text):
+        from apps.opspilot.models import BotConversationHistory
+
+        return BotConversationHistory.objects.create(bot=bot, conversation_role=role, conversation=text)
+
+    def _make_tag(self, history, question, content, knowledge_base_id=10):
+        from apps.opspilot.models import ConversationTag
+
+        return ConversationTag.objects.create(
+            answer=history,
+            question=question,
+            content=content,
+            knowledge_base_id=knowledge_base_id,
+            knowledge_document_id=20,
+        )
+
+    def test_cross_tenant_tag_returns_404(self, request_factory):
+        """team=1 用户用其他租户 tag_id 查询时，必须 404 且不泄漏标注内容。"""
+        from django.http import Http404
+
+        from apps.opspilot.viewsets.history_view import HistoryViewSet
+
+        other_bot = self._make_bot([2])
+        answer = self._make_history(other_bot, "bot", "secret answer")
+        tag = self._make_tag(answer, "secret question", "secret content")
+
+        request = _make_get_request(request_factory, params={"tag_id": tag.id}, current_team=1)
+        viewset = HistoryViewSet()
+        viewset.format_kwarg = None
+
+        with pytest.raises(Http404):
+            viewset.get_tag_detail(request)
+
+    def test_same_tenant_tag_is_returned(self, request_factory):
+        """team=1 用户查询本租户 tag_id 时，正常返回标注详情。"""
+        from apps.opspilot.viewsets.history_view import HistoryViewSet
+
+        my_bot = self._make_bot([1])
+        answer = self._make_history(my_bot, "bot", "answer")
+        tag = self._make_tag(answer, "question", "content", knowledge_base_id=99)
+
+        request = _make_get_request(request_factory, params={"tag_id": tag.id}, current_team=1)
+        viewset = HistoryViewSet()
+        viewset.format_kwarg = None
+
+        response = viewset.get_tag_detail(request)
+        data = json.loads(response.content)
+
+        assert data == {
+            "result": True,
+            "data": {
+                "knowledge_base_id": 99,
+                "content": "content",
+                "question": "question",
+            },
+        }
+
+    def test_unknown_tag_returns_404(self, request_factory):
+        """不存在的 tag_id 和非本租户 tag_id 一样返回 404，避免存在性枚举。"""
+        from django.http import Http404
+
+        from apps.opspilot.viewsets.history_view import HistoryViewSet
+
+        request = _make_get_request(request_factory, params={"tag_id": 999999}, current_team=1)
+        viewset = HistoryViewSet()
+        viewset.format_kwarg = None
+
+        with pytest.raises(Http404):
+            viewset.get_tag_detail(request)

--- a/server/apps/opspilot/viewsets/history_view.py
+++ b/server/apps/opspilot/viewsets/history_view.py
@@ -2,7 +2,7 @@ from django.core.paginator import Paginator
 from django.db import connection, transaction
 from django.db.models import Count, Max, Min, OuterRef, Subquery
 from django.db.models.functions import TruncDay
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
@@ -186,7 +186,13 @@ class HistoryViewSet(TeamPermissionMixin, viewsets.ModelViewSet):
     @action(methods=["GET"], detail=False)
     @HasPermission("bot_conversation_log-View")
     def get_tag_detail(self, request):
-        tag_obj = ConversationTag.objects.get(id=request.GET.get("tag_id"))
+        current_team = self._validate_current_team_permission(request)
+        tag_obj = ConversationTag.objects.filter(
+            id=request.GET.get("tag_id"),
+            answer__bot__team__contains=[current_team],
+        ).first()
+        if not tag_obj:
+            raise Http404("Conversation tag not found")
         return JsonResponse(
             {
                 "result": True,


### PR DESCRIPTION
## 问题

OpsPilot 对话记录里的标注详情接口只检查了 `bot_conversation_log-View` 权限，随后直接按自增的 `tag_id` 读取标注。这样同样有查看权限的用户只要枚举 `tag_id`，就可能读到其他团队标注里的问题、答案内容和关联知识库 ID。

## 根因

标注本身没有单独的团队字段，团队归属要从 `ConversationTag.answer -> BotConversationHistory.bot -> Bot.team` 这条链路判断。原接口绕过了这条归属判断，拿到任意 `tag_id` 后直接返回详情，导致团队边界失效。

## 怎么修的

在读取标注详情前先校验当前 `current_team`，再把标注查询限定到当前团队的 Bot 下；查不到时统一返回 404，避免暴露某个 `tag_id` 是否真实存在。

```python
tag_obj = ConversationTag.objects.filter(
    id=request.GET.get("tag_id"),
    answer__bot__team__contains=[current_team],
).first()
```

## 影响范围

只改了 OpsPilot 的 `get_tag_detail` 详情接口和对应回归测试，不改前端请求参数、不改模型、不改数据库结构。正常同团队标注仍按原字段返回；非本团队和不存在的 `tag_id` 都不再返回内容。该 PR 涉及权限收紧，请 @zhmf7408 @QiuJia-layla review。

## 验证

新增测试覆盖同团队可读、跨团队 404、未知 `tag_id` 404；如果移除本次过滤，跨团队测试会失败。已执行：

- `uv run python -m py_compile apps/opspilot/viewsets/history_view.py apps/opspilot/tests/test_history_view_tenant_isolation.py`
- `git diff --check -- server/apps/opspilot/viewsets/history_view.py server/apps/opspilot/tests/test_history_view_tenant_isolation.py`

本地目标 pytest 启动两次都在 Django/venv 初始化阶段长时间无输出后中断；第一次暴露本地 `.venv` 缺失 `h2-4.3.0.dist-info/entry_points.txt`，第二次卡在 `django.setup()` 的系统模块导入阶段，因此没有拿到完整 pytest 结果。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_tag_detail\nhistory_view.py"]
    end

    V["current_team 校验\nTeamPermissionMixin"]
    Q["ConversationTag 查询\n按 answer.bot.team 过滤"]

    subgraph N["核心处理层"]
        F1["同团队 tag\n返回标注详情"]
        F2["非本团队或不存在\n统一 404"]
    end

    T1 --> V --> Q --> F1
    Q -. "未命中" .-> F2
```

Fixes #3438