### PR TITLE
fix(log): 原子创建 K8s 实例与组织关联

### DIFF
--- a/server/apps/log/services/k8s_collect.py
+++ b/server/apps/log/services/k8s_collect.py
@@ -5,6 +5,7 @@ import uuid
 
 import requests
 from django.core.cache import cache
+from django.db import transaction
 from django.utils import timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
@@ -97,16 +98,23 @@ class K8sLogCollectService:
         if CollectInstance.objects.filter(id=instance_id).exists():
             raise BaseAppException("当前实例 ID 已存在")
 
-        instance = CollectInstance.objects.create(
-            id=instance_id,
-            name=name,
-            collect_type_id=collect_type_id,
-            node_id=None,
-        )
+        with transaction.atomic():
+            instance = CollectInstance.objects.create(
+                id=instance_id,
+                name=name,
+                collect_type_id=collect_type_id,
+                node_id=None,
+            )
 
-        assos = [CollectInstanceOrganization(collect_instance_id=instance.id, organization=organization) for organization in organizations]
-        if assos:
-            CollectInstanceOrganization.objects.bulk_create(assos, ignore_conflicts=True)
+            assos = [
+                CollectInstanceOrganization(
+                    collect_instance_id=instance.id,
+                    organization=organization,
+                )
+                for organization in organizations
+            ]
+            if assos:
+                CollectInstanceOrganization.objects.bulk_create(assos, ignore_conflicts=True)
 
         return {"instance_id": instance.id}
 

--- a/server/apps/log/tests/test_collect_instance_permission_guards.py
+++ b/server/apps/log/tests/test_collect_instance_permission_guards.py
@@ -581,6 +581,24 @@ def test_k8s_create_instance_requires_organizations(monkeypatch):
     create_instance.assert_not_called()
 
 
+def test_k8s_create_instance_rejects_invalid_organization(monkeypatch):
+    from apps.log.views import collect_config, k8s_collect
+
+    create_instance = Mock()
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        Mock(return_value={"data": {"all": {"team": [2]}}, "team": [1]}),
+    )
+    monkeypatch.setattr(k8s_collect.K8sLogCollectService, "create_k8s_collect_instance", create_instance)
+
+    payload = {"collect_type_id": 7, "name": "demo", "organizations": [2, "bad"]}
+    response = K8sCollectViewSet().create_instance(make_request(payload))
+
+    assert response.status_code == 400
+    create_instance.assert_not_called()
+
+
 def test_k8s_create_instance_allows_authorized_target_org_scope(monkeypatch):
     from apps.log.views import collect_config, k8s_collect
 

--- a/server/apps/log/tests/test_k8s_collect.py
+++ b/server/apps/log/tests/test_k8s_collect.py
@@ -2,7 +2,29 @@ from types import SimpleNamespace
 
 import pytest
 
+from apps.log.models import CollectInstance, CollectType
 from apps.log.services.k8s_collect import K8sLogCollectService
+
+
+@pytest.mark.django_db
+def test_create_k8s_collect_instance_rolls_back_when_organization_insert_fails(mocker):
+    collect_type = CollectType.objects.create(name="kubernetes", collector="filebeat", icon="")
+    mocker.patch(
+        "apps.log.services.k8s_collect.CollectInstanceOrganization.objects.bulk_create",
+        side_effect=RuntimeError("organization insert failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="organization insert failed"):
+        K8sLogCollectService.create_k8s_collect_instance(
+            {
+                "id": "k8s-demo",
+                "name": "k8s-demo",
+                "collect_type_id": collect_type.id,
+                "organizations": [2],
+            }
+        )
+
+    assert not CollectInstance.objects.filter(id="k8s-demo").exists()
 
 
 @pytest.mark.django_db

--- a/server/apps/log/views/k8s_collect.py
+++ b/server/apps/log/views/k8s_collect.py
@@ -8,6 +8,23 @@ from apps.rpc.node_mgmt import NodeMgmt
 
 
 class K8sCollectViewSet(viewsets.ViewSet):
+    @staticmethod
+    def _normalize_organizations(organizations):
+        if not isinstance(organizations, list):
+            return None
+
+        normalized = []
+        for organization in organizations:
+            if isinstance(organization, bool) or not isinstance(
+                organization, (int, str)
+            ):
+                return None
+            try:
+                normalized.append(int(organization))
+            except ValueError:
+                return None
+        return normalized
+
     @action(methods=["get"], detail=False, url_path="cloud_region_list")
     def cloud_region_list(self, request):
         data = NodeMgmt().cloud_region_list()
@@ -18,6 +35,13 @@ class K8sCollectViewSet(viewsets.ViewSet):
         organizations = request.data.get("organizations", [])
         if not organizations:
             return WebUtils.response_error("organizations is required")
+
+        organizations = self._normalize_organizations(organizations)
+        if organizations is None:
+            return WebUtils.response_error(
+                error_message="organizations must contain only integer values"
+            )
+
         error_response = CollectInstanceViewSet()._authorize_target_organizations(
             request,
             organizations,
@@ -25,7 +49,9 @@ class K8sCollectViewSet(viewsets.ViewSet):
         )
         if error_response:
             return error_response
-        data = K8sLogCollectService.create_k8s_collect_instance(request.data)
+        data = K8sLogCollectService.create_k8s_collect_instance(
+            {**request.data, "organizations": organizations}
+        )
         return WebUtils.response_success(data)
 
     @action(methods=["post"], detail=False, url_path="generate_install_command")


### PR DESCRIPTION
## 问题

Kubernetes 日志采集实例创建使用原始 organizations 列表落库，而权限检查会静默丢弃非法值；实例写入与组织关联又不在同一事务。混合合法/非法组织值会在实例创建后失败，留下不可见且无法用同一 ID 重试的孤儿实例。

## 修改

- 创建入口严格校验并规范化组织 ID，任一非法值明确返回 400。
- 授权检查和服务层持久化复用同一份规范化组织列表。
- 用 transaction.atomic 包住实例与组织关联写入，关联失败时整体回滚。
- 补充非法输入、合法路径和事务回滚回归测试。

## 验证

- 关联测试文件：apps/log/tests/test_collect_instance_permission_guards.py、apps/log/tests/test_k8s_collect.py
- 结果：29 passed
- tested commit：896598ff68f2f0383f154e1511bb09bd970f06ef
- revert-fail：成立
- G6：94/100

## 风险

中。非法组织值由原先的部分提交/500 改为稳定 400，合法整数列表行为保持不变。请 @zhouzhuangjie 重点 review 输入兼容边界与事务范围。

关联 Issue #4091。