### PR TITLE
bugfix: 补全运营分析画布默认组织回填

### DIFF
--- a/server/apps/operation_analysis/management/commands/init_default_groups.py
+++ b/server/apps/operation_analysis/management/commands/init_default_groups.py
@@ -8,7 +8,8 @@ from django.db import transaction
 
 from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
-from apps.operation_analysis.models.models import Architecture, Dashboard, Directory, Topology
+from apps.operation_analysis.models.models import Directory
+from apps.operation_analysis.services.canvas.registry import CANVAS_TYPE_REGISTRY
 
 
 def get_default_group_id():
@@ -45,9 +46,7 @@ class Command(BaseCommand):
         # 定义需要初始化的模型列表
         models_to_init = [
             (Directory, "目录"),
-            (Dashboard, "仪表盘"),
-            (Topology, "拓扑图"),
-            (Architecture, "架构图"),
+            *((meta.model, meta.node_label) for meta in CANVAS_TYPE_REGISTRY.values()),
             (DataSourceAPIModel, "数据源API"),
         ]
 

--- a/server/apps/operation_analysis/tests/test_management_commands.py
+++ b/server/apps/operation_analysis/tests/test_management_commands.py
@@ -8,6 +8,7 @@ from django.core.management import call_command
 
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, DataSourceTag, NameSpace
 from apps.operation_analysis.models.models import Directory
+from apps.operation_analysis.services.canvas.registry import CANVAS_TYPE_REGISTRY
 
 # --------------------------------------------------------------------------
 # init_default_namespace
@@ -197,6 +198,27 @@ def test_init_default_groups_fills_empty_groups():
     skip.refresh_from_db()
     assert obj.groups  # 已补充默认组织
     assert skip.groups == [5]  # 非空保持不变
+
+
+@pytest.mark.django_db
+def test_init_default_groups_covers_all_registered_canvas_models():
+    from apps.system_mgmt.models.user import Group
+
+    root_default, _ = Group.objects.get_or_create(name="Default", parent_id=0)
+    records = []
+
+    for object_type, meta in CANVAS_TYPE_REGISTRY.items():
+        empty = meta.model.objects.create(name=f"无组织-{object_type}", groups=[], created_by="system")
+        existing = meta.model.objects.create(name=f"已分组-{object_type}", groups=[99], created_by="system")
+        records.append((empty, existing))
+
+    call_command("init_default_groups")
+
+    for empty, existing in records:
+        empty.refresh_from_db()
+        existing.refresh_from_db()
+        assert empty.groups == [root_default.id]
+        assert existing.groups == [99]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

默认组织初始化命令维护了一份独立画布模型清单，遗漏了正式注册表中的大屏和报表，导致这些对象的空组织字段无法被回填。

## 修复

- 从权威画布注册表派生需要回填的模型，避免清单继续漂移
- 保持既有语义：仅回填空组织，不覆盖已设置的组织
- 补充 Screen、Report 与已有组织保留场景的回归覆盖

## 验证

- apps/operation_analysis/tests/test_management_commands.py：18/18 PASS
- G6：96/100
- tested commit：f93c49c0ade3693698a7e7787498aa4f9202ce5e

风险：中。涉及默认数据初始化范围，需 review 注册表派生是否符合预期。

Closes #4126