### PR TITLE
fix(job_mgmt): 收紧定时任务批量删除权限范围

### DIFF
--- a/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
+++ b/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
@@ -1,0 +1,80 @@
+"""ScheduledTask 批量删除的团队权限回归测试。"""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.job_mgmt.constants import JobType
+from apps.job_mgmt.models import ScheduledTask
+
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+
+URL = "/api/v1/job_mgmt/api/scheduled_task/batch_delete/"
+VIEW_SVC = "apps.job_mgmt.views.scheduled_task.ScheduledTaskService"
+
+
+def _make_task(name, team):
+    return ScheduledTask.objects.create(
+        name=name,
+        job_type=JobType.SCRIPT,
+        schedule_type="cron",
+        cron_expression="* * * * *",
+        script_content="echo",
+        script_type="shell",
+        target_source="node_mgmt",
+        target_list=[{"node_id": "n1"}],
+        team=team,
+    )
+
+
+def _grant_delete_permission(api_client, authenticated_user):
+    authenticated_user.permission = {"job": {"cron_task-Delete"}}
+    api_client.cookies["current_team"] = "1"
+
+
+def test_batch_delete_only_deletes_authorized_team_tasks(api_client, authenticated_user):
+    own_task = _make_task("own", [1])
+    foreign_task = _make_task("foreign", [2])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [1], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [own_task.id, foreign_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 1
+    assert not ScheduledTask.objects.filter(id=own_task.id).exists()
+    assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
+    delete_periodic_task.assert_called_once_with(own_task.id)
+
+
+def test_batch_delete_foreign_team_id_is_noop(api_client, authenticated_user):
+    foreign_task = _make_task("foreign", [2])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [1], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [foreign_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
+def test_batch_delete_superuser_keeps_cross_team_semantics(su_client):
+    own_task = _make_task("own", [1])
+    foreign_task = _make_task("foreign", [2])
+
+    with patch(VIEW_SVC + ".delete_periodic_task"):
+        response = su_client.post(URL, {"ids": [own_task.id, foreign_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 2
+    assert not ScheduledTask.objects.filter(id__in=[own_task.id, foreign_task.id]).exists()

--- a/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
+++ b/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
@@ -68,6 +68,74 @@ def test_batch_delete_foreign_team_id_is_noop(api_client, authenticated_user):
     delete_periodic_task.assert_not_called()
 
 
+def test_batch_delete_view_only_instance_rule_is_noop(api_client, authenticated_user):
+    task = _make_task("view-only", [1])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [], "instance": [{"id": task.id, "permission": ["View"]}]}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
+def test_batch_delete_operate_instance_rule_allows_same_team(api_client, authenticated_user):
+    task = _make_task("operate", [1])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [], "instance": [{"id": task.id, "permission": ["Operate"]}]}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 1
+    assert not ScheduledTask.objects.filter(id=task.id).exists()
+    delete_periodic_task.assert_called_once_with(task.id)
+
+
+def test_batch_delete_foreign_team_operate_instance_rule_is_noop(api_client, authenticated_user):
+    foreign_task = _make_task("foreign-operate", [2])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [], "instance": [{"id": foreign_task.id, "permission": ["Operate"]}]}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [foreign_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
+def test_destroy_foreign_team_task_is_denied(api_client, authenticated_user):
+    foreign_task = _make_task("foreign-single", [2])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules") as get_permission_rules,
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.delete(f"/api/v1/job_mgmt/api/scheduled_task/{foreign_task.id}/")
+
+    assert response.status_code == 200
+    assert response.json()["result"] is False
+    assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
+    get_permission_rules.assert_not_called()
+    delete_periodic_task.assert_not_called()
+
+
 def test_batch_delete_superuser_keeps_cross_team_semantics(su_client):
     own_task = _make_task("own", [1])
     foreign_task = _make_task("foreign", [2])

--- a/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
+++ b/server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py
@@ -39,7 +39,7 @@ def test_batch_delete_only_deletes_authorized_team_tasks(api_client, authenticat
 
     rules = {"team": [1], "instance": []}
     with (
-        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules) as get_permission_rules,
         patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
     ):
         response = api_client.post(URL, {"ids": [own_task.id, foreign_task.id]}, format="json")
@@ -49,6 +49,7 @@ def test_batch_delete_only_deletes_authorized_team_tasks(api_client, authenticat
     assert not ScheduledTask.objects.filter(id=own_task.id).exists()
     assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
     delete_periodic_task.assert_called_once_with(own_task.id)
+    get_permission_rules.assert_called_once()
 
 
 def test_batch_delete_foreign_team_id_is_noop(api_client, authenticated_user):
@@ -119,6 +120,89 @@ def test_batch_delete_foreign_team_operate_instance_rule_is_noop(api_client, aut
     delete_periodic_task.assert_not_called()
 
 
+def test_batch_delete_does_not_cross_current_team_for_multi_team_user(api_client, authenticated_user):
+    other_team_task = _make_task("other-membership", [2])
+    authenticated_user.group_list = [{"id": 1}, {"id": 2}]
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [1], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [other_team_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=other_team_task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
+def test_batch_delete_child_team_rule_does_not_grant_sibling_team(api_client, authenticated_user):
+    sibling_task = _make_task("sibling", [3])
+    authenticated_user.group_list = [{"id": 1}, {"id": 2}, {"id": 3}]
+    authenticated_user.group_tree = [
+        {
+            "id": 1,
+            "subGroups": [
+                {"id": 2, "subGroups": []},
+                {"id": 3, "subGroups": []},
+            ],
+        }
+    ]
+    _grant_delete_permission(api_client, authenticated_user)
+    api_client.cookies["include_children"] = "1"
+
+    rules = {"team": [2], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [sibling_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=sibling_task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
+def test_batch_delete_parent_team_rule_allows_child_when_including_children(api_client, authenticated_user):
+    child_task = _make_task("child", [2])
+    authenticated_user.group_list = [{"id": 1}, {"id": 2}]
+    authenticated_user.group_tree = [{"id": 1, "subGroups": [{"id": 2, "subGroups": []}]}]
+    _grant_delete_permission(api_client, authenticated_user)
+    api_client.cookies["include_children"] = "1"
+
+    rules = {"team": [1], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [child_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 1
+    assert not ScheduledTask.objects.filter(id=child_task.id).exists()
+    delete_periodic_task.assert_called_once_with(child_task.id)
+
+
+def test_batch_delete_global_task_is_superuser_only(api_client, authenticated_user):
+    global_task = _make_task("global", [])
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [1], "instance": [{"id": global_task.id, "permission": ["Operate"]}]}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.post(URL, {"ids": [global_task.id]}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["deleted_count"] == 0
+    assert ScheduledTask.objects.filter(id=global_task.id).exists()
+    delete_periodic_task.assert_not_called()
+
+
 def test_destroy_foreign_team_task_is_denied(api_client, authenticated_user):
     foreign_task = _make_task("foreign-single", [2])
     _grant_delete_permission(api_client, authenticated_user)
@@ -133,6 +217,24 @@ def test_destroy_foreign_team_task_is_denied(api_client, authenticated_user):
     assert response.json()["result"] is False
     assert ScheduledTask.objects.filter(id=foreign_task.id).exists()
     get_permission_rules.assert_not_called()
+    delete_periodic_task.assert_not_called()
+
+
+def test_destroy_does_not_cross_current_team_for_multi_team_user(api_client, authenticated_user):
+    other_team_task = _make_task("other-membership-single", [2])
+    authenticated_user.group_list = [{"id": 1}, {"id": 2}]
+    _grant_delete_permission(api_client, authenticated_user)
+
+    rules = {"team": [1], "instance": []}
+    with (
+        patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        patch(VIEW_SVC + ".delete_periodic_task") as delete_periodic_task,
+    ):
+        response = api_client.delete(f"/api/v1/job_mgmt/api/scheduled_task/{other_team_task.id}/")
+
+    assert response.status_code == 200
+    assert response.json()["result"] is False
+    assert ScheduledTask.objects.filter(id=other_team_task.id).exists()
     delete_periodic_task.assert_not_called()
 
 

--- a/server/apps/job_mgmt/views/scheduled_task.py
+++ b/server/apps/job_mgmt/views/scheduled_task.py
@@ -222,7 +222,10 @@ class ScheduledTaskViewSet(AuthViewSet):
         serializer.is_valid(raise_exception=True)
 
         ids = serializer.validated_data["ids"]
-        tasks = ScheduledTask.objects.filter(id__in=ids)
+        tasks = self.filter_queryset(self.get_queryset())
+        if not request.user.is_superuser:
+            tasks = self.get_queryset_by_permission(request, tasks)
+        tasks = tasks.filter(id__in=ids)
 
         # 删除关联的 PeriodicTask
         for task in tasks:

--- a/server/apps/job_mgmt/views/scheduled_task.py
+++ b/server/apps/job_mgmt/views/scheduled_task.py
@@ -204,6 +204,12 @@ class ScheduledTaskViewSet(AuthViewSet):
     @HasPermission("cron_task-Delete")
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        if not request.user.is_superuser:
+            current_team = self._validate_current_team_permission(request)
+            include_children = request.COOKIES.get("include_children", "0") == "1"
+            if not self.get_has_permission(request.user, instance, current_team, include_children=include_children):
+                message = self.loader.get("error.no_permission_delete") if self.loader else "User does not have permission to delete this instance"
+                return self.value_error(message)
 
         # 删除关联的 celery-beat PeriodicTask
         ScheduledTaskService.delete_periodic_task(instance.id)
@@ -222,10 +228,16 @@ class ScheduledTaskViewSet(AuthViewSet):
         serializer.is_valid(raise_exception=True)
 
         ids = serializer.validated_data["ids"]
-        tasks = self.filter_queryset(self.get_queryset())
+        tasks = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
         if not request.user.is_superuser:
-            tasks = self.get_queryset_by_permission(request, tasks)
-        tasks = tasks.filter(id__in=ids)
+            current_team = self._validate_current_team_permission(request)
+            include_children = request.COOKIES.get("include_children", "0") == "1"
+            authorized_ids = [
+                task.id
+                for task in tasks
+                if self.get_has_permission(request.user, task, current_team, include_children=include_children)
+            ]
+            tasks = tasks.filter(id__in=authorized_ids)
 
         # 删除关联的 PeriodicTask
         for task in tasks:

--- a/server/apps/job_mgmt/views/scheduled_task.py
+++ b/server/apps/job_mgmt/views/scheduled_task.py
@@ -5,7 +5,9 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.utils import viewset_utils
 from apps.core.utils.time_util import get_crontab_next_runs
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.job_mgmt.constants import ExecutionStatus, JobType
 from apps.job_mgmt.filters.scheduled_task import ScheduledTaskFilter
@@ -201,15 +203,66 @@ class ScheduledTaskViewSet(AuthViewSet):
             }
         )
 
+    def _get_delete_queryset(self, request, ids):
+        tasks = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
+        if request.user.is_superuser:
+            return tasks
+
+        current_team = self._validate_current_team_permission(request)
+        include_children = request.COOKIES.get("include_children", "0") == "1"
+        scope_team_ids = {current_team}
+        if include_children:
+            subtree_ids = self.extract_child_group_ids(getattr(request.user, "group_tree", []), current_team)
+            if subtree_ids:
+                scope_team_ids = set(normalize_user_group_ids(subtree_ids))
+
+        scope_query = viewset_utils.build_json_membership_query(tasks, self.ORGANIZATION_FIELD, scope_team_ids)
+        tasks = tasks.filter(scope_query)
+        if not tasks.exists():
+            return tasks
+
+        permission_rules = viewset_utils.get_permission_rules(
+            request.user,
+            current_team,
+            self._get_app_name(),
+            self.permission_key,
+            include_children,
+        )
+        if not isinstance(permission_rules, dict):
+            return tasks.none()
+
+        permission_teams = permission_rules.get("team", [])
+        permission_team_ids = set(normalize_user_group_ids(permission_teams if isinstance(permission_teams, list) else []))
+        if include_children and current_team in permission_team_ids:
+            granted_team_ids = scope_team_ids
+        else:
+            granted_team_ids = permission_team_ids & scope_team_ids
+
+        operate_instance_ids = set()
+        instance_rules = permission_rules.get("instance", [])
+        for rule in instance_rules if isinstance(instance_rules, list) else []:
+            if not isinstance(rule, dict) or "Operate" not in rule.get("permission", []):
+                continue
+            try:
+                operate_instance_ids.add(int(rule["id"]))
+            except (KeyError, TypeError, ValueError):
+                continue
+
+        authorized_ids = []
+        for task in tasks:
+            task_team_ids = set(normalize_user_group_ids(task.team))
+            if not task_team_ids & scope_team_ids:
+                continue
+            if task_team_ids & granted_team_ids or task.id in operate_instance_ids:
+                authorized_ids.append(task.id)
+        return tasks.filter(id__in=authorized_ids)
+
     @HasPermission("cron_task-Delete")
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        if not request.user.is_superuser:
-            current_team = self._validate_current_team_permission(request)
-            include_children = request.COOKIES.get("include_children", "0") == "1"
-            if not self.get_has_permission(request.user, instance, current_team, include_children=include_children):
-                message = self.loader.get("error.no_permission_delete") if self.loader else "User does not have permission to delete this instance"
-                return self.value_error(message)
+        if not self._get_delete_queryset(request, [instance.id]).exists():
+            message = self.loader.get("error.no_permission_delete") if self.loader else "User does not have permission to delete this instance"
+            return self.value_error(message)
 
         # 删除关联的 celery-beat PeriodicTask
         ScheduledTaskService.delete_periodic_task(instance.id)
@@ -228,16 +281,7 @@ class ScheduledTaskViewSet(AuthViewSet):
         serializer.is_valid(raise_exception=True)
 
         ids = serializer.validated_data["ids"]
-        tasks = self.filter_queryset(self.get_queryset()).filter(id__in=ids)
-        if not request.user.is_superuser:
-            current_team = self._validate_current_team_permission(request)
-            include_children = request.COOKIES.get("include_children", "0") == "1"
-            authorized_ids = [
-                task.id
-                for task in tasks
-                if self.get_has_permission(request.user, task, current_team, include_children=include_children)
-            ]
-            tasks = tasks.filter(id__in=authorized_ids)
+        tasks = self._get_delete_queryset(request, ids)
 
         # 删除关联的 PeriodicTask
         for task in tasks:


### PR DESCRIPTION
## 变更说明

- 单删和批量删除统一先按 `current_team` 或明确启用的子树范围收敛对象。
- 每次请求只读取一次权限规则，再按 team 授权或实例 `Operate` 授权过滤；实例 `View` 不可删除。
- 多组织用户不能借其他组织成员关系跨当前团队删除；子组授权不会扩散到兄弟组。
- `team=[]` 任务仅超级管理员可删除，超级管理员仍保留跨团队批量删除能力。

## 验证

- `server/apps/job_mgmt/tests/test_scheduled_task_batch_delete_permissions.py`
- `server/apps/job_mgmt/tests/test_scheduled_task_views.py`
- 结果：33 passed
- Black、compileall、diff-check 通过
- Standards 与 Issue #4129 Spec 双轴复审均无 P0-P2

## 风险

中风险权限收紧。没有新增参数、响应字段或数据迁移；合法当前团队、显式子树、实例 `Operate` 与超级管理员调用保持兼容。

Closes #4129
