### PR TITLE
fix(i18n): 修复插件语言冷加载性能

### DIFF
--- a/server/apps/core/tests/test_asgi_preload.py
+++ b/server/apps/core/tests/test_asgi_preload.py
@@ -1,0 +1,24 @@
+"""ASGI worker 启动时的语言缓存预热回归测试。"""
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_asgi_worker_preloads_monitor_language_cache(monkeypatch):
+    """插件翻译扫描在 worker 启动完成，不能落在首个监控 API 请求上。"""
+    from django.core import asgi as django_asgi
+    from apps.core.utils import loader as loader_mod
+
+    calls = []
+    monkeypatch.setattr(django_asgi, "get_asgi_application", lambda: object())
+    monkeypatch.setattr(loader_mod, "preload_language_cache", lambda **kwargs: calls.append(kwargs))
+
+    asgi_path = Path(__file__).resolve().parents[3] / "asgi.py"
+    runpy.run_path(str(asgi_path))
+
+    assert calls == [{"apps": ["monitor"]}]

--- a/server/apps/core/tests/utils/test_language_loader_v3.py
+++ b/server/apps/core/tests/utils/test_language_loader_v3.py
@@ -120,6 +120,37 @@ class TestLoadPluginLanguage:
         # 文件里只有 Wrong-Key 段,被原样合并
         assert result == {"Wrong-Key": {"name": "x"}}
 
+    def test_同一语言插件翻译只发现一次(self, tmp_path, monkeypatch):
+        """同一进程内插件翻译按语言共享，不能随调用方 app 重复扫描。"""
+        plugins_root = tmp_path / "plugins"
+        plugin_dir = plugins_root / "CollectorA" / "cat1" / "pluginA"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "metrics.json").write_text('{"plugin": "Plugin-A"}', encoding="utf-8")
+        (plugin_dir / "language").mkdir()
+        (plugin_dir / "language" / "cache-test.yaml").write_text(
+            "Plugin-A:\n  name: A Name\n  desc: A Desc\n", encoding="utf-8"
+        )
+
+        from apps.monitor.constants import plugin as plugin_constants
+        from apps.monitor.management import utils as monitor_utils
+
+        monkeypatch.setattr(plugin_constants.PluginConstants, "DIRECTORY", str(plugins_root))
+        monkeypatch.setattr(plugin_constants.PluginConstants, "ENTERPRISE_DIRECTORY", str(tmp_path / "no_enterprise"))
+        original_find = monitor_utils.find_files_by_pattern
+        calls = 0
+
+        def count_find_files(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original_find(*args, **kwargs)
+
+        monkeypatch.setattr(monitor_utils, "find_files_by_pattern", count_find_files)
+
+        lo = LanguageLoader(app="__no_such_app__", default_lang="en")
+        calls = 0
+        assert lo._load_plugin_language("cache-test") == lo._load_plugin_language("cache-test")
+        assert calls == 1
+
 
 class TestLoadEnterpriseLanguage:
     def test_语言过滤_en不加载zhHans(self, tmp_path, monkeypatch):
@@ -187,6 +218,20 @@ class TestLoadEnterpriseLanguage:
 
 
 class TestLoadLanguageFileMergeOrder:
+    def test_非monitor应用不加载插件翻译(self, tmp_path, monkeypatch):
+        """插件语言是 monitor 专属资源，core/cmdb 冷加载不得触发插件扫描。"""
+        lo = LanguageLoader(app="core", default_lang="en")
+        lo.base_dir = str(tmp_path / "base")
+        monkeypatch.setattr(lo, "_load_language_dir", lambda lang: {"core": {"ok": True}})
+        monkeypatch.setattr(lo, "_load_enterprise_language", lambda lang: {})
+
+        def fail_if_called(lang):
+            pytest.fail(f"非 monitor 应用不应加载插件翻译: {lang}")
+
+        monkeypatch.setattr(lo, "_load_plugin_language", fail_if_called)
+
+        assert lo._load_language_file("en") == {"core": {"ok": True}}
+
     def test_合并顺序base_plugins_enterprise(self, tmp_path, monkeypatch):
         """base 设值,plugins 覆盖,enterprise 再覆盖。"""
         # base: 一个 yaml 含 monitor_object_plugin.<x>.name

--- a/server/apps/core/utils/loader.py
+++ b/server/apps/core/utils/loader.py
@@ -1,3 +1,4 @@
+import json
 import os
 import threading
 from typing import Any, Dict, List, Optional, Tuple
@@ -10,6 +11,11 @@ from apps.core.logger import logger
 # 缓存永不过期，进程重启时自动清空，部署时通过 preload_language_cache() 预热
 _translation_cache: Dict[Tuple[str, str], dict] = {}
 _cache_lock = threading.Lock()
+
+# 插件翻译与调用它的 app 无关；以语言和插件根目录共享，避免 core/cmdb/monitor
+# 各自冷加载时重复扫描同一批插件。根目录进入 key，保证测试和运行时配置切换安全。
+_plugin_translation_cache: Dict[Tuple[str, str, str], dict] = {}
+_plugin_cache_lock = threading.Lock()
 
 
 class LanguageLoader:
@@ -92,39 +98,47 @@ class LanguageLoader:
         from apps.monitor.constants.plugin import PluginConstants
         from apps.monitor.management.utils import find_files_by_pattern
 
-        collected: Dict[str, Any] = {}
-        for root in (PluginConstants.DIRECTORY, PluginConstants.ENTERPRISE_DIRECTORY):
-            if not os.path.isdir(root):
-                continue
-            for metrics_path in find_files_by_pattern(root, filename_pattern="metrics.json"):
-                try:
-                    with open(metrics_path, "r", encoding="utf-8") as f:
-                        plugin_data = yaml.safe_load(f) or {}
-                except Exception as e:
-                    logger.error(f"Failed to read {metrics_path}: {e}")
+        roots = (PluginConstants.DIRECTORY, PluginConstants.ENTERPRISE_DIRECTORY)
+        cache_key = (lang, *roots)
+        cached = _plugin_translation_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        with _plugin_cache_lock:
+            cached = _plugin_translation_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
+            collected: Dict[str, Any] = {}
+            for root in roots:
+                if not os.path.isdir(root):
                     continue
-                plugin_name = plugin_data.get("plugin")
-                if not plugin_name:
-                    continue
-                lang_file = os.path.join(os.path.dirname(metrics_path), "language", f"{lang}.yaml")
-                if not os.path.isfile(lang_file):
-                    logger.warning(f"Plugin language missing: {lang_file}")
-                    continue
-                try:
-                    with open(lang_file, "r", encoding="utf-8") as f:
-                        sub = yaml.safe_load(f) or {}
-                    # sub 包含两部分:
-                    #   - sub[plugin_name] = {name, desc} 该 plugin 自身描述
-                    #   - sub[其它 top-level key] = 共享 4 段翻译(monitor_object/metric/group/type)
-                    # 把 plugin 自身包回 monitor_object_plugin.<plugin_name>(保持调用方 key 不变),
-                    # 其余 top-level key 留在 root(供 monitor_object_metric 等直接读取)
-                    if plugin_name in sub:
-                        plugin_desc = sub.pop(plugin_name)
-                        sub.setdefault("monitor_object_plugin", {})[plugin_name] = plugin_desc
-                    collected = self._deep_merge(collected, sub)
-                except Exception as e:
-                    logger.error(f"Failed to load {lang_file}: {e}")
-        return collected
+                for metrics_path in find_files_by_pattern(root, filename_pattern="metrics.json"):
+                    try:
+                        with open(metrics_path, "r", encoding="utf-8") as f:
+                            plugin_data = json.load(f)
+                    except Exception as e:
+                        logger.error(f"Failed to read {metrics_path}: {e}")
+                        continue
+                    plugin_name = plugin_data.get("plugin")
+                    if not plugin_name:
+                        continue
+                    lang_file = os.path.join(os.path.dirname(metrics_path), "language", f"{lang}.yaml")
+                    if not os.path.isfile(lang_file):
+                        logger.warning(f"Plugin language missing: {lang_file}")
+                        continue
+                    try:
+                        with open(lang_file, "r", encoding="utf-8") as f:
+                            sub = yaml.safe_load(f) or {}
+                        if plugin_name in sub:
+                            plugin_desc = sub.pop(plugin_name)
+                            sub.setdefault("monitor_object_plugin", {})[plugin_name] = plugin_desc
+                        collected = self._deep_merge(collected, sub)
+                    except Exception as e:
+                        logger.error(f"Failed to load {lang_file}: {e}")
+
+            _plugin_translation_cache[cache_key] = collected
+            return collected
 
     def _load_enterprise_language(self, lang: str) -> dict:
         """扫描 apps/<app>/enterprise/language/ 下匹配目标语言的 *.yaml,deep-merge。
@@ -170,7 +184,7 @@ class LanguageLoader:
         enterprise = apps/<app>/enterprise/language/ 多 yaml(企业版覆盖,优先级最高)
         """
         base = self._load_language_dir(lang)
-        plugins = self._load_plugin_language(lang)
+        plugins = self._load_plugin_language(lang) if self.app == "monitor" else {}
         enterprise = self._load_enterprise_language(lang)
 
         result = self._deep_merge(base, plugins)
@@ -236,10 +250,17 @@ def clear_language_cache(app: Optional[str] = None, lang: Optional[str] = None) 
     with _cache_lock:
         if app is None and lang is None:
             _translation_cache.clear()
+            with _plugin_cache_lock:
+                _plugin_translation_cache.clear()
         else:
             keys_to_remove = [key for key in _translation_cache if (app is None or key[0] == app) and (lang is None or key[1] == lang)]
             for key in keys_to_remove:
                 del _translation_cache[key]
+            if app is None or app == "monitor":
+                with _plugin_cache_lock:
+                    plugin_keys = [key for key in _plugin_translation_cache if lang is None or key[0] == lang]
+                    for key in plugin_keys:
+                        del _plugin_translation_cache[key]
 
 
 # 支持的语言列表

--- a/server/asgi.py
+++ b/server/asgi.py
@@ -51,4 +51,9 @@ if _db_engine == "dameng":
 
 from django.core.asgi import get_asgi_application  # noqa: E402
 
+from apps.core.utils.loader import preload_language_cache  # noqa: E402
+
 application = get_asgi_application()
+
+# 每个 uvicorn worker 启动时完成监控插件翻译预热，避免首个监控请求同步扫描插件目录。
+preload_language_cache(apps=["monitor"])


### PR DESCRIPTION
## 变更
- 仅在 monitor 加载插件翻译，避免 core/cmdb 等通用请求扫描插件目录。
- 按语言和插件根目录共享插件翻译缓存，并用 json.load 解析 metrics.json。
- 每个 ASGI worker 启动时预热监控中英文翻译，移除首个监控请求的同步扫描。

## 根因
#4099 将监控插件翻译扫描接入所有 LanguageLoader 冷路径，worker 重启后首批请求可能阻塞数秒。

## 验证
- ENABLE_CELERY=true uv run pytest apps/core/tests/test_asgi_preload.py apps/core/tests/utils/test_loader.py apps/core/tests/utils/test_language_loader_v3.py apps/core/tests/utils/test_language_loader_legacy_compat.py -q --no-cov
- 29 passed
- python -m py_compile asgi.py apps/core/utils/loader.py
- git diff --check

Closes #4179