### PR TITLE
bugfix: 避免 S3JSONField 重复请求对象存储

### DIFF
--- a/server/apps/core/fields/s3_json_field.py
+++ b/server/apps/core/fields/s3_json_field.py
@@ -306,14 +306,6 @@ class S3JSONField(models.CharField):
             return None
 
         try:
-            # 检查文件是否存在
-            exists = self.storage.exists(file_path)
-            logger.info(f"[S3JSONField] File exists check for {file_path}: {exists}")
-
-            if not exists:
-                logger.warning(f"S3 file not found: {file_path}")
-                return None
-
             # 读取文件内容
             with self.storage.open(file_path, "rb") as f:
                 content_bytes = f.read()

--- a/server/apps/core/tests/test_s3_json_field_service.py
+++ b/server/apps/core/tests/test_s3_json_field_service.py
@@ -28,6 +28,7 @@ class _FakeStorage:
     def __init__(self):
         self.objects = {}
         self.deleted = []
+        self.calls = []
 
     def save(self, filename, content):
         # 模拟 storage 真实行为：读取 ContentFile 字节并以路径为键存储
@@ -36,9 +37,11 @@ class _FakeStorage:
         return filename
 
     def exists(self, path):
+        self.calls.append(("exists", path))
         return path in self.objects
 
     def open(self, path, mode="rb"):
+        self.calls.append(("open", path, mode))
         return io.BytesIO(self.objects[path])
 
     def delete(self, path):
@@ -112,6 +115,13 @@ class TestUploadAndLoadRoundTrip:
 
 
 class TestLoadFromS3EdgeCases:
+    def test_load_opens_object_without_exists_request(self):
+        field = _make_field()
+        field.storage.objects["one-request.json"] = b'{"ok": true}'
+
+        assert field._load_from_s3("one-request.json") == {"ok": True}
+        assert field.storage.calls == [("open", "one-request.json", "rb")]
+
     def test_empty_path_returns_none(self):
         field = _make_field()
         assert field._load_from_s3("") is None
@@ -132,7 +142,7 @@ class TestLoadFromS3EdgeCases:
 
     def test_storage_error_returns_none(self, mocker):
         field = _make_field()
-        mocker.patch.object(field.storage, "exists", side_effect=RuntimeError("s3 down"))
+        mocker.patch.object(field.storage, "open", side_effect=RuntimeError("s3 down"))
         assert field._load_from_s3("x") is None
 
 


### PR DESCRIPTION
## 变更说明

- 移除 S3JSONField 延迟加载前的冗余 exists/HEAD 请求
- 直接通过 open/GET 读取对象，沿用既有异常处理语义
- 补充回归测试，锁定单次读取不调用 exists

## 验证

- `apps/core/tests/test_s3_json_field_service.py`：31 passed
- G6：98/100

Closes #4143