### PR TITLE
bugfix: 修复全局会话过期触发判断

### DIFF
--- a/web/scripts/session-expiry-trigger-test.ts
+++ b/web/scripts/session-expiry-trigger-test.ts
@@ -4,7 +4,8 @@ import { shouldTriggerSessionExpiry } from '../src/utils/sessionExpiry';
 
 const triggerSessionExpiry = shouldTriggerSessionExpiry as unknown as (
   input: string,
-  hasAuthenticatedSession: boolean,
+  currentSessionIdentity: string | null,
+  requestSessionIdentity?: string | null,
 ) => boolean;
 
 const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
@@ -25,29 +26,34 @@ Object.defineProperty(globalThis, 'document', {
 
 try {
   assert.equal(
-    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', true),
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', 'session-a'),
     true,
     'an authenticated NextAuth session should trigger expiry handling without a readable auth cookie',
   );
   assert.equal(
-    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', false),
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', null),
     false,
     'unauthenticated requests must not trigger the global expiry flow',
   );
   assert.equal(
-    triggerSessionExpiry('/api/proxy/core/api/login/', true),
+    triggerSessionExpiry('/api/proxy/core/api/login/', 'session-a'),
     false,
     'login requests must remain excluded',
   );
   assert.equal(
-    triggerSessionExpiry('https://other.example.com/api/metrics/', true),
+    triggerSessionExpiry('https://other.example.com/api/metrics/', 'session-a'),
     false,
     'cross-origin requests must remain excluded',
+  );
+  assert.equal(
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', 'session-b', 'session-a'),
+    false,
+    'a response from an earlier session must not expire the current authenticated session',
   );
 
   location.pathname = '/auth/signin';
   assert.equal(
-    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', true),
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', 'session-a'),
     false,
     'auth pages must not trigger the expiry flow',
   );

--- a/web/scripts/session-expiry-trigger-test.ts
+++ b/web/scripts/session-expiry-trigger-test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+
+import { shouldTriggerSessionExpiry } from '../src/utils/sessionExpiry';
+
+const triggerSessionExpiry = shouldTriggerSessionExpiry as unknown as (
+  input: string,
+  hasAuthenticatedSession: boolean,
+) => boolean;
+
+const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const location = {
+  origin: 'https://bk-lite.example.com',
+  pathname: '/monitor',
+};
+
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: { location },
+});
+Object.defineProperty(globalThis, 'document', {
+  configurable: true,
+  value: { cookie: '' },
+});
+
+try {
+  assert.equal(
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', true),
+    true,
+    'an authenticated NextAuth session should trigger expiry handling without a readable auth cookie',
+  );
+  assert.equal(
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', false),
+    false,
+    'unauthenticated requests must not trigger the global expiry flow',
+  );
+  assert.equal(
+    triggerSessionExpiry('/api/proxy/core/api/login/', true),
+    false,
+    'login requests must remain excluded',
+  );
+  assert.equal(
+    triggerSessionExpiry('https://other.example.com/api/metrics/', true),
+    false,
+    'cross-origin requests must remain excluded',
+  );
+
+  location.pathname = '/auth/signin';
+  assert.equal(
+    triggerSessionExpiry('/api/proxy/monitor/api/metrics/', true),
+    false,
+    'auth pages must not trigger the expiry flow',
+  );
+} finally {
+  if (windowDescriptor) {
+    Object.defineProperty(globalThis, 'window', windowDescriptor);
+  } else {
+    delete (globalThis as { window?: unknown }).window;
+  }
+  if (documentDescriptor) {
+    Object.defineProperty(globalThis, 'document', documentDescriptor);
+  } else {
+    delete (globalThis as { document?: unknown }).document;
+  }
+}
+
+console.log('session expiry trigger tests passed');

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -76,8 +76,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const authPaths = ['/auth/signin', '/auth/signout', '/auth/callback', '/auth/signin/login-auth-result'];
   const isCurrentAuthPath = isAuthPath(pathname);
   const isSessionValid = extendedSession && extendedSession.user && (extendedSession.user.id || extendedSession.user.username);
-  const hasAuthenticatedSessionRef = useRef(false);
-  hasAuthenticatedSessionRef.current = status === 'authenticated' && Boolean(isSessionValid);
+  const authenticatedSessionIdentityRef = useRef<string | null>(null);
+  authenticatedSessionIdentityRef.current = status === 'authenticated' && isSessionValid
+    ? String(extendedSession.user.token || extendedSession.user.id || extendedSession.user.username)
+    : null;
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -85,22 +87,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
 
     const nativeFetch = window.fetch.bind(window);
-    const shouldTriggerForCurrentSession = (input?: RequestInfo | URL | string | null) => (
-      shouldTriggerSessionExpiry(input, hasAuthenticatedSessionRef.current)
+    const axiosRequestSessionIdentities = new WeakMap<object, string | null>();
+    const shouldTriggerForSession = (
+      input: RequestInfo | URL | string | null | undefined,
+      requestSessionIdentity: string | null,
+    ) => (
+      shouldTriggerSessionExpiry(
+        input,
+        authenticatedSessionIdentityRef.current,
+        requestSessionIdentity,
+      )
     );
 
     window.fetch = async (input, init) => {
-      if (shouldTriggerForCurrentSession(input) && isSessionExpiredState()) {
+      const requestSessionIdentity = authenticatedSessionIdentityRef.current;
+
+      if (shouldTriggerForSession(input, requestSessionIdentity) && isSessionExpiredState()) {
         throw createSessionExpiredRequestError();
       }
 
       const response = await nativeFetch(input, init);
 
-      if (response.status === 460 && shouldTriggerForCurrentSession(input)) {
+      if (response.status === 460 && shouldTriggerForSession(input, requestSessionIdentity)) {
         void forceLogoutAndRedirect();
       }
 
-      if (response.status === 401 && shouldTriggerForCurrentSession(input)) {
+      if (response.status === 401 && shouldTriggerForSession(input, requestSessionIdentity)) {
         emitSessionExpired({ reason: 'global-fetch-session-expired', status: 401 });
       }
 
@@ -108,7 +120,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     };
 
     const axiosRequestInterceptor = axios.interceptors.request.use((config) => {
-      if (shouldTriggerForCurrentSession(config.url) && isSessionExpiredState()) {
+      const requestSessionIdentity = authenticatedSessionIdentityRef.current;
+      axiosRequestSessionIdentities.set(config, requestSessionIdentity);
+
+      if (shouldTriggerForSession(config.url, requestSessionIdentity) && isSessionExpiredState()) {
         return Promise.reject(createSessionExpiredRequestError());
       }
 
@@ -117,22 +132,28 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     const axiosResponseInterceptor = axios.interceptors.response.use(
       (response) => {
-        if (response.status === 460 && shouldTriggerForCurrentSession(response.config.url)) {
+        const requestSessionIdentity = axiosRequestSessionIdentities.get(response.config) ?? null;
+
+        if (response.status === 460 && shouldTriggerForSession(response.config.url, requestSessionIdentity)) {
           void forceLogoutAndRedirect();
         }
 
-        if (response.status === 401 && shouldTriggerForCurrentSession(response.config.url)) {
+        if (response.status === 401 && shouldTriggerForSession(response.config.url, requestSessionIdentity)) {
           emitSessionExpired({ reason: 'global-axios-session-expired', status: 401 });
         }
 
         return response;
       },
       (error) => {
-        if (axios.isAxiosError(error) && error.response?.status === 460 && shouldTriggerForCurrentSession(error.config?.url)) {
+        const requestSessionIdentity = error.config
+          ? axiosRequestSessionIdentities.get(error.config) ?? null
+          : null;
+
+        if (axios.isAxiosError(error) && error.response?.status === 460 && shouldTriggerForSession(error.config?.url, requestSessionIdentity)) {
           void forceLogoutAndRedirect();
         }
 
-        if (axios.isAxiosError(error) && error.response?.status === 401 && shouldTriggerForCurrentSession(error.config?.url)) {
+        if (axios.isAxiosError(error) && error.response?.status === 401 && shouldTriggerForSession(error.config?.url, requestSessionIdentity)) {
           emitSessionExpired({ reason: 'global-axios-session-expired', status: 401 });
         }
 

--- a/web/src/context/auth.tsx
+++ b/web/src/context/auth.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import { useSession, signIn } from 'next-auth/react';
 import type { Session } from 'next-auth';
@@ -76,6 +76,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const authPaths = ['/auth/signin', '/auth/signout', '/auth/callback', '/auth/signin/login-auth-result'];
   const isCurrentAuthPath = isAuthPath(pathname);
   const isSessionValid = extendedSession && extendedSession.user && (extendedSession.user.id || extendedSession.user.username);
+  const hasAuthenticatedSessionRef = useRef(false);
+  hasAuthenticatedSessionRef.current = status === 'authenticated' && Boolean(isSessionValid);
 
   useEffect(() => {
     if (typeof window === 'undefined') {
@@ -83,19 +85,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
 
     const nativeFetch = window.fetch.bind(window);
+    const shouldTriggerForCurrentSession = (input?: RequestInfo | URL | string | null) => (
+      shouldTriggerSessionExpiry(input, hasAuthenticatedSessionRef.current)
+    );
 
     window.fetch = async (input, init) => {
-      if (shouldTriggerSessionExpiry(input) && isSessionExpiredState()) {
+      if (shouldTriggerForCurrentSession(input) && isSessionExpiredState()) {
         throw createSessionExpiredRequestError();
       }
 
       const response = await nativeFetch(input, init);
 
-      if (response.status === 460 && shouldTriggerSessionExpiry(input)) {
+      if (response.status === 460 && shouldTriggerForCurrentSession(input)) {
         void forceLogoutAndRedirect();
       }
 
-      if (response.status === 401 && shouldTriggerSessionExpiry(input)) {
+      if (response.status === 401 && shouldTriggerForCurrentSession(input)) {
         emitSessionExpired({ reason: 'global-fetch-session-expired', status: 401 });
       }
 
@@ -103,7 +108,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     };
 
     const axiosRequestInterceptor = axios.interceptors.request.use((config) => {
-      if (shouldTriggerSessionExpiry(config.url) && isSessionExpiredState()) {
+      if (shouldTriggerForCurrentSession(config.url) && isSessionExpiredState()) {
         return Promise.reject(createSessionExpiredRequestError());
       }
 
@@ -112,22 +117,22 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     const axiosResponseInterceptor = axios.interceptors.response.use(
       (response) => {
-        if (response.status === 460 && shouldTriggerSessionExpiry(response.config.url)) {
+        if (response.status === 460 && shouldTriggerForCurrentSession(response.config.url)) {
           void forceLogoutAndRedirect();
         }
 
-        if (response.status === 401 && shouldTriggerSessionExpiry(response.config.url)) {
+        if (response.status === 401 && shouldTriggerForCurrentSession(response.config.url)) {
           emitSessionExpired({ reason: 'global-axios-session-expired', status: 401 });
         }
 
         return response;
       },
       (error) => {
-        if (axios.isAxiosError(error) && error.response?.status === 460 && shouldTriggerSessionExpiry(error.config?.url)) {
+        if (axios.isAxiosError(error) && error.response?.status === 460 && shouldTriggerForCurrentSession(error.config?.url)) {
           void forceLogoutAndRedirect();
         }
 
-        if (axios.isAxiosError(error) && error.response?.status === 401 && shouldTriggerSessionExpiry(error.config?.url)) {
+        if (axios.isAxiosError(error) && error.response?.status === 401 && shouldTriggerForCurrentSession(error.config?.url)) {
           emitSessionExpired({ reason: 'global-axios-session-expired', status: 401 });
         }
 

--- a/web/src/utils/sessionExpiry.ts
+++ b/web/src/utils/sessionExpiry.ts
@@ -72,16 +72,6 @@ const resolveRequestUrl = (input?: RequestInfo | URL | string | null) => {
   }
 };
 
-export const hasClientAuthToken = () => {
-  if (typeof document === 'undefined') {
-    return false;
-  }
-
-  return document.cookie
-    .split(';')
-    .some((cookie) => cookie.trim().startsWith('bklite_token='));
-};
-
 export const shouldHandleSessionExpiry = (input?: RequestInfo | URL | string | null) => {
   const requestUrl = resolveRequestUrl(input);
 
@@ -106,13 +96,16 @@ export const shouldHandleSessionExpiry = (input?: RequestInfo | URL | string | n
   return pathname.startsWith('/api/') || pathname.includes('/api/');
 };
 
-export const shouldTriggerSessionExpiry = (input?: RequestInfo | URL | string | null) => {
+export const shouldTriggerSessionExpiry = (
+  input: RequestInfo | URL | string | null | undefined,
+  hasAuthenticatedSession: boolean,
+) => {
   if (typeof window === 'undefined') {
     return false;
   }
 
-  return !isAuthPath(window.location.pathname)
-    && hasClientAuthToken()
+  return hasAuthenticatedSession
+    && !isAuthPath(window.location.pathname)
     && shouldHandleSessionExpiry(input);
 };
 

--- a/web/src/utils/sessionExpiry.ts
+++ b/web/src/utils/sessionExpiry.ts
@@ -98,13 +98,15 @@ export const shouldHandleSessionExpiry = (input?: RequestInfo | URL | string | n
 
 export const shouldTriggerSessionExpiry = (
   input: RequestInfo | URL | string | null | undefined,
-  hasAuthenticatedSession: boolean,
+  currentSessionIdentity: string | null,
+  requestSessionIdentity: string | null = currentSessionIdentity,
 ) => {
   if (typeof window === 'undefined') {
     return false;
   }
 
-  return hasAuthenticatedSession
+  return Boolean(currentSessionIdentity)
+    && requestSessionIdentity === currentSessionIdentity
     && !isAuthPath(window.location.pathname)
     && shouldHandleSessionExpiry(input);
 };


### PR DESCRIPTION
## 问题

全局 fetch/axios 会话过期拦截器本应只在用户已经登录时处理业务 API 的 401/460，但它通过 `document.cookie` 判断认证状态。后端认证 cookie 已是 HttpOnly，浏览器脚本无法读取，导致这条全局兜底路径被永久旁路。

核验后确认 `useApiClient` 的专用 axios 实例已直接处理 401/460，不受此缺陷影响；本次仅修复 `AuthProvider` 安装的全局拦截器。

## 根因

原实现把后端认证凭据的传输存在性当作前端会话状态来源，混淆了两个边界：HttpOnly cookie 应只由浏览器自动携带，而前端是否已有登录会话应由 NextAuth 会话状态判断。安全 cookie 属性生效后，旧判断自然退化为恒 false。

## 怎么修的

- 删除浏览器侧读取 `bklite_token` 的无效探测。
- 让 `shouldTriggerSessionExpiry` 显式接收“当前是否有已认证会话”。
- `AuthProvider` 通过实时 ref 将 NextAuth 的 `authenticated` 状态和会话身份传给已注册的全局拦截器，避免拦截器闭包拿到旧状态。
- 保留认证页、登录接口、跨域请求等既有排除规则，避免未登录流量误触发强制登出。

## 影响范围

改动仅限 Web 会话过期处理，共 2 个实现文件和 1 个回归测试；不改后端 cookie、API/RPC、数据模型或 NATS 协议。用户可见变化是：已登录用户遇到全局 fetch/axios 的 401 时能收到会话过期提示，460 时能执行既有强制登出流程。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["业务 API 返回 401/460\nauth.tsx"]
    end

    subgraph N["会话判断层"]
        N1["NextAuth 已认证状态\nauth.tsx"]
        N2["shouldTriggerSessionExpiry\nsessionExpiry.ts"]
    end

    subgraph C["处置层"]
        C1["401: emitSessionExpired"]
        C2["460: forceLogoutAndRedirect"]
    end

    T1 --> N2
    N1 --> N2
    N2 --> C1
    N2 --> C2
```

## 验证

- `tsx scripts/session-expiry-trigger-test.ts`：修复前 RED（无可读 cookie 时已认证场景返回 false），修复后 GREEN；覆盖已认证、未认证、登录接口、跨域和认证页。
- 变更文件 ESLint：通过。
- `pnpm type-check`：通过。

关联 Issue #3997。
