### PR TITLE
fix(system_mgmt): 用户同步超长外部字段防溢出,修复 AD 域同步整轮崩溃

### DIFF
--- a/server/apps/system_mgmt/services/user_sync_service.py
+++ b/server/apps/system_mgmt/services/user_sync_service.py
@@ -1,3 +1,4 @@
+import hashlib
 from copy import deepcopy
 from types import SimpleNamespace
 import uuid
@@ -385,10 +386,11 @@ def _sync_groups(source: UserSyncSource, group_list: list[dict], root_group: Gro
         for item in current_items:
             external_id = str(item["id"])
             scoped_external_id = _scoped_external_id(source.id, external_id)
+            group_name = _truncate_to_field(Group, "name", str(item.get("name", external_id)))
             group = existing_by_external_id.get(scoped_external_id)
             if group is None:
                 group = Group.objects.create(
-                    name=item.get("name", external_id),
+                    name=group_name,
                     parent_id=parent_group.id,
                     external_id=scoped_external_id,
                     description=f"user_sync_source_{source.id}",
@@ -396,8 +398,8 @@ def _sync_groups(source: UserSyncSource, group_list: list[dict], root_group: Gro
                 )
             else:
                 update_fields = []
-                if group.name != item.get("name", external_id):
-                    group.name = item.get("name", external_id)
+                if group.name != group_name:
+                    group.name = group_name
                     update_fields.append("name")
                 if group.sync_source_id != source.id:
                     group.sync_source = source
@@ -426,6 +428,8 @@ def _sync_users(
         username = str(_mapped_value(raw_user, field_mapping, "username") or raw_user.get("user_id") or raw_user.get("open_id") or "").strip()
         if not username:
             continue
+        # 截断后的 username 同时作为本轮匹配键,保证与写库值一致
+        username = _truncate_to_field(User, "username", username)
         departments = [str(item) for item in raw_user.get("department_ids") or raw_user.get("departments") or []]
         local_group_ids = []
         for department_id in departments:
@@ -439,9 +443,11 @@ def _sync_users(
         normalized_users.append(
             {
                 "username": username,
-                "display_name": str(_mapped_value(raw_user, field_mapping, "display_name") or username),
-                "email": str(_mapped_value(raw_user, field_mapping, "email") or ""),
-                "phone": str(_mapped_value(raw_user, field_mapping, "phone") or ""),
+                "display_name": _truncate_to_field(
+                    User, "display_name", str(_mapped_value(raw_user, field_mapping, "display_name") or username)
+                ),
+                "email": _truncate_to_field(User, "email", str(_mapped_value(raw_user, field_mapping, "email") or "")),
+                "phone": _truncate_to_field(User, "phone", str(_mapped_value(raw_user, field_mapping, "phone") or "")),
                 "group_list": sorted(set(local_group_ids)),
             }
         )
@@ -460,7 +466,9 @@ def _sync_users(
     # 解析 password_init 配置;仅在新建用户时触发。
     # 字段位置迁移:从 source.business_config.password_init → source.password_init_config
     # 后者避开 provider manifest contract 校验。
-    password_init_cfg = source.password_init_config or {}
+    # getattr 兜底:password_init_config 模型字段尚未落库(65afd9bb1 只提交了引用),
+    # 缺字段时按「未配置密码初始化」降级,不能让整轮同步崩掉
+    password_init_cfg = getattr(source, "password_init_config", None) or {}
     password_init_mode = password_init_cfg.get("mode")
 
     for item in normalized_users:
@@ -594,8 +602,25 @@ def _mapped_value(raw_user: dict, field_mapping: dict, logical_key: str):
     return raw_user.get(source_key)
 
 
+def _truncate_to_field(model, field_name: str, value: str) -> str:
+    """按模型字段 max_length 截断外部数据,防止超长值(如 AD 的 DN/名称)溢出 varchar 上限。"""
+    max_length = model._meta.get_field(field_name).max_length
+    if max_length is None or len(value) <= max_length:
+        return value
+    return value[:max_length]
+
+
 def _scoped_external_id(source_id: int, external_id: str):
-    return f"user-sync:{source_id}:{external_id}"
+    scoped = f"user-sync:{source_id}:{external_id}"
+    max_length = Group._meta.get_field("external_id").max_length
+    if max_length is None or len(scoped) <= max_length:
+        return scoped
+    # 外部 ID 超长(如 AD 组织的 DN):截断并追加摘要。同一外部 ID 每轮生成相同值
+    # (否则每轮同步都会删除重建组),不同外部 ID 截断后也不会互相碰撞。
+    digest = hashlib.sha256(external_id.encode("utf-8")).hexdigest()[:16]
+    prefix = f"user-sync:{source_id}:"
+    keep = max_length - len(prefix) - len(digest) - 1
+    return f"{prefix}{external_id[:max(keep, 0)]}~{digest}"
 
 
 def _get_user_sync_root_group(source: UserSyncSource):

--- a/server/apps/system_mgmt/tests/test_user_sync_service.py
+++ b/server/apps/system_mgmt/tests/test_user_sync_service.py
@@ -1592,3 +1592,103 @@ def test_user_sync_source_periodic_task_args_are_json_serialized(ready_integrati
         f'[{source.id},"{UserSyncTriggerModeChoices.SCHEDULE}"]',
         "apps.system_mgmt.tasks.execute_user_sync_source",
     )
+
+
+# ---------------------------------------------------------------------------
+# 超长外部字段防溢出(AD 场景:组织 id 为 LDAP DN,中文 OU 的 DN 轻易超过
+# Group.external_id / Group.name 等 varchar(100) 上限,曾导致整轮同步
+# StringDataRightTruncation 崩溃)
+# ---------------------------------------------------------------------------
+
+
+def _long_department_dn(rdn_label: str) -> str:
+    """构造一个超过 100 字符的 LDAP DN(模拟 AD 组织)。"""
+    return f"OU={rdn_label},OU=" + "部" * 60 + ",OU=某集团中国,DC=example,DC=com"
+
+
+def test_scoped_external_id_fits_group_field_and_stays_deterministic():
+    external_id_max_length = Group._meta.get_field("external_id").max_length
+
+    assert user_sync_service_module._scoped_external_id(1, "dept-a") == "user-sync:1:dept-a"
+
+    long_dn_a = _long_department_dn("研发中心")
+    long_dn_b = _long_department_dn("行政中心")
+    assert len(f"user-sync:1:{long_dn_a}") > external_id_max_length
+
+    scoped_a = user_sync_service_module._scoped_external_id(1, long_dn_a)
+    assert len(scoped_a) <= external_id_max_length
+    assert scoped_a.startswith("user-sync:1:")
+    # 同一外部 ID 每轮同步必须生成相同值,否则每轮都会删除重建组
+    assert scoped_a == user_sync_service_module._scoped_external_id(1, long_dn_a)
+    # 不同外部 ID 压缩后不能互相碰撞,不同 source 之间也要隔离
+    assert scoped_a != user_sync_service_module._scoped_external_id(1, long_dn_b)
+    assert scoped_a != user_sync_service_module._scoped_external_id(2, long_dn_a)
+
+
+@pytest.mark.django_db
+def test_execute_user_sync_survives_overlong_group_and_user_fields(ready_integration_instance):
+    root_dn = _long_department_dn("根组织")
+    parent_dn = _long_department_dn("华南分公司")
+    child_dn = _long_department_dn("华南分公司二级事业部")
+    source = UserSyncSource.objects.create(
+        name="source-ad-long-dn",
+        integration_instance=ready_integration_instance,
+        enabled=True,
+        root_group_name="AD Long Root",
+        business_config={"root_department_id": root_dn},
+        field_mapping={},
+        schedule_config={},
+    )
+
+    overlong_username = "u" * 130
+    payload = CapabilityExecutionResult.success_result(
+        "ok",
+        payload={
+            "group_list": [
+                {"id": parent_dn, "parent_id": root_dn, "name": "部" * 120},
+                {"id": child_dn, "parent_id": parent_dn, "name": "二级事业部"},
+            ],
+            "user_list": [
+                {
+                    "user_id": overlong_username,
+                    "name": "名" * 150,
+                    "email": "user1@example.com",
+                    "mobile": "1" * 40,
+                    "department_ids": [child_dn],
+                }
+            ],
+        },
+    )
+
+    with patch("apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute", return_value=payload):
+        first_result = execute_user_sync(source.id)
+
+    assert first_result["result"] is True, first_result["message"]
+
+    external_id_max_length = Group._meta.get_field("external_id").max_length
+    name_max_length = Group._meta.get_field("name").max_length
+
+    root_group = Group.objects.get(parent_id=0, name="AD Long Root")
+    assert len(root_group.external_id) <= external_id_max_length
+
+    parent_group = Group.objects.get(parent_id=root_group.id, sync_source=source)
+    assert len(parent_group.external_id) <= external_id_max_length
+    assert parent_group.name == "部" * name_max_length
+
+    child_group = Group.objects.get(parent_id=parent_group.id, sync_source=source)
+    assert child_group.name == "二级事业部"
+    assert len(child_group.external_id) <= external_id_max_length
+
+    user = User.objects.get(username=overlong_username[: User._meta.get_field("username").max_length])
+    assert user.display_name == "名" * User._meta.get_field("display_name").max_length
+    assert user.phone == "1" * User._meta.get_field("phone").max_length
+    assert user.group_list == [child_group.id]
+
+    # 再次同步必须幂等:组不重建、不残留重复,用户不翻倍
+    with patch("apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute", return_value=payload):
+        second_result = execute_user_sync(source.id)
+
+    assert second_result["result"] is True, second_result["message"]
+    assert Group.objects.filter(sync_source=source).count() == 3
+    assert Group.objects.get(parent_id=root_group.id, sync_source=source).id == parent_group.id
+    assert User.objects.filter(username__startswith="u").count() == 1


### PR DESCRIPTION
## 问题

AD 域用户源执行同步时整轮失败,日志报:

```
User sync failed for source '某客户-AD域': value too long for type character varying(100)
psycopg.errors.StringDataRightTruncation
```

## 根因

AD provider 把组织的 `id` 设为完整 LDAP DN(`server/apps/system_mgmt/providers/adapters/ad.py` 的 `_build_group_entries`),同步服务的 `_scoped_external_id` 再拼上 `user-sync:{source_id}:` 前缀写入 `Group.external_id`(`varchar(100)`)。中文 OU 的 DN 轻易超过 100 字符,插入即 `StringDataRightTruncation`,整轮同步事务回滚(0 用户 0 组织)。

## 改动

- **`_scoped_external_id`**(全部 external_id 的唯一生成点):超长时改为「截断 + sha256 摘要后缀」。同一外部 ID 每轮生成相同值(否则每轮同步都会删组重建),不同外部 ID 压缩后不碰撞,不同 source 之间隔离。
- **组织 `name`、用户 `username`/`display_name`/`email`/`phone`**:按各自模型字段 `max_length` 截断后写库(新增 `_truncate_to_field` helper,动态读字段上限,不硬编码);`username` 截断值同时作为本轮匹配键,保证幂等。
- **`password_init_config` 读取加 `getattr` 兜底**:65afd9bb1 在服务里引用了 `source.password_init_config`,但模型字段/migration/`password_init_service` 模块均未提交,任何同步都会 AttributeError。缺字段时按「未配置密码初始化」降级,不阻塞同步。补字段的收尾工作需单独 PR(见下)。

## 测试

- 新增 `_scoped_external_id` 单元测试(长度上限/确定性/防碰撞/source 隔离)。
- 新增超长 DN 组织树 + 超长用户字段的全链路测试,含二次同步幂等断言(组不重建、用户不翻倍)。
- `test_user_sync_service.py` 从基线 18 failed 降至 10 failed,剩余 10 个逐一与基线比对确认全部为 65afd9bb1 既有失败(serializer schedule 校验、bulk_create 测试腐化——该测试 mock 的 `bulk_create` 已被改成逐个 `create`,mock 永不生效),本 PR 零新增回归。
- `test_ad_provider.py` + `test_tasks_coverage.py` 40 全过;black/isort/flake8 与基线逐项对比零新增违规。

本地验证命令:

```bash
cd server && DB_ENGINE=sqlite DB_NAME=':memory:' ENABLE_CELERY=true INSTALL_APPS=system_mgmt \
  MINIO_ENDPOINT=127.0.0.1:9000 MINIO_ACCESS_KEY=test MINIO_SECRET_KEY=testtesttest MINIO_USE_HTTPS=false \
  uv run pytest -o addopts='' apps/system_mgmt/tests/test_user_sync_service.py -q
```

## 审阅提示

- external_id 压缩格式为 `user-sync:{source_id}:{DN前缀}~{sha256前16位}`,只在超长时启用,存量短 ID 的行为与格式完全不变,无需数据迁移。
- 65afd9bb1 的收尾(补 `UserSyncSource.password_init_config` 字段 + migration、缺失的 `password_init_service` 模块、11 个 serializer 测试失败)不在本 PR 范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
