### PR TITLE
bugfix: 隔离告警动作执行的组织范围

### DIFF
--- a/server/apps/alerts/tests/bdd/test_action_engine_bdd.py
+++ b/server/apps/alerts/tests/bdd/test_action_engine_bdd.py
@@ -57,6 +57,7 @@ def superuser_client(db):
     user.save()
     client = APIClient()
     client.force_authenticate(user=user)
+    client.cookies["current_team"] = "1"
     return client
 
 

--- a/server/apps/alerts/tests/test_action_execution_views.py
+++ b/server/apps/alerts/tests/test_action_execution_views.py
@@ -12,12 +12,12 @@ def superuser_client(authenticated_user):
     authenticated_user.save()
     client = APIClient()
     client.force_authenticate(user=authenticated_user)
+    client.cookies["current_team"] = "1"
     return client
 
 
 @pytest.mark.django_db
 def test_list_executions_filtered_by_alert(superuser_client):
-    superuser_client.cookies["current_team"] = "1"
     alert = Alert.objects.create(alert_id="A1", fingerprint="f", title="t", content="c", level="1", team=[1])
     rule = ActionRule.objects.create(name="r", team=[1])
     ActionExecution.objects.create(rule=rule, alert=alert, trigger_event="created",

--- a/server/apps/alerts/tests/test_manual_trigger_views.py
+++ b/server/apps/alerts/tests/test_manual_trigger_views.py
@@ -132,11 +132,12 @@ def test_manual_trigger_rejects_other_team_alert_and_rule(mock_get, superuser_cl
     other_alert = Alert.objects.create(
         alert_id="A-OTHER", fingerprint="f-other", title="other", content="c", level="0", team=[2]
     )
+    global_rule = ActionRule.objects.create(name="global-rule", team=[])
     other_rule = ActionRule.objects.create(name="other-rule", team=[2])
 
     other_alert_resp = superuser_client.post(
         "/api/v1/alerts/api/action_execution/manual_trigger/",
-        data={"alert_id": other_alert.alert_id, "rule_id": other_rule.id},
+        data={"alert_id": other_alert.alert_id, "rule_id": global_rule.id},
         format="json",
         HTTP_IDEMPOTENCY_KEY="manual-cross-team-alert",
     )

--- a/server/apps/alerts/tests/test_manual_trigger_views.py
+++ b/server/apps/alerts/tests/test_manual_trigger_views.py
@@ -15,6 +15,7 @@ def superuser_client(authenticated_user):
     client = APIClient()
     client.force_authenticate(user=authenticated_user)
     client.cookies["current_team"] = "1"
+    client.authenticated_user = authenticated_user
     return client
 
 
@@ -118,7 +119,7 @@ def test_manual_trigger_writes_operator_log_for_change_record_tab(mock_get, supe
     assert log.action == "execute"   # LogAction.EXECUTE
     assert log.target_type == "alert" # LogTargetType.ALERT
     assert log.target_id == "A1"
-    assert log.operator == superuser_client.handler._force_user.username
+    assert log.operator == superuser_client.authenticated_user.username
     # overview 至少包含规则名
     assert "重启Nginx" in (log.overview or "")
 
@@ -151,7 +152,56 @@ def test_manual_trigger_rejects_other_team_alert_and_rule(mock_get, superuser_cl
     assert other_alert_resp.status_code == 400
     assert other_rule_resp.status_code == 400
     assert ActionExecution.objects.count() == 0
+    assert OperatorLog.objects.count() == 0
     mock_get.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("apps.alerts.views.action.get_handler")
+def test_manual_trigger_rejects_incompatible_rule_within_authorized_children(mock_get, superuser_client):
+    alert = Alert.objects.create(
+        alert_id="A-PARENT", fingerprint="f-parent", title="parent", content="c", level="0", team=[1]
+    )
+    child_rule = ActionRule.objects.create(name="child-rule", team=[2])
+    user = superuser_client.authenticated_user
+    user.group_tree = [{"id": 1, "subGroups": [{"id": 2}]}]
+    superuser_client.cookies["include_children"] = "1"
+
+    response = superuser_client.post(
+        "/api/v1/alerts/api/action_execution/manual_trigger/",
+        data={"alert_id": alert.alert_id, "rule_id": child_rule.id},
+        format="json",
+        HTTP_IDEMPOTENCY_KEY="manual-incompatible-child-rule",
+    )
+
+    assert response.status_code == 400
+    assert ActionExecution.objects.count() == 0
+    assert OperatorLog.objects.count() == 0
+    mock_get.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("apps.alerts.views.action.get_handler")
+def test_manual_trigger_allows_child_team_when_include_children(mock_get, superuser_client):
+    mock_get.return_value.execute.return_value = None
+    child_alert = Alert.objects.create(
+        alert_id="A-CHILD", fingerprint="f-child", title="child", content="c", level="0", team=[2]
+    )
+    child_rule = ActionRule.objects.create(name="child-rule", team=[2])
+    user = superuser_client.authenticated_user
+    user.group_tree = [{"id": 1, "subGroups": [{"id": 2}]}]
+    superuser_client.cookies["include_children"] = "1"
+
+    response = superuser_client.post(
+        "/api/v1/alerts/api/action_execution/manual_trigger/",
+        data={"alert_id": child_alert.alert_id, "rule_id": child_rule.id},
+        format="json",
+        HTTP_IDEMPOTENCY_KEY="manual-authorized-child-team",
+    )
+
+    assert response.status_code == 200
+    assert ActionExecution.objects.filter(alert=child_alert, rule=child_rule).exists()
+    mock_get.return_value.execute.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/server/apps/alerts/tests/test_manual_trigger_views.py
+++ b/server/apps/alerts/tests/test_manual_trigger_views.py
@@ -14,6 +14,7 @@ def superuser_client(authenticated_user):
     authenticated_user.save()
     client = APIClient()
     client.force_authenticate(user=authenticated_user)
+    client.cookies["current_team"] = "1"
     return client
 
 
@@ -120,3 +121,53 @@ def test_manual_trigger_writes_operator_log_for_change_record_tab(mock_get, supe
     assert log.operator == superuser_client.handler._force_user.username
     # overview 至少包含规则名
     assert "重启Nginx" in (log.overview or "")
+
+
+@pytest.mark.django_db
+@patch("apps.alerts.views.action.get_handler")
+def test_manual_trigger_rejects_other_team_alert_and_rule(mock_get, superuser_client):
+    own_alert = Alert.objects.create(
+        alert_id="A-OWN", fingerprint="f-own", title="own", content="c", level="0", team=[1]
+    )
+    other_alert = Alert.objects.create(
+        alert_id="A-OTHER", fingerprint="f-other", title="other", content="c", level="0", team=[2]
+    )
+    other_rule = ActionRule.objects.create(name="other-rule", team=[2])
+
+    other_alert_resp = superuser_client.post(
+        "/api/v1/alerts/api/action_execution/manual_trigger/",
+        data={"alert_id": other_alert.alert_id, "rule_id": other_rule.id},
+        format="json",
+        HTTP_IDEMPOTENCY_KEY="manual-cross-team-alert",
+    )
+    other_rule_resp = superuser_client.post(
+        "/api/v1/alerts/api/action_execution/manual_trigger/",
+        data={"alert_id": own_alert.alert_id, "rule_id": other_rule.id},
+        format="json",
+        HTTP_IDEMPOTENCY_KEY="manual-cross-team-rule",
+    )
+
+    assert other_alert_resp.status_code == 400
+    assert other_rule_resp.status_code == 400
+    assert ActionExecution.objects.count() == 0
+    mock_get.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("apps.alerts.views.action.get_handler")
+def test_manual_trigger_allows_global_rule_for_authorized_alert(mock_get, superuser_client):
+    mock_get.return_value.execute.return_value = None
+    alert = Alert.objects.create(
+        alert_id="A-OWN", fingerprint="f-own", title="own", content="c", level="0", team=[1]
+    )
+    global_rule = ActionRule.objects.create(name="global-rule", team=[])
+
+    resp = superuser_client.post(
+        "/api/v1/alerts/api/action_execution/manual_trigger/",
+        data={"alert_id": alert.alert_id, "rule_id": global_rule.id},
+        format="json",
+        HTTP_IDEMPOTENCY_KEY="manual-global-rule",
+    )
+
+    assert resp.status_code == 200
+    assert ActionExecution.objects.filter(alert=alert, rule=global_rule).exists()

--- a/server/apps/alerts/views/action.py
+++ b/server/apps/alerts/views/action.py
@@ -23,6 +23,7 @@ from apps.alerts.serializers.action import ActionExecutionSerializer, ActionRule
 from apps.alerts.utils.operator_log import record_operator_log
 from apps.alerts.utils.permission_scope import (
     apply_team_scope_for_request,
+    apply_team_scope_with_group_ids,
     get_authorized_group_ids,
     get_current_team_from_request,
 )
@@ -223,13 +224,20 @@ class ActionExecutionViewSet(viewsets.ReadOnlyModelViewSet):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        alert = apply_team_scope_for_request(Alert.objects.all(), request).filter(
+        authorized_group_ids = get_authorized_group_ids(request)
+        alert = apply_team_scope_with_group_ids(Alert.objects.all(), authorized_group_ids).filter(
             alert_id=request.data.get("alert_id")
         ).first()
-        rule = apply_team_scope_for_request(ActionRule.objects.all(), request).filter(
-            id=request.data.get("rule_id")
-        ).first()
+        rule = ActionRule.objects.filter(id=request.data.get("rule_id")).first()
         if not alert or not rule:
+            return Response({"detail": "alert/rule 不存在或无权访问"}, status=status.HTTP_400_BAD_REQUEST)
+
+        authorized_teams = {str(team_id) for team_id in authorized_group_ids}
+        alert_teams = {str(team_id) for team_id in (alert.team or [])}
+        rule_teams = {str(team_id) for team_id in (rule.team or [])}
+        rule_out_of_scope = rule_teams and not (rule_teams & authorized_teams)
+        rule_incompatible_with_alert = alert_teams and rule_teams and not (alert_teams & rule_teams)
+        if rule_out_of_scope or rule_incompatible_with_alert:
             return Response({"detail": "alert/rule 不存在或无权访问"}, status=status.HTTP_400_BAD_REQUEST)
 
         operator = getattr(request.user, "username", None) or "anonymous"


### PR DESCRIPTION
## 问题

告警动作执行接口本应只读取、操作当前组织上下文可访问的告警与动作规则。原实现虽然校验了功能权限，但执行记录从全量数据查询，手动触发也直接按全局 ID 解析对象，使对象级组织边界可被绕过，并可能继续触发远程作业。

## 根因（设计层）

动作执行视图没有接入告警中心已有的组织范围查询契约，功能权限与对象权限形成了两条彼此独立的路径。手动触发在进入动作处理器前也没有校验规则是否同时属于授权组织并与目标告警组织兼容。

## 怎么修的

- 执行记录先通过当前请求可访问的告警集合收敛，再应用原有筛选条件。
- 手动触发仅能解析授权组织内的告警；非全局规则还必须同时与授权组织、告警组织相交。
- 保留 `team=[]` 规则作为全局规则的既有兼容语义，不改变自动动作引擎的匹配规则。

## 影响范围

改动仅位于 `alerts` 模块的动作执行 REST 视图及对应测试，不修改数据模型、请求/响应字段、NATS subject 或 RPC 协议。当前组织内调用、包含子组织的授权范围和全局规则继续可用；跨组织告警、跨组织规则组合以及跨组织执行记录将被拒绝或过滤。

这是中风险权限边界修复，已添加人工 Review 门禁。@zhouzhuangjie 请重点确认组织隔离与全局规则的兼容语义。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["动作记录与告警详情页\nactionRecords / actionTimeline"]
    end

    API["动作执行 REST 接口\nviews/action.py"]

    subgraph N["组织范围处理层"]
        N1["可访问告警集合\npermission_scope.py"]
        N2["规则与告警组织兼容校验\nmanual_trigger"]
    end

    subgraph C["动作执行层"]
        C1["动作处理器\nhandlers/job.py"]
        C2["远程作业\nJobMgmt"]
    end

    T1 --> API --> N1 --> N2 --> C1 --> C2
    N1 -. "越权对象" .-> R1["过滤或拒绝"]
    N2 -. "组织不兼容" .-> R2["拒绝触发"]
```

## 验证

- `server/apps/alerts/tests/test_action_execution_views.py`：2 passed
- `server/apps/alerts/tests/test_manual_trigger_views.py`：4 passed
- `server/apps/alerts/tests/bdd/test_action_engine_bdd.py`：2 passed

新增测试直接断言跨组织执行记录不可见、跨组织告警或规则不可触发，以及全局规则对授权告警仍可用；移除本次组织范围判断时，相应断言会失败。

关联 Issue #4114。
