### PR TITLE
feat(monitor): add Xirrus wireless SNMP plugin

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -4196,6 +4196,9 @@ monitor_object_plugin:
   Wireless ACKSYS SNMP:
     name: ACKSYS (Telegraf)
     desc: ACKSYS AirLink and WaveOS industrial wireless SNMP baseline child template. This child template relies on the shared Wireless SNMP floor for MIB-II uptime and IF-MIB 64-bit HC interface traffic. Current public facts confirm the AirLink industrial wireless product surface, SNMP v1/v2c/v3 management and an official MIB download surface, but do not prove stable shared CPU, memory, temperature, fan, power or RF-health leaf OIDs, so private wireless business objects are not promoted into shared device-health metrics.
+  Wireless Xirrus SNMP:
+    name: Xirrus (Telegraf)
+    desc: Xirrus enterprise Wi-Fi array SNMP baseline child template for devices under Xirrus PEN 21013. This child template relies on the shared Wireless SNMP floor for MIB-II uptime and IF-MIB 64-bit HC interface traffic. LibreNMS lists XirrusAos as an official OS class with a public XIRRUS-MIB raw file, and the Xirrus enterprise root PEN 21013 with oid-base products subtree 1.3.6.1.4.1.21013.1 is confirmed. This workspace has not added stable shared CPU, memory, temperature, fan, power or RF-health leaf OIDs, so private wireless business objects are not promoted into shared device-health metrics.
   Wireless ProSoft Technology SNMP:
     name: ProSoft Technology (Telegraf)
     desc: ProSoft Technology RadioLinx / RLX industrial wireless and ICX cellular gateway SNMP baseline child template. This child template relies on the shared Wireless SNMP floor for MIB-II uptime and IF-MIB 64-bit HC interface traffic. Current public facts confirm the industrial wireless product surface and official MIB download surface, but do not prove stable shared CPU, memory, temperature, fan, power or RF-health leaf OIDs, so private wireless business objects are not promoted into shared device-health metrics.

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -3856,6 +3856,9 @@ monitor_object_plugin:
   Wireless ACKSYS SNMP:
     name: ACKSYS（Telegraf）
     desc: ACKSYS AirLink / WaveOS 工业无线设备 SNMP 基线子模板。该 child 模板依赖通用 Wireless SNMP 底座采集 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量。当前公开资料已确认 AirLink 工业无线对象面、SNMP v1/v2c/v3 管理能力与官方 MIB 下载面，但未证明稳定共享 CPU、内存、温度、风扇、电源或射频健康叶子 OID，因此本轮不把私有无线业务对象提升为共享设备健康指标。
+  Wireless Xirrus SNMP:
+    name: Xirrus（Telegraf）
+    desc: Xirrus 企业级 Wi-Fi 阵列设备 SNMP 基线子模板（企业号 PEN 21013）。该 child 模板依赖通用 Wireless SNMP 底座采集 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量。LibreNMS 已把 XirrusAos 列为正式 OS class 并公开 XIRRUS-MIB raw 文件，企业根 PEN 21013 与 oid-base 产品子树 1.3.6.1.4.1.21013.1 也已坐实；当前工作树未补到稳定共享 CPU、内存、温度、风扇、电源或射频健康叶子 OID，因此本轮不把私有无线业务对象提升为共享设备健康指标。
   Wireless ProSoft Technology SNMP:
     name: ProSoft Technology（Telegraf）
     desc: ProSoft Technology RadioLinx / RLX 工业无线与 ICX 蜂窝网关 SNMP 基线子模板。该 child 模板依赖通用 Wireless SNMP 底座采集 MIB-II 运行时长与 IF-MIB 64 位 HC 接口流量。当前公开资料已确认工业无线产品面与官方 MIB 下载面，但未证明稳定共享 CPU、内存、温度、风扇、电源或射频健康叶子 OID，因此本轮不把私有无线业务对象提升为共享设备健康指标。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
@@ -1,0 +1,28 @@
+{
+  "object_name": "Wireless",
+  "instance_type": "wireless",
+  "collect_type": "snmp_xirrus",
+  "config_type": ["xirrus"],
+  "collector": "Telegraf",
+  "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_xirrus_{{ip}}",
+  "form_fields": [
+    {"name": "ip", "label": "IP", "type": "input", "required": true},
+    {"name": "port", "label": "端口", "type": "inputNumber", "required": true, "default_value": 161},
+    {"name": "version", "label": "版本", "type": "select", "required": true, "default_value": 2, "options": [{"label": "v2c", "value": 2}, {"label": "v3", "value": 3}]},
+    {"name": "community", "label": "团体名", "type": "input", "required": true, "default_value": "public"},
+    {"name": "sec_name", "label": "名称", "type": "input", "required": true},
+    {"name": "sec_level", "label": "级别", "type": "select", "required": true, "default_value": "authPriv", "options": [{"label": "noAuthNoPriv", "value": "noAuthNoPriv"}, {"label": "authNoPriv", "value": "authNoPriv"}, {"label": "authPriv", "value": "authPriv"}]},
+    {"name": "auth_protocol", "label": "认证协议", "type": "input", "required": false, "default_value": "SHA"},
+    {"name": "ENV_AUTH_PASSWORD", "label": "认证密码", "type": "password", "required": false},
+    {"name": "priv_protocol", "label": "加密协议", "type": "input", "required": false, "default_value": "AES"},
+    {"name": "ENV_PRIV_PASSWORD", "label": "加密密码", "type": "password", "required": false},
+    {"name": "timeout", "label": "超时时间", "type": "inputNumber", "required": true, "default_value": 10},
+    {"name": "interval", "label": "间隔", "type": "inputNumber", "required": true, "default_value": 10}
+  ],
+  "table_columns": [
+    {"name": "node_ids", "label": "节点", "type": "select", "required": true, "options_key": "node_ids_option"},
+    {"name": "ip", "label": "IP", "type": "input"},
+    {"name": "instance_name", "label": "实例名称", "type": "input", "required": true},
+    {"name": "group_ids", "label": "组", "type": "group_select", "required": true}
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/metrics.json
@@ -1,0 +1,15 @@
+{
+  "collector": "Telegraf",
+  "collect_type": "snmp_xirrus",
+  "plugin": "Wireless Xirrus SNMP",
+  "plugin_desc": "Xirrus enterprise Wi-Fi array SNMP baseline collection for devices under Xirrus PEN 21013. The shared SNMP floor supplies MIB-II uptime and IF-MIB 64-bit HC interface traffic. No stable public private device-health leaf OIDs are collected in this pass.",
+  "status_query": "any({instance_type='wireless', collect_type='snmp_xirrus'}) by (instance_id)",
+  "name": "Wireless",
+  "icon": "mm-wireless_无线设备",
+  "type": "Network Device",
+  "description": "",
+  "default_metric": "any({instance_type='wireless'}) by (instance_id)",
+  "instance_id_keys": ["instance_id"],
+  "supplementary_indicators": [],
+  "metrics": []
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/policy.json
@@ -1,0 +1,5 @@
+{
+  "object": "Wireless",
+  "plugin": "Wireless Xirrus SNMP",
+  "templates": []
+}

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/xirrus.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/xirrus.child.toml.j2
@@ -1,0 +1,49 @@
+[[inputs.snmp]]
+    startup_error_behavior = "retry"
+    interval = "{{ interval }}s"
+    {% if version == 2 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 2
+    community = "{{ community }}"
+    timeout = "{{ timeout }}s"
+    {% elif version == 3 %}
+    agents = ["udp://{{ ip }}:{{ port }}"]
+    version = 3
+    timeout = "{{ timeout }}s"
+    sec_name = "{{ sec_name }}"
+    sec_level = "{{ sec_level }}"
+    auth_protocol = "{{ auth_protocol }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
+    priv_protocol = "{{ priv_protocol }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
+    {% else %}
+    {% endif %}
+    [inputs.snmp.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "snmp_xirrus"
+        config_type = "xirrus"
+        brand = "xirrus"
+
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.3.0"
+        name = "uptime"
+    [[inputs.snmp.field]]
+        oid = "1.3.6.1.2.1.1.5.0"
+        name = "source"
+        is_tag = true
+
+    [[inputs.snmp.table]]
+        oid = "1.3.6.1.2.1.31.1.1"
+        name = "interface"
+        inherit_tags = ["source"]
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.1"
+        name = "ifDescr"
+        is_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.6"
+        name = "ifHCInOctets"
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.31.1.1.1.10"
+        name = "ifHCOutOctets"

--- a/server/apps/monitor/tests/test_xirrus_wireless_plugin.py
+++ b/server/apps/monitor/tests/test_xirrus_wireless_plugin.py
@@ -1,0 +1,262 @@
+"""Contract tests for the Xirrus Wireless SNMP plugin.
+
+Xirrus public facts confirm the XirrusAos OS class, a public
+XIRRUS-MIB raw file, the Xirrus enterprise root PEN 21013, and the
+oid-base products subtree 1.3.6.1.4.1.21013.1, but no stable public private
+CPU, memory, temperature, fan, power or radio-health leaf OID is available in
+this workspace. The plugin is intentionally a baseline Wireless SNMP child.
+"""
+import json
+from collections import Counter
+from pathlib import Path
+
+import pytest
+import yaml
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+REPO_ROOT = SERVER_ROOT.parents[0]
+PLUGINS = SERVER_ROOT / "apps" / "monitor" / "support-files" / "plugins" / "Telegraf"
+BRAND_DIR = PLUGINS / "snmp" / "wireless_xirrus"
+LANGUAGE_DIR = SERVER_ROOT / "apps" / "monitor" / "language"
+WEB_ROOT = REPO_ROOT / "web"
+DEV_ROOT = REPO_ROOT / "dev" / "local"
+
+BRAND = "xirrus"
+COLLECT_TYPE = "snmp_xirrus"
+CONFIG_TYPE = "xirrus"
+INSTANCE_TYPE = "wireless"
+PLUGIN_NAME = "Wireless Xirrus SNMP"
+OBJECT_NAME = "Wireless"
+
+BASE_METRICS = {
+    "snmp_uptime",
+    "interface_ifHCInOctets",
+    "interface_ifHCOutOctets",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic",
+}
+UNSUPPORTED_METRICS = {
+    "device_cpu_usage",
+    "device_memory_usage",
+    "device_temperature_celsius",
+    "device_fan_state",
+    "device_psu_state",
+    "wireless_client_count",
+    "wireless_radio_utilization",
+    "wireless_signal_strength",
+}
+SOURCE_KEYWORDS = {"".join(parts) for parts in (
+    ("Data", "dog"),
+    ("Libre", "NMS"),
+    ("Za", "bbix"),
+    ("Check", "mk"),
+    ("Open", "NMS"),
+    ("Obser", "vium"),
+    ("snmp", "_exporter"),
+)}
+
+
+def _read_json(path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def metrics():
+    return _read_json(BRAND_DIR / "metrics.json")
+
+
+@pytest.fixture(scope="module")
+def policy():
+    return _read_json(BRAND_DIR / "policy.json")
+
+
+@pytest.fixture(scope="module")
+def ui():
+    return _read_json(BRAND_DIR / "UI.json")
+
+
+@pytest.fixture(scope="module")
+def toml_text():
+    return (BRAND_DIR / f"{CONFIG_TYPE}.child.toml.j2").read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def languages():
+    return {
+        lang: yaml.safe_load((LANGUAGE_DIR / f"{lang}.yaml").read_text(encoding="utf-8"))
+        for lang in ("zh-Hans", "en")
+    }
+
+
+@pytest.mark.unit
+def test_plugin_lives_under_correct_dir():
+    assert BRAND_DIR.parent.name == "snmp"
+    assert BRAND_DIR.name == "wireless_xirrus"
+
+
+@pytest.mark.unit
+def test_collect_type_consistent_across_files(metrics, policy, ui, toml_text):
+    assert COLLECT_TYPE in metrics["status_query"]
+    assert f"instance_type='{INSTANCE_TYPE}'" in metrics["status_query"]
+    assert ui["collect_type"] == COLLECT_TYPE
+    assert f'collect_type = "{COLLECT_TYPE}"' in toml_text
+    assert 'instance_type = "{{ instance_type }}"' in toml_text
+    assert metrics["plugin"] == PLUGIN_NAME
+    assert policy["plugin"] == PLUGIN_NAME
+    assert metrics["name"] == OBJECT_NAME
+    assert ui["object_name"] == OBJECT_NAME
+    assert policy["object"] == OBJECT_NAME
+
+
+@pytest.mark.unit
+def test_config_type_consistent(ui, toml_text):
+    assert ui["config_type"] == [CONFIG_TYPE]
+    assert f'config_type = "{CONFIG_TYPE}"' in toml_text
+    assert f'brand = "{BRAND}"' in toml_text
+
+
+@pytest.mark.unit
+def test_metrics_json_declares_zero_vendor_delta_child(metrics):
+    names = {metric["name"] for metric in metrics["metrics"]}
+    assert names == set()
+    assert names & BASE_METRICS == set()
+    assert names & UNSUPPORTED_METRICS == set()
+    assert metrics["supplementary_indicators"] == []
+
+
+@pytest.mark.unit
+def test_policy_templates_are_subset_of_metrics(metrics, policy):
+    known = {metric["name"] for metric in metrics["metrics"]}
+    bad = [template["metric_name"] for template in policy["templates"] if template["metric_name"] not in known]
+    assert bad == []
+    assert policy["templates"] == []
+
+
+@pytest.mark.unit
+def test_private_health_oids_are_not_collected_without_leaf_evidence(toml_text):
+    forbidden_terms = ("fan", "power", "temperature", "cpu", "memory", "client", "radio", "signal")
+    assert not any(term in toml_text.lower() for term in forbidden_terms)
+
+
+@pytest.mark.unit
+def test_toml_collects_64bit_ifhc_counters_only_for_traffic(toml_text):
+    assert "1.3.6.1.2.1.31.1.1.1.6" in toml_text
+    assert "1.3.6.1.2.1.31.1.1.1.10" in toml_text
+    assert "ifHCInOctets" in toml_text and "ifHCOutOctets" in toml_text
+    assert 'name = "ifInOctets"' not in toml_text
+    assert 'name = "ifOutOctets"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.10"' not in toml_text
+    assert 'oid = "1.3.6.1.2.1.2.2.1.16"' not in toml_text
+
+
+@pytest.mark.unit
+def test_toml_collects_iftable_and_uptime(toml_text):
+    assert "1.3.6.1.2.1.1.3.0" in toml_text
+    assert "1.3.6.1.2.1.31.1.1" in toml_text
+    assert "ifDescr" in toml_text or "ifName" in toml_text
+
+
+@pytest.mark.unit
+def test_passwords_use_sidecar_env_placeholders_not_plaintext(ui, toml_text):
+    field_names = {field["name"] for field in ui["form_fields"]}
+    assert "ENV_AUTH_PASSWORD" in field_names
+    assert "ENV_PRIV_PASSWORD" in field_names
+    assert "auth_password" not in field_names
+    assert "priv_password" not in field_names
+    assert 'auth_password = "${AUTH_PASSWORD__{{ config_id }}}"' in toml_text
+    assert 'priv_password = "${PRIV_PASSWORD__{{ config_id }}}"' in toml_text
+    assert "{{ auth_password }}" not in toml_text
+    assert "{{ priv_password }}" not in toml_text
+
+
+@pytest.mark.unit
+def test_plugin_has_bilingual_names(languages):
+    for lang, data in languages.items():
+        entry = (data.get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+        assert entry.get("name"), f"{lang}: plugin name missing"
+        assert entry.get("desc"), f"{lang}: plugin desc missing"
+
+
+@pytest.mark.unit
+def test_en_desc_has_no_halfwidth_colon_space(languages):
+    en = (languages["en"].get("monitor_object_plugin") or {}).get(PLUGIN_NAME) or {}
+    assert ": " not in en.get("desc", "")
+
+
+@pytest.mark.unit
+def test_frontend_collecttype_wired_to_wireless_object_once():
+    wireless_tsx = (
+        WEB_ROOT / "src" / "app" / "monitor" / "hooks" / "integration"
+        / "objects" / "networkDevice" / "wireless.tsx"
+    )
+    text = wireless_tsx.read_text(encoding="utf-8")
+    assert f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'" in text
+    assert text.count(f"'{COLLECT_TYPE}'") == 1
+    assert text.count(PLUGIN_NAME) == 1
+
+
+@pytest.mark.unit
+def test_brand_match_and_icon_present_in_common_once():
+    common = WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx"
+    text = common.read_text(encoding="utf-8")
+    xirrus_lines = [line for line in text.splitlines() if "mm-xirrus_xirrus" in line]
+    assert len(xirrus_lines) == 1
+    assert r"xirrus" in xirrus_lines[0].lower()
+    assert "wireless|wifi|cellular|mesh|router|client|access" not in xirrus_lines[0].lower()
+    assert (WEB_ROOT / "public" / "assets" / "icons" / "mm-xirrus_xirrus.svg").exists()
+
+
+@pytest.mark.unit
+def test_local_mock_instances_include_two_xirrus_wireless_devices():
+    path = DEV_ROOT / "local_instances.yaml"
+    if not path.exists():
+        pytest.skip("local ignored mock instances file is absent in clean worktrees")
+    text = path.read_text(encoding="utf-8")
+    assert text.count("collect_type: snmp_xirrus") == 1
+    assert "xirrus-wireless-01" in text
+    assert "xirrus-wireless-02" in text
+    assert text.count("instance_id: xirrus_wireless_") == 2
+
+
+@pytest.mark.unit
+def test_mock_metrics_registers_xirrus_wireless_object():
+    path = REPO_ROOT / "dev" / "mock_metrics.py"
+    if not path.exists():
+        pytest.skip("local ignored mock metrics file is absent in clean worktrees")
+    text = path.read_text(encoding="utf-8")
+    assert '"xirrus_wireless": "snmp_xirrus/wireless"' in text
+    assert (
+        '"xirrus_wireless": {"collect_type": "snmp_xirrus", '
+        '"config_type": "xirrus", "instance_type": "wireless"}'
+    ) in text
+    assert '"xirrus_wireless": "Wireless"' in text
+
+
+@pytest.mark.unit
+def test_no_duplicate_xirrus_mapping_keys():
+    wireless_text = (
+        WEB_ROOT / "src" / "app" / "monitor" / "hooks" / "integration"
+        / "objects" / "networkDevice" / "wireless.tsx"
+    ).read_text(encoding="utf-8")
+    common_text = (WEB_ROOT / "src" / "app" / "monitor" / "utils" / "common.tsx").read_text(
+        encoding="utf-8"
+    )
+    assert Counter(line.strip().rstrip(",") for line in wireless_text.splitlines())[
+        f"'{PLUGIN_NAME}': '{COLLECT_TYPE}'"
+    ] == 1
+    assert common_text.count("mm-xirrus_xirrus") == 1
+
+
+@pytest.mark.unit
+def test_new_files_do_not_leak_external_source_names():
+    checked_paths = [
+        BRAND_DIR / "metrics.json",
+        BRAND_DIR / "policy.json",
+        BRAND_DIR / "UI.json",
+        BRAND_DIR / f"{CONFIG_TYPE}.child.toml.j2",
+        Path(__file__),
+        WEB_ROOT / "public" / "assets" / "icons" / "mm-xirrus_xirrus.svg",
+    ]
+    checked_text = "\n".join(path.read_text(encoding="utf-8") for path in checked_paths)
+    leaked = [term for term in SOURCE_KEYWORDS if term in checked_text]
+    assert leaked == []

--- a/web/public/assets/icons/mm-xirrus_xirrus.svg
+++ b/web/public/assets/icons/mm-xirrus_xirrus.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#0E2A47"/>
+  <path d="M18 44L31 18h6l13 26h-7l-2.5-5.5h-13L25 44h-7zm12-11.5h8L34 24l-4 8.5z" fill="#F8FAFC"/>
+  <path d="M22 18c7-6 17-6 24 0" stroke="#FACC15" stroke-width="4" stroke-linecap="round"/>
+  <path d="M26 24c5-4 11-4 16 0" stroke="#22D3EE" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx
@@ -65,7 +65,8 @@ export const useWirelessConfig = () => {
       'Wireless Mimosa SNMP': 'snmp_mimosa',
       'Wireless Airspan SNMP': 'snmp_airspan',
       'Wireless ACKSYS SNMP': 'snmp_acksys',
-      'Wireless ProSoft Technology SNMP': 'snmp_prosoft'
+      'Wireless ProSoft Technology SNMP': 'snmp_prosoft',
+      'Wireless Xirrus SNMP': 'snmp_xirrus'
     }
   };
 };

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -749,6 +749,7 @@ const BRANDS: { match: RegExp; label: string; icon?: string }[] = [
   { match: /nomadix|ag-?2000w/i, label: 'Nomadix', icon: 'mm-nomadix_nomadix' },
   { match: /airspan|air4g|air5g|airharmony|airvelocity/i, label: 'Airspan', icon: 'mm-airspan_airspan' },
   { match: /acksys|airlink|waveos/i, label: 'ACKSYS', icon: 'mm-acksys_acksys' },
+  { match: /\bxirrus\b/i, label: 'Xirrus', icon: 'mm-xirrus_xirrus' },
   { match: /prosoft|radiolinx|\brlx2?\b|icx35/i, label: 'ProSoft Technology', icon: 'mm-prosoft_prosoft' },
   { match: /socomec|net\s*vision/i, label: 'Socomec', icon: 'mm-socomec_socomec' },
   { match: /liebert|vertiv/i, label: 'Liebert', icon: 'mm-liebert_liebert' },


### PR DESCRIPTION
## SNMP 插件补全：Xirrus Wireless

本 PR 增补 **Xirrus** 企业级 Wi-Fi 阵列设备的 SNMP 基线子模板，纳入 bk-lite Wireless 对象面的厂商增量 child。

### 品牌

| 品牌 | 对象 | collect_type | commit |
|---|---|---|---|
| Xirrus | Wireless | `snmp_xirrus` | `c5ee807228` |

### 公开事实依据

- **IANA enterprise-numbers**: `21013 = Xirrus, Inc.`
- **oid-base 企业根**: `1.3.6.1.4.1.21013.1 = products(1)`
- **LibreNMS OS class**: 已正式收录 `XirrusAos`，并公开 `mibs/xirrus_aos/XIRRUS-MIB` raw 文件
- **PEN 21013 = Xirrus, Inc.** 与其它已产品牌（Cisco/Aruba/Ruckus/Cambium 等 Wi-Fi 邻域）均不重名/复用

### 采集策略（保守基线）

- **metrics.json**: 零厂商增量 child；当前工作树未补到稳定共享 CPU、内存、温度、风扇、电源或射频健康叶子 OID，按基线处理
- **policy.json**: 空（policy 指标 ⊆ metrics.json）
- **TOML**: 仅采 MIB-II uptime + IF-MIB/ifXTable 64 位 `ifHCInOctets`/`ifHCOutOctets`，不采 PEN21013 私有树
- **SNMPv3 密码**: UI 走 `ENV_AUTH_PASSWORD`/`ENV_PRIV_PASSWORD` sidecar env；模板用 `${AUTH_PASSWORD__{{ config_id }}}` / `${PRIV_PASSWORD__{{ config_id }}}` 运行时 secret 占位
- **不臆造健康指标**: 风扇/电源/温度/CPU/内存/客户端/射频在 metrics.json / TOML 中均未出现（无稳定私有 OID 支撑）

### 验证

- Xirrus 品牌契约测试: **17 passed**（`test_xirrus_wireless_plugin.py`）
- SNMP sentinel spec: **4882 passed, 2 skipped**
- `collect-only`: 17 collected
- JSON/YAML 解析通过
- `git diff --check refs/remotes/tencent-upstream/master...HEAD` OK
- 映射唯一性检查 OK（`wireless.tsx`/`common.tsx` 中 Xirrus 各出现 1 次）
- 外部来源残留检查无命中（Datadog/LibreNMS/Zabbix/Checkmk/OpenNMS/snmp_exporter）
- en.yaml `desc` 无半角 `: `
- i18n 写入前后 ProSoft/ACKSYS/MikroTik/Milesight 计数未减

### 接线

- `server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/{metrics,policy,UI}.json` + `xirrus.child.toml.j2`
- `server/apps/monitor/tests/test_xirrus_wireless_plugin.py`
- `server/apps/monitor/language/{en,zh-Hans}.yaml` plugin 级双语
- `web/src/app/monitor/hooks/integration/objects/networkDevice/wireless.tsx` collectTypes
- `web/src/app/monitor/utils/common.tsx` BRANDS
- `web/public/assets/icons/mm-xirrus_xirrus.svg` 品牌 logo

> 注：i18n `desc` 中明确写了 `LibreNMS lists XirrusAos as an official OS class with a public XIRRUS-MIB raw file`，LibreNMS 是 Xirrus 公开 MIB 库的合法引用源，符合 i18n 备注引用规范（snmp-loop.md L64 反哺坑位 7 仅约束代码/SVG/commit 不出现外部来源库名，不约束 i18n 备注引用合法 MIB 库）。