### PR TITLE
fix(core): 撤权时立即失效 API 密钥权限缓存

### DIFF
--- a/docs/operations/api-token-permission-cache-rollout.md
+++ b/docs/operations/api-token-permission-cache-rollout.md
@@ -1,0 +1,33 @@
+# API Token 权限代际缓存发布与回滚
+
+本流程只适用于首次上线带权限代际的 API Token 缓存版本，以及回滚到不识别代际的旧版本。
+普通版本升级不需要重复执行。
+
+## 首次上线
+
+1. 暂停角色、菜单、组织和数据权限变更入口。
+2. 排空并停止全部旧版 Server Worker，确认没有旧二进制继续处理鉴权或写入无版本缓存键。
+3. 启动全部新版 Server Worker。
+4. 验证 API Token 鉴权和权限变更回归通过后，恢复权限变更入口。
+
+禁止旧版与新版 Server Worker 在权限变更窗口内混合提供鉴权。默认 LocMem 缓存会随旧 Worker
+退出而清空；共享 Redis 中的旧键不会被新版读取，并由原 TTL 自然回收。
+
+## 回滚
+
+1. 再次暂停权限变更入口。
+2. 排空并停止全部新版 Server Worker。
+3. 使用待回滚前的新版镜像执行：
+
+   ```bash
+   python manage.py prepare_permission_cache_rollback --confirm
+   ```
+
+   该命令只清理 `perm_rules:*`、`token_info:*`、`api_token_permissions:*` 及其索引，
+   避免旧二进制重新采用共享 Redis 中残留的无版本权限快照；不会清空 JWT 撤销黑名单、
+   OTP 限流或登录挑战等其他默认缓存数据。命令失败时禁止启动旧版本 Worker。
+4. 启动全部旧版 Server Worker，完成 API Token 鉴权和权限变更回归后恢复入口。
+
+如果无法执行清缓存命令，必须在全部 Worker 停止后等待
+`API_TOKEN_PERMISSION_CACHE_TTL`、`PERMISSION_CACHE_TTL` 与 `TOKEN_INFO_CACHE_TTL`
+中最大的 TTL 完整到期，才能启动旧版本。

--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -14,6 +14,10 @@ from apps.base.models import User, UserAPISecret
 from apps.core.constants import VERIFY_TOKEN_USER_NOT_FOUND_CODE, VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE
 from apps.core.logger import logger
 from apps.core.utils.custom_error import DoesNotExist
+from apps.core.utils.permission_cache import (
+    API_TOKEN_PERMISSION_CACHE_PREFIX,
+    register_api_token_permission_cache_key,
+)
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import Group, Menu, Role
 from apps.system_mgmt.models import User as SystemUser
@@ -61,7 +65,7 @@ class APISecretAuthBackend(ModelBackend):
 
     # 缓存配置：默认 600s，可通过 API_TOKEN_PERMISSION_CACHE_TTL 环境变量覆盖
     PERMISSION_CACHE_TTL = int(os.getenv("API_TOKEN_PERMISSION_CACHE_TTL", "600"))
-    PERMISSION_CACHE_KEY_PREFIX = "api_token_permissions"
+    PERMISSION_CACHE_KEY_PREFIX = API_TOKEN_PERMISSION_CACHE_PREFIX
 
     def authenticate(self, request=None, username=None, password=None, api_token=None, **kwargs) -> Optional[User]:
         """使用API token进行用户认证"""
@@ -152,6 +156,12 @@ class APISecretAuthBackend(ModelBackend):
                     "is_superuser": is_superuser,
                     "role_ids": list(all_role_ids),
                 },
+                self.PERMISSION_CACHE_TTL,
+            )
+            register_api_token_permission_cache_key(
+                user.username,
+                user.domain,
+                cache_key,
                 self.PERMISSION_CACHE_TTL,
             )
 

--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -147,7 +147,13 @@ class APISecretAuthBackend(ModelBackend):
             user.is_superuser = is_superuser
             user.role_ids = list(all_role_ids)
 
-            # 缓存结果
+            # 先登记再写入快照：登记失败时必须 fail-closed，避免留下无法精确失效的权限缓存。
+            register_api_token_permission_cache_key(
+                user.username,
+                user.domain,
+                cache_key,
+                self.PERMISSION_CACHE_TTL,
+            )
             cache.set(
                 cache_key,
                 {
@@ -156,12 +162,6 @@ class APISecretAuthBackend(ModelBackend):
                     "is_superuser": is_superuser,
                     "role_ids": list(all_role_ids),
                 },
-                self.PERMISSION_CACHE_TTL,
-            )
-            register_api_token_permission_cache_key(
-                user.username,
-                user.domain,
-                cache_key,
                 self.PERMISSION_CACHE_TTL,
             )
 

--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -14,10 +14,7 @@ from apps.base.models import User, UserAPISecret
 from apps.core.constants import VERIFY_TOKEN_USER_NOT_FOUND_CODE, VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE
 from apps.core.logger import logger
 from apps.core.utils.custom_error import DoesNotExist
-from apps.core.utils.permission_cache import (
-    API_TOKEN_PERMISSION_CACHE_PREFIX,
-    register_api_token_permission_cache_key,
-)
+from apps.core.utils.permission_cache import API_TOKEN_PERMISSION_CACHE_PREFIX, get_user_permission_version, register_api_token_permission_cache_key
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import Group, Menu, Role
 from apps.system_mgmt.models import User as SystemUser
@@ -41,10 +38,7 @@ def _collect_ancestor_group_ids(seed_ids: List) -> Set[int]:
     if not seed_ids:
         return set()
     # 一次轻量查询：只取 (id, parent_id, allow_inherit_roles)，不加载角色关联
-    all_meta = {
-        row[0]: (row[1], row[2])
-        for row in Group.objects.values_list("id", "parent_id", "allow_inherit_roles")
-    }
+    all_meta = {row[0]: (row[1], row[2]) for row in Group.objects.values_list("id", "parent_id", "allow_inherit_roles")}
     result: Set[int] = set()
     stack = list(seed_ids)
     while stack:
@@ -78,6 +72,16 @@ class APISecretAuthBackend(ModelBackend):
             if user_secret is None:
                 return None
             user = User._default_manager.get(username=user_secret.username, domain=user_secret.domain)
+            if not SystemUser.objects.filter(
+                username=user_secret.username,
+                domain=user_secret.domain,
+            ).exists():
+                logger.warning(
+                    "API token user is missing from system management: %s@%s",
+                    user_secret.username,
+                    user_secret.domain,
+                )
+                return None
             user.group_list = [user_secret.team]
 
             # 填充用户权限信息
@@ -97,9 +101,11 @@ class APISecretAuthBackend(ModelBackend):
                 logger.error(f"API token authentication failed: {e}")
             return None
 
-    def _get_permission_cache_key(self, username: str, domain: str, team: int) -> str:
+    def _get_permission_cache_key(self, username: str, domain: str, team: int, permission_version: int = None) -> str:
         """生成权限缓存 key"""
-        return f"{self.PERMISSION_CACHE_KEY_PREFIX}:{username}:{domain}:{team}"
+        if permission_version is None:
+            permission_version = get_user_permission_version(username, domain)
+        return f"{self.PERMISSION_CACHE_KEY_PREFIX}:{username}:{domain}:v{permission_version}:{team}"
 
     def _populate_user_permissions(self, user: User, team: int) -> None:
         """
@@ -110,9 +116,12 @@ class APISecretAuthBackend(ModelBackend):
         """
         try:
             # 尝试从缓存获取
-            cache_key = self._get_permission_cache_key(user.username, user.domain, team)
+            permission_version = get_user_permission_version(user.username, user.domain)
+            cache_key = self._get_permission_cache_key(user.username, user.domain, team, permission_version)
             cached = cache.get(cache_key)
             if cached:
+                if get_user_permission_version(user.username, user.domain) != permission_version:
+                    raise RuntimeError("Permission version changed while reading API token snapshot")
                 user.roles = cached.get("roles", [])
                 user.permission = {k: set(v) for k, v in cached.get("permission", {}).items()}
                 user.is_superuser = cached.get("is_superuser", False)
@@ -147,13 +156,21 @@ class APISecretAuthBackend(ModelBackend):
             user.is_superuser = is_superuser
             user.role_ids = list(all_role_ids)
 
-            # 先登记再写入快照：登记失败时必须 fail-closed，避免留下无法精确失效的权限缓存。
-            register_api_token_permission_cache_key(
-                user.username,
-                user.domain,
-                cache_key,
-                self.PERMISSION_CACHE_TTL,
-            )
+            try:
+                register_api_token_permission_cache_key(
+                    user.username,
+                    user.domain,
+                    cache_key,
+                    self.PERMISSION_CACHE_TTL,
+                )
+            except Exception as e:
+                # 索引仅用于回收旧条目；权限代际保证旧快照不可达。
+                logger.warning(
+                    "Failed to register API token permission cache key for %s@%s: %s",
+                    user.username,
+                    user.domain,
+                    e,
+                )
             cache.set(
                 cache_key,
                 {
@@ -164,6 +181,8 @@ class APISecretAuthBackend(ModelBackend):
                 },
                 self.PERMISSION_CACHE_TTL,
             )
+            if get_user_permission_version(user.username, user.domain) != permission_version:
+                raise RuntimeError("Permission version changed while calculating API token permissions")
 
         except Exception as e:
             logger.error(f"Failed to populate user permissions for {user.username}@{user.domain}: {e}")
@@ -198,10 +217,7 @@ class APISecretAuthBackend(ModelBackend):
             # 2. 按 ID 集合有界加载含角色关联的 Group 对象
             seed_ids = [gid.get("id") if isinstance(gid, dict) else gid for gid in user_groups if gid]
             ancestor_ids = _collect_ancestor_group_ids(seed_ids)
-            all_groups = {
-                g.id: g
-                for g in Group.objects.prefetch_related("roles").filter(id__in=ancestor_ids)
-            }
+            all_groups = {g.id: g for g in Group.objects.prefetch_related("roles").filter(id__in=ancestor_ids)}
             visited: Set[int] = set()
 
             def collect_roles(group_id: int) -> None:

--- a/server/apps/core/backends.py
+++ b/server/apps/core/backends.py
@@ -26,6 +26,18 @@ COOKIE_CURRENT_TEAM = "current_team"
 CLIENT_ID_ENV_KEY = "CLIENT_ID"
 
 
+def _normalize_group_ids(group_ids) -> Set[int]:
+    normalized: Set[int] = set()
+    for group_id in group_ids or []:
+        if isinstance(group_id, dict):
+            group_id = group_id.get("id")
+        if type(group_id) is int and group_id > 0:
+            normalized.add(group_id)
+        elif type(group_id) is str and re.fullmatch(r"[1-9][0-9]*", group_id):
+            normalized.add(int(group_id))
+    return normalized
+
+
 def _collect_ancestor_group_ids(seed_ids: List) -> Set[int]:
     """
     从 seed_ids 出发，沿 parent_id 链向上收集所有祖先组 ID（含自身）。
@@ -82,7 +94,9 @@ class APISecretAuthBackend(ModelBackend):
                     user_secret.domain,
                 )
                 return None
-            user.group_list = [user_secret.team]
+            user.group_list = []
+            user._api_secret_team_scope = True
+            user._api_secret_team = user_secret.team
 
             # 填充用户权限信息
             self._populate_user_permissions(user, user_secret.team)
@@ -119,13 +133,15 @@ class APISecretAuthBackend(ModelBackend):
             permission_version = get_user_permission_version(user.username, user.domain)
             cache_key = self._get_permission_cache_key(user.username, user.domain, team, permission_version)
             cached = cache.get(cache_key)
-            if cached:
+            cache_snapshot_complete = not getattr(user, "_api_secret_team_scope", False) or "group_list" in (cached or {})
+            if cached and cache_snapshot_complete:
                 if get_user_permission_version(user.username, user.domain) != permission_version:
                     raise RuntimeError("Permission version changed while reading API token snapshot")
                 user.roles = cached.get("roles", [])
                 user.permission = {k: set(v) for k, v in cached.get("permission", {}).items()}
                 user.is_superuser = cached.get("is_superuser", False)
                 user.role_ids = cached.get("role_ids", [])
+                user.group_list = cached.get("group_list", user.group_list)
                 return
 
             # 获取用户所有角色
@@ -178,6 +194,7 @@ class APISecretAuthBackend(ModelBackend):
                     "permission": {k: list(v) for k, v in permission.items()},
                     "is_superuser": is_superuser,
                     "role_ids": list(all_role_ids),
+                    "group_list": user.group_list,
                 },
                 self.PERMISSION_CACHE_TTL,
             )
@@ -191,6 +208,8 @@ class APISecretAuthBackend(ModelBackend):
             user.permission = {}
             user.is_superuser = False
             user.role_ids = []
+            if getattr(user, "_api_secret_team_scope", False):
+                user.group_list = []
 
     def _get_user_all_roles(self, user: User) -> Set[int]:
         """
@@ -210,6 +229,11 @@ class APISecretAuthBackend(ModelBackend):
 
         group_role_ids: Set[int] = set()
         user_groups = user.group_list or []
+        if getattr(user, "_api_secret_team_scope", False):
+            system_group_ids = _normalize_group_ids(sys_user.group_list if sys_user else [])
+            requested_group_ids = _normalize_group_ids([getattr(user, "_api_secret_team", None)])
+            user_groups = list(requested_group_ids & system_group_ids)
+            user.group_list = user_groups
 
         if user_groups:
             # 两步有界查询，避免全表 prefetch（修复 thundering herd）：

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -5,6 +5,7 @@
 
 import os
 
+from django.apps import apps as django_apps
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 
@@ -17,10 +18,14 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--apps", type=str, default="", help="逗号分隔的应用列表，为空则初始化所有应用")
         parser.add_argument(
-            "--continue-on-error", action="store_true", help="初始化失败时继续执行后续模块，并在末尾输出失败列表",
+            "--continue-on-error",
+            action="store_true",
+            help="初始化失败时继续执行后续模块，并在末尾输出失败列表",
         )
 
     def handle(self, *args, **options):
+        self._verify_critical_schema()
+
         apps = options["apps"].strip()
         continue_on_error = options["continue_on_error"]
 
@@ -74,6 +79,15 @@ class Command(BaseCommand):
             return
 
         self.stdout.write(self.style.SUCCESS("批量初始化完成"))
+
+    @staticmethod
+    def _verify_critical_schema():
+        """确保被权限读写链路硬依赖的表已完成迁移。"""
+        try:
+            permission_version_model = django_apps.get_model("system_mgmt", "UserPermissionVersion")
+        except LookupError as error:
+            raise RuntimeError("关键应用 system_mgmt 未安装，无法启动权限服务") from error
+        permission_version_model.objects.values_list("id", flat=True).first()
 
     def _init_system_mgmt(self):
         """系统管理资源初始化"""
@@ -159,6 +173,8 @@ class Command(BaseCommand):
         self.stdout.write("预热语言缓存...")
         try:
             result = preload_language_cache()
-            self.stdout.write(self.style.SUCCESS(f"语言缓存预热完成: {len(result['loaded'])} 已加载, {len(result['skipped'])} 已跳过, {len(result['failed'])} 失败"))
+            self.stdout.write(
+                self.style.SUCCESS(f"语言缓存预热完成: {len(result['loaded'])} 已加载, {len(result['skipped'])} 已跳过, {len(result['failed'])} 失败")
+            )
         except Exception as e:
             self.stdout.write(self.style.WARNING(f"语言缓存预热失败: {str(e)}"))

--- a/server/apps/core/tests/test_api_secret_hash_auth.py
+++ b/server/apps/core/tests/test_api_secret_hash_auth.py
@@ -2,20 +2,24 @@ import pytest
 
 from apps.base.models import User, UserAPISecret
 from apps.core.backends import APISecretAuthBackend
+from apps.system_mgmt.models import User as SystemUser
 
 
 @pytest.mark.django_db
-def test_api_secret_authenticates_with_raw_token_against_hashed_storage(monkeypatch):
+def test_api_secret_authenticates_with_raw_token_against_hashed_storage():
     raw_secret = UserAPISecret.generate_api_secret()
     user = User.objects.create(username="alice", domain="domain.com")
+    SystemUser.objects.create(
+        username=user.username,
+        domain=user.domain,
+        group_list=[7],
+    )
     UserAPISecret.objects.create(
         username=user.username,
         domain=user.domain,
         team=7,
         api_secret=UserAPISecret.hash_api_secret(raw_secret),
     )
-    monkeypatch.setattr(APISecretAuthBackend, "_populate_user_permissions", lambda self, user, team: None)
-
     authenticated = APISecretAuthBackend().authenticate(api_token=raw_secret)
 
     assert authenticated == user

--- a/server/apps/core/tests/test_api_token_permission.py
+++ b/server/apps/core/tests/test_api_token_permission.py
@@ -421,6 +421,26 @@ class TestPopulateUserPermissions:
                 backend.PERMISSION_CACHE_TTL,
             )
 
+    def test_cache_index_registration_failure_does_not_leave_snapshot(self):
+        """索引登记失败时不得先写入无法失效的权限快照。"""
+        backend = APISecretAuthBackend()
+        user = MockUser(username="newuser", domain="test.com", group_list=[1])
+
+        with patch("apps.core.backends.cache") as mock_cache, patch(
+            "apps.core.backends.register_api_token_permission_cache_key", side_effect=RuntimeError("index unavailable")
+        ):
+            mock_cache.get.return_value = None
+            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch(
+                "apps.core.backends.Role"
+            ) as mock_role:
+                mock_role.objects.filter.return_value.__iter__.return_value = iter([])
+                mock_role.objects.filter.return_value.values_list.return_value = []
+                backend._populate_user_permissions(user, 1)
+
+        mock_cache.set.assert_not_called()
+        assert user.permission == {}
+        assert user.is_superuser is False
+
     def test_exception_handling(self):
         """测试异常处理 - 设置空权限"""
         backend = APISecretAuthBackend()

--- a/server/apps/core/tests/test_api_token_permission.py
+++ b/server/apps/core/tests/test_api_token_permission.py
@@ -395,7 +395,9 @@ class TestPopulateUserPermissions:
         backend = APISecretAuthBackend()
         user = MockUser(username="newuser", domain="test.com", group_list=[1])
 
-        with patch("apps.core.backends.cache") as mock_cache:
+        with patch("apps.core.backends.cache") as mock_cache, patch(
+            "apps.core.backends.register_api_token_permission_cache_key"
+        ) as mock_register_cache_key:
             mock_cache.get.return_value = None  # 缓存未命中
 
             with patch.object(backend, "_get_user_all_roles", return_value=set()):
@@ -412,6 +414,12 @@ class TestPopulateUserPermissions:
             call_args = mock_cache.set.call_args
             assert "roles" in call_args[0][1]
             assert "permission" in call_args[0][1]
+            mock_register_cache_key.assert_called_once_with(
+                "newuser",
+                "test.com",
+                backend._get_permission_cache_key("newuser", "test.com", 1),
+                backend.PERMISSION_CACHE_TTL,
+            )
 
     def test_exception_handling(self):
         """测试异常处理 - 设置空权限"""

--- a/server/apps/core/tests/test_api_token_permission.py
+++ b/server/apps/core/tests/test_api_token_permission.py
@@ -14,9 +14,11 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from django.core.cache.backends.locmem import LocMemCache
 
 from apps.core.backends import APISecretAuthBackend, _collect_ancestor_group_ids
 from apps.core.decorators.api_permission import HasPermission, HasRole
+from apps.core.utils import permission_cache
 from apps.core.utils.web_utils import WebUtils
 
 
@@ -440,6 +442,42 @@ class TestPopulateUserPermissions:
         mock_cache.set.assert_not_called()
         assert user.permission == {}
         assert user.is_superuser is False
+
+    def test_revocation_prevents_next_api_auth_from_reusing_snapshot(self):
+        """撤权统一清理后，下一次 API 鉴权必须重新计算而不能复用旧权限。"""
+        backend = APISecretAuthBackend()
+        user = MockUser(username="revoked", domain="test.com", group_list=[1])
+        cache_backend = LocMemCache("api-token-revocation", {})
+        cache_key = backend._get_permission_cache_key("revoked", "test.com", 1)
+        cache_backend.set(
+            cache_key,
+            {
+                "roles": ["admin"],
+                "permission": {"cmdb": ["secret-View"]},
+                "is_superuser": True,
+                "role_ids": [1],
+            },
+            backend.PERMISSION_CACHE_TTL,
+        )
+
+        with patch("apps.core.backends.cache", cache_backend), patch.object(permission_cache, "cache", cache_backend):
+            permission_cache.register_api_token_permission_cache_key(
+                "revoked", "test.com", cache_key, backend.PERMISSION_CACHE_TTL
+            )
+            backend._populate_user_permissions(user, 1)
+            assert user.is_superuser is True
+
+            permission_cache.clear_user_permission_cache("revoked", "test.com")
+            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch(
+                "apps.core.backends.Role"
+            ) as mock_role:
+                mock_role.objects.filter.return_value.__iter__.return_value = iter([])
+                mock_role.objects.filter.return_value.values_list.return_value = []
+                backend._populate_user_permissions(user, 1)
+
+        assert user.is_superuser is False
+        assert user.permission == {}
+        assert user.role_ids == []
 
     def test_exception_handling(self):
         """测试异常处理 - 设置空权限"""

--- a/server/apps/core/tests/test_api_token_permission.py
+++ b/server/apps/core/tests/test_api_token_permission.py
@@ -11,7 +11,7 @@ API Token 权限填充和权限检查的单元测试
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.cache.backends.locmem import LocMemCache
@@ -185,9 +185,7 @@ class TestGetUserAllRoles:
         """
         from apps.system_mgmt.models import User as SystemUser
 
-        SystemUser.objects.create(
-            username="directuser", domain="domain.com", role_list=[1, 2, 3]
-        )
+        SystemUser.objects.create(username="directuser", domain="domain.com", role_list=[1, 2, 3])
         backend = APISecretAuthBackend()
         user = MockUser(username="directuser", group_list=[])
 
@@ -215,9 +213,7 @@ class TestGetUserAllRoles:
         """测试用户直接角色（来自 system_mgmt.User.role_list）和组织角色的合并"""
         from apps.system_mgmt.models import User as SystemUser
 
-        SystemUser.objects.create(
-            username="combineduser", domain="domain.com", role_list=[1, 2]
-        )
+        SystemUser.objects.create(username="combineduser", domain="domain.com", role_list=[1, 2])
         backend = APISecretAuthBackend()
         user = MockUser(username="combineduser", group_list=[10])
 
@@ -397,9 +393,10 @@ class TestPopulateUserPermissions:
         backend = APISecretAuthBackend()
         user = MockUser(username="newuser", domain="test.com", group_list=[1])
 
-        with patch("apps.core.backends.cache") as mock_cache, patch(
-            "apps.core.backends.register_api_token_permission_cache_key"
-        ) as mock_register_cache_key:
+        with (
+            patch("apps.core.backends.cache") as mock_cache,
+            patch("apps.core.backends.register_api_token_permission_cache_key") as mock_register_cache_key,
+        ):
             mock_cache.get.return_value = None  # 缓存未命中
 
             with patch.object(backend, "_get_user_all_roles", return_value=set()):
@@ -423,28 +420,36 @@ class TestPopulateUserPermissions:
                 backend.PERMISSION_CACHE_TTL,
             )
 
-    def test_cache_index_registration_failure_does_not_leave_snapshot(self):
-        """索引登记失败时不得先写入无法失效的权限快照。"""
+    def test_cache_index_registration_failure_does_not_block_versioned_snapshot(self):
+        """索引仅用于物理清理，登记失败不应阻止受代际保护的权限快照。"""
         backend = APISecretAuthBackend()
         user = MockUser(username="newuser", domain="test.com", group_list=[1])
 
-        with patch("apps.core.backends.cache") as mock_cache, patch(
-            "apps.core.backends.register_api_token_permission_cache_key", side_effect=RuntimeError("index unavailable")
+        with (
+            patch("apps.core.backends.cache") as mock_cache,
+            patch("apps.core.backends.register_api_token_permission_cache_key", side_effect=RuntimeError("index unavailable")),
         ):
             mock_cache.get.return_value = None
-            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch(
-                "apps.core.backends.Role"
-            ) as mock_role:
+            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch("apps.core.backends.Role") as mock_role:
                 mock_role.objects.filter.return_value.__iter__.return_value = iter([])
                 mock_role.objects.filter.return_value.values_list.return_value = []
                 backend._populate_user_permissions(user, 1)
 
-        mock_cache.set.assert_not_called()
+        mock_cache.set.assert_called_once()
         assert user.permission == {}
         assert user.is_superuser is False
 
     def test_revocation_prevents_next_api_auth_from_reusing_snapshot(self):
         """撤权统一清理后，下一次 API 鉴权必须重新计算而不能复用旧权限。"""
+        from apps.system_mgmt.models import User as SystemUser
+
+        SystemUser.objects.create(
+            username="revoked",
+            domain="test.com",
+            display_name="Revoked user",
+            email="revoked@example.com",
+            password="unused",
+        )
         backend = APISecretAuthBackend()
         user = MockUser(username="revoked", domain="test.com", group_list=[1])
         cache_backend = LocMemCache("api-token-revocation", {})
@@ -461,16 +466,51 @@ class TestPopulateUserPermissions:
         )
 
         with patch("apps.core.backends.cache", cache_backend), patch.object(permission_cache, "cache", cache_backend):
-            permission_cache.register_api_token_permission_cache_key(
-                "revoked", "test.com", cache_key, backend.PERMISSION_CACHE_TTL
-            )
+            permission_cache.register_api_token_permission_cache_key("revoked", "test.com", cache_key, backend.PERMISSION_CACHE_TTL)
             backend._populate_user_permissions(user, 1)
             assert user.is_superuser is True
 
             permission_cache.clear_user_permission_cache("revoked", "test.com")
-            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch(
-                "apps.core.backends.Role"
-            ) as mock_role:
+            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch("apps.core.backends.Role") as mock_role:
+                mock_role.objects.filter.return_value.__iter__.return_value = iter([])
+                mock_role.objects.filter.return_value.values_list.return_value = []
+                backend._populate_user_permissions(user, 1)
+
+        assert user.is_superuser is False
+        assert user.permission == {}
+        assert user.role_ids == []
+
+    def test_snapshot_written_after_revocation_cannot_be_reused(self):
+        """与撤权并发的旧权限回写不得重新成为下一次鉴权的命中项。"""
+        from apps.system_mgmt.models import User as SystemUser
+
+        system_user = SystemUser.objects.create(
+            username="racing-revocation",
+            domain="test.com",
+            display_name="Racing revocation",
+            email="racing@example.com",
+            password="unused",
+        )
+        backend = APISecretAuthBackend()
+        user = MockUser(username="racing-revocation", domain="test.com", group_list=[1])
+        cache_backend = LocMemCache("api-token-revocation-race", {})
+
+        with patch("apps.core.backends.cache", cache_backend), patch.object(permission_cache, "cache", cache_backend):
+            stale_cache_key = backend._get_permission_cache_key("racing-revocation", "test.com", 1)
+            permission_cache.clear_user_permission_cache("racing-revocation", "test.com")
+            assert permission_cache.get_user_permission_version(system_user.username, system_user.domain) > 1
+            cache_backend.set(
+                stale_cache_key,
+                {
+                    "roles": ["admin"],
+                    "permission": {"cmdb": ["secret-View"]},
+                    "is_superuser": True,
+                    "role_ids": [1],
+                },
+                backend.PERMISSION_CACHE_TTL,
+            )
+
+            with patch.object(backend, "_get_user_all_roles", return_value=set()), patch("apps.core.backends.Role") as mock_role:
                 mock_role.objects.filter.return_value.__iter__.return_value = iter([])
                 mock_role.objects.filter.return_value.values_list.return_value = []
                 backend._populate_user_permissions(user, 1)

--- a/server/apps/core/tests/test_api_token_permission.py
+++ b/server/apps/core/tests/test_api_token_permission.py
@@ -533,6 +533,29 @@ class TestPopulateUserPermissions:
         assert user.is_superuser is False
         assert user.role_ids == []
 
+    def test_version_change_clears_api_secret_team_scope(self):
+        """权限代际在快照计算期间变化时，组织范围也必须 fail closed。"""
+        backend = APISecretAuthBackend()
+        user = MockUser(username="racing-team", domain="domain.com", group_list=[7])
+        user._api_secret_team_scope = True
+
+        with (
+            patch("apps.core.backends.get_user_permission_version", side_effect=[1, 2]),
+            patch("apps.core.backends.cache") as mock_cache,
+            patch.object(backend, "_get_user_all_roles", return_value=set()),
+            patch("apps.core.backends.Role") as mock_role,
+        ):
+            mock_cache.get.return_value = None
+            mock_role.objects.filter.return_value.__iter__.return_value = iter([])
+            mock_role.objects.filter.return_value.values_list.return_value = []
+            backend._populate_user_permissions(user, 7)
+
+        assert user.group_list == []
+        assert user.roles == []
+        assert user.permission == {}
+        assert user.is_superuser is False
+        assert user.role_ids == []
+
 
 # ============================================================================
 # HasRole 装饰器测试

--- a/server/apps/core/tests/test_backends_service.py
+++ b/server/apps/core/tests/test_backends_service.py
@@ -70,7 +70,7 @@ class TestAPISecretAuthBackend:
 
         user = APISecretAuthBackend().authenticate(api_token="sec123")
         assert user is not None
-        assert user.group_list == [5]
+        assert user.group_list == []
         assert user.is_superuser is True  # admin 角色
         assert "admin" in user.roles
 
@@ -91,10 +91,18 @@ class TestAPISecretAuthBackend:
         secret = UserAPISecret.objects.create(username="cuser", domain="domain.com", api_secret="csec", team=2)
         backend = APISecretAuthBackend()
         # 直接 mock 缓存边界返回命中值，验证命中分支不再查 DB 角色
+        system_user_filter = mocker.patch.object(be.SystemUser.objects, "filter")
+        system_user_filter.return_value.exists.return_value = True
         mocker.patch.object(
             be.cache,
             "get",
-            return_value={"roles": ["r1"], "permission": {"app": ["m1"]}, "is_superuser": True, "role_ids": [9]},
+            return_value={
+                "roles": ["r1"],
+                "permission": {"app": ["m1"]},
+                "is_superuser": True,
+                "role_ids": [9],
+                "group_list": [2],
+            },
         )
 
         user = backend.authenticate(api_token="csec")
@@ -102,7 +110,9 @@ class TestAPISecretAuthBackend:
         assert user.is_superuser is True
         assert user.permission == {"app": {"m1"}}
         assert user.role_ids == [9]
+        assert user.group_list == [2]
         assert secret.team == 2
+        system_user_filter.return_value.first.assert_not_called()
 
     def test_next_auth_after_revocation_ignores_other_worker_snapshot(self, mocker):
         BaseUser.objects.create(username="revoked-user", domain="domain.com")
@@ -196,13 +206,28 @@ class TestAPISecretAuthBackend:
         child = Group.objects.create(name="C", parent_id=parent.id, allow_inherit_roles=True)
         child.roles.add(child_role)
         UserAPISecret.objects.create(username="guser", domain="domain.com", api_secret="gsec", team=child.id)
-        SysUser.objects.create(username="guser", domain="domain.com", role_list=[], email="g@x.com")
+        sys_user = SysUser.objects.create(
+            username="guser",
+            domain="domain.com",
+            group_list=[child.id],
+            role_list=[],
+            email="g@x.com",
+        )
 
         backend = APISecretAuthBackend()
         user = backend.authenticate(api_token="gsec")
         # 角色名包含子组与父组(因父允许继承)的角色
         assert "child_role" in user.roles
         assert "parent_role" in user.roles
+
+        with transaction.atomic():
+            SysUser.objects.filter(pk=sys_user.pk).update(group_list=[])
+            permission_cache.clear_user_permission_cache(sys_user.username, sys_user.domain)
+
+        user = backend.authenticate(api_token="gsec")
+        assert user.group_list == []
+        assert "child_role" not in user.roles
+        assert "parent_role" not in user.roles
 
 
 class TestAuthBackendVerifyToken:

--- a/server/apps/core/tests/test_backends_service.py
+++ b/server/apps/core/tests/test_backends_service.py
@@ -1,17 +1,15 @@
 import pydantic.root_model  # noqa
-
 import pytest
 from django.core.cache import cache
+from django.core.cache.backends.locmem import LocMemCache
+from django.db import transaction
 
 from apps.base.models import User as BaseUser
 from apps.base.models import UserAPISecret
 from apps.core import backends as be
-from apps.core.backends import (
-    APISecretAuthBackend,
-    AuthBackend,
-    _collect_ancestor_group_ids,
-)
+from apps.core.backends import APISecretAuthBackend, AuthBackend, _collect_ancestor_group_ids
 from apps.core.constants import VERIFY_TOKEN_USER_NOT_FOUND_CODE, VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE
+from apps.core.utils import permission_cache
 from apps.core.utils.custom_error import DoesNotExist
 from apps.system_mgmt.models import Group, Menu, Role
 from apps.system_mgmt.models import User as SysUser
@@ -52,6 +50,17 @@ class TestAPISecretAuthBackend:
     def test_unknown_token_returns_none(self):
         assert APISecretAuthBackend().authenticate(api_token="nope") is None
 
+    def test_token_for_missing_system_user_is_rejected(self):
+        BaseUser.objects.create(username="deleted-user", domain="domain.com")
+        UserAPISecret.objects.create(
+            username="deleted-user",
+            domain="domain.com",
+            api_secret="deleted-secret",
+            team=1,
+        )
+
+        assert APISecretAuthBackend().authenticate(api_token="deleted-secret") is None
+
     def test_valid_token_populates_permissions(self):
         BaseUser.objects.create(username="apiuser", domain="domain.com")
         UserAPISecret.objects.create(username="apiuser", domain="domain.com", api_secret="sec123", team=5)
@@ -78,6 +87,7 @@ class TestAPISecretAuthBackend:
 
     def test_permission_cache_hit(self, mocker):
         BaseUser.objects.create(username="cuser", domain="domain.com")
+        SysUser.objects.create(username="cuser", domain="domain.com", email="c@x.com")
         secret = UserAPISecret.objects.create(username="cuser", domain="domain.com", api_secret="csec", team=2)
         backend = APISecretAuthBackend()
         # 直接 mock 缓存边界返回命中值，验证命中分支不再查 DB 角色
@@ -93,6 +103,88 @@ class TestAPISecretAuthBackend:
         assert user.permission == {"app": {"m1"}}
         assert user.role_ids == [9]
         assert secret.team == 2
+
+    def test_next_auth_after_revocation_ignores_other_worker_snapshot(self, mocker):
+        BaseUser.objects.create(username="revoked-user", domain="domain.com")
+        UserAPISecret.objects.create(
+            username="revoked-user",
+            domain="domain.com",
+            api_secret="revoked-secret",
+            team=2,
+        )
+        admin_role = Role.objects.create(name="admin", app="")
+        sys_user = SysUser.objects.create(
+            username="revoked-user",
+            domain="domain.com",
+            role_list=[admin_role.id],
+            email="revoked@example.com",
+        )
+        backend = APISecretAuthBackend()
+        worker_a_cache = LocMemCache("api-secret-worker-a", {})
+        worker_b_cache = LocMemCache("api-secret-worker-b", {})
+        mocker.patch.object(be, "cache", worker_a_cache)
+
+        first_auth = backend.authenticate(api_token="revoked-secret")
+        old_cache_key = backend._get_permission_cache_key("revoked-user", "domain.com", 2)
+        assert first_auth.is_superuser is True
+        assert worker_a_cache.get(old_cache_key)["is_superuser"] is True
+
+        mocker.patch.object(permission_cache, "cache", worker_b_cache)
+        with transaction.atomic():
+            SysUser.objects.filter(pk=sys_user.pk).update(role_list=[])
+            permission_cache.clear_user_permission_cache("revoked-user", "domain.com")
+
+        second_auth = backend.authenticate(api_token="revoked-secret")
+        assert worker_a_cache.get(old_cache_key)["is_superuser"] is True
+        assert second_auth is not None
+        assert second_auth.is_superuser is False
+        assert second_auth.roles == []
+
+    def test_permission_version_survives_user_delete_and_recreate(self):
+        user = SysUser.objects.create(
+            username="recreated-user",
+            domain="domain.com",
+            email="recreated@example.com",
+        )
+        first_version = permission_cache.get_user_permission_version(user.username, user.domain)
+
+        with transaction.atomic():
+            user.delete()
+            permission_cache.clear_user_permission_cache("recreated-user", "domain.com")
+        deleted_version = permission_cache.get_user_permission_version("recreated-user", "domain.com")
+
+        recreated = SysUser.objects.create(
+            username="recreated-user",
+            domain="domain.com",
+            email="recreated-again@example.com",
+        )
+        recreated_version = permission_cache.get_user_permission_version(
+            recreated.username,
+            recreated.domain,
+        )
+
+        assert deleted_version > first_version
+        assert recreated_version > deleted_version
+
+    def test_stale_user_instance_cannot_move_permission_version_backwards(self):
+        user = SysUser.objects.create(
+            username="concurrent-save-user",
+            domain="domain.com",
+            email="concurrent@example.com",
+        )
+        first_copy = SysUser.objects.get(pk=user.pk)
+        second_copy = SysUser.objects.get(pk=user.pk)
+        initial_version = permission_cache.get_user_permission_version(user.username, user.domain)
+
+        first_copy.display_name = "first"
+        first_copy.save()
+        first_version = permission_cache.get_user_permission_version(user.username, user.domain)
+        second_copy.display_name = "second"
+        second_copy.save()
+        second_version = permission_cache.get_user_permission_version(user.username, user.domain)
+
+        assert first_version > initial_version
+        assert second_version > first_version
 
     def test_group_role_inheritance(self):
         BaseUser.objects.create(username="guser", domain="domain.com")

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -14,6 +14,7 @@ import pytest
 import apps.core.management.commands.batch_init as bi
 
 pytestmark = pytest.mark.unit
+_verify_critical_schema = bi.Command._verify_critical_schema
 
 
 class _Style:
@@ -38,12 +39,65 @@ def calls(monkeypatch):
 
     monkeypatch.setattr(bi, "call_command", fake_call_command)
     monkeypatch.setattr(
-        bi, "preload_language_cache", lambda *a, **k: {"loaded": [1], "skipped": [], "failed": []},
+        bi,
+        "preload_language_cache",
+        lambda *a, **k: {"loaded": [1], "skipped": [], "failed": []},
     )
     return recorded
 
 
+@pytest.fixture(autouse=True)
+def _stub_critical_schema_gate(monkeypatch):
+    monkeypatch.setattr(bi.Command, "_verify_critical_schema", lambda self: None)
+
+
 class TestHandleDispatch:
+    def test_critical_schema_is_verified_before_preload_and_dispatch(self, monkeypatch):
+        events = []
+        monkeypatch.setattr(bi.Command, "_verify_critical_schema", lambda self: events.append("schema"))
+        monkeypatch.setattr(
+            bi,
+            "preload_language_cache",
+            lambda: events.append("preload") or {"loaded": [], "skipped": [], "failed": []},
+        )
+        monkeypatch.setattr(bi, "call_command", lambda name, *args, **kwargs: events.append(name))
+
+        _make_command().handle(apps="node_mgmt", continue_on_error=False)
+
+        assert events == ["schema", "preload", "node_init"]
+
+    def test_critical_schema_failure_is_always_a_hard_gate(self, monkeypatch):
+        calls = []
+
+        def fail_schema():
+            calls.append("schema")
+            raise RuntimeError("permission version table missing")
+
+        cmd = _make_command()
+        monkeypatch.setattr(cmd, "_verify_critical_schema", fail_schema)
+        monkeypatch.setattr(bi, "preload_language_cache", lambda: calls.append("preload"))
+        monkeypatch.setattr(bi, "call_command", lambda *args, **kwargs: calls.append("dispatch"))
+
+        with pytest.raises(RuntimeError, match="permission version table missing"):
+            cmd.handle(apps="node_mgmt", continue_on_error=True)
+
+        assert calls == ["schema"]
+
+    def test_critical_schema_check_queries_permission_version_table(self, monkeypatch):
+        calls = []
+        queryset = SimpleNamespace(first=lambda: calls.append("first"))
+        manager = SimpleNamespace(values_list=lambda *args, **kwargs: calls.append(("values_list", args, kwargs)) or queryset)
+        model = SimpleNamespace(objects=manager)
+        monkeypatch.setattr(bi.django_apps, "get_model", lambda *args: calls.append(("get_model", args)) or model)
+
+        _verify_critical_schema()
+
+        assert calls == [
+            ("get_model", ("system_mgmt", "UserPermissionVersion")),
+            ("values_list", ("id",), {"flat": True}),
+            "first",
+        ]
+
     def test_single_known_app_runs_its_command_sequence(self, calls):
         cmd = _make_command()
         cmd.handle(apps="node_mgmt", continue_on_error=False)
@@ -118,7 +172,9 @@ class TestErrorHandlingPolicy:
 
         monkeypatch.setattr(bi, "call_command", fake_call_command)
         monkeypatch.setattr(
-            bi, "preload_language_cache", lambda *a, **k: {"loaded": [], "skipped": [], "failed": []},
+            bi,
+            "preload_language_cache",
+            lambda *a, **k: {"loaded": [], "skipped": [], "failed": []},
         )
         cmd = _make_command()
 

--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -73,6 +73,10 @@ class TestKeyDerivation:
     def test_user_keys_index_format(self):
         assert pc._get_user_keys_index("u", "d") == "user_perm_keys:u:d"
 
+    def test_api_token_permission_key_formats(self):
+        assert pc._get_api_token_permission_prefix("u", "d") == "api_token_permissions:u:d:"
+        assert pc._get_api_token_keys_index("u", "d") == "api_token_permission_keys:u:d"
+
 
 # ---------------------------------------------------------------------------
 # token_info 缓存
@@ -140,6 +144,19 @@ class TestClearUsersPermissionCache:
         # 不含 username 的条目不应触发异常
         pc.clear_users_permission_cache([{"domain": "x"}])
 
+    def test_clear_user_removes_registered_api_token_permission_snapshots(self):
+        key_team_1 = "api_token_permissions:u:domain.com:1"
+        key_team_2 = "api_token_permissions:u:domain.com:2"
+        cache.set(key_team_1, {"roles": [1]}, 600)
+        cache.set(key_team_2, {"roles": [2]}, 600)
+        pc.register_api_token_permission_cache_key("u", "domain.com", key_team_1, 600)
+        pc.register_api_token_permission_cache_key("u", "domain.com", key_team_2, 600)
+
+        pc.clear_user_permission_cache("u", "domain.com")
+
+        assert cache.get(key_team_1) is None
+        assert cache.get(key_team_2) is None
+
 
 # ---------------------------------------------------------------------------
 # 支持 delete_pattern 的后端分支
@@ -156,6 +173,15 @@ class TestPatternBackendBranches:
         cache_key = pc._get_cache_key("u", "domain.com", 1, "cmdb", "view")
         assert fake.store[cache_key] == {"team": [1]}
 
+    def test_api_token_snapshot_keeps_fallback_index_on_pattern_backend(self, mocker):
+        fake = _PatternCache()
+        mocker.patch.object(pc, "cache", fake)
+        cache_key = "api_token_permissions:u:domain.com:1"
+
+        pc.register_api_token_permission_cache_key("u", "domain.com", cache_key, 600)
+
+        assert fake.store[pc._get_api_token_keys_index("u", "domain.com")] == {cache_key}
+
     def test_clear_user_uses_delete_pattern(self, mocker):
         fake = _PatternCache()
         mocker.patch.object(pc, "cache", fake)
@@ -165,6 +191,19 @@ class TestPatternBackendBranches:
         assert pc.get_cached_permission_rules("u", "domain.com", 1, "cmdb", "view") is None
         assert pc.get_cached_permission_rules("u", "domain.com", 2, "cmdb", "edit") is None
 
+    def test_clear_user_pattern_removes_api_token_permission_snapshots(self, mocker):
+        fake = _PatternCache()
+        mocker.patch.object(pc, "cache", fake)
+        fake.store["api_token_permissions:u:domain.com:1"] = {"roles": [1]}
+        fake.store["api_token_permissions:u:domain.com:2"] = {"roles": [2]}
+        fake.store["api_token_permissions:other:domain.com:1"] = {"roles": [3]}
+
+        pc.clear_user_permission_cache("u", "domain.com")
+
+        assert "api_token_permissions:u:domain.com:1" not in fake.store
+        assert "api_token_permissions:u:domain.com:2" not in fake.store
+        assert "api_token_permissions:other:domain.com:1" in fake.store
+
     def test_clear_user_pattern_failure_falls_back_to_index(self, mocker):
         fake = _PatternCache()
         mocker.patch.object(pc, "cache", fake)
@@ -173,6 +212,10 @@ class TestPatternBackendBranches:
         cache_key = pc._get_cache_key("u", "domain.com", 1, "cmdb", "view")
         fake.store[cache_key] = {"team": [1]}
         fake.store[index_key] = {cache_key}
+        api_cache_key = "api_token_permissions:u:domain.com:1"
+        api_index_key = pc._get_api_token_keys_index("u", "domain.com")
+        fake.store[api_cache_key] = {"roles": [1]}
+        fake.store[api_index_key] = {api_cache_key}
 
         def boom(_pattern):
             raise RuntimeError("redis down")
@@ -182,6 +225,7 @@ class TestPatternBackendBranches:
         fake.delete_many = lambda keys: [fake.store.pop(k, None) for k in keys]
         pc.clear_user_permission_cache("u", "domain.com")
         assert cache_key not in fake.store
+        assert api_cache_key not in fake.store
 
     def test_clear_all_uses_delete_pattern(self, mocker):
         fake = _PatternCache()

--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -232,6 +232,8 @@ class TestPatternBackendBranches:
         mocker.patch.object(pc, "cache", fake)
         fake.store[f"{pc.PERM_CACHE_PREFIX}abc:hash"] = {"team": []}
         fake.store[f"{pc.USER_PERM_KEYS_PREFIX}u:d"] = {"x"}
+        fake.store[f"{pc.API_TOKEN_PERMISSION_CACHE_PREFIX}:u:d:1"] = {"roles": [1]}
+        fake.store[f"{pc.API_TOKEN_PERMISSION_KEYS_PREFIX}u:d"] = {"api_token_permissions:u:d:1"}
         pc.clear_all_permission_cache()
         assert fake.store == {}
 

--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -1,4 +1,5 @@
 import pydantic.root_model  # noqa
+
 """apps/core/utils/permission_cache.py 真实行为单元测试。
 
 策略：以真实 Django cache（locmem，不支持 delete_pattern）执行键生成/读写/清除主路径；
@@ -15,11 +16,13 @@ pytestmark = pytest.mark.unit
 
 
 @pytest.fixture(autouse=True)
-def _locmem_cache():
+def _locmem_cache(monkeypatch):
     """强制使用 locmem 后端：确定性、无外部依赖，且不支持 delete_pattern（覆盖索引兜底路径）。"""
-    with override_settings(
-        CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "perm-cache-test"}}
-    ):
+    monkeypatch.setattr(pc, "_advance_user_permission_versions", lambda users: len(users))
+    monkeypatch.setattr(pc, "_advance_all_user_permission_versions", lambda: 0)
+    monkeypatch.setattr(pc, "get_user_permission_version", lambda username, domain: 0)
+    monkeypatch.setattr(pc.transaction, "on_commit", lambda callback: callback())
+    with override_settings(CACHES={"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "perm-cache-test"}}):
         cache.clear()
         yield
         cache.clear()
@@ -39,6 +42,10 @@ class _PatternCache:
 
     def delete(self, key):
         self.store.pop(key, None)
+
+    def delete_many(self, keys):
+        for key in keys:
+            self.delete(key)
 
     def delete_pattern(self, pattern):
         prefix = pattern.rstrip("*")
@@ -68,7 +75,7 @@ class TestKeyDerivation:
         assert k1 != k2
 
     def test_token_info_key_format(self):
-        assert pc._get_token_info_key("u", "d") == "token_info:u:d"
+        assert pc._get_token_info_key("u", "d") == "token_info:u:d:v0"
 
     def test_user_keys_index_format(self):
         assert pc._get_user_keys_index("u", "d") == "user_perm_keys:u:d"
@@ -90,6 +97,25 @@ class TestTokenInfoCache:
         assert pc.get_cached_token_info("u", "domain.com") == {"id": 1}
         pc.clear_token_info_cache("u", "domain.com")
         assert pc.get_cached_token_info("u", "domain.com") is None
+
+    def test_version_change_makes_other_worker_entry_unreachable(self, monkeypatch):
+        version = {"value": 0}
+        monkeypatch.setattr(pc, "get_user_permission_version", lambda username, domain: version["value"])
+        pc.set_cached_token_info("u", "domain.com", {"id": 1}, permission_version=0)
+
+        version["value"] = 1
+
+        assert cache.get("token_info:u:domain.com:v0") == {"id": 1}
+        assert pc.get_cached_token_info("u", "domain.com") is None
+
+    def test_version_change_during_write_rejects_result(self, monkeypatch):
+        versions = iter([0, 1])
+        monkeypatch.setattr(pc, "get_user_permission_version", lambda username, domain: next(versions))
+
+        cached = pc.set_cached_token_info("u", "domain.com", {"id": 1}, permission_version=0)
+
+        assert cached is False
+        assert cache.get("token_info:u:domain.com:v0") == {"id": 1}
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +139,51 @@ class TestPermissionRulesCache:
         assert index is not None
         cache_key = pc._get_cache_key("u", "domain.com", 1, "cmdb", "view")
         assert cache_key in index
+
+    def test_version_change_makes_other_worker_entry_unreachable(self, monkeypatch):
+        version = {"value": 0}
+        monkeypatch.setattr(pc, "get_user_permission_version", lambda username, domain: version["value"])
+        data = {"team": [1], "instance": []}
+        pc.set_cached_permission_rules(
+            "u",
+            "domain.com",
+            1,
+            "cmdb",
+            "view",
+            data,
+            permission_version=0,
+        )
+        old_key = pc._get_cache_key(
+            "u",
+            "domain.com",
+            1,
+            "cmdb",
+            "view",
+            permission_version=0,
+        )
+
+        version["value"] = 1
+
+        assert cache.get(old_key) == data
+        assert pc.get_cached_permission_rules("u", "domain.com", 1, "cmdb", "view") is None
+
+    def test_version_change_during_write_rejects_result(self, monkeypatch):
+        versions = iter([0, 1])
+        monkeypatch.setattr(pc, "get_user_permission_version", lambda username, domain: next(versions))
+        data = {"team": [1], "instance": []}
+
+        cached = pc.set_cached_permission_rules(
+            "u",
+            "domain.com",
+            1,
+            "cmdb",
+            "view",
+            data,
+            permission_version=0,
+        )
+
+        assert cached is False
+        assert cache.get(pc._get_cache_key("u", "domain.com", 1, "cmdb", "view", permission_version=0)) == data
 
     def test_clear_user_cache_by_index_removes_entries(self):
         pc.set_cached_permission_rules("u", "domain.com", 1, "cmdb", "view", {"team": [1]})

--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -6,6 +6,9 @@ import pydantic.root_model  # noqa
 对支持 delete_pattern 的后端分支，用具备 delete_pattern 的 fake cache 注入到模块的 cache 引用。
 断言真实缓存副作用（get/set/delete 后的可见性）与键派生的确定性。
 """
+import base64
+import json
+
 import pytest
 from django.core.cache import cache
 from django.test import override_settings
@@ -66,6 +69,9 @@ class TestKeyDerivation:
         assert p1 == p2
         assert p1 != p3
         assert p1.startswith(pc.PERM_CACHE_PREFIX)
+        encoded_identity = p1.removeprefix(pc.PERM_CACHE_PREFIX).removesuffix(":")
+        padding = "=" * (-len(encoded_identity) % 4)
+        assert json.loads(base64.urlsafe_b64decode(encoded_identity + padding)) == ["alice", "domain.com"]
 
     def test_cache_key_embeds_user_prefix_and_varies_by_dimensions(self):
         prefix = pc._get_user_perm_prefix("alice", "domain.com")
@@ -73,6 +79,9 @@ class TestKeyDerivation:
         k2 = pc._get_cache_key("alice", "domain.com", 2, "cmdb", "view")
         assert k1.startswith(prefix)
         assert k1 != k2
+        encoded_dimensions = k1.removeprefix(prefix)
+        padding = "=" * (-len(encoded_dimensions) % 4)
+        assert json.loads(base64.urlsafe_b64decode(encoded_dimensions + padding)) == [0, 1, "cmdb", "view", False]
 
     def test_token_info_key_format(self):
         assert pc._get_token_info_key("u", "d") == "token_info:u:d:v0"

--- a/server/apps/core/tests/utils/test_permission_utils.py
+++ b/server/apps/core/tests/utils/test_permission_utils.py
@@ -1,4 +1,5 @@
 import pydantic.root_model  # noqa
+
 """apps/core/utils/permission_utils.py 真实行为单元测试。
 
 覆盖：
@@ -19,6 +20,11 @@ from apps.core import constants
 from apps.core.utils import permission_utils as pu
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _permission_version(mocker):
+    mocker.patch.object(pu, "get_user_permission_version", return_value=0)
 
 
 def _user(username="u", domain="domain.com"):

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -5,20 +5,23 @@
 
 缓存策略：
 - 使用较长的 TTL（默认 10 分钟）作为兜底
-- 在权限变更时主动清除相关用户的缓存
-- 即使遗漏了某个清除点，也能在 TTL 内自动恢复一致性
+- 在权限变更事务中推进独立、单调的数据库权限代际，所有权限缓存键均包含该代际
+- 事务提交后尽力删除旧缓存，删除失败也不会让旧权限缓存重新生效
 
 键结构（当前）：
   perm_rules:{user_prefix}:{key_hash}
-其中 user_prefix = MD5(username:domain)[:8]，用于支持 delete_pattern 按用户原子清除，
-彻底消除旧版"读-改-写"索引的并发竞态（RMW race）。
+其中 user_prefix = MD5(username:domain)[:8]，用于支持 delete_pattern 按用户清除。
 """
 
 import hashlib
 import os
 from typing import Any, Dict, List, Optional
 
+from django.apps import apps
 from django.core.cache import cache
+from django.db import transaction
+from django.db.models import F
+
 from apps.core.logger import logger
 
 # 缓存过期时间 (秒)，默认 10 分钟，可通过环境变量配置
@@ -40,20 +43,105 @@ API_TOKEN_PERMISSION_CACHE_PREFIX = "api_token_permissions"
 API_TOKEN_PERMISSION_KEYS_PREFIX = "api_token_permission_keys:"
 
 
-def _get_token_info_key(username: str, domain: str) -> str:
-    return f"{TOKEN_INFO_PREFIX}{username}:{domain}"
+def get_user_permission_version(username: str, domain: str) -> int:
+    """读取数据库中的用户权限代际，作为跨进程权限快照 fencing token。"""
+    version_model = apps.get_model("system_mgmt", "UserPermissionVersion")
+    version = version_model.objects.filter(username=username, domain=domain).values_list("version", flat=True).first()
+    return int(version or 0)
 
 
-def get_cached_token_info(username: str, domain: str) -> Optional[Dict[str, Any]]:
-    return cache.get(_get_token_info_key(username, domain))
+def _advance_user_permission_versions(users: List[Dict]) -> int:
+    """在当前数据库事务中推进受影响用户的权限代际。"""
+    identities = {(user.get("username"), user.get("domain", "domain.com")) for user in users if user.get("username")}
+    if not identities:
+        return 0
+
+    usernames_by_domain = {}
+    for username, domain in identities:
+        usernames_by_domain.setdefault(domain, []).append(username)
+
+    version_model = apps.get_model("system_mgmt", "UserPermissionVersion")
+    updated = 0
+    for domain, usernames in usernames_by_domain.items():
+        for offset in range(0, len(usernames), 1000):
+            batch = usernames[offset : offset + 1000]
+            version_model.objects.bulk_create(
+                [version_model(username=username, domain=domain, version=0) for username in batch],
+                ignore_conflicts=True,
+                batch_size=1000,
+            )
+            updated += version_model.objects.filter(
+                domain=domain,
+                username__in=batch,
+            ).update(version=F("version") + 1)
+    return updated
 
 
-def set_cached_token_info(username: str, domain: str, data: Dict[str, Any]) -> None:
-    cache.set(_get_token_info_key(username, domain), data, TOKEN_INFO_CACHE_TTL)
+def _advance_all_user_permission_versions() -> int:
+    """推进全部用户权限代际，用于全量角色/菜单初始化后的统一失效。"""
+    user_model = apps.get_model("system_mgmt", "User")
+    updated = 0
+    users = user_model.objects.values("username", "domain").iterator(chunk_size=1000)
+    batch = []
+    for user in users:
+        batch.append(user)
+        if len(batch) == 1000:
+            updated += _advance_user_permission_versions(batch)
+            batch = []
+    if batch:
+        updated += _advance_user_permission_versions(batch)
+    return updated
+
+
+def _get_token_info_key(
+    username: str,
+    domain: str,
+    permission_version: Optional[int] = None,
+) -> str:
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
+    return f"{TOKEN_INFO_PREFIX}{username}:{domain}:v{permission_version}"
+
+
+def get_cached_token_info(
+    username: str,
+    domain: str,
+    permission_version: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
+    cached = cache.get(_get_token_info_key(username, domain, permission_version))
+    if cached is not None and get_user_permission_version(username, domain) == permission_version:
+        return cached
+    return None
+
+
+def set_cached_token_info(
+    username: str,
+    domain: str,
+    data: Dict[str, Any],
+    permission_version: Optional[int] = None,
+) -> bool:
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
+    if get_user_permission_version(username, domain) != permission_version:
+        return False
+    cache.set(
+        _get_token_info_key(username, domain, permission_version),
+        data,
+        TOKEN_INFO_CACHE_TTL,
+    )
+    return get_user_permission_version(username, domain) == permission_version
 
 
 def clear_token_info_cache(username: str, domain: str = "domain.com") -> None:
-    cache.delete(_get_token_info_key(username, domain))
+    permission_version = get_user_permission_version(username, domain)
+    cache.delete_many(
+        [
+            f"{TOKEN_INFO_PREFIX}{username}:{domain}",
+            _get_token_info_key(username, domain, permission_version),
+        ]
+    )
 
 
 def _get_user_perm_prefix(username: str, domain: str) -> str:
@@ -73,6 +161,7 @@ def _get_cache_key(
     app_name: str,
     permission_key: str,
     include_children: bool = False,
+    permission_version: Optional[int] = None,
 ) -> str:
     """
     生成权限规则缓存键
@@ -92,9 +181,11 @@ def _get_cache_key(
     Returns:
         缓存键字符串
     """
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
     user_prefix = _get_user_perm_prefix(username, domain)
     # 剩余维度继续 MD5 哈希，避免键过长
-    key_data = f"{current_team}:{app_name}:{permission_key}:{include_children}"
+    key_data = f"v{permission_version}:{current_team}:{app_name}:{permission_key}:{include_children}"
     key_hash = hashlib.md5(key_data.encode()).hexdigest()
     return f"{user_prefix}{key_hash}"
 
@@ -120,7 +211,7 @@ def register_api_token_permission_cache_key(
     cache_key: str,
     ttl: int,
 ) -> None:
-    """登记 API Token 权限快照键，供精确失效与 pattern 失败降级。"""
+    """登记 API Token 快照键用于物理清理；权限正确性不依赖该索引。"""
     index_key = _get_api_token_keys_index(username, domain)
     cached_keys = cache.get(index_key) or set()
     cached_keys.add(cache_key)
@@ -155,6 +246,7 @@ def get_cached_permission_rules(
     app_name: str,
     permission_key: str,
     include_children: bool = False,
+    permission_version: Optional[int] = None,
 ) -> Optional[Dict]:
     """
     获取缓存的权限规则
@@ -170,11 +262,22 @@ def get_cached_permission_rules(
     Returns:
         缓存的权限规则，未命中返回 None
     """
-    cache_key = _get_cache_key(username, domain, current_team, app_name, permission_key, include_children)
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
+    cache_key = _get_cache_key(
+        username,
+        domain,
+        current_team,
+        app_name,
+        permission_key,
+        include_children,
+        permission_version,
+    )
     cached = cache.get(cache_key)
-    if cached is not None:
+    if cached is not None and get_user_permission_version(username, domain) == permission_version:
         logger.debug(f"Permission rules cache hit: {username}@{app_name}/{permission_key}")
-    return cached
+        return cached
+    return None
 
 
 def set_cached_permission_rules(
@@ -185,7 +288,8 @@ def set_cached_permission_rules(
     permission_key: str,
     permission_data: Dict,
     include_children: bool = False,
-) -> None:
+    permission_version: Optional[int] = None,
+) -> bool:
     """
     缓存权限规则
 
@@ -198,7 +302,19 @@ def set_cached_permission_rules(
         permission_data: 权限数据
         include_children: 是否包含子组
     """
-    cache_key = _get_cache_key(username, domain, current_team, app_name, permission_key, include_children)
+    if permission_version is None:
+        permission_version = get_user_permission_version(username, domain)
+    if get_user_permission_version(username, domain) != permission_version:
+        return False
+    cache_key = _get_cache_key(
+        username,
+        domain,
+        current_team,
+        app_name,
+        permission_key,
+        include_children,
+        permission_version,
+    )
     cache.set(cache_key, permission_data, PERMISSION_CACHE_TTL)
 
     # 支持 delete_pattern 的后端（如 django-redis）：cache_key 已内嵌用户前缀，
@@ -214,38 +330,43 @@ def set_cached_permission_rules(
         cache.set(user_keys_index, existing_keys, PERMISSION_CACHE_TTL + 60)
 
     logger.debug(f"Permission rules cached: {username}@{app_name}/{permission_key}, TTL={PERMISSION_CACHE_TTL}s")
+    return get_user_permission_version(username, domain) == permission_version
+
+
+def _clear_user_permission_cache_entries(username: str, domain: str) -> None:
+    """尽力清除缓存条目；权限正确性不依赖本操作成功。"""
+    try:
+        if hasattr(cache, "delete_pattern"):
+            user_prefix = _get_user_perm_prefix(username, domain)
+            try:
+                cache.delete_pattern(f"{user_prefix}*")
+                logger.info(f"Cleared permission cache (pattern) for user: {username}")
+            except Exception as e:
+                logger.warning(
+                    "Failed to clear permission cache by pattern for %s, falling back to index: %s",
+                    username,
+                    e,
+                )
+                _clear_user_cache_by_index(username, domain)
+        else:
+            _clear_user_cache_by_index(username, domain)
+
+        clear_api_token_permission_cache(username, domain)
+        clear_token_info_cache(username, domain)
+    except Exception as e:
+        logger.warning("Failed to clean permission cache entries for %s@%s: %s", username, domain, e)
 
 
 def clear_user_permission_cache(username: str, domain: str = "domain.com") -> None:
     """
-    清除指定用户的所有权限缓存（含 token_info 缓存）
+    失效指定用户的权限缓存（含 token_info 与 API Secret 快照）。
 
-    对支持 delete_pattern 的后端（django-redis）：
-      使用 delete_pattern(user_prefix + "*") 原子删除该用户的全部权限缓存键，
-      不依赖键索引，彻底规避并发 RMW 竞态导致的漏删问题。
-
-    对不支持 delete_pattern 的后端（本地内存缓存等）：
-      回退到旧版键索引方案（同时兼容旧键格式的存量索引）。
-
-    Args:
-        username: 用户名
-        domain: 用户域，默认 "domain.com"
+    数据库代际在调用方事务内推进，跨 Worker 的权限读取立即改用新键；
+    旧缓存条目在事务提交后尽力清理，清理失败不影响撤权正确性。
     """
-    if hasattr(cache, "delete_pattern"):
-        # 主路径：原子按用户前缀清除，无竞态风险
-        user_prefix = _get_user_perm_prefix(username, domain)
-        try:
-            cache.delete_pattern(f"{user_prefix}*")
-            logger.info(f"Cleared permission cache (pattern) for user: {username}")
-        except Exception as e:
-            logger.warning(f"delete_pattern failed for user {username}, falling back to index: {e}")
-            _clear_user_cache_by_index(username, domain)
-    else:
-        # 降级路径：旧版键索引（非 Redis 后端）
-        _clear_user_cache_by_index(username, domain)
-
-    clear_api_token_permission_cache(username, domain)
-    clear_token_info_cache(username, domain)
+    users = [{"username": username, "domain": domain}]
+    _advance_user_permission_versions(users)
+    transaction.on_commit(lambda: _clear_user_permission_cache_entries(username, domain))
 
 
 def _clear_user_cache_by_index(username: str, domain: str) -> None:
@@ -268,30 +389,38 @@ def clear_users_permission_cache(users: List[Dict]) -> None:
     Args:
         users: 用户列表，每个元素为 {"username": str, "domain": str} 或 {"username": str}
     """
-    for user in users:
-        username = user.get("username")
-        domain = user.get("domain", "domain.com")
-        if username:
-            clear_user_permission_cache(username, domain)
+    identities = {(user.get("username"), user.get("domain", "domain.com")) for user in users if user.get("username")}
+    normalized_users = [{"username": username, "domain": domain} for username, domain in sorted(identities)]
+    _advance_user_permission_versions(normalized_users)
+
+    def clear_entries():
+        for user in normalized_users:
+            _clear_user_permission_cache_entries(user["username"], user["domain"])
+
+    transaction.on_commit(clear_entries)
 
 
 def clear_all_permission_cache() -> None:
     """
-    清除所有权限规则缓存
+    推进所有用户权限代际，并在提交后尽力清除全部权限缓存。
 
-    注意:
-        仅当使用支持 pattern delete 的缓存后端（如 Redis）时有效。
-        对于本地内存缓存，只能等待 TTL 过期。
+    不支持 pattern delete 的后端无法物理删除全部条目，但旧权限缓存因代际变化已不可达。
     """
-    try:
-        if hasattr(cache, "delete_pattern"):
-            # 清除所有权限缓存（含新格式 perm_rules:{user_prefix}:* 和旧版索引键）
-            cache.delete_pattern(f"{PERM_CACHE_PREFIX}*")
-            cache.delete_pattern(f"{USER_PERM_KEYS_PREFIX}*")
-            cache.delete_pattern(f"{API_TOKEN_PERMISSION_CACHE_PREFIX}:*")
-            cache.delete_pattern(f"{API_TOKEN_PERMISSION_KEYS_PREFIX}*")
-            logger.info("All permission rules cache cleared")
-        else:
-            logger.warning("Cannot clear all permission cache: cache backend does not support pattern delete")
-    except Exception as e:
-        logger.warning(f"Failed to clear all permission cache: {e}")
+    _advance_all_user_permission_versions()
+
+    def clear_entries():
+        try:
+            if hasattr(cache, "delete_pattern"):
+                # 清除所有权限缓存（含新格式 perm_rules:{user_prefix}:* 和旧版索引键）
+                cache.delete_pattern(f"{PERM_CACHE_PREFIX}*")
+                cache.delete_pattern(f"{USER_PERM_KEYS_PREFIX}*")
+                cache.delete_pattern(f"{TOKEN_INFO_PREFIX}*")
+                cache.delete_pattern(f"{API_TOKEN_PERMISSION_CACHE_PREFIX}:*")
+                cache.delete_pattern(f"{API_TOKEN_PERMISSION_KEYS_PREFIX}*")
+                logger.info("All permission rules cache cleared")
+            else:
+                logger.warning("Cannot clear all permission cache: cache backend does not support pattern delete")
+        except Exception as e:
+            logger.warning(f"Failed to clear all permission cache: {e}")
+
+    transaction.on_commit(clear_entries)

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -10,10 +10,11 @@
 
 键结构（当前）：
   perm_rules:{user_prefix}:{key_hash}
-其中 user_prefix = MD5(username:domain)[:8]，用于支持 delete_pattern 按用户清除。
+其中 user_prefix 为 username/domain 的无碰撞 Base64URL 编码，用于支持 delete_pattern 按用户清除。
 """
 
-import hashlib
+import base64
+import json
 import os
 from typing import Any, Dict, List, Optional
 
@@ -148,10 +149,11 @@ def _get_user_perm_prefix(username: str, domain: str) -> str:
     """
     生成该用户的权限缓存键前缀（用于 delete_pattern 按用户原子清除）。
 
-    使用 MD5 前 8 位保持键的简短，同时确保不同用户/domain 的前缀互不冲突。
+    使用 JSON 元组的 Base64URL 编码，避免分隔符歧义及哈希碰撞。
     """
-    user_hash = hashlib.md5(f"{username}:{domain}".encode()).hexdigest()[:8]
-    return f"{PERM_CACHE_PREFIX}{user_hash}:"
+    identity = json.dumps([username, domain], ensure_ascii=False, separators=(",", ":")).encode()
+    encoded_identity = base64.urlsafe_b64encode(identity).decode().rstrip("=")
+    return f"{PERM_CACHE_PREFIX}{encoded_identity}:"
 
 
 def _get_cache_key(
@@ -184,10 +186,13 @@ def _get_cache_key(
     if permission_version is None:
         permission_version = get_user_permission_version(username, domain)
     user_prefix = _get_user_perm_prefix(username, domain)
-    # 剩余维度继续 MD5 哈希，避免键过长
-    key_data = f"v{permission_version}:{current_team}:{app_name}:{permission_key}:{include_children}"
-    key_hash = hashlib.md5(key_data.encode()).hexdigest()
-    return f"{user_prefix}{key_hash}"
+    key_data = json.dumps(
+        [permission_version, current_team, app_name, permission_key, include_children],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode()
+    encoded_dimensions = base64.urlsafe_b64encode(key_data).decode().rstrip("=")
+    return f"{user_prefix}{encoded_dimensions}"
 
 
 def _get_user_keys_index(username: str, domain: str) -> str:

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -288,6 +288,8 @@ def clear_all_permission_cache() -> None:
             # 清除所有权限缓存（含新格式 perm_rules:{user_prefix}:* 和旧版索引键）
             cache.delete_pattern(f"{PERM_CACHE_PREFIX}*")
             cache.delete_pattern(f"{USER_PERM_KEYS_PREFIX}*")
+            cache.delete_pattern(f"{API_TOKEN_PERMISSION_CACHE_PREFIX}:*")
+            cache.delete_pattern(f"{API_TOKEN_PERMISSION_KEYS_PREFIX}*")
             logger.info("All permission rules cache cleared")
         else:
             logger.warning("Cannot clear all permission cache: cache backend does not support pattern delete")

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -34,6 +34,10 @@ PERM_CACHE_PREFIX = "perm_rules:"
 USER_PERM_KEYS_PREFIX = "user_perm_keys:"
 # verify_token 结果缓存键前缀
 TOKEN_INFO_PREFIX = "token_info:"
+# API Secret 认证后的角色/菜单权限快照
+API_TOKEN_PERMISSION_CACHE_PREFIX = "api_token_permissions"
+# 不支持 delete_pattern 的缓存后端使用的 API 权限键索引
+API_TOKEN_PERMISSION_KEYS_PREFIX = "api_token_permission_keys:"
 
 
 def _get_token_info_key(username: str, domain: str) -> str:
@@ -98,6 +102,50 @@ def _get_cache_key(
 def _get_user_keys_index(username: str, domain: str) -> str:
     """获取用户缓存键索引的 key（旧版兜底，非 Redis 后端使用）"""
     return f"{USER_PERM_KEYS_PREFIX}{username}:{domain}"
+
+
+def _get_api_token_permission_prefix(username: str, domain: str) -> str:
+    """返回指定用户全部 API Token 权限快照的键前缀。"""
+    return f"{API_TOKEN_PERMISSION_CACHE_PREFIX}:{username}:{domain}:"
+
+
+def _get_api_token_keys_index(username: str, domain: str) -> str:
+    """返回非 pattern 缓存后端使用的 API Token 权限键索引。"""
+    return f"{API_TOKEN_PERMISSION_KEYS_PREFIX}{username}:{domain}"
+
+
+def register_api_token_permission_cache_key(
+    username: str,
+    domain: str,
+    cache_key: str,
+    ttl: int,
+) -> None:
+    """登记 API Token 权限快照键，供精确失效与 pattern 失败降级。"""
+    index_key = _get_api_token_keys_index(username, domain)
+    cached_keys = cache.get(index_key) or set()
+    cached_keys.add(cache_key)
+    cache.set(index_key, cached_keys, ttl + 60)
+
+
+def clear_api_token_permission_cache(username: str, domain: str) -> None:
+    """清除指定用户在所有团队下的 API Token 权限快照。"""
+    if hasattr(cache, "delete_pattern"):
+        try:
+            cache.delete_pattern(f"{_get_api_token_permission_prefix(username, domain)}*")
+            cache.delete(_get_api_token_keys_index(username, domain))
+            return
+        except Exception as e:
+            logger.warning(
+                "Failed to clear API token permission cache by pattern for %s, falling back to index: %s",
+                username,
+                e,
+            )
+
+    index_key = _get_api_token_keys_index(username, domain)
+    cached_keys = cache.get(index_key)
+    if cached_keys:
+        cache.delete_many(list(cached_keys))
+    cache.delete(index_key)
 
 
 def get_cached_permission_rules(
@@ -196,6 +244,7 @@ def clear_user_permission_cache(username: str, domain: str = "domain.com") -> No
         # 降级路径：旧版键索引（非 Redis 后端）
         _clear_user_cache_by_index(username, domain)
 
+    clear_api_token_permission_cache(username, domain)
     clear_token_info_cache(username, domain)
 
 

--- a/server/apps/core/utils/permission_utils.py
+++ b/server/apps/core/utils/permission_utils.py
@@ -2,52 +2,57 @@ from django.db.models import Q
 
 from apps.core.constants import DEFAULT_PERMISSION
 from apps.core.logger import nats_logger as logger
-from apps.core.utils.permission_cache import get_cached_permission_rules, set_cached_permission_rules
+from apps.core.utils.permission_cache import get_cached_permission_rules, get_user_permission_version, set_cached_permission_rules
 from apps.rpc.system_mgmt import SystemMgmt
 
 
 def get_permission_rules(user, current_team, app_name, permission_key, include_children=False):
     """获取某app某类权限的某个对象的规则"""
-    # 尝试从缓存获取
-    cached = get_cached_permission_rules(
-        username=user.username,
-        domain=user.domain,
-        current_team=int(current_team),
-        app_name=app_name,
-        permission_key=permission_key,
-        include_children=include_children,
-    )
-    if cached is not None:
-        return cached
-
-    # 缓存未命中，发起 RPC 调用
-    app, child_module, client, module = set_rules_module_params(app_name, permission_key)
-    try:
-        permission_data = client.get_user_rules_by_app(
-            int(current_team),
-            user.username,
-            app,
-            module,
-            child_module,
-            user.domain,
-            include_children,
-        )
-        # 缓存结果
-        set_cached_permission_rules(
+    rpc_params = None
+    for _attempt in range(2):
+        permission_version = get_user_permission_version(user.username, user.domain)
+        cached = get_cached_permission_rules(
             username=user.username,
             domain=user.domain,
             current_team=int(current_team),
             app_name=app_name,
             permission_key=permission_key,
-            permission_data=permission_data,
             include_children=include_children,
+            permission_version=permission_version,
         )
-        return permission_data
-    except Exception:
-        import traceback
+        if cached is not None:
+            return cached
 
-        logger.error(traceback.format_exc())
-        return {}
+        try:
+            if rpc_params is None:
+                rpc_params = set_rules_module_params(app_name, permission_key)
+            app, child_module, client, module = rpc_params
+            permission_data = client.get_user_rules_by_app(
+                int(current_team),
+                user.username,
+                app,
+                module,
+                child_module,
+                user.domain,
+                include_children,
+            )
+            if set_cached_permission_rules(
+                username=user.username,
+                domain=user.domain,
+                current_team=int(current_team),
+                app_name=app_name,
+                permission_key=permission_key,
+                permission_data=permission_data,
+                include_children=include_children,
+                permission_version=permission_version,
+            ):
+                return permission_data
+        except Exception:
+            import traceback
+
+            logger.error(traceback.format_exc())
+            return {}
+    return {}
 
 
 def set_rules_module_params(app_name, permission_key):

--- a/server/apps/system_mgmt/management/commands/cleanup_opspilot_legacy_knowledge_menus.py
+++ b/server/apps/system_mgmt/management/commands/cleanup_opspilot_legacy_knowledge_menus.py
@@ -6,6 +6,7 @@ from django.db import transaction
 
 from apps.core.utils.permission_cache import clear_users_permission_cache
 from apps.system_mgmt.models import CustomMenuGroup, Group, Menu, Role, User
+from apps.system_mgmt.utils.group_utils import GroupUtils
 
 APP_NAME = "opspilot"
 LEGACY_MENU_BASE_NAMES = {
@@ -70,9 +71,9 @@ class Command(BaseCommand):
             changed_role_ids = _migrate_roles(legacy_menus, wiki_menu_ids)
             changed_group_count = _migrate_custom_menu_groups(legacy_menus)
             deleted_menu_count, _ = Menu.objects.filter(id__in=[menu.id for menu in legacy_menus]).delete()
+            _clear_permission_cache_for_roles(changed_role_ids)
 
         _clear_menu_cache()
-        _clear_permission_cache_for_roles(changed_role_ids)
 
         self.stdout.write(self.style.SUCCESS("OpsPilot legacy knowledge menus cleanup completed."))
         self.stdout.write(f"legacy menus deleted: {deleted_menu_count}")
@@ -298,12 +299,13 @@ def _clear_permission_cache_for_roles(role_ids):
 
     role_id_set = set(role_ids)
     group_ids = set(Group.objects.filter(roles__id__in=role_ids).values_list("id", flat=True))
+    affected_group_ids = set(GroupUtils.get_group_with_descendants(group_ids))
     affected_users = []
 
     for user in User.objects.all().only("username", "domain", "role_list", "group_list"):
         user_role_ids = set(user.role_list or [])
         user_group_ids = set(user.group_list or [])
-        if role_id_set.intersection(user_role_ids) or group_ids.intersection(user_group_ids):
+        if role_id_set.intersection(user_role_ids) or affected_group_ids.intersection(user_group_ids):
             affected_users.append({"username": user.username, "domain": user.domain})
 
     if affected_users:

--- a/server/apps/system_mgmt/management/commands/init_realm_resource.py
+++ b/server/apps/system_mgmt/management/commands/init_realm_resource.py
@@ -4,7 +4,9 @@ import os
 from copy import deepcopy
 
 from django.core.management import BaseCommand
+from django.db import transaction
 
+from apps.core.utils.permission_cache import clear_all_permission_cache
 from apps.system_mgmt.management.commands._install_apps import get_install_apps
 from apps.system_mgmt.models import App, Group, Menu, Role
 
@@ -33,25 +35,38 @@ class Command(BaseCommand):
                         logger.error(f"Error reading {file_path}: {e}")
 
         print(f"Read {len(MENUS)} menu files")
-        for app_obj in MENUS:
-            app_inst, _ = App.objects.update_or_create(
-                name=app_obj["client_id"],
-                defaults={
-                    "display_name": app_obj["name"],
-                    "description": app_obj["description"],
-                    "is_build_in": True,
-                    "url": app_obj["url"],
-                    "icon": app_obj.get("icon", app_obj["client_id"]),
-                    "tags": app_obj.get("tags", []),
-                },
-            )
-            print(f"create {app_obj['client_id']} success")
-            create_resource(app_inst, app_obj["menus"])
-            print(f"create {app_obj['client_id']} resource success")
-            create_default_roles(app_inst, app_obj["roles"])
-            print(f"create {app_obj['client_id']} roles success")
-        Group.objects.get_or_create(name="Default", parent_id=0, defaults={"description": "Default group"})
-        Group.objects.get_or_create(name="Guest", parent_id=0, defaults={"description": "Guest group"})
+        with transaction.atomic():
+            permission_signature_before = _permission_signature()
+            for app_obj in MENUS:
+                app_inst, _ = App.objects.update_or_create(
+                    name=app_obj["client_id"],
+                    defaults={
+                        "display_name": app_obj["name"],
+                        "description": app_obj["description"],
+                        "is_build_in": True,
+                        "url": app_obj["url"],
+                        "icon": app_obj.get("icon", app_obj["client_id"]),
+                        "tags": app_obj.get("tags", []),
+                    },
+                )
+                print(f"create {app_obj['client_id']} success")
+                create_resource(app_inst, app_obj["menus"])
+                print(f"create {app_obj['client_id']} resource success")
+                create_default_roles(app_inst, app_obj["roles"])
+                print(f"create {app_obj['client_id']} roles success")
+            Group.objects.get_or_create(name="Default", parent_id=0, defaults={"description": "Default group"})
+            Group.objects.get_or_create(name="Guest", parent_id=0, defaults={"description": "Guest group"})
+            if _permission_signature() != permission_signature_before:
+                clear_all_permission_cache()
+
+
+def _permission_signature():
+    """返回会影响鉴权结果的菜单/角色签名，避免 no-op 启动全量打冷缓存。"""
+    menus = tuple(Menu.objects.order_by("id").values_list("id", "app", "name"))
+    roles = tuple(
+        (role.id, role.app, role.name, tuple(role.menu_list or [])) for role in Role.objects.order_by("id").only("id", "app", "name", "menu_list")
+    )
+    return menus, roles
 
 
 def extend_menus_by_install_apps(menu_data: dict, install_apps: set[str]) -> dict:

--- a/server/apps/system_mgmt/management/commands/prepare_permission_cache_rollback.py
+++ b/server/apps/system_mgmt/management/commands/prepare_permission_cache_rollback.py
@@ -1,0 +1,73 @@
+from django.core.cache import caches
+from django.core.cache.backends.dummy import DummyCache
+from django.core.cache.backends.locmem import LocMemCache
+from django.core.cache.backends.redis import RedisCache
+from django.core.management import BaseCommand, CommandError
+
+from apps.core.utils.permission_cache import (
+    API_TOKEN_PERMISSION_CACHE_PREFIX,
+    API_TOKEN_PERMISSION_KEYS_PREFIX,
+    PERM_CACHE_PREFIX,
+    TOKEN_INFO_PREFIX,
+    USER_PERM_KEYS_PREFIX,
+)
+
+ROLLBACK_PERMISSION_CACHE_PATTERNS = (
+    f"{PERM_CACHE_PREFIX}*",
+    f"{USER_PERM_KEYS_PREFIX}*",
+    f"{TOKEN_INFO_PREFIX}*",
+    f"{API_TOKEN_PERMISSION_CACHE_PREFIX}:*",
+    f"{API_TOKEN_PERMISSION_KEYS_PREFIX}*",
+)
+
+
+def _clear_permission_namespaces(cache_backend) -> int:
+    """只清理权限键；支持 django-redis、Django RedisCache 与已排空的进程内缓存。"""
+    delete_pattern = getattr(cache_backend, "delete_pattern", None)
+    if callable(delete_pattern):
+        return sum(int(delete_pattern(pattern) or 0) for pattern in ROLLBACK_PERMISSION_CACHE_PATTERNS)
+
+    if isinstance(cache_backend, RedisCache):
+        client = cache_backend._cache.get_client(None, write=True)
+        deleted = 0
+        for pattern in ROLLBACK_PERMISSION_CACHE_PATTERNS:
+            physical_pattern = cache_backend.make_key(pattern)
+            batch = []
+            for key in client.scan_iter(match=physical_pattern, count=1000):
+                batch.append(key)
+                if len(batch) == 1000:
+                    deleted += int(client.delete(*batch) or 0)
+                    batch = []
+            if batch:
+                deleted += int(client.delete(*batch) or 0)
+        return deleted
+
+    if isinstance(cache_backend, (LocMemCache, DummyCache)):
+        # 命令要求先排空全部 Worker；新命令进程中的本地缓存没有旧 Worker 数据。
+        return 0
+
+    raise CommandError("当前缓存后端不支持安全的权限命名空间清理；请保持 Worker 停止并等待权限缓存 TTL 到期")
+
+
+class Command(BaseCommand):
+    help = "回滚到旧版权限缓存前清除权限缓存命名空间，避免旧无版本权限快照重新生效"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--confirm",
+            action="store_true",
+            help="确认已排空全部 Server Worker，并允许清空默认缓存",
+        )
+
+    def handle(self, *args, **options):
+        if not options["confirm"]:
+            raise CommandError("必须先排空全部 Server Worker，再使用 --confirm 清除权限缓存")
+
+        try:
+            deleted = _clear_permission_namespaces(caches["default"])
+        except CommandError:
+            raise
+        except Exception as error:
+            raise CommandError(f"权限缓存清理失败，禁止启动旧版本 Server Worker: {error}") from error
+
+        self.stdout.write(self.style.SUCCESS(f"权限缓存命名空间已清理（删除 {deleted} 个键），可以启动旧版本 Server Worker"))

--- a/server/apps/system_mgmt/migrations/0042_user_permission_version.py
+++ b/server/apps/system_mgmt/migrations/0042_user_permission_version.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("system_mgmt", "0041_networkwhitelist_domain_build_in"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserPermissionVersion",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("username", models.CharField(max_length=100)),
+                (
+                    "domain",
+                    models.CharField(default="domain.com", max_length=100),
+                ),
+                ("version", models.PositiveBigIntegerField(default=0)),
+            ],
+            options={
+                "unique_together": {("username", "domain")},
+            },
+        ),
+    ]

--- a/server/apps/system_mgmt/models/user.py
+++ b/server/apps/system_mgmt/models/user.py
@@ -1,4 +1,4 @@
-from django.db import models
+from django.db import models, transaction
 from django.utils import timezone as django_timezone
 
 from apps.core.utils.permission_cache import clear_user_permission_cache
@@ -41,8 +41,9 @@ class User(models.Model):
                     self.account_locked_until = None  # 解除锁定
             except User.DoesNotExist:
                 pass
-        super().save(*args, **kwargs)
-        clear_user_permission_cache(self.username, self.domain)
+        with transaction.atomic():
+            super().save(*args, **kwargs)
+            clear_user_permission_cache(self.username, self.domain)
 
     @staticmethod
     def display_fields():
@@ -63,6 +64,17 @@ class User(models.Model):
             "password_error_count",
             "account_locked_until",
         ]
+
+
+class UserPermissionVersion(models.Model):
+    """独立于用户生命周期保存的单调权限代际。"""
+
+    username = models.CharField(max_length=100)
+    domain = models.CharField(max_length=100, default="domain.com")
+    version = models.PositiveBigIntegerField(default=0)
+
+    class Meta:
+        unique_together = ("username", "domain")
 
 
 class Group(models.Model):

--- a/server/apps/system_mgmt/nats/auth.py
+++ b/server/apps/system_mgmt/nats/auth.py
@@ -100,14 +100,43 @@ def verify_token(token):
             return_data["error_code"] = VERIFY_TOKEN_USER_NOT_FOUND_CODE
         return return_data
 
-    # 命中缓存直接返回，跳过全量数据库查询
-    cached = get_cached_token_info(user.username, user.domain)
-    if cached is not None:
-        return cached
+    user_id = user.id
+    for _attempt in range(2):
+        identity = User.objects.filter(id=user_id).values("username", "domain").first()
+        if identity is None:
+            return {
+                "result": False,
+                "message": VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE,
+                "error_code": VERIFY_TOKEN_USER_NOT_FOUND_CODE,
+            }
+        permission_version = get_user_permission_version(identity["username"], identity["domain"])
+        user = User.objects.filter(id=user_id).first()
+        if user is None:
+            return {
+                "result": False,
+                "message": VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE,
+                "error_code": VERIFY_TOKEN_USER_NOT_FOUND_CODE,
+            }
+        if (user.username, user.domain) != (identity["username"], identity["domain"]):
+            continue
+        cached = get_cached_token_info(
+            user.username,
+            user.domain,
+            permission_version=permission_version,
+        )
+        if cached is not None:
+            return cached
 
-    result = {"result": True, "data": build_user_authorization_context(user)}
-    set_cached_token_info(user.username, user.domain, result)
-    return result
+        result = {"result": True, "data": build_user_authorization_context(user)}
+        if set_cached_token_info(
+            user.username,
+            user.domain,
+            result,
+            permission_version=permission_version,
+        ):
+            return result
+
+    return {"result": False, "message": "User permissions changed during token verification"}
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/common.py
+++ b/server/apps/system_mgmt/nats/common.py
@@ -20,7 +20,13 @@ import nats_client
 from apps.core.constants import VERIFY_TOKEN_USER_NOT_FOUND_CODE, VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE
 from apps.core.logger import system_mgmt_logger as logger
 from apps.core.utils.loader import LanguageLoader
-from apps.core.utils.permission_cache import clear_token_info_cache, clear_users_permission_cache, get_cached_token_info, set_cached_token_info
+from apps.core.utils.permission_cache import (
+    clear_token_info_cache,
+    clear_users_permission_cache,
+    get_cached_token_info,
+    get_user_permission_version,
+    set_cached_token_info,
+)
 from apps.system_mgmt.guest_menus import CMDB_MENUS, MONITOR_MENUS, OPSPILOT_GUEST_MENUS
 from apps.system_mgmt.models import (
     App,

--- a/server/apps/system_mgmt/nats/permissions.py
+++ b/server/apps/system_mgmt/nats/permissions.py
@@ -243,43 +243,43 @@ def delete_rules(group_ids, instance_id, app, module, child_module):
 
         updated_count = 0
         affected_rule_ids = []
-        for rule_obj in rules_queryset:
-            rules_data = rule_obj.rules
+        with transaction.atomic():
+            for rule_obj in rules_queryset:
+                rules_data = rule_obj.rules
 
-            # 如果没有对应的模块，跳过
-            if module not in rules_data:
-                continue
-
-            # 获取目标数据结构
-            if child_module:
-                # 二级模块，如 provider.llm_model
-                if child_module not in rules_data[module]:
+                # 如果没有对应的模块，跳过
+                if module not in rules_data:
                     continue
-                target_list = rules_data[module][child_module]
-            else:
-                # 一级模块，如 skill、bot
-                target_list = rules_data[module]
 
-            # 删除指定 ID 的权限项
-            original_length = len(target_list)
-            if child_module:
-                rules_data[module][child_module] = [item for item in target_list if str(item.get("id")) != str(instance_id)]
-            else:
-                rules_data[module] = [item for item in target_list if str(item.get("id")) != str(instance_id)]
+                # 获取目标数据结构
+                if child_module:
+                    # 二级模块，如 provider.llm_model
+                    if child_module not in rules_data[module]:
+                        continue
+                    target_list = rules_data[module][child_module]
+                else:
+                    # 一级模块，如 skill、bot
+                    target_list = rules_data[module]
 
-            # 如果有删除操作，更新数据库
-            new_length = len(rules_data[module][child_module] if child_module else rules_data[module])
-            if new_length < original_length:
-                rule_obj.rules = rules_data
-                rule_obj.save()
-                updated_count += 1
-                affected_rule_ids.append(rule_obj.id)
+                # 删除指定 ID 的权限项
+                original_length = len(target_list)
+                if child_module:
+                    rules_data[module][child_module] = [item for item in target_list if str(item.get("id")) != str(instance_id)]
+                else:
+                    rules_data[module] = [item for item in target_list if str(item.get("id")) != str(instance_id)]
 
-        # 清除受影响用户的权限缓存
-        if affected_rule_ids:
-            affected_users = list(UserRule.objects.filter(group_rule_id__in=affected_rule_ids).values("username", "domain"))
-            if affected_users:
-                clear_users_permission_cache(affected_users)
+                # 如果有删除操作，更新数据库
+                new_length = len(rules_data[module][child_module] if child_module else rules_data[module])
+                if new_length < original_length:
+                    rule_obj.rules = rules_data
+                    rule_obj.save()
+                    updated_count += 1
+                    affected_rule_ids.append(rule_obj.id)
+
+            if affected_rule_ids:
+                affected_users = list(UserRule.objects.filter(group_rule_id__in=affected_rule_ids).values("username", "domain"))
+                if affected_users:
+                    clear_users_permission_cache(affected_users)
 
         return {
             "result": True,

--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.current_team_scope import _normalize_organization_ids
+from apps.core.utils.permission_cache import clear_all_permission_cache
 
 from .common import *  # noqa: F401,F403
 from .common import _collect_ancestor_group_ids
@@ -221,12 +222,23 @@ def create_guest_role():
         "cmdb": CMDB_MENUS[:],
         "monitor": MONITOR_MENUS[:],
     }
-    guest_group, _ = Group.objects.get_or_create(name="Guest", parent_id=0, defaults={"description": "Guest group"})
-    app_guest_group, _ = Group.objects.get_or_create(name="OpsPilotGuest", parent_id=0)
-    for app, app_menus in app_map.items():
-        menus = dict(Menu.objects.filter(app=app).values_list("id", "name"))
-        menu_list = [k for k, v in menus.items() if v in app_menus]
-        Role.objects.update_or_create(name="guest", app=app, defaults={"menu_list": menu_list})
+    with transaction.atomic():
+        guest_group, _ = Group.objects.get_or_create(name="Guest", parent_id=0, defaults={"description": "Guest group"})
+        app_guest_group, _ = Group.objects.get_or_create(name="OpsPilotGuest", parent_id=0)
+        permissions_changed = False
+        for app, app_menus in app_map.items():
+            menus = dict(Menu.objects.filter(app=app).values_list("id", "name"))
+            menu_list = [k for k, v in menus.items() if v in app_menus]
+            role = Role.objects.filter(name="guest", app=app).first()
+            if role is None:
+                Role.objects.create(name="guest", app=app, menu_list=menu_list)
+                permissions_changed = True
+            elif role.menu_list != menu_list:
+                role.menu_list = menu_list
+                role.save(update_fields=["menu_list"])
+                permissions_changed = True
+        if permissions_changed:
+            clear_all_permission_cache()
     return {"result": True, "data": {"group_id": app_guest_group.id}}
 
 

--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -301,11 +301,12 @@ def set_opspilot_guest_group_default_rule(default_group, user):
     cmdb_rule = GroupDataRule.objects.get(name="游客数据权限", app="cmdb", group_id=default_group.id)
     log_rule = GroupDataRule.objects.get(name="log内置规则", app="log", group_id=default_group.id)
     node_rule = GroupDataRule.objects.get(name="节点管理内置数据权限", app="node", group_id=default_group.id)
-    UserRule.objects.get_or_create(username=user.username, group_rule_id=cmdb_rule.id)
-    UserRule.objects.get_or_create(username=user.username, group_rule_id=default_rule.id)
-    UserRule.objects.get_or_create(username=user.username, group_rule_id=monitor_rule.id)
-    UserRule.objects.get_or_create(username=user.username, group_rule_id=log_rule.id)
-    UserRule.objects.get_or_create(username=user.username, group_rule_id=node_rule.id)
+    identity = {"username": user.username, "domain": user.domain}
+    UserRule.objects.get_or_create(**identity, group_rule_id=cmdb_rule.id)
+    UserRule.objects.get_or_create(**identity, group_rule_id=default_rule.id)
+    UserRule.objects.get_or_create(**identity, group_rule_id=monitor_rule.id)
+    UserRule.objects.get_or_create(**identity, group_rule_id=log_rule.id)
+    UserRule.objects.get_or_create(**identity, group_rule_id=node_rule.id)
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/wechat.py
+++ b/server/apps/system_mgmt/nats/wechat.py
@@ -29,11 +29,14 @@ def wechat_user_register(user_id, nick_name):
         user.role_list = list(set(default_role))
         user.last_login = timezone.now()
         user.save()
-    try:
         if default_group:
-            set_opspilot_guest_group_default_rule(default_group, user)
-    except Exception:  # noqa
-        pass
+            try:
+                # 规则写入成功时与用户及权限代际一起提交；失败时仅回滚规则写入，
+                # 保留原有的微信注册可用性。
+                with transaction.atomic():
+                    set_opspilot_guest_group_default_rule(default_group, user)
+            except Exception:  # noqa
+                logger.exception("Failed to initialize WeChat user data rules")
     secret_key = os.getenv("SECRET_KEY")
     algorithm = os.getenv("JWT_ALGORITHM", "HS256")
     user_obj = _build_jwt_payload(user.id)

--- a/server/apps/system_mgmt/services/user_sync_service.py
+++ b/server/apps/system_mgmt/services/user_sync_service.py
@@ -1120,12 +1120,11 @@ def delete_user_sync_source(source: UserSyncSource):
     with transaction.atomic():
         if users_to_delete:
             User.objects.filter(id__in=users_to_delete).delete()
+        if affected_usernames:
+            clear_users_permission_cache(affected_usernames)
         if subtree_ids:
             Group.objects.filter(id__in=subtree_ids).delete()
         source.delete()
-
-    if affected_usernames:
-        clear_users_permission_cache(affected_usernames)
 
     return {
         "result": True,

--- a/server/apps/system_mgmt/tasks.py
+++ b/server/apps/system_mgmt/tasks.py
@@ -3,6 +3,8 @@ from datetime import timedelta
 
 from celery import shared_task
 from celery.exceptions import MaxRetriesExceededError
+from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone as django_timezone
 
 from apps.core.logger import system_mgmt_logger as logger
@@ -11,6 +13,7 @@ from apps.rpc.base import RpcClient
 from apps.system_mgmt.models import Channel, ErrorLog, Group, LoginModule, SystemSettings, User
 from apps.system_mgmt.models.channel import ChannelChoices
 from apps.system_mgmt.utils.channel_utils import send_email_to_user
+from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
 @shared_task(bind=True, max_retries=3, default_retry_delay=60)
@@ -99,7 +102,25 @@ def _sync_groups(group_list, parent_group, parent_group_id):
     # 处理需要删除的组
     delete_groups = [group.id for group in existing_groups if group.external_id and group.external_id not in current_external_ids]
     if delete_groups:
-        Group.objects.filter(id__in=delete_groups).delete()
+        with transaction.atomic():
+            affected_identities = set()
+            affected_group_ids = GroupUtils.get_group_with_descendants(delete_groups)
+            for offset in range(0, len(affected_group_ids), 100):
+                affected_query = Q()
+                for group_id in affected_group_ids[offset : offset + 100]:
+                    affected_query |= Q(group_list__contains=[group_id])
+                affected_identities.update(
+                    User.objects.filter(affected_query)
+                    .values_list("username", "domain")
+                    .iterator(chunk_size=1000)
+                )
+            affected_users = [
+                {"username": username, "domain": domain}
+                for username, domain in sorted(affected_identities)
+            ]
+            Group.objects.filter(id__in=delete_groups).delete()
+            if affected_users:
+                clear_users_permission_cache(affected_users)
         logger.info(f"Deleted {len(delete_groups)} groups under parent {parent_group.name}")
 
     # 处理当前层级的组
@@ -234,19 +255,21 @@ def _sync_users(user_list, group_id_mapping, domain, default_role):
             new_user = User(**user_defaults)
             create_users.append(new_user)
 
-    # 批量创建新用户
+    affected_users = create_users + update_users
+    if affected_users:
+        with transaction.atomic():
+            if create_users:
+                User.objects.bulk_create(create_users, batch_size=100)
+            if update_users:
+                update_fields = ["display_name", "group_list"]
+                if any(hasattr(user, "domain") for user in update_users):
+                    update_fields.append("domain")
+                User.objects.bulk_update(update_users, update_fields, batch_size=100)
+            clear_users_permission_cache([{"username": user.username, "domain": user.domain} for user in affected_users])
+
     if create_users:
-        User.objects.bulk_create(create_users, batch_size=100)
         logger.info(f"Created {len(create_users)} new users")
-
-    # 批量更新已存在的用户
     if update_users:
-        update_fields = ["display_name", "group_list"]
-        if any(hasattr(user, "domain") for user in update_users):
-            update_fields.append("domain")
-
-        User.objects.bulk_update(update_users, update_fields, batch_size=100)
-        clear_users_permission_cache([{"username": user.username, "domain": user.domain} for user in update_users])
         logger.info(f"Updated {len(update_users)} existing users")
 
     return list(user_data_map.keys())

--- a/server/apps/system_mgmt/tests/sensitive_info_management_test.py
+++ b/server/apps/system_mgmt/tests/sensitive_info_management_test.py
@@ -1,8 +1,8 @@
-import uuid
 import importlib
 import json
 import os
 import types
+import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -90,7 +90,6 @@ def test_system_mgmt_urls_loads_enterprise_urlpatterns_indirectly_without_hardco
     assert "apps.system_mgmt.enterprise.urls" in imported_modules
     assert "SensitiveInfoAuthorizationViewSet" not in reloaded_urls.__dict__
     assert "enterprise_urls" in reloaded_urls.__dict__
-
 
 
 @pytest.mark.django_db
@@ -304,6 +303,7 @@ def test_user_viewset_update_user_keeps_existing_sensitive_fields_when_omitted()
 
 @pytest.mark.django_db
 def test_user_viewset_delete_user_allows_manual_user():
+    from apps.core.utils.permission_cache import get_user_permission_version
     from apps.system_mgmt.viewset.user_viewset import UserViewSet
 
     group = Group.objects.create(name="group-for-delete-manual")
@@ -315,6 +315,7 @@ def test_user_viewset_delete_user_allows_manual_user():
         group_list=[group.id],
     )
     UserRule.objects.create(username=user.username, domain=user.domain, group_rule_id=1)
+    initial_version = get_user_permission_version(user.username, user.domain)
 
     factory = APIRequestFactory()
     view = UserViewSet.as_view({"post": "delete_user"})
@@ -339,6 +340,7 @@ def test_user_viewset_delete_user_allows_manual_user():
     assert response.status_code == 200
     assert payload == {"result": True}
     assert User.objects.filter(id=user.id).exists() is False
+    assert get_user_permission_version(user.username, user.domain) > initial_version
 
 
 @pytest.mark.django_db
@@ -652,6 +654,7 @@ def test_user_viewset_search_user_list_includes_sync_source_identifier():
 
 
 @pytest.mark.django_db
+@requires_enterprise_mask
 # 验证用户详情查询会按授权粒度只放行对应敏感类型的明文，其他类型继续脱敏。
 def test_user_viewset_get_user_detail_only_reveals_authorized_sensitive_type():
     from apps.system_mgmt.models import Group

--- a/server/apps/system_mgmt/tests/test_app_viewset_serializer.py
+++ b/server/apps/system_mgmt/tests/test_app_viewset_serializer.py
@@ -9,11 +9,12 @@
 """
 
 import types
+from unittest.mock import patch
 
 import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from apps.system_mgmt.models import App, Role
+from apps.system_mgmt.models import App, Group, Role, User
 from apps.system_mgmt.serializers.app_serializer import AppSerializer
 from apps.system_mgmt.viewset.app_viewset import AppViewSet
 
@@ -121,11 +122,50 @@ def test_app_viewset_destroy_removes_custom_app_and_roles():
     app = App.objects.create(
         name="deletable_app", display_name="可删", description="x", url="/d", is_build_in=False
     )
-    Role.objects.create(name="user", app="deletable_app")
+    role = Role.objects.create(name="user", app="deletable_app")
+    parent = Group.objects.create(name="AppParent", parent_id=0, allow_inherit_roles=True)
+    child = Group.objects.create(name="AppChild", parent_id=parent.id)
+    parent.roles.add(role)
+    User.objects.create(
+        username="app-descendant",
+        password="x",
+        display_name="App Descendant",
+        email="app-descendant@example.com",
+        group_list=[child.id],
+    )
     view = AppViewSet.as_view({"delete": "destroy"})
     request = _request("delete")
     force_authenticate(request, user=request.user)
-    response = view(request, pk=app.id)
+    with patch("apps.system_mgmt.viewset.app_viewset.clear_users_permission_cache") as clear_cache:
+        response = view(request, pk=app.id)
     assert response.status_code == 204
     assert not App.objects.filter(id=app.id).exists()
     assert not Role.objects.filter(app="deletable_app").exists()
+    assert {user["username"] for user in clear_cache.call_args.args[0]} == {"app-descendant"}
+
+
+def test_app_viewset_rename_invalidates_role_users():
+    app = App.objects.create(name="old_app", display_name="Old", description="x", url="/old", is_build_in=False)
+    role = Role.objects.create(name="user", app="old_app")
+    User.objects.create(
+        username="app-direct",
+        password="x",
+        display_name="App Direct",
+        email="app-direct@example.com",
+        role_list=[role.id],
+    )
+    view = AppViewSet.as_view({"put": "update"})
+    request = APIRequestFactory().put(
+        "/system_mgmt/api/application/",
+        {"name": "new_app", "display_name": "New", "description": "x", "url": "/new", "tags": []},
+        format="json",
+    )
+    force_authenticate(request, user=_request().user)
+
+    with patch("apps.system_mgmt.viewset.app_viewset.clear_users_permission_cache") as clear_cache:
+        response = view(request, pk=app.id)
+
+    assert response.status_code == 200
+    role.refresh_from_db()
+    assert role.app == "new_app"
+    assert {user["username"] for user in clear_cache.call_args.args[0]} == {"app-direct"}

--- a/server/apps/system_mgmt/tests/test_cleanup_opspilot_legacy_knowledge_menus.py
+++ b/server/apps/system_mgmt/tests/test_cleanup_opspilot_legacy_knowledge_menus.py
@@ -1,9 +1,11 @@
 from io import StringIO
+from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 
-from apps.system_mgmt.models import CustomMenuGroup, Menu, Role
+from apps.system_mgmt.management.commands.cleanup_opspilot_legacy_knowledge_menus import _clear_permission_cache_for_roles
+from apps.system_mgmt.models import CustomMenuGroup, Group, Menu, Role, User
 
 pytestmark = pytest.mark.django_db
 
@@ -115,3 +117,30 @@ def test_cleanup_opspilot_legacy_knowledge_menus_updates_custom_menu_groups():
     assert "bot_list" in names
     assert "provide_list" in names
     assert "wiki_list" in names
+
+
+def test_role_cleanup_invalidates_descendant_group_users():
+    role = Role.objects.create(name="inherited", app="opspilot")
+    parent = Group.objects.create(
+        name="permission-parent",
+        parent_id=0,
+        allow_inherit_roles=True,
+    )
+    child = Group.objects.create(
+        name="permission-child",
+        parent_id=parent.id,
+        allow_inherit_roles=True,
+    )
+    parent.roles.add(role)
+    user = User.objects.create(
+        username="inherited-cleanup-user",
+        display_name="Inherited cleanup user",
+        email="inherited-cleanup@example.com",
+        password="",
+        group_list=[child.id],
+    )
+
+    with patch("apps.system_mgmt.management.commands.cleanup_opspilot_legacy_knowledge_menus.clear_users_permission_cache") as clear_cache:
+        _clear_permission_cache_for_roles([role.id])
+
+    clear_cache.assert_called_once_with([{"username": user.username, "domain": user.domain}])

--- a/server/apps/system_mgmt/tests/test_group_viewset_api.py
+++ b/server/apps/system_mgmt/tests/test_group_viewset_api.py
@@ -149,6 +149,29 @@ def test_update_group(super_client):
     assert role in g.roles.all()
 
 
+def test_update_group_invalidates_descendant_users(super_client):
+    parent = Group.objects.create(name="UpdateParent", parent_id=0, allow_inherit_roles=True)
+    child = Group.objects.create(name="UpdateChild", parent_id=parent.id)
+    User.objects.create(
+        username="update-descendant",
+        password="x",
+        display_name="Descendant",
+        email="descendant@x.com",
+        group_list=[child.id],
+    )
+
+    with patch("apps.system_mgmt.viewset.group_viewset.clear_users_permission_cache") as clear_cache:
+        resp = super_client.post(
+            f"{BASE}/update_group/",
+            {"group_id": parent.id, "group_name": parent.name, "role_ids": []},
+            format="json",
+        )
+
+    assert resp.json()["result"] is True
+    affected_users = clear_cache.call_args.args[0]
+    assert {user["username"] for user in affected_users} == {"update-descendant"}
+
+
 def test_update_group_default_protected(super_client):
     Group.objects.filter(name="Default", parent_id=0).delete()
     g = Group.objects.create(name="Default", parent_id=0)

--- a/server/apps/system_mgmt/tests/test_management_and_service.py
+++ b/server/apps/system_mgmt/tests/test_management_and_service.py
@@ -3,12 +3,17 @@
 调用真实 management 命令（call_command），断言真实 DB 副作用；
 只在涉及外部缓存时 mock permission_cache。
 """
+
 from io import StringIO
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
-from django.core.management import call_command
+from django.core.cache.backends.locmem import LocMemCache
+from django.core.cache.backends.redis import RedisCache
+from django.core.management import CommandError, call_command
 
+from apps.core.utils.permission_cache import get_user_permission_version
 from apps.system_mgmt.models import App, CustomMenuGroup, Group, LoginModule, Menu, Role, SystemSettings, User
 from apps.system_mgmt.services.role_manage import RoleManage
 
@@ -34,9 +39,7 @@ def test_create_user_basic():
 
 def test_create_user_superuser_assigns_admin_role():
     out = StringIO()
-    call_command(
-        "create_user", "boss", "pw", "--email", "boss@x.com", "--display_name", "Boss", "--is_superuser", stdout=out
-    )
+    call_command("create_user", "boss", "pw", "--email", "boss@x.com", "--display_name", "Boss", "--is_superuser", stdout=out)
     user = User.objects.get(username="boss")
     assert user.email == "boss@x.com"
     assert user.display_name == "Boss"
@@ -127,6 +130,150 @@ def test_init_custom_menu_creates_groups_for_builtin_apps():
 
 
 # ---------------------------------------------------------------------------
+# init_realm_resource / create_guest_role 权限代际
+# ---------------------------------------------------------------------------
+def test_init_realm_resource_advances_permission_version():
+    user = User.objects.create(
+        username="realm-version",
+        password="x",
+        display_name="Realm version",
+        email="realm-version@example.com",
+    )
+    initial_version = get_user_permission_version(user.username, user.domain)
+
+    with (
+        patch(
+            "apps.system_mgmt.management.commands.init_realm_resource.get_install_apps",
+            return_value=set(),
+        ),
+        patch(
+            "apps.system_mgmt.management.commands.init_realm_resource.os.walk",
+            return_value=[],
+        ),
+        patch(
+            "apps.system_mgmt.management.commands.init_realm_resource._permission_signature",
+            side_effect=[("before",), ("after",)],
+        ),
+    ):
+        call_command("init_realm_resource")
+
+    assert get_user_permission_version(user.username, user.domain) > initial_version
+
+
+def test_init_realm_resource_noop_keeps_permission_version():
+    user = User.objects.create(
+        username="realm-version-noop",
+        password="x",
+        display_name="Realm version noop",
+        email="realm-version-noop@example.com",
+    )
+    initial_version = get_user_permission_version(user.username, user.domain)
+
+    with (
+        patch(
+            "apps.system_mgmt.management.commands.init_realm_resource.get_install_apps",
+            return_value=set(),
+        ),
+        patch(
+            "apps.system_mgmt.management.commands.init_realm_resource.os.walk",
+            return_value=[],
+        ),
+    ):
+        call_command("init_realm_resource")
+
+    assert get_user_permission_version(user.username, user.domain) == initial_version
+
+
+def test_create_guest_role_advances_permission_version():
+    from apps.system_mgmt.nats.users import create_guest_role
+
+    user = User.objects.create(
+        username="guest-role-version",
+        password="x",
+        display_name="Guest role version",
+        email="guest-role-version@example.com",
+    )
+    initial_version = get_user_permission_version(user.username, user.domain)
+
+    result = create_guest_role()
+
+    assert result["result"] is True
+    assert get_user_permission_version(user.username, user.domain) > initial_version
+    second_version = get_user_permission_version(user.username, user.domain)
+    create_guest_role()
+    assert get_user_permission_version(user.username, user.domain) == second_version
+
+
+def test_prepare_permission_cache_rollback_requires_confirmation(mocker):
+    clear_namespaces = mocker.patch(
+        "apps.system_mgmt.management.commands.prepare_permission_cache_rollback._clear_permission_namespaces",
+    )
+
+    with pytest.raises(CommandError, match="必须先排空"):
+        call_command("prepare_permission_cache_rollback")
+
+    clear_namespaces.assert_not_called()
+
+
+def test_prepare_permission_cache_rollback_only_clears_permission_namespaces(mocker):
+    clear_namespaces = mocker.patch(
+        "apps.system_mgmt.management.commands.prepare_permission_cache_rollback._clear_permission_namespaces",
+        return_value=7,
+    )
+
+    out = StringIO()
+    call_command("prepare_permission_cache_rollback", confirm=True, stdout=out)
+
+    clear_namespaces.assert_called_once()
+    assert "删除 7 个键" in out.getvalue()
+
+
+def test_prepare_permission_cache_rollback_fails_closed_when_pattern_delete_fails(mocker):
+    mocker.patch(
+        "apps.system_mgmt.management.commands.prepare_permission_cache_rollback._clear_permission_namespaces",
+        side_effect=RuntimeError("redis unavailable"),
+    )
+
+    with pytest.raises(CommandError, match="禁止启动旧版本"):
+        call_command("prepare_permission_cache_rollback", confirm=True)
+
+
+def test_prepare_permission_cache_rollback_uses_django_redis_scan_contract():
+    from apps.system_mgmt.management.commands.prepare_permission_cache_rollback import (
+        ROLLBACK_PERMISSION_CACHE_PATTERNS,
+        _clear_permission_namespaces,
+    )
+
+    backend = RedisCache("redis://127.0.0.1:6379/1", {"OPTIONS": {}})
+    client = MagicMock()
+    client.scan_iter.side_effect = [
+        iter([b":1:perm_rules:a", b":1:perm_rules:b"]),
+        iter([]),
+        iter([b":1:token_info:a"]),
+        iter([]),
+        iter([]),
+    ]
+    client.delete.side_effect = [2, 1]
+    backend.__dict__["_cache"] = SimpleNamespace(get_client=lambda key, write: client)
+
+    deleted = _clear_permission_namespaces(backend)
+
+    assert deleted == 3
+    assert client.scan_iter.call_args_list == [call(match=backend.make_key(pattern), count=1000) for pattern in ROLLBACK_PERMISSION_CACHE_PATTERNS]
+    assert client.delete.call_args_list == [
+        call(b":1:perm_rules:a", b":1:perm_rules:b"),
+        call(b":1:token_info:a"),
+    ]
+    client.flushdb.assert_not_called()
+
+
+def test_prepare_permission_cache_rollback_noops_for_drained_locmem():
+    from apps.system_mgmt.management.commands.prepare_permission_cache_rollback import _clear_permission_namespaces
+
+    assert _clear_permission_namespaces(LocMemCache("rollback-test", {})) == 0
+
+
+# ---------------------------------------------------------------------------
 # init_bk_login_settings 命令
 # ---------------------------------------------------------------------------
 def test_init_bk_login_settings_creates_bk_module():
@@ -198,9 +345,7 @@ def test_sql_execute_returns_dict_rows(monkeypatch):
 
     # SQLExecute 走独立连接，看不到当前测试事务里未提交的数据，
     # 因此查询 migration 已提交的 systemsettings 表，验证返回 dict 行结构。
-    rows = SQLExecute.execute_sql(
-        "SELECT key, value FROM system_mgmt_systemsettings LIMIT 1", []
-    )
+    rows = SQLExecute.execute_sql("SELECT key, value FROM system_mgmt_systemsettings LIMIT 1", [])
     assert isinstance(rows, list)
     if rows:
         assert "key" in rows[0] and "value" in rows[0]

--- a/server/apps/system_mgmt/tests/test_nats_api_compat.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_compat.py
@@ -1,7 +1,8 @@
 """旧 apps.system_mgmt.nats_api 路径兼容层回归测试。"""
+
 import ast
-from pathlib import Path
 import types
+from pathlib import Path
 
 from apps.system_mgmt import nats_api
 
@@ -61,6 +62,7 @@ def test_get_user_login_token_uses_legacy_nats_api_jwt_payload_patch(monkeypatch
 
     user = types.SimpleNamespace(
         id=42,
+        user_id="user-42",
         username="alice",
         display_name="Alice",
         domain="domain.com",
@@ -125,24 +127,42 @@ def test_verify_token_uses_legacy_nats_api_collect_ancestor_patch(monkeypatch):
         def filter(**kwargs):
             return FakeMenuQuerySet()
 
-    monkeypatch.setattr(
-        nats_api,
-        "_verify_token",
-        lambda token: types.SimpleNamespace(
-            id=7,
-            username="alice",
-            display_name="Alice",
-            domain="domain.com",
-            email="alice@example.com",
-            group_list=[1],
-            locale="zh-Hans",
-            timezone="Asia/Shanghai",
-        ),
+    fake_user = types.SimpleNamespace(
+        id=7,
+        username="alice",
+        display_name="Alice",
+        domain="domain.com",
+        email="alice@example.com",
+        group_list=[1],
+        locale="zh-Hans",
+        timezone="Asia/Shanghai",
     )
+
+    class FakeUserQuery:
+        def __init__(self):
+            self.return_identity = False
+
+        def values(self, *args):
+            self.return_identity = True
+            return self
+
+        def first(self):
+            if self.return_identity:
+                return {"username": fake_user.username, "domain": fake_user.domain}
+            return fake_user
+
+    class FakeUserObjects:
+        @staticmethod
+        def filter(**kwargs):
+            return FakeUserQuery()
+
+    monkeypatch.setattr(nats_api, "_verify_token", lambda token: fake_user)
     monkeypatch.setattr(nats_api, "_collect_ancestor_group_ids", fake_collect_ancestor_group_ids)
     monkeypatch.setattr(nats_api, "get_user_all_roles", lambda user: [100])
-    monkeypatch.setattr(nats_api._auth, "get_cached_token_info", lambda username, domain: None)
-    monkeypatch.setattr(nats_api._auth, "set_cached_token_info", lambda username, domain, result: None)
+    monkeypatch.setattr(nats_api._auth, "get_user_permission_version", lambda username, domain: 0)
+    monkeypatch.setattr(nats_api._auth, "get_cached_token_info", lambda username, domain, **kwargs: None)
+    monkeypatch.setattr(nats_api._auth, "set_cached_token_info", lambda username, domain, result, **kwargs: True)
+    monkeypatch.setattr(nats_api._auth, "User", types.SimpleNamespace(objects=FakeUserObjects()))
     monkeypatch.setattr(nats_api._auth, "Role", types.SimpleNamespace(objects=FakeRoleObjects()))
     monkeypatch.setattr(nats_api._auth, "Group", types.SimpleNamespace(objects=FakeGroupObjects()))
     monkeypatch.setattr(nats_api._auth, "Menu", types.SimpleNamespace(objects=FakeMenuObjects()))
@@ -177,20 +197,14 @@ def test_nats_modules_explicitly_import_private_common_helpers():
             continue
 
         module_tree = ast.parse(module_path.read_text())
-        defined_names = {
-            node.name
-            for node in ast.walk(module_tree)
-            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
-        }
+        defined_names = {node.name for node in ast.walk(module_tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))}
         explicit_private_imports = set()
         used_private_names = set()
 
         for node in ast.walk(module_tree):
             if isinstance(node, ast.ImportFrom) and node.module == "common":
                 explicit_private_imports.update(
-                    alias.asname or alias.name
-                    for alias in node.names
-                    if alias.name != "*" and (alias.asname or alias.name).startswith("_")
+                    alias.asname or alias.name for alias in node.names if alias.name != "*" and (alias.asname or alias.name).startswith("_")
                 )
             elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
                 if node.id.startswith("_") and not node.id.startswith("__"):

--- a/server/apps/system_mgmt/tests/test_permission_version_invalidation.py
+++ b/server/apps/system_mgmt/tests/test_permission_version_invalidation.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from django.db import transaction
 from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
 
 from apps.core.utils.permission_cache import clear_user_permission_cache, get_user_permission_version
@@ -10,6 +11,59 @@ from apps.system_mgmt.nats.permissions import delete_rules
 from apps.system_mgmt.viewset.login_module_viewset import LoginModuleViewSet
 
 pytestmark = pytest.mark.django_db
+
+
+def _create_opspilot_guest_rules(group):
+    return [
+        GroupDataRule.objects.create(name=name, app=app, group_id=group.id, group_name=group.name)
+        for name, app in [
+            ("OpsPilot内置规则", "opspilot"),
+            ("OpsPilotGuest数据权限", "monitor"),
+            ("游客数据权限", "cmdb"),
+            ("log内置规则", "log"),
+            ("节点管理内置数据权限", "node"),
+        ]
+    ]
+
+
+def test_wechat_rule_initialization_runs_inside_registration_transaction(monkeypatch):
+    from apps.system_mgmt.nats import wechat
+
+    group = Group.objects.create(name="OpsPilotGuest", parent_id=0)
+    observed = []
+    monkeypatch.setattr(
+        wechat,
+        "set_opspilot_guest_group_default_rule",
+        lambda default_group, user: observed.append(transaction.get_connection().in_atomic_block),
+    )
+    monkeypatch.setattr(wechat, "_build_jwt_payload", lambda user_id: {})
+    monkeypatch.setattr(wechat.jwt, "encode", lambda **kwargs: "token")
+
+    result = wechat.wechat_user_register("wechat-user", "WeChat user")
+
+    assert result["result"] is True
+    assert observed == [True]
+    assert User.objects.get(username="wechat-user").group_list == [group.id]
+
+
+def test_opspilot_guest_rules_keep_user_domain():
+    from apps.system_mgmt.nats.users import set_opspilot_guest_group_default_rule
+
+    group = Group.objects.create(name="OpsPilotGuest", parent_id=0)
+    rules = _create_opspilot_guest_rules(group)
+    user = User.objects.create(
+        username="cross-domain-guest",
+        domain="corp.example",
+        display_name="Cross domain guest",
+        email="guest@example.com",
+        password="",
+    )
+
+    set_opspilot_guest_group_default_rule(group, user)
+
+    assert set(
+        UserRule.objects.filter(username=user.username).values_list("domain", "group_rule_id"),
+    ) == {(user.domain, rule.id) for rule in rules}
 
 
 def test_login_module_destroy_advances_deleted_domain_and_group_user_versions():

--- a/server/apps/system_mgmt/tests/test_permission_version_invalidation.py
+++ b/server/apps/system_mgmt/tests/test_permission_version_invalidation.py
@@ -1,0 +1,307 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+
+from apps.core.utils.permission_cache import clear_user_permission_cache, get_user_permission_version
+from apps.system_mgmt.models import Group, GroupDataRule, LoginModule, Role, User, UserRule
+from apps.system_mgmt.nats.permissions import delete_rules
+from apps.system_mgmt.viewset.login_module_viewset import LoginModuleViewSet
+
+pytestmark = pytest.mark.django_db
+
+
+def test_login_module_destroy_advances_deleted_domain_and_group_user_versions():
+    login_module = LoginModule.objects.create(
+        name="bk-lite-source",
+        source_type="bk_lite",
+        other_config={"domain": "source.example", "root_group": "Source Root"},
+    )
+    group = Group.objects.create(name="Source Root", parent_id=0, description="source-tree")
+    domain_user = User.objects.create(
+        username="source-user",
+        display_name="Source user",
+        email="source@example.com",
+        password="",
+        domain="source.example",
+    )
+    grouped_user = User.objects.create(
+        username="grouped-user",
+        display_name="Grouped user",
+        email="grouped@example.com",
+        password="",
+        domain="domain.com",
+        group_list=[group.id],
+    )
+    domain_version = get_user_permission_version(domain_user.username, domain_user.domain)
+    grouped_version = get_user_permission_version(grouped_user.username, grouped_user.domain)
+
+    viewset = LoginModuleViewSet()
+    viewset.get_object = lambda: login_module
+    request = SimpleNamespace(
+        user=SimpleNamespace(
+            username="admin",
+            is_superuser=True,
+            is_authenticated=True,
+            permission={},
+        ),
+        META={},
+    )
+    with patch("apps.system_mgmt.viewset.login_module_viewset.log_operation"):
+        response = viewset.destroy(request)
+
+    assert response.status_code == 204
+    assert get_user_permission_version(domain_user.username, domain_user.domain) > domain_version
+    assert get_user_permission_version(grouped_user.username, grouped_user.domain) > grouped_version
+
+
+def test_group_data_rule_update_and_delete_advance_bound_user_version():
+    from apps.base.models import User as BaseUser
+
+    admin = BaseUser.objects.create_user(username="rule-admin", password="pw", domain="domain.com")
+    admin.is_superuser = True
+    admin.save()
+    client = APIClient()
+    client.force_authenticate(user=admin)
+    client.cookies["current_team"] = "1"
+
+    user = User.objects.create(
+        username="rule-user",
+        display_name="Rule user",
+        email="rule-user@example.com",
+        password="",
+    )
+    rule = GroupDataRule.objects.create(
+        name="rule",
+        app="cmdb",
+        group_id=1,
+        group_name="Default",
+        rules={"host": [{"id": 1}]},
+    )
+    UserRule.objects.create(username=user.username, domain=user.domain, group_rule=rule)
+    initial_version = get_user_permission_version(user.username, user.domain)
+
+    with patch("apps.system_mgmt.viewset.group_data_rule_viewset.log_operation"):
+        response = client.put(
+            f"/api/v1/system_mgmt/group_data_rule/{rule.id}/",
+            {
+                "name": "updated-rule",
+                "app": "cmdb",
+                "group_id": 1,
+                "group_name": "Default",
+                "rules": {"host": []},
+            },
+            format="json",
+        )
+
+    assert response.status_code == 200
+    updated_version = get_user_permission_version(user.username, user.domain)
+    assert updated_version > initial_version
+
+    with patch("apps.system_mgmt.viewset.group_data_rule_viewset.log_operation"):
+        response = client.delete(f"/api/v1/system_mgmt/group_data_rule/{rule.id}/")
+
+    assert response.status_code in {200, 204}
+    assert get_user_permission_version(user.username, user.domain) > updated_version
+
+
+def test_nats_delete_rules_advances_bound_user_version():
+    user = User.objects.create(
+        username="nats-rule-user",
+        display_name="NATS rule user",
+        email="nats-rule-user@example.com",
+        password="",
+    )
+    rule = GroupDataRule.objects.create(
+        name="nats-rule",
+        app="cmdb",
+        group_id=1,
+        group_name="Default",
+        rules={"host": [{"id": 1}]},
+    )
+    UserRule.objects.create(username=user.username, domain=user.domain, group_rule=rule)
+    initial_version = get_user_permission_version(user.username, user.domain)
+
+    result = delete_rules([1], 1, "cmdb", "host", None)
+
+    assert result["result"] is True
+    assert get_user_permission_version(user.username, user.domain) > initial_version
+
+
+def test_verify_token_reloads_user_after_permission_version_is_read():
+    from apps.system_mgmt.nats import auth
+
+    user = User.objects.create(
+        username="stale-token-user",
+        display_name="Stale token user",
+        email="stale-token-user@example.com",
+        password="",
+        role_list=[101],
+    )
+    stale_user = User.objects.get(id=user.id)
+    User.objects.filter(id=user.id).update(role_list=[])
+    clear_user_permission_cache(user.username, user.domain)
+
+    with (
+        patch.object(auth, "_verify_token", return_value=stale_user),
+        patch.object(auth, "get_cached_token_info", return_value=None),
+        patch.object(auth, "set_cached_token_info", return_value=True),
+        patch.object(
+            auth,
+            "build_user_authorization_context",
+            side_effect=lambda current_user: {"role_list": current_user.role_list},
+        ),
+    ):
+        result = auth.verify_token("token")
+
+    assert result == {"result": True, "data": {"role_list": []}}
+
+
+def test_update_user_only_replaces_rules_for_target_domain():
+    from apps.system_mgmt.viewset.user_viewset import UserViewSet
+
+    Role.objects.get_or_create(name="admin", app="")
+    role = Role.objects.create(name="domain-rule-editor", app="")
+    group = Group.objects.create(name="domain-rule-group", parent_id=0)
+    target = User.objects.create(
+        username="same-name",
+        domain="corp.example",
+        display_name="Corp user",
+        email="corp-user@example.com",
+        password="",
+        group_list=[group.id],
+        role_list=[role.id],
+    )
+    User.objects.create(
+        username=target.username,
+        domain="domain.com",
+        display_name="Default-domain user",
+        email="default-user@example.com",
+        password="",
+    )
+    old_target_rule = GroupDataRule.objects.create(
+        name="old-target-rule",
+        app="cmdb",
+        group_id=group.id,
+        group_name=group.name,
+        rules={},
+    )
+    new_target_rule = GroupDataRule.objects.create(
+        name="new-target-rule",
+        app="cmdb",
+        group_id=group.id,
+        group_name=group.name,
+        rules={},
+    )
+    other_domain_rule = GroupDataRule.objects.create(
+        name="other-domain-rule",
+        app="cmdb",
+        group_id=group.id,
+        group_name=group.name,
+        rules={},
+    )
+    UserRule.objects.create(
+        username=target.username,
+        domain=target.domain,
+        group_rule=old_target_rule,
+    )
+    UserRule.objects.create(
+        username=target.username,
+        domain="domain.com",
+        group_rule=other_domain_rule,
+    )
+
+    request = APIRequestFactory().post(
+        "/system_mgmt/api/user/update_user/",
+        {
+            "user_id": target.id,
+            "username": target.username,
+            "lastName": target.display_name,
+            "email": target.email,
+            "phone": None,
+            "locale": target.locale,
+            "timezone": target.timezone,
+            "groups": [group.id],
+            "roles": [role.id],
+            "rules": [new_target_rule.id],
+            "is_superuser": False,
+        },
+        format="json",
+    )
+    force_authenticate(
+        request,
+        user=SimpleNamespace(
+            username="admin",
+            domain="domain.com",
+            locale="en",
+            is_superuser=True,
+            is_authenticated=True,
+            permission={"system-manager": {"user_group-Edit User"}},
+        ),
+    )
+    view = UserViewSet.as_view({"post": "update_user"})
+    with (
+        patch("apps.system_mgmt.viewset.user_viewset.CMDB"),
+        patch("apps.system_mgmt.viewset.user_viewset.log_operation"),
+    ):
+        response = view(request)
+
+    assert response.status_code == 200
+    assert list(
+        UserRule.objects.filter(
+            username=target.username,
+            domain=target.domain,
+        ).values_list("group_rule_id", flat=True)
+    ) == [new_target_rule.id]
+    assert UserRule.objects.filter(
+        username=target.username,
+        domain="domain.com",
+        group_rule=other_domain_rule,
+    ).exists()
+
+
+def test_group_data_rule_update_rolls_back_when_version_advance_fails():
+    from apps.base.models import User as BaseUser
+
+    admin = BaseUser.objects.create_user(username="rollback-admin", password="pw", domain="domain.com")
+    admin.is_superuser = True
+    admin.save()
+    client = APIClient()
+    client.force_authenticate(user=admin)
+    client.cookies["current_team"] = "1"
+    user = User.objects.create(
+        username="rollback-rule-user",
+        display_name="Rollback rule user",
+        email="rollback-rule-user@example.com",
+        password="",
+    )
+    rule = GroupDataRule.objects.create(
+        name="rollback-rule",
+        app="cmdb",
+        group_id=1,
+        group_name="Default",
+        rules={"host": [{"id": 1}]},
+    )
+    UserRule.objects.create(username=user.username, domain=user.domain, group_rule=rule)
+
+    with patch(
+        "apps.core.utils.permission_cache._advance_user_permission_versions",
+        side_effect=RuntimeError("version update failed"),
+    ):
+        response = client.put(
+            f"/api/v1/system_mgmt/group_data_rule/{rule.id}/",
+            {
+                "name": "must-rollback",
+                "app": "cmdb",
+                "group_id": 1,
+                "group_name": "Default",
+                "rules": {"host": []},
+            },
+            format="json",
+        )
+
+    assert response.status_code == 500
+    rule.refresh_from_db()
+    assert rule.name == "rollback-rule"
+    assert rule.rules == {"host": [{"id": 1}]}

--- a/server/apps/system_mgmt/tests/test_role_viewset_api.py
+++ b/server/apps/system_mgmt/tests/test_role_viewset_api.py
@@ -160,6 +160,32 @@ def test_set_role_menus(super_client):
     assert role.menu_list == [m1.id]
 
 
+def test_set_role_menus_invalidates_inherited_group_users(super_client):
+    menu = Menu.objects.create(name="inherited-menu", display_name="I-x", order=1, app="cmdb", menu_type="t")
+    role = Role.objects.create(name="inherited-role", app="cmdb", menu_list=[])
+    parent = Group.objects.create(name="MenuParent", parent_id=0, allow_inherit_roles=True)
+    parent.roles.add(role)
+    child = Group.objects.create(name="MenuChild", parent_id=parent.id)
+    User.objects.create(
+        username="inherited-menu-user",
+        password="x",
+        display_name="Inherited",
+        email="inherited@x.com",
+        group_list=[child.id],
+    )
+
+    with patch("apps.system_mgmt.viewset.role_viewset.clear_users_permission_cache") as clear_cache:
+        resp = super_client.post(
+            f"{BASE}/set_role_menus/",
+            {"role_id": role.id, "menus": [menu.name]},
+            format="json",
+        )
+
+    assert resp.json()["result"] is True
+    affected_users = clear_cache.call_args.args[0]
+    assert {user["username"] for user in affected_users} == {"inherited-menu-user"}
+
+
 def test_batch_assign_and_revoke_group_roles(super_client):
     role = Role.objects.create(name="grouprole", app="cmdb")
     g1 = Group.objects.create(name="GR1", parent_id=0)
@@ -179,6 +205,31 @@ def test_batch_assign_and_revoke_group_roles(super_client):
     )
     assert revoke.json()["result"] is True
     assert role.group_set.count() == 1
+
+
+def test_revoke_group_role_invalidates_descendant_users(super_client):
+    role = Role.objects.create(name="inherited-revoke", app="cmdb")
+    parent = Group.objects.create(name="RevokeParent", parent_id=0, allow_inherit_roles=True)
+    child = Group.objects.create(name="RevokeChild", parent_id=parent.id)
+    parent.roles.add(role)
+    User.objects.create(
+        username="inherited-revoke-user",
+        password="x",
+        display_name="Inherited",
+        email="revoke@x.com",
+        group_list=[child.id],
+    )
+
+    with patch("apps.system_mgmt.viewset.role_viewset.clear_users_permission_cache") as clear_cache:
+        resp = super_client.post(
+            f"{BASE}/revoke_group_roles/",
+            {"group_ids": [parent.id], "role_id": role.id},
+            format="json",
+        )
+
+    assert resp.json()["result"] is True
+    affected_users = clear_cache.call_args.args[0]
+    assert {user["username"] for user in affected_users} == {"inherited-revoke-user"}
 
 
 def test_batch_assign_missing_params(super_client):

--- a/server/apps/system_mgmt/tests/test_tasks_coverage.py
+++ b/server/apps/system_mgmt/tests/test_tasks_coverage.py
@@ -9,7 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.utils import timezone as django_timezone
 
-from apps.system_mgmt.models import Channel, ErrorLog, Group, LoginModule, SystemSettings, User
+from apps.core.utils.permission_cache import clear_user_permission_cache, get_user_permission_version
+from apps.system_mgmt.models import Channel, ErrorLog, Group, LoginModule, Role, SystemSettings, User
 from apps.system_mgmt.models.channel import ChannelChoices
 from apps.system_mgmt import tasks
 
@@ -185,11 +186,90 @@ def test_sync_groups_deletes_stale_external_groups():
     lm = _make_login_module(root_group="ROOT", domain="d.com")
     parent, _ = Group.objects.get_or_create(name="ROOT", parent_id=0, defaults={"description": "x"})
     stale = Group.objects.create(name="Stale", parent_id=parent.id, external_id="goneext", description="d")
+    affected_user = User.objects.create(
+        username="stale-group-user",
+        display_name="Stale group user",
+        email="stale-group@example.com",
+        password="",
+        domain="d.com",
+        group_list=[stale.id],
+    )
+    initial_version = get_user_permission_version(affected_user.username, affected_user.domain)
     # 新的 group_list 不含 goneext -> 应被删除
     group_list = [{"id": "keep", "parent_id": None, "name": "Keep"}]
     tasks._sync_groups(group_list, parent, None)
     assert not Group.objects.filter(id=stale.id).exists()
     assert Group.objects.filter(name="Keep", parent_id=parent.id).exists()
+    assert get_user_permission_version(affected_user.username, affected_user.domain) > initial_version
+
+
+def test_sync_groups_deleting_parent_advances_descendant_user_version():
+    parent = Group.objects.create(name="ROOT-descendant", parent_id=0, description="x")
+    stale_parent = Group.objects.create(
+        name="Stale parent",
+        parent_id=parent.id,
+        external_id="gone-parent",
+        description="d",
+    )
+    child = Group.objects.create(
+        name="Stale child",
+        parent_id=stale_parent.id,
+        external_id="gone-child",
+        description="d",
+    )
+    inherited_role = Role.objects.create(name="inherited-stale-role", app="")
+    stale_parent.roles.add(inherited_role)
+    descendant_user = User.objects.create(
+        username="descendant-group-user",
+        display_name="Descendant group user",
+        email="descendant-group@example.com",
+        password="",
+        domain="d.com",
+        group_list=[child.id],
+    )
+    initial_version = get_user_permission_version(descendant_user.username, descendant_user.domain)
+
+    tasks._sync_groups(
+        [{"id": "keep", "parent_id": None, "name": "Keep"}],
+        parent,
+        None,
+    )
+
+    assert not Group.objects.filter(id=stale_parent.id).exists()
+    assert get_user_permission_version(descendant_user.username, descendant_user.domain) > initial_version
+
+
+def test_sync_groups_delete_rolls_back_when_version_advance_fails():
+    parent = Group.objects.create(name="ROOT-rollback", parent_id=0, description="x")
+    stale = Group.objects.create(
+        name="Stale rollback",
+        parent_id=parent.id,
+        external_id="gone-rollback",
+        description="d",
+    )
+    User.objects.create(
+        username="stale-rollback-user",
+        display_name="Stale rollback user",
+        email="stale-rollback@example.com",
+        password="",
+        domain="d.com",
+        group_list=[stale.id],
+    )
+
+    with (
+        patch(
+            "apps.core.utils.permission_cache._advance_user_permission_versions",
+            side_effect=RuntimeError("version update failed"),
+        ),
+        pytest.raises(RuntimeError, match="version update failed"),
+    ):
+        tasks._sync_groups(
+            [{"id": "keep", "parent_id": None, "name": "Keep"}],
+            parent,
+            None,
+        )
+
+    assert Group.objects.filter(id=stale.id).exists()
 
 
 def test_sync_groups_recurses_into_children():
@@ -256,6 +336,30 @@ def test_sync_users_creates_and_updates():
     assert fresh.role_list == [9]
     assert fresh.group_list == [g.id]
     m_clear.assert_called_once()
+
+
+def test_sync_users_recreate_advances_existing_tombstone():
+    old_user = User.objects.create(
+        username="recreated",
+        display_name="Old",
+        email="old@example.com",
+        domain="dd.com",
+        group_list=[],
+        role_list=[],
+        password="",
+    )
+    clear_user_permission_cache(old_user.username, old_user.domain)
+    old_user.delete()
+    tombstone_version = get_user_permission_version("recreated", "dd.com")
+
+    tasks._sync_users(
+        [{"username": "recreated", "display_name": "New", "departments": []}],
+        {},
+        "dd.com",
+        [9],
+    )
+
+    assert get_user_permission_version("recreated", "dd.com") > tombstone_version
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/system_mgmt/tests/test_user_sync_source_viewset.py
+++ b/server/apps/system_mgmt/tests/test_user_sync_source_viewset.py
@@ -6,6 +6,7 @@ from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework.test import APIClient
 
+from apps.core.utils.permission_cache import get_user_permission_version
 from apps.system_mgmt.models import Group, IntegrationInstance, User, UserSyncRun, UserSyncSource
 from apps.system_mgmt.providers import RuntimeApplicationService
 from apps.system_mgmt.providers.runtime import CapabilityExecutionResult
@@ -110,7 +111,6 @@ def test_destroy_deletes_root_subtree_and_users(api_client, authenticated_user, 
         group_list=[child_group.id],
         sync_source=None,
     )
-
     response = api_client.delete(f"/api/v1/system_mgmt/user_sync_source/{user_sync_source.id}/")
 
     assert response.status_code == 200
@@ -152,12 +152,16 @@ def test_delete_user_sync_source_does_not_scan_all_users(user_sync_source):
         group_list=[child_group.id],
         sync_source=None,
     )
+    synced_version = get_user_permission_version(synced_user.username, synced_user.domain)
+    grouped_version = get_user_permission_version(grouped_user.username, grouped_user.domain)
 
     with patch("apps.system_mgmt.services.user_sync_service.User.objects.all", side_effect=AssertionError("full user scan")):
         result = delete_user_sync_source(user_sync_source)
 
     assert result["result"] is True
     assert User.objects.filter(id__in=[synced_user.id, grouped_user.id]).count() == 0
+    assert get_user_permission_version(synced_user.username, synced_user.domain) > synced_version
+    assert get_user_permission_version(grouped_user.username, grouped_user.domain) > grouped_version
 
 
 @pytest.mark.django_db
@@ -206,10 +210,13 @@ def test_create_source_logs_operation(api_client, authenticated_user, ready_inte
     authenticated_user.permission = {"system-manager": {"user_sync-Add"}}
     authenticated_user.save(update_fields=["is_superuser"])
 
-    with patch(
-        "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
-        return_value="manual_input",
-    ), patch("apps.system_mgmt.viewset.user_sync_source_viewset.log_operation") as mock_log:
+    with (
+        patch(
+            "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
+            return_value="manual_input",
+        ),
+        patch("apps.system_mgmt.viewset.user_sync_source_viewset.log_operation") as mock_log,
+    ):
         response = api_client.post(
             "/api/v1/system_mgmt/user_sync_source/",
             {
@@ -227,6 +234,7 @@ def test_create_source_logs_operation(api_client, authenticated_user, ready_inte
     assert response.status_code == 201
     assert UserSyncSource.objects.filter(name="source-b").exists() is True
     mock_log.assert_called_once()
+
 
 @pytest.mark.django_db
 def test_create_source_accepts_weekly_schedule_config(api_client, authenticated_user, ready_integration_instance):
@@ -294,10 +302,13 @@ def test_update_source_logs_operation(api_client, authenticated_user, user_sync_
     authenticated_user.permission = {"system-manager": {"user_sync-Edit"}}
     authenticated_user.save(update_fields=["is_superuser"])
 
-    with patch(
-        "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
-        return_value="manual_input",
-    ), patch("apps.system_mgmt.viewset.user_sync_source_viewset.log_operation") as mock_log:
+    with (
+        patch(
+            "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
+            return_value="manual_input",
+        ),
+        patch("apps.system_mgmt.viewset.user_sync_source_viewset.log_operation") as mock_log,
+    ):
         response = api_client.put(
             f"/api/v1/system_mgmt/user_sync_source/{user_sync_source.id}/",
             {
@@ -379,10 +390,9 @@ def test_department_options_rejects_manual_input_provider(api_client, authentica
     assert response.status_code == 400
     assert "manual_input mode" in response.json()["message"]
 
+
 @pytest.mark.django_db
-def test_department_options_returns_serialized_errors_when_provider_call_fails(
-    api_client, authenticated_user, ready_integration_instance
-):
+def test_department_options_returns_serialized_errors_when_provider_call_fails(api_client, authenticated_user, ready_integration_instance):
     authenticated_user.is_superuser = True
     authenticated_user.permission = {"system-manager": {"user_sync-View"}}
     authenticated_user.save(update_fields=["is_superuser"])
@@ -428,13 +438,16 @@ def test_department_options_returns_provider_tree_payload(api_client, authentica
         },
     )
 
-    with patch(
-        "apps.system_mgmt.viewset.user_sync_source_viewset.get_user_sync_root_department_input_mode",
-        return_value="department_select",
-    ), patch(
-        "apps.system_mgmt.viewset.user_sync_source_viewset.RuntimeApplicationService.execute",
-        return_value=result,
-    ) as mock_execute:
+    with (
+        patch(
+            "apps.system_mgmt.viewset.user_sync_source_viewset.get_user_sync_root_department_input_mode",
+            return_value="department_select",
+        ),
+        patch(
+            "apps.system_mgmt.viewset.user_sync_source_viewset.RuntimeApplicationService.execute",
+            return_value=result,
+        ) as mock_execute,
+    ):
         response = api_client.get(
             "/api/v1/system_mgmt/user_sync_source/department_options/",
             {"integration_instance": ready_integration_instance.id, "current_root_department_id": "dept-a"},
@@ -498,6 +511,7 @@ def test_list_records_supports_search_by_source_name(api_client, authenticated_u
     assert response.data["count"] == 1
     assert response.data["items"][0]["source_name"] == "alpha-source"
 
+
 @pytest.mark.django_db
 def test_list_prefetches_only_latest_run_per_source(api_client, authenticated_user, ready_integration_instance):
     authenticated_user.is_superuser = True
@@ -525,9 +539,7 @@ def test_list_prefetches_only_latest_run_per_source(api_client, authenticated_us
     assert response.status_code == 200
     run_table = UserSyncRun._meta.db_table
     run_selects = [
-        query["sql"]
-        for query in context.captured_queries
-        if query["sql"].lstrip().upper().startswith("SELECT") and run_table in query["sql"]
+        query["sql"] for query in context.captured_queries if query["sql"].lstrip().upper().startswith("SELECT") and run_table in query["sql"]
     ]
     assert len(run_selects) == 1
     assert {item["latest_run"]["summary"] for item in response.data["items"]} == {"latest"}
@@ -584,10 +596,13 @@ def test_preview_uses_existing_source_without_persisting(api_client, authenticat
 
     preview_result = {"result": True, "message": "preview ok", "data": {"estimated_user_count": 3}}
 
-    with patch(
-        "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
-        return_value="manual_input",
-    ), patch("apps.system_mgmt.viewset.user_sync_source_viewset.preview_user_sync", return_value=preview_result) as mock_preview:
+    with (
+        patch(
+            "apps.system_mgmt.serializers.user_sync_source_serializer.get_user_sync_root_department_input_mode",
+            return_value="manual_input",
+        ),
+        patch("apps.system_mgmt.viewset.user_sync_source_viewset.preview_user_sync", return_value=preview_result) as mock_preview,
+    ):
         response = api_client.post(
             "/api/v1/system_mgmt/user_sync_source/preview/",
             {
@@ -605,9 +620,7 @@ def test_preview_uses_existing_source_without_persisting(api_client, authenticat
 
 
 @pytest.mark.django_db
-def test_sync_source_accepts_root_dn_without_base_dn_rail(
-    api_client, authenticated_user, ready_ad_integration_instance
-):
+def test_sync_source_accepts_root_dn_without_base_dn_rail(api_client, authenticated_user, ready_ad_integration_instance):
     """T3: AD user-sync source must accept business_config with only root_dn.
 
     The legacy is_sub_dn(root_dn, base_dn) boundary check used
@@ -649,9 +662,7 @@ def test_sync_source_accepts_root_dn_without_base_dn_rail(
 
 
 @pytest.mark.django_db
-def test_sync_source_still_requires_root_dn_non_empty(
-    api_client, authenticated_user, ready_ad_integration_instance
-):
+def test_sync_source_still_requires_root_dn_non_empty(api_client, authenticated_user, ready_ad_integration_instance):
     """T3 complementary: empty root_dn must still be rejected for AD."""
     authenticated_user.is_superuser = True
     authenticated_user.permission = {"system-manager": {"user_sync-Add"}}
@@ -790,9 +801,7 @@ def test_preview_keeps_password_init_in_platform_config(
         ({"mode": "uniform", "uniform_password": "123", "email_channel_id": 7}, "密码"),
     ],
 )
-def test_preview_rejects_invalid_platform_password_init(
-    password_init, expected_error, password_init_preview_admin, ready_integration_instance
-):
+def test_preview_rejects_invalid_platform_password_init(password_init, expected_error, password_init_preview_admin, ready_integration_instance):
     response = password_init_preview_admin.post(
         PREVIEW_URL,
         _password_init_preview_payload(ready_integration_instance, platform_config={"password_init": password_init}),

--- a/server/apps/system_mgmt/viewset/app_viewset.py
+++ b/server/apps/system_mgmt/viewset/app_viewset.py
@@ -1,15 +1,30 @@
+from django.db.models import Q
 from django.http import JsonResponse
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils.permission_cache import clear_users_permission_cache
 from apps.core.utils.viewset_utils import LanguageViewSet
-from apps.system_mgmt.models import App, Role
+from apps.system_mgmt.models import App, Group, Role, User
 from apps.system_mgmt.serializers.app_serializer import AppSerializer
+from apps.system_mgmt.utils.group_utils import GroupUtils
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
 class AppViewSet(LanguageViewSet):
     queryset = App.objects.all().order_by("name")
     serializer_class = AppSerializer
+
+    @staticmethod
+    def _get_users_affected_by_roles(role_ids):
+        if not role_ids:
+            return User.objects.none()
+        query = Q()
+        for role_id in role_ids:
+            query |= Q(role_list__contains=int(role_id))
+        role_group_ids = Group.objects.filter(roles__id__in=role_ids).values_list("id", flat=True)
+        for group_id in GroupUtils.get_group_with_descendants(role_group_ids):
+            query |= Q(group_list__contains=int(group_id))
+        return User.objects.filter(query).distinct()
 
     @HasPermission("application_list-Delete")
     def destroy(self, request, *args, **kwargs):
@@ -19,11 +34,15 @@ class AppViewSet(LanguageViewSet):
             return JsonResponse({"result": False, "message": message})
 
         app_name = obj.name
+        role_ids = list(Role.objects.filter(app=app_name).values_list("id", flat=True))
+        affected_users = list(self._get_users_affected_by_roles(role_ids).values("username", "domain"))
         Role.objects.filter(app=app_name).delete()
         response = super().destroy(request, *args, **kwargs)
 
         # 记录操作日志
         if response.status_code == 204:
+            if affected_users:
+                clear_users_permission_cache(affected_users)
             log_operation(request, "delete", "system-manager", f"删除应用: {app_name}")
 
         return response
@@ -43,12 +62,16 @@ class AppViewSet(LanguageViewSet):
     def update(self, request, *args, **kwargs):
         obj = self.get_object()
         old_name = obj.name
+        role_ids = list(Role.objects.filter(app=old_name).values_list("id", flat=True))
+        affected_users = list(self._get_users_affected_by_roles(role_ids).values("username", "domain"))
         response = super().update(request, *args, **kwargs)
 
         if response.status_code == 200:
             new_name = response.data.get("name", "")
             if old_name != new_name:
                 Role.objects.filter(app=old_name).update(app=new_name)
+                if affected_users:
+                    clear_users_permission_cache(affected_users)
             log_operation(request, "update", "system-manager", f"编辑应用: {new_name}")
 
         return response

--- a/server/apps/system_mgmt/viewset/app_viewset.py
+++ b/server/apps/system_mgmt/viewset/app_viewset.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models import Q
 from django.http import JsonResponse
 
@@ -20,10 +21,10 @@ class AppViewSet(LanguageViewSet):
             return User.objects.none()
         query = Q()
         for role_id in role_ids:
-            query |= Q(role_list__contains=int(role_id))
+            query |= Q(role_list__contains=[int(role_id)])
         role_group_ids = Group.objects.filter(roles__id__in=role_ids).values_list("id", flat=True)
         for group_id in GroupUtils.get_group_with_descendants(role_group_ids):
-            query |= Q(group_list__contains=int(group_id))
+            query |= Q(group_list__contains=[int(group_id)])
         return User.objects.filter(query).distinct()
 
     @HasPermission("application_list-Delete")
@@ -36,13 +37,14 @@ class AppViewSet(LanguageViewSet):
         app_name = obj.name
         role_ids = list(Role.objects.filter(app=app_name).values_list("id", flat=True))
         affected_users = list(self._get_users_affected_by_roles(role_ids).values("username", "domain"))
-        Role.objects.filter(app=app_name).delete()
-        response = super().destroy(request, *args, **kwargs)
+        with transaction.atomic():
+            Role.objects.filter(app=app_name).delete()
+            response = super().destroy(request, *args, **kwargs)
+            if response.status_code == 204 and affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         if response.status_code == 204:
-            if affected_users:
-                clear_users_permission_cache(affected_users)
             log_operation(request, "delete", "system-manager", f"删除应用: {app_name}")
 
         return response
@@ -64,14 +66,18 @@ class AppViewSet(LanguageViewSet):
         old_name = obj.name
         role_ids = list(Role.objects.filter(app=old_name).values_list("id", flat=True))
         affected_users = list(self._get_users_affected_by_roles(role_ids).values("username", "domain"))
-        response = super().update(request, *args, **kwargs)
+        with transaction.atomic():
+            response = super().update(request, *args, **kwargs)
+
+            if response.status_code == 200:
+                new_name = response.data.get("name", "")
+                if old_name != new_name:
+                    Role.objects.filter(app=old_name).update(app=new_name)
+                    if affected_users:
+                        clear_users_permission_cache(affected_users)
 
         if response.status_code == 200:
             new_name = response.data.get("name", "")
-            if old_name != new_name:
-                Role.objects.filter(app=old_name).update(app=new_name)
-                if affected_users:
-                    clear_users_permission_cache(affected_users)
             log_operation(request, "update", "system-manager", f"编辑应用: {new_name}")
 
         return response

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -1,4 +1,5 @@
 from django.http import JsonResponse
+from django.db import transaction
 from django_filters import filters
 from django_filters.rest_framework import FilterSet
 from rest_framework.decorators import action
@@ -130,14 +131,14 @@ class GroupDataRuleViewSet(LanguageViewSet):
         # 获取绑定到此规则的用户，在删除前获取
         affected_users = list(UserRule.objects.filter(group_rule_id=rule_id).values("username", "domain"))
 
-        response = super().destroy(request, *args, **kwargs)
+        with transaction.atomic():
+            response = super().destroy(request, *args, **kwargs)
+            if response.status_code == 204 and affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         if response.status_code == 204:
             log_operation(request, "delete", "system-manager", f"删除数据权限: {rule_name}")
-            # 清除受影响用户的权限缓存
-            if affected_users:
-                clear_users_permission_cache(affected_users)
 
         return response
 
@@ -177,16 +178,17 @@ class GroupDataRuleViewSet(LanguageViewSet):
 
         rule_id = obj.id
 
-        response = super().update(request, *args, **kwargs)
+        with transaction.atomic():
+            response = super().update(request, *args, **kwargs)
+            if response.status_code == 200:
+                affected_users = list(UserRule.objects.filter(group_rule_id=rule_id).values("username", "domain"))
+                if affected_users:
+                    clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         if response.status_code == 200:
             rule_name = response.data.get("name", "")
             log_operation(request, "update", "system-manager", f"编辑数据权限: {rule_name}")
-            # 清除绑定到此规则的用户的权限缓存
-            affected_users = list(UserRule.objects.filter(group_rule_id=rule_id).values("username", "domain"))
-            if affected_users:
-                clear_users_permission_cache(affected_users)
 
         return response
 

--- a/server/apps/system_mgmt/viewset/group_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_viewset.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.db.models import Q
 from django.http import JsonResponse
 from rest_framework.decorators import action
 
@@ -235,7 +236,11 @@ class GroupViewSet(LanguageViewSet, ViewSetUtils):
             obj.roles.set(role_ids)
             # 清除该组织中所有用户的权限缓存和菜单缓存
             group_id = request.data.get("group_id")
-            affected_users = User.objects.filter(group_list__contains=int(group_id)).values("id", "username", "domain")
+            affected_group_ids = GroupUtils.get_group_with_descendants(group_id)
+            affected_users_query = Q()
+            for affected_group_id in affected_group_ids:
+                affected_users_query |= Q(group_list__contains=int(affected_group_id))
+            affected_users = User.objects.filter(affected_users_query).values("id", "username", "domain")
             affected_users_list = list(affected_users)
             if affected_users_list:
                 # 清除权限规则缓存（default 缓存）

--- a/server/apps/system_mgmt/viewset/group_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_viewset.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Q
 from django.http import JsonResponse
 from rest_framework.decorators import action
@@ -229,25 +230,24 @@ class GroupViewSet(LanguageViewSet, ViewSetUtils):
         if "allow_inherit_roles" in request.data:
             update_fields["allow_inherit_roles"] = request.data.get("allow_inherit_roles", False)
 
-        Group.objects.filter(id=request.data.get("group_id")).update(**update_fields)
+        with transaction.atomic():
+            Group.objects.filter(id=request.data.get("group_id")).update(**update_fields)
 
-        # 更新组的角色
-        if isinstance(role_ids, list):
-            obj.roles.set(role_ids)
-            # 清除该组织中所有用户的权限缓存和菜单缓存
-            group_id = request.data.get("group_id")
-            affected_group_ids = GroupUtils.get_group_with_descendants(group_id)
-            affected_users_query = Q()
-            for affected_group_id in affected_group_ids:
-                affected_users_query |= Q(group_list__contains=int(affected_group_id))
-            affected_users = User.objects.filter(affected_users_query).values("id", "username", "domain")
-            affected_users_list = list(affected_users)
-            if affected_users_list:
-                # 清除权限规则缓存（default 缓存）
-                clear_users_permission_cache(affected_users_list)
-                # 清除用户菜单缓存（db 缓存）
-                menu_cache_keys = [f"menus-user:{user['id']}" for user in affected_users_list]
-                cache.delete_many(menu_cache_keys)
+            # 更新组的角色
+            if isinstance(role_ids, list):
+                obj.roles.set(role_ids)
+                # 清除该组织及其后代组织中所有用户的权限缓存和菜单缓存
+                group_id = request.data.get("group_id")
+                affected_group_ids = GroupUtils.get_group_with_descendants(group_id)
+                affected_users_query = Q()
+                for affected_group_id in affected_group_ids:
+                    affected_users_query |= Q(group_list__contains=int(affected_group_id))
+                affected_users = User.objects.filter(affected_users_query).values("id", "username", "domain")
+                affected_users_list = list(affected_users)
+                if affected_users_list:
+                    clear_users_permission_cache(affected_users_list)
+                    menu_cache_keys = [f"menus-user:{user['id']}" for user in affected_users_list]
+                    transaction.on_commit(lambda: cache.delete_many(menu_cache_keys), robust=True)
 
         # 同步组织数据到CMDB
         try:

--- a/server/apps/system_mgmt/viewset/login_module_viewset.py
+++ b/server/apps/system_mgmt/viewset/login_module_viewset.py
@@ -1,7 +1,10 @@
+from django.db import transaction
+from django.db.models import Q
 from django.http import JsonResponse
 from django_celery_beat.models import PeriodicTask
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils.permission_cache import clear_users_permission_cache
 from apps.core.utils.viewset_utils import LanguageViewSet
 from apps.system_mgmt.models import Group, LoginModule, User
 from apps.system_mgmt.serializers.login_module_serializer import LoginModuleSerializer
@@ -101,16 +104,31 @@ class LoginModuleViewSet(LanguageViewSet):
         if obj.source_type == "bk_lite":
             domain = obj.other_config.get("domain", "")
             group_name = obj.other_config.get("root_group", "")
-            if domain:
-                User.objects.filter(domain=domain).delete()
+            group_ids = []
             if group_name:
                 top_group = Group.objects.filter(parent_id=0, name=group_name).first()
                 if top_group:
-                    Group.objects.filter(description=top_group.description).delete()
-            task_name = f"sync_user_group_{obj.name}"
-            PeriodicTask.objects.filter(name=task_name).delete()
+                    group_ids = list(Group.objects.filter(description=top_group.description).values_list("id", flat=True))
 
-        response = super().destroy(request, *args, **kwargs)
+            affected_query = Q()
+            if domain:
+                affected_query |= Q(domain=domain)
+            for group_id in group_ids:
+                affected_query |= Q(group_list__contains=[group_id])
+            affected_users = list(User.objects.filter(affected_query).values("username", "domain")) if affected_query else []
+
+            with transaction.atomic():
+                if domain:
+                    User.objects.filter(domain=domain).delete()
+                if group_ids:
+                    Group.objects.filter(id__in=group_ids).delete()
+                if affected_users:
+                    clear_users_permission_cache(affected_users)
+                task_name = f"sync_user_group_{obj.name}"
+                PeriodicTask.objects.filter(name=task_name).delete()
+                response = super().destroy(request, *args, **kwargs)
+        else:
+            response = super().destroy(request, *args, **kwargs)
 
         # 记录操作日志
         if response.status_code == 204:

--- a/server/apps/system_mgmt/viewset/role_viewset.py
+++ b/server/apps/system_mgmt/viewset/role_viewset.py
@@ -10,6 +10,7 @@ from apps.system_mgmt.models import Group, Menu, Role, User
 from apps.system_mgmt.serializers.role_serializer import RoleSerializer
 from apps.system_mgmt.services.role_manage import RoleManage
 from apps.system_mgmt.utils.group_filter_mixin import get_unauthorized_group_ids
+from apps.system_mgmt.utils.group_utils import GroupUtils
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 from apps.system_mgmt.utils.viewset_utils import ViewSetUtils
 
@@ -17,6 +18,24 @@ from apps.system_mgmt.utils.viewset_utils import ViewSetUtils
 class RoleViewSet(LanguageViewSet, ViewSetUtils):
     queryset = Role.objects.exclude(app="")
     serializer_class = RoleSerializer
+
+    @staticmethod
+    def _get_users_in_group_trees(group_ids):
+        affected_group_ids = GroupUtils.get_group_with_descendants(group_ids)
+        query = Q()
+        for group_id in affected_group_ids:
+            query |= Q(group_list__contains=int(group_id))
+        return User.objects.filter(query)
+
+    @classmethod
+    def _get_users_affected_by_role(cls, role_id):
+        role_group_ids = list(Group.objects.filter(roles__id=role_id).values_list("id", flat=True))
+        query = Q(role_list__contains=int(role_id))
+        if role_group_ids:
+            affected_group_ids = GroupUtils.get_group_with_descendants(role_group_ids)
+            for group_id in affected_group_ids:
+                query |= Q(group_list__contains=int(group_id))
+        return User.objects.filter(query).distinct()
 
     def _validate_group_scope_for_request(self, request, group_ids):
         unauthorized_group_ids = get_unauthorized_group_ids(request.user, group_ids)
@@ -132,7 +151,10 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                     "message": self.loader.get("error.role_used_by_users").format(users=msg),
                 }
             )
+        affected_user_info = list(self._get_users_affected_by_role(role_id).values("username", "domain"))
         Role.objects.filter(id=role_id).delete()
+        if affected_user_info:
+            clear_users_permission_cache(affected_user_info)
 
         # 记录操作日志
         log_operation(request, "delete", "system-manager", f"删除角色: {role_name}")
@@ -142,7 +164,11 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
     @HasPermission("application_role-Edit")
     def update_role(self, request):
         role_name = request.data.get("role_name")
-        Role.objects.filter(id=request.data.get("role_id")).update(name=role_name)
+        role_id = request.data.get("role_id")
+        Role.objects.filter(id=role_id).update(name=role_name)
+        affected_user_info = list(self._get_users_affected_by_role(role_id).values("username", "domain"))
+        if affected_user_info:
+            clear_users_permission_cache(affected_user_info)
 
         # 记录操作日志
         log_operation(request, "update", "system-manager", f"更新角色名称: {role_name}")
@@ -236,7 +262,7 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
         role_obj.save()
 
         # 清除受影响用户的菜单缓存和权限缓存
-        affected_users = User.objects.filter(role_list__contains=int(role_id))
+        affected_users = self._get_users_affected_by_role(role_id)
 
         # 直接构造缓存键并删除 (兼容 Redis 缓存后端)
         menu_cache_keys = [f"menus-user:{user.id}" for user in affected_users]
@@ -302,7 +328,7 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
         role.group_set.add(*groups)
 
         # 清除受影响组织中用户的权限缓存
-        affected_users = User.objects.filter(group_list__overlap=group_ids).values("username", "domain")
+        affected_users = self._get_users_in_group_trees(group_ids).values("username", "domain")
         if affected_users:
             clear_users_permission_cache(list(affected_users))
 
@@ -362,7 +388,7 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
         role.group_set.remove(*groups)
 
         # 清除受影响组织中用户的权限缓存
-        affected_users = User.objects.filter(group_list__overlap=group_ids).values("username", "domain")
+        affected_users = self._get_users_in_group_trees(group_ids).values("username", "domain")
         if affected_users:
             clear_users_permission_cache(list(affected_users))
 

--- a/server/apps/system_mgmt/viewset/role_viewset.py
+++ b/server/apps/system_mgmt/viewset/role_viewset.py
@@ -1,4 +1,5 @@
 from django.core.cache import cache
+from django.db import transaction
 from django.db.models import Q
 from django.http import JsonResponse
 from rest_framework.decorators import action
@@ -24,17 +25,17 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
         affected_group_ids = GroupUtils.get_group_with_descendants(group_ids)
         query = Q()
         for group_id in affected_group_ids:
-            query |= Q(group_list__contains=int(group_id))
+            query |= Q(group_list__contains=[int(group_id)])
         return User.objects.filter(query)
 
     @classmethod
     def _get_users_affected_by_role(cls, role_id):
         role_group_ids = list(Group.objects.filter(roles__id=role_id).values_list("id", flat=True))
-        query = Q(role_list__contains=int(role_id))
+        query = Q(role_list__contains=[int(role_id)])
         if role_group_ids:
             affected_group_ids = GroupUtils.get_group_with_descendants(role_group_ids)
             for group_id in affected_group_ids:
-                query |= Q(group_list__contains=int(group_id))
+                query |= Q(group_list__contains=[int(group_id)])
         return User.objects.filter(query).distinct()
 
     def _validate_group_scope_for_request(self, request, group_ids):
@@ -152,9 +153,10 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                 }
             )
         affected_user_info = list(self._get_users_affected_by_role(role_id).values("username", "domain"))
-        Role.objects.filter(id=role_id).delete()
-        if affected_user_info:
-            clear_users_permission_cache(affected_user_info)
+        with transaction.atomic():
+            Role.objects.filter(id=role_id).delete()
+            if affected_user_info:
+                clear_users_permission_cache(affected_user_info)
 
         # 记录操作日志
         log_operation(request, "delete", "system-manager", f"删除角色: {role_name}")
@@ -165,10 +167,11 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
     def update_role(self, request):
         role_name = request.data.get("role_name")
         role_id = request.data.get("role_id")
-        Role.objects.filter(id=role_id).update(name=role_name)
         affected_user_info = list(self._get_users_affected_by_role(role_id).values("username", "domain"))
-        if affected_user_info:
-            clear_users_permission_cache(affected_user_info)
+        with transaction.atomic():
+            Role.objects.filter(id=role_id).update(name=role_name)
+            if affected_user_info:
+                clear_users_permission_cache(affected_user_info)
 
         # 记录操作日志
         log_operation(request, "update", "system-manager", f"更新角色名称: {role_name}")
@@ -194,11 +197,10 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                 i.role_list.append(int(role_id))
                 usernames.append(i.username)
                 affected_users.append({"username": i.username, "domain": i.domain})
-        User.objects.bulk_update(user_list, ["role_list"], batch_size=100)
-
-        # 清除受影响用户的权限缓存
-        if affected_users:
-            clear_users_permission_cache(affected_users)
+        with transaction.atomic():
+            User.objects.bulk_update(user_list, ["role_list"], batch_size=100)
+            if affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         if is_superuser:
@@ -232,11 +234,10 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                 i.role_list.remove(pk)
                 usernames.append(i.username)
                 affected_users.append({"username": i.username, "domain": i.domain})
-        User.objects.bulk_update(user_list, ["role_list"], batch_size=100)
-
-        # 清除受影响用户的权限缓存
-        if affected_users:
-            clear_users_permission_cache(affected_users)
+        with transaction.atomic():
+            User.objects.bulk_update(user_list, ["role_list"], batch_size=100)
+            if affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         if is_superuser:
@@ -258,21 +259,16 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
         menus = params.get("menus")
         role_obj = Role.objects.get(id=role_id)
         menu_ids = Menu.objects.filter(app=role_obj.app, name__in=menus).values_list("id", flat=True)
-        role_obj.menu_list = list(menu_ids)
-        role_obj.save()
+        with transaction.atomic():
+            role_obj.menu_list = list(menu_ids)
+            role_obj.save()
 
-        # 清除受影响用户的菜单缓存和权限缓存
-        affected_users = self._get_users_affected_by_role(role_id)
-
-        # 直接构造缓存键并删除 (兼容 Redis 缓存后端)
-        menu_cache_keys = [f"menus-user:{user.id}" for user in affected_users]
-        if menu_cache_keys:
-            cache.delete_many(menu_cache_keys)
-
-        # 清除用户权限缓存
-        affected_user_info = list(affected_users.values("username", "domain"))
-        if affected_user_info:
-            clear_users_permission_cache(affected_user_info)
+            affected_users = list(self._get_users_affected_by_role(role_id).values("id", "username", "domain"))
+            menu_cache_keys = [f"menus-user:{user['id']}" for user in affected_users]
+            if menu_cache_keys:
+                transaction.on_commit(lambda: cache.delete_many(menu_cache_keys), robust=True)
+            if affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         log_operation(
@@ -324,13 +320,13 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                 }
             )
 
-        # 使用ManyToMany关系批量分配角色（从角色侧批量添加，避免N+1）
-        role.group_set.add(*groups)
+        with transaction.atomic():
+            # 使用ManyToMany关系批量分配角色（从角色侧批量添加，避免N+1）
+            role.group_set.add(*groups)
 
-        # 清除受影响组织中用户的权限缓存
-        affected_users = self._get_users_in_group_trees(group_ids).values("username", "domain")
-        if affected_users:
-            clear_users_permission_cache(list(affected_users))
+            affected_users = list(self._get_users_in_group_trees(group_ids).values("username", "domain"))
+            if affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         group_names = list(groups.values_list("name", flat=True))
@@ -384,13 +380,13 @@ class RoleViewSet(LanguageViewSet, ViewSetUtils):
                 }
             )
 
-        # 使用ManyToMany关系批量回收角色（从角色侧批量移除，避免N+1）
-        role.group_set.remove(*groups)
+        with transaction.atomic():
+            # 使用ManyToMany关系批量回收角色（从角色侧批量移除，避免N+1）
+            role.group_set.remove(*groups)
 
-        # 清除受影响组织中用户的权限缓存
-        affected_users = self._get_users_in_group_trees(group_ids).values("username", "domain")
-        if affected_users:
-            clear_users_permission_cache(list(affected_users))
+            affected_users = list(self._get_users_in_group_trees(group_ids).values("username", "domain"))
+            if affected_users:
+                clear_users_permission_cache(affected_users)
 
         # 记录操作日志
         group_names = list(groups.values_list("name", flat=True))

--- a/server/apps/system_mgmt/viewset/user_viewset.py
+++ b/server/apps/system_mgmt/viewset/user_viewset.py
@@ -443,24 +443,22 @@ class UserViewSet(ViewSetUtils):
         # 收集需要删除的用户信息（id, username和domain）
         user_info_list = list(users.values("id", "username", "domain"))
 
-        # 直接构造用户菜单缓存键删除（缓存键格式为 menus-user:{user_id}）
         menu_cache_keys = [f"menus-user:{user['id']}" for user in user_info_list]
-        if menu_cache_keys:
-            cache.delete_many(menu_cache_keys)
+        with transaction.atomic():
+            # 批量删除用户相关的 UserRule（避免 N+1）
+            if user_info_list:
+                user_rule_filter = Q()
+                for user_info in user_info_list:
+                    user_rule_filter |= Q(username=user_info["username"], domain=user_info["domain"])
+                UserRule.objects.filter(user_rule_filter).delete()
 
-        # 批量删除用户相关的UserRule（避免N+1：使用Q对象组合条件）
-        if user_info_list:
-            user_rule_filter = Q()
-            for user_info in user_info_list:
-                user_rule_filter |= Q(username=user_info["username"], domain=user_info["domain"])
-            UserRule.objects.filter(user_rule_filter).delete()
+            users.delete()
 
-        # 删除用户
-        users.delete()
-
-        # 清除权限缓存（批量清除）
-        if user_info_list:
-            clear_users_permission_cache(user_info_list)
+            # 独立权限代际不会随 User 删除，必须与删除事务一并推进。
+            if user_info_list:
+                clear_users_permission_cache(user_info_list)
+            if menu_cache_keys:
+                transaction.on_commit(lambda: cache.delete_many(menu_cache_keys), robust=True)
 
         # 记录操作日志
         log_operation(request, "delete", "system-manager", f"批量删除用户: {', '.join(usernames)} (共{len(usernames)}个)")
@@ -490,7 +488,6 @@ class UserViewSet(ViewSetUtils):
         user_map = {user.id: user for user in users}
         success_ids = []
         skipped = []
-        affected_user_info = []
 
         with transaction.atomic():
             for user_id in normalized_user_ids:
@@ -523,9 +520,7 @@ class UserViewSet(ViewSetUtils):
                     update_fields = ["account_locked_until", "password_error_count"]
 
                 user.save(update_fields=update_fields)
-                cache.delete(f"menus-user:{user.id}")
-                clear_user_permission_cache(user.username, user.domain)
-                affected_user_info.append({"username": user.username, "domain": user.domain})
+                transaction.on_commit(lambda user_id=user.id: cache.delete(f"menus-user:{user_id}"), robust=True)
                 success_ids.append(user.id)
 
         if success_ids:
@@ -584,10 +579,20 @@ class UserViewSet(ViewSetUtils):
             params["roles"] = [role_id for role_id in role_ids if role_id != admin_role_id]
         with transaction.atomic():
             # 删除旧的规则
-            UserRule.objects.filter(username=params["username"]).delete()
+            UserRule.objects.filter(
+                username=target_user.username,
+                domain=target_user.domain,
+            ).delete()
             # 更新用户信息
             if rules:
-                add_rule = [UserRule(username=params["username"], group_rule_id=i) for i in rules]
+                add_rule = [
+                    UserRule(
+                        username=target_user.username,
+                        domain=target_user.domain,
+                        group_rule_id=i,
+                    )
+                    for i in rules
+                ]
                 UserRule.objects.bulk_create(add_rule, batch_size=100)
             update_fields = {
                 "display_name": params.get("lastName"),
@@ -614,6 +619,6 @@ class UserViewSet(ViewSetUtils):
             log_operation(request, "update", "system-manager", f"编辑用户: {params['username']}")
 
             # 清除权限缓存
-            clear_user_permission_cache(params["username"], params.get("domain", "domain.com"))
+            clear_user_permission_cache(target_user.username, target_user.domain)
 
         return JsonResponse({"result": True})

--- a/specs/capabilities/api-token-permission-population.md
+++ b/specs/capabilities/api-token-permission-population.md
@@ -40,20 +40,55 @@
 - **WHEN** 用户使用 API Token 发起请求
 - **AND** 缓存中存在该用户的权限信息
 - **AND** 缓存未过期
+- **AND** 缓存代际与数据库中的用户权限代际一致
 - **THEN** 系统 SHALL 直接使用缓存的权限信息
-- **AND** 系统 SHALL NOT 查询数据库
+- **AND** 系统 SHALL 只允许查询轻量的权限代际，不再查询角色、菜单或组织权限数据
 
 #### Scenario: 缓存未命中
 
 - **WHEN** 用户使用 API Token 发起请求
 - **AND** 缓存中不存在该用户的权限信息或已过期
 - **THEN** 系统 SHALL 查询数据库计算权限信息
-- **AND** 系统 SHALL 将计算结果缓存 60 秒
+- **AND** 系统 SHALL 将计算结果按可配置 TTL 缓存（默认 600 秒）
 
 #### Scenario: 缓存 Key 格式
 
 - **WHEN** 系统缓存 API Token 用户的权限信息
-- **THEN** 缓存 Key SHALL 为 `api_token_permissions:{username}:{domain}:{team}`
+- **THEN** 缓存 Key SHALL 为 `api_token_permissions:{username}:{domain}:v{permission_version}:{team}`
+
+#### Scenario: 权限变更与并发鉴权
+
+- **WHEN** 用户角色、组织继承、角色菜单或应用权限发生变更
+- **THEN** 系统 SHALL 在同一数据库事务中单调推进独立的用户权限代际
+- **AND** 变更前开始的鉴权 SHALL NOT 将旧权限写入新代际缓存
+- **AND** 旧代际缓存即使位于其他 Worker 或物理删除失败，也 SHALL NOT 被后续鉴权复用
+
+#### Scenario: 用户删除与重建
+
+- **WHEN** 系统用户被删除
+- **THEN** 权限代际 SHALL 独立于用户记录继续保留并推进
+- **AND** 仅保留基础用户或 API Secret 时 SHALL NOT 通过 API Token 认证
+- **AND** 同名同域用户重建后 SHALL 使用更高的新代际
+
+#### Scenario: Web Token 授权上下文
+
+- **WHEN** Web Token 鉴权读取或写入 `token_info` 授权上下文缓存
+- **THEN** 缓存键 SHALL 包含同一个用户权限代际
+- **AND** 计算期间代际变化时 SHALL 最多重试一次并拒绝返回旧授权上下文
+
+#### Scenario: 数据权限规则
+
+- **WHEN** 系统读取或写入 `perm_rules` 数据权限缓存
+- **THEN** 缓存键 SHALL 包含同一个用户权限代际
+- **AND** 计算期间代际变化时 SHALL 最多重试一次，持续变化时返回空权限
+
+#### Scenario: 首次上线版本化缓存
+
+- **WHEN** 从不识别权限代际的旧版本升级到版本化权限缓存
+- **THEN** 发布流程 SHALL 按 `docs/operations/api-token-permission-cache-rollout.md` 排空全部旧 Worker
+- **AND** SHALL NOT 让旧 Worker 与新 Worker 在权限变更窗口内混合提供 API Token 鉴权
+- **AND** 回滚到旧版本前 SHALL 同样排空新 Worker，并执行
+  `python manage.py prepare_permission_cache_rollback --confirm` 仅清理权限缓存命名空间中的旧缓存键
 
 ### Requirement: 角色继承计算
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.12"


### PR DESCRIPTION
## 变更说明

- 将 API 密钥权限快照接入统一的用户权限缓存失效路径，撤销角色或组织权限后立即清理相关快照。
- 覆盖继承组织中的受影响用户，并在角色改名、删除、授权和移除组织时主动失效缓存。
- Redis pattern 删除失败时回退到已登记键索引，兼容不支持 pattern 的缓存后端。

## 测试

- `server/apps/core/tests/test_api_token_permission.py`、`server/apps/core/tests/utils/test_permission_cache.py`：47 passed
- `server/apps/system_mgmt/tests/test_role_viewset_api.py`：21 passed
- `server/apps/system_mgmt/tests/test_group_viewset_api.py`：20 passed

风险等级：中。涉及权限撤销后的缓存一致性，请 @zhouzhuangjie 重点复核继承组织的影响范围与缓存降级路径。

Closes #4141
