### PR TITLE
Fix host metric tooltip plugin scoping

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -626,8 +626,7 @@ def monitor_metrics(monitor_obj_id: str, *args, **kwargs):
     user_info = kwargs.get("user_info", {}) or {}
     locale = user_info.get("locale", "en")
     lan = LanguageLoader(app=LanguageConstants.APP, default_lang=locale)
-    for metric, result in zip(metrics, results):
-        result["monitor_plugin_name"] = metric.monitor_plugin.name if metric.monitor_plugin else ""
+    for result in results:
         lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC}.{monitor_obj.name}.{result['name']}"
         result["display_name"] = lan.get(f"{lan_key}.name") or result.get("display_name") or result["name"]
         result["display_description"] = lan.get(f"{lan_key}.desc") or result.get("description")

--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -615,14 +615,19 @@ def monitor_metrics(monitor_obj_id: str, *args, **kwargs):
         return {"result": False, "data": [], "message": "监控对象不存在"}
 
     # 查询监控对象关联的指标
-    metrics = Metric.objects.filter(monitor_object=monitor_obj).order_by("metric_group__sort_order", "sort_order")
+    metrics = (
+        Metric.objects.filter(monitor_object=monitor_obj)
+        .select_related("monitor_plugin")
+        .order_by("metric_group__sort_order", "sort_order")
+    )
 
     serializer = MetricSerializer(metrics, many=True)
     results = serializer.data
     user_info = kwargs.get("user_info", {}) or {}
     locale = user_info.get("locale", "en")
     lan = LanguageLoader(app=LanguageConstants.APP, default_lang=locale)
-    for result in results:
+    for metric, result in zip(metrics, results):
+        result["monitor_plugin_name"] = metric.monitor_plugin.name if metric.monitor_plugin else ""
         lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC}.{monitor_obj.name}.{result['name']}"
         result["display_name"] = lan.get(f"{lan_key}.name") or result.get("display_name") or result["name"]
         result["display_description"] = lan.get(f"{lan_key}.desc") or result.get("description")

--- a/server/apps/monitor/serializers/monitor_metrics.py
+++ b/server/apps/monitor/serializers/monitor_metrics.py
@@ -47,6 +47,7 @@ class MetricGroupSerializer(serializers.ModelSerializer):
 class MetricSerializer(serializers.ModelSerializer):
     # 这里定义 is_pre 但不给默认值，防止用户传递该字段
     is_pre = serializers.BooleanField(read_only=True)
+    monitor_plugin_name = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Metric
@@ -68,6 +69,9 @@ class MetricSerializer(serializers.ModelSerializer):
             getattr(monitor_object, "instance_id_keys", []),
         )
         return data
+
+    def get_monitor_plugin_name(self, instance):
+        return instance.monitor_plugin.name if instance.monitor_plugin else ""
 
     def validate(self, attrs):
         attrs = super().validate(attrs)

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/en.yaml
@@ -1,7 +1,7 @@
 Windows WMI:
   desc: Through the Telegraf collector, gather and analyze host performance data,
     including CPU, memory, disk, and network utilization.
-  name: Host(Telegraf)
+  name: Windows Host Collection (WMI / Telegraf)
 monitor_object:
   Host: Host
 monitor_object_type:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/zh-Hans.yaml
@@ -1,6 +1,6 @@
 Windows WMI:
   desc: 通过Telegraf采集器收集和分析主机的性能数据，包括CPU、内存、磁盘和网络使用情况。
-  name: 主机（Telegraf）
+  name: Windows 主机采集（WMI / Telegraf）
 monitor_object:
   Host: 主机
 monitor_object_type:

--- a/server/apps/monitor/tests/test_metric_rest_plugin_contract.py
+++ b/server/apps/monitor/tests/test_metric_rest_plugin_contract.py
@@ -1,0 +1,53 @@
+"""指标列表 REST 契约回归测试。"""
+
+import json
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.models import User
+from apps.monitor.models import MonitorObject, MonitorPlugin
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
+from apps.monitor.views.monitor_metrics import MetricViewSet
+
+
+@pytest.mark.django_db
+def test_metric_list_returns_monitor_plugin_name():
+    """展示列按 plugin+metric 解析元数据时，REST 指标列表必须返回插件内部名。"""
+    monitor_object = MonitorObject.objects.create(
+        name="MetricRestContractHost",
+        display_name="MetricRestContractHost",
+        instance_id_keys=["instance_id"],
+    )
+    plugin = MonitorPlugin.objects.create(
+        name="MetricRestContractPlugin",
+        display_name="MetricRestContractPlugin",
+        template_id="metric-rest-contract",
+        template_type="api",
+        collector="test",
+        collect_type="api",
+        is_pre=False,
+    )
+    plugin.monitor_object.add(monitor_object)
+    group = MetricGroup.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        name="MetricRestContractGroup",
+    )
+    metric = Metric.objects.create(
+        monitor_object=monitor_object,
+        monitor_plugin=plugin,
+        metric_group=group,
+        name="metric_rest_contract_value",
+        display_name="Metric REST Contract Value",
+        instance_id_keys=["instance_id"],
+    )
+    user = User.objects.create_user(username="metric_rest_contract_user", password="testpass123")
+    request = APIRequestFactory().get("/monitor/api/metrics/", {"monitor_object_id": monitor_object.id})
+    force_authenticate(request, user=user)
+
+    response = MetricViewSet.as_view({"get": "list"})(request)
+    payload = json.loads(response.content)
+    result = next(item for item in payload["data"] if item["id"] == metric.id)
+
+    assert result["monitor_plugin_name"] == plugin.name

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -56,6 +56,7 @@ class TestMonitorMetricsHandler:
         out = nm.monitor_metrics(obj.id, user_info={"locale": "en"})
         assert out["result"] is True
         assert any(m["name"] == "cpu" for m in out["data"])
+        assert next(m for m in out["data"] if m["name"] == "cpu")["monitor_plugin_name"] == "NMMPlugin"
 
 
 class TestMonitorObjectInstancesHandler:

--- a/server/apps/monitor/tests/test_plugin_translation_l4_fix.py
+++ b/server/apps/monitor/tests/test_plugin_translation_l4_fix.py
@@ -61,3 +61,8 @@ class TestL4Fix:
             entry = zh_loader.get(f"monitor_object_plugin.{p}")
             assert entry is not None, f"{p} 翻译缺失"
             assert entry.get("name"), f"{p} 缺 name"
+
+    def test_windows_wmi展示名说明采集方式(self, zh_loader, en_loader):
+        """WMI 与本机 Telegraf 采集必须在展示指标配置中可区分。"""
+        assert zh_loader.get("monitor_object_plugin.Windows WMI.name") == "Windows 主机采集（WMI / Telegraf）"
+        assert en_loader.get("monitor_object_plugin.Windows WMI.name") == "Windows Host Collection (WMI / Telegraf)"

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -85,7 +85,7 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
 
 
 class MetricViewSet(viewsets.ModelViewSet):
-    queryset = Metric.objects.select_related('monitor_object').all().order_by("sort_order")
+    queryset = Metric.objects.select_related("monitor_object", "monitor_plugin").all().order_by("sort_order")
     serializer_class = MetricSerializer
     filterset_class = MetricFilter
     pagination_class = CustomPageNumberPagination

--- a/web/scripts/monitor-view-display-field-plugin-test.ts
+++ b/web/scripts/monitor-view-display-field-plugin-test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+
+import { resolveDisplayMetric } from '../src/app/monitor/(pages)/view/displayFieldMetric';
+
+const metrics = [
+  { id: 11, name: 'disk_used_percent', monitor_plugin_name: 'Host' },
+  { id: 12, name: 'disk_used_percent', monitor_plugin_name: 'Windows WMI' },
+  { id: 13, name: 'disk_used_percent', monitor_plugin_name: 'Host Remote' },
+];
+
+assert.equal(
+  resolveDisplayMetric(metrics, { plugin: 'Host', metric: 'disk_used_percent' })?.id,
+  11,
+);
+assert.equal(
+  resolveDisplayMetric(metrics, { plugin: 'Host Remote', metric: 'disk_used_percent' })?.id,
+  13,
+);
+
+console.log('monitor view display-field plugin scope validation passed');

--- a/web/src/app/monitor/(pages)/view/displayFieldMetric.ts
+++ b/web/src/app/monitor/(pages)/view/displayFieldMetric.ts
@@ -1,0 +1,26 @@
+interface DisplayMetric {
+  name: string;
+  monitor_plugin_name?: string;
+}
+
+interface DisplayMetricBinding {
+  plugin?: string;
+  metric?: string;
+}
+
+export const resolveDisplayMetric = <T extends DisplayMetric>(
+  metrics: T[],
+  binding: DisplayMetricBinding,
+): T | undefined => {
+  if (!binding.metric) return undefined;
+
+  if (binding.plugin) {
+    return metrics.find(
+      (metric) =>
+        metric.name === binding.metric &&
+        metric.monitor_plugin_name === binding.plugin,
+    );
+  }
+
+  return metrics.find((metric) => metric.name === binding.metric);
+};

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -14,6 +14,7 @@ import { getDisplayFieldType } from '@/app/monitor/utils/displayFieldType';
 import { useRouter } from 'next/navigation';
 import ViewModal from './viewModal';
 import MetricDimensionTooltip from './metricDimensionTooltip';
+import { resolveDisplayMetric } from './displayFieldMetric';
 import {
   ColumnItem,
   ModalRef,
@@ -298,10 +299,7 @@ const ViewList: React.FC<ViewListProps> = ({
       setMetrics(res[0] || []);
       if (objName) {
         const allMetrics: MetricItem[] = res[0] || [];
-        const metricByName = (name: string) =>
-          allMetrics.find((m: MetricItem) => m.name === name);
-
-        // 解析某行在某列应展示的绑定指标值（按绑定顺序取首个有值），返回 {value, unit, metricName}
+        // 解析某行在某列应展示的绑定指标值（按绑定顺序取首个有值），保留插件信息以精确定位指标元数据。
         const resolveCell = (record: TableDataItem, col: DisplayCol) => {
           for (const binding of col.metrics || []) {
             const key = displayFieldKey(
@@ -319,7 +317,8 @@ const ViewList: React.FC<ViewListProps> = ({
                 return {
                   value: cell as string | number,
                   unit: undefined,
-                  metricName: binding.metric
+                  metricName: binding.metric,
+                  pluginName: binding.plugin
                 };
               }
               continue;
@@ -330,14 +329,20 @@ const ViewList: React.FC<ViewListProps> = ({
                 : undefined;
             const v = metricCell?.value;
             if (v != null && v !== '') {
-              return { value: v, unit: metricCell?.unit, metricName: binding.metric };
+              return {
+                value: v,
+                unit: metricCell?.unit,
+                metricName: binding.metric,
+                pluginName: binding.plugin
+              };
             }
           }
           const primary = col.metrics?.[0]?.metric;
           return {
             value: undefined as string | number | undefined,
             unit: undefined as string | undefined,
-            metricName: primary
+            metricName: primary,
+            pluginName: col.metrics?.[0]?.plugin
           };
         };
 
@@ -347,8 +352,7 @@ const ViewList: React.FC<ViewListProps> = ({
 
         // 注：dataIndex 用占位键 df_<index>（display_fields 无稳定 id）；真实取值在 render 中经 resolveCell 完成
         const _columns = displayCols.map((col: DisplayCol, colIndex: number) => {
-          const primaryMetricName = col.metrics?.[0]?.metric as string | undefined;
-          const primaryMeta = primaryMetricName ? metricByName(primaryMetricName) : undefined;
+          const primaryMeta = resolveDisplayMetric(allMetrics, col.metrics?.[0] || {});
           const colType = getDisplayFieldType(primaryMeta);
           const dataKey = `df_${colIndex}`;
 
@@ -395,7 +399,10 @@ const ViewList: React.FC<ViewListProps> = ({
               sorter: baseSorter,
               render: (_: unknown, record: TableDataItem) => {
                 const cell = resolveCell(record, col);
-                const meta = cell.metricName ? metricByName(cell.metricName) : primaryMeta;
+                const meta = resolveDisplayMetric(allMetrics, {
+                  plugin: cell.pluginName,
+                  metric: cell.metricName
+                }) || primaryMeta;
                 const hasDimensions = (meta?.dimensions?.length ?? 0) > 0;
                 const size: [number, number] = hasDimensions ? [220, 20] : [240, 20];
                 const metricUnit = cell.unit || meta?.unit || '';
@@ -436,7 +443,10 @@ const ViewList: React.FC<ViewListProps> = ({
             ...(colType === 'value' ? { sorter: baseSorter } : {}),
             render: (_: unknown, record: TableDataItem) => {
               const cell = resolveCell(record, col);
-              const meta = cell.metricName ? metricByName(cell.metricName) : primaryMeta;
+              const meta = resolveDisplayMetric(allMetrics, {
+                plugin: cell.pluginName,
+                metric: cell.metricName
+              }) || primaryMeta;
               const color = getEnumColor(meta, cell.value);
               const hasDimensions = (meta?.dimensions?.length ?? 0) > 0;
               const metricUnit = cell.unit || meta?.unit || '';

--- a/web/src/app/monitor/types/index.ts
+++ b/web/src/app/monitor/types/index.ts
@@ -271,6 +271,7 @@ export interface MetricItem {
   metric_group: number;
   metric_object: number;
   name: string;
+  monitor_plugin_name?: string;
   type: string;
   display_name?: string;
   display_description?: string;


### PR DESCRIPTION
## Summary
- Scope display-field metric metadata by plugin and metric name.
- Return `monitor_plugin_name` from the metric API used by the view page.
- Clarify the Windows WMI template label as WMI / Telegraf.

## Root cause
Host display fields bind identical metric names from multiple plugins. The view resolved tooltip metadata by metric name only, so it could query a different plugin metric and return no dimension data.

## Validation
- `pnpm exec tsx scripts/monitor-view-display-field-plugin-test.ts`
- Targeted ESLint and Python syntax checks
- No-database `MetricViewSet.list` response contract validation

## Notes
The full Django database test is included but cannot run locally because the PostgreSQL test database is unavailable; the SQLite fallback is blocked by an existing unrelated migration failure.