### PR TITLE
fix(monitor): 监控采集频率统一为 60s

### DIFF
--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -576,7 +576,7 @@ data:
     [global_tags]
 
     [agent]
-      interval = "10s"
+      interval = "60s"
       round_interval = true
       metric_buffer_limit = 100000
       flush_buffer_when_full = true
@@ -705,7 +705,7 @@ data:
       instance_id="$HOST_NODE_NAME"
   
     [agent]
-      interval = "10s"
+      interval = "60s"
       round_interval = true
       metric_batch_size = 1000
       metric_buffer_limit = 10000

--- a/server/apps/monitor/services/custom_pull_plugin.py
+++ b/server/apps/monitor/services/custom_pull_plugin.py
@@ -81,7 +81,7 @@ DEFAULT_PULL_UI_TEMPLATE = {
             "label": "采集间隔",
             "type": "inputNumber",
             "required": True,
-            "default_value": 10,
+            "default_value": 60,
             "description": "监控数据的采集时间间隔（单位：秒）",
             "widget_props": {"min": 1, "precision": 0, "placeholder": "间隔", "addonAfter": "s"},
             "transform_on_edit": {

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx
@@ -51,7 +51,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({
 
   const initData = () => {
     form.setFieldsValue({
-      interval: collectType === 'http' ? 60 : 10,
+      interval: collectType === 'http' ? 60 : 60,
       ...configsInfo.defaultForm,
     });
   };


### PR DESCRIPTION
## 背景

业务规则:任何「采集频率/采集间隔」类默认值,不足 60s 一律改为 60s
(与 server 模型 default、内置 Telegraf 插件 UI.json 的 60s 默认保持一致)。
新建监控实例不再以 10s 高频采集拉端/后端。

## 改动

1. **前端手动接入监控** `web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx:54`
   原写法 `interval: collectType === 'http' ? 60 : 10` 让非 http 协议以 10s 高频采集,
   改为 `? 60 : 60`(三元结构保留)统一 60s。

2. **自定义拉取插件** `server/apps/monitor/services/custom_pull_plugin.py:84`
   `DEFAULT_PULL_UI_TEMPLATE.interval.default_value` 10 -> 60。

3. **K8s Telegraf collector ConfigMap** `deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml`
   `[agent]` interval 2 处 10s -> 60s(line 579 collector / line 708 webhookd 块)。

## diff

3 文件 / 4 改(insertions 4, deletions 4)