### PR TITLE
feat(stargazer): 企业存储 SNMP 采集底座（动态分发 + 原生客户端）

### DIFF
--- a/agents/stargazer/core/monitor/drivers/restconf_client.py
+++ b/agents/stargazer/core/monitor/drivers/restconf_client.py
@@ -20,6 +20,19 @@ class RestApiClient:
     def set_token(self, token):
         self.token = token
 
+    def set_header(self, key, value):
+        """Attach a sticky header for subsequent session requests.
+
+        Enterprise storage monitors (PowerStore, OceanStor, StorageGRID, …)
+        rely on this for token / CSRF / cookie headers issued at login.
+        """
+        if isinstance(self.session, requests.Session):
+            self.session.headers[key] = value
+        else:
+            if not hasattr(self, "_sticky_headers"):
+                self._sticky_headers = {}
+            self._sticky_headers[key] = value
+
     def request(
         self,
         method,
@@ -38,6 +51,10 @@ class RestApiClient:
 
         if headers is None:
             headers = {}
+        sticky = getattr(self, "_sticky_headers", None)
+        if sticky:
+            for key, value in sticky.items():
+                headers.setdefault(key, value)
         enable_json = json if json is not None else self.json
         if enable_json:
             headers.setdefault("Content-Type", "application/json")

--- a/agents/stargazer/core/monitor/snmp_client.py
+++ b/agents/stargazer/core/monitor/snmp_client.py
@@ -1,0 +1,200 @@
+"""Synchronous SNMP client used by Stargazer monitor collectors."""
+
+from urllib.parse import urlsplit
+
+
+class SnmpCollectionError(RuntimeError):
+    """Raised when an SNMP transport or protocol operation fails."""
+
+
+def _as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalize_protocol(value, default):
+    normalized = str(value or default).strip().lower()
+    return normalized
+
+
+def _parse_target(config):
+    raw_target = config.get("host") or config.get("base_url") or config.get("ip") or ""
+    raw_target = str(raw_target).strip()
+    if not raw_target:
+        raise ValueError("SNMP target host is required")
+
+    parsed = urlsplit(raw_target if "://" in raw_target else f"//{raw_target}")
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"Invalid SNMP target: {raw_target!r}")
+
+    configured_port = config.get("port") or config.get("snmp_port")
+    port = _as_int(configured_port or parsed.port, 161)
+    if not 1 <= port <= 65535:
+        raise ValueError(f"Invalid SNMP port: {port}")
+    return host, port
+
+
+class SnmpClient:
+    """Small pysnmp wrapper supporting v2c and v3 GET/WALK operations."""
+
+    def __init__(
+        self,
+        config,
+        *,
+        cmdgen_module=None,
+        protocols=None,
+    ):
+        self.config = dict(config or {})
+        self.host, self.port = _parse_target(self.config)
+        self.timeout = _as_int(self.config.get("timeout"), 5)
+        self.retries = _as_int(self.config.get("retries"), 1)
+
+        if cmdgen_module is None:
+            from pysnmp.entity.rfc3413.oneliner import cmdgen
+
+            cmdgen_module = cmdgen
+        if protocols is None:
+            from pysnmp.hlapi import (
+                usmAesCfb128Protocol,
+                usmDESPrivProtocol,
+                usmHMACMD5AuthProtocol,
+                usmHMACSHAAuthProtocol,
+            )
+
+            protocols = {
+                "sha": usmHMACSHAAuthProtocol,
+                "md5": usmHMACMD5AuthProtocol,
+                "aes": usmAesCfb128Protocol,
+                "des": usmDESPrivProtocol,
+            }
+
+        self._cmdgen = cmdgen_module
+        self._protocols = protocols
+        self._command_generator = self._cmdgen.CommandGenerator()
+
+    def _auth(self):
+        username = self.config.get("username") or self.config.get("sec_name")
+        explicit_version = str(self.config.get("version") or "").lower()
+        use_v3 = explicit_version in {"3", "v3"} or bool(username)
+        if not use_v3:
+            community = self.config.get("community")
+            if not community:
+                raise ValueError("SNMP v2c community is required")
+            return self._cmdgen.CommunityData(community)
+
+        if not username:
+            raise ValueError("SNMP v3 username is required")
+
+        auth_key = self.config.get("auth_key") or self.config.get("authkey")
+        priv_key = self.config.get("priv_key") or self.config.get("privkey")
+        level = self.config.get("sec_level") or self.config.get("level")
+        if not level:
+            level = "authPriv" if priv_key else "authNoPriv" if auth_key else "noAuthNoPriv"
+        level = str(level)
+        kwargs = {}
+        if level != "noAuthNoPriv":
+            if not auth_key:
+                raise ValueError(f"SNMP v3 {level} requires auth_key")
+            auth_protocol = _normalize_protocol(
+                self.config.get("auth_protocol") or self.config.get("integrity"),
+                "sha",
+            )
+            if auth_protocol not in {"sha", "md5"}:
+                raise ValueError(f"Unsupported SNMP auth protocol: {auth_protocol}")
+            kwargs.update(
+                authKey=auth_key,
+                authProtocol=self._protocols[auth_protocol],
+            )
+        if level == "authPriv":
+            if not priv_key:
+                raise ValueError("SNMP v3 authPriv requires priv_key")
+            priv_protocol = _normalize_protocol(
+                self.config.get("priv_protocol") or self.config.get("privacy"),
+                "aes",
+            )
+            if priv_protocol not in {"aes", "des"}:
+                raise ValueError(f"Unsupported SNMP privacy protocol: {priv_protocol}")
+            kwargs.update(
+                privKey=priv_key,
+                privProtocol=self._protocols[priv_protocol],
+            )
+        return self._cmdgen.UsmUserData(username, **kwargs)
+
+    def _target(self):
+        return self._cmdgen.UdpTransportTarget(
+            (self.host, self.port),
+            timeout=self.timeout,
+            retries=self.retries,
+        )
+
+    @staticmethod
+    def _pretty(value):
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        pretty_print = getattr(value, "prettyPrint", None)
+        return pretty_print() if callable(pretty_print) else value
+
+    @staticmethod
+    def _raise_on_error(error_indication, error_status, error_index):
+        if error_indication:
+            raise SnmpCollectionError(str(error_indication))
+        if error_status:
+            pretty_print = getattr(error_status, "prettyPrint", None)
+            message = pretty_print() if callable(pretty_print) else str(error_status)
+            raise SnmpCollectionError(f"{message} at index {error_index}")
+
+    def get(self, oid):
+        result = self._command_generator.getCmd(
+            self._auth(),
+            self._target(),
+            self._cmdgen.MibVariable(str(oid).lstrip(".")),
+            lookupMib=False,
+        )
+        error_indication, error_status, error_index, var_binds = result
+        self._raise_on_error(error_indication, error_status, error_index)
+        if not var_binds:
+            return None
+        return self._pretty(var_binds[0][1])
+
+    def walk(self, base_oid):
+        result = self._command_generator.nextCmd(
+            self._auth(),
+            self._target(),
+            self._cmdgen.MibVariable(str(base_oid).lstrip(".")),
+            lookupMib=False,
+            lexicographicMode=False,
+        )
+        error_indication, error_status, error_index, var_bind_table = result
+        self._raise_on_error(error_indication, error_status, error_index)
+
+        values = {}
+        for var_binds in var_bind_table or []:
+            for oid, value in var_binds:
+                oid_text = str(self._pretty(oid)).lstrip(".")
+                values[f".{oid_text}"] = self._pretty(value)
+        return values
+
+
+class SnmpApiAdapter:
+    """Compatibility adapter for existing storage monitor request calls."""
+
+    def __init__(self, client):
+        self.client = client
+
+    def request(self, method, endpoint, params=None, **_kwargs):
+        if str(method).upper() != "GET":
+            raise ValueError(f"Unsupported SNMP adapter method: {method}")
+        oid = (params or {}).get("oid")
+        if not oid:
+            raise ValueError("SNMP oid is required")
+        if endpoint == "/snmp/get":
+            return {"value": self.client.get(oid)}
+        if endpoint == "/snmp/walk":
+            return {"data": {full_oid: {"value": value} for full_oid, value in self.client.walk(oid).items()}}
+        raise ValueError(f"Unsupported SNMP adapter endpoint: {endpoint}")
+
+    def logout(self):
+        return None

--- a/agents/stargazer/core/worker.py
+++ b/agents/stargazer/core/worker.py
@@ -17,6 +17,32 @@ from core.redis_config import REDIS_CONFIG
 from sanic.log import logger
 
 
+def _is_safe_monitor_type(monitor_type: Any) -> bool:
+    if not isinstance(monitor_type, str) or not monitor_type:
+        return False
+    return all(ch.isalnum() or ch == "_" for ch in monitor_type)
+
+
+async def _try_collect_enterprise_monitor_task(
+    ctx: Dict, params: Dict[str, Any], task_id: str, monitor_type: str
+):
+    """Dispatch optional WeOpsX enterprise monitors without CE brand data."""
+    if not _is_safe_monitor_type(monitor_type):
+        return None
+
+    try:
+        from enterprise.tasks.handlers import storage_handler
+    except ImportError:
+        return None
+
+    handler_name = f"collect_{monitor_type}_metrics_task"
+    handler = getattr(storage_handler, handler_name, None)
+    if handler is None:
+        return None
+
+    return await handler(ctx, params, task_id)
+
+
 async def collect_task(
     ctx: Dict, params: Dict[str, Any], task_id: str
 ) -> Dict[str, Any]:
@@ -58,9 +84,13 @@ async def collect_task(
             result = await collect_qcloud_metrics_task(ctx, params, task_id)
 
         elif monitor_type == "oceanstor":
-            from tasks.handlers.monitor_handler import collect_oceanstor_metrics_task
+            result = await _try_collect_enterprise_monitor_task(
+                ctx, params, task_id, monitor_type
+            )
+            if result is None:
+                from tasks.handlers.monitor_handler import collect_oceanstor_metrics_task
 
-            result = await collect_oceanstor_metrics_task(ctx, params, task_id)
+                result = await collect_oceanstor_metrics_task(ctx, params, task_id)
 
         elif monitor_type == "host":
             from tasks.handlers.monitor_handler import collect_host_metrics_task
@@ -103,6 +133,19 @@ async def collect_task(
             from tasks.handlers.plugin_handler import collect_plugin_task
 
             result = await collect_plugin_task(ctx, params, task_id)
+
+        elif monitor_type:
+            result = await _try_collect_enterprise_monitor_task(
+                ctx, params, task_id, monitor_type
+            )
+            if result is None:
+                logger.error(f"Unknown task type for {task_id}")
+                result = {
+                    "task_id": task_id,
+                    "status": "failed",
+                    "error": "Unknown task type",
+                    "completed_at": int(time.time() * 1000),
+                }
 
         else:
             logger.error(f"Unknown task type for {task_id}")

--- a/agents/stargazer/tests/test_enterprise_monitor_dispatch.py
+++ b/agents/stargazer/tests/test_enterprise_monitor_dispatch.py
@@ -1,0 +1,106 @@
+import importlib.util
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+
+def _load_worker_module():
+    spec = importlib.util.spec_from_file_location(
+        "stargazer_worker_enterprise_dispatch_test_module",
+        Path(__file__).resolve().parents[1] / "core" / "worker.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_module(monkeypatch, name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_collect_task_dispatches_optional_enterprise_monitor(monkeypatch):
+    captured = {}
+
+    async def fake_enterprise_handler(ctx, params, task_id):
+        captured["ctx"] = ctx
+        captured["params"] = params
+        captured["task_id"] = task_id
+        return {"task_id": task_id, "status": "success", "monitor_type": "pure"}
+
+    storage_handler = _install_module(
+        monkeypatch,
+        "enterprise.tasks.handlers.storage_handler",
+        collect_pure_metrics_task=fake_enterprise_handler,
+    )
+    handlers = _install_module(
+        monkeypatch,
+        "enterprise.tasks.handlers",
+        storage_handler=storage_handler,
+    )
+    tasks = _install_module(monkeypatch, "enterprise.tasks", handlers=handlers)
+    _install_module(monkeypatch, "enterprise", tasks=tasks)
+    _install_module(monkeypatch, "arq", create_pool=lambda *args, **kwargs: None)
+    _install_module(monkeypatch, "arq.connections", RedisSettings=lambda **kwargs: kwargs)
+    _install_module(monkeypatch, "core")
+    _install_module(
+        monkeypatch,
+        "core.redis_config",
+        REDIS_CONFIG={"host": "localhost", "port": 6379, "password": "", "database": 0},
+    )
+
+    worker = _load_worker_module()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(worker, "_clear_dedupe_key", noop)
+    monkeypatch.setattr(worker, "_clear_running_flag", noop)
+
+    result = _run(
+        worker.collect_task(
+            {"job_id": "job-1"},
+            {"monitor_type": "pure", "host": "10.0.0.2"},
+            "task-1",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert captured["params"]["monitor_type"] == "pure"
+    assert captured["task_id"] == "task-1"
+
+
+def test_collect_task_keeps_unknown_monitor_type_unknown(monkeypatch):
+    _install_module(monkeypatch, "arq", create_pool=lambda *args, **kwargs: None)
+    _install_module(monkeypatch, "arq.connections", RedisSettings=lambda **kwargs: kwargs)
+    _install_module(monkeypatch, "core")
+    _install_module(
+        monkeypatch,
+        "core.redis_config",
+        REDIS_CONFIG={"host": "localhost", "port": 6379, "password": "", "database": 0},
+    )
+    worker = _load_worker_module()
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(worker, "_clear_dedupe_key", noop)
+    monkeypatch.setattr(worker, "_clear_running_flag", noop)
+
+    result = _run(
+        worker.collect_task(
+            {}, {"monitor_type": "not_existing_monitor"}, "task-unknown"
+        )
+    )
+
+    assert result["status"] == "failed"
+    assert result["error"] == "Unknown task type"

--- a/agents/stargazer/tests/test_snmp_client.py
+++ b/agents/stargazer/tests/test_snmp_client.py
@@ -1,0 +1,186 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class _Pretty:
+    def __init__(self, value):
+        self.value = value
+
+    def prettyPrint(self):
+        return str(self.value)
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.get_result = (None, None, 0, [])
+        self.walk_result = (None, None, 0, [])
+        self.get_calls = []
+        self.walk_calls = []
+
+    def getCmd(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return self.get_result
+
+    def nextCmd(self, *args, **kwargs):
+        self.walk_calls.append((args, kwargs))
+        return self.walk_result
+
+
+class _FakeCmdgen:
+    def __init__(self, backend):
+        self.backend = backend
+        self.community_calls = []
+        self.usm_calls = []
+        self.target_calls = []
+
+    def CommandGenerator(self):
+        return self.backend
+
+    def CommunityData(self, community):
+        self.community_calls.append(community)
+        return ("community", community)
+
+    def UsmUserData(self, username, **kwargs):
+        self.usm_calls.append((username, kwargs))
+        return ("usm", username, kwargs)
+
+    def UdpTransportTarget(self, target, **kwargs):
+        self.target_calls.append((target, kwargs))
+        return ("target", target, kwargs)
+
+    def MibVariable(self, oid):
+        return ("oid", oid)
+
+
+def _client(config, backend=None):
+    from core.monitor.snmp_client import SnmpClient
+
+    backend = backend or _FakeBackend()
+    cmdgen = _FakeCmdgen(backend)
+    protocols = {
+        "sha": "SHA",
+        "md5": "MD5",
+        "aes": "AES",
+        "des": "DES",
+    }
+    return (
+        SnmpClient(config, cmdgen_module=cmdgen, protocols=protocols),
+        backend,
+        cmdgen,
+    )
+
+
+def test_v2c_get_uses_community_target_and_transport_limits():
+    client, backend, cmdgen = _client(
+        {
+            "base_url": "udp://storage.example.com:2161",
+            "community": "private",
+            "timeout": 7,
+            "retries": 3,
+        }
+    )
+    backend.get_result = (
+        None,
+        None,
+        0,
+        [(_Pretty("1.3.6.1.2.1.1.3.0"), _Pretty("12345"))],
+    )
+
+    assert client.get("1.3.6.1.2.1.1.3.0") == "12345"
+    assert cmdgen.community_calls == ["private"]
+    assert cmdgen.target_calls == [(("storage.example.com", 2161), {"timeout": 7, "retries": 3})]
+
+
+def test_v3_auth_priv_maps_credentials_and_protocols():
+    client, backend, cmdgen = _client(
+        {
+            "host": "10.0.0.8",
+            "username": "snmp-user",
+            "auth_key": "auth-secret",
+            "priv_key": "priv-secret",
+            "auth_protocol": "MD5",
+            "priv_protocol": "DES",
+        }
+    )
+    backend.get_result = (
+        None,
+        None,
+        0,
+        [(_Pretty("1.3.6.1.2.1.1.1.0"), _Pretty("storage"))],
+    )
+
+    client.get("1.3.6.1.2.1.1.1.0")
+
+    assert cmdgen.usm_calls == [
+        (
+            "snmp-user",
+            {
+                "authKey": "auth-secret",
+                "authProtocol": "MD5",
+                "privKey": "priv-secret",
+                "privProtocol": "DES",
+            },
+        )
+    ]
+
+
+def test_walk_returns_full_dot_prefixed_oids_and_stops_at_subtree():
+    client, backend, _ = _client({"host": "10.0.0.9", "community": "public"})
+    backend.walk_result = (
+        None,
+        None,
+        0,
+        [
+            [(_Pretty("1.3.6.1.4.1.9.1.1"), _Pretty("up"))],
+            [(_Pretty(".1.3.6.1.4.1.9.1.2"), _Pretty("down"))],
+        ],
+    )
+
+    assert client.walk("1.3.6.1.4.1.9.1") == {
+        ".1.3.6.1.4.1.9.1.1": "up",
+        ".1.3.6.1.4.1.9.1.2": "down",
+    }
+    assert backend.walk_calls[0][1]["lexicographicMode"] is False
+
+
+def test_protocol_error_raises_collection_error():
+    from core.monitor.snmp_client import SnmpCollectionError
+
+    client, backend, _ = _client({"host": "10.0.0.10", "community": "public"})
+    backend.get_result = (None, _Pretty("authorizationError"), 1, [])
+
+    with pytest.raises(SnmpCollectionError, match="authorizationError"):
+        client.get("1.3.6.1.2.1.1.1.0")
+
+
+def test_v2c_does_not_silently_fall_back_to_public_community():
+    client, _, _ = _client({"host": "10.0.0.12"})
+
+    with pytest.raises(ValueError, match="community is required"):
+        client.get("1.3.6.1.2.1.1.1.0")
+
+
+def test_api_adapter_exposes_existing_get_and_walk_response_shapes():
+    from core.monitor.snmp_client import SnmpApiAdapter
+
+    client, backend, _ = _client({"host": "10.0.0.11", "community": "public"})
+    backend.get_result = (
+        None,
+        None,
+        0,
+        [(_Pretty("1.3.6.1.2.1.1.1.0"), _Pretty("array"))],
+    )
+    backend.walk_result = (
+        None,
+        None,
+        0,
+        [[(_Pretty("1.3.6.1.2.1.2.2.1.1.1"), _Pretty("1"))]],
+    )
+    adapter = SnmpApiAdapter(client)
+
+    assert adapter.request("GET", "/snmp/get", params={"oid": "1.3.6.1.2.1.1.1.0"}) == {"value": "array"}
+    assert adapter.request("GET", "/snmp/walk", params={"oid": "1.3.6.1.2.1.2.2.1.1"}) == {"data": {".1.3.6.1.2.1.2.2.1.1.1": {"value": "1"}}}


### PR DESCRIPTION
## Summary
- 为企业监控任务增加安全的动态分发入口，社区版不嵌入品牌逻辑。
- 新增 Stargazer 原生 SNMP 客户端（v2c/v3 GET/WALK）与兼容适配器，供企业存储 collector 直采设备。
- 补充 REST 客户端 sticky header，支撑企业存储登录态。

## 依赖
需与 WeOpsX-Enterprise 对应 PR 一起合入/部署（企业侧接线 `attach_snmp_adapter` + Telegraf 改 scrape Stargazer）。

## Test plan
- [x] `pytest agents/stargazer/tests/test_snmp_client.py agents/stargazer/tests/test_enterprise_monitor_dispatch.py`（8 passed）
- [ ] 与 EE 联调：至少 1 个品牌（NetApp / EqualLogic）v2c 现网或仿真，确认 NATS 入库非零指标
- [ ] 确认镜像含 `.[snmp]`（Dockerfile 已声明）

## 已知限制
- Telegraf scrape 仅返回 queued 受理指标，真实指标仍走 NATS（与现有 Pure 等一致）
- SNMP 全失败时 status 零计数可能仍通过 `ensure_storage_metrics`（follow-up）
- UI 未暴露全部 v3 协议字段时，默认 SHA/AES + 按 username 推断 v3