### PR TITLE
bugfix: 修复 sidecar 配置写入命令注入

### DIFF
--- a/server/apps/node_mgmt/services/sidecar_config.py
+++ b/server/apps/node_mgmt/services/sidecar_config.py
@@ -1,4 +1,6 @@
+import base64
 import logging
+import shlex
 
 import yaml
 
@@ -86,7 +88,13 @@ class SidecarConfigService:
             command = f"Set-Content -Path '{config_path}' -Value '{escaped_content}'"
             shell = "powershell"
         else:
-            command = f"cat > {config_path} << 'EOF'\n{config_content}EOF"
+            encoded_content = base64.b64encode(config_content.encode("utf-8")).decode(
+                "ascii"
+            )
+            command = (
+                f"printf %s {shlex.quote(encoded_content)} "
+                f"| base64 -d > {shlex.quote(config_path)}"
+            )
             shell = "bash"
 
         result = executor.execute_local(command, timeout=30, shell=shell)

--- a/server/apps/node_mgmt/tests/test_b75_sidecar_config_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_sidecar_config_service.py
@@ -2,8 +2,12 @@
 
 仅 mock Executor RPC 边界。断言真实合并逻辑与命令构建/异常。
 """
-import pytest
+import base64
+import shlex
 from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.models import Node
@@ -127,6 +131,33 @@ def test_write_config_success(linux_node):
 
 
 @pytest.mark.django_db
+def test_write_config_linux_does_not_embed_yaml_in_shell(linux_node):
+    executor = MagicMock()
+    executor.execute_local.return_value = {"success": True}
+    injected_name = "safe\nEOF\nid > /tmp/pwned\n"
+
+    with patch("apps.node_mgmt.services.sidecar_config.Executor", return_value=executor):
+        SidecarConfigService._write_config(linux_node, {"node_name": injected_name})
+
+    command = executor.execute_local.call_args.args[0]
+    kwargs = executor.execute_local.call_args.kwargs
+    assert kwargs["shell"] == "bash"
+    assert "<< 'EOF'" not in command
+    assert injected_name not in command
+    assert "id > /tmp/pwned" not in command
+    command_parts = shlex.split(command)
+    encoded_content = command_parts[2]
+    assert yaml.safe_load(base64.b64decode(encoded_content).decode("utf-8")) == {
+        "node_name": injected_name
+    }
+
+
+def _load_linux_write_command_yaml(command):
+    encoded_content = shlex.split(command)[2]
+    return yaml.safe_load(base64.b64decode(encoded_content).decode("utf-8"))
+
+
+@pytest.mark.django_db
 def test_write_config_permission_denied_raises(linux_node):
     executor = MagicMock()
     executor.execute_local.return_value = {"success": False, "stderr": "Permission denied"}
@@ -194,11 +225,9 @@ def test_sync_node_properties_updates_name_and_orgs(linux_node):
         SidecarConfigService.sync_node_properties(linux_node, name="newname", organizations=["5", "6"])
     # 写配置时第二次调用，验证内容含新名称与新 group tags
     write_command = executor.execute_local.call_args_list[1].args[0]
-    assert "newname" in write_command
-    assert "group:5" in write_command
-    assert "group:6" in write_command
-    assert "keepme" in write_command
-    assert "group:1" not in write_command
+    written_config = _load_linux_write_command_yaml(write_command)
+    assert written_config["node_name"] == "newname"
+    assert written_config["tags"] == ["keepme", "group:5", "group:6"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

节点名称更新后会异步同步到被管节点的 `sidecar.yaml`。Linux 写配置时原来把完整 YAML 直接塞进 bash here-doc，delimiter 固定为 `EOF`；如果节点名里带换行和独立 `EOF` 行，写文件命令会被提前结束，后续文本会被 bash 当成命令执行。

## 根因

这条链路把用户可控配置内容和 shell 控制语法放在同一个命令文本里。YAML dump 只保证配置格式，不负责 shell 边界；固定 here-doc delimiter 一旦和配置内容碰撞，shell 解析边界就会被用户输入改写。

## 怎么修的

Linux 写配置不再使用 here-doc。服务端先把 YAML 内容 base64 编码，远端只执行解码写文件命令，并对目标路径做 shell quote：

```python
encoded_content = base64.b64encode(config_content.encode("utf-8")).decode("ascii")
command = (
    f"printf %s {shlex.quote(encoded_content)} "
    f"| base64 -d > {shlex.quote(config_path)}"
)
```

这样节点名、标签等配置内容不会作为 shell 源码出现在命令体里。

## 影响范围

改动只在 `node_mgmt` 的 Linux sidecar 配置写入路径；读取配置、深度合并、重启服务、Windows PowerShell 写入逻辑不变。对外接口、Celery 参数、配置文件内容形态都不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NodeViewSet.update_node\nviews/node.py"]
    end

    Q["sync_node_properties_to_sidecar.delay\nCelery 队列"]

    subgraph N["核心处理层"]
        F1["sync_node_properties\nsidecar_config.py"]
        F2["_write_config\nsidecar_config.py"]
    end

    R["Executor.execute_local\n远端节点 bash"]

    T1 --> Q --> F1 --> F2 --> R
```

## 验证

新增回归用例覆盖节点名包含换行、独立 `EOF` 和命令片段的场景，断言 Linux 写配置命令不再包含 here-doc 或原始 YAML，同时解码 base64 后确认写入内容仍是原配置。

已执行：

- `INSTALL_APPS=node_mgmt,system_mgmt DB_ENGINE=sqlite DB_NAME=test_issue_3921.sqlite3 MINIO_ENDPOINT=localhost:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=test MINIO_USE_HTTPS=False uv run pytest apps/node_mgmt/tests/test_b75_sidecar_config_service.py -q -o addopts=''`
- `uv run --with isort==5.10.1 isort apps/node_mgmt/services/sidecar_config.py apps/node_mgmt/tests/test_b75_sidecar_config_service.py --settings-path=.isort.cfg --check-only --diff`
- `uv run --with flake8==7.1.1 flake8 apps/node_mgmt/services/sidecar_config.py apps/node_mgmt/tests/test_b75_sidecar_config_service.py --config=.flake8`
- `git diff --check`

说明：尝试跑 `apps/node_mgmt/tests` 宽回归时，本地裁剪测试环境下 442 passed / 42 failed，失败集中在缺少 `SECRET_KEY`、`django_celery_beat` 未加入 `INSTALLED_APPS` 的环境初始化问题，以及 installer/cloud region 相关旧路径；本次直接触及的 sidecar 配置服务测试已全绿。
