### PR TITLE
fix(cmdb): 限制变更趋势时间跨度

### DIFF
--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from functools import reduce
 from operator import or_
 from types import SimpleNamespace
@@ -48,6 +49,12 @@ from apps.system_mgmt.models.role import Role
 from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
+_CHANGE_TREND_MAX_SPAN_SECONDS = {
+    "hour": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_HOUR", str(90 * 24 * 3600))),
+    "day": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_DAY", str(730 * 24 * 3600))),
+    "week": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_WEEK", str(730 * 24 * 3600))),
+    "month": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_MONTH", str(730 * 24 * 3600))),
+}
 def _normalize_to_list(value):
     if value in (None, ""):
         return []
@@ -1137,12 +1144,40 @@ def get_change_trend(time=None, group_by="day", model_id=None, user_info=None, *
     if not time or len(time) != 2:
         return {"result": False, "data": {}, "message": "time parameter is required as [start_time, end_time]"}
 
+    if group_by not in _CHANGE_TREND_MAX_SPAN_SECONDS:
+        return {
+            "result": False,
+            "data": {},
+            "message": "group_by must be one of: hour, day, week, month",
+        }
+
     target_tz = _resolve_target_timezone((user_info or {}).get("timezone") or kwargs.pop("timezone", None))
     start_time, end_time = time
     aware_start = _parse_client_datetime(start_time, target_tz)
     aware_end = _parse_client_datetime(end_time, target_tz)
     local_start = aware_start.astimezone(target_tz)
     local_end = aware_end.astimezone(target_tz)
+
+    if aware_start >= aware_end:
+        return {"result": False, "data": {}, "message": "start_time must be earlier than end_time"}
+
+    span_seconds = (aware_end - aware_start).total_seconds()
+    max_span = _CHANGE_TREND_MAX_SPAN_SECONDS[group_by]
+    if span_seconds > max_span:
+        logger.warning(
+            "get_change_trend range %.0f seconds exceeds %s limit %d seconds",
+            span_seconds,
+            group_by,
+            max_span,
+        )
+        return {
+            "result": False,
+            "data": {},
+            "message": (
+                f"Time range exceeds the maximum limit for {group_by} grouping "
+                f"({max_span} seconds). Use a shorter range or coarser grouping."
+            ),
+        }
 
     trunc_func, _ = _get_trunc_func_and_format(group_by)
     all_periods = _generate_time_periods(local_start, local_end, group_by, target_tz)

--- a/server/apps/cmdb/tests/test_change_trend_limits.py
+++ b/server/apps/cmdb/tests/test_change_trend_limits.py
@@ -1,0 +1,35 @@
+from apps.cmdb.nats import nats as N
+
+
+class QueryMustNotRun:
+    def filter(self, **kwargs):
+        raise AssertionError("invalid range must be rejected before querying")
+
+
+def test_get_change_trend_rejects_oversized_range_before_query(monkeypatch):
+    monkeypatch.setitem(N._CHANGE_TREND_MAX_SPAN_SECONDS, "hour", 3600)
+    monkeypatch.setattr(N.ChangeRecord, "objects", QueryMustNotRun())
+
+    result = N.get_change_trend(
+        time=["2026-01-01 00:00:00", "2026-01-01 02:00:00"],
+        group_by="hour",
+    )
+
+    assert result["result"] is False
+    assert result["data"] == {}
+    assert "maximum limit" in result["message"]
+
+
+def test_get_change_trend_rejects_invalid_group_by_before_query(monkeypatch):
+    monkeypatch.setattr(N.ChangeRecord, "objects", QueryMustNotRun())
+
+    result = N.get_change_trend(
+        time=["2026-01-01 00:00:00", "2026-01-02 00:00:00"],
+        group_by="minute",
+    )
+
+    assert result == {
+        "result": False,
+        "data": {},
+        "message": "group_by must be one of: hour, day, week, month",
+    }

--- a/server/apps/cmdb/tests/test_change_trend_limits.py
+++ b/server/apps/cmdb/tests/test_change_trend_limits.py
@@ -1,9 +1,20 @@
+import pytest
+
 from apps.cmdb.nats import nats as N
 
 
 class QueryMustNotRun:
     def filter(self, **kwargs):
         raise AssertionError("invalid range must be rejected before querying")
+
+
+class QueryStarted(Exception):
+    pass
+
+
+class QueryProbe:
+    def filter(self, **kwargs):
+        raise QueryStarted
 
 
 def test_get_change_trend_rejects_oversized_range_before_query(monkeypatch):
@@ -18,6 +29,17 @@ def test_get_change_trend_rejects_oversized_range_before_query(monkeypatch):
     assert result["result"] is False
     assert result["data"] == {}
     assert "maximum limit" in result["message"]
+
+
+def test_get_change_trend_allows_range_at_maximum_limit(monkeypatch):
+    monkeypatch.setitem(N._CHANGE_TREND_MAX_SPAN_SECONDS, "hour", 3600)
+    monkeypatch.setattr(N.ChangeRecord, "objects", QueryProbe())
+
+    with pytest.raises(QueryStarted):
+        N.get_change_trend(
+            time=["2026-01-01 00:00:00", "2026-01-01 01:00:00"],
+            group_by="hour",
+        )
 
 
 def test_get_change_trend_rejects_invalid_group_by_before_query(monkeypatch):


### PR DESCRIPTION
## 背景

CMDB 变更趋势接口会按客户端时间范围生成完整时间桶；超长小时级范围可在进入查询前创建大量 Python 对象并放大结果集。

## 变更

- 校验 group_by 只允许 hour/day/week/month
- 在 ORM 查询和时间桶展开前校验起止顺序与分组粒度对应的最大跨度
- 最大跨度支持环境变量配置，正常默认范围和响应结构保持不变
- 增加超限范围、非法粒度均在查询前拒绝的回归测试

## 验证

-  apps/cmdb/tests/test_change_trend_limits.py
- 结果：3 passed
- tested commit：40ae037dfde75657e5b472981579e1494c920dac
- G6：89/100

风险等级：中。超大历史范围将返回明确参数错误；正常仪表盘范围不变。请 @zhaojinmeng 重点 review 默认跨度与配置边界。

Closes #4110