### PR TITLE
fix(cmdb): 修正容器节点筛选参数

### DIFF
--- a/server/apps/cmdb/tests/test_collect_views_actions.py
+++ b/server/apps/cmdb/tests/test_collect_views_actions.py
@@ -138,14 +138,19 @@ def test_nodes_invalid_page(superuser):
 @pytest.mark.django_db
 def test_nodes_success(superuser, monkeypatch):
     request = _req("get", superuser, query={"page": "1", "page_size": "10"}, current_team="1")
-    monkeypatch.setattr(
-        "apps.cmdb.views.collect.NodeMgmt.node_list",
-        lambda self, query_data: {"count": 1, "nodes": [{"id": "n1"}]},
-    )
+    captured_query = {}
+
+    def fake_node_list(self, query_data):
+        captured_query.update(query_data)
+        return {"count": 1, "nodes": [{"id": "n1"}]}
+
+    monkeypatch.setattr("apps.cmdb.views.collect.NodeMgmt.node_list", fake_node_list)
     resp = CollectModelViewSet.as_view({"get": "nodes"})(request)
     body = _body(resp)
     assert body["result"] is True
     assert body["data"]["count"] == 1
+    assert captured_query["is_container"] is True
+    assert "node_type" not in captured_query
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/views/collect.py
+++ b/server/apps/cmdb/views/collect.py
@@ -263,7 +263,7 @@ class CollectModelViewSet(AuthViewSet):
                 "domain": request.user.domain,
                 "current_team": get_current_team(request),
             },
-            "node_type": "container",
+            "is_container": True,
         }
         node = NodeMgmt()
         data = node.node_list(query_data)


### PR DESCRIPTION
## 问题

CMDB 容器节点列表向 node_mgmt 传递了已不再被消费的 node_type 参数，导致筛选被静默忽略并返回全部节点类型。

## 修复

- 按 node_list 当前契约改传 is_container=true。
- 增加回归断言，确保容器筛选参数存在且旧参数不再传递。

## 验证

- 关联测试：server/apps/cmdb/tests/test_collect_views_actions.py
- 结果：22 passed
- G6：98/100

风险：中。接口响应结构不变，仅修正下游筛选参数；请 @zhouzhuangjie review。

关联 Issue：#4077