### PR TITLE
fix(node_mgmt): 原子限制安装令牌使用次数并保持固定有效期

### DIFF
--- a/server/apps/node_mgmt/services/install_token.py
+++ b/server/apps/node_mgmt/services/install_token.py
@@ -7,6 +7,38 @@ from apps.node_mgmt.constants.installer import InstallerConstants
 class InstallTokenService:
     """节点安装令牌服务 - 管理限时安装令牌"""
 
+    USAGE_COUNT_CACHE_SUFFIX = "usage_count"
+
+    @classmethod
+    def _consume_token_usage(
+        cls,
+        cache_key: str,
+        data: dict,
+        max_usage: int,
+        timeout: int,
+        invalid_message: str,
+        exceeded_message: str,
+    ) -> int:
+        """Atomically consume one use without extending the token lifetime."""
+        usage_cache_key = f"{cache_key}:{cls.USAGE_COUNT_CACHE_SUFFIX}"
+
+        # ``add`` is atomic on supported cache backends. Seeding from the
+        # payload keeps tokens issued before the separate counter compatible.
+        cache.add(usage_cache_key, data.get("usage_count", 0), timeout=timeout)
+        try:
+            usage_count = cache.incr(usage_cache_key)
+        except ValueError:
+            raise BaseAppException(invalid_message)
+
+        if usage_count > max_usage:
+            # Keep the exhausted counter as a tombstone until its TTL ends.
+            # A request that already read ``data`` must not be able to recreate
+            # the counter from the stale payload after this token is deleted.
+            cache.delete(cache_key)
+            raise BaseAppException(exceeded_message)
+
+        return usage_count
+
     @staticmethod
     def generate_install_token(
         node_id: str,
@@ -71,20 +103,15 @@ class InstallTokenService:
         if not data:
             raise BaseAppException("Invalid or expired token")
 
-        # 检查使用次数
-        usage_count = data.get("usage_count", 0)
         max_usage = data.get("max_usage", InstallerConstants.INSTALL_TOKEN_MAX_USAGE)
-
-        if usage_count >= max_usage:
-            # 超过最大使用次数,删除令牌
-            cache.delete(cache_key)
-            raise BaseAppException(f"Token has exceeded maximum usage limit ({max_usage} times)")
-
-        # 增加使用次数
-        data["usage_count"] = usage_count + 1
-
-        # 更新 cache
-        cache.set(cache_key, data, timeout=InstallerConstants.INSTALL_TOKEN_EXPIRE_TIME)
+        usage_count = InstallTokenService._consume_token_usage(
+            cache_key=cache_key,
+            data=data,
+            max_usage=max_usage,
+            timeout=InstallerConstants.INSTALL_TOKEN_EXPIRE_TIME,
+            invalid_message="Invalid or expired token",
+            exceeded_message=f"Token has exceeded maximum usage limit ({max_usage} times)",
+        )
 
         return {
             "node_id": data["node_id"],
@@ -96,7 +123,7 @@ class InstallTokenService:
             "organizations": data["organizations"],
             "node_name": data["node_name"],
             "cpu_architecture": data.get("cpu_architecture", ""),
-            "remaining_usage": max_usage - data["usage_count"],
+            "remaining_usage": max_usage - usage_count,
         }
 
     @staticmethod
@@ -140,23 +167,18 @@ class InstallTokenService:
         if not data:
             raise BaseAppException("Invalid or expired download token")
 
-        # 检查使用次数
-        usage_count = data.get("usage_count", 0)
         max_usage = data.get("max_usage", InstallerConstants.DOWNLOAD_TOKEN_MAX_USAGE)
-
-        if usage_count >= max_usage:
-            # 超过最大使用次数,删除令牌
-            cache.delete(cache_key)
-            raise BaseAppException(f"Download token has exceeded maximum usage limit ({max_usage} times)")
-
-        # 增加使用次数
-        data["usage_count"] = usage_count + 1
-
-        # 更新 cache
-        cache.set(cache_key, data, timeout=InstallerConstants.DOWNLOAD_TOKEN_EXPIRE_TIME)
+        usage_count = InstallTokenService._consume_token_usage(
+            cache_key=cache_key,
+            data=data,
+            max_usage=max_usage,
+            timeout=InstallerConstants.DOWNLOAD_TOKEN_EXPIRE_TIME,
+            invalid_message="Invalid or expired download token",
+            exceeded_message=f"Download token has exceeded maximum usage limit ({max_usage} times)",
+        )
 
         return {
             "package_id": data["package_id"],
             "node_id": data["node_id"],
-            "remaining_usage": max_usage - data["usage_count"],
+            "remaining_usage": max_usage - usage_count,
         }

--- a/server/apps/node_mgmt/tests/test_slice_install_token_service.py
+++ b/server/apps/node_mgmt/tests/test_slice_install_token_service.py
@@ -1,5 +1,7 @@
-import pydantic.root_model  # noqa
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
+import pydantic.root_model  # noqa
 import pytest
 
 from django.core.cache import cache
@@ -81,9 +83,75 @@ class TestValidateInstallToken:
         # 第一次使用后剩余 = max - 1
         assert result["remaining_usage"] == InstallerConstants.INSTALL_TOKEN_MAX_USAGE - 1
 
-        # cache 中 usage_count 已自增
+        # payload 不再改写，独立计数键原子递增
         cache_key = f"{InstallerConstants.INSTALL_TOKEN_CACHE_PREFIX}:{token}"
-        assert cache.get(cache_key)["usage_count"] == 1
+        usage_cache_key = f"{cache_key}:{InstallTokenService.USAGE_COUNT_CACHE_SUFFIX}"
+        assert cache.get(cache_key)["usage_count"] == 0
+        assert cache.get(usage_cache_key) == 1
+
+    def test_validation_does_not_extend_token_ttl(self):
+        token = self._gen()
+
+        with patch.object(cache, "set", wraps=cache.set) as cache_set:
+            InstallTokenService.validate_and_get_token_data(token)
+
+        cache_set.assert_not_called()
+
+    def test_concurrent_validation_never_exceeds_max_usage(self):
+        token = self._gen()
+
+        def consume():
+            try:
+                InstallTokenService.validate_and_get_token_data(token)
+                return True
+            except BaseAppException:
+                return False
+
+        attempts = InstallerConstants.INSTALL_TOKEN_MAX_USAGE * 2
+        with ThreadPoolExecutor(max_workers=attempts) as executor:
+            results = list(executor.map(lambda _: consume(), range(attempts)))
+
+        assert sum(results) == InstallerConstants.INSTALL_TOKEN_MAX_USAGE
+
+    def test_legacy_payload_usage_count_seeds_atomic_counter(self):
+        token = self._gen()
+        cache_key = f"{InstallerConstants.INSTALL_TOKEN_CACHE_PREFIX}:{token}"
+        payload = cache.get(cache_key)
+        payload["usage_count"] = 2
+        cache.set(cache_key, payload, timeout=InstallerConstants.INSTALL_TOKEN_EXPIRE_TIME)
+
+        result = InstallTokenService.validate_and_get_token_data(token)
+
+        usage_cache_key = f"{cache_key}:{InstallTokenService.USAGE_COUNT_CACHE_SUFFIX}"
+        assert cache.get(usage_cache_key) == 3
+        assert result["remaining_usage"] == InstallerConstants.INSTALL_TOKEN_MAX_USAGE - 3
+
+    def test_stale_inflight_payload_cannot_recreate_exhausted_counter(self):
+        token = self._gen()
+        cache_key = f"{InstallerConstants.INSTALL_TOKEN_CACHE_PREFIX}:{token}"
+        stale_payload = cache.get(cache_key)
+
+        for _ in range(InstallerConstants.INSTALL_TOKEN_MAX_USAGE):
+            InstallTokenService.validate_and_get_token_data(token)
+        with pytest.raises(BaseAppException):
+            InstallTokenService.validate_and_get_token_data(token)
+
+        usage_cache_key = f"{cache_key}:{InstallTokenService.USAGE_COUNT_CACHE_SUFFIX}"
+        assert cache.get(cache_key) is None
+        assert cache.get(usage_cache_key) == InstallerConstants.INSTALL_TOKEN_MAX_USAGE + 1
+
+        with pytest.raises(BaseAppException) as exc:
+            InstallTokenService._consume_token_usage(
+                cache_key=cache_key,
+                data=stale_payload,
+                max_usage=InstallerConstants.INSTALL_TOKEN_MAX_USAGE,
+                timeout=InstallerConstants.INSTALL_TOKEN_EXPIRE_TIME,
+                invalid_message="Invalid or expired token",
+                exceeded_message="Token has exceeded maximum usage limit",
+            )
+
+        assert "exceeded maximum usage" in str(exc.value)
+        assert cache.get(usage_cache_key) == InstallerConstants.INSTALL_TOKEN_MAX_USAGE + 2
 
     def test_invalid_token_raises(self):
         with pytest.raises(BaseAppException) as exc:
@@ -128,6 +196,14 @@ class TestDownloadToken:
         with pytest.raises(BaseAppException) as exc:
             InstallTokenService.validate_and_get_download_token_data("nope")
         assert "Invalid or expired download token" in str(exc.value)
+
+    def test_download_validation_does_not_extend_token_ttl(self):
+        token = InstallTokenService.generate_download_token(package_id="p", node_id="n")
+
+        with patch.object(cache, "set", wraps=cache.set) as cache_set:
+            InstallTokenService.validate_and_get_download_token_data(token)
+
+        cache_set.assert_not_called()
 
     def test_download_token_exhaustion_deletes_and_raises(self):
         token = InstallTokenService.generate_download_token(package_id="p", node_id="n")


### PR DESCRIPTION
## 问题

安装令牌与下载令牌原先采用读取、递增、回写缓存的非原子流程；并发请求可能突破次数上限，每次校验还会重置有效期。

## 修改

- 使用独立计数键与缓存原子 `add`/`incr` 消费次数
- 保留耗尽计数作为 TTL 内墓碑，避免并发旧载荷重新创建计数
- 兼容旧令牌载荷中的 `usage_count`
- 增加并发、固定 TTL、旧载荷与 ABA 场景测试

## 验证

- 关联测试：`apps/node_mgmt/tests/test_slice_install_token_service.py`
- 结果：13 passed
- tested commit: `e674d386dfe162275169c9268ac2f5ef0cfc57f8`

## 风险

中。缓存后端需支持原子 `add`/`incr`；已覆盖并发上限及旧令牌兼容。请 @zhouzhuangjie review。

Closes #4074