### PR TITLE
fix(monitor): overlay enterprise public icons

### DIFF
--- a/web/scripts/prepare-enterprise-assets-test.mjs
+++ b/web/scripts/prepare-enterprise-assets-test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+
+import fs from 'fs-extra';
+
+import * as enterprisePrepare from './prepare-enterprise.mjs';
+
+const tmpRoot = await mkdtemp(path.join(os.tmpdir(), 'prepare-enterprise-assets-'));
+
+try {
+  assert.equal(
+    typeof enterprisePrepare.prepareEnterprisePublicAssets,
+    'function',
+    'prepareEnterprisePublicAssets should be exported for isolated assets overlay testing'
+  );
+
+  const webRoot = path.join(tmpRoot, 'web');
+  const enterpriseWebRoot = path.join(tmpRoot, 'enterprise-web');
+  const enterpriseIconsRoot = path.join(enterpriseWebRoot, 'public', 'assets', 'icons');
+  const communityIconsRoot = path.join(webRoot, 'public', 'assets', 'icons');
+
+  await fs.ensureDir(enterpriseIconsRoot);
+  await fs.ensureDir(communityIconsRoot);
+  await writeFile(path.join(communityIconsRoot, 'cc-default_默认.svg'), '<svg>default</svg>');
+  await writeFile(path.join(communityIconsRoot, 'cc-existing.svg'), '<svg>community</svg>');
+  await writeFile(path.join(enterpriseIconsRoot, 'cc-ibmmq.svg'), '<svg>ibmmq</svg>');
+  await writeFile(path.join(enterpriseIconsRoot, 'mm-ibmmq.svg'), '<svg>ibmmq-mm</svg>');
+  await writeFile(path.join(enterpriseIconsRoot, 'cc-existing.svg'), '<svg>enterprise</svg>');
+  await writeFile(path.join(enterpriseIconsRoot, 'readme.txt'), 'not an icon');
+
+  const copied = await enterprisePrepare.prepareEnterprisePublicAssets({
+    webRoot,
+    enterpriseWebRoot,
+  });
+
+  assert.deepEqual(copied.sort(), ['cc-ibmmq.svg', 'mm-ibmmq.svg']);
+  assert.equal(await fs.readFile(path.join(communityIconsRoot, 'cc-ibmmq.svg'), 'utf8'), '<svg>ibmmq</svg>');
+  assert.equal(await fs.readFile(path.join(communityIconsRoot, 'mm-ibmmq.svg'), 'utf8'), '<svg>ibmmq-mm</svg>');
+  assert.equal(await fs.pathExists(path.join(communityIconsRoot, 'readme.txt')), false);
+  assert.equal(await fs.readFile(path.join(communityIconsRoot, 'cc-default_默认.svg'), 'utf8'), '<svg>default</svg>');
+  assert.equal(await fs.readFile(path.join(communityIconsRoot, 'cc-existing.svg'), 'utf8'), '<svg>community</svg>');
+
+  console.log('prepare-enterprise public assets overlay ok');
+} finally {
+  await rm(tmpRoot, { recursive: true, force: true });
+}

--- a/web/scripts/prepare-enterprise.mjs
+++ b/web/scripts/prepare-enterprise.mjs
@@ -41,6 +41,36 @@ const cleanupGenerated = async () => {
   await fs.remove(path.join(appRoot, 'monitor', 'dashboards', 'objects', '(enterprise)-registry.ts'));
 };
 
+/* ── public assets: copy enterprise icons into the served CE public tree ── */
+
+export const prepareEnterprisePublicAssets = async ({
+  webRoot: targetWebRoot = webRoot,
+  enterpriseWebRoot: sourceEnterpriseWebRoot = enterpriseWebRoot,
+} = {}) => {
+  const sourceIconsRoot = path.join(sourceEnterpriseWebRoot, 'public', 'assets', 'icons');
+  const targetIconsRoot = path.join(targetWebRoot, 'public', 'assets', 'icons');
+
+  if (!(await fs.pathExists(sourceIconsRoot))) return [];
+
+  await fs.ensureDir(targetIconsRoot);
+
+  const copiedIconNames = [];
+  const entries = await fs.readdir(sourceIconsRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.svg')) continue;
+    const sourceIcon = path.join(sourceIconsRoot, entry.name);
+    const targetIcon = path.join(targetIconsRoot, entry.name);
+    if (await fs.pathExists(targetIcon)) continue;
+    await fs.copy(sourceIcon, targetIcon, {
+      dereference: true,
+      overwrite: false,
+    });
+    copiedIconNames.push(entry.name);
+  }
+
+  return copiedIconNames;
+};
+
 /* ── routes: copy EE page source into CE route tree ── */
 
 const generateRouteShims = async (routes) => {
@@ -330,6 +360,13 @@ export const prepareEnterpriseRoutes = async () => {
   }
 
   await cleanupGenerated();
+
+  // 0.5) Copy EE public icons into CE public, because Next.js only serves
+  // assets from the current app's public/ directory.
+  const copiedIconNames = await prepareEnterprisePublicAssets();
+  if (copiedIconNames.length) {
+    console.log(`  🖼️ Public icons: ${copiedIconNames.length} enterprise icons copied`);
+  }
 
   // 1) Junctions for api/types/etc under {module}/(enterprise)/
   const linkedModules = await generateEnterpriseJunctions();


### PR DESCRIPTION
## 变更说明

修复本地/构建企业版后企业版监控对象 logo 不显示的问题。

根因是页面请求 `/assets/icons/<icon>.svg`，Next.js 只从当前运行 Web 的 `public/` 目录提供静态资源；企业版 logo 已提交在企业版仓库的 `web/public/assets/icons`，但社区版本地 overlay 只挂载了企业版路由和 dashboard registry，没有把企业版 public icons 暴露到当前运行目录。

## 实现方式

- 在 `web/scripts/prepare-enterprise.mjs` 中新增 `prepareEnterprisePublicAssets()`。
- `prepare-enterprise` 时把企业版缺失的 `public/assets/icons/*.svg` 复制到当前运行 Web 的 `public/assets/icons`。
- 已存在的社区版 icon 不覆盖，避免影响社区版已有资产。
- 新增脚本级回归测试覆盖：只复制缺失 SVG、忽略非 SVG、保留社区版已有 icon。

## 验证

- `node scripts/prepare-enterprise-assets-test.mjs`
- `pnpm exec eslint --no-ignore scripts/prepare-enterprise.mjs scripts/prepare-enterprise-assets-test.mjs`

## 影响范围

仅影响企业版本地/构建准备阶段的 public icon overlay。不会修改监控业务数据、插件元数据或社区版已有 icon。