### PR TITLE
fix(log): 修复实时 tail 忙轮询与线程泄漏

### DIFF
--- a/server/apps/log/tests/test_tail_async_lifecycle_4081.py
+++ b/server/apps/log/tests/test_tail_async_lifecycle_4081.py
@@ -1,0 +1,99 @@
+import asyncio
+import threading
+
+import pytest
+
+from apps.log.utils.query_log import VictoriaMetricsAPI
+
+
+class _IdleStreamResponse:
+    status_code = 200
+
+    def __init__(self):
+        self.started = threading.Event()
+        self.closed = threading.Event()
+        self.finished = threading.Event()
+        self.encoding = "utf-8"
+
+    def raise_for_status(self):
+        pass
+
+    def iter_lines(self, chunk_size=None, decode_unicode=False):
+        self.started.set()
+        try:
+            self.closed.wait()
+            if False:
+                yield None
+        finally:
+            self.finished.set()
+
+    def close(self):
+        self.closed.set()
+
+
+class _EndlessStreamResponse(_IdleStreamResponse):
+    def __init__(self):
+        super().__init__()
+        self.lines_read = 0
+
+    def iter_lines(self, chunk_size=None, decode_unicode=False):
+        self.started.set()
+        try:
+            while not self.closed.is_set():
+                self.lines_read += 1
+                yield f"line-{self.lines_read}"
+        finally:
+            self.finished.set()
+
+
+@pytest.mark.asyncio
+async def test_tail_async_idle_wait_does_not_busy_poll(mocker):
+    fake_resp = _IdleStreamResponse()
+    mocker.patch("apps.log.utils.query_log.requests.post", return_value=fake_resp)
+
+    real_sleep = asyncio.sleep
+    zero_sleep_count = 0
+
+    async def tracked_sleep(delay):
+        nonlocal zero_sleep_count
+        if delay == 0:
+            zero_sleep_count += 1
+        await real_sleep(delay)
+
+    mocker.patch("apps.log.utils.query_log.asyncio.sleep", side_effect=tracked_sleep)
+
+    api = VictoriaMetricsAPI()
+    api.host = "http://victorialogs.local"
+    stream = api.tail_async("*")
+    next_line = asyncio.create_task(stream.__anext__())
+
+    await asyncio.to_thread(fake_resp.started.wait, 0.5)
+    await real_sleep(0.05)
+    assert zero_sleep_count == 0
+
+    next_line.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await next_line
+    assert fake_resp.finished.wait(0.5)
+
+
+@pytest.mark.asyncio
+async def test_tail_async_cancel_releases_producer_blocked_by_backpressure(mocker):
+    fake_resp = _EndlessStreamResponse()
+    mocker.patch("apps.log.utils.query_log.requests.post", return_value=fake_resp)
+
+    api = VictoriaMetricsAPI()
+    api.host = "http://victorialogs.local"
+    stream = api.tail_async("*")
+
+    assert await stream.__anext__() == "line-1"
+    for _ in range(100):
+        if fake_resp.lines_read >= 258:
+            break
+        await asyncio.sleep(0.01)
+    assert fake_resp.lines_read >= 258, "生产线程未进入满队列背压等待"
+
+    await stream.aclose()
+
+    assert fake_resp.closed.is_set()
+    assert fake_resp.finished.wait(0.5), "取消后生产线程未退出"

--- a/server/apps/log/utils/query_log.py
+++ b/server/apps/log/utils/query_log.py
@@ -1,16 +1,19 @@
-import json
 import asyncio
-import queue
+import json
 import re
-from decimal import Decimal, InvalidOperation
-import requests
-import requests.adapters
+import threading
 import time
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from decimal import Decimal, InvalidOperation
 from json import JSONDecodeError
 from typing import AsyncIterator
+
+import requests
+import requests.adapters
 from requests.auth import HTTPBasicAuth
-from apps.log.constants.victoriametrics import VictoriaLogsConstants
+
 from apps.core.logger import log_logger as logger
+from apps.log.constants.victoriametrics import VictoriaLogsConstants
 
 
 class VictoriaMetricsAPI:
@@ -324,35 +327,55 @@ class VictoriaMetricsAPI:
             )
 
             # 异步生成器，逐行处理数据
-            # 使用 Queue + 线程池将阻塞的 iter_lines() 卸载到 executor，
-            # 避免同步 I/O 阻塞 ASGI 事件循环。
+            # 使用 asyncio.Queue 在线程与事件循环间传递数据：消费端可以
+            # 真正挂起等待，生产端仍保留有界背压。
             _SENTINEL = object()
-            line_queue: queue.Queue = queue.Queue(maxsize=256)
+            line_queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+            stop_event = threading.Event()
             line_count = 0
             first_data_received = False
             start_time = time.time()
+
+            def _put_unless_stopped(item) -> bool:
+                """从生产线程向异步队列写入，并在消费端关闭时解除背压等待。"""
+                if stop_event.is_set():
+                    return False
+
+                put_future = asyncio.run_coroutine_threadsafe(line_queue.put(item), loop)
+                while True:
+                    try:
+                        put_future.result(timeout=0.1)
+                        return True
+                    except FutureTimeoutError:
+                        if stop_event.is_set():
+                            put_future.cancel()
+                            return False
 
             def _iter_lines_in_thread():
                 """在独立线程中消费流式响应，结果放入 Queue 供异步生成器读取。"""
                 try:
                     for line in response.iter_lines(chunk_size=8192, decode_unicode=True):
-                        line_queue.put(line)
+                        if not _put_unless_stopped(line):
+                            break
                 except Exception as exc:
-                    line_queue.put(exc)
+                    if not stop_event.is_set():
+                        _put_unless_stopped(exc)
                 finally:
-                    line_queue.put(_SENTINEL)
+                    if not stop_event.is_set():
+                        _put_unless_stopped(_SENTINEL)
 
             try:
-                # 将阻塞的 iter_lines 迭代移至线程池
-                iter_future = loop.run_in_executor(None, _iter_lines_in_thread)
+                # 流式读取使用独立 daemon 线程，避免异常上游长时间占用
+                # ASGI 共享的默认 ThreadPoolExecutor。
+                iter_thread = threading.Thread(
+                    target=_iter_lines_in_thread,
+                    name="victorialogs-tail-reader",
+                    daemon=True,
+                )
+                iter_thread.start()
 
                 while True:
-                    # 以非阻塞方式从队列取行，没有数据时让出事件循环
-                    try:
-                        item = line_queue.get_nowait()
-                    except queue.Empty:
-                        await asyncio.sleep(0)
-                        continue
+                    item = await line_queue.get()
 
                     if item is _SENTINEL:
                         break
@@ -394,14 +417,19 @@ class VictoriaMetricsAPI:
                             )
                             continue
 
-                # 等待线程完成，传播线程侧未捕获的异常
-                await iter_future
-
             finally:
-                # 确保响应对象被正确关闭
+                stop_event.set()
                 if response:
                     response.close()
                     logger.debug("VictoriaLogs响应连接已关闭")
+
+                # 不在事件循环中阻塞 join；response.close() 会中断正在等待的
+                # iter_lines，而满队列上的 put 最多 0.1 秒后观察到 stop_event。
+                join_deadline = loop.time() + 1.0
+                while iter_thread.is_alive() and loop.time() < join_deadline:
+                    await asyncio.sleep(0.01)
+                if iter_thread.is_alive():
+                    logger.warning("VictoriaLogs tail 读取线程未在关闭期限内退出")
 
         except requests.exceptions.ConnectTimeout:
             logger.error("异步VictoriaLogs连接超时", extra={"host": self.host, "timeout": "10秒"})


### PR DESCRIPTION
## 背景

实时日志 tail 在上游空闲时持续 `sleep(0)` 忙轮询；消费端断开后，生产线程还可能阻塞在满队列，长期占用共享执行器线程。

## 修改

- 改用 `asyncio.Queue`，让异步消费端无数据时真正挂起等待
- 为生产线程增加停止事件与可取消背压，断开时关闭响应并回收线程
- 使用独立 daemon reader，避免异常上游占住 ASGI 默认线程池
- 新增空闲等待与满队列取消回收测试

## 验证

- 关联测试：`server/apps/log/tests/test_tail_async_lifecycle_4081.py`
- 结果：2 passed（规定关联测试包装器）
- G6：90/100

Closes #4081