### PR TITLE
bugfix: 补全数据源连接器导入导出契约

### DIFF
--- a/server/apps/operation_analysis/constants/import_export.py
+++ b/server/apps/operation_analysis/constants/import_export.py
@@ -91,8 +91,10 @@ YAML_MAX_SIZE_BYTES = 2 * 1024 * 1024  # 2MB
 # 单次导入最大对象数量限制，超过此限制将拒绝导入
 IMPORT_OBJECT_LIMIT = 200
 
-# YAML schema版本号，用于版本兼容性检查
-YAML_SCHEMA_VERSION = "1.1.0"
+# YAML schema版本号，用于版本兼容性检查。1.2.0 增加数据源连接器配置；
+# 导入端继续接受 1.1.0，使存量 NATS YAML 可以迁移到新版本。
+YAML_SCHEMA_VERSION = "1.2.0"
+YAML_SUPPORTED_SCHEMA_VERSIONS = frozenset({"1.1.0", YAML_SCHEMA_VERSION})
 
 
 # ===== 敏感字段配置 =====
@@ -102,11 +104,13 @@ SENSITIVE_FIELDS = frozenset({"password", "secret", "token"})
 
 # 连接器配置允许嵌套自定义 headers/body，敏感键不一定是固定字段名。
 # 与数据源 API 的脱敏口径保持一致，避免 Authorization、api_key 等配置随 YAML 导出。
-SENSITIVE_FIELD_KEYWORDS = ("password", "token", "secret", "authorization", "api_key", "apikey")
+SENSITIVE_FIELD_KEYWORDS = ("password", "token", "secret", "authorization", "apikey")
 
 
 def is_sensitive_field_name(field: object) -> bool:
-    normalized = str(field).lower()
+    # Header/config keys commonly use mixed separators (for example X-API-Key).
+    # Strip separators before matching so these variants share one contract.
+    normalized = "".join(char for char in str(field).lower() if char.isalnum())
     return any(keyword in normalized for keyword in SENSITIVE_FIELD_KEYWORDS)
 
 # 敏感字段脱敏后的占位符值

--- a/server/apps/operation_analysis/constants/import_export.py
+++ b/server/apps/operation_analysis/constants/import_export.py
@@ -100,6 +100,15 @@ YAML_SCHEMA_VERSION = "1.1.0"
 # 导出时这些字段将被替换为脱敏占位符，导入时需补充实际值
 SENSITIVE_FIELDS = frozenset({"password", "secret", "token"})
 
+# 连接器配置允许嵌套自定义 headers/body，敏感键不一定是固定字段名。
+# 与数据源 API 的脱敏口径保持一致，避免 Authorization、api_key 等配置随 YAML 导出。
+SENSITIVE_FIELD_KEYWORDS = ("password", "token", "secret", "authorization", "api_key", "apikey")
+
+
+def is_sensitive_field_name(field: object) -> bool:
+    normalized = str(field).lower()
+    return any(keyword in normalized for keyword in SENSITIVE_FIELD_KEYWORDS)
+
 # 敏感字段脱敏后的占位符值
 SENSITIVE_PLACEHOLDER = "******"
 

--- a/server/apps/operation_analysis/schemas/import_export_schema.py
+++ b/server/apps/operation_analysis/schemas/import_export_schema.py
@@ -103,7 +103,10 @@ class DatasourceItem(BaseModel):
 
     key: str
     name: str
-    rest_api: str
+    rest_api: str = Field(default="")
+    source_type: str = Field(default="nats")
+    connection_config: dict = Field(default_factory=dict)
+    query_config: dict = Field(default_factory=dict)
     desc: str = Field(default="")
     is_active: bool = Field(default=True)
     params: dict | list | None = Field(default_factory=list)
@@ -112,13 +115,31 @@ class DatasourceItem(BaseModel):
     field_schema: list = Field(default_factory=list)
     namespace_keys: list = Field(default_factory=list)
 
-    @field_validator("key", "name", "rest_api")
+    @field_validator("key", "name")
     @classmethod
     def validate_required_non_empty_fields(cls, v: Any, info) -> str:
         value = "" if v is None else str(v).strip()
         if not value:
             raise ValueError(f"字段 '{info.field_name}' 不能为空")
         return value
+
+    @field_validator("rest_api", mode="before")
+    @classmethod
+    def normalize_rest_api(cls, v: Any) -> str:
+        return "" if v is None else str(v).strip()
+
+    @field_validator("source_type")
+    @classmethod
+    def validate_source_type(cls, v: str) -> str:
+        if v not in {"nats", "mysql", "postgresql", "rest_api", "excel"}:
+            raise ValueError("source_type 不支持")
+        return v
+
+    @model_validator(mode="after")
+    def validate_nats_rest_api(self):
+        if self.source_type == "nats" and not self.rest_api:
+            raise ValueError("NATS 数据源的 rest_api 不能为空")
+        return self
 
 
 class CanvasRefs(BaseModel):

--- a/server/apps/operation_analysis/schemas/import_export_schema.py
+++ b/server/apps/operation_analysis/schemas/import_export_schema.py
@@ -16,6 +16,7 @@ from apps.operation_analysis.constants.import_export import (
     CANVAS_TYPES,
     OBJECT_TYPE_TO_SECTION,
     YAML_SCHEMA_VERSION,
+    YAML_SUPPORTED_SCHEMA_VERSIONS,
     ImportExportErrorCode,
     ObjectType,
 )
@@ -69,10 +70,10 @@ class YAMLMeta(BaseModel):
     @field_validator("schema_version")
     @classmethod
     def validate_schema_version(cls, v: str) -> str:
-        if v != YAML_SCHEMA_VERSION:
+        if v not in YAML_SUPPORTED_SCHEMA_VERSIONS:
             raise ImportExportValidationError(
                 code=ImportExportErrorCode.YAML_SCHEMA_INVALID,
-                message=f"不支持的schema版本: {v}，当前仅支持 {YAML_SCHEMA_VERSION}",
+                message=f"不支持的schema版本: {v}，当前支持 {', '.join(sorted(YAML_SUPPORTED_SCHEMA_VERSIONS))}",
             )
         return v
 

--- a/server/apps/operation_analysis/serializers/datasource_serializers.py
+++ b/server/apps/operation_analysis/serializers/datasource_serializers.py
@@ -5,41 +5,43 @@
 from rest_framework import serializers
 
 from apps.core.utils.serializers import AuthSerializer
+from apps.operation_analysis.constants.import_export import SENSITIVE_PLACEHOLDER, is_sensitive_field_name
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, DataSourceTag, NameSpace
 from apps.operation_analysis.serializers.base_serializers import BaseFormatTimeSerializer
 
-SENSITIVE_CONFIG_KEYWORDS = ("password", "token", "secret", "authorization", "api_key", "apikey")
-
 
 def redact_sensitive_config(value):
+    if isinstance(value, list):
+        return [redact_sensitive_config(item) for item in value]
     if not isinstance(value, dict):
         return value
 
     redacted = {}
     for key, item in value.items():
-        normalized_key = str(key).lower()
-        if any(keyword in normalized_key for keyword in SENSITIVE_CONFIG_KEYWORDS):
-            redacted[key] = "******" if item not in (None, "") else item
-        elif isinstance(item, dict):
-            redacted[key] = redact_sensitive_config(item)
+        if is_sensitive_field_name(key):
+            redacted[key] = SENSITIVE_PLACEHOLDER if item not in (None, "") else item
         else:
-            redacted[key] = item
+            redacted[key] = redact_sensitive_config(item)
     return redacted
 
 
 def merge_redacted_config(existing, incoming):
-    if not isinstance(existing, dict) or not isinstance(incoming, dict):
+    if isinstance(incoming, list):
+        existing_items = existing if isinstance(existing, list) else []
+        return [
+            merge_redacted_config(existing_items[index] if index < len(existing_items) else None, item)
+            for index, item in enumerate(incoming)
+        ]
+    if not isinstance(incoming, dict):
         return incoming
 
+    existing_items = existing if isinstance(existing, dict) else {}
     merged = {}
     for key, item in incoming.items():
-        normalized_key = str(key).lower()
-        if item == "******" and any(keyword in normalized_key for keyword in SENSITIVE_CONFIG_KEYWORDS):
-            merged[key] = existing.get(key)
-        elif isinstance(item, dict):
-            merged[key] = merge_redacted_config(existing.get(key, {}), item)
+        if item == SENSITIVE_PLACEHOLDER and is_sensitive_field_name(key):
+            merged[key] = existing_items.get(key)
         else:
-            merged[key] = item
+            merged[key] = merge_redacted_config(existing_items.get(key), item)
     return merged
 
 
@@ -77,6 +79,8 @@ class DataSourceAPIModelSerializer(BaseFormatTimeSerializer, AuthSerializer):
             return {}
         if not isinstance(value, dict):
             raise serializers.ValidationError("query_config 必须为对象")
+        if self.instance:
+            return merge_redacted_config(self.instance.query_config or {}, value)
         return value
 
     def validate_field_schema(self, value):
@@ -100,6 +104,7 @@ class DataSourceAPIModelSerializer(BaseFormatTimeSerializer, AuthSerializer):
     def to_representation(self, instance):
         data = super().to_representation(instance)
         data["connection_config"] = redact_sensitive_config(data.get("connection_config"))
+        data["query_config"] = redact_sensitive_config(data.get("query_config"))
         return data
 
 

--- a/server/apps/operation_analysis/services/import_export/export_service.py
+++ b/server/apps/operation_analysis/services/import_export/export_service.py
@@ -15,11 +15,11 @@ from apps.operation_analysis.constants.import_export import (
     BUSINESS_KEY_SEPARATOR,
     CANVAS_TYPES,
     OBJECT_TYPE_TO_SECTION,
-    SENSITIVE_FIELDS,
     SENSITIVE_PLACEHOLDER,
     YAML_SCHEMA_VERSION,
     ObjectType,
     ScopeType,
+    is_sensitive_field_name,
 )
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
 from apps.operation_analysis.models.models import Architecture, Dashboard, NetworkTopology, Report, Screen, Topology
@@ -74,22 +74,23 @@ class ExportService:
             return f"{object_type.value}{BUSINESS_KEY_SEPARATOR}{obj.name}"
 
     @staticmethod
-    def mask_sensitive_fields(data: dict) -> dict:
+    def mask_sensitive_fields(data: Any) -> Any:
         """
         对敏感字段进行脱敏处理
 
-        遍历字典，将SENSITIVE_FIELDS中定义的字段值替换为占位符。
+        遍历字典，将敏感字段值替换为占位符。
         """
+        if isinstance(data, list):
+            return [ExportService.mask_sensitive_fields(item) for item in data]
+        if not isinstance(data, dict):
+            return data
+
         result = {}
         for key, value in data.items():
-            if key in SENSITIVE_FIELDS and value:
+            if is_sensitive_field_name(key) and value:
                 result[key] = SENSITIVE_PLACEHOLDER
-            elif isinstance(value, dict):
-                result[key] = ExportService.mask_sensitive_fields(value)
-            elif isinstance(value, list):
-                result[key] = [ExportService.mask_sensitive_fields(item) if isinstance(item, dict) else item for item in value]
             else:
-                result[key] = value
+                result[key] = ExportService.mask_sensitive_fields(value)
         return result
 
     @staticmethod
@@ -119,6 +120,9 @@ class ExportService:
                 "key": ExportService.generate_business_key(ds, ObjectType.DATASOURCE),
                 "name": ds.name,
                 "rest_api": ds.rest_api,
+                "source_type": ds.source_type,
+                "connection_config": ds.connection_config or {},
+                "query_config": ds.query_config or {},
                 "desc": ds.desc or "",
                 # [内部预留] is_active 字段仅内部使用，无产品功能依赖
                 "is_active": ds.is_active,

--- a/server/apps/operation_analysis/services/import_export/import_service.py
+++ b/server/apps/operation_analysis/services/import_export/import_service.py
@@ -13,10 +13,19 @@ Tech Plan参考：
 - 5.3 导入执行流程
 """
 
+from copy import deepcopy
+
 from django.db import transaction
 
 from apps.core.logger import operation_analysis_logger as logger
-from apps.operation_analysis.constants.import_export import RENAME_SUFFIX, SENSITIVE_PLACEHOLDER, ConflictAction, ImportStatus, ObjectType
+from apps.operation_analysis.constants.import_export import (
+    RENAME_SUFFIX,
+    SENSITIVE_PLACEHOLDER,
+    ConflictAction,
+    ImportStatus,
+    ObjectType,
+    is_sensitive_field_name,
+)
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, DataSourceTag, NameSpace
 from apps.operation_analysis.models.models import Architecture, Dashboard, Directory, NetworkTopology, Report, Screen, Topology
 from apps.operation_analysis.schemas.import_export_schema import (
@@ -100,6 +109,61 @@ class ImportService:
         """获取敏感字段的补充值"""
         supplements = self.secret_supplements.get(object_key, {})
         return supplements.get(field, default)
+
+    @staticmethod
+    def _nested_value(value, path):
+        current = value
+        for item in path:
+            if isinstance(item, str) and isinstance(current, dict):
+                current = current.get(item)
+            elif isinstance(item, int) and isinstance(current, list) and item < len(current):
+                current = current[item]
+            else:
+                return None
+        return current
+
+    def _resolve_config_placeholders(self, object_key: str, field: str, config: dict, existing: dict | None = None):
+        """用显式补密值或覆盖目标中的原值替换连接器配置里的脱敏占位符。"""
+        resolved = deepcopy(config)
+        missing = []
+        supplements = self.secret_supplements.get(object_key, {})
+
+        def visit(value, path, display_path):
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    item_path = (*path, key)
+                    item_display_path = f"{display_path}.{key}"
+                    if item == SENSITIVE_PLACEHOLDER and is_sensitive_field_name(key):
+                        replacement = supplements.get(item_display_path, supplements.get(str(key)))
+                        if replacement in (None, "", SENSITIVE_PLACEHOLDER) and existing is not None:
+                            replacement = self._nested_value(existing, item_path)
+                        if replacement in (None, "", SENSITIVE_PLACEHOLDER):
+                            missing.append(item_display_path)
+                        else:
+                            value[key] = replacement
+                    else:
+                        visit(item, item_path, item_display_path)
+            elif isinstance(value, list):
+                for index, item in enumerate(value):
+                    visit(item, (*path, index), f"{display_path}[{index}]")
+
+        visit(resolved, (), field)
+        return resolved, missing
+
+    def _prepare_datasource_configs(self, ds_item: DatasourceItem, existing: DataSourceAPIModel | None = None):
+        connection_config, missing_connection = self._resolve_config_placeholders(
+            ds_item.key,
+            "connection_config",
+            ds_item.connection_config,
+            existing.connection_config if existing else None,
+        )
+        query_config, missing_query = self._resolve_config_placeholders(
+            ds_item.key,
+            "query_config",
+            ds_item.query_config,
+            existing.query_config if existing else None,
+        )
+        return connection_config, query_config, missing_connection + missing_query
 
     def _generate_rename_name(self, original_name: str, model) -> str:
         """
@@ -289,7 +353,19 @@ class ImportService:
                 return existing.id
 
             elif action == ConflictAction.OVERWRITE.value:
+                connection_config, query_config, missing_secrets = self._prepare_datasource_configs(ds_item, existing)
+                if missing_secrets:
+                    self._record_result(
+                        ds_item.key,
+                        ObjectType.DATASOURCE.value,
+                        ImportStatus.FAILED.value,
+                        f"数据源缺少敏感配置: {', '.join(missing_secrets)}",
+                    )
+                    return None
                 existing.desc = ds_item.desc
+                existing.source_type = ds_item.source_type
+                existing.connection_config = connection_config
+                existing.query_config = query_config
                 # [内部预留] is_active 字段仅内部使用，无产品功能依赖
                 existing.is_active = ds_item.is_active
                 existing.params = ds_item.params
@@ -309,10 +385,22 @@ class ImportService:
                 return existing.id
 
             else:  # rename
+                connection_config, query_config, missing_secrets = self._prepare_datasource_configs(ds_item)
+                if missing_secrets:
+                    self._record_result(
+                        ds_item.key,
+                        ObjectType.DATASOURCE.value,
+                        ImportStatus.FAILED.value,
+                        f"数据源缺少敏感配置: {', '.join(missing_secrets)}",
+                    )
+                    return None
                 new_name = self._generate_rename_name(ds_item.name, DataSourceAPIModel)
                 ds = DataSourceAPIModel.objects.create(
                     name=new_name,
                     rest_api=ds_item.rest_api,
+                    source_type=ds_item.source_type,
+                    connection_config=connection_config,
+                    query_config=query_config,
                     desc=ds_item.desc,
                     # [内部预留] is_active 字段仅内部使用，无产品功能依赖
                     is_active=ds_item.is_active,
@@ -335,9 +423,21 @@ class ImportService:
                 return ds.id
         else:
             # 新建
+            connection_config, query_config, missing_secrets = self._prepare_datasource_configs(ds_item)
+            if missing_secrets:
+                self._record_result(
+                    ds_item.key,
+                    ObjectType.DATASOURCE.value,
+                    ImportStatus.FAILED.value,
+                    f"数据源缺少敏感配置: {', '.join(missing_secrets)}",
+                )
+                return None
             ds = DataSourceAPIModel.objects.create(
                 name=ds_item.name,
                 rest_api=ds_item.rest_api,
+                source_type=ds_item.source_type,
+                connection_config=connection_config,
+                query_config=query_config,
                 desc=ds_item.desc,
                 # [内部预留] is_active 字段仅内部使用，无产品功能依赖
                 is_active=ds_item.is_active,

--- a/server/apps/operation_analysis/services/import_export/precheck_service.py
+++ b/server/apps/operation_analysis/services/import_export/precheck_service.py
@@ -26,6 +26,7 @@ from apps.operation_analysis.constants.import_export import (
     ImportExportErrorCode,
     ImportExportWarningCode,
     ObjectType,
+    is_sensitive_field_name,
 )
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
 from apps.operation_analysis.models.models import Architecture, Dashboard, NetworkTopology, Report, Screen, Topology
@@ -241,6 +242,33 @@ class PrecheckService:
                         "field": "token",
                     }
                 )
+
+        def collect_config_placeholders(value, path=""):
+            placeholders = []
+            if isinstance(value, dict):
+                for key, item in value.items():
+                    item_path = f"{path}.{key}" if path else str(key)
+                    if item == SENSITIVE_PLACEHOLDER and is_sensitive_field_name(key):
+                        placeholders.append(item_path)
+                    else:
+                        placeholders.extend(collect_config_placeholders(item, item_path))
+            elif isinstance(value, list):
+                for index, item in enumerate(value):
+                    placeholders.extend(collect_config_placeholders(item, f"{path}[{index}]"))
+            return placeholders
+
+        for datasource in doc.datasources:
+            for config_field in ("connection_config", "query_config"):
+                config = getattr(datasource, config_field)
+                for field_path in collect_config_placeholders(config, config_field):
+                    warnings.append(
+                        {
+                            "code": ImportExportWarningCode.SECRET_PLACEHOLDER,
+                            "message": f"数据源 '{datasource.name}' 的 {field_path} 字段需要补充",
+                            "object_key": datasource.key,
+                            "field": field_path,
+                        }
+                    )
 
         return warnings
 

--- a/server/apps/operation_analysis/tests/test_datasource_filters_serializers.py
+++ b/server/apps/operation_analysis/tests/test_datasource_filters_serializers.py
@@ -199,6 +199,35 @@ def test_datasource_serializer_preserves_redacted_connection_secret(authenticate
     assert serializer.validated_data["connection_config"]["password"] == "real-password"
 
 
+@pytest.mark.django_db
+def test_datasource_serializer_redacts_and_preserves_nested_separator_variants(authenticated_user):
+    from apps.operation_analysis.serializers.datasource_serializers import DataSourceAPIModelSerializer
+
+    datasource = DataSourceAPIModel.objects.create(
+        name="rest-source",
+        rest_api="",
+        source_type="rest_api",
+        connection_config={"headers": {"X-API-Key": "real-api-key"}},
+        query_config={"body": {"items": [{"client-secret": "real-client-secret"}]}},
+        groups=[1],
+        created_by="s",
+        updated_by="s",
+    )
+
+    output = DataSourceAPIModelSerializer(datasource, context={"request": _serializer_request(authenticated_user)}).data
+    assert output["connection_config"]["headers"]["X-API-Key"] == "******"
+    assert output["query_config"]["body"]["items"][0]["client-secret"] == "******"
+
+    serializer = DataSourceAPIModelSerializer(
+        datasource,
+        context={"request": _serializer_request(authenticated_user)},
+        data={**output, "namespaces": [], "tag": []},
+    )
+    assert serializer.is_valid(), serializer.errors
+    assert serializer.validated_data["connection_config"]["headers"]["X-API-Key"] == "real-api-key"
+    assert serializer.validated_data["query_config"]["body"]["items"][0]["client-secret"] == "real-client-secret"
+
+
 # --------------------------------------------------------------------------
 # schema 校验工具函数
 # --------------------------------------------------------------------------

--- a/server/apps/operation_analysis/tests/test_export_and_viewsets.py
+++ b/server/apps/operation_analysis/tests/test_export_and_viewsets.py
@@ -195,13 +195,18 @@ def test_generate_business_key_variants():
 
 
 def test_mask_sensitive_fields_nested():
-    data = {"password": "p", "nested": {"token": "t", "ok": 1}, "list": [{"secret": "s"}, 2]}
+    data = {
+        "password": "p",
+        "nested": {"token": "t", "ok": 1},
+        "list": [{"secret": "s"}, 2, [[{"api_key": "deep-secret"}]]],
+    }
     out = ExportService.mask_sensitive_fields(data)
     assert out["password"] == "******"
     assert out["nested"]["token"] == "******"
     assert out["nested"]["ok"] == 1
     assert out["list"][0]["secret"] == "******"
     assert out["list"][1] == 2
+    assert out["list"][2][0][0]["api_key"] == "******"
 
 
 def test_extract_canvas_dependencies_collects_datasource_ids():
@@ -257,7 +262,20 @@ def test_export_config_namespace():
 @pytest.mark.django_db
 def test_export_config_datasource_pulls_in_namespace():
     ns = NameSpace.objects.create(name="ns-a", domain="d", account="a", password="p")
-    ds = DataSourceAPIModel.objects.create(name="ds-a", rest_api="monitor/q", created_by="s", updated_by="s")
+    ds = DataSourceAPIModel.objects.create(
+        name="ds-a",
+        rest_api="",
+        source_type=DataSourceAPIModel.SOURCE_TYPE_MYSQL,
+        connection_config={
+            "host": "db.example.com",
+            "username": "reader",
+            "password": "db-secret",
+            "headers": {"Authorization": "Bearer secret"},
+        },
+        query_config={"table": "orders"},
+        created_by="s",
+        updated_by="s",
+    )
     ds.namespaces.set([ns.id])
     tag = DataSourceTag.objects.create(tag_id="t1", name="Tag1", created_by="s", updated_by="s")
     ds.tag.set([tag.id])
@@ -269,6 +287,15 @@ def test_export_config_datasource_pulls_in_namespace():
     assert parsed["meta"]["object_counts"]["namespaces"] == 1
     assert parsed["datasources"][0]["namespace_keys"] == ["ns-a"]
     assert parsed["datasources"][0]["tags"] == ["Tag1"]
+    assert parsed["datasources"][0]["rest_api"] == ""
+    assert parsed["datasources"][0]["source_type"] == "mysql"
+    assert parsed["datasources"][0]["connection_config"] == {
+        "host": "db.example.com",
+        "username": "reader",
+        "password": "******",
+        "headers": {"Authorization": "******"},
+    }
+    assert parsed["datasources"][0]["query_config"] == {"table": "orders"}
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/tests/test_export_and_viewsets.py
+++ b/server/apps/operation_analysis/tests/test_export_and_viewsets.py
@@ -197,12 +197,13 @@ def test_generate_business_key_variants():
 def test_mask_sensitive_fields_nested():
     data = {
         "password": "p",
-        "nested": {"token": "t", "ok": 1},
+        "nested": {"token": "t", "ok": 1, "X-API-Key": "header-secret"},
         "list": [{"secret": "s"}, 2, [[{"api_key": "deep-secret"}]]],
     }
     out = ExportService.mask_sensitive_fields(data)
     assert out["password"] == "******"
     assert out["nested"]["token"] == "******"
+    assert out["nested"]["X-API-Key"] == "******"
     assert out["nested"]["ok"] == 1
     assert out["list"][0]["secret"] == "******"
     assert out["list"][1] == 2

--- a/server/apps/operation_analysis/tests/test_import_service.py
+++ b/server/apps/operation_analysis/tests/test_import_service.py
@@ -310,7 +310,10 @@ def test_import_new_datasource_rejects_unresolved_secret_placeholder():
 
 
 def test_datasource_schema_keeps_legacy_defaults_and_accepts_blank_rest_api():
-    legacy_datasource = _doc(datasources=[_ds_section()]).datasources[0]
+    legacy_datasource = YAMLDocument(
+        meta={"schema_version": "1.1.0"},
+        datasources=[_ds_section()],
+    ).datasources[0]
     connector_datasource = _doc(datasources=[_ds_section(rest_api=None, source_type="mysql")]).datasources[0]
 
     assert legacy_datasource.source_type == "nats"

--- a/server/apps/operation_analysis/tests/test_import_service.py
+++ b/server/apps/operation_analysis/tests/test_import_service.py
@@ -13,6 +13,7 @@ from apps.operation_analysis.models.datasource_models import DataSourceAPIModel,
 from apps.operation_analysis.models.models import Dashboard, Directory, Topology
 from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 from apps.operation_analysis.services.import_export.import_service import ImportService
+from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
 from apps.operation_analysis.views import view as view_module
 
 
@@ -227,6 +228,119 @@ def test_import_datasource_overwrite_existing():
     assert result["summary"]["overwritten"] == 1
     existing.refresh_from_db()
     assert existing.desc == "new desc"
+
+
+@pytest.mark.django_db
+def test_import_non_nats_datasource_restores_connector_contract_and_secret():
+    doc = _doc(
+        datasources=[
+            _ds_section(
+                key="mysql-source::",
+                name="mysql-source",
+                rest_api="",
+                source_type="mysql",
+                connection_config={"host": "db.example.com", "password": "******"},
+                query_config={"table": "orders"},
+            )
+        ]
+    )
+
+    result = _service(
+        doc,
+        secret_supplements={"mysql-source::": {"connection_config.password": "real-password"}},
+    ).execute()
+
+    assert result["success"] is True
+    datasource = DataSourceAPIModel.objects.get(name="mysql-source")
+    assert datasource.rest_api == ""
+    assert datasource.source_type == "mysql"
+    assert datasource.connection_config == {"host": "db.example.com", "password": "real-password"}
+    assert datasource.query_config == {"table": "orders"}
+
+
+@pytest.mark.django_db
+def test_import_datasource_overwrite_preserves_redacted_target_secret():
+    existing = DataSourceAPIModel.objects.create(
+        name="mysql-source",
+        rest_api="",
+        source_type="mysql",
+        connection_config={"host": "old.example.com", "password": "target-password"},
+        query_config={"table": "old_table"},
+        created_by="s",
+        updated_by="s",
+    )
+    doc = _doc(
+        datasources=[
+            _ds_section(
+                key="mysql-source::",
+                name="mysql-source",
+                rest_api="",
+                source_type="mysql",
+                connection_config={"host": "new.example.com", "password": "******"},
+                query_config={"table": "new_table"},
+            )
+        ]
+    )
+
+    result = _service(doc, conflict_decisions={"mysql-source::": ConflictAction.OVERWRITE.value}).execute()
+
+    assert result["success"] is True
+    existing.refresh_from_db()
+    assert existing.connection_config == {"host": "new.example.com", "password": "target-password"}
+    assert existing.query_config == {"table": "new_table"}
+
+
+@pytest.mark.django_db
+def test_import_new_datasource_rejects_unresolved_secret_placeholder():
+    doc = _doc(
+        datasources=[
+            _ds_section(
+                source_type="rest_api",
+                rest_api="",
+                connection_config={"headers": {"Authorization": "******"}},
+            )
+        ]
+    )
+
+    result = _service(doc).execute()
+
+    assert result["success"] is False
+    assert "connection_config.headers.Authorization" in result["results"][0]["message"]
+    assert not DataSourceAPIModel.objects.exists()
+
+
+def test_datasource_schema_keeps_legacy_defaults_and_accepts_blank_rest_api():
+    legacy_datasource = _doc(datasources=[_ds_section()]).datasources[0]
+    connector_datasource = _doc(datasources=[_ds_section(rest_api=None, source_type="mysql")]).datasources[0]
+
+    assert legacy_datasource.source_type == "nats"
+    assert legacy_datasource.connection_config == {}
+    assert legacy_datasource.query_config == {}
+    assert connector_datasource.rest_api == ""
+    assert connector_datasource.source_type == "mysql"
+
+
+def test_precheck_warns_for_nested_datasource_secret_placeholder():
+    doc = _doc(
+        datasources=[
+            _ds_section(
+                source_type="rest_api",
+                rest_api="",
+                connection_config={"headers": {"Authorization": "******"}},
+            )
+        ]
+    )
+
+    warnings = PrecheckService.check_sensitive_placeholders(doc)
+
+    assert warnings == [
+        {
+            "code": "OA_SECRET_PLACEHOLDER",
+            "message": "数据源 'ds-a' 的 connection_config.headers.Authorization 字段需要补充",
+            "object_key": "ds1::api/x",
+            "field": "connection_config.headers.Authorization",
+        }
+    ]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

数据源模型已经支持 MySQL、PostgreSQL、REST API 和 Excel 等连接器，但 YAML
导入导出契约仍只承载旧的 NATS 字段。非 NATS 数据源经过导出再导入后会丢失
连接器类型、连接配置和查询配置，并回落为默认 NATS 数据源。

## 根因

连接器模型扩展后，Schema、导出序列化、导入创建与覆盖、预检逻辑没有同步演进，
导致持久化模型和迁移契约之间出现断层；敏感配置也缺少递归脱敏与补密规则。

## 怎么修的

- 在 YAML 数据源契约中补充 `source_type`、`connection_config` 和 `query_config`，同时兼容旧 YAML 的默认值。
- 导出连接器配置时递归识别并脱敏密码、令牌、Authorization 和 API Key。
- 导入创建、覆盖和重命名路径统一恢复连接器配置；脱敏占位符优先使用显式补密值，覆盖时可保留目标对象原密钥。
- 预检阶段提前报告无法补全的敏感配置，避免导入到一半才留下错误对象。

## 影响范围

改动仅覆盖运营分析的数据源 YAML 导入导出链路，不改变数据源运行时查询协议和权限边界。
旧版 NATS YAML 继续按默认 `source_type=nats` 导入；非 NATS 数据源获得完整往返能力。

## 调用链

```mermaid
flowchart TD
    subgraph T["导出层"]
        T1["convert_datasource_to_yaml\nexport_service.py"]
    end

    Y["YAML 数据源契约\nimport_export_schema.py"]

    subgraph N["导入层"]
        N1["precheck\nprecheck_service.py"]
        N2["import_datasource\nimport_service.py"]
    end

    S["敏感配置补密或保留"]

    T1 --> Y --> N1 --> N2 --> S
    N1 -. "缺少密钥" .-> S
```

## 验证

- `apps/operation_analysis/tests/test_export_and_viewsets.py`
- `apps/operation_analysis/tests/test_import_service.py`
- 共 49 项关联测试通过。

Closes #4121
