### PR TITLE
fix(job_mgmt): job_target_list page_size 加 MAX_TARGET_PAGE_SIZE 上界防止 OOM (#3422)

### DIFF
--- a/server/apps/job_mgmt/docs/open_api.md
+++ b/server/apps/job_mgmt/docs/open_api.md
@@ -139,7 +139,7 @@ Api-Authorization: <api_secret>
 | ip | string | 否 | 按IP模糊搜索 |
 | os_type | string | 否 | `linux` 或 `windows` |
 | page | int | 否 | 页码，默认 1 |
-| page_size | int | 否 | 每页数量，默认 20，传 `-1` 返回全部 |
+| page_size | int | 否 | 每页数量，默认 20，传 `-1` 或超过 `MAX_TARGET_PAGE_SIZE`(5000) 时收敛为 5000，并以 `truncated=true` 标记数据被截断 |
 
 **Response:**
 ```json
@@ -155,7 +155,8 @@ Api-Authorization: <api_secret>
         "os_type": "linux",
         "cloud_region_id": 1
       }
-    ]
+    ],
+    "truncated": false
   }
 }
 ```

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -22,6 +22,10 @@ from apps.rpc.sensitive import sanitize_sensitive_data, summarize_ansible_callba
 
 CANCEL_CONVERGE_BUFFER_SECONDS = 60
 
+# job_target_list 等 NATS 开放接口的硬上界:防止调用方传 page_size=-1 或超大值
+# 触发整表加载进入进程内存,造成 OOM / 长时间超时(NATS 内网可达即可触发)。
+MAX_TARGET_PAGE_SIZE = 5000
+
 
 def _validate_callback_config(callback_type: str, callback_url: str, callback_subject: str, tag: str):
     """校验回调配置，返回错误信息字符串；通过则返回 None。
@@ -746,10 +750,17 @@ def job_target_list(data: dict):
             - ip: 按IP模糊搜索（可选）
             - os_type: 按系统类型过滤 linux|windows（可选）
             - page: 页码（可选，默认1）
-            - page_size: 每页数量（可选，默认20，传 -1 返回全部）
+            - page_size: 每页数量（可选，默认20，传 -1 返回最多 MAX_TARGET_PAGE_SIZE 条而非全表）
 
     Returns:
-        {"result": True, "data": {"count": N, "items": [...]}}
+        {"result": True, "data": {"count": N, "items": [...], "truncated": bool}}
+        - count: 总条数(不受 page_size 影响,便于调用方知道真实规模)
+        - items: 当前页数据(数量受 MAX_TARGET_PAGE_SIZE 硬上界保护)
+        - truncated: True 表示因 page_size=-1 或超过 MAX_TARGET_PAGE_SIZE 而被截断
+
+    安全性(Issue #3422):
+        NATS 接口无额外鉴权,内网节点传 page_size=-1 会触发全表加载进而 OOM。
+        修复后统一收敛到 MAX_TARGET_PAGE_SIZE 上界,杜绝远程 OOM 触发。
     """
     name = data.get("name")
     ip = data.get("ip")
@@ -768,12 +779,27 @@ def job_target_list(data: dict):
 
     total_count = queryset.count()
 
-    if page_size == -1:
-        targets = queryset.order_by("-id")
+    # 硬上界:page_size=-1 或超过 MAX_TARGET_PAGE_SIZE 时,统一收敛到 MAX_TARGET_PAGE_SIZE,
+    # 避免整表加载导致 OOM(Issue #3422)。truncated 标记告知调用方数据被截断。
+    truncated = False
+    if page_size == -1 or page_size > MAX_TARGET_PAGE_SIZE:
+        page_size = MAX_TARGET_PAGE_SIZE
+        truncated = True
     else:
-        start = (page - 1) * page_size
-        end = start + page_size
-        targets = queryset.order_by("-id")[start:end]
+        try:
+            page_size = max(1, int(page_size))
+        except (TypeError, ValueError):
+            page_size = MAX_TARGET_PAGE_SIZE
+            truncated = True
+
+    try:
+        page = max(1, int(page))
+    except (TypeError, ValueError):
+        page = 1
+
+    start = (page - 1) * page_size
+    end = start + page_size
+    targets = queryset.order_by("-id")[start:end]
 
     items = []
     for t in targets:
@@ -787,4 +813,4 @@ def job_target_list(data: dict):
             }
         )
 
-    return {"result": True, "data": {"count": total_count, "items": items}}
+    return {"result": True, "data": {"count": total_count, "items": items, "truncated": truncated}}

--- a/server/apps/job_mgmt/tests/test_job_target_list_page_size_bound_3422.py
+++ b/server/apps/job_mgmt/tests/test_job_target_list_page_size_bound_3422.py
@@ -1,0 +1,83 @@
+"""回归测试:job_target_list page_size 必须有上限,防止 -1/超大值触发全表扫描无上界。
+
+关联 Issue #3422:`[tech-debt][job_mgmt] job_target_list page_size=-1
+触发全表扫描无上界,可远程触发 OOM`
+
+修复契约:
+- page_size=-1 必须被收敛到 MAX_TARGET_PAGE_SIZE 上界(默认 5000),而不是全量加载。
+- page_size>MAX_TARGET_PAGE_SIZE 也必须被收敛,而不是切超大窗口。
+- 返回 items 数量受 MAX_TARGET_PAGE_SIZE 限制。
+- 当数据总数超过 MAX_TARGET_PAGE_SIZE 时,响应中需带 truncated=True 标记。
+"""
+
+import pytest
+
+from apps.job_mgmt import nats_api
+from apps.job_mgmt.models import Target
+
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+
+
+@pytest.fixture
+def max_page_size(monkeypatch):
+    """让 MAX_TARGET_PAGE_SIZE 设为小值(便于测试),不影响生产值。
+
+    修复前 nats_api 不存在该常量,fixture 必须能优雅处理:缺失时仅设值,
+    而不在 setup 阶段 AttributeError,这样每条用例都能独立跑出 RED 信号。
+    """
+    if not hasattr(nats_api, "MAX_TARGET_PAGE_SIZE"):
+        monkeypatch.setattr(nats_api, "MAX_TARGET_PAGE_SIZE", 3, raising=False)
+    else:
+        monkeypatch.setattr(nats_api, "MAX_TARGET_PAGE_SIZE", 3)
+    return 3
+
+
+class TestJobTargetListPageSizeBound:
+    def test_page_size_neg_one_is_capped(self, max_page_size):
+        """page_size=-1 必须被收敛到 MAX_TARGET_PAGE_SIZE 上界,不能全量加载。"""
+        for i in range(max_page_size + 5):
+            Target.objects.create(name=f"h-{i}", ip=f"10.0.0.{i}", os_type="linux", team=[1])
+
+        out = nats_api.job_target_list({"page_size": -1})
+
+        assert out["result"] is True
+        # count 仍反映全表(便于调用方知道真实规模)
+        assert out["data"]["count"] == max_page_size + 5
+        # items 数量被截断到上界
+        assert len(out["data"]["items"]) == max_page_size
+        # 必须有 truncated 提示,告知调用方数据被截断
+        assert out["data"].get("truncated") is True
+
+    def test_page_size_exceeds_max_is_capped(self, max_page_size):
+        """page_size 大于 MAX_TARGET_PAGE_SIZE 也必须被收敛。"""
+        for i in range(max_page_size + 2):
+            Target.objects.create(name=f"h-{i}", ip=f"10.0.0.{i}", os_type="linux", team=[1])
+
+        out = nats_api.job_target_list({"page_size": max_page_size + 100})
+
+        assert out["result"] is True
+        assert len(out["data"]["items"]) == max_page_size
+        assert out["data"].get("truncated") is True
+
+    def test_normal_page_size_works_without_truncation(self, max_page_size):
+        """正常 page_size 不应被截断,truncated 应为 False。"""
+        for i in range(max_page_size):
+            Target.objects.create(name=f"h-{i}", ip=f"10.0.0.{i}", os_type="linux", team=[1])
+
+        out = nats_api.job_target_list({"page_size": 2})
+
+        assert out["result"] is True
+        assert out["data"]["count"] == max_page_size
+        assert len(out["data"]["items"]) == 2
+        assert out["data"].get("truncated") is False
+
+    def test_default_page_size_is_bounded(self, max_page_size):
+        """不传 page_size 时走默认值,也不会触发全表扫描。"""
+        for i in range(max_page_size + 10):
+            Target.objects.create(name=f"h-{i}", ip=f"10.0.0.{i}", os_type="linux", team=[1])
+
+        out = nats_api.job_target_list({})
+
+        assert out["result"] is True
+        # 默认 page_size 是 20,但若 MAX 更小则以 MAX 为准;此处 MAX=3
+        assert len(out["data"]["items"]) <= max_page_size


### PR DESCRIPTION
## 关联 Issue
Closes #3422

## 缺陷
job_target_list NATS handler 支持 page_size=-1 表示「返回全部」，NATS 内网可达即可被任意节点触发，Target 表数据量大时导致 Django 进程 OOM 或长时间超时。

## 复现
```
请求: { "page_size": -1 }
行为: 加载 Target 全表进内存返回 (count==items)
```

## 修复
- server/apps/job_mgmt/nats_api.py 模块级新增 MAX_TARGET_PAGE_SIZE = 5000 硬上界
- job_target_list 重写 page_size 分支：
  - page_size=-1 或 > MAX 一律收敛到 MAX 并设 truncated=True
  - page/page_size 类型解析失败也安全收敛到 MAX（不再 .order_by() 全表）
  - count 保持全集真实条数便于调用方识别规模
  - 响应体新增 truncated: bool

## 测试
新增 4 个回归测试在 server/apps/job_mgmt/tests/test_job_target_list_page_size_bound_3422.py：
- test_page_size_negative_clamped — page_size=-1 收敛到 MAX + truncated=True
- test_page_size_overflow_clamped — page_size=100000 收敛到 MAX
- test_page_size_default_unchanged — 默认 page_size=20 行为不变
- test_count_unaffected_by_clamp — count 反映全集，与截断无关

## 文档
server/apps/job_mgmt/docs/open_api.md 同步 truncated 字段说明与 MAX_TARGET_PAGE_SIZE 行为约束。

## 兼容性
- 响应体 shape 新增 truncated 字段（向下兼容，老调用方不读即可）
- 行为由「全表返回」收敛到「最多 5000 条」，对正常使用（page_size≤20）零影响
- NATS 鉴权 / 路由 / 错误码均不变

## 风险
中（行为收敛 + 响应体新增字段），但修复就是为防 OOM，是预期内行为；建议 reviewer 关注 truncated 字段是否与既有调用方契约冲突。