### PR TITLE
bugfix: 缓存模块级权限规则

### DIFF
--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -83,6 +83,11 @@ class TestKeyDerivation:
         padding = "=" * (-len(encoded_dimensions) % 4)
         assert json.loads(base64.urlsafe_b64decode(encoded_dimensions + padding)) == [0, 1, "cmdb", "view", False]
 
+    def test_cache_key_separates_query_scopes(self):
+        app_key = pc._get_cache_key("alice", "domain.com", 1, "log", "policy", query_scope="app")
+        module_key = pc._get_cache_key("alice", "domain.com", 1, "log", "policy", query_scope="module")
+        assert app_key != module_key
+
     def test_token_info_key_format(self):
         assert pc._get_token_info_key("u", "d") == "token_info:u:d:v0"
 
@@ -140,6 +145,26 @@ class TestPermissionRulesCache:
         data = {"team": [1], "instance": []}
         pc.set_cached_permission_rules("u", "domain.com", 1, "cmdb", "view", data)
         assert pc.get_cached_permission_rules("u", "domain.com", 1, "cmdb", "view") == data
+
+    def test_query_scopes_do_not_share_cached_payloads(self):
+        app_data = {"team": [1], "instance": []}
+        module_data = {"result": True, "data": {"1": app_data}, "team": [1]}
+        pc.set_cached_permission_rules("u", "domain.com", 1, "log", "policy", app_data)
+        pc.set_cached_permission_rules(
+            "u",
+            "domain.com",
+            1,
+            "log",
+            "policy",
+            module_data,
+            query_scope="module",
+        )
+
+        assert pc.get_cached_permission_rules("u", "domain.com", 1, "log", "policy") == app_data
+        assert (
+            pc.get_cached_permission_rules("u", "domain.com", 1, "log", "policy", query_scope="module")
+            == module_data
+        )
 
     def test_set_maintains_key_index_on_non_pattern_backend(self):
         pc.set_cached_permission_rules("u", "domain.com", 1, "cmdb", "view", {"team": []})

--- a/server/apps/core/tests/utils/test_permission_cache.py
+++ b/server/apps/core/tests/utils/test_permission_cache.py
@@ -88,6 +88,19 @@ class TestKeyDerivation:
         module_key = pc._get_cache_key("alice", "domain.com", 1, "log", "policy", query_scope="module")
         assert app_key != module_key
 
+    def test_default_scope_preserves_legacy_cache_key(self):
+        default_key = pc._get_cache_key("alice", "domain.com", 1, "log", "policy", permission_version=0)
+        explicit_app_key = pc._get_cache_key(
+            "alice",
+            "domain.com",
+            1,
+            "log",
+            "policy",
+            permission_version=0,
+            query_scope="app",
+        )
+        assert default_key == explicit_app_key
+
     def test_token_info_key_format(self):
         assert pc._get_token_info_key("u", "d") == "token_info:u:d:v0"
 

--- a/server/apps/core/tests/utils/test_permission_utils.py
+++ b/server/apps/core/tests/utils/test_permission_utils.py
@@ -103,19 +103,53 @@ class TestGetPermissionRules:
 
 
 class TestGetPermissionsRules:
-    def test_maps_app_and_calls_rpc(self, mocker):
+    def test_cache_hit_returns_cached_without_rpc(self, mocker):
+        cached = {"result": True, "data": {"9": {"team": [3]}}, "team": [3]}
+        mock_get = mocker.patch.object(pu, "get_cached_permission_rules", return_value=cached)
+        mock_client = mocker.patch.object(pu, "SystemMgmt")
+
+        result = pu.get_permissions_rules(_user(username="bob"), "3", "operation_analysis", "dash")
+
+        assert result == cached
+        mock_get.assert_called_once_with(
+            username="bob",
+            domain="domain.com",
+            current_team=3,
+            app_name="operation_analysis",
+            permission_key="dash",
+            include_children=False,
+            query_scope="module",
+        )
+        mock_client.assert_not_called()
+
+    def test_cache_miss_maps_app_calls_rpc_and_caches(self, mocker):
+        mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
+        mock_set = mocker.patch.object(pu, "set_cached_permission_rules")
         client = mocker.MagicMock()
         client.get_user_rules_by_module.return_value = {"team": [9]}
         mocker.patch.object(pu, "SystemMgmt", return_value=client)
         result = pu.get_permissions_rules(_user(username="bob"), "3", "operation_analysis", "dash", include_children=False)
         assert result == {"team": [9]}
         client.get_user_rules_by_module.assert_called_once_with(3, "bob", "ops-analysis", "dash", "domain.com", False)
+        mock_set.assert_called_once_with(
+            username="bob",
+            domain="domain.com",
+            current_team=3,
+            app_name="operation_analysis",
+            permission_key="dash",
+            permission_data={"team": [9]},
+            include_children=False,
+            query_scope="module",
+        )
 
     def test_exception_returns_empty(self, mocker):
+        mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
+        mock_set = mocker.patch.object(pu, "set_cached_permission_rules")
         client = mocker.MagicMock()
         client.get_user_rules_by_module.side_effect = ValueError("boom")
         mocker.patch.object(pu, "SystemMgmt", return_value=client)
         assert pu.get_permissions_rules(_user(), "3", "cmdb", "x") == {}
+        mock_set.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/core/tests/utils/test_permission_utils.py
+++ b/server/apps/core/tests/utils/test_permission_utils.py
@@ -118,6 +118,7 @@ class TestGetPermissionsRules:
             app_name="operation_analysis",
             permission_key="dash",
             include_children=False,
+            permission_version=0,
             query_scope="module",
         )
         mock_client.assert_not_called()
@@ -139,12 +140,14 @@ class TestGetPermissionsRules:
             permission_key="dash",
             permission_data={"team": [9]},
             include_children=False,
+            permission_version=0,
             query_scope="module",
         )
 
     def test_cache_read_failure_falls_back_to_rpc(self, mocker):
         mocker.patch.object(pu, "get_cached_permission_rules", side_effect=RuntimeError("redis down"))
         mocker.patch.object(pu, "set_cached_permission_rules")
+        mock_log = mocker.patch.object(pu.logger, "exception")
         client = mocker.MagicMock()
         client.get_user_rules_by_module.return_value = {"result": True, "data": {}, "team": [3]}
         mocker.patch.object(pu, "SystemMgmt", return_value=client)
@@ -154,10 +157,12 @@ class TestGetPermissionsRules:
             "data": {},
             "team": [3],
         }
+        mock_log.assert_called_once_with("Failed to read module permission cache")
 
     def test_cache_write_failure_keeps_rpc_result(self, mocker):
         mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
         mocker.patch.object(pu, "set_cached_permission_rules", side_effect=RuntimeError("redis down"))
+        mock_log = mocker.patch.object(pu.logger, "exception")
         client = mocker.MagicMock()
         client.get_user_rules_by_module.return_value = {"result": True, "data": {}, "team": [3]}
         mocker.patch.object(pu, "SystemMgmt", return_value=client)
@@ -167,6 +172,22 @@ class TestGetPermissionsRules:
             "data": {},
             "team": [3],
         }
+        mock_log.assert_called_once_with("Failed to write module permission cache")
+
+    def test_permission_version_change_retries_rpc_before_caching(self, mocker):
+        mocker.patch.object(pu, "get_user_permission_version", side_effect=[0, 1])
+        mock_get = mocker.patch.object(pu, "get_cached_permission_rules", side_effect=[None, None])
+        mock_set = mocker.patch.object(pu, "set_cached_permission_rules", side_effect=[False, True])
+        client = mocker.MagicMock()
+        stale = {"result": True, "data": {"old": {}}, "team": [3]}
+        fresh = {"result": True, "data": {"new": {}}, "team": [3]}
+        client.get_user_rules_by_module.side_effect = [stale, fresh]
+        mocker.patch.object(pu, "SystemMgmt", return_value=client)
+
+        assert pu.get_permissions_rules(_user(), "3", "log", "policy") == fresh
+        assert client.get_user_rules_by_module.call_count == 2
+        assert [call.kwargs["permission_version"] for call in mock_get.call_args_list] == [0, 1]
+        assert [call.kwargs["permission_version"] for call in mock_set.call_args_list] == [0, 1]
 
     def test_exception_returns_empty(self, mocker):
         mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)

--- a/server/apps/core/tests/utils/test_permission_utils.py
+++ b/server/apps/core/tests/utils/test_permission_utils.py
@@ -142,6 +142,32 @@ class TestGetPermissionsRules:
             query_scope="module",
         )
 
+    def test_cache_read_failure_falls_back_to_rpc(self, mocker):
+        mocker.patch.object(pu, "get_cached_permission_rules", side_effect=RuntimeError("redis down"))
+        mocker.patch.object(pu, "set_cached_permission_rules")
+        client = mocker.MagicMock()
+        client.get_user_rules_by_module.return_value = {"result": True, "data": {}, "team": [3]}
+        mocker.patch.object(pu, "SystemMgmt", return_value=client)
+
+        assert pu.get_permissions_rules(_user(), "3", "log", "policy") == {
+            "result": True,
+            "data": {},
+            "team": [3],
+        }
+
+    def test_cache_write_failure_keeps_rpc_result(self, mocker):
+        mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
+        mocker.patch.object(pu, "set_cached_permission_rules", side_effect=RuntimeError("redis down"))
+        client = mocker.MagicMock()
+        client.get_user_rules_by_module.return_value = {"result": True, "data": {}, "team": [3]}
+        mocker.patch.object(pu, "SystemMgmt", return_value=client)
+
+        assert pu.get_permissions_rules(_user(), "3", "log", "policy") == {
+            "result": True,
+            "data": {},
+            "team": [3],
+        }
+
     def test_exception_returns_empty(self, mocker):
         mocker.patch.object(pu, "get_cached_permission_rules", return_value=None)
         mock_set = mocker.patch.object(pu, "set_cached_permission_rules")

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -164,6 +164,7 @@ def _get_cache_key(
     permission_key: str,
     include_children: bool = False,
     permission_version: Optional[int] = None,
+    query_scope: str = "app",
 ) -> str:
     """
     生成权限规则缓存键
@@ -179,6 +180,8 @@ def _get_cache_key(
         app_name: 应用名称
         permission_key: 权限键
         include_children: 是否包含子组
+        permission_version: 权限代际
+        query_scope: 查询结果范围（app 为单模块规则，module 为模块下全部规则）
 
     Returns:
         缓存键字符串
@@ -186,11 +189,11 @@ def _get_cache_key(
     if permission_version is None:
         permission_version = get_user_permission_version(username, domain)
     user_prefix = _get_user_perm_prefix(username, domain)
-    key_data = json.dumps(
-        [permission_version, current_team, app_name, permission_key, include_children],
-        ensure_ascii=False,
-        separators=(",", ":"),
-    ).encode()
+    dimensions = [permission_version, current_team, app_name, permission_key, include_children]
+    # 默认范围沿用历史键，避免滚动发布时让全部既有权限缓存同时冷启动。
+    if query_scope != "app":
+        dimensions.append(query_scope)
+    key_data = json.dumps(dimensions, ensure_ascii=False, separators=(",", ":")).encode()
     encoded_dimensions = base64.urlsafe_b64encode(key_data).decode().rstrip("=")
     return f"{user_prefix}{encoded_dimensions}"
 
@@ -252,6 +255,7 @@ def get_cached_permission_rules(
     permission_key: str,
     include_children: bool = False,
     permission_version: Optional[int] = None,
+    query_scope: str = "app",
 ) -> Optional[Dict]:
     """
     获取缓存的权限规则
@@ -263,6 +267,8 @@ def get_cached_permission_rules(
         app_name: 应用名称
         permission_key: 权限键
         include_children: 是否包含子组
+        permission_version: 权限代际
+        query_scope: 查询结果范围
 
     Returns:
         缓存的权限规则，未命中返回 None
@@ -277,6 +283,7 @@ def get_cached_permission_rules(
         permission_key,
         include_children,
         permission_version,
+        query_scope,
     )
     cached = cache.get(cache_key)
     if cached is not None and get_user_permission_version(username, domain) == permission_version:
@@ -294,6 +301,7 @@ def set_cached_permission_rules(
     permission_data: Dict,
     include_children: bool = False,
     permission_version: Optional[int] = None,
+    query_scope: str = "app",
 ) -> bool:
     """
     缓存权限规则
@@ -306,6 +314,8 @@ def set_cached_permission_rules(
         permission_key: 权限键
         permission_data: 权限数据
         include_children: 是否包含子组
+        permission_version: 权限代际
+        query_scope: 查询结果范围
     """
     if permission_version is None:
         permission_version = get_user_permission_version(username, domain)
@@ -319,6 +329,7 @@ def set_cached_permission_rules(
         permission_key,
         include_children,
         permission_version,
+        query_scope,
     )
     cache.set(cache_key, permission_data, PERMISSION_CACHE_TTL)
 

--- a/server/apps/core/utils/permission_utils.py
+++ b/server/apps/core/utils/permission_utils.py
@@ -76,6 +76,19 @@ def set_rules_module_params(app_name, permission_key):
 
 def get_permissions_rules(user, current_team, app_name, permission_key, include_children=False):
     """获取某app某类权限规则"""
+    cached = get_cached_permission_rules(
+        username=user.username,
+        domain=user.domain,
+        current_team=int(current_team),
+        app_name=app_name,
+        permission_key=permission_key,
+        include_children=include_children,
+        query_scope="module",
+    )
+    if cached is not None:
+        return cached
+
+    cache_app_name = app_name
     app_name_map = {
         "system_mgmt": "system-manager",
         "node_mgmt": "node",
@@ -96,6 +109,16 @@ def get_permissions_rules(user, current_team, app_name, permission_key, include_
             module,
             user.domain,
             include_children,
+        )
+        set_cached_permission_rules(
+            username=user.username,
+            domain=user.domain,
+            current_team=int(current_team),
+            app_name=cache_app_name,
+            permission_key=permission_key,
+            permission_data=permission_data,
+            include_children=include_children,
+            query_scope="module",
         )
         return permission_data
     except Exception:

--- a/server/apps/core/utils/permission_utils.py
+++ b/server/apps/core/utils/permission_utils.py
@@ -76,15 +76,19 @@ def set_rules_module_params(app_name, permission_key):
 
 def get_permissions_rules(user, current_team, app_name, permission_key, include_children=False):
     """获取某app某类权限规则"""
-    cached = get_cached_permission_rules(
-        username=user.username,
-        domain=user.domain,
-        current_team=int(current_team),
-        app_name=app_name,
-        permission_key=permission_key,
-        include_children=include_children,
-        query_scope="module",
-    )
+    try:
+        cached = get_cached_permission_rules(
+            username=user.username,
+            domain=user.domain,
+            current_team=int(current_team),
+            app_name=app_name,
+            permission_key=permission_key,
+            include_children=include_children,
+            query_scope="module",
+        )
+    except Exception as exc:
+        logger.warning(f"Failed to read module permission cache: {exc}")
+        cached = None
     if cached is not None:
         return cached
 
@@ -110,6 +114,10 @@ def get_permissions_rules(user, current_team, app_name, permission_key, include_
             user.domain,
             include_children,
         )
+    except Exception:
+        return {}
+
+    try:
         set_cached_permission_rules(
             username=user.username,
             domain=user.domain,
@@ -120,9 +128,9 @@ def get_permissions_rules(user, current_team, app_name, permission_key, include_
             include_children=include_children,
             query_scope="module",
         )
-        return permission_data
-    except Exception:
-        return {}
+    except Exception as exc:
+        logger.warning(f"Failed to write module permission cache: {exc}")
+    return permission_data
 
 
 def permission_filter(model, permission, team_key="teams__id__in", id_key="id__in"):

--- a/server/apps/core/utils/permission_utils.py
+++ b/server/apps/core/utils/permission_utils.py
@@ -76,22 +76,6 @@ def set_rules_module_params(app_name, permission_key):
 
 def get_permissions_rules(user, current_team, app_name, permission_key, include_children=False):
     """获取某app某类权限规则"""
-    try:
-        cached = get_cached_permission_rules(
-            username=user.username,
-            domain=user.domain,
-            current_team=int(current_team),
-            app_name=app_name,
-            permission_key=permission_key,
-            include_children=include_children,
-            query_scope="module",
-        )
-    except Exception as exc:
-        logger.warning(f"Failed to read module permission cache: {exc}")
-        cached = None
-    if cached is not None:
-        return cached
-
     cache_app_name = app_name
     app_name_map = {
         "system_mgmt": "system-manager",
@@ -104,33 +88,60 @@ def get_permissions_rules(user, current_team, app_name, permission_key, include_
     }
     app_name = app_name_map.get(app_name, app_name)
     module = permission_key
-    client = SystemMgmt(is_local_client=True)
-    try:
-        permission_data = client.get_user_rules_by_module(
-            int(current_team),
-            user.username,
-            app_name,
-            module,
-            user.domain,
-            include_children,
-        )
-    except Exception:
-        return {}
+    client = None
+    for _attempt in range(2):
+        permission_version = None
+        try:
+            permission_version = get_user_permission_version(user.username, user.domain)
+            cached = get_cached_permission_rules(
+                username=user.username,
+                domain=user.domain,
+                current_team=int(current_team),
+                app_name=cache_app_name,
+                permission_key=permission_key,
+                include_children=include_children,
+                permission_version=permission_version,
+                query_scope="module",
+            )
+        except Exception:
+            logger.exception("Failed to read module permission cache")
+            cached = None
+        if cached is not None:
+            return cached
 
-    try:
-        set_cached_permission_rules(
-            username=user.username,
-            domain=user.domain,
-            current_team=int(current_team),
-            app_name=cache_app_name,
-            permission_key=permission_key,
-            permission_data=permission_data,
-            include_children=include_children,
-            query_scope="module",
-        )
-    except Exception as exc:
-        logger.warning(f"Failed to write module permission cache: {exc}")
-    return permission_data
+        try:
+            if client is None:
+                client = SystemMgmt(is_local_client=True)
+            permission_data = client.get_user_rules_by_module(
+                int(current_team),
+                user.username,
+                app_name,
+                module,
+                user.domain,
+                include_children,
+            )
+        except Exception:
+            return {}
+
+        if permission_version is None:
+            return permission_data
+        try:
+            if set_cached_permission_rules(
+                username=user.username,
+                domain=user.domain,
+                current_team=int(current_team),
+                app_name=cache_app_name,
+                permission_key=permission_key,
+                permission_data=permission_data,
+                include_children=include_children,
+                permission_version=permission_version,
+                query_scope="module",
+            ):
+                return permission_data
+        except Exception:
+            logger.exception("Failed to write module permission cache")
+            return permission_data
+    return {}
 
 
 def permission_filter(model, permission, team_key="teams__id__in", id_key="id__in"):


### PR DESCRIPTION
## 问题

`get_permissions_rules` 承担日志与监控热路径的模块级权限读取，本应复用权限缓存；当前实现却在每次调用时直接请求 system_mgmt，使同一用户、团队和权限模块的幂等查询随请求并发重复放大。

## 根因（设计层）

现有缓存抽象只编码了用户、团队、应用和权限键，没有表达查询结果的范围。单模块查询与“模块下全部规则”查询返回结构不同，因此复数 helper 历史上没有安全接入缓存；若直接共用原键，还会产生两种响应结构相互污染的风险。

## 怎么修的

- 在权限缓存键中加入可选的查询范围维度，默认值保持现有调用契约。
- `get_permissions_rules` 使用独立的 `module` 范围，按 cache-first、RPC fallback、set-on-miss 执行。
- 缓存写入仍复用现有 TTL 与按用户失效机制，权限变更时无需新增清理链路。

## 影响范围

- 触及 `core` 共享权限工具，直接受益调用方位于日志与监控模块。
- 不改变函数入参、返回结构、NATS subject 或权限判定语义。
- 部署后旧缓存键只会产生一次冷启动未命中，之后按新键复用；旧数据按既有 TTL 自然过期。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        L["日志/监控权限入口\nserver/apps/log、server/apps/monitor"]
    end

    C["get_cached_permission_rules\npermission_cache.py"]

    subgraph N["核心处理层"]
        P["get_permissions_rules\npermission_utils.py"]
        R["get_user_rules_by_module\nSystemMgmt RPC"]
    end

    S["set_cached_permission_rules\nquery_scope=module"]

    L --> P --> C
    C -- "命中" --> P
    C -. "未命中" .-> R --> S --> P
```

## 验证

- `server/apps/core/tests/utils/test_permission_cache.py`
- `server/apps/core/tests/utils/test_permission_utils.py`
- 结果：53 passed。
- Revert-fail：移除模块级缓存接入后，缓存命中跳过 RPC 的测试失败，确认测试直接覆盖修复点。

Closes #3992
