### PR TITLE
fix(log): 阻止插件解析失败触发差集删除

### DIFF
--- a/server/apps/log/management/services/plugin.py
+++ b/server/apps/log/management/services/plugin.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+from django.db import transaction
 from django.db.models import Q
 
 from apps.core.logger import log_logger as logger
@@ -25,7 +26,7 @@ def migrate_collect_type():
                     collect_types_path.append(config_path)
                     continue
 
-    valid_keys = set()
+    collect_types = []
 
     for file_path in collect_types_path:
         try:
@@ -33,22 +34,25 @@ def migrate_collect_type():
                 collect_types_data = json.load(file)
                 name = collect_types_data["name"]
                 collector = collect_types_data["collector"]
-                valid_keys.add((name, collector))
-                CollectType.objects.update_or_create(
-                    name=name,
-                    collector=collector,
-                    defaults=collect_types_data,
-                )
+                collect_types.append((name, collector, collect_types_data))
         except Exception as e:
             logger.error(f"导入采集方式 {file_path} 失败！原因：{e}")
+            raise
 
-    if valid_keys:
-        try:
+    valid_keys = {(name, collector) for name, collector, _ in collect_types}
+
+    with transaction.atomic():
+        for name, collector, collect_types_data in collect_types:
+            CollectType.objects.update_or_create(
+                name=name,
+                collector=collector,
+                defaults=collect_types_data,
+            )
+
+        if valid_keys:
             keep_condition = Q()
             for name, collector in valid_keys:
                 keep_condition |= Q(name=name, collector=collector)
             deleted_count, _ = CollectType.objects.exclude(keep_condition).delete()
             if deleted_count:
                 logger.info(f"已删除 {deleted_count} 个不再存在的采集方式")
-        except Exception as e:
-            logger.warning(f"清理已删除的采集方式失败：{e}")

--- a/server/apps/log/tests/test_migrate_collect_type_atomic_4079.py
+++ b/server/apps/log/tests/test_migrate_collect_type_atomic_4079.py
@@ -1,0 +1,91 @@
+import json
+from contextlib import nullcontext
+
+from apps.log.constants.plugin import PluginConstants
+from apps.log.management.services import plugin
+
+
+def _write_collect_type(root, collector, name, content):
+    plugin_dir = root / collector / name
+    plugin_dir.mkdir(parents=True)
+    config_path = plugin_dir / "collect_type.json"
+    if isinstance(content, dict):
+        config_path.write_text(json.dumps(content), encoding="utf-8")
+    else:
+        config_path.write_text(content, encoding="utf-8")
+
+
+class _CollectTypeObjects:
+    def __init__(self):
+        self.updated = []
+        self.excluded = []
+        self.deleted = False
+
+    def update_or_create(self, **kwargs):
+        self.updated.append(kwargs)
+
+    def exclude(self, condition):
+        self.excluded.append(condition)
+        return self
+
+    def delete(self):
+        self.deleted = True
+        return 1, {"log.CollectType": 1}
+
+
+def test_migrate_collect_type_does_not_write_when_any_config_is_invalid(tmp_path, monkeypatch):
+    _write_collect_type(
+        tmp_path,
+        "Vector",
+        "valid",
+        {
+            "name": "valid",
+            "collector": "Vector",
+            "icon": "valid",
+        },
+    )
+    _write_collect_type(tmp_path, "Vector", "invalid", "{invalid json")
+    monkeypatch.setattr(PluginConstants, "DIRECTORY", str(tmp_path))
+    objects = _CollectTypeObjects()
+    monkeypatch.setattr(plugin.CollectType, "objects", objects)
+    monkeypatch.setattr(plugin.transaction, "atomic", nullcontext)
+
+    try:
+        plugin.migrate_collect_type()
+    except json.JSONDecodeError:
+        pass
+    else:
+        raise AssertionError("invalid plugin configuration must fail the synchronization")
+
+    assert objects.updated == []
+    assert objects.excluded == []
+    assert objects.deleted is False
+
+
+def test_migrate_collect_type_updates_and_cleans_up_after_all_configs_parse(tmp_path, monkeypatch):
+    _write_collect_type(
+        tmp_path,
+        "Vector",
+        "valid",
+        {
+            "name": "valid",
+            "collector": "Vector",
+            "icon": "new",
+        },
+    )
+    monkeypatch.setattr(PluginConstants, "DIRECTORY", str(tmp_path))
+    objects = _CollectTypeObjects()
+    monkeypatch.setattr(plugin.CollectType, "objects", objects)
+    monkeypatch.setattr(plugin.transaction, "atomic", nullcontext)
+
+    plugin.migrate_collect_type()
+
+    assert objects.updated == [
+        {
+            "name": "valid",
+            "collector": "Vector",
+            "defaults": {"name": "valid", "collector": "Vector", "icon": "new"},
+        }
+    ]
+    assert len(objects.excluded) == 1
+    assert objects.deleted is True


### PR DESCRIPTION
## 背景

插件配置同步在部分 `collect_type.json` 解析失败时，仍会用不完整集合执行差集删除，可能级联删除采集实例、策略和告警。

## 变更

- 先完整解析全部插件配置，任一解析失败即中止且不写数据库
- 全部解析成功后，在同一事务中执行更新与失效记录清理
- 增加“失败零写入”和“成功后正常清理”的回归测试

## 验证

- ` apps/log/tests/test_migrate_collect_type_atomic_4079.py`
- 结果：2/2 PASS
- G6：87/100

风险等级：中。正常同步语义不变；异常路径改为 fail-closed。

Closes #4079