### PR TITLE
bugfix: 限制节点列表全量分页

### DIFF
--- a/server/apps/cmdb/services/node_mgmt_sync_service.py
+++ b/server/apps/cmdb/services/node_mgmt_sync_service.py
@@ -449,7 +449,7 @@ class NodeMgmtSyncService:
             page_nodes = cls._extract_nodes(rows)
             nodes.extend(page_nodes)
             count = cls._safe_count(rows.get("count") if isinstance(rows, dict) else len(page_nodes))
-            if not page_nodes or len(page_nodes) < cls.NODE_MGMT_SYNC_PAGE_SIZE or len(nodes) >= count:
+            if not page_nodes or len(nodes) >= count:
                 break
             page += 1
         return nodes

--- a/server/apps/cmdb/services/node_mgmt_sync_service.py
+++ b/server/apps/cmdb/services/node_mgmt_sync_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import os
 from typing import Any
 
 from django.db import transaction
@@ -18,6 +19,14 @@ from apps.rpc.node_mgmt import NodeMgmt
 from apps.core.logger import cmdb_logger as logger
 
 
+def _get_positive_int_env(name, default):
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return max(1, value)
+
+
 class NodeMgmtSyncService:
     SYNC_PERIODIC_TASK_NAME = "cmdb_node_mgmt_sync_hosts"
     COLLECT_PERIODIC_TASK_NAME = "cmdb_node_mgmt_collect_hosts"
@@ -32,6 +41,7 @@ class NodeMgmtSyncService:
     DISPLAY_SOURCE_COLLECT = "collect"
     DISPLAY_SOURCE_SYNC_FALLBACK = "sync_fallback"
     DISPLAY_SOURCE_NONE = "none"
+    NODE_MGMT_SYNC_PAGE_SIZE = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_PAGE_SIZE", 500)
     RAW_DATA_FIELDS = (
         "id",
         "_id",
@@ -429,22 +439,32 @@ class NodeMgmtSyncService:
         return result
 
     @classmethod
+    def _fetch_node_mgmt_pages(cls, query: dict[str, Any]) -> list[dict[str, Any]]:
+        page = 1
+        nodes: list[dict[str, Any]] = []
+        client = cls._node_mgmt_client()
+        while True:
+            payload = {**query, "page": page, "page_size": cls.NODE_MGMT_SYNC_PAGE_SIZE}
+            rows = client.node_list(payload)
+            page_nodes = cls._extract_nodes(rows)
+            nodes.extend(page_nodes)
+            count = cls._safe_count(rows.get("count") if isinstance(rows, dict) else len(page_nodes))
+            if not page_nodes or len(page_nodes) < cls.NODE_MGMT_SYNC_PAGE_SIZE or len(nodes) >= count:
+                break
+            page += 1
+        return nodes
+
+    @classmethod
     def _fetch_non_container_nodes(cls) -> list[dict[str, Any]]:
         logger.info("[NodeMgmtSync] 开始获取非容器节点列表")
         cloud_region_names = cls._cloud_region_name_map()
         logger.debug("[NodeMgmtSync] 获取到云区域名称映射, region_count=%d", len(cloud_region_names))
-        rows = cls._node_mgmt_client().node_list(
-                {
-                    "page": 1,
-                    "page_size": -1,
-                    "is_container": False,
-                }
-            )
-        total_nodes = len(rows.get("nodes", []))
+        nodes = cls._fetch_node_mgmt_pages({"is_container": False})
+        total_nodes = len(nodes)
         logger.info("[NodeMgmtSync] 从节点管理获取到节点数据, total=%d", total_nodes)
         result: list[dict[str, Any]] = []
         skipped_count = 0
-        for node in rows["nodes"]:
+        for node in nodes:
             cloud_region_id = cls._safe_int(node.get("cloud_region_id") or node.get("cloud_region"))
             if cloud_region_id is None:
                 skipped_count += 1
@@ -486,16 +506,7 @@ class NodeMgmtSyncService:
     def _pick_access_point(cls, cloud_region_id: int) -> dict[str, Any] | None:
         logger.debug("[NodeMgmtSync] 查找云区域接入点, cloud_region_id=%d", cloud_region_id)
         cloud_region_name = cls._cloud_region_name_map().get(int(cloud_region_id), "")
-        nodes = cls._extract_nodes(
-            cls._node_mgmt_client().node_list(
-                {
-                    "page": 1,
-                    "page_size": -1,
-                    "cloud_region_id": cloud_region_id,
-                    "is_container": True,
-                }
-            )
-        )
+        nodes = cls._fetch_node_mgmt_pages({"cloud_region_id": cloud_region_id, "is_container": True})
         if not nodes:
             logger.warning("[NodeMgmtSync] 云区域无可用容器节点作为接入点, cloud_region_id=%d", cloud_region_id)
             return None

--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -1357,7 +1357,11 @@ def test_node_mgmt_sync_service_fetch_non_container_nodes_uses_rpc_payload():
             "_error": "",
         }
     ]
-    node_mgmt.node_list.assert_called_once_with({"page": 1, "page_size": -1, "is_container": False})
+    node_mgmt.node_list.assert_called_once_with({
+        "page": 1,
+        "page_size": NodeMgmtSyncService.NODE_MGMT_SYNC_PAGE_SIZE,
+        "is_container": False,
+    })
 
 
 def test_node_mgmt_sync_service_pick_access_point_uses_rpc_payload():
@@ -1377,7 +1381,12 @@ def test_node_mgmt_sync_service_pick_access_point_uses_rpc_payload():
         result = NodeMgmtSyncService._pick_access_point(1)
 
     assert result == {"id": "container-new", "name": "new", "cloud": 1, "cloud_name": "default"}
-    node_mgmt.node_list.assert_called_once_with({"page": 1, "page_size": -1, "cloud_region_id": 1, "is_container": True})
+    node_mgmt.node_list.assert_called_once_with({
+        "page": 1,
+        "page_size": NodeMgmtSyncService.NODE_MGMT_SYNC_PAGE_SIZE,
+        "cloud_region_id": 1,
+        "is_container": True,
+    })
 
 
 def test_node_mgmt_sync_service_serialize_config_returns_defaults():

--- a/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
+++ b/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
@@ -189,22 +189,37 @@ class TestRpcWrappers:
     def test_fetch_non_container_nodes_过滤无云区域(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]
-        rpc.node_list.return_value = {
-            "nodes": [
-                {"id": "n1", "name": "host1", "ip": "1.1.1.1", "cloud_region_id": 1,
-                 "operating_system": "linux", "organization": [10]},
-                {"id": "n2", "name": "host2", "ip": "2.2.2.2"},  # 无云区域被跳过
-            ]
-        }
+        rpc.node_list.side_effect = [
+            {
+                "count": 3,
+                "nodes": [
+                    {"id": "n1", "name": "host1", "ip": "1.1.1.1", "cloud_region_id": 1,
+                     "operating_system": "linux", "organization": [10]},
+                    {"id": "n2", "name": "host2", "ip": "2.2.2.2", "cloud_region_id": 1,
+                     "operating_system": "linux", "organization": [10]},
+                ],
+            },
+            {
+                "count": 3,
+                "nodes": [
+                    {"id": "n3", "name": "host3", "ip": "3.3.3.3"},  # 无云区域被跳过
+                ],
+            },
+        ]
+        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 2)
         mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
         out = S._fetch_non_container_nodes()
-        assert len(out) == 1
+        assert len(out) == 2
         node = out[0]
         assert node["id"] == "n1"
         assert node["cloud_region_name"] == "华东"
         assert node["os_type"] == "linux"
         assert node["organization_ids"] == [10]
         assert node["model_id"] == "host"
+        assert rpc.node_list.call_args_list == [
+            mocker.call({"is_container": False, "page": 1, "page_size": 2}),
+            mocker.call({"is_container": False, "page": 2, "page_size": 2}),
+        ]
 
     def test_pick_access_point_无容器节点返回None(self, mocker):
         rpc = mocker.MagicMock()
@@ -216,17 +231,26 @@ class TestRpcWrappers:
     def test_pick_access_point_选最新updated_at(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]
-        rpc.node_list.return_value = {
-            "nodes": [
-                {"id": "c1", "name": "old", "updated_at": "2026-01-01"},
-                {"id": "c2", "name": "new", "updated_at": "2026-06-01"},
-            ]
-        }
+        rpc.node_list.side_effect = [
+            {
+                "count": 3,
+                "nodes": [
+                    {"id": "c1", "name": "old", "updated_at": "2026-01-01"},
+                    {"id": "c2", "name": "middle", "updated_at": "2026-06-01"},
+                ],
+            },
+            {"count": 3, "nodes": [{"id": "c3", "name": "new", "updated_at": "2026-07-01"}]},
+        ]
+        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 2)
         mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
         ap = S._pick_access_point(1)
-        assert ap["id"] == "c2"
+        assert ap["id"] == "c3"
         assert ap["cloud"] == 1
         assert ap["cloud_name"] == "华东"
+        assert rpc.node_list.call_args_list == [
+            mocker.call({"cloud_region_id": 1, "is_container": True, "page": 1, "page_size": 2}),
+            mocker.call({"cloud_region_id": 1, "is_container": True, "page": 2, "page_size": 2}),
+        ]
 
 
 class TestDbSerialization:

--- a/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
+++ b/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
@@ -221,6 +221,25 @@ class TestRpcWrappers:
             mocker.call({"is_container": False, "page": 2, "page_size": 2}),
         ]
 
+    def test_fetch_node_mgmt_pages_按count继续翻页(self, mocker):
+        rpc = mocker.MagicMock()
+        rpc.node_list.side_effect = [
+            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(500)]},
+            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(500, 1000)]},
+            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(1000, 1200)]},
+        ]
+        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 1000)
+        mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
+
+        nodes = S._fetch_node_mgmt_pages({"is_container": False})
+
+        assert len(nodes) == 1200
+        assert rpc.node_list.call_args_list == [
+            mocker.call({"is_container": False, "page": 1, "page_size": 1000}),
+            mocker.call({"is_container": False, "page": 2, "page_size": 1000}),
+            mocker.call({"is_container": False, "page": 3, "page_size": 1000}),
+        ]
+
     def test_pick_access_point_无容器节点返回None(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timezone
 from django.utils import timezone as dj_timezone
 
@@ -28,7 +29,17 @@ from apps.rpc.system_mgmt import SystemMgmt
 from apps.core.utils.safe_template import build_sandboxed_env
 
 
+def _get_positive_int_env(name, default):
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return max(1, value)
+
+
 class NodeService:
+    NODE_LIST_PAGE_SIZE_MAX = _get_positive_int_env("NODE_MGMT_NODE_LIST_PAGE_SIZE_MAX", 500)
+
     @staticmethod
     def _build_scoped_permission(permission_data):
         user_obj = User(username=permission_data["username"], domain=permission_data["domain"])
@@ -406,12 +417,11 @@ class NodeService:
             qs = qs.filter(updated_at__lt=one_minute_ago)
 
         count = qs.count()
-        if page_size == -1:
-            nodes = qs
-        else:
-            start = (page - 1) * page_size
-            end = start + page_size
-            nodes = qs[start:end]
+        page = NodeService._normalize_page(page)
+        page_size = NodeService._normalize_page_size(page_size)
+        start = (page - 1) * page_size
+        end = start + page_size
+        nodes = qs[start:end]
 
         # 应用预加载优化，避免 N+1 查询
         nodes = NodeSerializer.setup_eager_loading(nodes)
@@ -419,6 +429,24 @@ class NodeService:
         serializer = NodeSerializer(nodes, many=True)
         node_data = serializer.data
         return dict(count=count, nodes=node_data)
+
+    @staticmethod
+    def _normalize_page(page):
+        try:
+            page = int(page)
+        except (TypeError, ValueError):
+            page = 1
+        return max(1, page)
+
+    @staticmethod
+    def _normalize_page_size(page_size):
+        try:
+            page_size = int(page_size)
+        except (TypeError, ValueError):
+            page_size = 10
+        if page_size == -1:
+            return NodeService.NODE_LIST_PAGE_SIZE_MAX
+        return max(1, min(page_size, NodeService.NODE_LIST_PAGE_SIZE_MAX))
 
     @staticmethod
     def get_authorized_nodes_by_ids(node_ids, permission_data=None):

--- a/server/apps/node_mgmt/tests/test_b75_node_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_node_service.py
@@ -96,6 +96,52 @@ def test_get_node_list_page_size_all(setup):
 
 
 @pytest.mark.django_db
+def test_get_node_list_page_size_all_is_capped(setup, monkeypatch):
+    region, collector, node = setup
+    Node.objects.create(
+        id="node-svc-2", name="beta", ip="10.1.1.2", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    Node.objects.create(
+        id="node-svc-3", name="gamma", ip="10.1.1.3", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 2)
+
+    result = NodeService.get_node_list(
+        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
+        page=1, page_size=-1, is_active=None, is_manual=None, is_container=None,
+        skip_permission=True,
+    )
+
+    assert result["count"] == 3
+    assert len(result["nodes"]) == 2
+
+
+@pytest.mark.django_db
+def test_get_node_list_page_size_above_limit_is_capped(setup, monkeypatch):
+    region, collector, node = setup
+    Node.objects.create(
+        id="node-svc-2", name="beta", ip="10.1.1.2", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    Node.objects.create(
+        id="node-svc-3", name="gamma", ip="10.1.1.3", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 2)
+
+    result = NodeService.get_node_list(
+        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
+        page=1, page_size=999, is_active=None, is_manual=None, is_container=None,
+        skip_permission=True,
+    )
+
+    assert result["count"] == 3
+    assert len(result["nodes"]) == 2
+
+
+@pytest.mark.django_db
 def test_get_node_list_is_container_and_is_manual_filters(setup):
     region, collector, node = setup
     Node.objects.create(


### PR DESCRIPTION
## 问题

节点管理的 NATS 节点列表支持传 `page_size=-1`。这个值原本是“全部返回”的快捷写法，但 CMDB 同步等内部任务会直接拿它拉全量节点。节点规模变大后，一次 RPC 会把完整 QuerySet 预加载、序列化成大 JSON 再返回，容易放大 node_mgmt worker、NATS 和调用方同步任务的 CPU、内存和网络压力。

## 根因

同一个 `node_list` 契约同时承担分页查询和系统同步，`-1` 没有资源边界。调用方只要传这个值，就绕过分页切片，导致同步任务和查询接口共享了一个无上限全量出口。

## 怎么修的

节点列表统一规范分页参数：非法页码回退到第 1 页，`page_size=-1` 和超大 `page_size` 都收敛到 `NODE_MGMT_NODE_LIST_PAGE_SIZE_MAX`，默认 500。CMDB 节点同步不再依赖单次全量 RPC，改为按 `CMDB_NODE_MGMT_SYNC_PAGE_SIZE` 分页拉取并累积处理。

```python
page_size = NodeService._normalize_page_size(page_size)
start = (page - 1) * page_size
end = start + page_size
nodes = qs[start:end]
```

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["CMDB 节点同步\nnode_mgmt_sync_service.py"]
        T2["跨模块 RPC\nrpc/node_mgmt.py"]
    end

    BU["Node 查询切片\nservices/node.py"]

    subgraph N["核心处理层"]
        F1["node_list handler\nnats/node.py"]
        F2["NodeService.get_node_list\nservices/node.py"]
        F3["NodeSerializer\nserializers/node.py"]
    end

    T1 --> T2 --> F1 --> F2 --> BU --> F3
    T1 -. "多页同步" .-> T2
```

## 影响范围

改动涉及 `node_mgmt` 的 NATS 列表资源边界，以及 `cmdb` 的节点管理同步调用方。Job 等已有调用方使用明确分页值，不依赖全量返回；Log/Monitor/Alerts 仍通过各自用户入口或已有查询参数调用，服务端会统一受到上限保护。新增上限都保留环境变量可调，避免把容量参数写死。

## 验证

- 已确认 `weops/master` 仍存在 `page_size == -1` 直接返回全量 QuerySet 的路径。
- 已跑关键用例并观察到断言通过：
  - `apps/node_mgmt/tests/test_b75_node_service.py -k 'page_size_all_is_capped or page_size_above_limit_is_capped'`
  - `apps/cmdb/tests/test_node_mgmt_sync_helpers.py -k 'fetch_non_container_nodes or pick_access_point'`
- 本地 pytest 在用例通过后清理阶段长时间不退出，已手动终止收尾进程；失败不来自断言。

关联 Issue #3925。