### PR TITLE
bugfix: 收敛 NATS 作业派发失败状态

### DIFF
--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -11,6 +11,7 @@ from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 from apps.job_mgmt.constants import CallbackType, ExecutionStatus, JobType, TriggerSource
 from apps.job_mgmt.models import DangerousPath, DangerousRule, DistributionFile, JobExecution, Playbook, ScheduledTask, Script, Target
 from apps.job_mgmt.services.callback_service import send_callback
+from apps.job_mgmt.services.celery_dispatch import dispatch_celery_task
 from apps.job_mgmt.services.dangerous_checker import DangerousChecker
 from apps.job_mgmt.services.execution_stream_service import publish_done_sentinel
 from apps.job_mgmt.services.script_normalize import normalize_script_line_endings
@@ -454,9 +455,8 @@ def job_script_execute(data: dict):
     )
 
     # 触发异步执行（Celery Worker）
-    result = execute_script_task.delay(execution.id)
-    execution.celery_task_id = result.id
-    execution.save(update_fields=["celery_task_id", "updated_at"])
+    if not dispatch_celery_task(execute_script_task, execution):
+        return {"result": False, "message": "任务调度服务暂不可用，请稍后重试"}
 
     return {"result": True, "data": {"task_id": execution.id}}
 
@@ -552,9 +552,8 @@ def job_file_distribute(data: dict):
     )
 
     # 触发异步执行（Celery Worker）
-    result = distribute_files_task.delay(execution.id)
-    execution.celery_task_id = result.id
-    execution.save(update_fields=["celery_task_id", "updated_at"])
+    if not dispatch_celery_task(distribute_files_task, execution):
+        return {"result": False, "message": "任务调度服务暂不可用，请稍后重试"}
 
     return {"result": True, "data": {"task_id": execution.id}}
 

--- a/server/apps/job_mgmt/tests/test_nats_open_api.py
+++ b/server/apps/job_mgmt/tests/test_nats_open_api.py
@@ -1,5 +1,6 @@
 """NATS 开放接口单元测试"""
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -34,6 +35,22 @@ class TestJobScriptExecute:
 
         assert result["result"] is True
         assert "task_id" in result["data"]
+
+    def test_dispatch_failure_marks_execution_failed(self):
+        from apps.job_mgmt.constants import ExecutionStatus
+        from apps.job_mgmt.models import JobExecution
+        from apps.job_mgmt.nats_api import job_script_execute
+
+        with patch("apps.job_mgmt.services.dangerous_checker.DangerousChecker.check_command") as mock_check, patch(
+            "apps.job_mgmt.nats_api.execute_script_task.delay", side_effect=ConnectionError("broker unavailable")
+        ):
+            mock_check.return_value = MagicMock(can_execute=True, forbidden=[])
+            result = job_script_execute(self._valid_data(name="dispatch-failed-script"))
+
+        assert result == {"result": False, "message": "任务调度服务暂不可用，请稍后重试"}
+        execution = JobExecution.objects.get(name="dispatch-failed-script")
+        assert execution.status == ExecutionStatus.FAILED
+        assert execution.celery_task_id == ""
 
     def test_empty_target_list(self):
         from apps.job_mgmt.nats_api import job_script_execute
@@ -180,6 +197,38 @@ class TestJobScriptExecute:
 @pytest.mark.unit
 @pytest.mark.django_db
 class TestJobFileDistribute:
+    def test_dispatch_failure_marks_execution_failed(self):
+        from django.utils import timezone
+
+        from apps.job_mgmt.constants import ExecutionStatus
+        from apps.job_mgmt.models import DistributionFile, JobExecution
+        from apps.job_mgmt.nats_api import job_file_distribute
+
+        DistributionFile.objects.create(
+            original_name="package.tar.gz",
+            file_key="job-files/package.tar.gz",
+            expire_at=timezone.now() + timedelta(days=1),
+            team=1,
+        )
+        data = {
+            "name": "dispatch-failed-file",
+            "file_keys": ["job-files/package.tar.gz"],
+            "target_source": "node_mgmt",
+            "target_list": [{"node_id": "n1", "name": "h1", "ip": "1.1.1.1", "os": "linux", "cloud_region_id": "r1"}],
+            "target_path": "/tmp/",
+            "team": [1],
+        }
+        with patch("apps.job_mgmt.services.dangerous_checker.DangerousChecker.check_path") as mock_check, patch(
+            "apps.job_mgmt.nats_api.distribute_files_task.delay", side_effect=ConnectionError("broker unavailable")
+        ):
+            mock_check.return_value = MagicMock(can_execute=True, forbidden=[])
+            result = job_file_distribute(data)
+
+        assert result == {"result": False, "message": "任务调度服务暂不可用，请稍后重试"}
+        execution = JobExecution.objects.get(name="dispatch-failed-file")
+        assert execution.status == ExecutionStatus.FAILED
+        assert execution.celery_task_id == ""
+
     def test_empty_file_ids(self):
         from apps.job_mgmt.nats_api import job_file_distribute
 


### PR DESCRIPTION
## 问题

NATS 开放执行入口应在“执行记录已落库”与“Celery 任务已可靠派发”之间守住状态一致性。原实现在 broker 不可用或序列化失败时抛出异常，已创建的记录却永久停留在 `PENDING`。

## 根因

REST/定时任务执行链已经通过 `dispatch_celery_task` 统一处理“派发 + task id 回填 + 失败收敛”，但两条 NATS handler 绕过了这个可靠性边界，直接调用 `.delay()`。

## 怎么修的

- `job_script_execute` 和 `job_file_distribute` 统一复用 `dispatch_celery_task`。
- 派发失败时由已有封装将执行记录收敛为 `FAILED`，handler 返回稳定的结构化失败响应。
- 派发成功时仍回填 `celery_task_id`，原有成功响应契约不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["NATS 触发层"]
        T1["job_script_execute / job_file_distribute\nnats_api.py"]
    end

    DB["JobExecution.objects.create\nstatus=PENDING"]

    subgraph N["可靠派发层"]
        F1["dispatch_celery_task\ncelery_dispatch.py"]
        F2["Celery task.delay\ntasks.py"]
    end

    subgraph C["失败收敛层"]
        C1["JobExecution.save\nstatus=FAILED"]
        C2["NATS 结构化失败响应"]
    end

    T1 --> DB --> F1 --> F2
    F2 -. "broker/序列化异常" .-> C1
    C1 --> C2
```

## 影响范围

改动仅位于 `job_mgmt` 两条 NATS 开放执行入口的派发步骤，复用同模块已在 REST/定时任务路径使用的封装。不改 NATS subject、请求字段、成功响应或 agents/web 契约；只改善派发失败时的状态与响应。

## 验证

- `apps/job_mgmt/tests/test_nats_open_api.py`：21 个关联测试通过。
- 新增脚本执行和文件分发两个 broker 异常场景，断言返回失败、执行记录为 `FAILED`且未伪造 task id；回退实现后测试会因 `ConnectionError` 外溢而失败。

Closes #4131
