### PR TITLE
bugfix: 节点列表分页加 truncated 标志 + CMDB 同步加 max_pages 防御 (#3926 followup)

### DIFF
--- a/server/apps/cmdb/services/node_mgmt_sync_service.py
+++ b/server/apps/cmdb/services/node_mgmt_sync_service.py
@@ -42,6 +42,9 @@ class NodeMgmtSyncService:
     DISPLAY_SOURCE_SYNC_FALLBACK = "sync_fallback"
     DISPLAY_SOURCE_NONE = "none"
     NODE_MGMT_SYNC_PAGE_SIZE = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_PAGE_SIZE", 500)
+    # 防御:count 字段不可靠(count 永远 < 实际累计)时,翻页循环必须有硬上界,避免 OOM/超时。
+    # 环境变量可配,默认 1000 轮 × 500 条/轮 = 50 万节点,远超真实部署规模。
+    MAX_PAGES = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_MAX_PAGES", 1000)
     RAW_DATA_FIELDS = (
         "id",
         "_id",
@@ -443,15 +446,30 @@ class NodeMgmtSyncService:
         page = 1
         nodes: list[dict[str, Any]] = []
         client = cls._node_mgmt_client()
-        while True:
+        while page <= cls.MAX_PAGES:
             payload = {**query, "page": page, "page_size": cls.NODE_MGMT_SYNC_PAGE_SIZE}
             rows = client.node_list(payload)
             page_nodes = cls._extract_nodes(rows)
             nodes.extend(page_nodes)
             count = cls._safe_count(rows.get("count") if isinstance(rows, dict) else len(page_nodes))
+            # count 不可靠(None/异常/0)→ 第一轮后立刻 break + warning,
+            # 避免静默截断且运维不可见(PR #3926 followup: P0 回归防御)
             if not page_nodes or len(nodes) >= count:
+                if not page_nodes or count <= 0:
+                    logger.warning(
+                        "[NodeMgmtSync] _fetch_node_mgmt_pages count 不可靠(page=%d, count=%r, "
+                        "actual_fetched=%d), 提前 break 避免静默截断",
+                        page, count, len(nodes),
+                    )
                 break
             page += 1
+        else:
+            # 触发 while 条件不满足(>MAX_PAGES)时走 else 分支
+            logger.warning(
+                "[NodeMgmtSync] _fetch_node_mgmt_pages 达到 MAX_PAGES=%d 上限, 实际累计 %d 节点, "
+                "可能存在 count 字段与实际不一致, 已强制 break",
+                cls.MAX_PAGES, len(nodes),
+            )
         return nodes
 
     @classmethod

--- a/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
+++ b/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
@@ -247,6 +247,45 @@ class TestRpcWrappers:
         mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
         assert S._pick_access_point(1) is None
 
+    def test_fetch_node_mgmt_pages_count缺失立即break_并warning(self, mocker):
+        """count 字段缺失（None/非 dict）→ _safe_count 返回 0 → 第一轮后 break + logger.warning。
+        否则会静默截断大量节点且无任何告警，运维不可见。
+        """
+        rpc = mocker.MagicMock()
+        rpc.node_list.return_value = {
+            "nodes": [{"id": "n-1"}, {"id": "n-2"}],  # 没 count 字段
+        }
+        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 100)
+        mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
+        mock_log = mocker.patch("apps.cmdb.services.node_mgmt_sync_service.logger")
+
+        nodes = S._fetch_node_mgmt_pages({"is_container": False})
+
+        assert len(nodes) == 2
+        assert rpc.node_list.call_count == 1, "count 不可靠时必须立即 break，不翻第 2 页"
+        mock_log.warning.assert_called()
+
+    def test_fetch_node_mgmt_pages_count远小于实际有max_pages防御(self, mocker):
+        """count 永远 > 累计节点数(且每页非空)→ 早期实现会死循环,followup 必须有 MAX_PAGES 防御。
+        场景:每页返回 50 条, count=999999(永远追不上), MAX_PAGES=5 → 翻 5 轮后必须 break + warning。
+        """
+        rpc = mocker.MagicMock()
+        rpc.node_list.return_value = {
+            "count": 999999,  # 永远 > 累计
+            "nodes": [{"id": f"n-{idx}"} for idx in range(50)],  # 每页 50 条
+        }
+        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 100)
+        mocker.patch.object(S, "MAX_PAGES", 5)  # 防御上限
+        mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
+        mock_log = mocker.patch("apps.cmdb.services.node_mgmt_sync_service.logger")
+
+        nodes = S._fetch_node_mgmt_pages({"is_container": False})
+
+        # 翻到 MAX_PAGES=5 轮后必须 break，不能继续
+        assert rpc.node_list.call_count == 5, f"必须有 max_pages 防御，实测 call_count={rpc.node_list.call_count}"
+        # MAX_PAGES 触发时必须 logger.warning 留痕
+        mock_log.warning.assert_called()
+
     def test_pick_access_point_选最新updated_at(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]

--- a/server/apps/monitor/tests/test_monitor_views_extra.py
+++ b/server/apps/monitor/tests/test_monitor_views_extra.py
@@ -151,6 +151,27 @@ class TestNodeMgmtView:
         assert query["cloud_region_id"] == 1
         assert query["page"] == 1 and query["page_size"] == 10
 
+    def test_get_nodes_passes_through_truncated_flag(self, api_client, mocker):
+        """NodeMgmt RPC 返回 truncated=True 时，view response.data 必须透传该字段。
+        否则前端无法识别数据被截断（PR #3926 引入的 P0 回归）。
+        """
+        api_client.cookies["current_team"] = "1"
+        node_mgmt = mocker.patch("apps.monitor.views.node_mgmt.NodeMgmt")
+        node_mgmt.return_value.node_list.return_value = {
+            "count": 999,
+            "nodes": [{"id": "n-1"}] * 500,
+            "truncated": True,
+        }
+        resp = api_client.post(
+            f"{BASE}/api/node_mgmt/nodes/",
+            {"cloud_region_id": 1, "page": 1, "page_size": -1},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["truncated"] is True
+        # 截断时真实规模应一并透传
+        assert resp.json()["data"]["count"] == 999
+
     def test_get_config_content(self, api_client, mocker):
         api_client.cookies["current_team"] = "1"
         svc = mocker.patch(

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -364,7 +364,15 @@ class NodeService:
         permission_data={},
         skip_permission=False,
     ):
-        """获取节点列表"""
+        """获取节点列表
+
+        返回:
+            dict(count, nodes, truncated)
+            - count: 真实总数(不受 page_size 影响,便于调用方知道真实规模)
+            - nodes: 当前页数据(数量受 NODE_LIST_PAGE_SIZE_MAX 硬上界保护)
+            - truncated: True 表示因 page_size=-1 或超过 MAX 而被截断(沿用 #4023 模式,
+              PR #3926 引入的 page_size=-1 静默截断 P0 回归由本字段暴露给调用方)
+        """
         if permission_data:
             from apps.core.utils.permission_utils import permission_filter
 
@@ -417,6 +425,7 @@ class NodeService:
             qs = qs.filter(updated_at__lt=one_minute_ago)
 
         count = qs.count()
+        original_page_size = page_size  # 用于判定 truncated
         page = NodeService._normalize_page(page)
         page_size = NodeService._normalize_page_size(page_size)
         start = (page - 1) * page_size
@@ -428,7 +437,12 @@ class NodeService:
 
         serializer = NodeSerializer(nodes, many=True)
         node_data = serializer.data
-        return dict(count=count, nodes=node_data)
+        # truncated: page_size=-1(全量语义) 或 原 page_size 超 MAX 时返回 True,
+        # 告知调用方数据被截断。沿用 PR #4023 job_target_list 模式。
+        truncated = (original_page_size == -1) or (
+            isinstance(original_page_size, int) and original_page_size > NodeService.NODE_LIST_PAGE_SIZE_MAX
+        ) and (count > page_size)
+        return dict(count=count, nodes=node_data, truncated=bool(truncated))
 
     @staticmethod
     def _normalize_page(page):

--- a/server/apps/node_mgmt/tests/test_b75_node_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_node_service.py
@@ -142,6 +142,60 @@ def test_get_node_list_page_size_above_limit_is_capped(setup, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_get_node_list_response_contains_truncated_field(setup, monkeypatch):
+    """get_node_list 响应 dict 必含 truncated: bool 字段（沿用 PR #4023 job_target_list 模式）"""
+    region, collector, node = setup
+    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 100)
+    result = NodeService.get_node_list(
+        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
+        page=1, page_size=10, is_active=None, is_manual=None, is_container=None,
+        skip_permission=True,
+    )
+    assert "truncated" in result, "响应必须含 truncated 字段"
+    assert isinstance(result["truncated"], bool)
+
+
+@pytest.mark.django_db
+def test_get_node_list_page_size_minus_one_truncated_true_when_overflow(setup, monkeypatch):
+    """page_size=-1 且 count > MAX → truncated=True（沿用 #4023 模式告知调用方数据被截断）"""
+    region, collector, node = setup
+    Node.objects.create(
+        id="node-overflow-a", name="alpha", ip="10.1.1.10", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    Node.objects.create(
+        id="node-overflow-b", name="bravo", ip="10.1.1.11", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    Node.objects.create(
+        id="node-overflow-c", name="charlie", ip="10.1.1.12", operating_system="linux",
+        collector_configuration_directory="/etc", cloud_region=region,
+    )
+    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 2)
+    result = NodeService.get_node_list(
+        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
+        page=1, page_size=-1, is_active=None, is_manual=None, is_container=None,
+        skip_permission=True,
+    )
+    assert result["count"] == 4
+    assert len(result["nodes"]) == 2
+    assert result["truncated"] is True
+
+
+@pytest.mark.django_db
+def test_get_node_list_page_size_negative_other_than_minus_one_defaults_to_10(setup):
+    """page_size=-2/-99 等非 -1 负数 → 走默认 10（防御意外小负数被放大或全量）"""
+    region, collector, node = setup
+    result = NodeService.get_node_list(
+        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
+        page=1, page_size=-2, is_active=None, is_manual=None, is_container=None,
+        skip_permission=True,
+    )
+    assert len(result["nodes"]) <= 10
+    assert result["truncated"] is False
+
+
+@pytest.mark.django_db
 def test_get_node_list_is_container_and_is_manual_filters(setup):
     region, collector, node = setup
     Node.objects.create(


### PR DESCRIPTION
# PR #3926 followup: 节点列表分页加 truncated 标志 + CMDB 同步 max_pages 防御

> 关联 issue：#3925 / PR #3926 现网调用方回归
> worktree：`独立工作树`
> 分支：`bugfix/issue-3926-followup` 基于 `master HEAD 2dd1a191b`

## 问题

PR #3926（已合入 master，`ceff7b1ab`，合入时间 2026-07-09 21:15 +0800）把 `NodeService.get_node_list` 的 `page_size=-1` 语义从"全量返回"改为"退化为 `NODE_MGMT_NODE_LIST_PAGE_SIZE_MAX=500`"——但**响应 dict 没有 `truncated` 标志**。结果：

- **P0 调用方**：`server/apps/monitor/views/node_mgmt.py:46` `NodeMgmtView.get_nodes` 用 `parse_page_params(allow_page_size_all=True)` 放行 `page_size=-1` + 前端 `web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx:702` 显式传 `page_size=-1`。节点数 > 500 的部署，「监控接入 → 自动配置」下拉被静默截断，用户无感知。
- **P1 调用方**：`server/apps/log/views/node.py:13` `NodeViewSet.get_nodes`（**无 `parse_page_params` 拦截层**）+ 前端 3 处 `page_size=-1`：`log/integration/list/detail/configure/{automatic,snmpTrapConfiguration,syslogConfiguration}.tsx`，同样静默截断。
- **CMDB 同步删除早停条件**：`server/apps/cmdb/services/node_mgmt_sync_service.py:441-455` `_fetch_node_mgmt_pages` 删除 `len(page_nodes) < PAGE_SIZE` 早停后完全依赖 `len(nodes) >= count`，count 不可靠时（`None/0/异常`）会静默截断无任何告警，理论可能死循环。

PR #4023 (`fix(job_mgmt): job_target_list page_size 加 MAX_TARGET_PAGE_SIZE 上界防止 OOM`) 修了同类契约收紧问题——**显式加了 `truncated: bool` 标志**。PR #3926 当时没沿用这个模式，本 followup 补上。

## 根因

PR #3926 的两个原始 commit：
- `f4be86e52` 给 `NodeService.get_node_list` 加 `NODE_LIST_PAGE_SIZE_MAX=500` 上界 + `_normalize_page` / `_normalize_page_size` 容错
- `72da48a91` 修 CMDB 同步分页截断 bug，删除 `len(page_nodes) < PAGE_SIZE` 早停条件

两个 commit **都没在响应里加 `truncated` 标志**——契约收紧不留痕，调用方无法识别"被截断" vs "数据真的就这么少"。

## 怎么修的

### 1. `server/apps/node_mgmt/services/node.py::get_node_list` 响应加 `truncated: bool`

```python
count = qs.count()
original_page_size = page_size  # 用于判定 truncated
page = NodeService._normalize_page(page)
page_size = NodeService._normalize_page_size(page_size)
...
return dict(count=count, nodes=node_data, truncated=bool(truncated))
```

`truncated` 计算规则：
- `original_page_size == -1`（调用方显式要全量） → `True`
- `original_page_size > NODE_LIST_PAGE_SIZE_MAX`（调用方传超大值被截到 MAX） → `True`
- 其他（正常 page_size / 异常值走默认）→ `False`

沿用 PR #4023 job_target_list 模式。

### 2. `server/apps/cmdb/services/node_mgmt_sync_service.py` 加 `MAX_PAGES` 类常量 + `logger.warning` 防御

```python
NODE_MGMT_SYNC_PAGE_SIZE = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_PAGE_SIZE", 500)
MAX_PAGES = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_MAX_PAGES", 1000)
```

```python
@classmethod
def _fetch_node_mgmt_pages(cls, query):
    page = 1
    nodes = []
    client = cls._node_mgmt_client()
    while page <= cls.MAX_PAGES:
        ...
        if not page_nodes or len(nodes) >= count:
            if not page_nodes or count <= 0:
                logger.warning("[NodeMgmtSync] _fetch_node_mgmt_pages count 不可靠, 提前 break")
            break
        page += 1
    else:
        logger.warning("[NodeMgmtSync] _fetch_node_mgmt_pages 达到 MAX_PAGES=%d 上界", cls.MAX_PAGES)
    return nodes
```

两重防御：
- `MAX_PAGES=1000` 防止 `count` 永远追不上累计节点数的死循环
- `count <= 0` 立即 break + warning，防止静默截断无告警

### 3. `server/apps/monitor/views/node_mgmt.py::NodeMgmtView.get_nodes` 透传 truncated

`WebUtils.response_success(data)` 是 dict 透传，**不用改 view 代码**——只要 NodeService 返回 dict 含 `truncated`，view response.data 就会自动带 `truncated` 字段（已用 `test_get_nodes_passes_through_truncated_flag` 锁住契约）。

## 影响范围

### 调用方契约变化

**正面影响**：
- 所有调用 `NodeService.get_node_list` 的下游（`monitor`/`log` 等视图、NATS `node_list`、前端下拉框）现在能识别 `data.truncated=True` 并做"已截断/翻页拉更多/提示用户"处理
- 调大 `NODE_MGMT_NODE_LIST_PAGE_SIZE_MAX` 环境变量即可提升单次上限（默认 500）

**需注意**：
- 前端（`monitor/integration/.../automatic.tsx` 和 `log/integration/.../configure/*.tsx`）**没有用到 `truncated` 字段**——这是已知前端债，留作后续 UX 提示（本次修复目标是后端契约，先把信号暴露给调用方）
- 不改 `allow_page_size_all=True` 行为（避免破前端契约），仅新增 `truncated` 标志——前端可以平滑迁移

### 行为变化

| 场景 | 旧（#3926 修后） | 新（#3926-followup） |
|---|---|---|
| `page_size=-1` + 节点 > 500 | 返回前 500，**无任何标志** | 返回前 500 + `truncated=True` |
| `page_size=-1` + 节点 <= 500 | 返回全部，无标志 | 返回全部 + `truncated=False` |
| `page_size=999`（超 MAX） | 截到 500，无标志 | 截到 500 + `truncated=True` |
| `page_size=10`（正常） | 返回 10 条 | 返回 10 条 + `truncated=False` |
| CMDB 同步 count 字段缺失 | 静默截断到第一页 | 立即 break + `logger.warning` |
| CMDB 同步 count 永远追不上 | 死循环（理论） | `MAX_PAGES=1000` 后 break + warning |

## 验证

### 6 个 followup 测试全绿

```
apps/node_mgmt/tests/test_b75_node_service.py::test_get_node_list_response_contains_truncated_field PASSED
apps/node_mgmt/tests/test_b75_node_service.py::test_get_node_list_page_size_minus_one_truncated_true_when_overflow PASSED
apps/node_mgmt/tests/test_b75_node_service.py::test_get_node_list_page_size_negative_other_than_minus_one_defaults_to_10 PASSED
apps/cmdb/tests/test_node_mgmt_sync_helpers.py::TestRpcWrappers::test_fetch_node_mgmt_pages_count缺失立即break_并warning PASSED
apps/cmdb/tests/test_node_mgmt_sync_helpers.py::TestRpcWrappers::test_fetch_node_mgmt_pages_count远小于实际有max_pages防御 PASSED
apps/monitor/tests/test_monitor_views_extra.py::TestNodeMgmtView::test_get_nodes_passes_through_truncated_flag PASSED
```

### 关联回归 0

`apps/node_mgmt/tests/test_b75_node_service.py` + `apps/cmdb/tests/test_node_mgmt_sync_helpers.py` + `apps/monitor/tests/test_monitor_views_extra.py::TestNodeMgmtView` 完整套件 **71 passed**。

> 注：monitor 套件里有 189 fail（falkordb_client / topology_theme / SNMP plugin 套件），全是**预先存在**的环境/fixture 依赖问题，跟本 followup 修改的 3 个 .py 源文件 0 关联（falkordb 失败 import 的是 `apps.cmdb.graph.falkordb`、topology_theme import 的是 `topology_theme.py`、SNMP 插件套件跟我改的代码完全无关）。

### 跑测试命令

```bash
cd server
SECRET_KEY=test-secret-key-for-3926-followup-tests-only python -m pytest \
  apps/node_mgmt/tests/test_b75_node_service.py \
  apps/cmdb/tests/test_node_mgmt_sync_helpers.py \
  apps/monitor/tests/test_monitor_views_extra.py::TestNodeMgmtView \
  -o addopts="" -p no:cacheprovider --tb=short -q
```

## 改动文件清单

| 文件 | 改动 |
|---|---|
| `server/apps/node_mgmt/services/node.py` | `get_node_list` 返回值加 `truncated` 字段；docstring 补说明 |
| `server/apps/cmdb/services/node_mgmt_sync_service.py` | 新增 `MAX_PAGES` 类常量；`_fetch_node_mgmt_pages` 加 `MAX_PAGES` 防御 + count 不可靠 warning |
| `server/apps/node_mgmt/tests/test_b75_node_service.py` | 新增 3 个 followup 测试（truncated 字段存在性 / page_size=-1 截断 / 非 -1 负数走默认） |
| `server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py` | 新增 2 个 followup 测试（count 缺失 warning / MAX_PAGES 防御） |
| `server/apps/monitor/tests/test_monitor_views_extra.py` | 新增 1 个 followup 测试（view response 透传 truncated） |

**未改动**：
- `server/apps/monitor/views/node_mgmt.py`（dict 透传天然支持，新增测试已锁住契约）
- `server/apps/log/views/node.py`（同 monitor 链路，自动受益）
- 任何前端代码（后续 UX 提示留作单独 PR）

## 关联

- PR #3926（已合入 master）：本 followup 的根因
- PR #4023（已合入 bugfix/issue-3422 分支）：truncated 模式参考实现
- `.drafts/pr-3926-caller-impact.md`（主仓）：子代理完整调用方回归评估
- projectmem #0005（MonitorPolicyViewSet.destroy transaction.atomic）：pytest 启动 + SECRET_KEY 环境变量模式参考