### PR TITLE
bugfix: 保持 system_mgmt NATS 旧入口兼容

### DIFF
--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -5,15 +5,68 @@ Handlers live in apps.system_mgmt.nats and are imported here so older tests and
 callers using apps.system_mgmt.nats_api keep working.
 """
 
+from importlib import import_module
+
 from apps.system_mgmt.nats import *  # noqa: F401,F403
-from apps.system_mgmt.nats import channels as _channels
-from apps.system_mgmt.nats import login as _login
+
+
+_auth = import_module("apps.system_mgmt.nats.auth")
+_channels = import_module("apps.system_mgmt.nats.channels")
+_login = import_module("apps.system_mgmt.nats.login")
+_otp = import_module("apps.system_mgmt.nats.otp")
+_settings = import_module("apps.system_mgmt.nats.settings")
+_wechat = import_module("apps.system_mgmt.nats.wechat")
+
+
+_COMPAT_GLOBALS_BY_MODULE = {
+    _auth: (
+        "_verify_token",
+        "get_user_all_roles",
+    ),
+    _login: (
+        "_verify_token",
+        "_build_jwt_payload",
+        "_get_pwd_policy_settings",
+        "create_challenge",
+    ),
+    _otp: (
+        "_build_jwt_payload",
+        "_get_pwd_policy_settings",
+        "check_rate_limit",
+        "invalidate_challenge",
+        "record_failed_attempt",
+        "reset_rate_limit",
+        "verify_challenge",
+    ),
+    _settings: (
+        "_build_jwt_payload",
+        "get_bk_user_info",
+    ),
+    _wechat: (
+        "_build_jwt_payload",
+        "set_opspilot_guest_group_default_rule",
+    ),
+}
 
 
 def _sync_compat_globals():
     _channels.send_nats_message = send_nats_message
     _channels._normalize_nats_content = _normalize_nats_content
-    _login._get_pwd_policy_settings = _get_pwd_policy_settings
+
+    for module, names in _COMPAT_GLOBALS_BY_MODULE.items():
+        for name in names:
+            if name in globals():
+                setattr(module, name, globals()[name])
+
+
+def get_pilot_permission_by_token(*args, **kwargs):
+    _sync_compat_globals()
+    return _auth.get_pilot_permission_by_token(*args, **kwargs)
+
+
+def verify_token(*args, **kwargs):
+    _sync_compat_globals()
+    return _auth.verify_token(*args, **kwargs)
 
 
 def send_msg_with_channel(*args, **kwargs):
@@ -24,3 +77,33 @@ def send_msg_with_channel(*args, **kwargs):
 def login(*args, **kwargs):
     _sync_compat_globals()
     return _login.login(*args, **kwargs)
+
+
+def reset_pwd(*args, **kwargs):
+    _sync_compat_globals()
+    return _login.reset_pwd(*args, **kwargs)
+
+
+def bk_lite_user_login(*args, **kwargs):
+    _sync_compat_globals()
+    return _login.bk_lite_user_login(*args, **kwargs)
+
+
+def get_user_login_token(*args, **kwargs):
+    _sync_compat_globals()
+    return _login.get_user_login_token(*args, **kwargs)
+
+
+def verify_otp_login(*args, **kwargs):
+    _sync_compat_globals()
+    return _otp.verify_otp_login(*args, **kwargs)
+
+
+def verify_bk_token(*args, **kwargs):
+    _sync_compat_globals()
+    return _settings.verify_bk_token(*args, **kwargs)
+
+
+def wechat_user_register(*args, **kwargs):
+    _sync_compat_globals()
+    return _wechat.wechat_user_register(*args, **kwargs)

--- a/server/apps/system_mgmt/tests/test_nats_api_compat.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_compat.py
@@ -1,0 +1,76 @@
+"""旧 apps.system_mgmt.nats_api 路径兼容层回归测试。"""
+import types
+
+from apps.system_mgmt import nats_api
+
+
+def test_nats_api_compat_syncs_sensitive_monkeypatch_helpers(monkeypatch):
+    def fake_verify_token(token):
+        return types.SimpleNamespace(username="alice", domain="domain.com")
+
+    def fake_build_jwt_payload(user_id):
+        return {"patched_user_id": user_id}
+
+    monkeypatch.setattr(nats_api, "_verify_token", fake_verify_token)
+    monkeypatch.setattr(nats_api, "_build_jwt_payload", fake_build_jwt_payload)
+
+    nats_api._sync_compat_globals()
+
+    assert nats_api._auth._verify_token is fake_verify_token
+    assert nats_api._login._verify_token is fake_verify_token
+    assert nats_api._login._build_jwt_payload is fake_build_jwt_payload
+    assert nats_api._otp._build_jwt_payload is fake_build_jwt_payload
+    assert nats_api._settings._build_jwt_payload is fake_build_jwt_payload
+    assert nats_api._wechat._build_jwt_payload is fake_build_jwt_payload
+
+
+def test_reset_pwd_uses_legacy_nats_api_verify_token_patch(monkeypatch):
+    monkeypatch.setattr(
+        nats_api,
+        "_verify_token",
+        lambda token: types.SimpleNamespace(username="bob", domain="domain.com"),
+    )
+
+    result = nats_api.reset_pwd("alice", "domain.com", "ValidPass1!", caller_token="bob-token")
+
+    assert result == {"result": False, "message": "Unauthorized: caller does not match target user"}
+
+
+def test_get_user_login_token_uses_legacy_nats_api_jwt_payload_patch(monkeypatch):
+    captured = {}
+
+    def fake_build_jwt_payload(user_id):
+        return {"patched_user_id": user_id}
+
+    def fake_jwt_encode(**kwargs):
+        captured.update(kwargs)
+        return "patched-token"
+
+    class EmptySystemSettings:
+        class objects:
+            @staticmethod
+            def filter(key):
+                return types.SimpleNamespace(first=lambda: None)
+
+    user = types.SimpleNamespace(
+        id=42,
+        username="alice",
+        display_name="Alice",
+        domain="domain.com",
+        locale="zh-Hans",
+        timezone="Asia/Shanghai",
+        temporary_pwd=False,
+        disabled=False,
+        otp_secret="",
+        last_login=None,
+        save=lambda: None,
+    )
+    monkeypatch.setattr(nats_api, "_build_jwt_payload", fake_build_jwt_payload)
+    monkeypatch.setattr(nats_api._login, "SystemSettings", EmptySystemSettings)
+    monkeypatch.setattr(nats_api.jwt, "encode", fake_jwt_encode)
+
+    result = nats_api.get_user_login_token(user, "alice")
+
+    assert result["result"] is True
+    assert result["data"]["token"] == "patched-token"
+    assert captured["payload"] == {"patched_user_id": 42}

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers.py
@@ -3,9 +3,6 @@
 nats handler 直接可调用（@nats_client.register 返回原函数）。
 只 mock 真实外部边界（cache、send_msg、jwt token 验证等），断言真实 DB 行为与返回结构。
 """
-import types
-from unittest.mock import MagicMock, patch
-
 import nats_client
 import pytest
 
@@ -17,7 +14,6 @@ from apps.system_mgmt.models import (
     GroupDataRule,
     Menu,
     Role,
-    SystemSettings,
     User,
 )
 from apps.system_mgmt.models.channel import ChannelChoices
@@ -153,7 +149,7 @@ def test_get_client_superuser_sees_all():
 
 
 def test_get_client_detail_found_and_missing():
-    app = App.objects.create(name="dc", display_name="DC", description="d", description_cn="中文", url="/dc")
+    App.objects.create(name="dc", display_name="DC", description="d", description_cn="中文", url="/dc")
     ok = nats_api.get_client_detail("dc")
     assert ok["result"] is True
     assert ok["data"]["name"] == "dc"


### PR DESCRIPTION
## 背景

`system_mgmt` NATS handler 拆分后，旧入口 `apps.system_mgmt.nats_api` 仍被历史测试、调用方或 monkeypatch 路径依赖。直接 `from apps.system_mgmt.nats import *` 只能导出函数对象，无法把旧路径上的 monkeypatch 同步回真实子模块，容易出现客户端/测试仍 patch 旧入口但服务端实际调用新模块原始实现的半截子兼容问题。

## 改动

- 在 `apps.system_mgmt.nats_api` 中显式导入真实 NATS 子模块。
- 补齐旧入口 wrapper，并在调用前同步敏感 helper monkeypatch 到下游子模块。
- 新增兼容回归测试，覆盖 `_verify_token`、`_build_jwt_payload` 等旧路径 patch 的同步行为。
- 清理 `test_nats_api_handlers.py` 中 rebase 后遗留的无用 import / 变量。

## 验证

- `python3 -m py_compile server/apps/system_mgmt/nats_api.py server/apps/system_mgmt/tests/test_nats_api_compat.py server/apps/system_mgmt/tests/test_nats_api_handlers.py`
- `git diff --check weops/master...HEAD`
- `cd server && uv run flake8 apps/system_mgmt/nats_api.py apps/system_mgmt/tests/test_nats_api_compat.py apps/system_mgmt/tests/test_nats_api_handlers.py`
- `cd server && INSTALL_APPS=system_mgmt,alerts,console_mgmt,job_mgmt,log,monitor,node_mgmt,operation_analysis,opspilot,cmdb ENABLE_CELERY=True DB_ENGINE=sqlite DB_NAME=/tmp/nats-compat-pr.sqlite3 SECRET_KEY=test MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=testtest MINIO_USE_HTTPS=False uv run pytest apps/system_mgmt/tests/test_nats_api_compat.py`：3 passed

补充：`test_nats_api_handlers.py` 在本地 sqlite 建库阶段失败，错误为既有 migration 问题 `NewSessionEventRelation has no field named 'event'`，未进入本次改动逻辑。