### PR TITLE
fix(web): 登录页语言切换不再调用 update_user（避免清空登录用户 profile）

### DIFF
--- a/web/src/app/(core)/auth/signin/login-auth/SigninLanguageToggle.tsx
+++ b/web/src/app/(core)/auth/signin/login-auth/SigninLanguageToggle.tsx
@@ -34,31 +34,21 @@ const SUPPORTED_LANGUAGES: ReadonlyArray<LanguageOption> = [
  *      dropdown 仍 absolute(不参与文档流、不挤下方)。
  *
  * 行为契约:
- *   - 不引入 fetch / useSession / try-catch。
+ *   - 不引入 fetch / useSession / try-catch / async 副作用。
  *   - 仅作为 useLocale().setLocale 的触发器;副作用收敛到
  *     LocaleProvider.changeLocale。
  *   - Dropdown 项过滤当前 locale,只展示另一语言。
  *   - aria-label 走 signin.languageToggle.label(i18n 键)。
+ *   - 后端 User.locale 持久化由个人设置 console_mgmt/update_user_base_info,
+ *     登录页 toggle 只改前端 localStorage,登录后由后端按 user.locale 渲染。
+ *     (曾尝试 syncBackendLocale→editUser/update_user,但该接口受
+ *     user_group-Edit User 限制,会越权 / 清空 profile,故撤销。)
  */
-import { useSession } from 'next-auth/react';
-import { useUserApi } from '@/app/system-manager/api/user';
 export default function SigninLanguageToggle() {
   const { t } = useTranslation();
   const { locale, setLocale } = useLocale();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-  const { data: session } = useSession();
-  const { editUser } = useUserApi();
-
-  // 同步后端 User.locale(已登录用户改完后端才能返回对应语言的 monitor i18n)
-  const syncBackendLocale = async (langKey: string) => {
-    if (!session?.user?.id) return;
-    try {
-      await editUser({ id: session.user.id, locale: langKey });
-    } catch {
-      // 后端同步失败不影响前端切换(本地化已生效,只是后端 monitor i18n 仍按旧 locale)
-    }
-  };
 
   // 点击外部关闭
   useEffect(() => {
@@ -123,7 +113,6 @@ export default function SigninLanguageToggle() {
                   role="menuitem"
                   onClick={() => {
                     setLocale(lang.key);
-                    syncBackendLocale(lang.key);
                     setOpen(false);
                   }}
                   className="flex w-full items-center px-3 py-2 text-left text-sm text-(--color-text-1) hover:bg-white/10"


### PR DESCRIPTION
## Summary
- 登录页 `SigninLanguageToggle` 曾在切换语言时调用 `editUser({ id, locale })` → `system_mgmt/user/update_user/`，存在 P0 风险：字段不匹配、越权拦截，一旦请求“成功”还会清空 `UserRule` / groups / roles / display_name；外层 `try/catch` 还会静默吞错。
- 本次撤掉 `useSession` / `editUser` / `syncBackendLocale`，登录页仅更新前端 `localStorage`（`useLocale().setLocale`）。
- 后端 `User.locale` 持久化继续走个人设置的安全接口 `console_mgmt/update_user_base_info`，不再误用管理员受限的 `update_user`。

## Test plan
- [ ] 打开登录页，切换中英文：界面文案立刻切换，且 Network 中无 `system_mgmt/user/update_user/` 请求
- [ ] 用普通用户登录后，检查该用户的 group / role / UserRule / display_name 未被改动
- [ ] 个人设置中修改语言：仍可经 `console_mgmt/update_user_base_info/` 正常落库，且前端语言同步