### PR TITLE
bugfix: 修复定时作业派发任务ID回填竞态

### DIFF
--- a/server/apps/job_mgmt/tasks.py
+++ b/server/apps/job_mgmt/tasks.py
@@ -1,5 +1,7 @@
 """作业执行 Celery 任务入口"""
 
+from uuid import uuid4
+
 from asgiref.sync import async_to_sync
 from celery import current_app, shared_task
 from django.db import transaction
@@ -270,23 +272,42 @@ _JOB_TYPE_TO_TASK_NAME = {
 
 
 def _dispatch_execution_job(job_type: str, execution_id: int) -> bool:
-    """通过 Celery 派发执行任务并回填 ``celery_task_id``。
+    """持久化 Celery task id 后派发执行任务。
 
-    Returns ``False`` 当作业类型未知或 broker 派发失败（broker 不可用、连接超时等）；
-    调用方应据此把执行记录置为 FAILED，避免留下 PENDING 孤立记录。
+    Returns ``False`` 当作业类型未知、执行记录不可写或 broker 派发失败；调用方应据此把
+    执行记录置为 FAILED，避免留下 PENDING 孤立记录。
     """
     task_name = _JOB_TYPE_TO_TASK_NAME.get(job_type)
     if not task_name:
         return False
 
+    celery_task_id = uuid4().hex
     try:
-        result = current_app.send_task(task_name, args=[execution_id])
+        updated = JobExecution.objects.filter(id=execution_id).update(celery_task_id=celery_task_id)
     except Exception as e:
-        logger.exception(f"[_dispatch_execution_job] Celery 派发失败: execution_id={execution_id}, job_type={job_type}, error={e}")
+        logger.exception(
+            f"[_dispatch_execution_job] Celery 任务ID持久化失败: "
+            f"execution_id={execution_id}, job_type={job_type}, error={e}"
+        )
+        return False
+    if not updated:
+        logger.error(f"[_dispatch_execution_job] 执行记录不存在: execution_id={execution_id}, job_type={job_type}")
         return False
 
-    if result:
-        JobExecution.objects.filter(id=execution_id).update(celery_task_id=result.id)
+    try:
+        current_app.send_task(task_name, args=[execution_id], task_id=celery_task_id)
+    except Exception as e:
+        logger.exception(f"[_dispatch_execution_job] Celery 派发失败: execution_id={execution_id}, job_type={job_type}, error={e}")
+        try:
+            # 发布异常不代表 broker 一定未接收。保留已持久化的 ID，并尽力撤销可能已入队的任务。
+            current_app.control.revoke(celery_task_id)
+        except Exception as revoke_error:
+            logger.exception(
+                f"[_dispatch_execution_job] Celery 任务撤销失败: "
+                f"execution_id={execution_id}, task_id={celery_task_id}, error={revoke_error}"
+            )
+        return False
+
     return True
 
 

--- a/server/apps/job_mgmt/tests/test_scheduled_dispatch_service.py
+++ b/server/apps/job_mgmt/tests/test_scheduled_dispatch_service.py
@@ -6,7 +6,7 @@ service 层的 ``dispatch_celery_task``（走 ``.delay``）并行，需独立锁
 
 - 未知作业类型 → 返回 False（不发起派发）；
 - send_task 抛异常（broker 不可用）→ 返回 False；
-- 派发成功 → 返回 True 且回填 ``celery_task_id``。
+- 派发前写入 ``celery_task_id``，成功时返回 True。
 """
 
 from types import SimpleNamespace
@@ -25,21 +25,62 @@ class TestDispatchExecutionJob:
             assert _dispatch_execution_job("not-a-job-type", 1) is False
             mock_app.send_task.assert_not_called()
 
-    def test_broker_error_returns_false(self):
+    def test_broker_error_retains_task_id_and_revokes(self):
         with patch("apps.job_mgmt.tasks.current_app") as mock_app, patch("apps.job_mgmt.tasks.JobExecution") as mock_exec:
             mock_app.send_task.side_effect = ConnectionError("broker down")
-            assert _dispatch_execution_job(JobType.SCRIPT, 7) is False
-            # 失败时不回填 celery_task_id
-            mock_exec.objects.filter.assert_not_called()
+            mock_exec.objects.filter.return_value.update.return_value = 1
 
-    def test_success_backfills_celery_task_id(self):
+            assert _dispatch_execution_job(JobType.SCRIPT, 7) is False
+
+            persisted_task_id = mock_exec.objects.filter.return_value.update.call_args_list[0].kwargs["celery_task_id"]
+            mock_app.send_task.assert_called_once_with(
+                "apps.job_mgmt.tasks.execute_script_task",
+                args=[7],
+                task_id=persisted_task_id,
+            )
+            mock_app.control.revoke.assert_called_once_with(persisted_task_id)
+            mock_exec.objects.filter.assert_called_once_with(id=7)
+            mock_exec.objects.filter.return_value.update.assert_called_once_with(celery_task_id=persisted_task_id)
+
+    def test_missing_execution_returns_false_without_dispatch(self):
         with patch("apps.job_mgmt.tasks.current_app") as mock_app, patch("apps.job_mgmt.tasks.JobExecution") as mock_exec:
-            mock_app.send_task.return_value = SimpleNamespace(id="celery-xyz")
+            mock_exec.objects.filter.return_value.update.return_value = 0
+
+            assert _dispatch_execution_job(JobType.SCRIPT, 7) is False
+
+            mock_app.send_task.assert_not_called()
+
+    def test_persist_error_returns_false_without_dispatch(self):
+        with patch("apps.job_mgmt.tasks.current_app") as mock_app, patch("apps.job_mgmt.tasks.JobExecution") as mock_exec:
+            mock_exec.objects.filter.return_value.update.side_effect = OSError("database unavailable")
+
+            assert _dispatch_execution_job(JobType.SCRIPT, 7) is False
+
+            mock_app.send_task.assert_not_called()
+
+    def test_broker_and_revoke_errors_retain_task_id(self):
+        with patch("apps.job_mgmt.tasks.current_app") as mock_app, patch("apps.job_mgmt.tasks.JobExecution") as mock_exec:
+            mock_exec.objects.filter.return_value.update.return_value = 1
+            mock_app.send_task.side_effect = ConnectionError("publish result unknown")
+            mock_app.control.revoke.side_effect = ConnectionError("control unavailable")
+
+            assert _dispatch_execution_job(JobType.SCRIPT, 7) is False
+
+            mock_exec.objects.filter.return_value.update.assert_called_once()
+
+    def test_success_persists_task_id_before_dispatch(self):
+        with patch("apps.job_mgmt.tasks.current_app") as mock_app, patch("apps.job_mgmt.tasks.JobExecution") as mock_exec:
             mock_update = MagicMock()
             mock_exec.objects.filter.return_value = mock_update
+            events = []
+            mock_update.update.side_effect = lambda **kwargs: events.append(("persist", kwargs)) or 1
+            mock_app.send_task.side_effect = lambda *args, **kwargs: events.append(("dispatch", kwargs)) or SimpleNamespace(id=kwargs["task_id"])
 
             assert _dispatch_execution_job(JobType.SCRIPT, 7) is True
 
-            mock_app.send_task.assert_called_once_with("apps.job_mgmt.tasks.execute_script_task", args=[7])
             mock_exec.objects.filter.assert_called_once_with(id=7)
-            mock_update.update.assert_called_once_with(celery_task_id="celery-xyz")
+            persisted_task_id = events[0][1]["celery_task_id"]
+            assert events == [
+                ("persist", {"celery_task_id": persisted_task_id}),
+                ("dispatch", {"args": [7], "task_id": persisted_task_id}),
+            ]

--- a/server/apps/job_mgmt/tests/test_tasks_service.py
+++ b/server/apps/job_mgmt/tests/test_tasks_service.py
@@ -127,10 +127,10 @@ class TestDispatchExecutionJob:
     def test_script_dispatch_sets_celery_id(self):
         ex = self._exec(JobType.SCRIPT)
         with patch("apps.job_mgmt.tasks.current_app") as app:
-            app.send_task.return_value = MagicMock(id="celery-1")
             assert tasks._dispatch_execution_job(JobType.SCRIPT, ex.id) is True
+            persisted_task_id = app.send_task.call_args.kwargs["task_id"]
         ex.refresh_from_db()
-        assert ex.celery_task_id == "celery-1"
+        assert ex.celery_task_id == persisted_task_id
 
     def test_unknown_job_type_returns_false(self):
         ex = self._exec(JobType.SCRIPT)
@@ -141,6 +141,8 @@ class TestDispatchExecutionJob:
         with patch("apps.job_mgmt.tasks.current_app") as app:
             app.send_task.side_effect = ConnectionError("broker down")
             assert tasks._dispatch_execution_job(JobType.PLAYBOOK, ex.id) is False
+        ex.refresh_from_db()
+        assert ex.celery_task_id
 
 
 class TestCleanupExpiredFiles:


### PR DESCRIPTION
## 问题

定时作业派发必须保证：只要任务进入 Celery broker，执行记录中就已经存在可用于取消的同一个 task id。原实现先派发、后回填；两步之间若进程退出或数据库写入失败，取消接口无法定位已经运行的任务。

## 根因（设计层）

取消链路依赖 `JobExecution.celery_task_id`，派发链路却把 broker 返回值当作该字段的来源。这使取消标识的生命周期晚于任务本身，破坏了“先可追踪、后产生外部副作用”的边界。

## 怎么修的

- 派发前预生成 task id，并先写入现有执行记录。
- 只有写入成功才调用 `send_task`，同时显式传入同一个 `task_id`。
- 数据库写入失败时不产生 broker 副作用；broker 返回异常时保留可追踪 id，并尽力 revoke 可能已经入队的任务。
- 不新增表、字段或配置，也不改变对外接口。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["execute_scheduled_task\ntasks.py"]
    end

    DB["预写 celery_task_id\nJobExecution"]

    subgraph N["核心处理层"]
        F1["_dispatch_execution_job\ntasks.py"]
        F2["send_task(task_id)\nCelery broker"]
    end

    subgraph C["取消/失败处理层"]
        C1["job_task_terminate / cancel\n复用同一 task id"]
        C2["派发结果不确定\n保留 id 并尽力 revoke"]
    end

    T1 --> F1 --> DB --> F2
    F2 -. "取消时" .-> C1
    F2 -. "抛出异常" .-> C2
```

## 影响范围

改动仅覆盖 `job_mgmt` 的定时作业派发 helper，复用 Celery 原生显式 task id 能力。NATS、REST 取消接口以及三个 worker 任务入口不改签名；既有执行记录与数据库结构不变。

## 验证

- 回退实现时，新契约测试会失败，证明测试直接覆盖写库与派发顺序。
- `server/apps/job_mgmt/tests/test_scheduled_dispatch_service.py`、`server/apps/job_mgmt/tests/test_tasks_service.py`：24 passed。

Fixes #3978
