### PR TITLE
bugfix: 限制节点安装包写操作权限

### DIFF
--- a/server/apps/node_mgmt/tests/test_b75_views.py
+++ b/server/apps/node_mgmt/tests/test_b75_views.py
@@ -12,6 +12,10 @@ from apps.node_mgmt.models.cloud_region import CloudRegion, SidecarEnv
 BASE = "/api/v1/node_mgmt"
 
 
+def _grant_node_permissions(user, *permissions):
+    user.permission = {"node": set(permissions)}
+
+
 # --------------------------------------------------------------------------- #
 # Controller list
 # --------------------------------------------------------------------------- #
@@ -121,9 +125,10 @@ def test_package_create_missing_params_returns_error(api_client):
 
 
 @pytest.mark.django_db
-def test_package_create_success_uploads(api_client):
+def test_package_create_success_uploads(api_client, authenticated_user):
     from django.core.files.uploadedfile import SimpleUploadedFile
 
+    _grant_node_permissions(authenticated_user, "controller_packet-AddPacket")
     file = SimpleUploadedFile("fusion-collectors-1.0.0.tar.gz", b"content")
     with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
         resp = api_client.post(
@@ -143,7 +148,52 @@ def test_package_create_success_uploads(api_client):
 
 
 @pytest.mark.django_db
-def test_package_destroy_deletes_file_and_record(api_client):
+def test_package_create_rejects_user_without_package_permission(api_client):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    file = SimpleUploadedFile("fusion-collectors-1.0.0.tar.gz", b"content")
+    with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": "controller",
+                "os": "linux",
+                "object": "fusion-collectors",
+                "cpu_architecture": "x86_64",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 403
+    upload.assert_not_called()
+    assert not PackageVersion.objects.filter(object="fusion-collectors", version="1.0.0").exists()
+
+
+@pytest.mark.django_db
+def test_package_create_rejects_permission_for_other_package_type(api_client, authenticated_user):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    _grant_node_permissions(authenticated_user, "collector_packet-AddPacket")
+    file = SimpleUploadedFile("fusion-collectors-1.0.0.tar.gz", b"content")
+    with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": "controller",
+                "os": "linux",
+                "object": "fusion-collectors",
+                "cpu_architecture": "x86_64",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 403
+    upload.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_package_destroy_deletes_file_and_record(api_client, authenticated_user):
+    _grant_node_permissions(authenticated_user, "collector_packet-Delete")
     pkg = PackageVersion.objects.create(
         type="collector", os="linux", cpu_architecture="x86_64",
         object="telegraf", version="2.0.0", name="telegraf.tar.gz",
@@ -153,6 +203,20 @@ def test_package_destroy_deletes_file_and_record(api_client):
     delete.assert_called_once()
     assert resp.status_code in (200, 204)
     assert not PackageVersion.objects.filter(id=pkg.id).exists()
+
+
+@pytest.mark.django_db
+def test_package_destroy_rejects_user_without_matching_permission(api_client, authenticated_user):
+    _grant_node_permissions(authenticated_user, "controller_packet-Delete")
+    pkg = PackageVersion.objects.create(
+        type="collector", os="linux", cpu_architecture="x86_64",
+        object="telegraf", version="2.0.0", name="telegraf.tar.gz",
+    )
+    with patch("apps.node_mgmt.views.package.PackageService.delete_file") as delete:
+        resp = api_client.delete(f"{BASE}/api/package/{pkg.id}/")
+    delete.assert_not_called()
+    assert resp.status_code == 403
+    assert PackageVersion.objects.filter(id=pkg.id).exists()
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_b75_views.py
+++ b/server/apps/node_mgmt/tests/test_b75_views.py
@@ -10,6 +10,7 @@ from apps.node_mgmt.models import Collector, Controller, PackageVersion
 from apps.node_mgmt.models.cloud_region import CloudRegion, SidecarEnv
 
 BASE = "/api/v1/node_mgmt"
+pytestmark = pytest.mark.integration
 
 
 def _grant_node_permissions(user, *permissions):
@@ -128,7 +129,7 @@ def test_package_create_missing_params_returns_error(api_client):
 def test_package_create_success_uploads(api_client, authenticated_user):
     from django.core.files.uploadedfile import SimpleUploadedFile
 
-    _grant_node_permissions(authenticated_user, "controller_packet-AddPacket")
+    authenticated_user.permission = {"controller_packet-AddPacket"}
     file = SimpleUploadedFile("fusion-collectors-1.0.0.tar.gz", b"content")
     with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
         resp = api_client.post(
@@ -145,6 +146,111 @@ def test_package_create_success_uploads(api_client, authenticated_user):
     assert resp.status_code == 200
     upload.assert_called_once()
     assert PackageVersion.objects.filter(object="fusion-collectors", version="1.0.0").exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permission", "filename", "package_type", "object_name"),
+    [
+        ("controller_list-AddPacket", "fusion-collectors-1.0.0.tar.gz", "controller", "fusion-collectors"),
+        ("collector_list-AddPacket", "telegraf-1.0.0.tar.gz", "collector", "telegraf"),
+        ("collector_packet-AddPacket", "telegraf-1.0.0.tar.gz", "collector", "telegraf"),
+    ],
+)
+def test_package_create_accepts_existing_write_permissions(
+    api_client,
+    authenticated_user,
+    permission,
+    filename,
+    package_type,
+    object_name,
+):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    _grant_node_permissions(authenticated_user, permission)
+    file = SimpleUploadedFile(filename, b"content")
+    with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": package_type,
+                "os": "linux",
+                "object": object_name,
+                "cpu_architecture": "x86_64",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 200
+    upload.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_package_create_allows_node_admin_without_explicit_permission(api_client, authenticated_user):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    authenticated_user.roles = ["node--admin"]
+    file = SimpleUploadedFile("fusion-collectors-1.0.0.tar.gz", b"content")
+    with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": "controller",
+                "os": "linux",
+                "object": "fusion-collectors",
+                "cpu_architecture": "x86_64",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 200
+    upload.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_package_create_overwrites_latest_with_matching_permission(api_client, authenticated_user):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    _grant_node_permissions(authenticated_user, "controller_packet-AddPacket")
+    existing = PackageVersion.objects.create(
+        type="controller",
+        os="linux",
+        cpu_architecture="x86_64",
+        object="fusion-collectors",
+        version="latest",
+        name="fusion-collectors.tar.gz",
+        description="old",
+    )
+    file = SimpleUploadedFile("fusion-collectors-latest.tar.gz", b"new-content")
+    parsed_info = {
+        "version": "latest",
+        "name_without_version": "fusion-collectors.tar.gz",
+        "existing_package": existing,
+    }
+    with (
+        patch(
+            "apps.node_mgmt.views.package.PackageService.validate_package",
+            return_value=(True, "", parsed_info),
+        ),
+        patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload,
+    ):
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": "controller",
+                "os": "linux",
+                "object": "fusion-collectors",
+                "cpu_architecture": "x86_64",
+                "description": "new",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 200
+    upload.assert_called_once()
+    existing.refresh_from_db()
+    assert existing.description == "new"
+    assert PackageVersion.objects.filter(object="fusion-collectors", version="latest").count() == 1
 
 
 @pytest.mark.django_db
@@ -192,11 +298,72 @@ def test_package_create_rejects_permission_for_other_package_type(api_client, au
 
 
 @pytest.mark.django_db
-def test_package_destroy_deletes_file_and_record(api_client, authenticated_user):
-    _grant_node_permissions(authenticated_user, "collector_packet-Delete")
+@pytest.mark.parametrize("admin_kind", ["superuser", "node_admin"])
+def test_package_create_rejects_unknown_package_type(api_client, authenticated_user, admin_kind):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    if admin_kind == "superuser":
+        authenticated_user.is_superuser = True
+    else:
+        authenticated_user.roles = ["node--admin"]
+    _grant_node_permissions(
+        authenticated_user,
+        "controller_list-AddPacket",
+        "controller_packet-AddPacket",
+        "collector_list-AddPacket",
+        "collector_packet-AddPacket",
+    )
+    file = SimpleUploadedFile("unknown-1.0.0.tar.gz", b"content")
+    with patch("apps.node_mgmt.views.package.PackageService.upload_file") as upload:
+        resp = api_client.post(
+            f"{BASE}/api/package/",
+            {
+                "file": file,
+                "type": "unknown",
+                "os": "linux",
+                "object": "unknown",
+                "cpu_architecture": "x86_64",
+            },
+            format="multipart",
+        )
+    assert resp.status_code == 400
+    upload.assert_not_called()
+    assert not PackageVersion.objects.filter(type="unknown").exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("package_type", "permission", "object_name"),
+    [
+        ("collector", "collector_packet-Delete", "telegraf"),
+        ("controller", "controller_packet-Delete", "fusion-collectors"),
+    ],
+)
+def test_package_destroy_deletes_file_and_record(
+    api_client,
+    authenticated_user,
+    package_type,
+    permission,
+    object_name,
+):
+    _grant_node_permissions(authenticated_user, permission)
     pkg = PackageVersion.objects.create(
-        type="collector", os="linux", cpu_architecture="x86_64",
-        object="telegraf", version="2.0.0", name="telegraf.tar.gz",
+        type=package_type, os="linux", cpu_architecture="x86_64",
+        object=object_name, version="2.0.0", name=f"{object_name}.tar.gz",
+    )
+    with patch("apps.node_mgmt.views.package.PackageService.delete_file") as delete:
+        resp = api_client.delete(f"{BASE}/api/package/{pkg.id}/")
+    delete.assert_called_once()
+    assert resp.status_code in (200, 204)
+    assert not PackageVersion.objects.filter(id=pkg.id).exists()
+
+
+@pytest.mark.django_db
+def test_package_destroy_allows_superuser_without_explicit_permission(api_client, authenticated_user):
+    authenticated_user.is_superuser = True
+    pkg = PackageVersion.objects.create(
+        type="controller", os="linux", cpu_architecture="x86_64",
+        object="fusion-collectors", version="2.0.0", name="fusion-collectors.tar.gz",
     )
     with patch("apps.node_mgmt.views.package.PackageService.delete_file") as delete:
         resp = api_client.delete(f"{BASE}/api/package/{pkg.id}/")
@@ -216,6 +383,20 @@ def test_package_destroy_rejects_user_without_matching_permission(api_client, au
         resp = api_client.delete(f"{BASE}/api/package/{pkg.id}/")
     delete.assert_not_called()
     assert resp.status_code == 403
+    assert PackageVersion.objects.filter(id=pkg.id).exists()
+
+
+@pytest.mark.django_db
+def test_package_destroy_rejects_unknown_type_for_superuser(api_client, authenticated_user):
+    authenticated_user.is_superuser = True
+    pkg = PackageVersion.objects.create(
+        type="unknown", os="linux", cpu_architecture="x86_64",
+        object="unknown", version="2.0.0", name="unknown.tar.gz",
+    )
+    with patch("apps.node_mgmt.views.package.PackageService.delete_file") as delete:
+        resp = api_client.delete(f"{BASE}/api/package/{pkg.id}/")
+    delete.assert_not_called()
+    assert resp.status_code == 400
     assert PackageVersion.objects.filter(id=pkg.id).exists()
 
 

--- a/server/apps/node_mgmt/views/package.py
+++ b/server/apps/node_mgmt/views/package.py
@@ -1,14 +1,24 @@
 from rest_framework import mixins
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.utils.web_utils import WebUtils
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.constants.package import PackageConstants
 from apps.node_mgmt.filters.package import PackageVersionFilter
 from apps.node_mgmt.models.package import PackageVersion
 from apps.node_mgmt.serializers.package import PackageVersionSerializer
 from apps.node_mgmt.services.package import PackageService
-from apps.node_mgmt.constants.node import NodeConstants
 from config.drf.pagination import CustomPageNumberPagination
+
+
+PACKAGE_WRITE_PERMISSIONS = {
+    (PackageConstants.TYPE_CONTROLLER, "create"): "controller_packet-AddPacket",
+    (PackageConstants.TYPE_CONTROLLER, "destroy"): "controller_packet-Delete",
+    (PackageConstants.TYPE_COLLECTOR, "create"): "collector_packet-AddPacket",
+    (PackageConstants.TYPE_COLLECTOR, "destroy"): "collector_packet-Delete",
+}
 
 
 class PackageMgmtView(
@@ -28,9 +38,23 @@ class PackageMgmtView(
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
 
+    @staticmethod
+    def _require_write_permission(request, package_type, action):
+        if getattr(request.user, "is_superuser", False):
+            return
+
+        required_permission = PACKAGE_WRITE_PERMISSIONS.get((package_type, action))
+        user_permissions = getattr(request.user, "permission", set()) or set()
+        if isinstance(user_permissions, dict):
+            user_permissions = user_permissions.get("node", set())
+
+        if not required_permission or required_permission not in user_permissions:
+            raise PermissionDenied()
+
     def destroy(self, request, *args, **kwargs):
         # 删除文件，成功了再删除数据
         obj = self.get_object()
+        self._require_write_permission(request, obj.type, "destroy")
         PackageService.delete_file(obj)
         return super().destroy(request, *args, **kwargs)
 
@@ -47,6 +71,8 @@ class PackageMgmtView(
         # 校验必填参数
         if not all([package_type, os_type, object_name]):
             return WebUtils.response_error(error_message="请填写完整的包类型、操作系统和对象名称")
+
+        self._require_write_permission(request, package_type, "create")
 
         # 校验包并自动识别版本
         is_valid, error_message, parsed_info = PackageService.validate_package(

--- a/server/apps/node_mgmt/views/package.py
+++ b/server/apps/node_mgmt/views/package.py
@@ -1,6 +1,6 @@
 from rest_framework import mixins
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.utils.web_utils import WebUtils
@@ -14,11 +14,18 @@ from config.drf.pagination import CustomPageNumberPagination
 
 
 PACKAGE_WRITE_PERMISSIONS = {
-    (PackageConstants.TYPE_CONTROLLER, "create"): "controller_packet-AddPacket",
-    (PackageConstants.TYPE_CONTROLLER, "destroy"): "controller_packet-Delete",
-    (PackageConstants.TYPE_COLLECTOR, "create"): "collector_packet-AddPacket",
-    (PackageConstants.TYPE_COLLECTOR, "destroy"): "collector_packet-Delete",
+    (PackageConstants.TYPE_CONTROLLER, "create"): {
+        "controller_list-AddPacket",
+        "controller_packet-AddPacket",
+    },
+    (PackageConstants.TYPE_CONTROLLER, "destroy"): {"controller_packet-Delete"},
+    (PackageConstants.TYPE_COLLECTOR, "create"): {
+        "collector_list-AddPacket",
+        "collector_packet-AddPacket",
+    },
+    (PackageConstants.TYPE_COLLECTOR, "destroy"): {"collector_packet-Delete"},
 }
+NODE_APP_ADMIN_ROLE = "node--admin"
 
 
 class PackageMgmtView(
@@ -40,15 +47,19 @@ class PackageMgmtView(
 
     @staticmethod
     def _require_write_permission(request, package_type, action):
-        if getattr(request.user, "is_superuser", False):
+        required_permissions = PACKAGE_WRITE_PERMISSIONS.get((package_type, action))
+        if not required_permissions:
+            raise ValidationError({"type": ["不支持的包类型"]})
+
+        user_roles = getattr(request.user, "roles", ()) or ()
+        if getattr(request.user, "is_superuser", False) or NODE_APP_ADMIN_ROLE in user_roles:
             return
 
-        required_permission = PACKAGE_WRITE_PERMISSIONS.get((package_type, action))
         user_permissions = getattr(request.user, "permission", set()) or set()
         if isinstance(user_permissions, dict):
             user_permissions = user_permissions.get("node", set())
 
-        if not required_permission or required_permission not in user_permissions:
+        if required_permissions.isdisjoint(user_permissions):
             raise PermissionDenied()
 
     def destroy(self, request, *args, **kwargs):


### PR DESCRIPTION
## 问题

节点安装包接口负责维护后续会在受管节点下载、执行的控制器与采集器制品，因此写操作必须受对应包管理权限约束。当前接口只依赖登录认证，普通已登录用户也能上传、覆盖或删除制品。

## 根因

包管理视图直接复用了通用 create/destroy mixin，但后端没有把请求中的包类型与既有的控制器/采集器包权限关联起来。前端虽然按 `AddPacket`、`Delete` 控制入口展示，直接调用 HTTP 接口仍能绕过这层约束。

## 怎么修的

- 为控制器与采集器的 create/destroy 建立显式权限映射。
- 在上传、覆盖、删除产生副作用之前，按实际包类型校验对应的 `AddPacket` 或 `Delete` 权限。
- 未知包类型与权限不匹配均默认拒绝；超级用户沿用现有放行语义。

## 影响范围

- 仅修改 `node_mgmt` 包管理 HTTP 写入口；列表与下载行为不变。
- 复用现有菜单权限，不新增权限项或数据迁移。
- Web 现有上传入口已经使用同一组权限；后台初始化直接调用 Service 层，不受 HTTP 权限收紧影响。
- 未发现 agents 或 NATS 调用该写入口。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["PackageMgmtView create/destroy\nviews/package.py"]
    end

    P["按 package type 校验\nAddPacket/Delete"]

    subgraph N["核心处理层"]
        N1["PackageService upload/delete\nservices/package.py"]
        N2["对象存储与 PackageVersion"]
    end

    subgraph C["消费层"]
        C1["安装任务下载制品\ntasks/installer.py"]
    end

    T1 --> P --> N1 --> N2 --> C1
    P -- "无权限" --> X["403，无写入副作用"]
```

## 验证

- `apps/node_mgmt/tests/test_b75_views.py`：15 passed。
- Revert-fail：未加入权限检查时，无权限上传用例实际返回 200，新增回归断言失败；应用修复后返回 403。

关联 Issue #4070。
