### PR TITLE
fix(custom-chat): 引导语字号小一号 + 去加粗

### DIFF
--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -1077,7 +1077,7 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
               </div>
               <div
                 dangerouslySetInnerHTML={{ __html: guideData.renderedHtml }}
-                className={`${styles.markdownBody} flex-1 p-3 bg-[var(--color-bg)] rounded-lg`}
+                className={`${styles.markdownBody} ${styles.guideText} flex-1 p-3 bg-[var(--color-bg)] rounded-lg`}
               />
             </div>
           )}

--- a/web/src/app/opspilot/components/custom-chat/index.module.scss
+++ b/web/src/app/opspilot/components/custom-chat/index.module.scss
@@ -170,6 +170,16 @@
     height: 30px;
   }
 
+  // 引导语(默认欢迎语)字号比 markdownBody 小一档,不影响 LLM 回复正文
+  .guideText {
+    font-size: 12px;
+    line-height: 1.6;
+    // markdownBody 默认 h1-h6 + strong 都是 600 (semibold),引导语不加重
+    h1, h2, h3, h4, h5, h6, strong, b {
+      font-weight: 400;
+    }
+  }
+
   .sender {
     background-color: var(--color-bg);
   }


### PR DESCRIPTION
chat 面板"测试"区右侧的默认欢迎语(您好,请问有什么可以帮您的吗? ...),
之前跟 LLM 回复正文用同一套 markdownBody 样式(14px + h1-h6/strong 默认 600), 字号看着太大、加粗看着不必要。

新增一个 .guideText class,只挂在引导语那一个 div 上:
- font-size: 12px(比 markdownBody 默认 14px 小一档)
- h1-h6/strong/b 全部 font-weight: 400(去掉 markdownBody 默认的 600)
- 嵌套选择器 .guideText h1, h2, ... 只匹配引导语内部,LLM 回复正文 / 文档渲染 完全不受影响(它们没 .guideText class)