### PR TITLE
bugfix: 原子化日志策略与周期任务写入

### DIFF
--- a/server/apps/log/tests/test_policy_write_atomic_4085.py
+++ b/server/apps/log/tests/test_policy_write_atomic_4085.py
@@ -1,0 +1,106 @@
+"""Issue #4085: policy and scheduled-task writes must commit atomically."""
+
+import pytest
+from django.db import DatabaseError
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.log.models.policy import Policy, PolicyOrganization
+from apps.log.views.policy import PolicyViewSet
+
+
+def _policy_payload(name, organizations):
+    return {
+        "name": name,
+        "alert_type": "keyword",
+        "alert_name": name,
+        "alert_level": "warning",
+        "alert_condition": {"query": "error"},
+        "schedule": {"type": "min", "value": 5},
+        "period": {"type": "min", "value": 5},
+        "organizations": organizations,
+    }
+
+
+def _allow_policy_operations(mocker, policy_id=None, teams=None):
+    instance_permissions = []
+    if policy_id is not None:
+        instance_permissions.append({"id": policy_id, "permission": ["View", "Operate"]})
+    mocker.patch(
+        "apps.log.views.policy.get_permissions_rules",
+        return_value={
+            "data": {"None": {"instance": instance_permissions}},
+            "team": teams or [1],
+        },
+    )
+
+
+def _fail_periodic_task_create(mocker):
+    mocker.patch(
+        "apps.log.views.policy.PeriodicTask.objects.create",
+        side_effect=DatabaseError("injected periodic-task write failure"),
+    )
+
+
+def _call_policy_view(http_method, path, data, user, **kwargs):
+    request = getattr(APIRequestFactory(), http_method)(path, data=data, format="json")
+    force_authenticate(request, user=user)
+    action = {"post": "create", "put": "update", "patch": "partial_update"}[http_method]
+    view = PolicyViewSet.as_view({http_method: action})
+    return view(request, **kwargs)
+
+
+@pytest.mark.django_db
+def test_policy_create_rolls_back_when_periodic_task_write_fails(authenticated_user, mocker):
+    _allow_policy_operations(mocker)
+    _fail_periodic_task_create(mocker)
+
+    with pytest.raises(DatabaseError, match="injected periodic-task write failure"):
+        _call_policy_view(
+            "post",
+            "/api/v1/log/policy/",
+            _policy_payload("atomic-create", [1]),
+            authenticated_user,
+        )
+
+    assert not Policy.objects.filter(name="atomic-create").exists()
+    assert not PolicyOrganization.objects.exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("http_method", ["put", "patch"])
+def test_policy_update_rolls_back_when_periodic_task_write_fails(
+    authenticated_user,
+    mocker,
+    http_method,
+):
+    policy_data = _policy_payload("atomic-update", [1])
+    policy_data.pop("organizations")
+    policy = Policy.objects.create(**policy_data)
+    PolicyOrganization.objects.create(policy=policy, organization=1)
+    old_crontab = CrontabSchedule.objects.create(minute="*/1")
+    PeriodicTask.objects.create(
+        name=f"log_policy_task_{policy.id}",
+        task="apps.log.tasks.policy.scan_log_policy_task",
+        crontab=old_crontab,
+    )
+    _allow_policy_operations(mocker, policy.id, teams=[1, 2])
+    _fail_periodic_task_create(mocker)
+
+    payload = _policy_payload("atomic-update", [2])
+    payload["alert_name"] = "changed-name"
+
+    with pytest.raises(DatabaseError, match="injected periodic-task write failure"):
+        _call_policy_view(
+            http_method,
+            f"/api/v1/log/policy/{policy.id}/",
+            payload,
+            authenticated_user,
+            pk=policy.id,
+        )
+
+    policy.refresh_from_db()
+    assert policy.alert_name == "atomic-update"
+    assert list(policy.policyorganization_set.values_list("organization", flat=True)) == [1]
+    restored_task = PeriodicTask.objects.get(name=f"log_policy_task_{policy.id}")
+    assert restored_task.crontab_id == old_crontab.id

--- a/server/apps/log/views/policy.py
+++ b/server/apps/log/views/policy.py
@@ -313,6 +313,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
 
         return WebUtils.response_success(dict(count=queryset.count(), items=results))
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         # 补充创建人
         request.data["created_by"] = request.user.username
@@ -343,6 +344,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         instance = self.get_queryset().get(id=policy_id)
         return self._refresh_response_data(response, instance)
 
+    @transaction.atomic
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
         error_response = self._authorize_policy(request, instance)
@@ -386,6 +388,7 @@ class PolicyViewSet(viewsets.ModelViewSet):
         instance.refresh_from_db()
         return self._refresh_response_data(response, instance)
 
+    @transaction.atomic
     def partial_update(self, request, *args, **kwargs):
         instance = self.get_object()
         error_response = self._authorize_policy(request, instance)


### PR DESCRIPTION
## 背景

日志策略创建、更新和部分更新会替换关联 `PeriodicTask`，但此前策略、组织关系与周期任务不在同一事务边界内。任务写入失败时，请求虽报错仍可能提交新策略并删除唯一扫描任务。

Closes #4085

## 修改

- 为策略 create、update、partial_update 写入补齐统一事务边界
- 保持现有 serializer 与调度语义不变
- 补充任务写入失败时策略、组织关系和周期任务整体回滚测试

## 验证

- `apps/log/tests/test_policy_write_atomic_4085.py`：3 passed
- 关联测试通过规定包装器执行，证据对应 commit `05e28f5c8abd2db3804bf22276f8086577257103`
- G6：97/100

## 风险

中风险。变更收紧失败路径的提交语义；请 @baiyf-git 重点 review 事务边界及 `PeriodicTask` 替换行为。