### PR TITLE
fix(monitor): JVM JMX 基本信息表头监听端口前置

### DIFF
--- a/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/UI.json
+++ b/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/UI.json
@@ -117,6 +117,19 @@
       "label_en": "Node"
     },
     {
+      "name": "ENV_LISTEN_PORT",
+      "label": "监听端口",
+      "type": "inputNumber",
+      "required": true,
+      "widget_props": {
+        "placeholder": "监听端口",
+        "min": 1,
+        "precision": 0,
+        "placeholder_en": "Listen Port"
+      },
+      "label_en": "Listen Port"
+    },
+    {
       "name": "jmx_url",
       "label": "URL",
       "type": "input",
@@ -132,19 +145,6 @@
         "target_field": "instance_name"
       },
       "label_en": "URL"
-    },
-    {
-      "name": "ENV_LISTEN_PORT",
-      "label": "监听端口",
-      "type": "inputNumber",
-      "required": true,
-      "widget_props": {
-        "placeholder": "监听端口",
-        "min": 1,
-        "precision": 0,
-        "placeholder_en": "Listen Port"
-      },
-      "label_en": "Listen Port"
     },
     {
       "name": "instance_name",


### PR DESCRIPTION
## Summary
- 调整 `JVM-JMX/jmx/jvm/UI.json` 的 `table_columns` 顺序
- 将 `ENV_LISTEN_PORT` 提前到 `jmx_url` 之前，与 OceanBase 顺序（节点 → 监听端口 → 主机 → 实例名称 → 组）保持一致
- 与 WeOpsX-Enterprise PR `fix/middleware-listening-port-first` 行为一致

## Test plan
- [ ] 打开 JVM（JMX）监控对象集成配置页，确认「基本信息」表头顺序符合规范
- [ ] 编辑已有实例，检查 jmx_url 的 change_handler 仍能正确联动 instance_name
- [ ] 重新执行 plugin_init 验证

> 同一个 commit 也推到了 fork `ZhongmingFan/bk-lite:fix/jvm-listening-port-first`，PR #5 是误提到 fork 上的 master，请先忽略或关闭。