### PR TITLE
feat(monitor): add 4 brand svg for enterprise storage vendors

### DIFF
--- a/web/public/assets/icons/mm-dellpowerstore_dellpowerstore.svg
+++ b/web/public/assets/icons/mm-dellpowerstore_dellpowerstore.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="Dell PowerStore logo">
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="#ffffff"/>
+  <path d="M22 50h76v3H22zM22 67h76v3H22z" fill="#0076ce"/>
+  <text x="60" y="42" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="800" fill="#0076ce" letter-spacing="0.5">DELL</text>
+  <text x="60" y="83" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="11" font-weight="600" fill="#0076ce" letter-spacing="0.3">PowerStore</text>
+</svg>

--- a/web/public/assets/icons/mm-infinidat_infinidat.svg
+++ b/web/public/assets/icons/mm-infinidat_infinidat.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="INFINIDAT logo">
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="#ffffff"/>
+  <rect x="26" y="22" width="68" height="68" rx="8" fill="#111111"/>
+  <g fill="none" stroke-linecap="round">
+    <ellipse cx="60" cy="56" rx="30" ry="16" stroke="#7df33f" stroke-width="4" transform="rotate(-18 60 56)"/>
+    <ellipse cx="60" cy="56" rx="26" ry="13" stroke="#4ed72f" stroke-width="3" transform="rotate(-8 60 56)"/>
+    <ellipse cx="60" cy="56" rx="21" ry="10" stroke="#9cfb5a" stroke-width="3" transform="rotate(12 60 56)"/>
+  </g>
+  <text x="60" y="105" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="10" font-weight="700" fill="#222222" letter-spacing="1.6">INFINIDAT</text>
+</svg>

--- a/web/public/assets/icons/mm-netappstoragegrid_netappstoragegrid.svg
+++ b/web/public/assets/icons/mm-netappstoragegrid_netappstoragegrid.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="NetApp StorageGRID logo">
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="#ffffff"/>
+  <path d="M22 38h76v3H22zM22 56h76v3H22zM22 74h76v3H22z" fill="#0067c5"/>
+  <circle cx="36" cy="40" r="4" fill="#0067c5"/>
+  <circle cx="60" cy="58" r="4" fill="#0067c5"/>
+  <circle cx="84" cy="76" r="4" fill="#0067c5"/>
+  <text x="60" y="98" text-anchor="middle" font-family="Helvetica, Arial, sans-serif" font-size="9" font-weight="600" fill="#0067c5">STORAGEGRID</text>
+</svg>

--- a/web/public/assets/icons/mm-purestorage_purestorage.svg
+++ b/web/public/assets/icons/mm-purestorage_purestorage.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-label="Pure Storage logo">
+  <rect x="8" y="8" width="104" height="104" rx="22" fill="#ffffff"/>
+  <path d="M21 36h18l12 16-12 16H21l12-16-12-16Z" fill="#ff5a1f"/>
+  <path d="M41 36h18l12 16-12 16H41l12-16-12-16Z" fill="#ff5a1f"/>
+  <text x="60" y="89" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="19" font-weight="800" fill="#111111">PURE</text>
+  <text x="60" y="104" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="12" font-weight="500" fill="#404040" letter-spacing="1">STORAGE</text>
+</svg>


### PR DESCRIPTION
## 背景

接入页 5 个企业版存储监控卡片(Pure Storage / InfiniBox / Dell PowerStore / NetApp ONTAP / NetApp StorageGRID)fallback 到默认蓝盾。本 PR 提交 4 个品牌 svg 资源,等 dev merge main 后,被 BRANDS 系统引用。

注意: BRANDS regex 改动在 dev 分支上已有,不在本 PR 范围。

## 改动

4 个新 svg 资源 (web/public/assets/icons/):

| 文件 | 内容 | 字节 |
|---|---|---|
| mm-purestorage_purestorage.svg | 橙红 #ff5a1f + PURE 字标 | 631 |
| mm-infinidat_infinidat.svg | 黑色 + 绿/亮绿环 + INFINIDAT 字标 | 800 |
| mm-dellpowerstore_dellpowerstore.svg | Dell 蓝 #0076ce + DELL/PowerStore 字标 | 584 |
| mm-netappstoragegrid_netappstoragegrid.svg | NetApp 蓝 #0067c5 + StorageGRID 字标 | 562 |

总计 4 文件,31 行新增。

## 后续

BRANDS regex + getPluginBrandIcon 函数在 bk-lite dev 分支已有(commit history),
等 dev merge main 后,本 PR 的 svg 资源会被 dev 上的 BRANDS 表引用,
5 个企业版存储卡片显示品牌 logo。