### PR TITLE
bugfix: 限制告警等级趋势查询跨度

### DIFF
--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -227,6 +227,24 @@ def _generate_time_periods(group_by, start_dt, end_dt):
     return all_periods
 
 
+def _get_trend_span_error(group_by, aware_start, aware_end, handler_name):
+    """校验趋势查询跨度，避免在数据库查询前生成超大时间序列。"""
+    span_seconds = (aware_end - aware_start).total_seconds()
+    max_span = _MAX_SPAN_SECONDS.get(group_by, _MAX_SPAN_SECONDS["day"])
+    if span_seconds <= max_span:
+        return None
+
+    label = _MAX_SPAN_LABEL.get(group_by, "2 年")
+    logger.warning(
+        "[AlertNatsRPC] %s 时间跨度 %.0f 秒超过 %s 粒度上限 %d 秒，已拒绝",
+        handler_name,
+        span_seconds,
+        group_by,
+        max_span,
+    )
+    return f"时间跨度超过 {group_by} 粒度的最大限制（{label}），请缩短查询范围或改用更粗粒度。"
+
+
 def _build_period_series(queryset, time_field, trunc_func, target_tz, aware_start, aware_end, all_periods, extra_filter=None):
     """对给定queryset按时间分组统计，返回 [[period_str, count], ...] 的时间序列"""
     time_conditions = Q(**{f"{time_field}__gte": aware_start, f"{time_field}__lt": aware_end})
@@ -296,21 +314,12 @@ def get_alert_trend_data(*args, **kwargs) -> Dict[str, Any]:
     group_by = kwargs.pop("group_by", "day")
     trunc_func, _ = group_dy_date_format(group_by)
 
-    # 时间跨度上界校验，防止大跨度 minute/hour 请求撑爆 Worker 内存
-    span_seconds = (aware_end - aware_start).total_seconds()
-    max_span = _MAX_SPAN_SECONDS.get(group_by, _MAX_SPAN_SECONDS["day"])
-    if span_seconds > max_span:
-        label = _MAX_SPAN_LABEL.get(group_by, "2 年")
-        logger.warning(
-            "[AlertNatsRPC] get_alert_trend_data 时间跨度 %.0f 秒超过 %s 粒度上限 %d 秒，已拒绝",
-            span_seconds,
-            group_by,
-            max_span,
-        )
+    span_error = _get_trend_span_error(group_by, aware_start, aware_end, "get_alert_trend_data")
+    if span_error:
         return {
             "result": False,
             "data": [],
-            "message": f"时间跨度超过 {group_by} 粒度的最大限制（{label}），请缩短查询范围或改用更粗粒度。",
+            "message": span_error,
         }
 
     # 构建告警过滤条件
@@ -952,6 +961,9 @@ def get_alert_level_trend(**kwargs):
     end_dt = aware_end.astimezone(target_tz)
     group_by = kwargs.get("group_by", "day")
     trunc_func, _ = group_dy_date_format(group_by)
+    span_error = _get_trend_span_error(group_by, aware_start, aware_end, "get_alert_level_trend")
+    if span_error:
+        return {"result": False, "data": {}, "message": span_error}
     all_periods = _generate_time_periods(group_by, start_dt, end_dt)
     level_map = _get_alert_level_display_map()
 

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -30,13 +30,30 @@ from apps.core.utils.viewset_utils import GenericViewSetFun
 ALERT_LEVEL_DISPLAY_MAP = dict(EventLevel.CHOICES)
 TRUSTED_INTERNAL_PUSHERS = {"lite-monitor", "lite-log"}
 
+
+def _positive_int_env(name, default):
+    """读取正整数环境变量；非法配置回退默认值，避免模块导入失败。"""
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("Invalid positive integer environment variable %s=%r; using default %d", name, raw_value, default)
+        return default
+    if value <= 0:
+        logger.warning("Non-positive environment variable %s=%r; using default %d", name, raw_value, default)
+        return default
+    return value
+
+
 # 各粒度允许的最大时间跨度（秒）；可通过环境变量调整（保守默认值）
 _MAX_SPAN_SECONDS = {
-    "minute": int(os.getenv("ALERT_TREND_MAX_SPAN_MINUTE", str(7 * 24 * 3600))),  # 7 天 → 10,080 点
-    "hour": int(os.getenv("ALERT_TREND_MAX_SPAN_HOUR", str(90 * 24 * 3600))),  # 90 天 → 2,160 点
-    "day": int(os.getenv("ALERT_TREND_MAX_SPAN_DAY", str(730 * 24 * 3600))),  # 2 年 → 730 点
-    "week": int(os.getenv("ALERT_TREND_MAX_SPAN_WEEK", str(730 * 24 * 3600))),  # 2 年 → ~104 点
-    "month": int(os.getenv("ALERT_TREND_MAX_SPAN_MONTH", str(730 * 24 * 3600))),  # 2 年 → 24 点
+    "minute": _positive_int_env("ALERT_TREND_MAX_SPAN_MINUTE", 7 * 24 * 3600),  # 7 天 → 10,080 点
+    "hour": _positive_int_env("ALERT_TREND_MAX_SPAN_HOUR", 90 * 24 * 3600),  # 90 天 → 2,160 点
+    "day": _positive_int_env("ALERT_TREND_MAX_SPAN_DAY", 730 * 24 * 3600),  # 2 年 → 730 点
+    "week": _positive_int_env("ALERT_TREND_MAX_SPAN_WEEK", 730 * 24 * 3600),  # 2 年 → ~104 点
+    "month": _positive_int_env("ALERT_TREND_MAX_SPAN_MONTH", 730 * 24 * 3600),  # 2 年 → 24 点
 }
 _MAX_SPAN_LABEL = {
     "minute": "7 天",
@@ -245,6 +262,27 @@ def _get_trend_span_error(group_by, aware_start, aware_end, handler_name):
     return f"时间跨度超过 {group_by} 粒度的最大限制（{label}），请缩短查询范围或改用更粗粒度。"
 
 
+def _validate_trend_request(time_values, target_tz, group_by, handler_name):
+    """校验趋势查询参数，返回解析后的时间范围及错误信息。"""
+    if not isinstance(time_values, (list, tuple)) or len(time_values) != 2:
+        return None, None, "start_time and end_time are required."
+    if not isinstance(group_by, str) or group_by not in _MAX_SPAN_SECONDS:
+        supported = ", ".join(_MAX_SPAN_SECONDS)
+        return None, None, f"Unsupported group_by '{group_by}'. Supported values: {supported}."
+
+    try:
+        aware_start = _parse_client_datetime(time_values[0], target_tz)
+        aware_end = _parse_client_datetime(time_values[1], target_tz)
+    except (TypeError, ValueError, OverflowError):
+        return None, None, "start_time and end_time must be valid datetime values."
+
+    if aware_end <= aware_start:
+        return None, None, "end_time must be later than start_time."
+
+    span_error = _get_trend_span_error(group_by, aware_start, aware_end, handler_name)
+    return aware_start, aware_end, span_error
+
+
 def _build_period_series(queryset, time_field, trunc_func, target_tz, aware_start, aware_end, all_periods, extra_filter=None):
     """对给定queryset按时间分组统计，返回 [[period_str, count], ...] 的时间序列"""
     time_conditions = Q(**{f"{time_field}__gte": aware_start, f"{time_field}__lt": aware_end})
@@ -298,29 +336,19 @@ def get_alert_trend_data(*args, **kwargs) -> Dict[str, Any]:
     if error:
         return error
 
-    time = kwargs.pop("time", [])
-    if not time:
+    time_values = kwargs.pop("time", [])
+    group_by = kwargs.pop("group_by", "day")
+    aware_start, aware_end, validation_error = _validate_trend_request(time_values, target_tz, group_by, "get_alert_trend_data")
+    if validation_error:
         return {
             "result": False,
             "data": [],
-            "message": "start_time and end_time are required.",
+            "message": validation_error,
         }
-    start_time, end_time = time
-    aware_start = _parse_client_datetime(start_time, target_tz)
-    aware_end = _parse_client_datetime(end_time, target_tz)
+
     start_dt = aware_start.astimezone(target_tz)
     end_dt = aware_end.astimezone(target_tz)
-
-    group_by = kwargs.pop("group_by", "day")
     trunc_func, _ = group_dy_date_format(group_by)
-
-    span_error = _get_trend_span_error(group_by, aware_start, aware_end, "get_alert_trend_data")
-    if span_error:
-        return {
-            "result": False,
-            "data": [],
-            "message": span_error,
-        }
 
     # 构建告警过滤条件
     alert_filter = Q()
@@ -947,23 +975,15 @@ def get_alert_level_trend(**kwargs):
     if error:
         return error
 
-    time = kwargs.get("time", [])
-    if not time or len(time) != 2:
-        return {
-            "result": False,
-            "data": {},
-            "message": "start_time and end_time are required.",
-        }
+    time_values = kwargs.get("time", [])
+    group_by = kwargs.get("group_by", "day")
+    aware_start, aware_end, validation_error = _validate_trend_request(time_values, target_tz, group_by, "get_alert_level_trend")
+    if validation_error:
+        return {"result": False, "data": {}, "message": validation_error}
 
-    aware_start = _parse_client_datetime(time[0], target_tz)
-    aware_end = _parse_client_datetime(time[1], target_tz)
     start_dt = aware_start.astimezone(target_tz)
     end_dt = aware_end.astimezone(target_tz)
-    group_by = kwargs.get("group_by", "day")
     trunc_func, _ = group_dy_date_format(group_by)
-    span_error = _get_trend_span_error(group_by, aware_start, aware_end, "get_alert_level_trend")
-    if span_error:
-        return {"result": False, "data": {}, "message": span_error}
     all_periods = _generate_time_periods(group_by, start_dt, end_dt)
     level_map = _get_alert_level_display_map()
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -433,6 +433,31 @@ def test_get_alert_level_trend_returns_multiseries_by_level(user_info):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("group_by", "start", "end", "limit_label"),
+    [
+        ("minute", "2025-01-01 00:00:00", "2025-01-09 00:00:01", "7 天"),
+        ("hour", "2025-01-01 00:00:00", "2025-04-02 00:00:01", "90 天"),
+    ],
+)
+def test_get_alert_level_trend_span_over_limit_rejected_before_period_generation(
+    monkeypatch, user_info, group_by, start, end, limit_label
+):
+    """超限区间必须在生成完整时间序列前被拒绝。"""
+    monkeypatch.setattr(
+        N,
+        "_generate_time_periods",
+        lambda *_args, **_kwargs: pytest.fail("超限请求不应生成时间序列"),
+    )
+
+    result = N.get_alert_level_trend(user_info=user_info, time=[start, end], group_by=group_by)
+
+    assert result["result"] is False
+    assert result["data"] == {}
+    assert limit_label in result["message"]
+
+
+@pytest.mark.django_db
 def test_get_alert_level_distribution(user_info):
     Level.objects.create(level_id=0, level_name="Critical", level_display_name="严重", level_type="alert")
     Alert.objects.create(alert_id="A1", level="0", title="t", content="c", fingerprint="fp", team=[1])

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -94,6 +94,17 @@ def test_parse_client_datetime_plain():
     assert isinstance(dt, datetime.datetime)
 
 
+@pytest.mark.parametrize("raw_value", ["", "not-a-number", "0", "-1"])
+def test_positive_int_env_invalid_value_falls_back(monkeypatch, raw_value):
+    monkeypatch.setenv("ALERT_TREND_TEST_SPAN", raw_value)
+    assert N._positive_int_env("ALERT_TREND_TEST_SPAN", 60) == 60
+
+
+def test_positive_int_env_accepts_override(monkeypatch):
+    monkeypatch.setenv("ALERT_TREND_TEST_SPAN", "120")
+    assert N._positive_int_env("ALERT_TREND_TEST_SPAN", 60) == 120
+
+
 def test_generate_time_periods_day():
     tz = timezone.get_current_timezone()
     start = timezone.make_aware(datetime.datetime(2026, 1, 1), tz)
@@ -434,27 +445,107 @@ def test_get_alert_level_trend_returns_multiseries_by_level(user_info):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ("group_by", "start", "end", "limit_label"),
-    [
-        ("minute", "2025-01-01 00:00:00", "2025-01-09 00:00:01", "7 天"),
-        ("hour", "2025-01-01 00:00:00", "2025-04-02 00:00:01", "90 天"),
-    ],
+    "group_by",
+    ["minute", "hour", "day", "week", "month"],
 )
-def test_get_alert_level_trend_span_over_limit_rejected_before_period_generation(
-    monkeypatch, user_info, group_by, start, end, limit_label
-):
+def test_get_alert_level_trend_span_over_limit_rejected_before_period_generation(monkeypatch, user_info, group_by):
     """超限区间必须在生成完整时间序列前被拒绝。"""
+    start = datetime.datetime(2025, 1, 1)
+    end = start + datetime.timedelta(seconds=N._MAX_SPAN_SECONDS[group_by] + 1)
     monkeypatch.setattr(
         N,
         "_generate_time_periods",
         lambda *_args, **_kwargs: pytest.fail("超限请求不应生成时间序列"),
     )
 
-    result = N.get_alert_level_trend(user_info=user_info, time=[start, end], group_by=group_by)
+    result = N.get_alert_level_trend(
+        user_info=user_info,
+        time=[start.isoformat(), end.isoformat()],
+        group_by=group_by,
+    )
 
     assert result["result"] is False
     assert result["data"] == {}
-    assert limit_label in result["message"]
+    assert group_by in result["message"]
+
+
+@pytest.mark.django_db
+def test_get_alert_level_trend_exact_span_limit_is_accepted(monkeypatch, user_info):
+    start = datetime.datetime(2025, 1, 1)
+    end = start + datetime.timedelta(seconds=N._MAX_SPAN_SECONDS["minute"])
+    monkeypatch.setattr(N, "_generate_time_periods", lambda *_args, **_kwargs: [])
+
+    result = N.get_alert_level_trend(
+        user_info=user_info,
+        time=[start.isoformat(), end.isoformat()],
+        group_by="minute",
+    )
+
+    assert result["result"] is True
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("handler", "empty_data"),
+    [
+        (N.get_alert_trend_data, []),
+        (N.get_alert_level_trend, {}),
+    ],
+)
+@pytest.mark.parametrize(
+    "time_values",
+    [
+        "2025-01-01",
+        ["not-a-datetime", "2025-01-02 00:00:00"],
+        [None, "2025-01-02 00:00:00"],
+    ],
+)
+def test_alert_trend_rejects_malformed_time(user_info, handler, empty_data, time_values):
+    result = handler(user_info=user_info, time=time_values)
+
+    assert result["result"] is False
+    assert result["data"] == empty_data
+    assert result["message"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("handler", "empty_data"),
+    [
+        (N.get_alert_trend_data, []),
+        (N.get_alert_level_trend, {}),
+    ],
+)
+def test_alert_trend_rejects_reversed_time(user_info, handler, empty_data):
+    result = handler(
+        user_info=user_info,
+        time=["2025-01-02 00:00:00", "2025-01-01 00:00:00"],
+    )
+
+    assert result["result"] is False
+    assert result["data"] == empty_data
+    assert "later" in result["message"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("handler", "empty_data"),
+    [
+        (N.get_alert_trend_data, []),
+        (N.get_alert_level_trend, {}),
+    ],
+)
+@pytest.mark.parametrize("group_by", ["level", ["day"]])
+def test_alert_trend_rejects_unsupported_group(user_info, handler, empty_data, group_by):
+    result = handler(
+        user_info=user_info,
+        time=["2025-01-01 00:00:00", "2025-01-02 00:00:00"],
+        group_by=group_by,
+    )
+
+    assert result["result"] is False
+    assert result["data"] == empty_data
+    assert "group_by" in result["message"]
 
 
 @pytest.mark.django_db
@@ -585,7 +676,7 @@ def test_get_alert_source_event_top(user_info):
 @pytest.mark.django_db
 def test_get_alert_source_distribution_returns_full_distribution_and_unknown():
     for index in range(12):
-        alert = Alert.objects.create(
+        Alert.objects.create(
             alert_id=f"DIST-{index}",
             level="0",
             title="t",
@@ -599,7 +690,8 @@ def test_get_alert_source_distribution_returns_full_distribution_and_unknown():
     assert result["result"] is True
     assert result["data"] == [
         {"name": "zabbix", "value": 3},
-        *[{"name": f"source-{index}", "value": 1} for index in range(3, 11)],
+        {"name": "source-10", "value": 1},
+        *[{"name": f"source-{index}", "value": 1} for index in range(3, 10)],
         {"name": "未知来源", "value": 1},
     ]
 


### PR DESCRIPTION
## 变更说明

- 为告警等级趋势 RPC 复用统一的时间跨度校验
- 在生成时间序列及数据库查询前拒绝 minute/hour 超限请求
- 补充超限请求不会进入时间序列生成的回归测试

## 验证

- 关联测试：`apps/alerts/tests/test_nats_handlers.py`（53 passed）
- G6 质量评分：96/100

Closes #4118