### PR TITLE
bugfix: 限制默认规则初始化为本地调用

### DIFF
--- a/server/apps/console_mgmt/tests/test_init_guest_role_command.py
+++ b/server/apps/console_mgmt/tests/test_init_guest_role_command.py
@@ -6,11 +6,14 @@ SystemMgmt.create_default_rule。只 mock 两个 RPC 客户端边界，断言调
 """
 import pydantic.root_model  # noqa
 
+from importlib import import_module
+from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from apps.console_mgmt.management.commands import init_guest_role as cmd_mod
+from apps.system_mgmt.models import GroupDataRule
 
 pytestmark = pytest.mark.unit
 
@@ -38,6 +41,27 @@ def test_全链路成功调用create_default_rule():
 
         pilot_inst.get_guest_provider.assert_called_once_with(5)
         sys_inst.create_default_rule.assert_called_once_with("llm", "ocr", "emb", "rr")
+
+
+@pytest.mark.django_db
+def test_真实本地链路首调兼容导出():
+    compat_module = import_module("apps.system_mgmt.nats_api")
+    assert isinstance(compat_module, ModuleType)
+
+    with patch.object(cmd_mod, "OpsPilot") as MockPilot:
+        MockPilot.return_value.get_guest_provider.return_value = {
+            "result": True,
+            "data": {
+                "llm_model": {"id": 1, "name": "llm"},
+                "ocr_model": [{"id": 2, "name": "ocr"}],
+                "embed_model": [{"id": 3, "name": "embed"}],
+                "rerank_model": {"id": 4, "name": "rerank"},
+            },
+        }
+
+        _run()
+
+    assert GroupDataRule.objects.filter(name="OpsPilot内置规则", app="opspilot").exists()
 
 
 def test_provider失败时短路不调create_default_rule():

--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -242,7 +242,9 @@ def create_guest_role():
     return {"result": True, "data": {"group_id": app_guest_group.id}}
 
 
-@nats_client.register
+# This initializer is intentionally local-only: console_mgmt calls it through
+# AppClient, while exposing it on NATS would let unauthenticated publishers
+# create the built-in OpsPilot data rule when it is missing.
 def create_default_rule(llm_model, ocr_model, embed_model, rerank_model):
     guest_group = Group.objects.get(name="OpsPilotGuest", parent_id=0)
     GroupDataRule.objects.get_or_create(

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers.py
@@ -7,6 +7,7 @@ nats handler 直接可调用（@nats_client.register 返回原函数）。
 import types
 
 import pytest
+from nats_client.registry import default_registry
 
 import nats_client
 from apps.system_mgmt import nats_api
@@ -16,7 +17,7 @@ from apps.system_mgmt.models.channel import ChannelChoices
 pytestmark = pytest.mark.django_db
 
 
-def test_nats_api_compat_exports_all_nats_entrypoints():
+def test_nats_api_compat_exports_local_and_nats_entrypoints():
     expected_entrypoints = {
         "get_pilot_permission_by_token",
         "verify_token",
@@ -63,13 +64,15 @@ def test_nats_api_compat_exports_all_nats_entrypoints():
         "save_error_log",
         "save_operation_log",
     }
-    registered_entrypoints = expected_entrypoints - {"_list_opspilot_nats_channels"}
+    local_only_entrypoints = {"_list_opspilot_nats_channels", "create_default_rule"}
+    registered_entrypoints = expected_entrypoints - local_only_entrypoints
 
     exported_entrypoints = {name for name in expected_entrypoints if callable(getattr(nats_api, name, None))}
-    actual_registered_entrypoints = {item["name"] for item in nats_client.default_registry.registry.values()}
+    actual_registered_entrypoints = {item["name"] for item in default_registry.registry.values()}
 
     assert exported_entrypoints == expected_entrypoints
     assert registered_entrypoints <= actual_registered_entrypoints
+    assert "create_default_rule" not in actual_registered_entrypoints
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

`create_default_rule` 只应由 Guest 角色初始化流程在服务进程内调用，用于首次创建 OpsPilot 内置数据权限规则。当前函数同时注册为 NATS handler，使任何能发布对应 subject 的进程都能在规则缺失时传入 provider 数据并触发重建。

现有实现使用 `get_or_create`，不会覆盖已经存在的规则；风险边界是“远程创建缺失规则”，不是任意改写已有规则。

## 根因

函数位于 NATS handler 模块中，注册装饰器把“供 `nats_api` 兼容导出、本地 RPC facade 调用”与“允许远程 NATS 调用”混成同一边界。初始化命令实际使用 `AppClient` 直接导入 Python 函数，不需要 NATS subject。

## 修复

- 取消 `create_default_rule` 的 NATS 注册，使其保持为仅本地初始化入口。
- 保留函数本身及 `nats_api` 兼容导出，现有 Guest 角色初始化链路无需改参。
- 注册表测试同时断言本地函数可调用、NATS 注册表不再包含该入口。
- 真实链路测试保留 `Command → SystemMgmt → AppClient → nats_api → handler → DB`，只 mock OpsPilot 外部 provider 边界。

## 兼容性核对

- 全仓唯一业务调用是 `console_mgmt` 的 `init_guest_role` 管理命令，仍通过进程内 `AppClient` 执行。
- server、agents、配置样例和部署模板均未发现远程 NATS 生产者。
- NATS listener 仅分发注册表中的 handler，不会对 `nats_api` 做动态方法转发，因此保留本地兼容导出不会重新形成远程入口。
- 未发现具体已知合法调用方会因本变更失败；仅理论上的仓外未知调用不作为人工阻断。

## 验证

以下 3 个关联测试文件在最新提交共 72 passed：

- `apps/system_mgmt/tests/test_nats_api_handlers.py`
- `apps/rpc/tests/test_system_mgmt_forwarding.py`
- `apps/console_mgmt/tests/test_init_guest_role_command.py`

Standards / Issue Spec 双轴深审均 PASS，P0/P1/P2/P3 均为 0。

Fixes #3986
