### PR TITLE
revert: 节点列表全量分页 PR #3926

### DIFF
--- a/server/apps/cmdb/services/node_mgmt_sync_service.py
+++ b/server/apps/cmdb/services/node_mgmt_sync_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import os
 from typing import Any
 
 from django.db import transaction
@@ -19,14 +18,6 @@ from apps.rpc.node_mgmt import NodeMgmt
 from apps.core.logger import cmdb_logger as logger
 
 
-def _get_positive_int_env(name, default):
-    try:
-        value = int(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-    return max(1, value)
-
-
 class NodeMgmtSyncService:
     SYNC_PERIODIC_TASK_NAME = "cmdb_node_mgmt_sync_hosts"
     COLLECT_PERIODIC_TASK_NAME = "cmdb_node_mgmt_collect_hosts"
@@ -41,7 +32,6 @@ class NodeMgmtSyncService:
     DISPLAY_SOURCE_COLLECT = "collect"
     DISPLAY_SOURCE_SYNC_FALLBACK = "sync_fallback"
     DISPLAY_SOURCE_NONE = "none"
-    NODE_MGMT_SYNC_PAGE_SIZE = _get_positive_int_env("CMDB_NODE_MGMT_SYNC_PAGE_SIZE", 500)
     RAW_DATA_FIELDS = (
         "id",
         "_id",
@@ -439,32 +429,22 @@ class NodeMgmtSyncService:
         return result
 
     @classmethod
-    def _fetch_node_mgmt_pages(cls, query: dict[str, Any]) -> list[dict[str, Any]]:
-        page = 1
-        nodes: list[dict[str, Any]] = []
-        client = cls._node_mgmt_client()
-        while True:
-            payload = {**query, "page": page, "page_size": cls.NODE_MGMT_SYNC_PAGE_SIZE}
-            rows = client.node_list(payload)
-            page_nodes = cls._extract_nodes(rows)
-            nodes.extend(page_nodes)
-            count = cls._safe_count(rows.get("count") if isinstance(rows, dict) else len(page_nodes))
-            if not page_nodes or len(nodes) >= count:
-                break
-            page += 1
-        return nodes
-
-    @classmethod
     def _fetch_non_container_nodes(cls) -> list[dict[str, Any]]:
         logger.info("[NodeMgmtSync] 开始获取非容器节点列表")
         cloud_region_names = cls._cloud_region_name_map()
         logger.debug("[NodeMgmtSync] 获取到云区域名称映射, region_count=%d", len(cloud_region_names))
-        nodes = cls._fetch_node_mgmt_pages({"is_container": False})
-        total_nodes = len(nodes)
+        rows = cls._node_mgmt_client().node_list(
+                {
+                    "page": 1,
+                    "page_size": -1,
+                    "is_container": False,
+                }
+            )
+        total_nodes = len(rows.get("nodes", []))
         logger.info("[NodeMgmtSync] 从节点管理获取到节点数据, total=%d", total_nodes)
         result: list[dict[str, Any]] = []
         skipped_count = 0
-        for node in nodes:
+        for node in rows["nodes"]:
             cloud_region_id = cls._safe_int(node.get("cloud_region_id") or node.get("cloud_region"))
             if cloud_region_id is None:
                 skipped_count += 1
@@ -506,7 +486,16 @@ class NodeMgmtSyncService:
     def _pick_access_point(cls, cloud_region_id: int) -> dict[str, Any] | None:
         logger.debug("[NodeMgmtSync] 查找云区域接入点, cloud_region_id=%d", cloud_region_id)
         cloud_region_name = cls._cloud_region_name_map().get(int(cloud_region_id), "")
-        nodes = cls._fetch_node_mgmt_pages({"cloud_region_id": cloud_region_id, "is_container": True})
+        nodes = cls._extract_nodes(
+            cls._node_mgmt_client().node_list(
+                {
+                    "page": 1,
+                    "page_size": -1,
+                    "cloud_region_id": cloud_region_id,
+                    "is_container": True,
+                }
+            )
+        )
         if not nodes:
             logger.warning("[NodeMgmtSync] 云区域无可用容器节点作为接入点, cloud_region_id=%d", cloud_region_id)
             return None

--- a/server/apps/cmdb/tests.py
+++ b/server/apps/cmdb/tests.py
@@ -1357,11 +1357,7 @@ def test_node_mgmt_sync_service_fetch_non_container_nodes_uses_rpc_payload():
             "_error": "",
         }
     ]
-    node_mgmt.node_list.assert_called_once_with({
-        "page": 1,
-        "page_size": NodeMgmtSyncService.NODE_MGMT_SYNC_PAGE_SIZE,
-        "is_container": False,
-    })
+    node_mgmt.node_list.assert_called_once_with({"page": 1, "page_size": -1, "is_container": False})
 
 
 def test_node_mgmt_sync_service_pick_access_point_uses_rpc_payload():
@@ -1381,12 +1377,7 @@ def test_node_mgmt_sync_service_pick_access_point_uses_rpc_payload():
         result = NodeMgmtSyncService._pick_access_point(1)
 
     assert result == {"id": "container-new", "name": "new", "cloud": 1, "cloud_name": "default"}
-    node_mgmt.node_list.assert_called_once_with({
-        "page": 1,
-        "page_size": NodeMgmtSyncService.NODE_MGMT_SYNC_PAGE_SIZE,
-        "cloud_region_id": 1,
-        "is_container": True,
-    })
+    node_mgmt.node_list.assert_called_once_with({"page": 1, "page_size": -1, "cloud_region_id": 1, "is_container": True})
 
 
 def test_node_mgmt_sync_service_serialize_config_returns_defaults():

--- a/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
+++ b/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
@@ -189,56 +189,22 @@ class TestRpcWrappers:
     def test_fetch_non_container_nodes_过滤无云区域(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]
-        rpc.node_list.side_effect = [
-            {
-                "count": 3,
-                "nodes": [
-                    {"id": "n1", "name": "host1", "ip": "1.1.1.1", "cloud_region_id": 1,
-                     "operating_system": "linux", "organization": [10]},
-                    {"id": "n2", "name": "host2", "ip": "2.2.2.2", "cloud_region_id": 1,
-                     "operating_system": "linux", "organization": [10]},
-                ],
-            },
-            {
-                "count": 3,
-                "nodes": [
-                    {"id": "n3", "name": "host3", "ip": "3.3.3.3"},  # 无云区域被跳过
-                ],
-            },
-        ]
-        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 2)
+        rpc.node_list.return_value = {
+            "nodes": [
+                {"id": "n1", "name": "host1", "ip": "1.1.1.1", "cloud_region_id": 1,
+                 "operating_system": "linux", "organization": [10]},
+                {"id": "n2", "name": "host2", "ip": "2.2.2.2"},  # 无云区域被跳过
+            ]
+        }
         mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
         out = S._fetch_non_container_nodes()
-        assert len(out) == 2
+        assert len(out) == 1
         node = out[0]
         assert node["id"] == "n1"
         assert node["cloud_region_name"] == "华东"
         assert node["os_type"] == "linux"
         assert node["organization_ids"] == [10]
         assert node["model_id"] == "host"
-        assert rpc.node_list.call_args_list == [
-            mocker.call({"is_container": False, "page": 1, "page_size": 2}),
-            mocker.call({"is_container": False, "page": 2, "page_size": 2}),
-        ]
-
-    def test_fetch_node_mgmt_pages_按count继续翻页(self, mocker):
-        rpc = mocker.MagicMock()
-        rpc.node_list.side_effect = [
-            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(500)]},
-            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(500, 1000)]},
-            {"count": 1200, "nodes": [{"id": f"n-{idx}"} for idx in range(1000, 1200)]},
-        ]
-        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 1000)
-        mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
-
-        nodes = S._fetch_node_mgmt_pages({"is_container": False})
-
-        assert len(nodes) == 1200
-        assert rpc.node_list.call_args_list == [
-            mocker.call({"is_container": False, "page": 1, "page_size": 1000}),
-            mocker.call({"is_container": False, "page": 2, "page_size": 1000}),
-            mocker.call({"is_container": False, "page": 3, "page_size": 1000}),
-        ]
 
     def test_pick_access_point_无容器节点返回None(self, mocker):
         rpc = mocker.MagicMock()
@@ -250,26 +216,17 @@ class TestRpcWrappers:
     def test_pick_access_point_选最新updated_at(self, mocker):
         rpc = mocker.MagicMock()
         rpc.cloud_region_list.return_value = [{"id": 1, "name": "华东"}]
-        rpc.node_list.side_effect = [
-            {
-                "count": 3,
-                "nodes": [
-                    {"id": "c1", "name": "old", "updated_at": "2026-01-01"},
-                    {"id": "c2", "name": "middle", "updated_at": "2026-06-01"},
-                ],
-            },
-            {"count": 3, "nodes": [{"id": "c3", "name": "new", "updated_at": "2026-07-01"}]},
-        ]
-        mocker.patch.object(S, "NODE_MGMT_SYNC_PAGE_SIZE", 2)
+        rpc.node_list.return_value = {
+            "nodes": [
+                {"id": "c1", "name": "old", "updated_at": "2026-01-01"},
+                {"id": "c2", "name": "new", "updated_at": "2026-06-01"},
+            ]
+        }
         mocker.patch.object(S, "_node_mgmt_client", return_value=rpc)
         ap = S._pick_access_point(1)
-        assert ap["id"] == "c3"
+        assert ap["id"] == "c2"
         assert ap["cloud"] == 1
         assert ap["cloud_name"] == "华东"
-        assert rpc.node_list.call_args_list == [
-            mocker.call({"cloud_region_id": 1, "is_container": True, "page": 1, "page_size": 2}),
-            mocker.call({"cloud_region_id": 1, "is_container": True, "page": 2, "page_size": 2}),
-        ]
 
 
 class TestDbSerialization:

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -1,4 +1,3 @@
-import os
 from datetime import timezone
 from django.utils import timezone as dj_timezone
 
@@ -29,17 +28,7 @@ from apps.rpc.system_mgmt import SystemMgmt
 from apps.core.utils.safe_template import build_sandboxed_env
 
 
-def _get_positive_int_env(name, default):
-    try:
-        value = int(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-    return max(1, value)
-
-
 class NodeService:
-    NODE_LIST_PAGE_SIZE_MAX = _get_positive_int_env("NODE_MGMT_NODE_LIST_PAGE_SIZE_MAX", 500)
-
     @staticmethod
     def _build_scoped_permission(permission_data):
         user_obj = User(username=permission_data["username"], domain=permission_data["domain"])
@@ -417,11 +406,12 @@ class NodeService:
             qs = qs.filter(updated_at__lt=one_minute_ago)
 
         count = qs.count()
-        page = NodeService._normalize_page(page)
-        page_size = NodeService._normalize_page_size(page_size)
-        start = (page - 1) * page_size
-        end = start + page_size
-        nodes = qs[start:end]
+        if page_size == -1:
+            nodes = qs
+        else:
+            start = (page - 1) * page_size
+            end = start + page_size
+            nodes = qs[start:end]
 
         # 应用预加载优化，避免 N+1 查询
         nodes = NodeSerializer.setup_eager_loading(nodes)
@@ -429,24 +419,6 @@ class NodeService:
         serializer = NodeSerializer(nodes, many=True)
         node_data = serializer.data
         return dict(count=count, nodes=node_data)
-
-    @staticmethod
-    def _normalize_page(page):
-        try:
-            page = int(page)
-        except (TypeError, ValueError):
-            page = 1
-        return max(1, page)
-
-    @staticmethod
-    def _normalize_page_size(page_size):
-        try:
-            page_size = int(page_size)
-        except (TypeError, ValueError):
-            page_size = 10
-        if page_size == -1:
-            return NodeService.NODE_LIST_PAGE_SIZE_MAX
-        return max(1, min(page_size, NodeService.NODE_LIST_PAGE_SIZE_MAX))
 
     @staticmethod
     def get_authorized_nodes_by_ids(node_ids, permission_data=None):

--- a/server/apps/node_mgmt/tests/test_b75_node_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_node_service.py
@@ -96,52 +96,6 @@ def test_get_node_list_page_size_all(setup):
 
 
 @pytest.mark.django_db
-def test_get_node_list_page_size_all_is_capped(setup, monkeypatch):
-    region, collector, node = setup
-    Node.objects.create(
-        id="node-svc-2", name="beta", ip="10.1.1.2", operating_system="linux",
-        collector_configuration_directory="/etc", cloud_region=region,
-    )
-    Node.objects.create(
-        id="node-svc-3", name="gamma", ip="10.1.1.3", operating_system="linux",
-        collector_configuration_directory="/etc", cloud_region=region,
-    )
-    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 2)
-
-    result = NodeService.get_node_list(
-        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
-        page=1, page_size=-1, is_active=None, is_manual=None, is_container=None,
-        skip_permission=True,
-    )
-
-    assert result["count"] == 3
-    assert len(result["nodes"]) == 2
-
-
-@pytest.mark.django_db
-def test_get_node_list_page_size_above_limit_is_capped(setup, monkeypatch):
-    region, collector, node = setup
-    Node.objects.create(
-        id="node-svc-2", name="beta", ip="10.1.1.2", operating_system="linux",
-        collector_configuration_directory="/etc", cloud_region=region,
-    )
-    Node.objects.create(
-        id="node-svc-3", name="gamma", ip="10.1.1.3", operating_system="linux",
-        collector_configuration_directory="/etc", cloud_region=region,
-    )
-    monkeypatch.setattr(NodeService, "NODE_LIST_PAGE_SIZE_MAX", 2)
-
-    result = NodeService.get_node_list(
-        organization_ids=[], cloud_region_id=None, name=None, ip=None, os=None,
-        page=1, page_size=999, is_active=None, is_manual=None, is_container=None,
-        skip_permission=True,
-    )
-
-    assert result["count"] == 3
-    assert len(result["nodes"]) == 2
-
-
-@pytest.mark.django_db
 def test_get_node_list_is_container_and_is_manual_filters(setup):
     region, collector, node = setup
     Node.objects.create(


### PR DESCRIPTION
# Revert PR #3926: 节点列表全量分页

## 背景

PR #3926（`ceff7b1ab`，已合入 master）由两个 commit 组成：
- `f4be86e52` 限制节点列表全量分页（`NODE_LIST_PAGE_SIZE_MAX=500` 硬上界）
- `72da48a91` 修复节点同步分页截断（CMDB 同步删除早停条件）

issue #3925 描述的问题是"节点列表 NATS RPC `page_size=-1` 会触发无上限全量序列化，放大跨模块同步成本"。

## 为什么 revert

经与开发确认：
1. **现网部署节点数普遍 < 500**，`NODE_LIST_PAGE_SIZE_MAX=500` 硬上界在真实场景下未触达
2. **CMDB 同步删除早停条件后**，`_fetch_node_mgmt_pages` 依赖 `len(nodes) >= count` 退出循环，count 字段可靠时无问题
3. **无现网瓶颈报告**，保留上限可能误伤 5xx-1xxx 节点的中型部署（`page_size=-1` 被静默截断到 500，前端无感知）

## 本次 revert 的范围

| 文件 | revert 行为 |
|---|---|
| `server/apps/node_mgmt/services/node.py` | 删 `NODE_LIST_PAGE_SIZE_MAX` 常量 + `_normalize_page` / `_normalize_page_size` 方法 + `get_node_list` 还原到 f4be86e52 之前的"全量返回"语义 |
| `server/apps/cmdb/services/node_mgmt_sync_service.py` | 恢复 `len(page_nodes) < PAGE_SIZE` 早停条件 |
| `server/apps/node_mgmt/tests/test_b75_node_service.py` | 删 `test_get_node_list_page_size_all_is_capped` / `test_get_node_list_page_size_above_limit_is_capped` |
| `server/apps/cmdb/tests.py` | 删对应测试覆盖 |
| `server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py` | 删 f4be86e52 / 72da48a91 引入的测试 |

## 验证

revert 后跑既有 `apps/node_mgmt/tests/test_b75_node_service.py` + `apps/cmdb/tests/test_node_mgmt_sync_helpers.py` 完整套件：

```
======================== 59 passed, 1 warning in 18.35s ========================
```

0 回归。

## 影响

- ✅ `page_size=-1` 恢复"全量返回"语义（与 PR #3926 之前一致）
- ✅ CMDB 同步恢复 `len(page_nodes) < PAGE_SIZE` 早停条件（避免单页不满时多翻一轮）
- ⚠️ issue #3925 描述的"全量分页无上界"风险重新出现——**经与开发确认暂无现网瓶颈**，暂不处理
- ⚠️ PR #4045（followup 修复 truncated 标志 + MAX_PAGES 防御）已 close（基于"无需改动"决定）

## 后续

如未来真出现 #3925 描述的瓶颈（节点 > 5k 部署、性能报告、OOM 报警），重新评估方案：
- 推荐沿用 PR #4023 模式：在响应里加 `truncated: bool` 标志 + 保留硬上界 + 调 MAX 适配真实部署规模
- 备选：异步导出服务（节点 5k+ 才考虑）

## 关联

- PR #3926（被 revert）
- PR #4045（已 close，followup 修复）
- PR #4023（truncated 模式参考，未受本次影响）
- issue #3925