### PR TITLE
optimization: 移除 agent.py 重复的 _build_agui_sse_line 助手

### DIFF
--- a/server/apps/opspilot/utils/chat_flow_utils/nodes/agent/agent.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/nodes/agent/agent.py
@@ -2,7 +2,6 @@
 智能体节点
 """
 
-import json
 import time
 from typing import Any, Dict
 
@@ -14,12 +13,9 @@ from apps.opspilot.services.chat_service import ChatService, chat_service
 from apps.opspilot.services.skill_package.runtime import build_skill_package_prompt, build_skill_package_strategy, hydrate_skill_packages
 from apps.opspilot.services.workflow_attachment_service import build_signed_attachment_download_url
 from apps.opspilot.utils.agent_factory import create_agent_instance
+from apps.opspilot.utils.agui_chat import _build_sse_line
 from apps.opspilot.utils.chat_flow_utils.engine.core.base_executor import BaseNodeExecutor
 from apps.opspilot.utils.prompt_utils import resolve_skill_params
-
-
-def _build_agui_sse_line(payload: dict) -> str:
-    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
 def _build_wiki_citations_event(extra_config: dict | None) -> dict | None:
@@ -313,7 +309,7 @@ class AgentNode(BaseNodeExecutor):
 
                 wiki_citations_event = _build_wiki_citations_event(request.extra_config)
                 if wiki_citations_event:
-                    yield _build_agui_sse_line(wiki_citations_event)
+                    yield _build_sse_line(wiki_citations_event)
 
                 chunk_index = 0
                 async for sse_line in graph.agui_stream(request):
@@ -327,7 +323,7 @@ class AgentNode(BaseNodeExecutor):
                     "error": f"节点执行错误: {str(e)}",
                     "timestamp": int(time.time() * 1000),
                 }
-                yield _build_agui_sse_line(error_data)
+                yield _build_sse_line(error_data)
 
         return generate_agui_stream()
 


### PR DESCRIPTION
agent.py:21-22 新增的 _build_agui_sse_line 与 agui_chat.py:83 已有的 _build_sse_line 助手函数体完全一致(`return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"`),重复定义违反"import as 重命名若有重复,原则上只导一个"原则。

修复:删除 _build_agui_sse_line 本地实现,顶部加 `from apps.opspilot.utils.agui_chat import _build_sse_line`,2 处调用点改 _build_sse_line。json 模块随之不再使用,删除 import。

测试: test_workflow_agent_node_wiki_citations_dispatch + test_agui_chat_wiki_citations_dispatch + test_bot_view_publish_chat_application 共 10 个测试全过。