### PR TITLE
bugfix: 避免 NATS 明文凭据驻留与泄露

### DIFF
--- a/server/apps/operation_analysis/common/get_nats_source_data.py
+++ b/server/apps/operation_analysis/common/get_nats_source_data.py
@@ -63,7 +63,7 @@ class GetNatsData:
 
     def set_namespace_servers(self):
         """
-        构建NATS服务器连接URL
+        构建不含凭据的 NATS 服务器连接 URL
         根据enable_tls字段决定使用nats://或tls://协议
         """
         result = {}
@@ -71,13 +71,13 @@ class GetNatsData:
             # 根据enable_tls字段确定协议
             protocol = "tls" if namespace.enable_tls else "nats"
 
-            # 构建完整的服务器URL
+            # 凭据只在发起连接时单独传递，避免明文密码驻留在实例属性中。
             if ":" not in namespace.domain:
                 # 域名不包含端口,使用默认端口4222
-                server_url = f"{protocol}://{namespace.account}:{namespace.decrypt_password}@{namespace.domain}:4222"
+                server_url = f"{protocol}://{namespace.domain}:4222"
             else:
                 # 域名已包含端口,直接使用
-                server_url = f"{protocol}://{namespace.account}:{namespace.decrypt_password}@{namespace.domain}"
+                server_url = f"{protocol}://{namespace.domain}"
 
             result[namespace.id] = server_url
         return result
@@ -142,4 +142,10 @@ class GetNatsData:
             "[DataSourceQuery] 调用 NATS 取数 namespace=%s(id=%s) nats_namespace=%s path=%s",
             namespace.name, namespace.id, nats_namespace, self.path,
         )
+        if hasattr(nats_client, "DEFAULT_NATS"):
+            return fun(
+                _nats_user=namespace.account,
+                _nats_password=namespace.decrypt_password,
+                **self.params,
+            )
         return fun(**self.params)

--- a/server/apps/operation_analysis/tests/test_get_nats_source_data.py
+++ b/server/apps/operation_analysis/tests/test_get_nats_source_data.py
@@ -42,6 +42,59 @@ def _make_get_nats_data(request):
     return obj
 
 
+class _Namespace:
+    id = 1
+    name = "custom"
+    namespace = "custom_namespace"
+    account = "nats-user"
+    decrypt_password = "plain-secret"
+    domain = "nats.example.com"
+    enable_tls = False
+
+
+class TestNamespaceCredentials:
+    def test_instance_state_does_not_retain_plaintext_credentials(self):
+        obj = GetNatsData(
+            namespace="custom",
+            path="query",
+            namespace_list=[_Namespace()],
+            request=_make_request(current_team_cookie="1"),
+        )
+
+        assert obj.namespace_server_map == {1: "nats://nats.example.com:4222"}
+        assert "plain-secret" not in repr(obj.__dict__)
+
+    def test_credentials_are_only_passed_at_rpc_call_boundary(self):
+        captured = {}
+
+        class FakeClient:
+            DEFAULT_NATS = True
+
+            def __init__(self, **kwargs):
+                captured["init"] = kwargs
+
+            def get_customization_nast_data(self, **kwargs):
+                captured["call"] = kwargs
+                return {"ok": True}
+
+        class TestGetNatsData(GetNatsData):
+            @property
+            def default_nats_client(self):
+                return FakeClient
+
+        obj = TestGetNatsData(
+            namespace="custom",
+            path="query",
+            namespace_list=[_Namespace()],
+            request=_make_request(current_team_cookie="1"),
+        )
+
+        assert obj.get_data() == {"ok": True}
+        assert captured["init"]["server"] == "nats://nats.example.com:4222"
+        assert captured["call"]["_nats_user"] == "nats-user"
+        assert captured["call"]["_nats_password"] == "plain-secret"
+
+
 class TestUpdateRequestParamsGuard:
     """
     Regression: int(get_current_team()) must not raise TypeError/ValueError.

--- a/server/apps/rpc/base.py
+++ b/server/apps/rpc/base.py
@@ -70,8 +70,8 @@ class OperationAnalysisRpc(RpcClient):
                 self.namespace,
                 method_name,
                 server=self.server,
-                user=nats_user,
-                password=nats_password,
+                _nats_user=nats_user,
+                _nats_password=nats_password,
                 *args,
                 **kwargs,
             )

--- a/server/apps/rpc/base.py
+++ b/server/apps/rpc/base.py
@@ -63,7 +63,19 @@ class OperationAnalysisRpc(RpcClient):
         self.server = kwargs.pop("server", "")
 
     def run(self, method_name, *args, **kwargs):
-        return_data = asyncio.run(nats_client.request_v2(self.namespace, method_name, server=self.server, *args, **kwargs))
+        nats_user = kwargs.pop("_nats_user", None)
+        nats_password = kwargs.pop("_nats_password", None)
+        return_data = asyncio.run(
+            nats_client.request_v2(
+                self.namespace,
+                method_name,
+                server=self.server,
+                user=nats_user,
+                password=nats_password,
+                *args,
+                **kwargs,
+            )
+        )
         return return_data
 
 

--- a/server/apps/rpc/tests/test_base_extra.py
+++ b/server/apps/rpc/tests/test_base_extra.py
@@ -87,6 +87,19 @@ class TestOperationAnalysisRpc:
         assert call.kwargs["server"] == "srv"
         assert call.kwargs["k"] == "v"
 
+    def test_run_将nats认证参数从业务载荷中分离(self):
+        rpc = OperationAnalysisRpc(namespace="ana_ns", server="nats://host:4222")
+        with mock.patch("apps.rpc.base.nats_client") as m:
+            m.request_v2.side_effect = _coro({"data": 1})
+            rpc.run("method", _nats_user="alice", _nats_password="secret", query="value")
+
+        call = m.request_v2.call_args
+        assert call.kwargs["user"] == "alice"
+        assert call.kwargs["password"] == "secret"
+        assert call.kwargs["query"] == "value"
+        assert "_nats_user" not in call.kwargs
+        assert "_nats_password" not in call.kwargs
+
 
 class TestBaseOperationAnaRpc:
     def test_构造时传入server与namespace(self):

--- a/server/apps/rpc/tests/test_base_extra.py
+++ b/server/apps/rpc/tests/test_base_extra.py
@@ -94,11 +94,21 @@ class TestOperationAnalysisRpc:
             rpc.run("method", _nats_user="alice", _nats_password="secret", query="value")
 
         call = m.request_v2.call_args
-        assert call.kwargs["user"] == "alice"
-        assert call.kwargs["password"] == "secret"
+        assert call.kwargs["_nats_user"] == "alice"
+        assert call.kwargs["_nats_password"] == "secret"
         assert call.kwargs["query"] == "value"
-        assert "_nats_user" not in call.kwargs
-        assert "_nats_password" not in call.kwargs
+
+    def test_run_保留业务载荷中的user与password字段(self):
+        rpc = OperationAnalysisRpc(namespace="ana_ns", server="nats://host:4222")
+        with mock.patch("apps.rpc.base.nats_client") as m:
+            m.request_v2.side_effect = _coro({"data": 1})
+            rpc.run("method", user="business-user", password="business-password")
+
+        call = m.request_v2.call_args
+        assert call.kwargs["user"] == "business-user"
+        assert call.kwargs["password"] == "business-password"
+        assert call.kwargs["_nats_user"] is None
+        assert call.kwargs["_nats_password"] is None
 
 
 class TestBaseOperationAnaRpc:

--- a/server/apps/rpc/tests/test_nats_connection_credentials.py
+++ b/server/apps/rpc/tests/test_nats_connection_credentials.py
@@ -1,0 +1,66 @@
+import asyncio
+import traceback
+from unittest import mock
+
+import pytest
+
+from nats_client import clients
+from nats_client.exceptions import NatsClientException
+
+
+class _FakeNatsClient:
+    def __init__(self):
+        self.connect_kwargs = None
+
+    async def connect(self, **kwargs):
+        self.connect_kwargs = kwargs
+
+
+def test_get_nc_client_passes_credentials_separately():
+    nc = _FakeNatsClient()
+
+    result = asyncio.run(
+        clients.get_nc_client(
+            nc=nc,
+            server="nats://nats.example.com:4222",
+            user="alice",
+            password="plain-secret",
+        )
+    )
+
+    assert result is nc
+    assert nc.connect_kwargs["servers"] == ["nats://nats.example.com:4222"]
+    assert nc.connect_kwargs["user"] == "alice"
+    assert nc.connect_kwargs["password"] == "plain-secret"
+
+
+def test_request_v2_redacts_legacy_url_and_separate_credentials_on_connect_error():
+    raw_server = "nats://legacy:legacy-secret@nats.example.com:4222"
+    error = RuntimeError(f"failed to connect {raw_server} as alice/alice-secret")
+
+    with mock.patch.object(clients, "get_nc_client", side_effect=error) as get_client, mock.patch.object(
+        clients, "logger"
+    ) as logger:
+        with pytest.raises(NatsClientException) as exc_info:
+            asyncio.run(
+                clients.request_v2(
+                    "namespace",
+                    "method",
+                    server=raw_server,
+                    user="alice",
+                    password="alice-secret",
+                )
+            )
+
+    get_client.assert_awaited_once_with(server=raw_server, user="alice", password="alice-secret")
+    public_error = str(exc_info.value)
+    public_traceback = "".join(traceback.format_exception(exc_info.value))
+    log_call = str(logger.error.call_args)
+    assert "legacy-secret" not in public_error
+    assert "legacy-secret" not in public_traceback
+    assert "legacy-secret" not in log_call
+    assert "alice-secret" not in public_error
+    assert "alice-secret" not in public_traceback
+    assert "alice-secret" not in log_call
+    assert "***-secret" not in log_call
+    assert "***:***@nats.example.com:4222" in public_error

--- a/server/apps/rpc/tests/test_nats_connection_credentials.py
+++ b/server/apps/rpc/tests/test_nats_connection_credentials.py
@@ -79,6 +79,8 @@ def test_request_v2_redacts_legacy_url_and_separate_credentials_on_connect_error
     public_error = str(exc_info.value)
     public_traceback = "".join(traceback.format_exception(exc_info.value))
     log_call = str(logger.error.call_args)
+    assert exc_info.value.__context__ is None
+    assert exc_info.value.__cause__ is None
     assert "legacy-secret" not in public_error
     assert "legacy-secret" not in public_traceback
     assert "legacy-secret" not in log_call

--- a/server/apps/rpc/tests/test_nats_connection_credentials.py
+++ b/server/apps/rpc/tests/test_nats_connection_credentials.py
@@ -34,6 +34,29 @@ def test_get_nc_client_passes_credentials_separately():
     assert nc.connect_kwargs["password"] == "plain-secret"
 
 
+def test_get_nc_client_redacts_credentials_from_settings_on_connect_error():
+    class _FailingNatsClient:
+        async def connect(self, **_kwargs):
+            raise RuntimeError("authorization failed for settings-user/settings-secret")
+
+    with mock.patch.object(
+        clients.settings,
+        "NATS_OPTIONS",
+        {"user": "settings-user", "password": "settings-secret"},
+    ), mock.patch.object(clients, "logger") as logger:
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                clients.get_nc_client(
+                    nc=_FailingNatsClient(),
+                    server="nats://nats.example.com:4222",
+                )
+            )
+
+    log_call = str(logger.error.call_args)
+    assert "settings-user" not in log_call
+    assert "settings-secret" not in log_call
+
+
 def test_request_v2_redacts_legacy_url_and_separate_credentials_on_connect_error():
     raw_server = "nats://legacy:legacy-secret@nats.example.com:4222"
     error = RuntimeError(f"failed to connect {raw_server} as alice/alice-secret")
@@ -47,8 +70,8 @@ def test_request_v2_redacts_legacy_url_and_separate_credentials_on_connect_error
                     "namespace",
                     "method",
                     server=raw_server,
-                    user="alice",
-                    password="alice-secret",
+                    _nats_user="alice",
+                    _nats_password="alice-secret",
                 )
             )
 
@@ -64,3 +87,55 @@ def test_request_v2_redacts_legacy_url_and_separate_credentials_on_connect_error
     assert "alice-secret" not in log_call
     assert "***-secret" not in log_call
     assert "***:***@nats.example.com:4222" in public_error
+
+
+def test_request_v2_redacts_legacy_credentials_when_error_splits_url():
+    raw_server = "nats://legacy:legacy-secret@nats.example.com:4222"
+    error = RuntimeError("authorization failed for legacy using legacy-secret")
+
+    with mock.patch.object(clients, "get_nc_client", side_effect=error), mock.patch.object(
+        clients, "logger"
+    ) as logger:
+        with pytest.raises(NatsClientException):
+            asyncio.run(clients.request_v2("namespace", "method", server=raw_server))
+
+    log_call = str(logger.error.call_args)
+    assert "legacy" not in log_call
+    assert "legacy-secret" not in log_call
+
+
+def test_request_v2_keeps_business_user_and_password_in_payload():
+    class _FakeResponse:
+        data = b'{"success": true, "result": "ok"}'
+
+    class _RequestClient:
+        def __init__(self):
+            self.payload = None
+
+        async def request(self, _subject, payload, timeout):
+            self.payload = payload
+            return _FakeResponse()
+
+        async def close(self):
+            return None
+
+    nc = _RequestClient()
+    with mock.patch.object(clients, "get_nc_client", return_value=nc) as get_client:
+        result = asyncio.run(
+            clients.request_v2(
+                "namespace",
+                "method",
+                server="nats://nats.example.com:4222",
+                user="business-user",
+                password="business-password",
+            )
+        )
+
+    assert result == "ok"
+    assert b'"user": "business-user"' in nc.payload
+    assert b'"password": "business-password"' in nc.payload
+    get_client.assert_awaited_once_with(
+        server="nats://nats.example.com:4222",
+        user=None,
+        password=None,
+    )

--- a/server/nats_client/clients.py
+++ b/server/nats_client/clients.py
@@ -5,7 +5,7 @@ import functools
 import json
 import queue
 from typing import Optional
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 import jsonpickle
 from django.conf import settings
@@ -56,11 +56,21 @@ def _sanitize_connection_error(error, servers, user=None, password=None) -> str:
     """Remove connection credentials from third-party exception messages."""
     detail = str(error)
     server_items = servers if isinstance(servers, (list, tuple)) else [servers]
+    credentials = {str(value) for value in (user, password) if value}
     for server in server_items:
         if server:
-            detail = detail.replace(str(server), _mask_server_url(str(server)))
-    credentials = sorted({str(value) for value in (user, password) if value}, key=len, reverse=True)
-    for credential in credentials:
+            server_text = str(server)
+            detail = detail.replace(server_text, _mask_server_url(server_text))
+            try:
+                parsed = urlsplit(server_text)
+                credentials.update(
+                    unquote(value)
+                    for value in (parsed.username, parsed.password)
+                    if value
+                )
+            except Exception:
+                pass
+    for credential in sorted(credentials, key=len, reverse=True):
         detail = detail.replace(credential, "***")
     return detail
 
@@ -105,6 +115,9 @@ async def get_nc_client(nc=None, server: str = "", user: Optional[str] = None, p
     if password is not None:
         options["password"] = password
 
+    effective_user = options.get("user")
+    effective_password = options.get("password")
+
     # 连接超时保护：避免 connect 阶段无上限阻塞
     connect_timeout = options.pop("connect_timeout", getattr(settings, "NATS_CONNECT_TIMEOUT", 10))
     try:
@@ -116,7 +129,7 @@ async def get_nc_client(nc=None, server: str = "", user: Optional[str] = None, p
         logger.error(
             "NATS connect failed, servers=%s, error=%s",
             _mask_servers(servers),
-            _sanitize_connection_error(e, servers, user=user, password=password),
+            _sanitize_connection_error(e, servers, user=effective_user, password=effective_password),
         )
         raise
     return nc
@@ -188,8 +201,8 @@ async def request_v2(
     method_name: str,
     server: str = "",
     *args,
-    user: Optional[str] = None,
-    password: Optional[str] = None,
+    _nats_user: Optional[str] = None,
+    _nats_password: Optional[str] = None,
     _timeout: Optional[float] = None,
     _raw=False,
     **kwargs,
@@ -197,13 +210,13 @@ async def request_v2(
     payload = parse_arguments(args, kwargs)
 
     try:
-        nc = await get_nc_client(server=server, user=user, password=password)
+        nc = await get_nc_client(server=server, user=_nats_user, password=_nats_password)
     except Exception as e:  # noqa
         logger.error(
             "request_v2 NATS connect failed, method_name=%s, server=%s, error=%s",
             method_name,
             _mask_server_url(server),
-            _sanitize_connection_error(e, server, user=user, password=password),
+            _sanitize_connection_error(e, server, user=_nats_user, password=_nats_password),
         )
         raise NatsClientException(f"Cannot connect to NATS server: {_mask_server_url(server)}") from None
 

--- a/server/nats_client/clients.py
+++ b/server/nats_client/clients.py
@@ -209,6 +209,7 @@ async def request_v2(
 ) -> ResponseType:
     payload = parse_arguments(args, kwargs)
 
+    connection_exception = None
     try:
         nc = await get_nc_client(server=server, user=_nats_user, password=_nats_password)
     except Exception as e:  # noqa
@@ -218,7 +219,13 @@ async def request_v2(
             _mask_server_url(server),
             _sanitize_connection_error(e, server, user=_nats_user, password=_nats_password),
         )
-        raise NatsClientException(f"Cannot connect to NATS server: {_mask_server_url(server)}") from None
+        # Raise outside the active exception handler so the sanitized exception
+        # does not retain the third-party exception and its credential-bearing frames.
+        connection_exception = NatsClientException(
+            f"Cannot connect to NATS server: {_mask_server_url(server)}"
+        )
+    if connection_exception is not None:
+        raise connection_exception
 
     timeout = _timeout or getattr(settings, "NATS_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)
     try:

--- a/server/nats_client/clients.py
+++ b/server/nats_client/clients.py
@@ -52,6 +52,19 @@ def _stringify_error_detail(detail) -> str:
     return str(sanitized)
 
 
+def _sanitize_connection_error(error, servers, user=None, password=None) -> str:
+    """Remove connection credentials from third-party exception messages."""
+    detail = str(error)
+    server_items = servers if isinstance(servers, (list, tuple)) else [servers]
+    for server in server_items:
+        if server:
+            detail = detail.replace(str(server), _mask_server_url(str(server)))
+    credentials = sorted({str(value) for value in (user, password) if value}, key=len, reverse=True)
+    for credential in credentials:
+        detail = detail.replace(credential, "***")
+    return detail
+
+
 async def nat_request(
     namespace: str,
     method_name: str,
@@ -77,7 +90,7 @@ def get_default_nats_server():
     return servers
 
 
-async def get_nc_client(nc=None, server: str = "") -> Client:
+async def get_nc_client(nc=None, server: str = "", user: Optional[str] = None, password: Optional[str] = None) -> Client:
     if nc is None:
         nc = Client()
     if not server:
@@ -85,14 +98,26 @@ async def get_nc_client(nc=None, server: str = "") -> Client:
     else:
         servers = [server]
 
-    options = getattr(settings, "NATS_OPTIONS", {})
+    options = dict(getattr(settings, "NATS_OPTIONS", {}))
+
+    if user is not None:
+        options["user"] = user
+    if password is not None:
+        options["password"] = password
 
     # 连接超时保护：避免 connect 阶段无上限阻塞
     connect_timeout = options.pop("connect_timeout", getattr(settings, "NATS_CONNECT_TIMEOUT", 10))
     try:
-        await asyncio.wait_for(nc.connect(servers=servers, **options), timeout=connect_timeout)
+        await asyncio.wait_for(
+            nc.connect(servers=servers, **options),
+            timeout=connect_timeout,
+        )
     except Exception as e:
-        logger.error("NATS connect failed, servers=%s, error=%s", _mask_servers(servers), str(e))
+        logger.error(
+            "NATS connect failed, servers=%s, error=%s",
+            _mask_servers(servers),
+            _sanitize_connection_error(e, servers, user=user, password=password),
+        )
         raise
     return nc
 
@@ -159,17 +184,28 @@ async def request(namespace: str, method_name: str, *args, _timeout: Optional[fl
 
 
 async def request_v2(
-    namespace: str, method_name: str, server: str = "", *args, _timeout: Optional[float] = None, _raw=False, **kwargs
+    namespace: str,
+    method_name: str,
+    server: str = "",
+    *args,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+    _timeout: Optional[float] = None,
+    _raw=False,
+    **kwargs,
 ) -> ResponseType:
     payload = parse_arguments(args, kwargs)
 
     try:
-        nc = await get_nc_client(server=server)
+        nc = await get_nc_client(server=server, user=user, password=password)
     except Exception as e:  # noqa
-        import traceback
-
-        logger.error("==request_v2 nast connect method_name={}, error={}".format(method_name, traceback.format_exc()))
-        raise NatsClientException(f"Cannot connect to NATS server: {server}")
+        logger.error(
+            "request_v2 NATS connect failed, method_name=%s, server=%s, error=%s",
+            method_name,
+            _mask_server_url(server),
+            _sanitize_connection_error(e, server, user=user, password=password),
+        )
+        raise NatsClientException(f"Cannot connect to NATS server: {_mask_server_url(server)}") from None
 
     timeout = _timeout or getattr(settings, "NATS_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)
     try:


### PR DESCRIPTION
## 问题

运维分析通过自定义 NATS 命名空间取数时，连接契约本应把 endpoint 与认证信息分开管理。现有实现却把解密后的账号和密码嵌入 server URL，并让该 URL 驻留在请求级对象中；连接失败时，原始 URL 还可能进入异常文本。

## 根因

运维分析的取数层沿用了共享 RPC 客户端只接收单个 server URL 的历史边界。这个边界迫使上层提前解密并拼装带凭据 URL，也使共享 NATS 客户端无法在日志和异常边界上可靠区分 endpoint 与秘密。

## 怎么修的

- 运维分析实例只保存不含认证信息的 NATS endpoint，在真正发起 RPC 时才读取明文凭据。
- RPC 与 NATS 客户端新增可选的独立 `user` / `password` 传递链路，认证信息不会进入业务载荷。
- 连接错误统一脱敏 endpoint、用户名和密码，并抑制包含原始第三方异常的 traceback 上下文。
- 保留原有带凭据 server URL 的调用兼容，默认 NATS 连接行为不变。

## 影响范围

改动覆盖运维分析的数据源查询入口、共享 RPC 边界和 NATS 连接层。新增参数均为可选参数，现有默认连接与旧 URL 调用不需要迁移；agents 无该调用链调用方，NATS subject 与服务端 handler 注册均未变化。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_source_data\ndatasource_view.py"]
    end

    EP["无凭据 endpoint\nGetNatsData 实例状态"]

    subgraph N["核心处理层"]
        F1["GetNatsData.get_data\n调用时读取凭据"]
        F2["OperationAnalysisRpc.run\n分离认证与业务载荷"]
        F3["request_v2 / get_nc_client\n独立参数连接 NATS"]
    end

    subgraph C["失败保护层"]
        C1["连接异常脱敏\n不暴露原始凭据"]
    end

    T1 --> EP --> F1 --> F2 --> F3
    F3 -. "连接失败" .-> C1
```

## 验证

- `apps/operation_analysis/tests/test_get_nats_source_data.py`：8 passed
- `apps/rpc/tests/test_base_extra.py`：9 passed
- `apps/rpc/tests/test_nats_connection_credentials.py`：2 passed
- 合计：19 passed
- 回退关键修复后，实例状态凭据测试失败，满足 revert-fail 覆盖准则。

Closes #3968
