### PR TITLE
bugfix: 回收超时的用户同步运行记录

### DIFF
--- a/server/apps/system_mgmt/services/user_sync_service.py
+++ b/server/apps/system_mgmt/services/user_sync_service.py
@@ -3,11 +3,12 @@ import os
 import uuid
 from copy import deepcopy
 from datetime import timedelta
+from threading import Event, Thread
 
 from django.contrib.auth.hashers import make_password
-from django.db import IntegrityError, transaction
+from django.db import IntegrityError, close_old_connections, connection, transaction
 from django.db.models import Count, Q
-from django.db.utils import NotSupportedError
+from django.db.utils import NotSupportedError, OperationalError
 from django.utils import timezone
 
 from apps.core.logger import system_mgmt_logger as logger
@@ -23,6 +24,7 @@ DEFAULT_FIELD_MAPPING = {
 }
 ALL_DEPARTMENT_SELECTION_ID = "__all__"
 DEFAULT_USER_SYNC_STALE_TIMEOUT_SECONDS = 6 * 60 * 60
+MAX_USER_SYNC_HEARTBEAT_INTERVAL_SECONDS = 60
 
 
 def _get_user_sync_stale_timeout_seconds() -> int:
@@ -42,26 +44,100 @@ def _get_user_sync_stale_timeout_seconds() -> int:
     return max(timeout_seconds, 60)
 
 
+def _supports_user_sync_row_locks() -> bool:
+    return connection.features.has_select_for_update
+
+
+def _supports_user_sync_skip_locked() -> bool:
+    return connection.features.has_select_for_update_skip_locked
+
+
 def _release_stale_user_sync_runs(source: UserSyncSource) -> int:
-    now = timezone.now()
-    stale_before = now - timedelta(seconds=_get_user_sync_stale_timeout_seconds())
-    return UserSyncRun.objects.filter(
-        source=source,
-        status=UserSyncRunStatusChoices.RUNNING,
-        updated_at__lt=stale_before,
-    ).update(
-        status=UserSyncRunStatusChoices.FAILED,
-        summary="User sync timed out and was released automatically",
-        finished_at=now,
-        updated_at=now,
-    )
+    if not _supports_user_sync_row_locks():
+        now = timezone.now()
+        stale_before = now - timedelta(seconds=_get_user_sync_stale_timeout_seconds())
+        try:
+            # SQLite 等无行锁数据库依靠条件 UPDATE 竞争写锁：活跃阶段先写
+            # heartbeat 并持有事务写锁；回收若遇到锁竞争则 fail closed。
+            return UserSyncRun.objects.filter(
+                source=source,
+                status=UserSyncRunStatusChoices.RUNNING,
+                updated_at__lt=stale_before,
+            ).update(
+                status=UserSyncRunStatusChoices.FAILED,
+                summary="User sync timed out and was released automatically",
+                finished_at=now,
+                updated_at=now,
+            )
+        except OperationalError as error:
+            if "locked" in str(error).lower() or "busy" in str(error).lower():
+                logger.info(
+                    "Skipped stale user sync release because the database is busy: source_id=%s",
+                    source.id,
+                )
+                return 0
+            raise
+
+    with transaction.atomic():
+        select_for_update_kwargs = {}
+        if _supports_user_sync_skip_locked():
+            select_for_update_kwargs["skip_locked"] = True
+        locked_source = (
+            UserSyncSource.objects.select_for_update(**select_for_update_kwargs)
+            .filter(pk=source.pk)
+            .first()
+        )
+        # 活跃落库阶段持有 source 行锁。支持 SKIP LOCKED 的数据库立即跳过，
+        # 其余数据库等待阶段提交后再用最新 heartbeat 判断，均不会误回收。
+        if locked_source is None:
+            return 0
+        now = timezone.now()
+        stale_before = now - timedelta(seconds=_get_user_sync_stale_timeout_seconds())
+        stale_run_ids = list(
+            UserSyncRun.objects.select_for_update()
+            .filter(
+                source=source,
+                status=UserSyncRunStatusChoices.RUNNING,
+                updated_at__lt=stale_before,
+            )
+            .values_list("id", flat=True)
+        )
+        if not stale_run_ids:
+            return 0
+        return UserSyncRun.objects.filter(
+            id__in=stale_run_ids,
+            status=UserSyncRunStatusChoices.RUNNING,
+            updated_at__lt=stale_before,
+        ).update(
+            status=UserSyncRunStatusChoices.FAILED,
+            summary="User sync timed out and was released automatically",
+            finished_at=now,
+            updated_at=now,
+        )
 
 
 class UserSyncRunExpired(RuntimeError):
     pass
 
 
+def _lock_user_sync_source(source_id: int) -> UserSyncSource:
+    if not _supports_user_sync_row_locks():
+        return UserSyncSource.objects.get(pk=source_id)
+    return UserSyncSource.objects.select_for_update().get(pk=source_id)
+
+
 def _lock_running_user_sync_run(run_id: int) -> UserSyncRun:
+    if not _supports_user_sync_row_locks():
+        # 单条条件 UPDATE 同时完成状态 fencing 与写锁获取。若回收先提交，
+        # status 条件使旧 worker 无法继续；若本事务先写，则回收只能等待/失败。
+        updated_count = UserSyncRun.objects.filter(
+            pk=run_id,
+            status=UserSyncRunStatusChoices.RUNNING,
+        ).update(updated_at=timezone.now())
+        if not updated_count:
+            raise UserSyncRunExpired("User sync run expired before applying provider result")
+        return UserSyncRun.objects.get(pk=run_id)
+
     run = UserSyncRun.objects.select_for_update().get(pk=run_id)
     if run.status != UserSyncRunStatusChoices.RUNNING:
         raise UserSyncRunExpired("User sync run expired before applying provider result")
@@ -73,6 +149,50 @@ def _touch_running_user_sync_run(run_id: int) -> UserSyncRun:
     run.updated_at = timezone.now()
     run.save(update_fields=["updated_at"])
     return run
+
+
+def _get_user_sync_heartbeat_interval_seconds() -> float:
+    timeout_seconds = _get_user_sync_stale_timeout_seconds()
+    return max(min(timeout_seconds / 3, MAX_USER_SYNC_HEARTBEAT_INTERVAL_SECONDS), 1)
+
+
+def _heartbeat_user_sync_run(run_id: int, stop_event: Event, interval_seconds: float) -> None:
+    """Provider 阻塞调用期间用独立数据库连接续租；进程退出时心跳自然停止。"""
+    close_old_connections()
+    try:
+        while not stop_event.wait(interval_seconds):
+            try:
+                with transaction.atomic():
+                    _touch_running_user_sync_run(run_id)
+            except UserSyncRunExpired:
+                return
+            except Exception as error:
+                logger.warning(
+                    "Failed to refresh user sync heartbeat: run_id=%s, error=%r",
+                    run_id,
+                    error,
+                )
+    finally:
+        close_old_connections()
+
+
+def _start_user_sync_run_heartbeat(run_id: int) -> tuple[Event, Thread]:
+    stop_event = Event()
+    thread = Thread(
+        target=_heartbeat_user_sync_run,
+        args=(run_id, stop_event, _get_user_sync_heartbeat_interval_seconds()),
+        name=f"user-sync-heartbeat-{run_id}",
+        daemon=True,
+    )
+    thread.start()
+    return stop_event, thread
+
+
+def _stop_user_sync_run_heartbeat(stop_event: Event, thread: Thread) -> None:
+    stop_event.set()
+    thread.join(timeout=5)
+    if thread.is_alive():
+        logger.warning("User sync heartbeat thread did not stop promptly: thread=%s", thread.name)
 
 
 # 同步进度阶段 key(在 payload.phase_progress 下作为子键使用)
@@ -318,13 +438,17 @@ def execute_user_sync(source_id: int, trigger_mode: str = UserSyncTriggerModeCho
         return {"result": False, "message": "User sync is already running"}
 
     runtime_service = RuntimeApplicationService()
-    result = runtime_service.execute(
-        provider_key=instance.provider_key,
-        capability_key="user_sync",
-        operation="sync_users",
-        config=instance.get_runtime_config(),
-        source=source,
-    )
+    heartbeat_stop, heartbeat_thread = _start_user_sync_run_heartbeat(run.id)
+    try:
+        result = runtime_service.execute(
+            provider_key=instance.provider_key,
+            capability_key="user_sync",
+            operation="sync_users",
+            config=instance.get_runtime_config(),
+            source=source,
+        )
+    finally:
+        _stop_user_sync_run_heartbeat(heartbeat_stop, heartbeat_thread)
     input_summary = _extract_input_summary(result.payload)
 
     try:
@@ -595,11 +719,14 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
     try:
         with transaction.atomic():
             if has_run:
+                _lock_user_sync_source(source.id)
                 _touch_running_user_sync_run(current_run.id)
             root_group = _get_or_create_root_group(source)
             group_id_mapping, active_group_ids = _sync_groups(
                 source, group_list, root_group, root_scope_value, group_counters
             )
+            if has_run:
+                _touch_running_user_sync_run(current_run.id)
     except Exception as error:
         logger.exception("User sync group stage failed: source=%s, error=%r", source.name, error)
         _record_error(PHASE_SYNC_GROUPS, current=0, total=len(group_list), error=error)
@@ -633,6 +760,7 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
                 with transaction.atomic():
                     # 锁定 run,供 batch 内的 password_init_service 复用同一实例
                     if has_run:
+                        _lock_user_sync_source(source.id)
                         locked_run = _touch_running_user_sync_run(current_run.id)
                     else:
                         locked_run = None
@@ -644,6 +772,8 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
                         root_department_id=root_scope_value,
                         locked_run=locked_run,
                     )
+                    if has_run:
+                        _touch_running_user_sync_run(current_run.id)
             except Exception as error:
                 logger.exception(
                     f"User sync batch failed: source={source.name}, "
@@ -671,6 +801,7 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
     try:
         with transaction.atomic():
             if has_run:
+                _lock_user_sync_source(source.id)
                 _touch_running_user_sync_run(current_run.id)
             reconcile_result = _reconcile_synced_directory(
                 source=source,
@@ -678,6 +809,8 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
                 active_group_ids=active_group_ids,
                 root_group_id=root_group.id,
             )
+            if has_run:
+                _touch_running_user_sync_run(current_run.id)
     except Exception as error:
         logger.exception("User sync reconcile stage failed: source=%s, error=%r", source.name, error)
         _record_error(PHASE_RECONCILE, current=0, total=1, error=error)

--- a/server/apps/system_mgmt/services/user_sync_service.py
+++ b/server/apps/system_mgmt/services/user_sync_service.py
@@ -1,6 +1,8 @@
 import hashlib
+import os
 import uuid
 from copy import deepcopy
+from datetime import timedelta
 
 from django.contrib.auth.hashers import make_password
 from django.db import IntegrityError, transaction
@@ -20,6 +22,40 @@ DEFAULT_FIELD_MAPPING = {
     "phone": "mobile",
 }
 ALL_DEPARTMENT_SELECTION_ID = "__all__"
+DEFAULT_USER_SYNC_STALE_TIMEOUT_SECONDS = 6 * 60 * 60
+
+
+def _get_user_sync_stale_timeout_seconds() -> int:
+    raw_value = os.getenv(
+        "USER_SYNC_STALE_TIMEOUT_SECONDS",
+        str(DEFAULT_USER_SYNC_STALE_TIMEOUT_SECONDS),
+    )
+    try:
+        timeout_seconds = int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid USER_SYNC_STALE_TIMEOUT_SECONDS=%r; using default %s",
+            raw_value,
+            DEFAULT_USER_SYNC_STALE_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_USER_SYNC_STALE_TIMEOUT_SECONDS
+    return max(timeout_seconds, 60)
+
+
+def _release_stale_user_sync_runs(source: UserSyncSource) -> int:
+    now = timezone.now()
+    stale_before = now - timedelta(seconds=_get_user_sync_stale_timeout_seconds())
+    return UserSyncRun.objects.filter(
+        source=source,
+        status=UserSyncRunStatusChoices.RUNNING,
+        started_at__lt=stale_before,
+    ).update(
+        status=UserSyncRunStatusChoices.FAILED,
+        summary="User sync timed out and was released automatically",
+        finished_at=now,
+        updated_at=now,
+    )
+
 
 # 同步进度阶段 key(在 payload.phase_progress 下作为子键使用)
 PHASE_FETCH_DIRECTORY = "fetch_directory"
@@ -236,6 +272,14 @@ def execute_user_sync(source_id: int, trigger_mode: str = UserSyncTriggerModeCho
     instance = source.integration_instance
     if not instance.enabled or instance.status != "ready" or instance.capability_status.get("user_sync") != "ready":
         return {"result": False, "message": "User sync source is not ready"}
+
+    released_count = _release_stale_user_sync_runs(source)
+    if released_count:
+        logger.warning(
+            "Released %s stale user sync run(s) for source '%s'",
+            released_count,
+            source.name,
+        )
 
     if UserSyncRun.objects.filter(source=source, status=UserSyncRunStatusChoices.RUNNING).exists():
         return {"result": False, "message": "User sync is already running"}

--- a/server/apps/system_mgmt/services/user_sync_service.py
+++ b/server/apps/system_mgmt/services/user_sync_service.py
@@ -48,13 +48,31 @@ def _release_stale_user_sync_runs(source: UserSyncSource) -> int:
     return UserSyncRun.objects.filter(
         source=source,
         status=UserSyncRunStatusChoices.RUNNING,
-        started_at__lt=stale_before,
+        updated_at__lt=stale_before,
     ).update(
         status=UserSyncRunStatusChoices.FAILED,
         summary="User sync timed out and was released automatically",
         finished_at=now,
         updated_at=now,
     )
+
+
+class UserSyncRunExpired(RuntimeError):
+    pass
+
+
+def _lock_running_user_sync_run(run_id: int) -> UserSyncRun:
+    run = UserSyncRun.objects.select_for_update().get(pk=run_id)
+    if run.status != UserSyncRunStatusChoices.RUNNING:
+        raise UserSyncRunExpired("User sync run expired before applying provider result")
+    return run
+
+
+def _touch_running_user_sync_run(run_id: int) -> UserSyncRun:
+    run = _lock_running_user_sync_run(run_id)
+    run.updated_at = timezone.now()
+    run.save(update_fields=["updated_at"])
+    return run
 
 
 # 同步进度阶段 key(在 payload.phase_progress 下作为子键使用)
@@ -114,7 +132,7 @@ def _mutate_run_payload(run_id: int, mutate) -> None:
     都必须通过该入口或同事务已锁定的 run 实例进行,不得直接使用外层旧实例覆盖。
     """
     with transaction.atomic():
-        run = UserSyncRun.objects.select_for_update().get(pk=run_id)
+        run = _lock_running_user_sync_run(run_id)
         next_payload = dict(run.payload or {})
         mutate(next_payload)
         run.payload = next_payload
@@ -309,51 +327,63 @@ def execute_user_sync(source_id: int, trigger_mode: str = UserSyncTriggerModeCho
     )
     input_summary = _extract_input_summary(result.payload)
 
-    # 写 request_id(同步元数据,不需要走 _mutate_run_payload)
-    UserSyncRun.objects.filter(id=run.id).update(request_id=result.request_id or "")
-    # 同步 in-memory 实例,避免 _apply_user_sync_payload 读到空 request_id
-    run.refresh_from_db(fields=["request_id", "payload"])
+    try:
+        with transaction.atomic():
+            run = _lock_running_user_sync_run(run.id)
+            run.request_id = result.request_id or ""
+            run.updated_at = timezone.now()
+            run.save(update_fields=["request_id", "updated_at"])
+    except UserSyncRunExpired as error:
+        return {"result": False, "message": str(error)}
 
     # 阶段 1: 拉取目录
     if not result.success:
         # provider 调用失败,写 fetch_directory 阶段脱敏错误
         safe_error_code = "provider_fetch_failed"
-        _write_phase_error(
-            run.id,
-            PHASE_FETCH_DIRECTORY,
-            0,
-            0,
-            Exception(result.summary or "provider call failed"),
-            error_code=safe_error_code,
-        )
-        _save_terminal_state(
-            run.id,
-            status=UserSyncRunStatusChoices.FAILED,
-            summary=safe_error_code,
-            payload_overrides={"request_id": result.request_id or ""},
-        )
+        try:
+            _write_phase_error(
+                run.id,
+                PHASE_FETCH_DIRECTORY,
+                0,
+                0,
+                Exception(result.summary or "provider call failed"),
+                error_code=safe_error_code,
+            )
+            _save_terminal_state(
+                run.id,
+                status=UserSyncRunStatusChoices.FAILED,
+                summary=safe_error_code,
+                payload_overrides={"request_id": result.request_id or ""},
+            )
+        except UserSyncRunExpired as error:
+            return {"result": False, "message": str(error)}
         return {"result": False, "message": safe_error_code}
 
     user_list = result.payload.get("user_list") or []
     group_list = result.payload.get("group_list") or []
     fetch_total = len(user_list) + len(group_list)
-    _write_phase_progress(run.id, PHASE_FETCH_DIRECTORY, current=fetch_total, total=fetch_total, status="finish")
 
     # 阶段 2-4: 同步组织 / 同步用户(按 batch)/ 全量对账
     try:
+        _write_phase_progress(run.id, PHASE_FETCH_DIRECTORY, current=fetch_total, total=fetch_total, status="finish")
         sync_summary = _apply_user_sync_payload(source, result.payload, current_run=run)
+    except UserSyncRunExpired as error:
+        return {"result": False, "message": str(error)}
     except Exception as error:
         logger.exception(f"User sync failed for source '{source.name}': request_id={result.request_id}, error={error!r}")
         safe_error_code = _to_safe_error_code(error)
-        _save_terminal_state(
-            run.id,
-            status=UserSyncRunStatusChoices.FAILED,
-            summary=safe_error_code,
-            payload_overrides={
-                "request_id": result.request_id or "",
-                "external_request_id": str((result.payload or {}).get("external_request_id") or ""),
-            },
-        )
+        try:
+            _save_terminal_state(
+                run.id,
+                status=UserSyncRunStatusChoices.FAILED,
+                summary=safe_error_code,
+                payload_overrides={
+                    "request_id": result.request_id or "",
+                    "external_request_id": str((result.payload or {}).get("external_request_id") or ""),
+                },
+            )
+        except UserSyncRunExpired as expired_error:
+            return {"result": False, "message": str(expired_error)}
         return {"result": False, "message": safe_error_code}
 
     # 终态保存
@@ -366,17 +396,20 @@ def execute_user_sync(source_id: int, trigger_mode: str = UserSyncTriggerModeCho
         )
     else:
         final_status = UserSyncRunStatusChoices.SUCCESS
-    _save_terminal_state(
-        run.id,
-        status=final_status,
-        summary=sync_summary["summary"],
-        payload_overrides=payload_overrides,
-        instance_overrides={
-            "synced_user_count": sync_summary["synced_user_count"],
-            "synced_group_count": sync_summary["synced_group_count"],
-            "disabled_user_count": sync_summary["disabled_user_count"],
-        },
-    )
+    try:
+        _save_terminal_state(
+            run.id,
+            status=final_status,
+            summary=sync_summary["summary"],
+            payload_overrides=payload_overrides,
+            instance_overrides={
+                "synced_user_count": sync_summary["synced_user_count"],
+                "synced_group_count": sync_summary["synced_group_count"],
+                "disabled_user_count": sync_summary["disabled_user_count"],
+            },
+        )
+    except UserSyncRunExpired as error:
+        return {"result": False, "message": str(error)}
     return {"result": True, "message": sync_summary["summary"], "data": {"run_id": run.id}}
 
 
@@ -393,7 +426,7 @@ def _save_terminal_state(
     再保存终态字段。任何终态保存都必须经此入口,禁止直接操作外层旧 run 实例。
     """
     with transaction.atomic():
-        run = UserSyncRun.objects.select_for_update().get(pk=run_id)
+        run = _lock_running_user_sync_run(run_id)
         run.status = status
         run.summary = summary
         if payload_overrides:
@@ -561,6 +594,8 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
     group_counters = {"created_groups": 0, "updated_groups": 0}
     try:
         with transaction.atomic():
+            if has_run:
+                _touch_running_user_sync_run(current_run.id)
             root_group = _get_or_create_root_group(source)
             group_id_mapping, active_group_ids = _sync_groups(
                 source, group_list, root_group, root_scope_value, group_counters
@@ -598,7 +633,7 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
                 with transaction.atomic():
                     # 锁定 run,供 batch 内的 password_init_service 复用同一实例
                     if has_run:
-                        locked_run = UserSyncRun.objects.select_for_update().get(pk=current_run.id)
+                        locked_run = _touch_running_user_sync_run(current_run.id)
                     else:
                         locked_run = None
                     batch_result = _process_user_batch(
@@ -635,6 +670,8 @@ def _apply_user_sync_payload(source: UserSyncSource, payload: dict, current_run:
     # 阶段 C: 全量对账 (单事务) - 依据完整同步名单禁用 stale 用户、删除 stale 组织
     try:
         with transaction.atomic():
+            if has_run:
+                _touch_running_user_sync_run(current_run.id)
             reconcile_result = _reconcile_synced_directory(
                 source=source,
                 synced_usernames=all_synced_usernames,

--- a/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
+++ b/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
@@ -1,0 +1,83 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from apps.system_mgmt.models import (
+    IntegrationInstance,
+    UserSyncRun,
+    UserSyncRunStatusChoices,
+    UserSyncSource,
+)
+from apps.system_mgmt.providers.runtime import CapabilityExecutionResult
+from apps.system_mgmt.services.user_sync_service import execute_user_sync
+
+
+@pytest.fixture
+def ready_user_sync_source(db):
+    instance = IntegrationInstance.objects.create(
+        name="stale-recovery-provider",
+        provider_key="feishu",
+        enabled=True,
+        status="ready",
+        capability_status={"user_sync": "ready"},
+        config={"app_id": "cli_xxx", "app_secret": "plain-secret"},
+    )
+    return UserSyncSource.objects.create(
+        name="stale-recovery-source",
+        integration_instance=instance,
+        enabled=True,
+        root_group_name="Stale Recovery Root",
+        business_config={"root_department_id": "0"},
+        field_mapping={},
+        schedule_config={},
+    )
+
+
+@pytest.mark.django_db
+def test_execute_user_sync_releases_stale_running_run(monkeypatch, ready_user_sync_source):
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "1800")
+    stale_run = UserSyncRun.objects.create(
+        source=ready_user_sync_source,
+        status=UserSyncRunStatusChoices.RUNNING,
+        started_at=timezone.now() - timedelta(hours=1),
+    )
+    provider_failure = CapabilityExecutionResult.failed_result(
+        "provider unavailable",
+        code="provider.request_failed",
+        retryable=True,
+    )
+
+    with patch(
+        "apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute",
+        return_value=provider_failure,
+    ):
+        result = execute_user_sync(ready_user_sync_source.id)
+
+    stale_run.refresh_from_db()
+    replacement_run = UserSyncRun.objects.exclude(id=stale_run.id).get(source=ready_user_sync_source)
+    assert result["message"] == "provider unavailable"
+    assert stale_run.status == UserSyncRunStatusChoices.FAILED
+    assert stale_run.finished_at is not None
+    assert "timed out" in stale_run.summary.lower()
+    assert replacement_run.status == UserSyncRunStatusChoices.FAILED
+    assert replacement_run.summary == "provider unavailable"
+
+
+@pytest.mark.django_db
+def test_execute_user_sync_keeps_fresh_running_run(monkeypatch, ready_user_sync_source):
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "1800")
+    fresh_run = UserSyncRun.objects.create(
+        source=ready_user_sync_source,
+        status=UserSyncRunStatusChoices.RUNNING,
+        started_at=timezone.now() - timedelta(minutes=10),
+    )
+
+    with patch("apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute") as mock_execute:
+        result = execute_user_sync(ready_user_sync_source.id)
+
+    fresh_run.refresh_from_db()
+    assert result == {"result": False, "message": "User sync is already running"}
+    assert fresh_run.status == UserSyncRunStatusChoices.RUNNING
+    mock_execute.assert_not_called()

--- a/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
+++ b/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
@@ -43,6 +43,11 @@ def test_execute_user_sync_releases_stale_running_run(monkeypatch, ready_user_sy
         status=UserSyncRunStatusChoices.RUNNING,
         started_at=timezone.now() - timedelta(hours=1),
     )
+    stale_timestamp = timezone.now() - timedelta(hours=1)
+    UserSyncRun.objects.filter(pk=stale_run.pk).update(
+        started_at=stale_timestamp,
+        updated_at=stale_timestamp,
+    )
     provider_failure = CapabilityExecutionResult.failed_result(
         "provider unavailable",
         code="provider.request_failed",
@@ -57,12 +62,12 @@ def test_execute_user_sync_releases_stale_running_run(monkeypatch, ready_user_sy
 
     stale_run.refresh_from_db()
     replacement_run = UserSyncRun.objects.exclude(id=stale_run.id).get(source=ready_user_sync_source)
-    assert result["message"] == "provider unavailable"
+    assert result["message"] == "provider_fetch_failed"
     assert stale_run.status == UserSyncRunStatusChoices.FAILED
     assert stale_run.finished_at is not None
     assert "timed out" in stale_run.summary.lower()
     assert replacement_run.status == UserSyncRunStatusChoices.FAILED
-    assert replacement_run.summary == "provider unavailable"
+    assert replacement_run.summary == "provider_fetch_failed"
 
 
 @pytest.mark.django_db
@@ -71,7 +76,11 @@ def test_execute_user_sync_keeps_fresh_running_run(monkeypatch, ready_user_sync_
     fresh_run = UserSyncRun.objects.create(
         source=ready_user_sync_source,
         status=UserSyncRunStatusChoices.RUNNING,
-        started_at=timezone.now() - timedelta(minutes=10),
+        started_at=timezone.now() - timedelta(hours=1),
+    )
+    UserSyncRun.objects.filter(pk=fresh_run.pk).update(
+        started_at=timezone.now() - timedelta(hours=1),
+        updated_at=timezone.now() - timedelta(minutes=10),
     )
 
     with patch("apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute") as mock_execute:
@@ -81,3 +90,74 @@ def test_execute_user_sync_keeps_fresh_running_run(monkeypatch, ready_user_sync_
     assert result == {"result": False, "message": "User sync is already running"}
     assert fresh_run.status == UserSyncRunStatusChoices.RUNNING
     mock_execute.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_execute_user_sync_does_not_apply_result_after_run_was_released(ready_user_sync_source):
+    provider_result = CapabilityExecutionResult.success_result(
+        "ok",
+        payload={"group_list": [], "user_list": []},
+    )
+
+    def release_run_before_returning_result(**_kwargs):
+        UserSyncRun.objects.filter(
+            source=ready_user_sync_source,
+            status=UserSyncRunStatusChoices.RUNNING,
+        ).update(
+            status=UserSyncRunStatusChoices.FAILED,
+            summary="User sync timed out and was released automatically",
+            finished_at=timezone.now(),
+        )
+        return provider_result
+
+    with (
+        patch(
+            "apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute",
+            side_effect=release_run_before_returning_result,
+        ),
+        patch("apps.system_mgmt.services.user_sync_service._apply_user_sync_payload") as mock_apply,
+    ):
+        result = execute_user_sync(ready_user_sync_source.id)
+
+    assert result == {
+        "result": False,
+        "message": "User sync run expired before applying provider result",
+    }
+    mock_apply.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_execute_user_sync_stops_before_group_write_when_run_expires_after_provider_result(
+    ready_user_sync_source,
+):
+    provider_result = CapabilityExecutionResult.success_result(
+        "ok",
+        payload={"group_list": [], "user_list": []},
+    )
+
+    def expire_after_fetch_progress(run_id, phase, **_kwargs):
+        if phase == "fetch_directory":
+            UserSyncRun.objects.filter(pk=run_id).update(
+                status=UserSyncRunStatusChoices.FAILED,
+                summary="User sync timed out and was released automatically",
+                finished_at=timezone.now(),
+            )
+
+    with (
+        patch(
+            "apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute",
+            return_value=provider_result,
+        ),
+        patch(
+            "apps.system_mgmt.services.user_sync_service._write_phase_progress",
+            side_effect=expire_after_fetch_progress,
+        ),
+        patch("apps.system_mgmt.services.user_sync_service._get_or_create_root_group") as mock_create_root,
+    ):
+        result = execute_user_sync(ready_user_sync_source.id)
+
+    assert result == {
+        "result": False,
+        "message": "User sync run expired before applying provider result",
+    }
+    mock_create_root.assert_not_called()

--- a/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
+++ b/server/apps/system_mgmt/tests/test_user_sync_stale_recovery.py
@@ -1,7 +1,11 @@
 from datetime import timedelta
+from threading import Event, Thread
+from time import monotonic, sleep
 from unittest.mock import patch
 
 import pytest
+from django.db import close_old_connections, connection, transaction
+from django.db.utils import OperationalError
 from django.utils import timezone
 
 from apps.system_mgmt.models import (
@@ -11,7 +15,12 @@ from apps.system_mgmt.models import (
     UserSyncSource,
 )
 from apps.system_mgmt.providers.runtime import CapabilityExecutionResult
-from apps.system_mgmt.services.user_sync_service import execute_user_sync
+from apps.system_mgmt.services.user_sync_service import (
+    _lock_user_sync_source,
+    _release_stale_user_sync_runs,
+    _touch_running_user_sync_run,
+    execute_user_sync,
+)
 
 
 @pytest.fixture
@@ -90,6 +99,267 @@ def test_execute_user_sync_keeps_fresh_running_run(monkeypatch, ready_user_sync_
     assert result == {"result": False, "message": "User sync is already running"}
     assert fresh_run.status == UserSyncRunStatusChoices.RUNNING
     mock_execute.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_execute_user_sync_heartbeats_during_blocking_provider_call(monkeypatch, ready_user_sync_source):
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "60")
+    provider_entered = Event()
+    allow_provider_return = Event()
+    thread_errors = []
+    first_result = {}
+    provider_failure = CapabilityExecutionResult.failed_result(
+        "provider unavailable",
+        code="provider.request_failed",
+        retryable=True,
+    )
+
+    def blocking_provider(**_kwargs):
+        provider_entered.set()
+        if not allow_provider_return.wait(5):
+            raise TimeoutError("test did not release provider")
+        return provider_failure
+
+    def run_first_sync():
+        close_old_connections()
+        try:
+            first_result.update(execute_user_sync(ready_user_sync_source.id))
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    with (
+        patch(
+            "apps.system_mgmt.services.user_sync_service._get_user_sync_heartbeat_interval_seconds",
+            return_value=0.02,
+        ),
+        patch(
+            "apps.system_mgmt.services.user_sync_service.RuntimeApplicationService.execute",
+            side_effect=blocking_provider,
+        ) as mock_execute,
+    ):
+        sync_thread = Thread(target=run_first_sync)
+        sync_thread.start()
+        try:
+            assert provider_entered.wait(5)
+            running_run = UserSyncRun.objects.get(
+                source=ready_user_sync_source,
+                status=UserSyncRunStatusChoices.RUNNING,
+            )
+            stale_timestamp = timezone.now() - timedelta(minutes=2)
+            UserSyncRun.objects.filter(pk=running_run.pk).update(updated_at=stale_timestamp)
+
+            deadline = monotonic() + 5
+            while monotonic() < deadline:
+                running_run.refresh_from_db(fields=["updated_at"])
+                if running_run.updated_at > timezone.now() - timedelta(seconds=60):
+                    break
+                sleep(0.02)
+            else:
+                pytest.fail("provider heartbeat did not refresh updated_at")
+
+            second_result = execute_user_sync(ready_user_sync_source.id)
+            assert second_result == {"result": False, "message": "User sync is already running"}
+            assert mock_execute.call_count == 1
+        finally:
+            allow_provider_return.set()
+            sync_thread.join(timeout=5)
+
+    assert not sync_thread.is_alive()
+    assert thread_errors == []
+    assert first_result["message"] == "provider_fetch_failed"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stale_release_skips_actively_locked_run(monkeypatch, ready_user_sync_source):
+    if not connection.features.has_select_for_update_skip_locked:
+        pytest.skip("database does not support SELECT FOR UPDATE SKIP LOCKED")
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "60")
+    stale_timestamp = timezone.now() - timedelta(minutes=2)
+    run = UserSyncRun.objects.create(
+        source=ready_user_sync_source,
+        status=UserSyncRunStatusChoices.RUNNING,
+    )
+    UserSyncRun.objects.filter(pk=run.pk).update(updated_at=stale_timestamp)
+    run_locked = Event()
+    allow_commit = Event()
+    thread_errors = []
+
+    def hold_active_stage_lock():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                _lock_user_sync_source(ready_user_sync_source.id)
+                _touch_running_user_sync_run(run.id)
+                run_locked.set()
+                if not allow_commit.wait(5):
+                    raise TimeoutError("test did not release active stage")
+                _touch_running_user_sync_run(run.id)
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    stage_thread = Thread(target=hold_active_stage_lock)
+    stage_thread.start()
+    try:
+        assert run_locked.wait(5)
+        started_at = monotonic()
+        assert _release_stale_user_sync_runs(ready_user_sync_source) == 0
+        assert monotonic() - started_at < 2
+    finally:
+        allow_commit.set()
+        stage_thread.join(timeout=5)
+
+    assert not stage_thread.is_alive()
+    assert thread_errors == []
+    run.refresh_from_db()
+    assert run.status == UserSyncRunStatusChoices.RUNNING
+    assert run.updated_at > stale_timestamp
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stale_release_without_skip_locked_waits_for_latest_heartbeat(monkeypatch, ready_user_sync_source):
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "60")
+    stale_timestamp = timezone.now() - timedelta(minutes=2)
+    run = UserSyncRun.objects.create(
+        source=ready_user_sync_source,
+        status=UserSyncRunStatusChoices.RUNNING,
+    )
+    UserSyncRun.objects.filter(pk=run.pk).update(updated_at=stale_timestamp)
+    stage_locked = Event()
+    allow_commit = Event()
+    release_result = {}
+    thread_errors = []
+
+    def hold_active_stage():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                _lock_user_sync_source(ready_user_sync_source.id)
+                _touch_running_user_sync_run(run.id)
+                stage_locked.set()
+                if not allow_commit.wait(5):
+                    raise TimeoutError("test did not release active stage")
+                _touch_running_user_sync_run(run.id)
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    def release_stale_run():
+        close_old_connections()
+        try:
+            release_result["count"] = _release_stale_user_sync_runs(ready_user_sync_source)
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    with patch(
+        "apps.system_mgmt.services.user_sync_service._supports_user_sync_skip_locked",
+        return_value=False,
+    ):
+        stage_thread = Thread(target=hold_active_stage)
+        stage_thread.start()
+        assert stage_locked.wait(5)
+        release_thread = Thread(target=release_stale_run)
+        release_thread.start()
+        try:
+            sleep(0.1)
+            assert release_thread.is_alive()
+        finally:
+            allow_commit.set()
+            stage_thread.join(timeout=5)
+            release_thread.join(timeout=5)
+
+    assert not stage_thread.is_alive()
+    assert not release_thread.is_alive()
+    assert thread_errors == []
+    assert release_result == {"count": 0}
+    run.refresh_from_db()
+    assert run.status == UserSyncRunStatusChoices.RUNNING
+    assert run.updated_at > stale_timestamp
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stale_release_without_row_locks_rechecks_after_active_write(monkeypatch, ready_user_sync_source):
+    monkeypatch.setenv("USER_SYNC_STALE_TIMEOUT_SECONDS", "60")
+    stale_timestamp = timezone.now() - timedelta(minutes=2)
+    run = UserSyncRun.objects.create(
+        source=ready_user_sync_source,
+        status=UserSyncRunStatusChoices.RUNNING,
+    )
+    UserSyncRun.objects.filter(pk=run.pk).update(updated_at=stale_timestamp)
+    active_write_started = Event()
+    allow_commit = Event()
+    release_result = {}
+    thread_errors = []
+
+    def hold_active_write():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                _touch_running_user_sync_run(run.id)
+                active_write_started.set()
+                if not allow_commit.wait(5):
+                    raise TimeoutError("test did not release active write")
+                _touch_running_user_sync_run(run.id)
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    def release_stale_run():
+        close_old_connections()
+        try:
+            release_result["count"] = _release_stale_user_sync_runs(ready_user_sync_source)
+        except Exception as error:
+            thread_errors.append(error)
+        finally:
+            close_old_connections()
+
+    with patch(
+        "apps.system_mgmt.services.user_sync_service._supports_user_sync_row_locks",
+        return_value=False,
+    ):
+        stage_thread = Thread(target=hold_active_write)
+        stage_thread.start()
+        assert active_write_started.wait(5)
+        release_thread = Thread(target=release_stale_run)
+        release_thread.start()
+        try:
+            sleep(0.1)
+            assert release_thread.is_alive()
+        finally:
+            allow_commit.set()
+            stage_thread.join(timeout=5)
+            release_thread.join(timeout=5)
+
+    assert not stage_thread.is_alive()
+    assert not release_thread.is_alive()
+    assert thread_errors == []
+    assert release_result == {"count": 0}
+    run.refresh_from_db()
+    assert run.status == UserSyncRunStatusChoices.RUNNING
+    assert run.updated_at > stale_timestamp
+
+
+@pytest.mark.django_db
+def test_stale_release_without_row_locks_fails_closed_when_database_is_busy(ready_user_sync_source):
+    with (
+        patch(
+            "apps.system_mgmt.services.user_sync_service._supports_user_sync_row_locks",
+            return_value=False,
+        ),
+        patch.object(
+            UserSyncRun.objects,
+            "filter",
+            side_effect=OperationalError("database is locked"),
+        ),
+    ):
+        assert _release_stale_user_sync_runs(ready_user_sync_source) == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

用户同步通过 `RUNNING` 记录保证同一同步源只执行一次，但进程异常退出后没有陈旧记录回收。后续手动或定时触发会一直返回“正在运行”，只能人工修改数据库恢复。

## 根因

原有互斥只有运行状态检查和数据库条件唯一约束，没有可续租的活性时间，也没有在新触发前回收已失活的运行。单纯按开始时间释放又会误伤正常的长同步，并可能让旧执行与替代执行并发落库。

## 修复

- 新触发在互斥检查前，按 `updated_at` 回收无活动超时的 `RUNNING` 记录，并写入 `FAILED`、结束时间和可读摘要。
- 增加 `USER_SYNC_STALE_TIMEOUT_SECONDS` 配置，默认 21600 秒、最小 60 秒，非法值回退到默认值。
- provider 阻塞调用期间使用独立数据库连接周期刷新心跳；进程退出后心跳自然停止。
- 用户、组织和全量对账阶段通过同步源行锁保护活跃事务，并在提交前刷新心跳。支持 `SKIP LOCKED` 的数据库会直接跳过活跃阶段，其他有行锁数据库等待提交后按最新心跳复核。
- 对不支持行锁的数据库，使用带 `RUNNING` 条件的原子更新完成 fencing；遇到活跃写锁时 fail-closed，不会误释放正在工作的运行。
- provider 返回、阶段进度写入和终态写入都会复核本次运行仍为 `RUNNING`；已经被释放的旧执行不能继续覆盖新执行的数据或状态。
- 保留原有新鲜运行互斥和数据库唯一约束，继续兜底并发触发。

## 验证

`apps/system_mgmt/tests/test_user_sync_stale_recovery.py`：9 passed。

覆盖：

- 陈旧运行被释放并可创建替代运行。
- 最近仍有活动的运行继续阻止重复触发。
- 阻塞 provider 调用期间心跳续租，不会启动第二次 provider 调用。
- 活跃落库事务持锁时，超时回收不会等待后误释放。
- 覆盖支持 `SKIP LOCKED`、仅支持行锁、不支持行锁三类数据库并发路径。
- 已释放的旧 provider 结果不会继续落库。
- provider 返回后被释放的运行会在组织写入前停止。

关联 Issue #3988。
