### PR TITLE
fix(fusion-collector): 镜像内补齐工作目录 VERSION 文件

### DIFF
--- a/agents/fusion-collector/agent/Dockerfile
+++ b/agents/fusion-collector/agent/Dockerfile
@@ -21,6 +21,11 @@ ADD ./startup.sh startup.sh
 ADD ./snmptrap-to-socket ./bin/snmptrap-to-socket
 ADD ./misc misc
 
+# sidecar 从工作目录读 VERSION 返回版本信息；与发布 zip 包一致，
+# 从 misc/VERSION（版本真源）派生纯版本号文件
+RUN . /opt/fusion-collectors/misc/VERSION && \
+    echo "${LINUX_SIDECAR_VERSION}" > /opt/fusion-collectors/VERSION
+
 RUN bash -c "mkdir -p /opt/fusion-collectors/{bin,cache,log,generated} /opt/release && \
     chmod +x /opt/fusion-collectors/startup.sh /opt/fusion-collectors/bin/snmptrap-to-socket"
 


### PR DESCRIPTION
## 问题

sidecar 从工作目录 `/opt/fusion-collectors/VERSION` 读取纯版本号返回版本信息。Linux 节点发布 zip 的包根一直有该文件（打包流程从 `misc/VERSION` 派生生成），但**容器镜像里缺失**（实机容器内验证 `ls /opt/fusion-collectors/VERSION` 不存在），容器内 sidecar 无法上报版本。

## 修复

Dockerfile 在 `ADD ./misc misc` 之后从 `misc/VERSION`（版本真源，不硬编码）派生：

```dockerfile
RUN . /opt/fusion-collectors/misc/VERSION && \
    echo "${LINUX_SIDECAR_VERSION}" > /opt/fusion-collectors/VERSION
```

## 验证

- 最小上下文真实 `docker build` + `docker run`：产出恰为 `1.0.1`+换行（6 字节，无引号/变量名），与发布 zip 内 VERSION 的 sha256 一致；
- 部署侧 build-packages（k8s job 与 bootstrap.sh）会对同一路径 `echo >` 覆盖写：实验回放确认幂等、内容不变，互不影响；
- `misc/VERSION` 为 LF 行尾（CRLF 会污染派生值，当前无此问题，已留档）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)