### PR TITLE
bugfix: 限制 REST 预览实际响应大小

### DIFF
--- a/server/apps/operation_analysis/services/datasource_preview/rest_api.py
+++ b/server/apps/operation_analysis/services/datasource_preview/rest_api.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import requests
@@ -6,6 +7,26 @@ from apps.operation_analysis.services.datasource_preview.base import BaseConnect
 from apps.operation_analysis.services.datasource_preview.schema import infer_fields
 
 MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+RESPONSE_CHUNK_BYTES = 64 * 1024
+
+
+def read_limited_json(response) -> Any:
+    content_length = response.headers.get("content-length")
+    try:
+        declared_length = int(content_length) if content_length is not None else 0
+    except (TypeError, ValueError):
+        declared_length = 0
+    if declared_length > MAX_RESPONSE_BYTES:
+        raise ConnectorError("REST API 响应体过大", code="rest_response_too_large", status_code=400)
+
+    content = bytearray()
+    for chunk in response.iter_content(chunk_size=RESPONSE_CHUNK_BYTES):
+        if not chunk:
+            continue
+        content.extend(chunk)
+        if len(content) > MAX_RESPONSE_BYTES:
+            raise ConnectorError("REST API 响应体过大", code="rest_response_too_large", status_code=400)
+    return json.loads(content)
 
 
 def extract_response_path(payload: Any, response_path: str | None) -> Any:
@@ -73,12 +94,13 @@ class RestApiConnectorExecutor(BaseConnectorExecutor):
                 params=params,
                 json=body if method == "POST" else None,
                 timeout=timeout,
+                stream=True,
             )
-            content_length = int(response.headers.get("content-length") or 0)
-            if content_length > MAX_RESPONSE_BYTES:
-                raise ConnectorError("REST API 响应体过大", code="rest_response_too_large", status_code=400)
-            response.raise_for_status()
-            payload = response.json()
+            try:
+                response.raise_for_status()
+                payload = read_limited_json(response)
+            finally:
+                response.close()
         except ConnectorError:
             raise
         except Exception as exc:

--- a/server/apps/operation_analysis/tests/test_datasource_preview_rest_api.py
+++ b/server/apps/operation_analysis/tests/test_datasource_preview_rest_api.py
@@ -1,7 +1,12 @@
 import pytest
 
 from apps.operation_analysis.services.datasource_preview.base import ConnectorError
-from apps.operation_analysis.services.datasource_preview.rest_api import RestApiConnectorExecutor, extract_response_path, normalize_rest_items
+from apps.operation_analysis.services.datasource_preview.rest_api import (
+    MAX_RESPONSE_BYTES,
+    RestApiConnectorExecutor,
+    extract_response_path,
+    normalize_rest_items,
+)
 
 
 def test_extract_response_path_reads_nested_list():
@@ -30,8 +35,12 @@ def test_rest_preview_uses_http_client_and_infers_fields():
         def raise_for_status(self):
             return None
 
-        def json(self):
-            return {"data": {"items": [{"date": "2026-06-01", "users": 120}], "count": 1}}
+        def iter_content(self, chunk_size):
+            assert chunk_size > 0
+            yield b'{"data":{"items":[{"date":"2026-06-01","users":120}],"count":1}}'
+
+        def close(self):
+            return None
 
     class FakeClient:
         def request(self, **kwargs):
@@ -52,6 +61,7 @@ def test_rest_preview_uses_http_client_and_infers_fields():
 
     assert calls[0]["method"] == "GET"
     assert calls[0]["url"] == "https://example.com/orders"
+    assert calls[0]["stream"] is True
     assert result.as_dict() == {
         "items": [{"date": "2026-06-01", "users": 120}],
         "count": 1,
@@ -60,3 +70,60 @@ def test_rest_preview_uses_http_client_and_infers_fields():
             {"key": "users", "title": "users", "value_type": "number"},
         ],
     }
+
+
+@pytest.mark.parametrize("headers", [{}, {"content-length": "1"}])
+def test_rest_preview_limits_actual_streamed_bytes(headers):
+    class FakeResponse:
+        closed = False
+
+        def __init__(self):
+            self.headers = headers
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b"["
+            yield b" " * MAX_RESPONSE_BYTES
+
+        def close(self):
+            self.closed = True
+
+    response = FakeResponse()
+
+    class FakeClient:
+        def request(self, **kwargs):
+            return response
+
+    executor = RestApiConnectorExecutor(http_client=FakeClient())
+    with pytest.raises(ConnectorError) as exc:
+        executor.preview({"url": "https://example.com/large"}, {})
+
+    assert exc.value.code == "rest_response_too_large"
+    assert response.closed is True
+
+
+def test_rest_preview_accepts_small_chunked_response_without_content_length():
+    class FakeResponse:
+        headers = {}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size):
+            yield b'[{"name":"ok"}]'
+
+        def close(self):
+            return None
+
+    class FakeClient:
+        def request(self, **kwargs):
+            return FakeResponse()
+
+    result = RestApiConnectorExecutor(http_client=FakeClient()).preview(
+        {"url": "https://example.com/chunked"},
+        {},
+    )
+
+    assert result.items == [{"name": "ok"}]


### PR DESCRIPTION
## 问题

REST 数据源预览仅在完整下载后检查响应大小，并信任可缺失或低报的 `Content-Length`，超限响应仍会被全部读入内存。

## 修复

- 改为流式读取响应体，并按实际累计字节数即时拒绝超限响应。
- 保留声明长度的快速拒绝，同时覆盖无 `Content-Length` 和低报长度场景。
- 不改变正常响应的解析与返回契约。

## 验证

- `apps/operation_analysis/tests/test_datasource_preview_rest_api.py`：7 passed
- 关联测试入口：`关联测试入口 `
- G6：96/100

风险：中。请 @zhaojinmeng 重点 review 流式读取的兼容性与上限边界。

Closes #4123