### PR TITLE
bugfix: 修复 NATS 私有 helper 导入遗漏

### DIFF
--- a/server/apps/system_mgmt/nats/auth.py
+++ b/server/apps/system_mgmt/nats/auth.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .common import *  # noqa: F401,F403
+from .common import _collect_ancestor_group_ids, _verify_token
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/login.py
+++ b/server/apps/system_mgmt/nats/login.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .common import *  # noqa: F401,F403
+from .common import _build_jwt_payload, _get_pwd_policy_settings, _verify_token
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/otp.py
+++ b/server/apps/system_mgmt/nats/otp.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .common import *  # noqa: F401,F403
+from .common import _build_jwt_payload, _get_pwd_policy_settings
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/settings.py
+++ b/server/apps/system_mgmt/nats/settings.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .common import *  # noqa: F401,F403
+from .common import _build_jwt_payload
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/wechat.py
+++ b/server/apps/system_mgmt/nats/wechat.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 from .common import *  # noqa: F401,F403
+from .common import _build_jwt_payload
 from .users import set_opspilot_guest_group_default_rule
 
 

--- a/server/apps/system_mgmt/nats_api.py
+++ b/server/apps/system_mgmt/nats_api.py
@@ -21,6 +21,7 @@ _wechat = import_module("apps.system_mgmt.nats.wechat")
 _COMPAT_GLOBALS_BY_MODULE = {
     _auth: (
         "_verify_token",
+        "_collect_ancestor_group_ids",
         "get_user_all_roles",
     ),
     _login: (

--- a/server/apps/system_mgmt/tests/test_nats_api_compat.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_compat.py
@@ -1,4 +1,6 @@
 """旧 apps.system_mgmt.nats_api 路径兼容层回归测试。"""
+import ast
+from pathlib import Path
 import types
 
 from apps.system_mgmt import nats_api
@@ -11,12 +13,17 @@ def test_nats_api_compat_syncs_sensitive_monkeypatch_helpers(monkeypatch):
     def fake_build_jwt_payload(user_id):
         return {"patched_user_id": user_id}
 
+    def fake_collect_ancestor_group_ids(seed_ids):
+        return set(seed_ids)
+
     monkeypatch.setattr(nats_api, "_verify_token", fake_verify_token)
     monkeypatch.setattr(nats_api, "_build_jwt_payload", fake_build_jwt_payload)
+    monkeypatch.setattr(nats_api, "_collect_ancestor_group_ids", fake_collect_ancestor_group_ids)
 
     nats_api._sync_compat_globals()
 
     assert nats_api._auth._verify_token is fake_verify_token
+    assert nats_api._auth._collect_ancestor_group_ids is fake_collect_ancestor_group_ids
     assert nats_api._login._verify_token is fake_verify_token
     assert nats_api._login._build_jwt_payload is fake_build_jwt_payload
     assert nats_api._otp._build_jwt_payload is fake_build_jwt_payload
@@ -74,3 +81,120 @@ def test_get_user_login_token_uses_legacy_nats_api_jwt_payload_patch(monkeypatch
     assert result["result"] is True
     assert result["data"]["token"] == "patched-token"
     assert captured["payload"] == {"patched_user_id": 42}
+
+
+def test_verify_token_uses_legacy_nats_api_collect_ancestor_patch(monkeypatch):
+    captured = {}
+
+    def fake_collect_ancestor_group_ids(seed_ids):
+        captured["seed_ids"] = seed_ids
+        return {1, 2}
+
+    class FakeRoleList:
+        def __iter__(self):
+            return iter([types.SimpleNamespace(app="cmdb", name="viewer")])
+
+        def values_list(self, *args, **kwargs):
+            return [[10]]
+
+    class FakeRoleObjects:
+        @staticmethod
+        def filter(**kwargs):
+            return FakeRoleList()
+
+    class FakeGroupQuerySet:
+        def filter(self, **kwargs):
+            captured["group_filter"] = kwargs
+            return self
+
+        def order_by(self, *args):
+            return [types.SimpleNamespace(id=1, name="team-a", parent_id=None)]
+
+    class FakeGroupObjects:
+        @staticmethod
+        def prefetch_related(*args):
+            return FakeGroupQuerySet()
+
+    class FakeMenuQuerySet:
+        @staticmethod
+        def values_list(*args):
+            return [("cmdb", "host-view")]
+
+    class FakeMenuObjects:
+        @staticmethod
+        def filter(**kwargs):
+            return FakeMenuQuerySet()
+
+    monkeypatch.setattr(
+        nats_api,
+        "_verify_token",
+        lambda token: types.SimpleNamespace(
+            id=7,
+            username="alice",
+            display_name="Alice",
+            domain="domain.com",
+            email="alice@example.com",
+            group_list=[1],
+            locale="zh-Hans",
+            timezone="Asia/Shanghai",
+        ),
+    )
+    monkeypatch.setattr(nats_api, "_collect_ancestor_group_ids", fake_collect_ancestor_group_ids)
+    monkeypatch.setattr(nats_api, "get_user_all_roles", lambda user: [100])
+    monkeypatch.setattr(nats_api._auth, "get_cached_token_info", lambda username, domain: None)
+    monkeypatch.setattr(nats_api._auth, "set_cached_token_info", lambda username, domain, result: None)
+    monkeypatch.setattr(nats_api._auth, "Role", types.SimpleNamespace(objects=FakeRoleObjects()))
+    monkeypatch.setattr(nats_api._auth, "Group", types.SimpleNamespace(objects=FakeGroupObjects()))
+    monkeypatch.setattr(nats_api._auth, "Menu", types.SimpleNamespace(objects=FakeMenuObjects()))
+    monkeypatch.setattr(nats_api._auth.GroupUtils, "build_group_tree", lambda queryset, is_superuser, group_ids: [])
+    monkeypatch.setattr(nats_api._auth.cache, "get", lambda key: None)
+    monkeypatch.setattr(nats_api._auth.cache, "set", lambda key, value, timeout: None)
+
+    result = nats_api.verify_token("token")
+
+    assert result["result"] is True
+    assert captured["seed_ids"] == [1]
+    assert captured["group_filter"] == {"id__in": {1, 2}}
+
+
+def test_nats_modules_explicitly_import_private_common_helpers():
+    nats_dir = Path(nats_api.__file__).parent / "nats"
+    common_tree = ast.parse((nats_dir / "common.py").read_text())
+    common_private_names = {
+        node.name
+        for node in common_tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name.startswith("_")
+    }
+    for node in common_tree.body:
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                imported_name = alias.asname or alias.name
+                if imported_name.startswith("_"):
+                    common_private_names.add(imported_name)
+
+    for module_path in sorted(nats_dir.glob("*.py")):
+        if module_path.name in {"__init__.py", "common.py"}:
+            continue
+
+        module_tree = ast.parse(module_path.read_text())
+        defined_names = {
+            node.name
+            for node in ast.walk(module_tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+        }
+        explicit_private_imports = set()
+        used_private_names = set()
+
+        for node in ast.walk(module_tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "common":
+                explicit_private_imports.update(
+                    alias.asname or alias.name
+                    for alias in node.names
+                    if alias.name != "*" and (alias.asname or alias.name).startswith("_")
+                )
+            elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                if node.id.startswith("_") and not node.id.startswith("__"):
+                    used_private_names.add(node.id)
+
+        missing = sorted((used_private_names & common_private_names) - defined_names - explicit_private_imports)
+        assert missing == [], f"{module_path.name} must explicitly import private common helpers: {missing}"


### PR DESCRIPTION
## 背景

`system_mgmt` NATS handler 拆分后，部分子模块继续通过 `from .common import *` 使用 `_xxx` 私有 helper。Python 星号导入默认不会导入下划线开头的名称，导致 `auth.verify_token` 非超管 cache-miss 路径可能在 `_collect_ancestor_group_ids` 处抛 `NameError`，进而造成 Token 鉴权失败。

## 变更

- 为 `auth/login/otp/settings/wechat` 显式导入实际使用的 `common.py` 私有 helper。
- 在旧 `apps.system_mgmt.nats_api` 兼容层同步列表中补齐 `_collect_ancestor_group_ids`。
- 增加兼容层与静态防线测试，确保后续 NATS 子模块使用 `common.py` 私有 helper 时必须显式导入。

## 验证

```bash
cd server && INSTALL_APPS=system_mgmt MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=false uv run --extra dev --group dev pytest apps/system_mgmt/tests/test_nats_api_compat.py --no-cov -q
# 5 passed

cd server && INSTALL_APPS=system_mgmt MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=false uv run --extra dev --group dev python -m py_compile apps/system_mgmt/nats/auth.py apps/system_mgmt/nats/login.py apps/system_mgmt/nats/otp.py apps/system_mgmt/nats/settings.py apps/system_mgmt/nats/wechat.py apps/system_mgmt/nats_api.py apps/system_mgmt/tests/test_nats_api_compat.py

git diff --check -- server/apps/system_mgmt/nats/auth.py server/apps/system_mgmt/nats/login.py server/apps/system_mgmt/nats/otp.py server/apps/system_mgmt/nats/settings.py server/apps/system_mgmt/nats/wechat.py server/apps/system_mgmt/nats_api.py server/apps/system_mgmt/tests/test_nats_api_compat.py
```

说明：`test_nats_api_handlers.py` 依赖 PostgreSQL 测试库；当前本地环境缺 `DB_NAME`/测试库配置，未作为本次 PR 验证命令。