### PR TITLE
bugfix: 收敛控制器凭据解密失败

### DIFF
--- a/server/apps/node_mgmt/tasks/installer.py
+++ b/server/apps/node_mgmt/tasks/installer.py
@@ -517,17 +517,15 @@ def install_controller_on_nodes(task_obj, nodes, package_obj):
             ],
         )
 
-        password = None
-        if has_password:
-            password = aes_obj.decode(node_obj.password)
-
-        private_key = None
-        if has_private_key:
-            private_key = aes_obj.decode(node_obj.private_key)
-
-        passphrase = None
-        if node_obj.passphrase:
-            passphrase = aes_obj.decode(node_obj.passphrase)
+        try:
+            password = aes_obj.decode(node_obj.password) if has_password else None
+            private_key = aes_obj.decode(node_obj.private_key) if has_private_key else None
+            passphrase = aes_obj.decode(node_obj.passphrase) if node_obj.passphrase else None
+        except Exception as e:
+            _handle_step_exception(node_obj, "Credential decryption failed", e)
+            _save_node_result(node_obj, "error", "Credential decryption failed")
+            _dispatch_or_finalize_controller_task(task_obj.id)
+            continue
 
         try:
             resolved_package = package_obj

--- a/server/apps/node_mgmt/tests/test_installer_failure_enrichment.py
+++ b/server/apps/node_mgmt/tests/test_installer_failure_enrichment.py
@@ -1,5 +1,9 @@
+from types import SimpleNamespace
+
 import pytest
 
+from apps.node_mgmt.constants.installer import InstallerConstants
+from apps.node_mgmt.tasks import installer as installer_tasks
 from apps.node_mgmt.tasks.installer import _handle_step_exception
 from apps.node_mgmt.utils.installer_schema import build_installer_event_record, normalize_failure
 from apps.node_mgmt.utils.task_result_schema import normalize_task_result_for_read
@@ -12,6 +16,55 @@ class _DummyNode:
 
     def save(self, update_fields=None):
         return None
+
+
+class _InstallNode(_DummyNode):
+    def __init__(self, password="", private_key="", passphrase=""):
+        super().__init__(
+            result={InstallerConstants.EXECUTION_PHASE_KEY: InstallerConstants.EXECUTION_PHASE_BOOTSTRAP_RUNNING}
+        )
+        self.password = password
+        self.private_key = private_key
+        self.passphrase = passphrase
+        self.status = InstallerConstants.STEP_STATUS_RUNNING
+        self.cpu_architecture = ""
+
+
+class _FailingCryptor:
+    def decode(self, ciphertext):
+        if ciphertext == "invalid-ciphertext":
+            raise ValueError("invalid encrypted value")
+        return "decoded-value"
+
+
+@pytest.mark.parametrize(
+    ("password", "private_key", "passphrase"),
+    [
+        ("invalid-ciphertext", "", ""),
+        ("", "invalid-ciphertext", ""),
+        ("", "valid-ciphertext", "invalid-ciphertext"),
+    ],
+)
+def test_install_controller_on_nodes_converges_credential_decryption_failure(
+    monkeypatch, password, private_key, passphrase
+):
+    node = _InstallNode(password=password, private_key=private_key, passphrase=passphrase)
+    dispatch_calls = []
+    monkeypatch.setattr(installer_tasks, "AESCryptor", _FailingCryptor)
+    monkeypatch.setattr(
+        installer_tasks,
+        "_dispatch_or_finalize_controller_task",
+        lambda task_id: dispatch_calls.append(task_id),
+    )
+
+    installer_tasks.install_controller_on_nodes(SimpleNamespace(id=4076), [node], SimpleNamespace())
+
+    assert node.status == InstallerConstants.STEP_STATUS_ERROR
+    assert node.result[InstallerConstants.EXECUTION_PHASE_KEY] == InstallerConstants.EXECUTION_PHASE_FINISHED
+    assert node.result["overall_status"] == InstallerConstants.OVERALL_STATUS_ERROR
+    assert node.result["final_message"] == "Credential decryption failed"
+    assert node.result["steps"][-1]["status"] == InstallerConstants.STEP_STATUS_ERROR
+    assert dispatch_calls == [4076]
 
 
 def test_normalize_failure_classifies_object_missing_and_preserves_context():


### PR DESCRIPTION
## 问题

控制器安装任务先把节点置为运行中，再解密 SSH 凭据。密码、私钥或口令短语的密文一旦损坏，异常会跳过节点级失败收敛，使节点与父任务长期停留在运行状态，并持续占用并发槽位。

## 根因（设计层）

凭据准备和安装执行属于同一个单节点状态转换，但原实现将解密放在状态机的异常边界之外。结果是解密失败没有进入统一的步骤失败记录、节点结果持久化与后续调度契约。

## 怎么修的

- 将三类凭据解密纳入一个最小异常边界。
- 解密失败时复用既有步骤异常结构并将节点收敛为错误终态。
- 完成失败持久化后继续任务调度，让同批其他节点获得空出的执行槽位。
- 错误结果只记录通用解密失败信息，不写入密文或解密后的秘密。

## 影响范围

改动仅涉及 `node_mgmt` 的控制器安装任务和关联测试，不改变成功路径、API 字段、权限规则、远程 Agent 协议或 NATS subject。实现复用现有节点失败收敛范式，坏凭据只影响对应节点。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["controller_install\nviews/installer.py"]
        T2["install_controller_for_node\ntasks/installer.py"]
    end

    subgraph N["核心处理层"]
        N1["install_controller_on_nodes\ntasks/installer.py"]
        N2["解密 SSH 凭据"]
    end

    subgraph C["失败收敛层"]
        C1["记录步骤失败"]
        C2["保存节点错误终态"]
        C3["继续任务调度"]
    end

    T1 --> T2 --> N1 --> N2
    N2 -. "解密失败" .-> C1 --> C2 --> C3
```

## 验证

- `apps/node_mgmt/tests/test_installer_failure_enrichment.py`：17 passed。
- 新增参数化用例分别覆盖坏密码、坏私钥和坏口令短语，直接断言节点进入错误终态并触发后续调度。

Closes #4076
