### PR TITLE
bugfix: 限制控制器安装节点查询范围

### DIFF
--- a/server/apps/node_mgmt/migrations/0036_controllertasknode_node_id.py
+++ b/server/apps/node_mgmt/migrations/0036_controllertasknode_node_id.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("node_mgmt", "0035_backfill_container_node_cpu_architecture"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="controllertasknode",
+            name="node_id",
+            field=models.CharField(blank=True, db_index=True, default="", max_length=100, verbose_name="节点ID"),
+        ),
+    ]

--- a/server/apps/node_mgmt/models/installer.py
+++ b/server/apps/node_mgmt/models/installer.py
@@ -34,6 +34,7 @@ class ControllerTask(TimeInfo, MaintainerInfo):
 
 class ControllerTaskNode(models.Model):
     task = models.ForeignKey(ControllerTask, on_delete=models.CASCADE, verbose_name="任务")
+    node_id = models.CharField(max_length=100, blank=True, default="", db_index=True, verbose_name="节点ID")
     ip = models.CharField(max_length=100, verbose_name="IP地址")
     node_name = models.CharField(max_length=200, default="", verbose_name="节点名称")
     os = models.CharField(max_length=100, verbose_name="操作系统")

--- a/server/apps/node_mgmt/services/installer.py
+++ b/server/apps/node_mgmt/services/installer.py
@@ -1,4 +1,5 @@
 from asgiref.sync import async_to_sync
+from django.db.models import Q
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.crypto.aes_crypto import AESCryptor
@@ -139,7 +140,15 @@ class InstallerService:
         return install_command
 
     @staticmethod
-    def install_controller(cloud_region_id, work_node, package_version_id, nodes, cpu_architecture: str):
+    def install_controller(
+        cloud_region_id,
+        work_node,
+        package_version_id,
+        nodes,
+        cpu_architecture: str,
+        created_by: str = "",
+        domain: str = "domain.com",
+    ):
         """安装控制器"""
         task_obj = ControllerTask.objects.create(
             cloud_region_id=cloud_region_id,
@@ -147,6 +156,10 @@ class InstallerService:
             package_version_id=package_version_id,
             type="install",
             status="waiting",
+            created_by=created_by,
+            updated_by=created_by,
+            domain=domain,
+            updated_by_domain=domain,
         )
         creates = []
         aes_obj = AESCryptor()
@@ -165,6 +178,7 @@ class InstallerService:
             creates.append(
                 ControllerTaskNode(
                     task_id=task_obj.id,
+                    node_id=node.get("node_id", ""),
                     ip=node["ip"],
                     node_name=node["node_name"],
                     os=node["os"],
@@ -199,13 +213,23 @@ class InstallerService:
         return result
 
     @staticmethod
-    def uninstall_controller(cloud_region_id, work_node, nodes):
+    def uninstall_controller(
+        cloud_region_id,
+        work_node,
+        nodes,
+        created_by: str = "",
+        domain: str = "domain.com",
+    ):
         """卸载控制器"""
         task_obj = ControllerTask.objects.create(
             cloud_region_id=cloud_region_id,
             work_node=work_node,
             type="uninstall",
             status="waiting",
+            created_by=created_by,
+            updated_by=created_by,
+            domain=domain,
+            updated_by_domain=domain,
         )
         creates = []
         aes_obj = AESCryptor()
@@ -220,6 +244,7 @@ class InstallerService:
             creates.append(
                 ControllerTaskNode(
                     task_id=task_obj.id,
+                    node_id=node.get("node_id", ""),
                     ip=node["ip"],
                     os=node["os"],
                     cpu_architecture=node.get("cpu_architecture", ""),
@@ -235,14 +260,25 @@ class InstallerService:
         return task_obj.id
 
     @staticmethod
-    def install_controller_nodes(task_id):
+    def install_controller_nodes(task_id, authorized_nodes=None, request_user=None):
         """获取控制器安装节点信息"""
-        task_nodes = ControllerTaskNode.objects.filter(task_id=task_id)
+        task_nodes = ControllerTaskNode.objects.filter(task_id=task_id).select_related("task").order_by("id")
+        if authorized_nodes is not None and not getattr(request_user, "is_superuser", False):
+            authorized_node_ids = list(authorized_nodes.values_list("id", flat=True))
+            username = getattr(request_user, "username", "") if request_user is not None else ""
+            legacy_owner_filter = Q(pk__in=[])
+            if username:
+                legacy_owner_filter = Q(node_id="") & Q(task__created_by=username)
+            task_nodes = task_nodes.filter(
+                (~Q(node_id="") & Q(node_id__in=authorized_node_ids)) | legacy_owner_filter
+            )
+
         result = []
         for task_node in task_nodes:
             result.append(
                 dict(
                     task_node_id=task_node.id,
+                    node_id=task_node.node_id,
                     ip=task_node.ip,
                     os=task_node.os,
                     cpu_architecture=task_node.cpu_architecture,

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -768,6 +768,38 @@ def test_config_node_asso_hides_unauthorized_nodes(monkeypatch):
     ]
 
 
+def test_controller_install_nodes_passes_authorized_queryset(monkeypatch):
+    authorized_nodes = _FakeNodeQuerySet([_FakeNode("node-allowed")])
+    captured = {}
+
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.get_authorized_node_queryset",
+        lambda request: authorized_nodes,
+    )
+
+    def fake_install_controller_nodes(task_id, authorized_nodes=None, request_user=None):
+        captured["task_id"] = task_id
+        captured["authorized_nodes"] = authorized_nodes
+        captured["request_user"] = request_user
+        return []
+
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.InstallerService.install_controller_nodes",
+        fake_install_controller_nodes,
+    )
+
+    view = InstallerViewSet.as_view({"post": "controller_install_nodes"})
+    response = view(
+        _make_permission_request(permissions=("cloud_region_node-Edit",)),
+        task_id="task-3923",
+    )
+
+    assert response.status_code != 403
+    assert captured["task_id"] == "task-3923"
+    assert captured["authorized_nodes"] is authorized_nodes
+    assert captured["request_user"].username == "permission-test-user"
+
+
 def test_apply_to_node_prevalidates_permissions_before_mutation(monkeypatch):
     monkeypatch.setattr(
         collector_configuration,

--- a/server/apps/node_mgmt/tests/test_b75_installer_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_installer_service.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.node_mgmt.constants.node import NodeConstants
-from apps.node_mgmt.models import Collector, Node, PackageVersion
+from apps.node_mgmt.models import Collector, Node, NodeOrganization, PackageVersion
 from apps.node_mgmt.models.cloud_region import CloudRegion, SidecarEnv
 from apps.node_mgmt.models.installer import (
     CollectorTask,
@@ -99,15 +99,34 @@ def test_install_controller_creates_task_and_nodes():
     region = CloudRegion.objects.create(name="cr-install-ctrl")
     nodes = [
         {
-            "ip": "10.0.0.1", "node_name": "n1", "os": "linux", "cpu_architecture": "x86_64",
-            "organizations": [1], "port": 22, "username": "root",
-            "password": "secret", "private_key": "", "passphrase": "",
+            "ip": "10.0.0.1",
+            "node_id": "node-ctrl-install",
+            "node_name": "n1",
+            "os": "linux",
+            "cpu_architecture": "x86_64",
+            "organizations": [1],
+            "port": 22,
+            "username": "root",
+            "password": "secret",
+            "private_key": "",
+            "passphrase": "",
         }
     ]
-    task_id = InstallerService.install_controller(region.id, "work-1", 5, nodes, "x86_64")
+    task_id = InstallerService.install_controller(
+        region.id,
+        "work-1",
+        5,
+        nodes,
+        "x86_64",
+        created_by="operator",
+        domain="example.com",
+    )
     task = ControllerTask.objects.get(id=task_id)
     assert task.type == "install"
+    assert task.created_by == "operator"
+    assert task.domain == "example.com"
     node = ControllerTaskNode.objects.get(task=task)
+    assert node.node_id == "node-ctrl-install"
     assert node.ip == "10.0.0.1"
     # 密码被加密（不等于明文）
     assert node.password != "secret"
@@ -119,14 +138,29 @@ def test_uninstall_controller_creates_task_and_nodes():
     region = CloudRegion.objects.create(name="cr-uninstall")
     nodes = [
         {
-            "ip": "10.0.0.2", "os": "linux", "port": 22, "username": "root",
-            "password": "", "private_key": "key", "passphrase": "",
+            "ip": "10.0.0.2",
+            "node_id": "node-ctrl-uninstall",
+            "os": "linux",
+            "port": 22,
+            "username": "root",
+            "password": "",
+            "private_key": "key",
+            "passphrase": "",
         }
     ]
-    task_id = InstallerService.uninstall_controller(region.id, "work-2", nodes)
+    task_id = InstallerService.uninstall_controller(
+        region.id,
+        "work-2",
+        nodes,
+        created_by="operator",
+        domain="example.com",
+    )
     task = ControllerTask.objects.get(id=task_id)
     assert task.type == "uninstall"
+    assert task.created_by == "operator"
+    assert task.domain == "example.com"
     node = ControllerTaskNode.objects.get(task=task)
+    assert node.node_id == "node-ctrl-uninstall"
     assert node.private_key != "key"
 
 
@@ -175,6 +209,114 @@ def test_install_controller_nodes_returns_info():
     assert len(result) == 1
     assert result[0]["ip"] == "10.0.0.5"
     assert result[0]["status"] == "waiting"
+
+
+@pytest.mark.django_db
+def test_install_controller_nodes_filters_by_authorized_nodes():
+    region = CloudRegion.objects.create(name="cr-ctrl-auth")
+    allowed_node = Node.objects.create(
+        id="n-ctrl-allowed",
+        name="allowed",
+        ip="10.0.0.10",
+        operating_system="linux",
+        collector_configuration_directory="/etc",
+        cloud_region=region,
+    )
+    denied_node = Node.objects.create(
+        id="n-ctrl-denied",
+        name="denied",
+        ip="10.0.0.11",
+        operating_system="linux",
+        collector_configuration_directory="/etc",
+        cloud_region=region,
+    )
+    task = ControllerTask.objects.create(
+        cloud_region=region, type="install", status="waiting", package_version_id=1
+    )
+    ControllerTaskNode.objects.create(
+        task=task,
+        node_id=allowed_node.id,
+        ip=allowed_node.ip,
+        os="linux",
+        port=22,
+        username="root",
+        password="x",
+        node_name="allowed",
+        organizations=[1],
+        status="waiting",
+    )
+    ControllerTaskNode.objects.create(
+        task=task,
+        node_id=denied_node.id,
+        ip=denied_node.ip,
+        os="linux",
+        port=22,
+        username="root",
+        password="x",
+        node_name="denied",
+        organizations=[2],
+        status="waiting",
+    )
+
+    result = InstallerService.install_controller_nodes(
+        task.id,
+        authorized_nodes=Node.objects.filter(id=allowed_node.id),
+    )
+
+    assert [item["node_id"] for item in result] == [allowed_node.id]
+    assert [item["ip"] for item in result] == ["10.0.0.10"]
+
+
+@pytest.mark.django_db
+def test_install_controller_nodes_limits_legacy_rows_to_task_owner_or_superuser():
+    region = CloudRegion.objects.create(name="cr-ctrl-legacy")
+    node = Node.objects.create(
+        id="n-ctrl-legacy",
+        name="legacy",
+        ip="10.0.0.12",
+        operating_system="linux",
+        collector_configuration_directory="/etc",
+        cloud_region=region,
+    )
+    NodeOrganization.objects.create(node=node, organization=1)
+    task = ControllerTask.objects.create(
+        cloud_region=region,
+        type="install",
+        status="waiting",
+        package_version_id=1,
+        created_by="owner",
+    )
+    ControllerTaskNode.objects.create(
+        task=task,
+        ip=node.ip,
+        os="linux",
+        port=22,
+        username="root",
+        password="x",
+        node_name="legacy",
+        organizations=[1],
+        status="waiting",
+    )
+
+    denied = InstallerService.install_controller_nodes(
+        task.id,
+        authorized_nodes=Node.objects.filter(id=node.id),
+        request_user=type("User", (), {"username": "other", "is_superuser": False})(),
+    )
+    owner = InstallerService.install_controller_nodes(
+        task.id,
+        authorized_nodes=Node.objects.filter(id=node.id),
+        request_user=type("User", (), {"username": "owner", "is_superuser": False})(),
+    )
+    superuser = InstallerService.install_controller_nodes(
+        task.id,
+        authorized_nodes=Node.objects.none(),
+        request_user=type("User", (), {"username": "admin", "is_superuser": True})(),
+    )
+
+    assert denied == []
+    assert [item["ip"] for item in owner] == [node.ip]
+    assert [item["ip"] for item in superuser] == [node.ip]
 
 
 # --------------------------------------------------------------------------- #

--- a/server/apps/node_mgmt/views/installer.py
+++ b/server/apps/node_mgmt/views/installer.py
@@ -44,6 +44,8 @@ class InstallerViewSet(ViewSet):
             data["package_id"],
             data["nodes"],
             data["cpu_architecture"],
+            request.user.username,
+            getattr(request.user, "domain", "domain.com"),
         )
         install_controller.delay(task_id)
         timeout_controller_install_task.apply_async(
@@ -64,6 +66,8 @@ class InstallerViewSet(ViewSet):
             request.data["cloud_region_id"],
             request.data["work_node"],
             request.data["nodes"],
+            request.user.username,
+            getattr(request.user, "domain", "domain.com"),
         )
         uninstall_controller.delay(task_id)
         return WebUtils.response_success(dict(task_id=task_id))
@@ -123,7 +127,12 @@ class InstallerViewSet(ViewSet):
     )
     @HasPermission("cloud_region_node-Edit")
     def controller_install_nodes(self, request, task_id):
-        data = InstallerService.install_controller_nodes(task_id)
+        authorized_nodes = get_authorized_node_queryset(request)
+        data = InstallerService.install_controller_nodes(
+            task_id,
+            authorized_nodes=authorized_nodes,
+            request_user=request.user,
+        )
         return WebUtils.response_success(data)
 
     # 采集器


### PR DESCRIPTION
## 问题
控制器安装节点查询接口只拿到一个 `task_id` 就把该任务下的节点明细全部返回。用户只要有节点管理编辑权限，就可能看到自己无权访问的节点 IP、用户名、端口、组织归属、状态和失败上下文。

## 根因
控制器任务节点表只保存了当时提交的节点快照，没有记录可用于权限过滤的 `node_id`。查询入口也没有像采集器安装节点查询那样把当前用户可见节点范围传给服务层，导致任务维度的查询绕过了节点维度授权边界。

## 怎么修的
新增 `ControllerTaskNode.node_id`，创建控制器安装/卸载任务时写入节点 ID，同时把任务创建者写到 `ControllerTask`。查询控制器安装节点时，入口先取当前用户授权节点 queryset，再由服务层过滤：

```python
task_nodes = task_nodes.filter(
    (~Q(node_id="") & Q(node_id__in=authorized_node_ids)) | legacy_owner_filter
)
```

历史无 `node_id` 的任务没有可靠节点边界，只允许任务创建者继续看；超管保留全量排障视角。

## 影响范围
改动集中在 `node_mgmt` 控制器安装节点查询链路，并新增一个字段 migration。web 侧仍调用同一个接口，返回结构只额外带出 `node_id`；采集器安装查询、NATS handler、agents 调用方未改。该修复会收紧普通用户对跨授权节点的可见性，属于中风险权限修复，已加 review 标签。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["controller_install_nodes\nviews/installer.py"]
    end

    subgraph P["授权层"]
        P1["get_authorized_node_queryset\nutils/permission.py"]
    end

    subgraph N["核心处理层"]
        F1["install_controller_nodes\nservices/installer.py"]
        F2["ControllerTaskNode filter\nmodels/installer.py"]
    end

    subgraph C["历史兜底层"]
        C1["task.created_by / superuser\nlegacy node_id empty"]
    end

    T1 --> P1 --> F1 --> F2
    F1 -. "历史无 node_id" .-> C1
```

## 验证
- `ENABLE_CELERY=False INSTALL_APPS=system_mgmt,node_mgmt DB_ENGINE=sqlite DB_NAME=<临时路径> SECRET_KEY=test-secret-key-3923 MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=0 uv run pytest apps/node_mgmt/tests/test_b75_installer_service.py -v --tb=short --no-cov`：24 passed
- `ENABLE_CELERY=False INSTALL_APPS=system_mgmt,node_mgmt DB_ENGINE=sqlite DB_NAME=<临时路径> SECRET_KEY=test-secret-key-3923 MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=0 uv run pytest apps/node_mgmt/tests/test_architecture_support.py -k 'controller_install_nodes_passes_authorized_queryset' -v --tb=short --no-cov`：1 passed
- `ENABLE_CELERY=False INSTALL_APPS=system_mgmt,node_mgmt DB_ENGINE=sqlite DB_NAME=<临时路径> SECRET_KEY=test-secret-key-3923 MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=0 uv run python manage.py makemigrations node_mgmt --check --dry-run --skip-checks`：No changes detected