### PR TITLE
fix(core): 修正安全请求重定向语义

### DIFF
--- a/server/apps/core/tests/test_safe_requests_service.py
+++ b/server/apps/core/tests/test_safe_requests_service.py
@@ -10,12 +10,39 @@ from apps.core.utils.ssrf_validator import SSRFError
 def _make_response(*, is_redirect=False, location=None, status_code=None):
     resp = requests.Response()
     resp.status_code = status_code if status_code is not None else (302 if is_redirect else 200)
+    resp._content = b""
+    resp._content_consumed = True
     if location:
         resp.headers["Location"] = location
     return resp
 
 
 class TestSafeRequest:
+    @pytest.mark.parametrize(
+        ("status_code", "method", "expected_method", "keeps_body"),
+        [
+            (301, "POST", "GET", False),
+            (301, "PUT", "PUT", False),
+            (302, "PATCH", "GET", False),
+            (303, "DELETE", "GET", False),
+            (303, "HEAD", "HEAD", False),
+            (307, "POST", "POST", True),
+            (308, "PATCH", "PATCH", True),
+        ],
+    )
+    def test_redirect_method_and_body_matrix(self, status_code, method, expected_method, keeps_body):
+        redirect_method, redirect_kwargs = sr._prepare_redirect_request(
+            method,
+            "https://service.example/start",
+            "https://service.example/next",
+            status_code,
+            {"json": {"state": "ready"}, "headers": {"Content-Type": "application/json"}},
+        )
+
+        assert redirect_method == expected_method
+        assert ("json" in redirect_kwargs) is keeps_body
+        assert ("Content-Type" in redirect_kwargs["headers"]) is keeps_body
+
     def test_validates_url_and_returns_response(self, mocker):
         validate = mocker.patch.object(sr.SSRFValidator, "validate", return_value="https://safe.example/api")
         req = mocker.patch.object(sr.requests, "request", return_value=_make_response())
@@ -53,6 +80,22 @@ class TestSafeRequest:
         assert validate.call_args_list[1][0][0] == "https://redirect-target"
         assert req.call_count == 2
 
+    def test_relative_redirect_is_resolved_and_intermediate_response_closed(self, mocker):
+        validate = mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://service.example/v1/start", "https://service.example/v2/next"],
+        )
+        first = _make_response(status_code=302, location="../v2/next")
+        close = mocker.patch.object(first, "close")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+
+        sr.safe_request("GET", "https://service.example/v1/start", allow_redirects=True)
+
+        assert validate.call_args_list[1].args[0] == "https://service.example/v2/next"
+        assert req.call_args_list[1].args == ("GET", "https://service.example/v2/next")
+        close.assert_called_once_with()
+
     def test_cross_origin_303_uses_get_without_body_or_credentials(self, mocker):
         mocker.patch.object(
             sr.SSRFValidator,
@@ -64,6 +107,7 @@ class TestSafeRequest:
         headers = {
             "Authorization": "Bearer secret",
             "Cookie": "session=secret",
+            "Proxy-Authorization": "Basic proxy-secret",
             "Content-Type": "application/json",
             "X-Request-ID": "request-id",
         }
@@ -99,7 +143,7 @@ class TestSafeRequest:
             "PUT",
             "https://service.example/start",
             allow_redirects=True,
-            headers={"Authorization": "Bearer secret"},
+            headers={"Authorization": "Bearer secret", "Proxy-Authorization": "Basic proxy-secret"},
             cookies={"session": "secret"},
             json={"state": "ready"},
         )
@@ -107,6 +151,7 @@ class TestSafeRequest:
         redirect_call = req.call_args_list[1]
         assert redirect_call.args == ("PUT", "https://service.example/next")
         assert redirect_call.kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert "Proxy-Authorization" not in redirect_call.kwargs["headers"]
         assert redirect_call.kwargs["cookies"] == {"session": "secret"}
         assert redirect_call.kwargs["json"] == {"state": "ready"}
 

--- a/server/apps/core/tests/test_safe_requests_service.py
+++ b/server/apps/core/tests/test_safe_requests_service.py
@@ -7,9 +7,9 @@ from apps.core.utils import safe_requests as sr
 from apps.core.utils.ssrf_validator import SSRFError
 
 
-def _make_response(*, is_redirect=False, location=None):
+def _make_response(*, is_redirect=False, location=None, status_code=None):
     resp = requests.Response()
-    resp.status_code = 302 if is_redirect else 200
+    resp.status_code = status_code if status_code is not None else (302 if is_redirect else 200)
     if location:
         resp.headers["Location"] = location
     return resp
@@ -53,6 +53,84 @@ class TestSafeRequest:
         assert validate.call_args_list[1][0][0] == "https://redirect-target"
         assert req.call_count == 2
 
+    def test_cross_origin_303_uses_get_without_body_or_credentials(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://source.example/start", "https://target.example/next"],
+        )
+        first = _make_response(status_code=303, location="https://target.example/next")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+        headers = {
+            "Authorization": "Bearer secret",
+            "Cookie": "session=secret",
+            "Content-Type": "application/json",
+            "X-Request-ID": "request-id",
+        }
+
+        sr.safe_request(
+            "POST",
+            "https://source.example/start",
+            allow_redirects=True,
+            headers=headers,
+            cookies={"session": "secret"},
+            json={"action": "charge"},
+            params={"source": "tool"},
+        )
+
+        redirect_call = req.call_args_list[1]
+        assert redirect_call.args == ("GET", "https://target.example/next")
+        assert redirect_call.kwargs["headers"] == {"X-Request-ID": "request-id"}
+        assert "cookies" not in redirect_call.kwargs
+        assert "json" not in redirect_call.kwargs
+        assert "params" not in redirect_call.kwargs
+        assert headers["Authorization"] == "Bearer secret"
+
+    def test_same_origin_307_preserves_method_body_and_credentials(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://service.example/start", "https://service.example/next"],
+        )
+        first = _make_response(status_code=307, location="https://service.example/next")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+
+        sr.safe_request(
+            "PUT",
+            "https://service.example/start",
+            allow_redirects=True,
+            headers={"Authorization": "Bearer secret"},
+            cookies={"session": "secret"},
+            json={"state": "ready"},
+        )
+
+        redirect_call = req.call_args_list[1]
+        assert redirect_call.args == ("PUT", "https://service.example/next")
+        assert redirect_call.kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert redirect_call.kwargs["cookies"] == {"session": "secret"}
+        assert redirect_call.kwargs["json"] == {"state": "ready"}
+
+    def test_http_to_https_upgrade_keeps_same_host_credentials(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["http://service.example/start", "https://service.example/next"],
+        )
+        first = _make_response(status_code=307, location="https://service.example/next")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+
+        sr.safe_request(
+            "GET",
+            "http://service.example/start",
+            allow_redirects=True,
+            headers={"Authorization": "Bearer secret"},
+            cookies={"session": "secret"},
+        )
+
+        redirect_kwargs = req.call_args_list[1].kwargs
+        assert redirect_kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert redirect_kwargs["cookies"] == {"session": "secret"}
+
     def test_redirect_without_location_breaks(self, mocker):
         mocker.patch.object(sr.SSRFValidator, "validate", return_value="https://safe")
         resp = _make_response(is_redirect=True)  # no Location header
@@ -95,6 +173,28 @@ class TestSafeRequestLLMEndpoint:
         mocker.patch.object(sr.requests, "request", return_value=_make_response(is_redirect=True, location="http://x"))
         with pytest.raises(SSRFError):
             sr.safe_request_llm_endpoint("GET", "http://10.0.0.5", allow_redirects=False)
+
+    def test_llm_303_uses_get_without_body(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate_llm_endpoint",
+            side_effect=["http://10.0.0.5/v1", "http://10.0.0.6/v1"],
+        )
+        first = _make_response(status_code=303, location="http://10.0.0.6/v1")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+
+        sr.safe_request_llm_endpoint(
+            "POST",
+            "http://10.0.0.5/v1",
+            allow_redirects=True,
+            headers={"Authorization": "Bearer secret", "Content-Type": "application/json"},
+            json={"prompt": "hello"},
+        )
+
+        redirect_call = req.call_args_list[1]
+        assert redirect_call.args == ("GET", "http://10.0.0.6/v1")
+        assert redirect_call.kwargs["headers"] == {}
+        assert "json" not in redirect_call.kwargs
 
     def test_llm_request_exception_wrapped(self, mocker):
         mocker.patch.object(sr.SSRFValidator, "validate_llm_endpoint", return_value="http://10.0.0.5")

--- a/server/apps/core/tests/test_safe_requests_service.py
+++ b/server/apps/core/tests/test_safe_requests_service.py
@@ -1,5 +1,6 @@
-import pydantic.root_model  # noqa
+from io import BytesIO
 
+import pydantic.root_model  # noqa
 import pytest
 import requests
 
@@ -30,18 +31,29 @@ class TestSafeRequest:
             (308, "PATCH", "PATCH", True),
         ],
     )
-    def test_redirect_method_and_body_matrix(self, status_code, method, expected_method, keeps_body):
-        redirect_method, redirect_kwargs = sr._prepare_redirect_request(
+    def test_redirect_method_and_body_matrix_from_public_entry(
+        self, mocker, status_code, method, expected_method, keeps_body
+    ):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://service.example/start", "https://service.example/next"],
+        )
+        first = _make_response(status_code=status_code, location="https://service.example/next")
+        req = mocker.patch.object(sr.requests, "request", side_effect=[first, _make_response()])
+
+        sr.safe_request(
             method,
             "https://service.example/start",
-            "https://service.example/next",
-            status_code,
-            {"json": {"state": "ready"}, "headers": {"Content-Type": "application/json"}},
+            allow_redirects=True,
+            json={"state": "ready"},
+            headers={"Content-Type": "application/json"},
         )
 
-        assert redirect_method == expected_method
-        assert ("json" in redirect_kwargs) is keeps_body
-        assert ("Content-Type" in redirect_kwargs["headers"]) is keeps_body
+        redirect_call = req.call_args_list[1]
+        assert redirect_call.args == (expected_method, "https://service.example/next")
+        assert ("json" in redirect_call.kwargs) is keeps_body
+        assert ("Content-Type" in redirect_call.kwargs["headers"]) is keeps_body
 
     def test_validates_url_and_returns_response(self, mocker):
         validate = mocker.patch.object(sr.SSRFValidator, "validate", return_value="https://safe.example/api")
@@ -107,6 +119,7 @@ class TestSafeRequest:
         headers = {
             "Authorization": "Bearer secret",
             "Cookie": "session=secret",
+            "Host": "source.example",
             "Proxy-Authorization": "Basic proxy-secret",
             "Content-Type": "application/json",
             "X-Request-ID": "request-id",
@@ -120,15 +133,72 @@ class TestSafeRequest:
             cookies={"session": "secret"},
             json={"action": "charge"},
             params={"source": "tool"},
+            auth=("user", "password"),
         )
 
         redirect_call = req.call_args_list[1]
         assert redirect_call.args == ("GET", "https://target.example/next")
         assert redirect_call.kwargs["headers"] == {"X-Request-ID": "request-id"}
         assert "cookies" not in redirect_call.kwargs
+        assert "auth" not in redirect_call.kwargs
         assert "json" not in redirect_call.kwargs
         assert "params" not in redirect_call.kwargs
         assert headers["Authorization"] == "Bearer secret"
+
+    def test_307_rewinds_seekable_stream_before_redirect(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://service.example/start", "https://service.example/next"],
+        )
+        class NonIterableStream:
+            def __init__(self, content):
+                self._stream = BytesIO(content)
+
+            def read(self):
+                return self._stream.read()
+
+            def tell(self):
+                return self._stream.tell()
+
+            def seek(self, position):
+                return self._stream.seek(position)
+
+        stream = NonIterableStream(b"request-body")
+        payloads = []
+
+        def request(method, url, **kwargs):
+            payloads.append(kwargs["data"].read())
+            if len(payloads) == 1:
+                return _make_response(status_code=307, location="https://service.example/next")
+            return _make_response()
+
+        mocker.patch.object(sr.requests, "request", side_effect=request)
+
+        sr.safe_request("POST", "https://service.example/start", allow_redirects=True, data=stream)
+
+        assert payloads == [b"request-body", b"request-body"]
+
+    def test_307_rejects_unrewindable_stream(self, mocker):
+        mocker.patch.object(
+            sr.SSRFValidator,
+            "validate",
+            side_effect=["https://service.example/start", "https://service.example/next"],
+        )
+
+        def body():
+            yield b"request-body"
+
+        def request(method, url, **kwargs):
+            list(kwargs["data"])
+            return _make_response(status_code=307, location="https://service.example/next")
+
+        req = mocker.patch.object(sr.requests, "request", side_effect=request)
+
+        with pytest.raises(sr.SafeRequestsError, match="重定向请求体不可回卷"):
+            sr.safe_request("POST", "https://service.example/start", allow_redirects=True, data=body())
+
+        assert req.call_count == 1
 
     def test_same_origin_307_preserves_method_body_and_credentials(self, mocker):
         mocker.patch.object(

--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -14,6 +14,7 @@
 """
 
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 import requests
 from requests import Response
@@ -26,6 +27,78 @@ class SafeRequestsError(Exception):
     """安全请求错误"""
 
     pass
+
+
+def _should_strip_credentials(current_url: str, redirect_url: str) -> bool:
+    """Match requests' auth boundary, including its compatible HTTP-to-HTTPS upgrade."""
+    current = urlparse(current_url)
+    redirect = urlparse(redirect_url)
+    if current.hostname != redirect.hostname:
+        return True
+    if (
+        current.scheme == "http"
+        and current.port in (80, None)
+        and redirect.scheme == "https"
+        and redirect.port in (443, None)
+    ):
+        return False
+
+    changed_port = current.port != redirect.port
+    changed_scheme = current.scheme != redirect.scheme
+    default_port = ({"http": 80, "https": 443}.get(current.scheme), None)
+    if not changed_scheme and current.port in default_port and redirect.port in default_port:
+        return False
+    return changed_port or changed_scheme
+
+
+def _without_headers(headers: dict[str, Any], names: set[str]) -> dict[str, Any]:
+    blocked = {name.lower() for name in names}
+    return {name: value for name, value in headers.items() if name.lower() not in blocked}
+
+
+def _prepare_redirect_request(
+    method: str,
+    current_url: str,
+    redirect_url: str,
+    status_code: int,
+    kwargs: dict[str, Any],
+) -> tuple[str, dict[str, Any]]:
+    """Apply requests-compatible method rules and credential boundaries to one redirect."""
+    redirect_method = method
+    upper_method = method.upper()
+    if status_code == requests.codes.see_other and upper_method != "HEAD":
+        redirect_method = "GET"
+    elif status_code == requests.codes.found and upper_method != "HEAD":
+        redirect_method = "GET"
+    elif status_code == requests.codes.moved and upper_method == "POST":
+        redirect_method = "GET"
+
+    redirect_kwargs = kwargs.copy()
+    # The original query parameters have already been applied to the first URL.
+    redirect_kwargs.pop("params", None)
+
+    headers = redirect_kwargs.get("headers")
+    if headers is not None:
+        headers = dict(headers)
+
+    # requests discards the entity when following 301/302/303 responses. 307/308
+    # intentionally preserve both the method and body.
+    if status_code not in (requests.codes.temporary_redirect, requests.codes.permanent_redirect):
+        for key in ("data", "files", "json"):
+            redirect_kwargs.pop(key, None)
+        if headers is not None:
+            headers = _without_headers(headers, {"Content-Length", "Content-Type", "Transfer-Encoding"})
+
+    if _should_strip_credentials(current_url, redirect_url):
+        redirect_kwargs.pop("auth", None)
+        redirect_kwargs.pop("cookies", None)
+        if headers is not None:
+            headers = _without_headers(headers, {"Authorization", "Cookie", "Host", "Proxy-Authorization"})
+
+    if headers is not None:
+        redirect_kwargs["headers"] = headers
+
+    return redirect_method, redirect_kwargs
 
 
 def safe_request(
@@ -66,6 +139,7 @@ def safe_request(
 
     try:
         response = requests.request(method, validated_url, **kwargs)
+        current_url = validated_url
 
         # 3. 手动处理重定向
         redirect_count = 0
@@ -82,7 +156,11 @@ def safe_request(
             # 校验重定向目标
             validated_redirect = SSRFValidator.validate(redirect_url, allowlist=allowlist)
             logger.info(f"[SafeRequests] 重定向: {url} -> {validated_redirect}")
+            method, kwargs = _prepare_redirect_request(
+                method, current_url, validated_redirect, response.status_code, kwargs
+            )
             response = requests.request(method, validated_redirect, **kwargs)
+            current_url = validated_redirect
             redirect_count += 1
 
         return response
@@ -162,6 +240,7 @@ def safe_request_llm_endpoint(
 
     try:
         response = requests.request(method, validated_url, **kwargs)
+        current_url = validated_url
 
         # 3. 手动处理重定向
         redirect_count = 0
@@ -178,7 +257,11 @@ def safe_request_llm_endpoint(
             # 校验重定向目标（宽松模式）
             validated_redirect = SSRFValidator.validate_llm_endpoint(redirect_url)
             logger.info(f"[SafeRequests-LLM] 重定向: {url} -> {validated_redirect}")
+            method, kwargs = _prepare_redirect_request(
+                method, current_url, validated_redirect, response.status_code, kwargs
+            )
             response = requests.request(method, validated_redirect, **kwargs)
+            current_url = validated_redirect
             redirect_count += 1
 
         return response

--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -14,7 +14,7 @@
 """
 
 from typing import Any, Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import requests
 from requests import Response
@@ -80,6 +80,9 @@ def _prepare_redirect_request(
     headers = redirect_kwargs.get("headers")
     if headers is not None:
         headers = dict(headers)
+        # Proxy credentials are rebuilt from ``proxies`` by requests and must
+        # never be copied as an origin header across redirect hops.
+        headers = _without_headers(headers, {"Proxy-Authorization"})
 
     # requests discards the entity when following 301/302/303 responses. 307/308
     # intentionally preserve both the method and body.
@@ -147,6 +150,7 @@ def safe_request(
         while response.is_redirect and redirect_count < max_redirects:
             if not allow_redirects:
                 logger.warning(f"[SafeRequests] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                response.close()
                 raise SSRFError("不允许重定向")
 
             redirect_url = response.headers.get("Location")
@@ -154,11 +158,15 @@ def safe_request(
                 break
 
             # 校验重定向目标
-            validated_redirect = SSRFValidator.validate(redirect_url, allowlist=allowlist)
-            logger.info(f"[SafeRequests] 重定向: {url} -> {validated_redirect}")
-            method, kwargs = _prepare_redirect_request(
-                method, current_url, validated_redirect, response.status_code, kwargs
-            )
+            redirect_url = urljoin(current_url, redirect_url)
+            try:
+                validated_redirect = SSRFValidator.validate(redirect_url, allowlist=allowlist)
+                logger.info(f"[SafeRequests] 重定向: {current_url} -> {validated_redirect}")
+                method, kwargs = _prepare_redirect_request(
+                    method, current_url, validated_redirect, response.status_code, kwargs
+                )
+            finally:
+                response.close()
             response = requests.request(method, validated_redirect, **kwargs)
             current_url = validated_redirect
             redirect_count += 1
@@ -248,6 +256,7 @@ def safe_request_llm_endpoint(
         while response.is_redirect and redirect_count < max_redirects:
             if not allow_redirects:
                 logger.warning(f"[SafeRequests-LLM] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                response.close()
                 raise SSRFError("不允许重定向")
 
             redirect_url = response.headers.get("Location")
@@ -255,11 +264,15 @@ def safe_request_llm_endpoint(
                 break
 
             # 校验重定向目标（宽松模式）
-            validated_redirect = SSRFValidator.validate_llm_endpoint(redirect_url)
-            logger.info(f"[SafeRequests-LLM] 重定向: {url} -> {validated_redirect}")
-            method, kwargs = _prepare_redirect_request(
-                method, current_url, validated_redirect, response.status_code, kwargs
-            )
+            redirect_url = urljoin(current_url, redirect_url)
+            try:
+                validated_redirect = SSRFValidator.validate_llm_endpoint(redirect_url)
+                logger.info(f"[SafeRequests-LLM] 重定向: {current_url} -> {validated_redirect}")
+                method, kwargs = _prepare_redirect_request(
+                    method, current_url, validated_redirect, response.status_code, kwargs
+                )
+            finally:
+                response.close()
             response = requests.request(method, validated_redirect, **kwargs)
             current_url = validated_redirect
             redirect_count += 1

--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -13,11 +13,13 @@
     response = safe_post("https://example.com/api", json={"key": "value"})
 """
 
+from collections.abc import Iterable, Mapping
 from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
 import requests
 from requests import Response
+from requests.exceptions import UnrewindableBodyError
 
 from apps.core.logger import logger
 from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
@@ -54,6 +56,55 @@ def _should_strip_credentials(current_url: str, redirect_url: str) -> bool:
 def _without_headers(headers: dict[str, Any], names: set[str]) -> dict[str, Any]:
     blocked = {name.lower() for name in names}
     return {name: value for name, value in headers.items() if name.lower() not in blocked}
+
+
+def _iter_request_body_streams(kwargs: dict[str, Any]):
+    data = kwargs.get("data")
+    if hasattr(data, "read") or (
+        isinstance(data, Iterable) and not isinstance(data, (str, bytes, list, tuple, Mapping))
+    ):
+        yield data
+
+    files = kwargs.get("files")
+    if not files:
+        return
+    file_values = files.values() if isinstance(files, Mapping) else (value for _, value in files)
+    for file_value in file_values:
+        payload = file_value[1] if isinstance(file_value, (tuple, list)) and len(file_value) > 1 else file_value
+        if hasattr(payload, "read"):
+            yield payload
+
+
+def _capture_request_body_positions(kwargs: dict[str, Any]) -> list[tuple[Any, int | None]]:
+    positions = []
+    seen = set()
+    for stream in _iter_request_body_streams(kwargs):
+        if id(stream) in seen:
+            continue
+        seen.add(id(stream))
+        try:
+            position = stream.tell() if callable(getattr(stream, "tell", None)) else None
+        except (OSError, ValueError):
+            position = None
+        if not callable(getattr(stream, "seek", None)):
+            position = None
+        positions.append((stream, position))
+    return positions
+
+
+def _rewind_request_body(
+    kwargs: dict[str, Any],
+    positions: list[tuple[Any, int | None]],
+) -> None:
+    if not any(key in kwargs for key in ("data", "files")):
+        return
+    for stream, position in positions:
+        if position is None:
+            raise UnrewindableBodyError("重定向请求体不可回卷")
+        try:
+            stream.seek(position)
+        except (OSError, ValueError) as exc:
+            raise UnrewindableBodyError("重定向请求体回卷失败") from exc
 
 
 def _prepare_redirect_request(
@@ -139,6 +190,7 @@ def safe_request(
     # 2. 禁用自动重定向，手动处理
     kwargs["allow_redirects"] = False
     kwargs["timeout"] = timeout
+    body_positions = _capture_request_body_positions(kwargs)
 
     try:
         response = requests.request(method, validated_url, **kwargs)
@@ -165,6 +217,8 @@ def safe_request(
                 method, kwargs = _prepare_redirect_request(
                     method, current_url, validated_redirect, response.status_code, kwargs
                 )
+                if response.status_code in (requests.codes.temporary_redirect, requests.codes.permanent_redirect):
+                    _rewind_request_body(kwargs, body_positions)
             finally:
                 response.close()
             response = requests.request(method, validated_redirect, **kwargs)
@@ -245,6 +299,7 @@ def safe_request_llm_endpoint(
     # 2. 禁用自动重定向，手动处理
     kwargs["allow_redirects"] = False
     kwargs["timeout"] = timeout
+    body_positions = _capture_request_body_positions(kwargs)
 
     try:
         response = requests.request(method, validated_url, **kwargs)
@@ -271,6 +326,8 @@ def safe_request_llm_endpoint(
                 method, kwargs = _prepare_redirect_request(
                     method, current_url, validated_redirect, response.status_code, kwargs
                 )
+                if response.status_code in (requests.codes.temporary_redirect, requests.codes.permanent_redirect):
+                    _rewind_request_body(kwargs, body_positions)
             finally:
                 response.close()
             response = requests.request(method, validated_redirect, **kwargs)


### PR DESCRIPTION
## 问题

安全请求封装为逐跳执行 SSRF 校验而手动处理重定向，但此前每一跳都复用原始方法、请求体和凭据。301/302/303 可能重复提交副作用请求，跨来源跳转还可能携带不应继续发送的认证信息。

Closes #3991

## 根因

重定向安全校验与 HTTP 客户端的重定向语义被拆开实现：目标 URL 虽然重新校验，但下一跳请求没有同步执行方法转换、实体清理、凭据隔离和流式实体回卷。

## 怎么修的

- 按 `requests` 兼容语义处理 301/302/303/307/308 的方法与实体。
- 跨来源跳转移除 `Authorization`、`Cookie`、`Host`、显式认证和代理认证信息。
- 支持相对 `Location`，每跳继续执行 SSRF 校验，并及时关闭中间响应。
- 307/308 在发送下一跳前回卷可重放的文件流；不可回卷的单次流明确失败，避免静默发送空实体。
- 普通安全请求与 LLM 端点请求采用同一组下一跳边界规则。

## 影响范围

改动仅涉及 `core` 安全 HTTP 客户端及其回归测试，不改变函数签名、默认禁止重定向的行为或响应结构。仓库内显式允许非 GET 重定向的生产调用集中在 OpsPilot HTTP fetch 工具；该链路迁移前使用 `requests` 自动重定向，本次恢复其既有客户端语义。未发现依赖“跨域携带凭据”或“301/302/303 保留原实体”的合法调用、配置或部署样例。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["safe_get / safe_post 等调用方"]
    end

    subgraph N["安全重定向层"]
        N1["校验当前 URL"]
        N2["发起单跳请求"]
        N3["解析并校验 Location"]
        N4["转换方法、隔离凭据、回卷实体"]
    end

    T1 --> N1 --> N2
    N2 -- "30x" --> N3 --> N4 --> N2
    N3 -. "目标不安全" .-> F1["拒绝并关闭响应"]
    N4 -. "实体不可回卷" .-> F2["明确失败"]
```

## 验证

- `apps/core/tests/test_safe_requests_service.py`：24 passed。
- Standards 轴：PASS，无硬违规。
- Spec 轴：PASS，Issue #3991 契约已闭环。
- `git diff --check`：通过。
