### PR TITLE
bugfix: 修复聚合日志告警身份冲突

### DIFF
--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -112,6 +112,31 @@ class LogPolicyScan:
         digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
         return f"policy_{self.policy.id}_{digest}"
 
+    def _build_aggregate_source_id(self, result, group_by):
+        """构建有长度边界且无分隔符歧义的聚合告警身份。"""
+        group_key = self._build_group_key(result, group_by)
+        legacy_source_id = f"policy_{self.policy.id}_{group_key}"
+        legacy_safe = all(
+            isinstance(field, str)
+            and field
+            and not any(separator in field for separator in (",", "="))
+            and field in result
+            and isinstance(result[field], str)
+            and result[field] not in {"null", "unknown"}
+            and not any(separator in result[field] for separator in (",", "="))
+            for field in group_by
+        )
+        if legacy_safe and len(legacy_source_id) <= Alert._meta.get_field("source_id").max_length:
+            return legacy_source_id
+
+        identity = [
+            {"field": field, "present": field in result, "value": result.get(field)}
+            for field in sorted(group_by)
+        ]
+        canonical = json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        return f"policy_{self.policy.id}_agg_{digest}"
+
     def _get_keyword_match_count(self, query, start_timestamp, end_timestamp):
         """获取关键字告警真实命中数量"""
         count_query = f"{query} | stats count() as total_count"
@@ -292,9 +317,8 @@ class LogPolicyScan:
                 if self._check_rule_conditions(aggregate_data, rule):
                     # 渲染告警名称模板
                     rendered_alert_name = self._render_alert_name(result, group_by)
-                    # 构建分组标识和source_id
-                    group_key = self._build_group_key(result, group_by)
-                    source_id = f"policy_{self.policy.id}_{group_key}"
+                    # 构建有长度边界且无分隔符歧义的 source_id
+                    source_id = self._build_aggregate_source_id(result, group_by)
 
                     events.append(
                         {

--- a/server/apps/log/tests/test_policy_scan_pure.py
+++ b/server/apps/log/tests/test_policy_scan_pure.py
@@ -270,6 +270,57 @@ class TestBuildGroupKey:
         assert _scan()._build_group_key({}, ["host"]) == "host=unknown"
 
 
+class TestBuildAggregateSourceId:
+    def test_short_unambiguous_group_preserves_legacy_source_id(self):
+        scan = _scan(id=9)
+
+        assert scan._build_aggregate_source_id({"host": "h1"}, ["host"]) == "policy_9_host=h1"
+
+    def test_long_group_uses_bounded_hash(self):
+        source_id = _scan(id=9)._build_aggregate_source_id({"host": "x" * 200}, ["host"])
+
+        assert source_id.startswith("policy_9_agg_")
+        assert len(source_id) <= 100
+
+    def test_legacy_collision_groups_get_distinct_source_ids(self):
+        scan = _scan(id=9)
+        first = {"a": "x, b=y", "b": "z"}
+        second = {"a": "x", "b": "y, b=z"}
+
+        assert scan._build_group_key(first, ["a", "b"]) == scan._build_group_key(second, ["a", "b"])
+        assert scan._build_aggregate_source_id(first, ["a", "b"]) != scan._build_aggregate_source_id(
+            second, ["a", "b"]
+        )
+
+    def test_hashed_identity_is_independent_of_group_field_order(self):
+        scan = _scan(id=9)
+        result = {"a": "x,y", "b": "z"}
+
+        assert scan._build_aggregate_source_id(result, ["a", "b"]) == scan._build_aggregate_source_id(
+            result, ["b", "a"]
+        )
+
+    def test_aggregate_detection_uses_bounded_source_id(self, monkeypatch):
+        scan = _scan(
+            id=9,
+            alert_type="aggregate",
+            alert_condition={
+                "query": "*",
+                "group_by": ["host"],
+                "rule": {
+                    "mode": "and",
+                    "conditions": [{"func": "count", "field": "_msg", "op": ">", "value": 2}],
+                },
+            },
+        )
+        monkeypatch.setattr(scan.vlogs_api, "query", lambda **_kwargs: [{"host": "x" * 200, "count__msg": "9"}])
+
+        events = scan.aggregate_alert_detection()
+
+        assert events[0]["source_id"].startswith("policy_9_agg_")
+        assert len(events[0]["source_id"]) <= 100
+
+
 class TestCheckRuleConditions:
     def test_no_conditions_false(self):
         assert _scan()._check_rule_conditions({}, {"conditions": []}) is False


### PR DESCRIPTION
## 背景

关联 #4087。聚合告警此前直接把日志分组展示值拼入 `source_id`，可能超过字段长度，并在不同字段组合下产生确定性碰撞。

## 变更

- 对超长或存在拼接歧义的分组值生成带命名空间的 canonical 哈希身份
- 保留安全范围内既有 `source_id` 的兼容行为
- 补充长度边界、字段顺序、碰撞与存量兼容测试

## 验证

- `apps/log/tests/test_policy_scan_pure.py`
- `apps/log/tests/test_policy_scan_db.py`
- 关联测试 101/101 PASS
- G6: 97/100

风险：中。请 @baiyf-git review 聚合身份兼容边界。