### PR TITLE
fix: 修复日志采集编辑模式多行合并开关不回填 bug

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,7 @@
     "test:log-group-field-bootstrap": "pnpm exec tsx scripts/log-group-field-bootstrap-test.ts",
     "test:log-terminal-token": "pnpm exec tsx scripts/log-terminal-token-test.ts",
     "test:log-policy-form": "pnpm exec tsx scripts/log-policy-form-state-test.ts",
+    "test:log-vector-config": "pnpm exec tsx scripts/log-vector-config-test.ts",
     "test:monitor-search-plugin-scope": "pnpm exec tsx scripts/monitor-search-plugin-scope-test.ts",
     "test:monitor-query-step": "pnpm exec tsx scripts/monitor-query-step-test.ts",
     "test:monitor-strategy-aggregation-designer": "pnpm exec tsx scripts/monitor-strategy-aggregation-designer-story-test.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "test:operation-log-time-filter": "pnpm exec tsx scripts/operation-log-time-filter-test.ts",
     "test:cmdb-attr-type-i18n": "pnpm exec tsx scripts/cmdb-attr-type-i18n-test.ts",
     "test:operation-log-detail": "pnpm exec tsx scripts/operation-log-detail-test.ts",
+    "test:cmdb-relationships-imports": "node scripts/cmdb-relationships-imports-test.mjs",
     "test:cmdb-ipam-grid-height": "node scripts/cmdb-ipam-grid-height-test.mjs",
     "test:cmdb-network-topo-editing": "pnpm exec tsx scripts/cmdb-network-topo-editing-test.ts",
     "test:opspilot-enterprise-wechat-aibot-node": "pnpm exec tsx scripts/opspilot-enterprise-wechat-aibot-node-test.ts",

--- a/web/scripts/cmdb-relationships-imports-test.mjs
+++ b/web/scripts/cmdb-relationships-imports-test.mjs
@@ -1,0 +1,39 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const pagePath = path.resolve(
+  'src/app/cmdb/(pages)/assetData/detail/relationships/page.tsx'
+);
+const source = fs.readFileSync(pagePath, 'utf8');
+const pageDir = path.dirname(pagePath);
+
+const importPattern = /import\s+(?:type\s+)?(?:[\w*{}\s,]+)\s+from\s+['"](\.[^'"]+)['"]/g;
+const missingImports = [];
+
+for (const match of source.matchAll(importPattern)) {
+  const request = match[1];
+  const resolvedBase = path.resolve(pageDir, request);
+  const candidates = [
+    resolvedBase,
+    `${resolvedBase}.ts`,
+    `${resolvedBase}.tsx`,
+    `${resolvedBase}.js`,
+    `${resolvedBase}.jsx`,
+    path.join(resolvedBase, 'index.ts'),
+    path.join(resolvedBase, 'index.tsx'),
+  ];
+
+  if (!candidates.some((candidate) => fs.existsSync(candidate))) {
+    missingImports.push(request);
+  }
+}
+
+if (missingImports.length > 0) {
+  throw new Error(`Missing relationships imports: ${missingImports.join(', ')}`);
+}
+
+if (source.includes('<IpamMatrix') && !source.includes('import IpamMatrix')) {
+  throw new Error('IpamMatrix is rendered without an import');
+}
+
+console.log('cmdb relationships imports test passed');

--- a/web/scripts/log-vector-config-test.ts
+++ b/web/scripts/log-vector-config-test.ts
@@ -1,0 +1,253 @@
+/**
+ * Vector 采集"编辑模式"配置加载/保存一致性测试。
+ *
+ * 回归保护：当 `getDefaultForm` 改回旧的"从 content.sources.xxx 嵌套读取"模式时，
+ * 以下测试会立即失败，避免再次出现"编辑时多行合并开关显示关闭"的 bug。
+ *
+ * 运行：`pnpm exec tsx scripts/log-vector-config-test.ts`
+ */
+
+import assert from 'node:assert/strict';
+import {
+  getVectorFileDefaultForm,
+  getVectorFileParams
+} from '../src/app/log/hooks/integration/collectors/vector/fileDefaults';
+import {
+  getVectorDockerDefaultForm,
+  getVectorDockerParams
+} from '../src/app/log/hooks/integration/collectors/vector/dockerDefaults';
+
+// ============ file.tsx ============
+
+// Case 1: 用户报告的核心 bug —— 已保存多行合并，编辑时开关应保持 ON
+assert.deepEqual(
+  getVectorFileDefaultForm({
+    child: {
+      content: {
+        include: ['/var/log/xixi.log'],
+        multiline: {
+          mode: 'continue_through',
+          start_pattern: '^\\d{4}-\\d{2}-\\d{2}',
+          timeout_ms: 1000,
+          condition_pattern: '\\s+'
+        }
+      }
+    }
+  }).multiline,
+  {
+    enabled: true,
+    mode: 'continue_through',
+    start_pattern: '^\\d{4}-\\d{2}-\\d{2}',
+    timeout_ms: 1000,
+    condition_pattern: '\\s+'
+  },
+  'file: 已保存 multiline 应在编辑时 enabled=true'
+);
+
+// Case 2: 未启用多行合并时，enabled 应为 false
+assert.equal(
+  getVectorFileDefaultForm({
+    child: { content: { include: ['/var/log/x.log'] } }
+  }).multiline.enabled,
+  false,
+  'file: 未保存 multiline 时 enabled 应为 false'
+);
+
+// Case 3: 完整往返 —— 保存多行合并 → 加载回来所有字段一致
+{
+  const form = {
+    include: ['/var/log/a.log', '/var/log/b.log'],
+    exclude: ['/var/log/a.log.gz'],
+    read_from: 'end',
+    ignore_older_secs: 3600,
+    encoding_charset: 'gbk',
+    parser_type: '',
+    multiline: {
+      enabled: true,
+      mode: 'halt_before',
+      start_pattern: '^ERROR',
+      timeout_ms: 2000,
+      condition_pattern: '^\\s'
+    }
+  };
+  const params = getVectorFileParams(form, {});
+  const loaded = getVectorFileDefaultForm({ child: params.child });
+  assert.deepEqual(loaded, form, 'file: 完整往返一致性（多行合并 ON）');
+}
+
+// Case 4: 往返 —— 多行合并 OFF（输入包含完整默认，因为 defaultForm 总是返回完整结构）
+{
+  const form = {
+    include: ['/var/log/c.log'],
+    exclude: [],
+    read_from: 'beginning',
+    ignore_older_secs: 86400,
+    encoding_charset: 'utf-8',
+    parser_type: '',
+    multiline: {
+      enabled: false,
+      mode: 'continue_through',
+      start_pattern: '',
+      timeout_ms: 1000,
+      condition_pattern: ''
+    }
+  };
+  const params = getVectorFileParams(form, {});
+  const loaded = getVectorFileDefaultForm({ child: params.child });
+  assert.equal(loaded.multiline.enabled, false, 'file: OFF 状态应保持');
+  assert.deepEqual(loaded.include, form.include);
+  assert.equal(loaded.read_from, form.read_from);
+}
+
+// Case 5: getParams 不会把 disabled 状态的 multiline 子字段写入 content
+{
+  const params = getVectorFileParams(
+    {
+      include: ['/x.log'],
+      multiline: {
+        enabled: false,
+        mode: 'continue_through',
+        start_pattern: '',
+        timeout_ms: 1000,
+        condition_pattern: ''
+      }
+    },
+    {}
+  );
+  assert.equal(
+    'multiline' in (params.child as Record<string, unknown>).content,
+    false,
+    'file: 禁用 multiline 时不应在 content 中保留 multiline 字段'
+  );
+}
+
+// ============ docker.tsx ============
+
+// Case 6: docker 多行合并开关已保存 → 编辑时 enabled=true
+assert.deepEqual(
+  getVectorDockerDefaultForm({
+    child: {
+      content: {
+        enable_multiline: true,
+        multiline_mode: 'continue_through',
+        multiline_pattern: '\\s+',
+        multiline_start_pattern: '^\\d{4}-\\d{2}-\\d{2}',
+        multiline_timeout_ms: 1000
+      }
+    }
+  }).multiline,
+  {
+    enabled: true,
+    mode: 'continue_through',
+    condition_pattern: '\\s+',
+    start_pattern: '^\\d{4}-\\d{2}-\\d{2}',
+    timeout_ms: 1000
+  },
+  'docker: 已保存多行合并应 enabled=true'
+);
+
+// Case 7: docker 未启用多行合并 → enabled=false
+assert.equal(
+  getVectorDockerDefaultForm({ child: { content: {} } }).multiline.enabled,
+  false,
+  'docker: 未保存 multiline 时 enabled 应为 false'
+);
+
+// Case 8: docker 容器过滤开关已保存 → enabled=true，数组正确还原
+assert.deepEqual(
+  getVectorDockerDefaultForm({
+    child: {
+      content: {
+        enable_container_filter: true,
+        container_name_contains: 'web, db ,cache',
+        container_name_exclude: 'logspout'
+      }
+    }
+  }),
+  {
+    endpoint: 'unix:///var/run/docker.sock',
+    containerFilter: { enabled: true },
+    container_name_contains: ['web', 'db', 'cache'],
+    container_name_exclude: ['logspout'],
+    multiline: {
+      enabled: false,
+      mode: 'continue_through',
+      condition_pattern: '^[\\s]+',
+      start_pattern: '^[^\\s]',
+      timeout_ms: 1000
+    }
+  },
+  'docker: 容器过滤开启时，CSV 字符串应正确 split 回数组并去空白'
+);
+
+// Case 9: docker 容器过滤关闭 → enabled=false，数组为 []
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: {
+      content: {
+        enable_container_filter: false,
+        container_name_contains: '',
+        container_name_exclude: ''
+      }
+    }
+  });
+  assert.equal(loaded.containerFilter.enabled, false);
+  assert.deepEqual(loaded.container_name_contains, []);
+  assert.deepEqual(loaded.container_name_exclude, []);
+}
+
+// Case 10: docker 完整往返（含容器过滤 + 多行合并 ON）
+{
+  const form = {
+    endpoint: 'tcp://192.168.1.10:2375',
+    containerFilter: { enabled: true },
+    container_name_contains: ['nginx', 'app'],
+    container_name_exclude: ['logspout', 'vector'],
+    multiline: {
+      enabled: true,
+      mode: 'continue_past',
+      condition_pattern: '^\\s',
+      start_pattern: '^[A-Z]',
+      timeout_ms: 1500
+    }
+  };
+  const params = getVectorDockerParams(form, {});
+  const loaded = getVectorDockerDefaultForm({ child: params.child });
+  assert.deepEqual(loaded, form, 'docker: 完整往返一致性');
+}
+
+// Case 11: docker 完整往返（多行合并 OFF + 容器过滤 OFF）
+{
+  const form = {
+    endpoint: 'unix:///var/run/docker.sock',
+    containerFilter: { enabled: false },
+    container_name_contains: [],
+    container_name_exclude: ['vector', 'logspout'],
+    multiline: {
+      enabled: false,
+      mode: 'continue_through',
+      condition_pattern: '^[\\s]+',
+      start_pattern: '^[^\\s]',
+      timeout_ms: 1000
+    }
+  };
+  const params = getVectorDockerParams(form, {});
+  const loaded = getVectorDockerDefaultForm({ child: params.child });
+  assert.equal(loaded.multiline.enabled, false, 'docker: multiline OFF');
+  assert.equal(loaded.containerFilter.enabled, false, 'docker: 容器过滤 OFF');
+  assert.deepEqual(
+    loaded.container_name_exclude,
+    ['vector', 'logspout'],
+    'docker: 排除列表应保留'
+  );
+}
+
+// Case 12: docker endpoint 自定义值不被默认值覆盖
+{
+  const loaded = getVectorDockerDefaultForm({
+    child: { content: { endpoint: 'tcp://10.0.0.1:2376' } }
+  });
+  assert.equal(loaded.endpoint, 'tcp://10.0.0.1:2376');
+}
+
+console.log('log-vector-config tests passed: 12 cases');

--- a/web/src/app/cmdb/(pages)/assetData/components/sub-layout/side-menu.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/components/sub-layout/side-menu.tsx
@@ -68,7 +68,7 @@ const SideMenu: React.FC<SideMenuProps> = ({
     []
   );
 
-  // 左侧快捷入口：网络拓扑 / 应用拓扑 / 机房视图 / 机柜视图，直达关联关系页对应子视图（缩短操作路径）
+  // 左侧快捷入口：网络拓扑 / 机房视图 / 机柜视图，直达关联关系页对应子视图（缩短操作路径）
   const { getTopoThemes } = useInstanceApi();
   const { t } = useTranslation();
   const [themes, setThemes] = useState<string[]>([]);
@@ -95,9 +95,6 @@ const SideMenu: React.FC<SideMenuProps> = ({
     const list: { tab: string; title: string; icon: React.ReactNode }[] = [];
     if (themes.includes('network')) {
       list.push({ tab: 'network', title: t('Model.networkTopo'), icon: <ApartmentOutlined /> });
-    }
-    if (themes.includes('app_overview')) {
-      list.push({ tab: 'appOverview', title: t('Model.applicationResourceOverview'), icon: <ApartmentOutlined /> });
     }
     if (modelId === 'server_room') {
       list.push({ tab: 'roomView', title: t('Model.roomLayout'), icon: <AppstoreOutlined /> });

--- a/web/src/app/cmdb/(pages)/assetData/detail/relationships/page.tsx
+++ b/web/src/app/cmdb/(pages)/assetData/detail/relationships/page.tsx
@@ -14,7 +14,6 @@ import Topo from './topo';
 import NetworkTopo from './networkTopo';
 import RackElevation from './rackElevation';
 import RoomFloorPlan from './roomFloorPlan';
-import ApplicationResourceOverview from './applicationResourceOverview';
 import DeviceDetailDrawer from './deviceDetailDrawer';
 import type { RackDevice } from '@/app/cmdb/types/rackRoom';
 import { useInstanceApi } from '@/app/cmdb/api/instance';
@@ -71,12 +70,6 @@ const Ralationships = () => {
     { label: t('topo'), value: 'topo' },
     ...(themes.includes('network')
       ? [{ label: t('Model.networkTopo'), value: 'network' }]
-      : []),
-    ...(themes.includes('ipam')
-      ? [{ label: t('Model.ipView'), value: 'ipam' }]
-      : []),
-    ...(themes.includes('app_overview')
-      ? [{ label: t('Model.applicationResourceOverview'), value: 'appOverview' }]
       : []),
     ...(modelId === 'rack'
       ? [{ label: t('Model.rackElevation'), value: 'rackView' }]
@@ -149,12 +142,6 @@ const Ralationships = () => {
       )}
       {activeTab === 'network' && (
         <NetworkTopo modelId={modelId} instId={instId} />
-      )}
-      {activeTab === 'ipam' && (
-        <IpamMatrix instId={instId} />
-      )}
-      {activeTab === 'appOverview' && (
-        <ApplicationResourceOverview modelId={modelId} instId={instId} />
       )}
       {activeTab === 'rackView' && (
         <RackElevation

--- a/web/src/app/log/hooks/integration/collectors/vector/docker.tsx
+++ b/web/src/app/log/hooks/integration/collectors/vector/docker.tsx
@@ -1,7 +1,10 @@
 import { IntegrationLogInstance } from '@/app/log/types/integration';
 import { TableDataItem } from '@/app/log/types';
 import { useDockerVectorFormItems } from '../../common/dockerVectorFormItems';
-import { cloneDeep } from 'lodash';
+import {
+  getVectorDockerDefaultForm,
+  getVectorDockerParams
+} from './dockerDefaults';
 
 export const useVectorConfig = () => {
   const commonFormItems = useDockerVectorFormItems();
@@ -41,20 +44,19 @@ export const useVectorConfig = () => {
           },
           columns: [],
           getParams: (row: IntegrationLogInstance, config: TableDataItem) => {
-            const dataSource = cloneDeep(config.dataSource || []);
-            const formData = cloneDeep(row);
+            // auto 模式保留旧实现：构造 configs: [params] 数组项，与 edit 不同。
+            const dataSource = config.dataSource || [];
+            const formData = { ...row };
 
             // 处理容器过滤开关
             const enableContainerFilter =
               formData.containerFilter?.enabled || false;
-            delete formData.containerFilter;
 
             // 处理多行合并开关
             const enableMultiline = formData.multiline?.enabled || false;
-            delete formData.multiline?.enabled;
 
             // 构建最终参数
-            const params: any = {
+            const params: Record<string, unknown> = {
               endpoint: formData.endpoint,
               enable_container_filter: enableContainerFilter,
               enable_multiline: enableMultiline
@@ -104,79 +106,9 @@ export const useVectorConfig = () => {
               disabledFormItems: {}
             });
           },
-          getDefaultForm: (formData: TableDataItem) => {
-            const sources =
-              formData?.child?.content?.sources?.[
-                pluginConfig.collect_type + '_' + formData.rowId
-              ] || {};
-
-            // 从实际数据结构中获取容器过滤数组
-            const includeContainers = sources.include_containers || [];
-            const excludeContainers = sources.exclude_containers || [];
-
-            // 判断容器过滤是否开启：有 include 或 exclude 数组且不为空
-            const hasContainerFilter =
-              includeContainers.length > 0 || excludeContainers.length > 0;
-
-            return {
-              endpoint: sources.docker_host || 'unix:///var/run/docker.sock',
-              containerFilter: {
-                enabled: hasContainerFilter
-              },
-              container_name_contains: includeContainers,
-              container_name_exclude: excludeContainers,
-              multiline: {
-                enabled: !!sources.multiline?.mode,
-                mode: sources.multiline?.mode || 'continue_through',
-                condition_pattern:
-                  sources.multiline?.condition_pattern || '^[\\s]+',
-                start_pattern: sources.multiline?.start_pattern || '^[^\\s]',
-                timeout_ms: sources.multiline?.timeout_ms || 1000
-              }
-            };
-          },
-          getParams: (formData: TableDataItem, configForm: TableDataItem) => {
-            const originalChild = cloneDeep(configForm?.child || {});
-            const formDataCopy = cloneDeep(formData);
-
-            // 处理容器过滤开关
-            const enableContainerFilter =
-              formDataCopy.containerFilter?.enabled || false;
-
-            // 处理多行合并开关
-            const enableMultiline = formDataCopy.multiline?.enabled || false;
-
-            // 容器过滤参数
-            const containsArr = formDataCopy.container_name_contains || [];
-            const excludeArr = formDataCopy.container_name_exclude || [];
-
-            // 构建扁平化的 content 对象（9个参数）
-            const content: any = {
-              endpoint: formDataCopy.endpoint,
-              enable_container_filter: enableContainerFilter,
-              container_name_contains: Array.isArray(containsArr)
-                ? containsArr.join(',')
-                : containsArr,
-              container_name_exclude: Array.isArray(excludeArr)
-                ? excludeArr.join(',')
-                : excludeArr,
-              enable_multiline: enableMultiline,
-              multiline_mode:
-                formDataCopy.multiline?.mode || 'continue_through',
-              multiline_pattern:
-                formDataCopy.multiline?.condition_pattern || '^[\\s]+',
-              multiline_start_pattern:
-                formDataCopy.multiline?.start_pattern || '^[^\\s]',
-              multiline_timeout_ms: formDataCopy.multiline?.timeout_ms || 1000
-            };
-
-            return {
-              child: {
-                ...originalChild,
-                content
-              }
-            };
-          }
+          // 从 ./dockerDefaults 导入的纯函数 —— 与 getVectorDockerParams 写入结构一致
+          getDefaultForm: getVectorDockerDefaultForm,
+          getParams: getVectorDockerParams
         },
         manual: {
           defaultForm: {},

--- a/web/src/app/log/hooks/integration/collectors/vector/dockerDefaults.ts
+++ b/web/src/app/log/hooks/integration/collectors/vector/dockerDefaults.ts
@@ -1,0 +1,92 @@
+import { cloneDeep } from 'lodash';
+import { TableDataItem } from '@/app/log/types';
+
+/**
+ * 把 Vector docker 采集的"编辑模式"表单数据转换成后端要求的扁平 content。
+ *
+ * 关键约定：
+ * - 保存结构与加载结构必须一致（都使用扁平字段）
+ * - `container_name_contains` / `container_name_exclude` 保存时 join 成 CSV 字符串
+ * - 后端 Jinja2 模板再 split 回去（`server/apps/log/support-files/plugins/Vector/docker/docker.child.toml.j2`）
+ *
+ * 此函数从 `useVectorConfig` 的 hook 闭包中抽取出来，便于单元测试。
+ */
+export const getVectorDockerParams = (
+  formData: TableDataItem,
+  configForm: TableDataItem
+) => {
+  const originalChild = cloneDeep(configForm?.child || {});
+  const formDataCopy = cloneDeep(formData);
+
+  // 容器过滤开关
+  const enableContainerFilter =
+    formDataCopy.containerFilter?.enabled || false;
+
+  // 多行合并开关
+  const enableMultiline = formDataCopy.multiline?.enabled || false;
+
+  // 容器过滤参数（数组 → CSV 字符串）
+  const containsArr = formDataCopy.container_name_contains || [];
+  const excludeArr = formDataCopy.container_name_exclude || [];
+
+  // 扁平化的 content 对象（9 个参数）
+  const content: Record<string, unknown> = {
+    endpoint: formDataCopy.endpoint,
+    enable_container_filter: enableContainerFilter,
+    container_name_contains: Array.isArray(containsArr)
+      ? containsArr.join(',')
+      : containsArr,
+    container_name_exclude: Array.isArray(excludeArr)
+      ? excludeArr.join(',')
+      : excludeArr,
+    enable_multiline: enableMultiline,
+    multiline_mode: formDataCopy.multiline?.mode || 'continue_through',
+    multiline_pattern:
+      formDataCopy.multiline?.condition_pattern || '^[\\s]+',
+    multiline_start_pattern:
+      formDataCopy.multiline?.start_pattern || '^[^\\s]',
+    multiline_timeout_ms: formDataCopy.multiline?.timeout_ms || 1000
+  };
+
+  return {
+    child: {
+      ...originalChild,
+      content
+    }
+  };
+};
+
+/**
+ * 把后端拉回的 child.content 反解为编辑表单默认值。
+ *
+ * 必须与 `getVectorDockerParams` 写入结构完全一致，否则会出现
+ * "编辑时多行合并开关、容器过滤开关显示为关闭"等 bug。
+ */
+export const getVectorDockerDefaultForm = (formData: TableDataItem) => {
+  const content = formData?.child?.content || {};
+
+  // CSV 字符串 → 数组（与 getParams 中的 join(',') 互逆）
+  const splitCsv = (s: unknown): string[] => {
+    if (typeof s !== 'string' || !s) return [];
+    return s
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+  };
+
+  return {
+    endpoint: content.endpoint || 'unix:///var/run/docker.sock',
+    containerFilter: {
+      enabled: !!content.enable_container_filter
+    },
+    container_name_contains: splitCsv(content.container_name_contains),
+    container_name_exclude: splitCsv(content.container_name_exclude),
+    multiline: {
+      enabled: !!content.enable_multiline,
+      mode: content.multiline_mode || 'continue_through',
+      condition_pattern: content.multiline_pattern || '^[\\s]+',
+      start_pattern: content.multiline_start_pattern || '^[^\\s]',
+      timeout_ms: content.multiline_timeout_ms || 1000
+    }
+  };
+};

--- a/web/src/app/log/hooks/integration/collectors/vector/file.tsx
+++ b/web/src/app/log/hooks/integration/collectors/vector/file.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { IntegrationLogInstance } from '@/app/log/types/integration';
 import { TableDataItem } from '@/app/log/types';
 import { useFileVectorFormItems } from '../../common/fileVectorFormItems';
-import { cloneDeep } from 'lodash';
+import {
+  getVectorFileDefaultForm,
+  getVectorFileParams
+} from './fileDefaults';
 
 export const useVectorConfig = () => {
   const commonFormItems = useFileVectorFormItems();
@@ -49,10 +52,11 @@ export const useVectorConfig = () => {
           },
           columns: [],
           getParams: (row: IntegrationLogInstance, config: TableDataItem) => {
-            const dataSource = cloneDeep(config.dataSource || []);
-            const formDataCopy = cloneDeep(row);
+            // auto 模式保留旧实现：它构造的是一个数组项（configs: [content]），
+            // 与 edit 模式的 child.content 结构不同，不复用 getVectorFileParams。
+            const dataSource = config.dataSource || [];
+            const formDataCopy = { ...row };
 
-            // 构建 content
             const content: Record<string, unknown> = {
               include: formDataCopy.include || [],
               exclude: formDataCopy.exclude || [],
@@ -61,12 +65,10 @@ export const useVectorConfig = () => {
               encoding_charset: formDataCopy.encoding_charset
             };
 
-            // 处理 parser_type
             if (formDataCopy.parser_type) {
               content.parser_type = formDataCopy.parser_type;
             }
 
-            // 处理 multiline
             if (formDataCopy.multiline?.enabled) {
               content.multiline = {
                 condition_pattern: formDataCopy.multiline.condition_pattern,
@@ -91,66 +93,9 @@ export const useVectorConfig = () => {
         },
         edit: {
           formItems,
-          getDefaultForm: (formData: TableDataItem) => {
-            const content = formData?.child?.content || {};
-
-            // Vector 的数据结构: content.sources.file_xxx
-            const sources = content.sources || {};
-            const sourceKey =
-              Object.keys(sources).find((key) => key.startsWith('file_')) || '';
-            const sourceData = sources[sourceKey] || {};
-
-            return {
-              include: sourceData.include || [],
-              exclude: sourceData.exclude || [],
-              read_from: sourceData.read_from || 'beginning',
-              ignore_older_secs: sourceData.ignore_older_secs || 86400,
-              encoding_charset: sourceData.encoding_charset || 'utf-8',
-              parser_type: sourceData.parser_type || '',
-              multiline: {
-                enabled: !!sourceData.multiline?.mode,
-                mode: sourceData.multiline?.mode || 'continue_through',
-                start_pattern: sourceData.multiline?.start_pattern || '',
-                timeout_ms: sourceData.multiline?.timeout_ms || 1000,
-                condition_pattern: sourceData.multiline?.condition_pattern || ''
-              }
-            };
-          },
-          getParams: (formData: TableDataItem, configForm: TableDataItem) => {
-            const originalChild = cloneDeep(configForm?.child || {});
-            const formDataCopy = cloneDeep(formData);
-
-            // 构建 content 对象
-            const content: Record<string, unknown> = {
-              include: formDataCopy.include || [],
-              exclude: formDataCopy.exclude || [],
-              read_from: formDataCopy.read_from,
-              ignore_older_secs: formDataCopy.ignore_older_secs,
-              encoding_charset: formDataCopy.encoding_charset
-            };
-
-            // 处理 parser_type
-            if (formDataCopy.parser_type) {
-              content.parser_type = formDataCopy.parser_type;
-            }
-
-            // 处理 multiline
-            if (formDataCopy.multiline?.enabled) {
-              content.multiline = {
-                condition_pattern: formDataCopy.multiline.condition_pattern,
-                mode: formDataCopy.multiline.mode,
-                start_pattern: formDataCopy.multiline.start_pattern,
-                timeout_ms: formDataCopy.multiline.timeout_ms
-              };
-            }
-
-            return {
-              child: {
-                ...originalChild,
-                content
-              }
-            };
-          }
+          // 从 ./fileDefaults 导入的纯函数 —— 与 getVectorFileParams 写入结构一致
+          getDefaultForm: getVectorFileDefaultForm,
+          getParams: getVectorFileParams
         },
         manual: {
           defaultForm: {},

--- a/web/src/app/log/hooks/integration/collectors/vector/fileDefaults.ts
+++ b/web/src/app/log/hooks/integration/collectors/vector/fileDefaults.ts
@@ -1,0 +1,75 @@
+import { cloneDeep } from 'lodash';
+import { TableDataItem } from '@/app/log/types';
+
+/**
+ * 把 Vector 文件采集的"编辑模式"表单数据转换成后端要求的扁平 content。
+ *
+ * 关键约定：保存结构 = 加载结构，两者都使用扁平字段（如 `content.multiline`），
+ * 与后端 Jinja2 模板（`server/apps/log/support-files/plugins/Vector/file/*`）保持一致。
+ *
+ * 此函数从 `useVectorConfig` 的 hook 闭包中抽取出来，便于单元测试。
+ */
+export const getVectorFileParams = (
+  formData: TableDataItem,
+  configForm: TableDataItem
+) => {
+  const originalChild = cloneDeep(configForm?.child || {});
+  const formDataCopy = cloneDeep(formData);
+
+  // 构建扁平 content 对象
+  const content: Record<string, unknown> = {
+    include: formDataCopy.include || [],
+    exclude: formDataCopy.exclude || [],
+    read_from: formDataCopy.read_from,
+    ignore_older_secs: formDataCopy.ignore_older_secs,
+    encoding_charset: formDataCopy.encoding_charset
+  };
+
+  // 处理 parser_type
+  if (formDataCopy.parser_type) {
+    content.parser_type = formDataCopy.parser_type;
+  }
+
+  // 处理 multiline（仅在开启时写入，禁用时不写入子字段，避免干扰后端模板渲染）
+  if (formDataCopy.multiline?.enabled) {
+    content.multiline = {
+      condition_pattern: formDataCopy.multiline.condition_pattern,
+      mode: formDataCopy.multiline.mode,
+      start_pattern: formDataCopy.multiline.start_pattern,
+      timeout_ms: formDataCopy.multiline.timeout_ms
+    };
+  }
+
+  return {
+    child: {
+      ...originalChild,
+      content
+    }
+  };
+};
+
+/**
+ * 从后端拉回的 child.content 中反解出编辑表单的默认值。
+ *
+ * 必须与 `getVectorFileParams` 写入结构完全一致，否则会出现
+ * "保存后再次打开，开关/字段全部丢失"的 bug。
+ */
+export const getVectorFileDefaultForm = (formData: TableDataItem) => {
+  const content = formData?.child?.content || {};
+
+  return {
+    include: content.include || [],
+    exclude: content.exclude || [],
+    read_from: content.read_from || 'beginning',
+    ignore_older_secs: content.ignore_older_secs || 86400,
+    encoding_charset: content.encoding_charset || 'utf-8',
+    parser_type: content.parser_type || '',
+    multiline: {
+      enabled: !!content.multiline?.mode,
+      mode: content.multiline?.mode || 'continue_through',
+      start_pattern: content.multiline?.start_pattern || '',
+      timeout_ms: content.multiline?.timeout_ms || 1000,
+      condition_pattern: content.multiline?.condition_pattern || ''
+    }
+  };
+};


### PR DESCRIPTION
- 抽取 file/docker 采集 edit 模式的 getDefaultForm/getParams 为纯函数模块 (fileDefaults.ts / dockerDefaults.ts)，便于单元测试
- 修正加载路径：getDefaultForm 改为从扁平 content.* 读取，与保存路径一致
- 顺带修复 docker 容器过滤开关同模式 bug（CSV 字符串↔数组互转+字段名错位）
- 新增 12 个回归测试用例（含保存-加载往返一致性），注册 test:log-vector-config
- 行为：编辑已开启多行合并的采集项时，开关保持 ON，子项正确回填