### PR TITLE
bugfix: 统一分类训练脚本环境配置校验

### DIFF
--- a/algorithms/classify_image_classification_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_image_classification_server/support-files/scripts/train-model.sh
@@ -20,10 +20,10 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"
+# MinIO 连接配置（必须通过环境变量提供）
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -31,8 +31,8 @@ MINIO_BUCKET="${1:-${MINIO_BUCKET:-datasets}}"
 DATASET_NAME="${2:-${DATASET_NAME:-image_classification_train_data.zip}}"
 CONFIG_NAME="$3"
 
-# MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://127.0.0.1:15000}"
+# MLflow 配置（必须通过环境变量提供）
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -62,16 +62,7 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方强制校验，缺失时立即退出。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/algorithms/classify_log_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_log_server/support-files/scripts/train-model.sh
@@ -20,10 +20,10 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"
+# MinIO 连接配置（必须通过环境变量提供）
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -31,8 +31,8 @@ MINIO_BUCKET="${1:-${MINIO_BUCKET:-datasets}}"
 DATASET_NAME="${2:-${DATASET_NAME:-log_train_data.zip}}"
 CONFIG_NAME="$3"
 
-# MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://127.0.0.1:15000}"
+# MLflow 配置（必须通过环境变量提供）
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -62,16 +62,7 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方强制校验，缺失时立即退出。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/algorithms/classify_object_detection_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_object_detection_server/support-files/scripts/train-model.sh
@@ -20,10 +20,10 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"
+# MinIO 连接配置（必须通过环境变量提供）
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -31,8 +31,8 @@ MINIO_BUCKET="${1:-${MINIO_BUCKET:-datasets}}"
 DATASET_NAME="${2:-${DATASET_NAME:-object_detection_train_data.zip}}"
 CONFIG_NAME="$3"
 
-# MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://127.0.0.1:15000}"
+# MLflow 配置（必须通过环境变量提供）
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -62,16 +62,7 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方强制校验，缺失时立即退出。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/algorithms/classify_text_classification_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_text_classification_server/support-files/scripts/train-model.sh
@@ -20,10 +20,10 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"
+# MinIO 连接配置（必须通过环境变量提供）
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -31,8 +31,8 @@ MINIO_BUCKET="${1:-${MINIO_BUCKET:-datasets}}"
 DATASET_NAME="${2:-${DATASET_NAME:-text_classification_train_data.zip}}"
 CONFIG_NAME="$3"
 
-# MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://127.0.0.1:15000}"
+# MLflow 配置（必须通过环境变量提供）
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -62,16 +62,7 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方强制校验，缺失时立即退出。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/algorithms/classify_timeseries_server/support-files/scripts/train-model.sh
+++ b/algorithms/classify_timeseries_server/support-files/scripts/train-model.sh
@@ -22,10 +22,10 @@ DOWNLOAD_DIR="${DOWNLOAD_DIR:-${SCRIPT_DIR}/data/downloads}"
 EXTRACT_DIR="${EXTRACT_DIR:-${SCRIPT_DIR}/data/datasets}"
 CONFIG_DIR="${CONFIG_DIR:-${SCRIPT_DIR}/data/configs}"
 
-# MinIO 连接配置（通过环境变量配置）
-MINIO_ENDPOINT="${MINIO_ENDPOINT:-}"
-MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:-}"
-MINIO_SECRET_KEY="${MINIO_SECRET_KEY:-}"
+# MinIO 连接配置（必须通过环境变量提供）
+MINIO_ENDPOINT="${MINIO_ENDPOINT:?必须设置 MINIO_ENDPOINT 环境变量}"
+MINIO_ACCESS_KEY="${MINIO_ACCESS_KEY:?必须设置 MINIO_ACCESS_KEY 环境变量}"
+MINIO_SECRET_KEY="${MINIO_SECRET_KEY:?必须设置 MINIO_SECRET_KEY 环境变量}"
 MINIO_USE_HTTPS="${MINIO_USE_HTTPS:-0}"
 
 # ==================== 参数解析 ====================
@@ -33,8 +33,8 @@ MINIO_BUCKET="${1:-${MINIO_BUCKET:-datasets}}"
 DATASET_NAME="${2:-${DATASET_NAME:-timeseries_train_data.zip}}"
 CONFIG_NAME="$3"
 
-# MLflow 配置
-MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:-http://10.10.41.149:15000}"
+# MLflow 配置（必须通过环境变量提供）
+MLFLOW_TRACKING_URI="${MLFLOW_TRACKING_URI:?必须设置 MLFLOW_TRACKING_URI 环境变量}"
 
 # ==================== 函数定义 ====================
 function log_info() {
@@ -64,16 +64,7 @@ fi
 
 log_info "使用下载脚本: ${DOWNLOAD_SCRIPT}"
 
-# 检查 MinIO 连接配置
-if [ -z "${MINIO_ENDPOINT}" ] || [ -z "${MINIO_ACCESS_KEY}" ] || [ -z "${MINIO_SECRET_KEY}" ]; then
-    log_error "MinIO 连接信息未配置"
-    log_error "请设置以下环境变量："
-    log_error "  MINIO_ENDPOINT=10.10.41.149:9000"
-    log_error "  MINIO_ACCESS_KEY=minio"
-    log_error "  MINIO_SECRET_KEY=your-secret-key"
-    log_error "  MINIO_USE_HTTPS=0  # 可选，默认为 0"
-    exit 1
-fi
+# MinIO / MLflow 连接配置已在上方强制校验，缺失时立即退出。
 
 log_info "MinIO Endpoint: ${MINIO_ENDPOINT}"
 

--- a/server/apps/core/tests/test_issue_4008_train_scripts_fail_fast.py
+++ b/server/apps/core/tests/test_issue_4008_train_scripts_fail_fast.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+TRAIN_SCRIPTS = [
+    REPOSITORY_ROOT / "algorithms" / service / "support-files" / "scripts" / "train-model.sh"
+    for service in (
+        "classify_image_classification_server",
+        "classify_log_server",
+        "classify_object_detection_server",
+        "classify_text_classification_server",
+        "classify_timeseries_server",
+    )
+]
+REQUIRED_VARIABLES = (
+    "MINIO_ENDPOINT",
+    "MINIO_ACCESS_KEY",
+    "MINIO_SECRET_KEY",
+    "MLFLOW_TRACKING_URI",
+)
+
+
+@pytest.mark.parametrize("script", TRAIN_SCRIPTS, ids=lambda path: path.parents[2].name)
+def test_train_script_has_no_internal_address_and_valid_shell_syntax(script):
+    text = script.read_text()
+
+    assert "10.10.41.149" not in text
+    subprocess.run(["bash", "-n", str(script)], check=True)
+
+
+@pytest.mark.parametrize("script", TRAIN_SCRIPTS, ids=lambda path: path.parents[2].name)
+@pytest.mark.parametrize("missing_variable", REQUIRED_VARIABLES)
+def test_train_script_fails_fast_when_required_variable_is_missing(script, missing_variable):
+    env = os.environ.copy()
+    env.update(
+        {
+            "MINIO_ENDPOINT": "minio:9000",
+            "MINIO_ACCESS_KEY": "access-key",
+            "MINIO_SECRET_KEY": "secret-key",
+            "MLFLOW_TRACKING_URI": "http://mlflow:15000",
+        }
+    )
+    env.pop(missing_variable)
+
+    result = subprocess.run(
+        ["bash", str(script)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert missing_variable in result.stderr
+    assert "10.10.41.149" not in result.stderr


### PR DESCRIPTION
## 问题

分类模型训练脚本本应只从部署或运维环境接收 MinIO、MLflow 连接配置，避免把环境专属地址写入仓库或日志。当前 5 个服务仍在错误提示中回显固定内网地址，其中 timeseries 还会在未配置 MLflow 时静默连接该地址，造成配置边界不一致。

## 根因

6 个算法服务各自维护独立的 `train-model.sh`。此前安全修复只在 anomaly 服务建立了“必需连接配置必须显式注入”的契约，其余副本仍保留旧的空值检查和默认地址，因此同一训练入口出现不同的配置语义。

## 怎么修的

- 将 image classification、log、object detection、text classification、timeseries 的 MinIO endpoint、access key、secret key 和 MLflow URI 统一改为 shell 参数展开的必需配置，缺失或为空时立即退出。
- 删除错误提示和默认值中的固定内网地址；`MINIO_USE_HTTPS` 继续保留可选默认值。
- 增加跨 5 个服务的回归测试，逐一验证四个必需变量的 fail-fast 行为、地址脱敏和 shell 语法。

## 影响范围

- 仅修改 5 个算法训练镜像内的离线训练脚本，不影响在线推理接口、数据模型或 NATS 协议。
- server → webhookd 的 Docker/Kubernetes 训练链路已显式校验并传入上述配置，现有自动训练调用保持兼容。
- 直接手工运行脚本且依赖旧默认值的流程会改为明确失败；这是负责人确认的统一 fail-fast 方案，调用方需先提供完整环境变量。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MLOps 训练操作\nserver/apps/mlops/views"]
        T2["手工执行\ntrain-model.sh"]
    end

    W["WebhookClient.train\nwebhook_client.py"]

    subgraph A["训练调度层"]
        A1["Docker / Kubernetes train\nagents/webhookd/mlops"]
        A2["显式注入连接配置"]
    end

    subgraph C["算法训练层"]
        C1["必需环境变量校验\ntrain-model.sh"]
        C2["下载数据并启动训练"]
    end

    T1 --> W --> A1 --> A2 --> C1 --> C2
    T2 --> C1
    C1 -. "配置缺失" .-> E["立即报错退出"]
```

## 验证

- RED：修改前新增测试首先因脚本包含固定内网地址失败。
- GREEN：`apps/core/tests/test_issue_4008_train_scripts_fail_fast.py`，25 passed。
- 覆盖 5 个脚本 × 4 个必需变量的缺失场景，并执行 `bash -n` 语法检查。

关联 Issue #4008。
