### PR TITLE
feat(monitor): 接入东方通 TongLink 9.0.5.1 Prometheus exporter

### DIFF
--- a/server/apps/monitor/constants/monitor_object.py
+++ b/server/apps/monitor/constants/monitor_object.py
@@ -19,6 +19,7 @@ class MonitorObjConstants:
                 "Consul",
                 "Etcd",
                 "Tomcat",
+                "TongLink",
                 "Zookeeper",
                 "ActiveMQ",
                 "MinIO",

--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -2542,6 +2542,55 @@ monitor_object_metric:
     net_response_string_found:
       name: String Found
       desc: Whether the expected string was matched in the response. Reported only when an expect string is configured; 1 means found, 0 means not found.
+  TongLink:
+    object:
+      name: TongLink
+      name_zh: TongLink
+      description: TongLink 9.0.5.1 message middleware monitoring
+      description_zh: TongLink 9.0.5.1 message middleware monitoring
+    plugin:
+      TongLink-Exporter: TongLink Monitoring
+    metric:
+      cluster_state: Cluster Manager State
+      cluster_condition: Broker Node Condition
+      alive_broker: Alive Brokers
+      cluster_alive_client: Cluster Alive Clients
+      broker_monitor: Broker Health
+      broker_lookup: Broker Lookup Result
+      register_count: Registered Brokers
+      topic_msg_num: Topic Message Backlog
+      queue_msg_num: Queue Message Backlog
+      queue_total_count: Total Queues
+      link_speed: Link Throughput
+      send_link_count: Send Links
+      local_link_count: Local Links
+      route_link_count: Route Links
+      link_total_count: Total Links
+      up_flow_total_bytes: Total Upstream Flow
+      down_flow_total_bytes: Total Downstream Flow
+      commitlog_disk_util: commitlog Disk Usage
+      consumequeue_disk_util: consumequeue Disk Usage
+      commitlog_total_size: commitlog Disk Size
+      consumequeue_total_size: consumequeue Disk Size
+      consume_offset_size: Consume Offset Size
+      commitlog_alarm_action: commitlog Alarm Action
+      consumequeue_alarm_action: consumequeue Alarm Action
+      license_warning: License Warning State
+      license_expiry_timestamp_seconds: License Expiry Timestamp
+      license_type_info: License Type
+      up: Exporter Up
+      scrape_errors_total: Scrape Errors Total
+      scrape_duration_seconds: Scrape Duration Seconds
+    group:
+      cluster: Cluster
+      broker: Broker
+      message: Message
+      queue: Queue
+      link: Link
+      resource: Resource
+      setting: Setting
+      license: License
+      process: Process
   Nginx:
     nginx_active:
       name: Active Connections
@@ -4858,6 +4907,7 @@ monitor_object:
   Mysql: MySQL
   Website: Website
   MSSQL: MSSQL
+  TongLink: TongLink
 monitor_object_type:
   VMware: VMware(Telegraf)
   Middleware: Middleware

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -2542,6 +2542,55 @@ monitor_object_metric:
     net_response_string_found:
       name: 返回匹配
       desc: 是否在响应内容中匹配到期望字符串。仅在配置了期望返回串时上报，1表示命中，0表示未命中。
+  TongLink:
+    object:
+      name: TongLink
+      name_zh: 东方通 TongLink
+      description: 东方通 TongLink 9.0.5.1 消息中间件监控
+      description_zh: 东方通 TongLink 9.0.5.1 消息中间件监控
+    plugin:
+      TongLink-Exporter: TongLink 监控
+    metric:
+      cluster_state: 集群管理节点状态
+      cluster_condition: Broker 节点 condition
+      alive_broker: 存活 Broker 数
+      cluster_alive_client: 集群活跃 Client 数
+      broker_monitor: Broker 健康度
+      broker_lookup: Broker Lookup 结果
+      register_count: 已注册 Broker 总数
+      topic_msg_num: 主题消息堆积数
+      queue_msg_num: 队列消息堆积数
+      queue_total_count: 队列总数
+      link_speed: 链路传输速度
+      send_link_count: 发送链路数
+      local_link_count: 本地链路数
+      route_link_count: 分发链路数
+      link_total_count: 链路总数
+      up_flow_total_bytes: 累计上行流量
+      down_flow_total_bytes: 累计下行流量
+      commitlog_disk_util: commitlog 磁盘占用率
+      consumequeue_disk_util: consumequeue 磁盘占用率
+      commitlog_total_size: commitlog 占用空间
+      consumequeue_total_size: consumequeue 占用空间
+      consume_offset_size: 消费历史文件大小
+      commitlog_alarm_action: commitlog 超阈值动作
+      consumequeue_alarm_action: consumequeue 超阈值动作
+      license_warning: License 告警状态
+      license_expiry_timestamp_seconds: License 到期时间戳
+      license_type_info: License 类型
+      up: Exporter 进程存活
+      scrape_errors_total: 抓取错误总数
+      scrape_duration_seconds: 抓取耗时
+    group:
+      cluster: 集群
+      broker: Broker
+      message: 消息
+      queue: 队列
+      link: 链路
+      resource: 资源
+      setting: 配置
+      license: License
+      process: 进程
   Nginx:
     nginx_active:
       name: 活跃连接数
@@ -4860,6 +4909,7 @@ monitor_object:
   Mysql: MySQL
   Website: 网站
   MSSQL: MSSQL
+  TongLink: 东方通 TongLink
 monitor_object_type:
   VMware: VMware（Telegraf）
   Middleware: 中间件

--- a/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/UI.json
+++ b/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/UI.json
@@ -1,0 +1,184 @@
+{
+  "object_name": "TongLink",
+  "instance_type": "tonglink",
+  "collect_type": "exporter",
+  "config_type": ["tonglink"],
+  "collector": "TongLink-Exporter",
+  "instance_id": "{{cloud_region}}_{{ENV_TONGLINK_HOST}}_{{ENV_TONGLINK_PORT}}",
+  "form_fields": [
+    {
+      "name": "ENV_TONGLINK_HOST",
+      "label": "TongLink 管理节点",
+      "type": "input",
+      "required": true,
+      "description": "TongLink 管理节点地址(默认 127.0.0.1)",
+      "widget_props": {
+        "placeholder": "127.0.0.1"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.TONGLINK_HOST__{{config_id}}"
+      }
+    },
+    {
+      "name": "ENV_TONGLINK_PORT",
+      "label": "TongLink 管理端口",
+      "type": "inputNumber",
+      "required": true,
+      "description": "TongLink 管理节点端口(默认 52011)",
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "52011"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.TONGLINK_PORT__{{config_id}}"
+      }
+    },
+    {
+      "name": "ENV_BEARER_TOKEN",
+      "label": "Bearer Token",
+      "type": "password",
+      "required": false,
+      "description": "访问 TongLink 管理 API 的 Bearer Token(留空则不使用认证)",
+      "widget_props": {
+        "placeholder": "Bearer Token"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.BEARER_TOKEN__{{config_id}}"
+      }
+    },
+    {
+      "name": "ENV_TLS_SKIP_VERIFY",
+      "label": "跳过 TLS 校验",
+      "type": "switch",
+      "required": false,
+      "default_value": true,
+      "description": "是否跳过 TongLink 管理 API 的 TLS 证书校验",
+      "transform_on_create": {
+        "mapping": {
+          "true": "--tls-skip-verify",
+          "false": ""
+        }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.TLS_SKIP_VERIFY__{{config_id}}",
+        "to_form": {
+          "mapping": {
+            "true": ["--tls-skip-verify"],
+            "false": ["", null]
+          }
+        },
+        "to_api": {
+          "mapping": {
+            "true": "--tls-skip-verify",
+            "false": ""
+          }
+        }
+      }
+    },
+    {
+      "name": "ENV_LISTEN_PORT",
+      "label": "Exporter 监听端口",
+      "type": "inputNumber",
+      "required": true,
+      "visible_in": "edit",
+      "description": "tonglink_exporter 暴露 Prometheus 指标的端口",
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "9601"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.LISTEN_PORT__{{config_id}}"
+      }
+    },
+    {
+      "name": "interval",
+      "label": "采集间隔",
+      "type": "inputNumber",
+      "required": true,
+      "default_value": 30,
+      "description": "Exporter 抓取 TongLink 管理 API 的间隔(秒)",
+      "widget_props": {
+        "min": 5,
+        "precision": 0,
+        "placeholder": "30",
+        "addonAfter": "s"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.interval",
+        "to_form": {
+          "regex": "^(\\d+)s$"
+        },
+        "to_api": {
+          "suffix": "s"
+        }
+      }
+    }
+  ],
+  "table_columns": [
+    {
+      "name": "node_ids",
+      "label": "节点",
+      "type": "select",
+      "required": true,
+      "widget_props": {
+        "placeholder": "请选择节点"
+      },
+      "enable_row_filter": false
+    },
+    {
+      "name": "ENV_TONGLINK_HOST",
+      "label": "TongLink 管理节点",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "127.0.0.1"
+      }
+    },
+    {
+      "name": "ENV_TONGLINK_PORT",
+      "label": "TongLink 管理端口",
+      "type": "inputNumber",
+      "required": true,
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "52011"
+      }
+    },
+    {
+      "name": "ENV_LISTEN_PORT",
+      "label": "Exporter 端口",
+      "type": "inputNumber",
+      "required": true,
+      "widget_props": {
+        "min": 1,
+        "max": 65535,
+        "precision": 0,
+        "placeholder": "9601"
+      }
+    },
+    {
+      "name": "instance_name",
+      "label": "实例名称",
+      "type": "input",
+      "required": true,
+      "widget_props": {
+        "placeholder": "实例名称"
+      }
+    },
+    {
+      "name": "group_ids",
+      "label": "组",
+      "type": "group_select",
+      "required": false,
+      "widget_props": {
+        "placeholder": "请选择组"
+      }
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/metrics.json
+++ b/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/metrics.json
@@ -1,0 +1,351 @@
+{
+  "plugin": "TongLink-Exporter",
+  "plugin_desc": "东方通 TongLink 9.0.5.1 消息中间件监控采集器,通过 Prometheus 文本格式暴露集群、Broker、消息、队列、链路、资源、配置、License 等运行指标。",
+  "status_query": "any({instance_type='tonglink', collect_type='exporter'}) by (instance_id)",
+  "name": "TongLink",
+  "icon": "mm-rabbitmq_Rabbitmq",
+  "type": "Middleware",
+  "description": "TongLink 9.0.5.1 消息中间件监控",
+  "default_metric": "any({instance_type='tonglink'}) by (instance_id)",
+  "instance_id_keys": ["instance_id"],
+  "supplementary_indicators": [
+    "tonglink_exporter_up",
+    "tonglink_exporter_cluster_state",
+    "tonglink_exporter_alive_broker",
+    "tonglink_exporter_license_expiry_timestamp_seconds"
+  ],
+  "display_fields": [
+    {"name": "Exporter 存活", "sort_order": 0, "metrics": [{"plugin": "TongLink-Exporter", "metric": "tonglink_exporter_up"}]},
+    {"name": "集群状态", "sort_order": 1, "metrics": [{"plugin": "TongLink-Exporter", "metric": "tonglink_exporter_cluster_state"}]},
+    {"name": "存活 Broker 数", "sort_order": 2, "metrics": [{"plugin": "TongLink-Exporter", "metric": "tonglink_exporter_alive_broker"}]},
+    {"name": "License 到期", "sort_order": 3, "metrics": [{"plugin": "TongLink-Exporter", "metric": "tonglink_exporter_license_expiry_timestamp_seconds"}]}
+  ],
+  "metrics": [
+    {
+      "metric_group": "Process",
+      "name": "tonglink_exporter_up",
+      "display_name": "Exporter 存活",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"异常\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"}]",
+      "dimensions": [],
+      "description": "1 if all targets scraped successfully, 0 otherwise.",
+      "query": "tonglink_exporter_up{__$labels__}"
+    },
+    {
+      "metric_group": "Process",
+      "name": "tonglink_exporter_scrape_errors_total",
+      "display_name": "抓取错误总数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "errors",
+      "dimensions": [
+        {"name": "endpoint", "description": "TongLink API endpoint"},
+        {"name": "target", "description": "TongLink target host"}
+      ],
+      "description": "Total TongLink scrape errors by endpoint and target.",
+      "query": "sum by (endpoint, target) (tonglink_exporter_scrape_errors_total{__$labels__})"
+    },
+    {
+      "metric_group": "Cluster",
+      "name": "tonglink_exporter_cluster_state",
+      "display_name": "集群管理节点状态",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"离线\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"在线\",\"id\":1,\"color\":\"#1ac44a\"}]",
+      "dimensions": [],
+      "description": "TongLink 集群管理节点在线状态,0/1",
+      "query": "tonglink_exporter_cluster_state{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster",
+      "name": "tonglink_exporter_cluster_condition",
+      "display_name": "Broker 节点 condition",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "boolean",
+      "dimensions": [
+        {"name": "brokerName", "description": "Broker 名称"},
+        {"name": "brokerId", "description": "Broker ID"},
+        {"name": "is_proxy", "description": "是否代理节点"}
+      ],
+      "description": "集群 broker 节点 condition 状态",
+      "query": "tonglink_exporter_cluster_condition{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster",
+      "name": "tonglink_exporter_alive_broker",
+      "display_name": "存活 Broker 数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 集群当前存活 broker 数量",
+      "query": "sum(tonglink_exporter_alive_broker{__$labels__})"
+    },
+    {
+      "metric_group": "Cluster",
+      "name": "tonglink_exporter_cluster_alive_client",
+      "display_name": "集群活跃 Client 数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 集群当前活跃 client 连接数",
+      "query": "sum(tonglink_exporter_cluster_alive_client{__$labels__})"
+    },
+    {
+      "metric_group": "Broker",
+      "name": "tonglink_exporter_broker_monitor",
+      "display_name": "Broker 健康度",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "boolean",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink broker 健康监控状态",
+      "query": "tonglink_exporter_broker_monitor{__$labels__}"
+    },
+    {
+      "metric_group": "Broker",
+      "name": "tonglink_exporter_broker_lookup",
+      "display_name": "Broker Lookup 结果",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "boolean",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink broker lookup 结果",
+      "query": "tonglink_exporter_broker_lookup{__$labels__}"
+    },
+    {
+      "metric_group": "Broker",
+      "name": "tonglink_exporter_register_count",
+      "display_name": "已注册 Broker 总数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 集群已注册 broker 数量",
+      "query": "sum(tonglink_exporter_register_count{__$labels__})"
+    },
+    {
+      "metric_group": "Message",
+      "name": "tonglink_exporter_topic_msg_num",
+      "display_name": "主题消息堆积数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [{"name": "topic", "description": "主题名称"}],
+      "description": "TongLink 主题消息堆积数量",
+      "query": "sum by (topic) (tonglink_exporter_topic_msg_num{__$labels__})"
+    },
+    {
+      "metric_group": "Message",
+      "name": "tonglink_exporter_queue_msg_num",
+      "display_name": "队列消息堆积数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [{"name": "queue", "description": "队列名称"}],
+      "description": "TongLink 队列消息堆积数量",
+      "query": "sum by (queue) (tonglink_exporter_queue_msg_num{__$labels__})"
+    },
+    {
+      "metric_group": "Queue",
+      "name": "tonglink_exporter_queue_total_count",
+      "display_name": "队列总数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 集群队列总数",
+      "query": "sum(tonglink_exporter_queue_total_count{__$labels__})"
+    },
+    {
+      "metric_group": "Link",
+      "name": "tonglink_exporter_link_speed",
+      "display_name": "链路传输速度",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "B/s",
+      "dimensions": [{"name": "link", "description": "链路名称"}],
+      "description": "TongLink 链路当前传输速度",
+      "query": "tonglink_exporter_link_speed{__$labels__}"
+    },
+    {
+      "metric_group": "Link",
+      "name": "tonglink_exporter_send_link_count",
+      "display_name": "发送链路数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 发送链路数量",
+      "query": "sum(tonglink_exporter_send_link_count{__$labels__})"
+    },
+    {
+      "metric_group": "Link",
+      "name": "tonglink_exporter_local_link_count",
+      "display_name": "本地链路数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 本地链路数量",
+      "query": "sum(tonglink_exporter_local_link_count{__$labels__})"
+    },
+    {
+      "metric_group": "Link",
+      "name": "tonglink_exporter_route_link_count",
+      "display_name": "分发链路数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 分发链路数量",
+      "query": "sum(tonglink_exporter_route_link_count{__$labels__})"
+    },
+    {
+      "metric_group": "Link",
+      "name": "tonglink_exporter_link_total_count",
+      "display_name": "链路总数",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "TongLink 链路总数",
+      "query": "sum(tonglink_exporter_link_total_count{__$labels__})"
+    },
+    {
+      "metric_group": "Resource",
+      "name": "tonglink_exporter_up_flow_total_bytes",
+      "display_name": "累计上行流量",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "target", "description": "TongLink 目标"}],
+      "description": "TongLink 累计上行流量字节数",
+      "query": "sum by (target) (tonglink_exporter_up_flow_total_bytes{__$labels__})"
+    },
+    {
+      "metric_group": "Resource",
+      "name": "tonglink_exporter_down_flow_total_bytes",
+      "display_name": "累计下行流量",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "target", "description": "TongLink 目标"}],
+      "description": "TongLink 累计下行流量字节数",
+      "query": "sum by (target) (tonglink_exporter_down_flow_total_bytes{__$labels__})"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_commitlog_disk_util",
+      "display_name": "commitlog 磁盘占用率",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "%",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink commitlog 目录磁盘占用百分比",
+      "query": "tonglink_exporter_commitlog_disk_util{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_consumequeue_disk_util",
+      "display_name": "consumequeue 磁盘占用率",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "%",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink consumequeue 目录磁盘占用百分比",
+      "query": "tonglink_exporter_consumequeue_disk_util{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_commitlog_total_size",
+      "display_name": "commitlog 占用空间",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink commitlog 目录占用磁盘字节数",
+      "query": "tonglink_exporter_commitlog_total_size{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_consumequeue_total_size",
+      "display_name": "consumequeue 占用空间",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink consumequeue 目录占用磁盘字节数",
+      "query": "tonglink_exporter_consumequeue_total_size{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_consume_offset_size",
+      "display_name": "消费历史文件大小",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink 消费历史文件占用字节数",
+      "query": "tonglink_exporter_consume_offset_size{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_commitlog_alarm_action",
+      "display_name": "commitlog 超阈值动作",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "code",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink commitlog 触发告警后采取的动作码",
+      "query": "tonglink_exporter_commitlog_alarm_action{__$labels__}"
+    },
+    {
+      "metric_group": "Setting",
+      "name": "tonglink_exporter_consumequeue_alarm_action",
+      "display_name": "consumequeue 超阈值动作",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "code",
+      "dimensions": [{"name": "broker", "description": "Broker 标识"}],
+      "description": "TongLink consumequeue 触发告警后采取的动作码",
+      "query": "tonglink_exporter_consumequeue_alarm_action{__$labels__}"
+    },
+    {
+      "metric_group": "License",
+      "name": "tonglink_exporter_license_warning",
+      "display_name": "License 告警状态",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"正常\",\"id\":0,\"color\":\"#1ac44a\"},{\"name\":\"告警\",\"id\":1,\"color\":\"#faad14\"},{\"name\":\"即将到期\",\"id\":2,\"color\":\"#ff4d4f\"}]",
+      "dimensions": [],
+      "description": "TongLink license 告警状态码",
+      "query": "tonglink_exporter_license_warning{__$labels__}"
+    },
+    {
+      "metric_group": "License",
+      "name": "tonglink_exporter_license_expiry_timestamp_seconds",
+      "display_name": "License 到期时间戳",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "s",
+      "dimensions": [],
+      "description": "TongLink license 到期 Unix 时间戳(秒)",
+      "query": "tonglink_exporter_license_expiry_timestamp_seconds{__$labels__}"
+    },
+    {
+      "metric_group": "License",
+      "name": "tonglink_exporter_license_type_info",
+      "display_name": "License 类型",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "code",
+      "dimensions": [],
+      "description": "TongLink license 类型标识",
+      "query": "tonglink_exporter_license_type_info{__$labels__}"
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/policy.json
+++ b/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/policy.json
@@ -1,0 +1,175 @@
+{
+  "object": "TongLink",
+  "plugin": "TongLink-Exporter",
+  "templates": [
+    {
+      "name": "Exporter 进程不可用",
+      "alert_name": "TongLink ${resource_name} Exporter 进程异常",
+      "description": "Exporter 未抓到任何指标,可能进程崩溃或与 TongLink 管理节点失联,需立即排查。",
+      "metric_name": "tonglink_exporter_up",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 1,
+          "method": "!="
+        }
+      ],
+      "group_algorithm": "avg"
+    },
+    {
+      "name": "TongLink 集群管理节点离线",
+      "alert_name": "TongLink ${resource_name} 集群管理节点离线",
+      "description": "TongLink 集群管理节点状态为 0,集群可能不可用,需立即检查管理节点。",
+      "metric_name": "tonglink_exporter_cluster_state",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 0,
+          "method": "=="
+        }
+      ],
+      "group_algorithm": "avg"
+    },
+    {
+      "name": "存活 Broker 数量过低",
+      "alert_name": "TongLink ${resource_name} 存活 Broker 不足",
+      "description": "TongLink 集群无存活 broker,集群不可用,需立即排查。",
+      "metric_name": "tonglink_exporter_alive_broker",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 0,
+          "method": "<="
+        }
+      ],
+      "group_algorithm": "avg"
+    },
+    {
+      "name": "Broker 健康度异常",
+      "alert_name": "TongLink ${resource_name} Broker 健康度异常",
+      "description": "TongLink broker 健康度异常(返回 0),broker 进程可能异常。",
+      "metric_name": "tonglink_exporter_broker_monitor",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 0,
+          "method": "=="
+        }
+      ],
+      "group_algorithm": "avg"
+    },
+    {
+      "name": "主题消息堆积严重",
+      "alert_name": "TongLink ${resource_name} 主题消息堆积",
+      "description": "TongLink 单个主题消息堆积超过阈值,可能消费能力不足。",
+      "metric_name": "tonglink_exporter_topic_msg_num",
+      "algorithm": "max_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 100000,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 10000,
+          "method": ">="
+        }
+      ],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "队列消息堆积严重",
+      "alert_name": "TongLink ${resource_name} 队列消息堆积",
+      "description": "TongLink 队列消息堆积超过阈值,可能消费能力不足。",
+      "metric_name": "tonglink_exporter_queue_msg_num",
+      "algorithm": "max_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 100000,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 10000,
+          "method": ">="
+        }
+      ],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "Broker commitlog 磁盘水位告警",
+      "alert_name": "TongLink ${resource_name} commitlog 磁盘水位高",
+      "description": "TongLink broker commitlog 目录磁盘占用率超过阈值,可能导致写入失败。",
+      "metric_name": "tonglink_exporter_commitlog_disk_util",
+      "algorithm": "max_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 90,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 80,
+          "method": ">="
+        }
+      ],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "Broker consumequeue 磁盘水位告警",
+      "alert_name": "TongLink ${resource_name} consumequeue 磁盘水位高",
+      "description": "TongLink broker consumequeue 目录磁盘占用率超过阈值,可能影响消费。",
+      "metric_name": "tonglink_exporter_consumequeue_disk_util",
+      "algorithm": "max_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 90,
+          "method": ">="
+        },
+        {
+          "level": "warning",
+          "value": 80,
+          "method": ">="
+        }
+      ],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "License 告警状态触发",
+      "description": "TongLink license 告警状态触发 (license_warning=1 表示 license 异常或即将到期),需检查 license 状态并续期。",
+      "metric_name": "tonglink_exporter_license_warning",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "warning",
+          "value": 0,
+          "method": ">"
+        }
+      ],
+      "group_algorithm": "avg"
+    },
+    {
+      "name": "License 告警状态非正常",
+      "alert_name": "TongLink ${resource_name} License 状态异常",
+      "description": "TongLink license 处于告警状态(>=1),需检查 license 是否合规。",
+      "metric_name": "tonglink_exporter_license_warning",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "warning",
+          "value": 0,
+          "method": ">"
+        }
+      ],
+      "group_algorithm": "avg"
+    }
+  ]
+}

--- a/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/tonglink.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/tonglink.child.toml.j2
@@ -1,0 +1,11 @@
+[[inputs.prometheus]]
+    startup_error_behavior = "retry"
+    urls = ["http://127.0.0.1:${LISTEN_PORT__{{ config_id }}}/metrics"]
+    interval = "{{ interval }}s"
+    timeout = "20s"
+    response_timeout = "20s"
+    [inputs.prometheus.tags]
+        instance_id = "{{ instance_id }}"
+        instance_type = "{{ instance_type }}"
+        collect_type = "exporter"
+        config_type = "tonglink"

--- a/server/apps/node_mgmt/support-files/collectors/TongLink-Exporter.json
+++ b/server/apps/node_mgmt/support-files/collectors/TongLink-Exporter.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "exporter_tonglink_linux",
+    "name": "TongLink-Exporter",
+    "controller_default_run": false,
+    "icon": "",
+    "node_operating_system": "linux",
+    "service_type": "exec",
+    "executable_path": "/opt/fusion-collectors/bin/tonglink_exporter",
+    "execute_parameters": "--host $HOST --port $PORT --web.listen-address 127.0.0.1:$LISTEN_PORT --bearer-token $BEARER_TOKEN --tls-skip-verify $TLS_SKIP_VERIFY",
+    "validation_parameters": "",
+    "default_template": "",
+    "introduction": "TongLink Exporter collects metrics from TongLink 9.0.5.1 message middleware, exposing cluster, broker, message, queue, link, resource, setting and license metrics in Prometheus text format.",
+    "tags": [
+      "linux",
+      "exporter",
+      "monitor",
+      "x86_64"
+    ],
+    "package_name": "tonglink_exporter",
+    "cpu_architecture": "x86_64",
+    "default_config": {}
+  }
+]

--- a/web/src/app/monitor/hooks/integration/index.tsx
+++ b/web/src/app/monitor/hooks/integration/index.tsx
@@ -48,6 +48,7 @@ import { useCvmConfig } from './objects/tencentCloud/cvm';
 import { useTongWebConfig } from './objects/middleware/tongWeb';
 import { useJbossConfig } from './objects/middleware/jboss';
 import { useKafkaConfig } from './objects/middleware/kafka';
+import { useTongLinkConfig } from './objects/middleware/tonglink';
 import { useMssqlConfig } from './objects/database/mssql';
 import { useClusterConfig } from './objects/k8s/cluster';
 import { useNodeConfig } from './objects/k8s/node';
@@ -121,6 +122,7 @@ export const useMonitorConfig = () => {
   const tongWebConfig = useTongWebConfig();
   const jbossConfig = useJbossConfig();
   const kafkaConfig = useKafkaConfig();
+  const tongLinkConfig = useTongLinkConfig();
   const mssqlConfig = useMssqlConfig();
   const clusterConfig = useClusterConfig();
   const podConfig = usePodConfig();
@@ -180,6 +182,7 @@ export const useMonitorConfig = () => {
       TongWeb: tongWebConfig,
       JBoss: jbossConfig,
       Kafka: kafkaConfig,
+      TongLink: tongLinkConfig,
       MSSQL: mssqlConfig,
       Cluster: clusterConfig,
       Pod: podConfig,

--- a/web/src/app/monitor/hooks/integration/objects/middleware/tonglink.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/middleware/tonglink.tsx
@@ -1,0 +1,10 @@
+export const useTongLinkConfig = () => {
+  return {
+    instance_type: 'tonglink',
+    dashboardDisplay: [],
+    groupIds: {},
+    collectTypes: {
+      'TongLink-Exporter': 'exporter',
+    },
+  };
+};


### PR DESCRIPTION
## 背景

东方通 TongLink 9.0.5.1 是国内常见的消息中间件。本 PR 把它的监控能力以 bk-lite 一等公民形态接入，与 Kafka-Exporter / Oracle-Exporter / JVM-JMX 等兄弟 plugin 平级。

TongLink exporter 二进制源码在独立仓库维护（不在 bk-lite 仓内），本 PR 仅登记 bk-lite 端的集成入口与展示元数据。

## 本 PR 落地的 10 个文件

- server/apps/monitor/constants/monitor_object.py — DEFAULT_OBJ_ORDER Middleware 组加 TongLink
- server/apps/node_mgmt/support-files/collectors/TongLink-Exporter.json — 节点采集器声明
- server/apps/monitor/support-files/plugins/TongLink-Exporter/exporter/tonglink/ (UI.json / metrics.json / policy.json / tonglink.child.toml.j2)
- server/apps/monitor/language/{zh-Hans,en}.yaml 加 TongLink 段
- web/src/app/monitor/hooks/integration/index.tsx — 中间件注册
- web/src/app/monitor/hooks/integration/objects/middleware/tonglink.tsx — TongLink 监控配置 hook

## 工程层要点

- icon: mm-rabbitmq_Rabbitmq (TongLink 在仓库里无原生图标,复用 RabbitMQ 占位)
- 告警模板阈值方向已校正:cluster_state==0、alive_broker<=0、broker_monitor==0、license_warning>0

## 与上游 exporter 的关系

| 关注点 | 上游 exporter 仓库 | 本 bk-lite 仓 |
|---|---|---|
| TongLink exporter 二进制 | ✅ | 仅声明入口 |
| 工程层修复 E1-E18 + 11 collector | ✅ | — |
| 监控能力集成 (实例列表 / 详情 / 告警) | — | ✅ |

## 测试 & 风险

- 本 PR 不含 .go / go.mod / go.sum
- 端到端 mock 验证需要带 Postgres 环境跑 `python manage.py plugin_init && node_init`

🤖 Generated with [Claude Code](https://claude.ai/code)