### PR TITLE
fix(monitor): manual.tsx 删死代码 + 加契约 test 守护默认 interval 60s

### DIFF
--- a/server/apps/monitor/tests/test_collector_yaml_interval.py
+++ b/server/apps/monitor/tests/test_collector_yaml_interval.py
@@ -1,0 +1,64 @@
+"""锁定 K8s / webhookd collector yaml 的 Telegraf [agent] interval 必须 = "60s" 的回归测试。
+
+业务规则：监控采集频率统一为 60s（见 PR #4044 commit 5be4782774）。
+两个 ConfigMap 中的 telegraf.conf 内嵌配置里，[agent] section 的 interval
+值如果被改回 10s 或其它高频值，新部署的 collector 会对目标端发起高频采集，
+导致拉端/拉后端。该测试锁住 yaml 内 [agent].interval = "60s"。
+"""
+import re
+from pathlib import Path
+
+# pytest 在 server/ 目录运行,test 文件位于 server/apps/monitor/tests/,
+# __file__.parents[3] 指向 server/, parents[4] 指向仓库根。
+REPO_ROOT = Path(__file__).resolve().parents[4]
+EXPECTED_INTERVAL = "60s"
+
+# 每个 yaml 可能包含多个 [agent] section (例如 deploy 这份 collector
+# ConfigMap + 同文件中的 webhookd ConfigMap),全部都必须命中。
+COLLECTOR_YAML_PATHS = [
+    REPO_ROOT / "deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml",
+    REPO_ROOT / "agents/webhookd/bk-lite-metric-collector.yaml",
+]
+
+# 匹配 "[agent]" 行之后、紧随其后的 "interval = "60s"" 行。
+# yaml 中 [agent] 通常嵌在 literal block (|) 内,前面会有 yaml 缩进;
+# 该缩进层级比 interval 的缩进浅 2 格,因此捕获时只关心同 block 内紧邻
+# 的下一行配置。
+_AGENT_INTERVAL_RE = re.compile(
+    r"^\s*\[agent\][^\n]*\n[ \t]+interval[ \t]*=[ \t]*\"([^\"]+)\"",
+    re.MULTILINE,
+)
+
+
+def _extract_agent_intervals(yaml_text):
+    """提取 yaml 中每个 [agent] section 的 interval 值列表(按出现顺序)。"""
+    return _AGENT_INTERVAL_RE.findall(yaml_text)
+
+
+def test_collector_yaml_files_exist():
+    """两个 collector yaml 必须存在;不存在即视为回归(被误删)。"""
+    missing = [str(p) for p in COLLECTOR_YAML_PATHS if not p.exists()]
+    assert not missing, (
+        "以下 collector yaml 缺失,无法守护 [agent] interval 契约:\n"
+        + "\n".join(f"  {p}" for p in missing)
+    )
+
+
+def test_collector_yaml_agent_interval_is_60s():
+    """每个 collector yaml 的所有 [agent] section 中,interval 必须 = "60s"。"""
+    violations = []
+    for path in COLLECTOR_YAML_PATHS:
+        assert path.exists(), f"yaml 缺失: {path}"
+        text = path.read_text(encoding="utf-8")
+        intervals = _extract_agent_intervals(text)
+        assert intervals, f"{path} 中未找到 [agent] interval 配置"
+
+        for idx, value in enumerate(intervals, start=1):
+            if value != EXPECTED_INTERVAL:
+                violations.append((str(path), idx, value))
+
+    assert not violations, (
+        "以下 [agent] section 的 interval 不为 "
+        f"{EXPECTED_INTERVAL!r},违反 60s 采集频率契约:\n"
+        + "\n".join(f"  {p} [agent#{i}]: interval = {v!r}" for p, i, v in violations)
+    )

--- a/server/apps/monitor/tests/test_custom_pull_default_interval.py
+++ b/server/apps/monitor/tests/test_custom_pull_default_interval.py
@@ -1,0 +1,36 @@
+"""锁定 custom_pull_plugin.DEFAULT_PULL_UI_TEMPLATE.interval.default_value = 60 的回归测试。
+
+业务规则：监控采集频率统一为 60s（见 PR #4044 commit 5be4782774，
+. projectmem/summary.md Decisions）。
+custom_pull_plugin.DEFAULT_PULL_UI_TEMPLATE 是自定义拉取监控实例的 UI
+表单模板，新建实例时 interval 字段默认值必须为 60s，防止后续误改回 10s。
+"""
+from apps.monitor.services.custom_pull_plugin import DEFAULT_PULL_UI_TEMPLATE
+
+EXPECTED_DEFAULT_INTERVAL_SECONDS = 60
+
+
+def _find_interval_field(template):
+    """从 form_fields 中定位 name == 'interval' 的字段。
+
+    DEFAULT_PULL_UI_TEMPLATE 的 interval 位于 form_fields 列表内
+    （不是模板顶层 key），所以需要遍历一次。
+    """
+    form_fields = template.get("form_fields") or []
+    for field in form_fields:
+        if field.get("name") == "interval":
+            return field
+    return None
+
+
+def test_default_pull_ui_template_interval_default_value_is_60_seconds():
+    """custom_pull_plugin DEFAULT_PULL_UI_TEMPLATE 中 interval 字段默认值必须 = 60s。"""
+    interval_field = _find_interval_field(DEFAULT_PULL_UI_TEMPLATE)
+    assert interval_field is not None, (
+        "DEFAULT_PULL_UI_TEMPLATE.form_fields 中未找到 name == 'interval' 的字段"
+    )
+    actual = interval_field.get("default_value")
+    assert actual == EXPECTED_DEFAULT_INTERVAL_SECONDS, (
+        f"DEFAULT_PULL_UI_TEMPLATE.interval.default_value 应为 "
+        f"{EXPECTED_DEFAULT_INTERVAL_SECONDS}, 实际为 {actual!r}"
+    )

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx
@@ -36,10 +36,6 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({
     });
   }, [pluginName, objectName]);
 
-  const collectType = useMemo(() => {
-    return configsInfo.collect_type || '';
-  }, [configsInfo]);
-
   const formItems = useMemo(() => {
     return configsInfo.formItems;
   }, [configsInfo]);
@@ -51,7 +47,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({
 
   const initData = () => {
     form.setFieldsValue({
-      interval: collectType === 'http' ? 60 : 60,
+      interval: 60,
       ...configsInfo.defaultForm,
     });
   };


### PR DESCRIPTION
## 改动

### 1. web/manual.tsx 死代码清理
- 删除未使用的 `collectType` useMemo (5 行)
- 简化 `initData()` 的 interval 赋值: `collectType === 'http' ? 60 : 60` → `60` (原三元两个分支都是 60，纯死代码)

### 2. server 契约 test 守护默认 interval 60s (PR #4044 回归护栏)
- `tests/test_collector_yaml_interval.py` (新): 验证内置 collector yaml 默认 interval = 60s
- `tests/test_custom_pull_default_interval.py` (新): 验证自定义拉取监控实例默认 interval = 60s

## 动机
- PR #4044 已把全局默认采集频率从 10s 统一为 60s，本次加契约 test 防止后续被回归
- manual.tsx 的 `collectType` 三元是 collectType 拆分支后留下的死代码，顺手清理

## 文件改动
```
3 files changed, 101 insertions(+), 5 deletions(-)
+ server/apps/monitor/tests/test_collector_yaml_interval.py       (64 lines)
+ server/apps/monitor/tests/test_custom_pull_default_interval.py (36 lines)
M web/src/app/monitor/(pages)/integration/list/detail/configure/manual.tsx
```

## 验证
- `pytest apps/monitor/tests/test_collector_yaml_interval.py test_custom_pull_default_interval.py` 3/3 PASS
- `pnpm type-check` manual.tsx 0 错