### PR TITLE
perf(collector): 按实际消费裁剪 kube-state-metrics 与 cadvisor 的指标和维度

### DIFF
--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -39,6 +39,10 @@ spec:
           - --docker_only
           - --store_container_labels=false
           - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace
+          # 监控链路只消费 cpu/内存/磁盘IO/网络四类指标，关闭其余采集组
+          # （尤其 disk 用量统计开销大），降低 cadvisor 自身资源占用；
+          # 与 deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml 保持一致
+          - --enable_metrics=cpu,diskIO,memory,network
         volumeMounts:
           - name: rootfs
             mountPath: /rootfs
@@ -374,10 +378,19 @@ data:
         - target_label: instance_name
           replacement: "%{CLUSTER_NAME}"
         metric_relabel_configs:
+        # 监控链路（metrics.json 与 web k8s dashboard）只消费以下 6 个指标族，
+        # 其余全部丢弃；与 deploy/dist/bk-lite-kubernetes-collector/
+        # bk-lite-metric-collector.yaml 保持一致，新增图表指标时需同步扩充
+        - source_labels: [__name__]
+          action: keep
+          regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_reads_total|container_fs_writes_total|container_network_receive_bytes_total|container_network_transmit_bytes_total
         - source_labels: [container_label_io_kubernetes_pod_name]
           target_label: pod
           regex: (.+)
           action: replace
+        # id(cgroup 路径)/name/image 超长且无查询消费；pod_name 已复制为 pod
+        - regex: id|name|image|container_label_io_kubernetes_pod_name
+          action: labeldrop
 
 ---
 apiVersion: v1

--- a/agents/webhookd/bk-lite-resource-collector.yaml
+++ b/agents/webhookd/bk-lite-resource-collector.yaml
@@ -40,9 +40,11 @@ spec:
             memory: 256Mi
             cpu: 200m
         args:
-          - '--metric-labels-allowlist=*=[*]'
-          - '--metric-annotations-allowlist=*=[*]'
-          - '--metric-labels-allowlist=namespaces=[*]'
+          # CMDB 资源发现链路只消费下列指标（server/apps/cmdb/collection/constants.py），
+          # annotations 仅解析 last-applied-configuration 一个 key，按需暴露以削减冗余传输
+          - '--resources=cronjobs,daemonsets,deployments,jobs,namespaces,nodes,pods,replicasets,statefulsets'
+          - '--metric-allowlist=kube_cronjob_annotations,kube_cronjob_info,kube_daemonset_annotations,kube_daemonset_created,kube_deployment_annotations,kube_deployment_created,kube_deployment_spec_replicas,kube_job_annotations,kube_job_info,kube_namespace_labels,kube_node_info,kube_node_role,kube_node_status_capacity,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_info,kube_replicaset_annotations,kube_replicaset_created,kube_replicaset_owner,kube_replicaset_spec_replicas,kube_statefulset_annotations,kube_statefulset_created,kube_statefulset_replicas'
+          - '--metric-annotations-allowlist=cronjobs=[kubectl.kubernetes.io/last-applied-configuration],daemonsets=[kubectl.kubernetes.io/last-applied-configuration],deployments=[kubectl.kubernetes.io/last-applied-configuration],jobs=[kubectl.kubernetes.io/last-applied-configuration],replicasets=[kubectl.kubernetes.io/last-applied-configuration],statefulsets=[kubectl.kubernetes.io/last-applied-configuration]'
         livenessProbe:
           httpGet:
             path: /livez
@@ -324,6 +326,8 @@ data:
     [[inputs.prometheus]]
       urls = ["http://kube-state-metrics:8080/metrics"]
       metric_version = 2
+      ## CMDB 采集(collect_plugin/k8s.py)未消费的维度，上报前丢弃以削减传输
+      tagexclude = ["uid", "unit", "host_ip", "host_network", "priority_class", "system_uuid", "provider_id", "kubeproxy_version", "owner_is_controller", "url"]
       [inputs.prometheus.tags]
         instance_id = "${CLUSTER_NAME:-k8s-bklite-cluster}"
         instance_type = "k8s"

--- a/agents/webhookd/bk-lite-resource-collector.yaml
+++ b/agents/webhookd/bk-lite-resource-collector.yaml
@@ -40,11 +40,18 @@ spec:
             memory: 256Mi
             cpu: 200m
         args:
-          # CMDB 资源发现链路只消费下列指标（server/apps/cmdb/collection/constants.py），
-          # annotations 仅解析 last-applied-configuration 一个 key，按需暴露以削减冗余传输
+          # 注意：本 KSM 与 deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+          # 的 KSM 是同名共享实例（bk-lite-collector/kube-state-metrics），同集群共装时后
+          # apply 者覆盖先 apply 者，因此本段 args 必须与该文件逐字一致——取两条链路消费
+          # 指标的并集（监控 metrics.json/web dashboard 17 个 + CMDB collection/constants.py
+          # 23 个，重叠 6 个）；各链路的精确过滤在采集侧（vmagent keep / telegraf fieldpass）
           - '--resources=cronjobs,daemonsets,deployments,jobs,namespaces,nodes,pods,replicasets,statefulsets'
-          - '--metric-allowlist=kube_cronjob_annotations,kube_cronjob_info,kube_daemonset_annotations,kube_daemonset_created,kube_deployment_annotations,kube_deployment_created,kube_deployment_spec_replicas,kube_job_annotations,kube_job_info,kube_namespace_labels,kube_node_info,kube_node_role,kube_node_status_capacity,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_info,kube_replicaset_annotations,kube_replicaset_created,kube_replicaset_owner,kube_replicaset_spec_replicas,kube_statefulset_annotations,kube_statefulset_created,kube_statefulset_replicas'
+          - '--metric-allowlist=kube_cronjob_annotations,kube_cronjob_info,kube_daemonset_annotations,kube_daemonset_created,kube_daemonset_status_desired_number_scheduled,kube_daemonset_status_number_available,kube_daemonset_status_number_unavailable,kube_deployment_annotations,kube_deployment_created,kube_deployment_spec_replicas,kube_deployment_status_replicas_available,kube_deployment_status_replicas_unavailable,kube_job_annotations,kube_job_info,kube_namespace_labels,kube_node_info,kube_node_role,kube_node_status_allocatable,kube_node_status_capacity,kube_node_status_condition,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_container_status_restarts_total,kube_pod_container_status_waiting_reason,kube_pod_info,kube_pod_status_phase,kube_replicaset_annotations,kube_replicaset_created,kube_replicaset_owner,kube_replicaset_spec_replicas,kube_statefulset_annotations,kube_statefulset_created,kube_statefulset_replicas,kube_statefulset_status_replicas_ready'
+          # annotations 仅 CMDB 解析 last-applied-configuration 一个 key
           - '--metric-annotations-allowlist=cronjobs=[kubectl.kubernetes.io/last-applied-configuration],daemonsets=[kubectl.kubernetes.io/last-applied-configuration],deployments=[kubectl.kubernetes.io/last-applied-configuration],jobs=[kubectl.kubernetes.io/last-applied-configuration],replicasets=[kubectl.kubernetes.io/last-applied-configuration],statefulsets=[kubectl.kubernetes.io/last-applied-configuration]'
+          # KSM 2.13 在 labels allowlist 为空时 kube_namespace_labels 整族不输出任何样本
+          # （internal/store/namespace.go），而 CMDB namespace 发现依赖该指标，必须保留
+          - '--metric-labels-allowlist=namespaces=[*]'
         livenessProbe:
           httpGet:
             path: /livez
@@ -326,6 +333,10 @@ data:
     [[inputs.prometheus]]
       urls = ["http://kube-state-metrics:8080/metrics"]
       metric_version = 2
+      ## KSM 实例暴露的是两条链路的并集，CMDB 链路只消费以下 23 个指标
+      ## （server/apps/cmdb/collection/constants.py），其余（监控专属的 status_phase/
+      ## condition 等）不上报；metric_version=2 下指标名是 field 名，故用 fieldpass
+      fieldpass = ["kube_cronjob_annotations", "kube_cronjob_info", "kube_daemonset_annotations", "kube_daemonset_created", "kube_deployment_annotations", "kube_deployment_created", "kube_deployment_spec_replicas", "kube_job_annotations", "kube_job_info", "kube_namespace_labels", "kube_node_info", "kube_node_role", "kube_node_status_capacity", "kube_pod_container_resource_limits", "kube_pod_container_resource_requests", "kube_pod_info", "kube_replicaset_annotations", "kube_replicaset_created", "kube_replicaset_owner", "kube_replicaset_spec_replicas", "kube_statefulset_annotations", "kube_statefulset_created", "kube_statefulset_replicas"]
       ## CMDB 采集(collect_plugin/k8s.py)未消费的维度，上报前丢弃以削减传输
       tagexclude = ["uid", "unit", "host_ip", "host_network", "priority_class", "system_uuid", "provider_id", "kubeproxy_version", "owner_is_controller", "url"]
       [inputs.prometheus.tags]

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -170,10 +170,18 @@ spec:
             memory: 256Mi
             cpu: 200m
         args:
-          # 监控链路只消费下列指标（server/apps/monitor metrics.json 与 web k8s dashboard），
-          # 按需暴露以削减冗余传输；新增图表指标时需同步扩充此清单
-          - '--resources=daemonsets,deployments,nodes,pods,statefulsets'
-          - '--metric-allowlist=kube_daemonset_status_desired_number_scheduled,kube_daemonset_status_number_available,kube_daemonset_status_number_unavailable,kube_deployment_spec_replicas,kube_deployment_status_replicas_available,kube_deployment_status_replicas_unavailable,kube_node_info,kube_node_status_allocatable,kube_node_status_condition,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_container_status_restarts_total,kube_pod_container_status_waiting_reason,kube_pod_info,kube_pod_status_phase,kube_statefulset_replicas,kube_statefulset_status_replicas_ready'
+          # 注意：本 KSM 与 agents/webhookd/bk-lite-resource-collector.yaml 的 KSM 是同名
+          # 共享实例（bk-lite-collector/kube-state-metrics），同集群共装时后 apply 者覆盖
+          # 先 apply 者，因此本段 args 必须与该文件逐字一致——取两条链路消费指标的并集
+          # （监控 metrics.json/web dashboard 17 个 + CMDB collection/constants.py 23 个，
+          # 重叠 6 个）；各链路的精确过滤在采集侧（vmagent keep / telegraf fieldpass）
+          - '--resources=cronjobs,daemonsets,deployments,jobs,namespaces,nodes,pods,replicasets,statefulsets'
+          - '--metric-allowlist=kube_cronjob_annotations,kube_cronjob_info,kube_daemonset_annotations,kube_daemonset_created,kube_daemonset_status_desired_number_scheduled,kube_daemonset_status_number_available,kube_daemonset_status_number_unavailable,kube_deployment_annotations,kube_deployment_created,kube_deployment_spec_replicas,kube_deployment_status_replicas_available,kube_deployment_status_replicas_unavailable,kube_job_annotations,kube_job_info,kube_namespace_labels,kube_node_info,kube_node_role,kube_node_status_allocatable,kube_node_status_capacity,kube_node_status_condition,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_container_status_restarts_total,kube_pod_container_status_waiting_reason,kube_pod_info,kube_pod_status_phase,kube_replicaset_annotations,kube_replicaset_created,kube_replicaset_owner,kube_replicaset_spec_replicas,kube_statefulset_annotations,kube_statefulset_created,kube_statefulset_replicas,kube_statefulset_status_replicas_ready'
+          # annotations 仅 CMDB 解析 last-applied-configuration 一个 key
+          - '--metric-annotations-allowlist=cronjobs=[kubectl.kubernetes.io/last-applied-configuration],daemonsets=[kubectl.kubernetes.io/last-applied-configuration],deployments=[kubectl.kubernetes.io/last-applied-configuration],jobs=[kubectl.kubernetes.io/last-applied-configuration],replicasets=[kubectl.kubernetes.io/last-applied-configuration],statefulsets=[kubectl.kubernetes.io/last-applied-configuration]'
+          # KSM 2.13 在 labels allowlist 为空时 kube_namespace_labels 整族不输出任何样本
+          # （internal/store/namespace.go），而 CMDB namespace 发现依赖该指标，必须保留
+          - '--metric-labels-allowlist=namespaces=[*]'
         livenessProbe:
           httpGet:
             path: /livez
@@ -672,6 +680,12 @@ data:
         - target_label: instance_name
           replacement: "%{CLUSTER_NAME}"
         metric_relabel_configs:
+        # KSM 实例暴露的是两条链路的并集，监控链路只消费以下 17 个指标
+        # （metrics.json 与 web k8s dashboard），其余（CMDB 专属的 annotations/
+        # created/owner 等）丢弃；新增图表指标时需同步扩充此清单
+        - source_labels: [__name__]
+          action: keep
+          regex: kube_daemonset_status_desired_number_scheduled|kube_daemonset_status_number_available|kube_daemonset_status_number_unavailable|kube_deployment_spec_replicas|kube_deployment_status_replicas_available|kube_deployment_status_replicas_unavailable|kube_node_info|kube_node_status_allocatable|kube_node_status_condition|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_status_phase|kube_statefulset_replicas|kube_statefulset_status_replicas_ready
         # 监控链路只按 instance_id/node/pod/namespace/container/phase/reason/
         # condition/status/resource 及工作负载名聚合，其余维度未被任何查询消费，
         # 抓取时丢弃以削减传输与存储

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -39,6 +39,9 @@ spec:
           - --docker_only
           - --store_container_labels=false
           - --whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace
+          # 监控链路只消费 cpu/内存/磁盘IO/网络四类指标，关闭其余采集组
+          # （尤其 disk 用量统计开销大），降低 cadvisor 自身资源占用
+          - --enable_metrics=cpu,diskIO,memory,network
         volumeMounts:
           - name: rootfs
             mountPath: /rootfs
@@ -167,9 +170,10 @@ spec:
             memory: 256Mi
             cpu: 200m
         args:
-          - '--metric-labels-allowlist=*=[*]'
-          - '--metric-annotations-allowlist=*=[*]'
-          - '--metric-labels-allowlist=namespaces=[*]'
+          # 监控链路只消费下列指标（server/apps/monitor metrics.json 与 web k8s dashboard），
+          # 按需暴露以削减冗余传输；新增图表指标时需同步扩充此清单
+          - '--resources=daemonsets,deployments,nodes,pods,statefulsets'
+          - '--metric-allowlist=kube_daemonset_status_desired_number_scheduled,kube_daemonset_status_number_available,kube_daemonset_status_number_unavailable,kube_deployment_spec_replicas,kube_deployment_status_replicas_available,kube_deployment_status_replicas_unavailable,kube_node_info,kube_node_status_allocatable,kube_node_status_condition,kube_pod_container_resource_limits,kube_pod_container_resource_requests,kube_pod_container_status_restarts_total,kube_pod_container_status_waiting_reason,kube_pod_info,kube_pod_status_phase,kube_statefulset_replicas,kube_statefulset_status_replicas_ready'
         livenessProbe:
           httpGet:
             path: /livez
@@ -630,10 +634,18 @@ data:
         - target_label: instance_name
           replacement: "%{CLUSTER_NAME}"
         metric_relabel_configs:
+        # 监控链路（metrics.json 与 web k8s dashboard）只消费以下 6 个指标族，
+        # 其余全部丢弃；新增图表指标时需同步扩充此清单
+        - source_labels: [__name__]
+          action: keep
+          regex: container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_fs_reads_total|container_fs_writes_total|container_network_receive_bytes_total|container_network_transmit_bytes_total
         - source_labels: [container_label_io_kubernetes_pod_name]
           target_label: pod
           regex: (.+)
           action: replace
+        # id(cgroup 路径)/name/image 超长且无查询消费；pod_name 已复制为 pod
+        - regex: id|name|image|container_label_io_kubernetes_pod_name
+          action: labeldrop
       - job_name: 'kubernetes-kube-state-metrics'
         kubernetes_sd_configs:
         - role: pod
@@ -659,6 +671,12 @@ data:
           replacement: k8s
         - target_label: instance_name
           replacement: "%{CLUSTER_NAME}"
+        metric_relabel_configs:
+        # 监控链路只按 instance_id/node/pod/namespace/container/phase/reason/
+        # condition/status/resource 及工作负载名聚合，其余维度未被任何查询消费，
+        # 抓取时丢弃以削减传输与存储
+        - regex: uid|unit|created_by_kind|created_by_name|host_ip|pod_ip|host_network|priority_class|internal_ip|os_image|kernel_version|kubelet_version|container_runtime_version|kubeproxy_version|pod_cidr|system_uuid|provider_id
+          action: labeldrop
 
 ---
 apiVersion: v1


### PR DESCRIPTION
## 背景

生产环境实测 kube-state-metrics 单次抓取 **24.4MB / 11.7 万条时间序列**，而 BK-Lite 两条消费链路实际只使用其中 **35 个指标族**；两条链路（监控 vmagent + CMDB telegraf）各自全量抓取，冗余指标传输占用大量带宽、NATS 吞吐与存储。cadvisor 同理：默认暴露 60+ 指标族，仅 6 个被消费。

## 改动内容

所有裁剪均以消费方代码为证据逐项核对（监控插件 `server/apps/monitor/.../k8s/metrics.json`、`monitor_instance.py`、web 端 k8s 三个 dashboard 的 PromQL、CMDB `server/apps/cmdb/collection/`），未被任何查询/解析引用的指标与维度才裁剪。

### kube-state-metrics · 监控链路（`deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml`）
- `--resources` 收窄到 5 类资源，`--metric-allowlist` 仅保留被消费的 17 个指标
- 移除 `--metric-labels-allowlist=*=[*]` / `--metric-annotations-allowlist=*=[*]`（监控链路不消费任何扩展维度）
- vmagent 抓取时 `labeldrop` 掉 `uid`/`created_by_*`/`host_ip`/`pod_ip` 及 node 版本信息等 17 个无查询引用的内置维度（去除后序列仍由 namespace+pod 等唯一确定，无冲突）

### kube-state-metrics · CMDB 链路（`agents/webhookd/bk-lite-resource-collector.yaml`）
- `--resources` 收窄到 9 类资源，`--metric-allowlist` 仅保留被消费的 23 个指标
- annotations 从全量收窄到唯一被解析的 `kubectl.kubernetes.io/last-applied-configuration`（此前单条 replicaset annotations 序列携带整个序列化 BkApp JSON，仅 annotations 两族即占 6MB）
- telegraf `tagexclude` 丢弃 `uid`/`url` 等无消费维度；保留代码实际读取的 `pod_ip`/`created_by_*`/node 内核与运行时版本等字段

### cadvisor（同监控链路 YAML）
- 新增 `--enable_metrics=cpu,diskIO,memory,network`，关闭无消费的采集组（尤其 disk 用量统计开销大），降低 cadvisor 自身节点资源占用
- vmagent `keep` 仅放行 6 个被消费指标族；`labeldrop` 掉 `id`（cgroup 路径+容器 ID）/`name`/`image` 超长维度
- 保留 `container_label_io_kubernetes_container_name`（多容器 Pod 的序列区分键）与 `container_label_io_kubernetes_pod_namespace`（dashboard 按其聚合）

## 效果（按生产数据估算，单次抓取）

| 链路 | 优化前 | 优化后 |
|---|---|---|
| 监控链路 KSM | 24.4MB / 11.7 万序列 | 约 2.2MB / 1.7 万序列 |
| CMDB 链路 KSM | 24.4MB / 11.7 万序列 | 约 2.5MB / 1.4 万序列 |
| cadvisor | 60+ 指标族（每节点） | 6 指标族，预计降至 5%–10% |

两条 KSM 链路合计削减约 **90%**；`--resources` 收窄同时降低 KSM 对 apiserver 的 watch 压力。

## 注意事项

- 后续新增 dashboard 图表指标或 CMDB 采集字段时，需同步扩充对应 allowlist / 移出 labeldrop 清单（配置旁均有注释说明清单来源）
- cadvisor 去除 `id` 后，容器重启瞬间新旧容器会短暂产生同 label 序列（一个采集周期内 `sum by(pod)` 可能多算一次），为社区通行做法，对趋势图无实质影响
- 组件均无状态，发布即 `kubectl apply` 滚动重启，回滚 = 还原配置
- 两份 YAML 及内嵌 prometheus.yml 已通过语法校验

🤖 Generated with [Claude Code](https://claude.com/claude-code)