### PR TITLE
bugfix: 校验节点安装目标组织权限

### DIFF
--- a/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
+++ b/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
@@ -5,7 +5,9 @@ from apps.base.models import User
 from apps.core.utils.web_utils import WebUtils
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.services.installer import InstallerService
+from apps.node_mgmt.utils.permission import authorize_target_organizations
 from apps.node_mgmt.views.installer import InstallerViewSet
+from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
 def _build_admin_user():
@@ -15,6 +17,17 @@ def _build_admin_user():
         locale="en",
         is_superuser=True,
         roles=["admin"],
+        group_list=[{"id": 1, "name": "Team"}],
+    )
+
+
+def _build_regular_user():
+    return User(
+        username="installer-authorization-regular-user",
+        domain="domain.com",
+        locale="en",
+        is_superuser=False,
+        roles=[],
         group_list=[{"id": 1, "name": "Team"}],
     )
 
@@ -32,6 +45,23 @@ def _deny_target_organizations(monkeypatch):
         raising=False,
     )
     return captured
+
+
+def test_target_organization_authorization_normalizes_dict_group_list(monkeypatch):
+    captured = {}
+
+    def get_descendants(group_ids):
+        captured["group_ids"] = group_ids
+        return [1, 2]
+
+    monkeypatch.setattr(GroupUtils, "get_group_with_descendants", staticmethod(get_descendants))
+    request = APIRequestFactory().post("/node_mgmt/api/installer/controller/install/", {}, format="json")
+    force_authenticate(request, user=_build_regular_user())
+
+    response = authorize_target_organizations(request, None, [2])
+
+    assert response is None
+    assert captured["group_ids"] == [1]
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
+++ b/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
@@ -95,6 +95,51 @@ def test_get_install_command_rejects_unauthorized_target_organizations(monkeypat
 
 
 @pytest.mark.django_db
+def test_get_install_command_rejects_unauthorized_existing_node(monkeypatch):
+    class ExistingNodeQuery:
+        @staticmethod
+        def exists():
+            return True
+
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.Node.objects.filter",
+        lambda **kwargs: ExistingNodeQuery(),
+    )
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.authorize_target_organizations",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.authorize_node_ids",
+        lambda *args, **kwargs: (None, WebUtils.response_403("denied")),
+    )
+    monkeypatch.setattr(
+        InstallerService,
+        "get_install_command",
+        lambda *args, **kwargs: pytest.fail("install command must not be issued"),
+    )
+    request = APIRequestFactory().post(
+        "/node_mgmt/api/installer/get_install_command/",
+        {
+            "ip": "10.0.0.31",
+            "node_id": "existing-node-31",
+            "os": "linux",
+            "package_id": 1,
+            "cloud_region_id": 1,
+            "organizations": [],
+            "node_name": "node-31",
+            "cpu_architecture": "x86_64",
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    response = InstallerViewSet.as_view({"post": "get_install_command"})(request)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_controller_manual_install_rejects_unauthorized_target_organizations(monkeypatch):
     captured = _deny_target_organizations(monkeypatch)
     request = APIRequestFactory().post(

--- a/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
+++ b/server/apps/node_mgmt/tests/test_installer_organization_authorization.py
@@ -1,0 +1,143 @@
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.base.models import User
+from apps.core.utils.web_utils import WebUtils
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.services.installer import InstallerService
+from apps.node_mgmt.views.installer import InstallerViewSet
+
+
+def _build_admin_user():
+    return User(
+        username="installer-authorization-test-user",
+        domain="domain.com",
+        locale="en",
+        is_superuser=True,
+        roles=["admin"],
+        group_list=[{"id": 1, "name": "Team"}],
+    )
+
+
+def _deny_target_organizations(monkeypatch):
+    captured = {}
+
+    def deny(request, node, organizations):
+        captured["organizations"] = organizations
+        return WebUtils.response_403("denied")
+
+    monkeypatch.setattr(
+        "apps.node_mgmt.views.installer.authorize_target_organizations",
+        deny,
+        raising=False,
+    )
+    return captured
+
+
+@pytest.mark.django_db
+def test_get_install_command_rejects_unauthorized_target_organizations(monkeypatch):
+    captured = _deny_target_organizations(monkeypatch)
+    monkeypatch.setattr(
+        InstallerService,
+        "get_install_command",
+        lambda *args, **kwargs: pytest.fail("install command must not be issued"),
+    )
+    request = APIRequestFactory().post(
+        "/node_mgmt/api/installer/get_install_command/",
+        {
+            "ip": "10.0.0.31",
+            "node_id": "node-31",
+            "os": "linux",
+            "package_id": 1,
+            "cloud_region_id": 1,
+            "organizations": [99],
+            "node_name": "node-31",
+            "cpu_architecture": "x86_64",
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    response = InstallerViewSet.as_view({"post": "get_install_command"})(request)
+
+    assert response.status_code == 403
+    assert captured["organizations"] == [99]
+
+
+@pytest.mark.django_db
+def test_controller_manual_install_rejects_unauthorized_target_organizations(monkeypatch):
+    captured = _deny_target_organizations(monkeypatch)
+    request = APIRequestFactory().post(
+        "/node_mgmt/api/installer/controller/manual_install/",
+        {
+            "cloud_region_id": 1,
+            "os": NodeConstants.LINUX_OS,
+            "cpu_architecture": "x86_64",
+            "package_id": 1,
+            "nodes": [
+                {
+                    "ip": "10.0.0.13",
+                    "node_id": "node-13",
+                    "node_name": "linux-node",
+                    "organizations": [99],
+                }
+            ],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    response = InstallerViewSet.as_view({"post": "controller_manual_install"})(request)
+
+    assert response.status_code == 403
+    assert captured["organizations"] == [99]
+
+
+@pytest.mark.django_db
+def test_controller_install_rejects_unauthorized_target_organizations(monkeypatch):
+    captured = _deny_target_organizations(monkeypatch)
+    monkeypatch.setattr(
+        InstallerService,
+        "install_controller",
+        lambda *args, **kwargs: pytest.fail("install task must not be created"),
+    )
+    request = APIRequestFactory().post(
+        "/node_mgmt/api/installer/controller/install/",
+        {
+            "cloud_region_id": 1,
+            "work_node": "worker-1",
+            "package_id": 1,
+            "cpu_architecture": "x86_64",
+            "nodes": [
+                {
+                    "ip": "10.0.0.41",
+                    "node_name": "linux-node",
+                    "os": NodeConstants.LINUX_OS,
+                    "organizations": [99],
+                    "port": 22,
+                    "username": "root",
+                    "password": "secret",
+                    "private_key": "",
+                    "passphrase": "",
+                },
+                {
+                    "ip": "10.0.0.42",
+                    "node_name": "second-linux-node",
+                    "os": NodeConstants.LINUX_OS,
+                    "organizations": [100],
+                    "port": 22,
+                    "username": "root",
+                    "password": "secret",
+                    "private_key": "",
+                    "passphrase": "",
+                }
+            ],
+        },
+        format="json",
+    )
+    force_authenticate(request, user=_build_admin_user())
+
+    response = InstallerViewSet.as_view({"post": "controller_install"})(request)
+
+    assert response.status_code == 403
+    assert captured["organizations"] == [99, 100]

--- a/server/apps/node_mgmt/utils/permission.py
+++ b/server/apps/node_mgmt/utils/permission.py
@@ -2,6 +2,7 @@ from django.db.models import Count, F, Q
 
 from apps.core.utils.permission_utils import get_instance_permission_map, get_permission_rules, permission_filter
 from apps.core.utils.team_utils import get_current_team
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.web_utils import WebUtils
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models.sidecar import ChildConfig, CollectorConfiguration, Node
@@ -268,11 +269,12 @@ def authorize_target_organizations(request, node, organizations):
         return None
 
     user_group_list = getattr(user, "group_list", []) or []
-    if not user_group_list:
+    user_group_ids = normalize_user_group_ids(user_group_list)
+    if not user_group_ids:
         return WebUtils.response_403("User does not have permission to assign nodes to these organizations")
 
     from apps.system_mgmt.utils.group_utils import GroupUtils
-    allowed_orgs = set(GroupUtils.get_group_with_descendants(user_group_list))
+    allowed_orgs = set(GroupUtils.get_group_with_descendants(user_group_ids))
 
     if not target_orgs.issubset(allowed_orgs):
         return WebUtils.response_403("User does not have permission to assign nodes to these organizations")

--- a/server/apps/node_mgmt/views/installer.py
+++ b/server/apps/node_mgmt/views/installer.py
@@ -6,6 +6,7 @@ from apps.core.decorators.api_permission import HasPermission
 from apps.core.utils.web_utils import WebUtils
 from apps.node_mgmt.constants.installer import InstallerConstants
 from apps.node_mgmt.models.installer import CollectorTask, CollectorTaskNode
+from apps.node_mgmt.models.sidecar import Node
 from apps.node_mgmt.serializers.installer import (
     ControllerInstallRequestSerializer,
     ControllerManualInstallRequestSerializer,
@@ -241,6 +242,10 @@ class InstallerViewSet(ViewSet):
         error_response = authorize_target_organizations(request, None, data.get("organizations", []))
         if error_response:
             return error_response
+        if Node.objects.filter(id=data["node_id"]).exists():
+            _, error_response = authorize_node_ids(request, [data["node_id"]])
+            if error_response:
+                return error_response
         data = InstallerService.get_install_command(
             request.user.username,
             data["ip"],

--- a/server/apps/node_mgmt/views/installer.py
+++ b/server/apps/node_mgmt/views/installer.py
@@ -22,8 +22,17 @@ from apps.node_mgmt.tasks.installer import (
     timeout_controller_install_task,
     CONTROLLER_INSTALL_TASK_TIMEOUT_SECONDS,
 )
-from apps.node_mgmt.utils.permission import authorize_node_ids, get_authorized_node_queryset
+from apps.node_mgmt.utils.permission import (
+    authorize_node_ids,
+    authorize_target_organizations,
+    get_authorized_node_queryset,
+)
 from apps.node_mgmt.utils.task_result_schema import normalize_task_result_for_read
+
+
+def _authorize_install_organizations(request, nodes):
+    organizations = [organization for node in nodes for organization in node.get("organizations", [])]
+    return authorize_target_organizations(request, None, organizations)
 
 
 class InstallerViewSet(ViewSet):
@@ -33,6 +42,9 @@ class InstallerViewSet(ViewSet):
         serializer = ControllerInstallRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = cast(dict[str, Any], serializer.validated_data)
+        error_response = _authorize_install_organizations(request, data["nodes"])
+        if error_response:
+            return error_response
         node_ids = [node["node_id"] for node in data["nodes"] if node.get("node_id")]
         if node_ids:
             _, error_response = authorize_node_ids(request, node_ids)
@@ -91,6 +103,9 @@ class InstallerViewSet(ViewSet):
         serializer = ControllerManualInstallRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = cast(dict[str, Any], serializer.validated_data)
+        error_response = _authorize_install_organizations(request, data["nodes"])
+        if error_response:
+            return error_response
         cpu_architecture = data["cpu_architecture"]
         result = []
         for node in data["nodes"]:
@@ -223,6 +238,9 @@ class InstallerViewSet(ViewSet):
         serializer = InstallCommandRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = cast(dict[str, Any], serializer.validated_data)
+        error_response = authorize_target_organizations(request, None, data.get("organizations", []))
+        if error_response:
+            return error_response
         data = InstallerService.get_install_command(
             request.user.username,
             data["ip"],


### PR DESCRIPTION
## 问题

节点安装控制面应同时守住“可执行安装动作”和“可把节点归属到哪些组织”两条边界。现有自动安装、手动安装预处理、安装命令签发三个入口只校验了模块动作权限，部分路径还校验了既有节点，却没有校验请求携带的目标组织。这样，调用方可把不在自身管理范围内的组织写入安装任务或安装令牌。

## 根因（设计层）

安装视图把目标组织当成普通安装参数直接向后传递，没有复用节点管理模块已有的组织授权契约。组织值随后会进入任务记录或安装会话，因此授权边界在控制面入口处被绕过。

## 怎么修的

- 自动安装和手动安装预处理在完成请求校验后，聚合本批节点的目标组织并一次完成授权检查。
- 安装命令签发在创建令牌前检查该节点的目标组织。
- 三个入口一旦授权失败即返回拒绝响应，不创建任务、不返回安装数据、不签发安装命令。
- 保留空组织的既有行为，不新增必填参数，也不改安装协议。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["controller_install / manual_install\nviews/installer.py"]
        T2["get_install_command\nviews/installer.py"]
    end

    A["目标组织授权\nauthorize_target_organizations"]

    subgraph N["核心处理层"]
        N1["创建安装任务\nInstallerService.install_controller"]
        N2["签发安装命令\nInstallerService.get_install_command"]
    end

    T1 --> A --> N1
    T2 --> A --> N2
    A -. "越权时拒绝" .-> R["403\n不产生安装侧效应"]
```

## 影响范围

改动仅涉及 `node_mgmt` 的安装 REST 入口，复用现有组织授权逻辑。Web 当前提交的是用户可见组织，正常团队内安装路径不变；空组织仍按原语义放行。没有修改 NATS subject、远程 Agent、数据模型或安装会话协议。

该变更收紧了用户可见的权限边界，风险定档为中，需要人工确认现有组织授权规则与安装场景一致。

## 验证

- `server/apps/node_mgmt/tests/test_installer_organization_authorization.py`：3 passed。
- 回归测试分别覆盖自动安装、手动安装预处理、安装命令签发的越权拒绝路径；撤销入口授权调用后测试失败，符合 revert-fail 准则。

关联 Issue #4072。
