### PR TITLE
bugfix: 统一移动端工作台标签配置

### DIFF
--- a/mobile/src/app/search/page.tsx
+++ b/mobile/src/app/search/page.tsx
@@ -9,6 +9,7 @@ import Image from 'next/image';
 import { useTranslation } from '@/utils/i18n';
 import { getApplication } from '@/api/bot';
 import { getAvatar } from '@/utils/avatar';
+import { getAppTagColor, getAppTagLabel } from '@/constants/workbenchTags';
 
 type SearchType = 'ConversationList' | 'WorkbenchPage' | 'ChatHistory';
 
@@ -117,25 +118,6 @@ export default function SearchPage() {
 
     // 获取搜索结果
     const searchResults = searchType === 'WorkbenchPage' ? workbenchResults : getOtherSearchResults();
-
-    // app_tags 映射
-    const appTagsMap: { [key: string]: string } = {
-        'routine_ops': t('workbench.routineOps'),
-        'monitor_alarm': t('workbench.monitorAlarm'),
-        'automation': t('workbench.automation'),
-        'security_audit': t('workbench.securityAudit'),
-        'performance_analysis': t('workbench.performanceAnalysis'),
-        'ops_plan': t('workbench.opsPlan'),
-    };
-
-    const appTagColors: { [key: string]: { bg: string; text: string } } = {
-        'routine_ops': { bg: '#E5F4FF', text: '#4A9EFF' },
-        'monitor_alarm': { bg: '#FFE5E5', text: '#FF6B9D' },
-        'automation': { bg: '#FFF4E5', text: '#FFB84D' },
-        'security_audit': { bg: '#E5FFE5', text: '#52C41A' },
-        'performance_analysis': { bg: '#F0E5FF', text: '#9B59B6' },
-        'ops_plan': { bg: '#E5F0FF', text: '#3498DB' },
-    };
 
     // 通用渲染函数 - 对话列表项和聊天记录项
     const renderListItem = (item: ChatItem | ChatMessageRecord, type: 'conversation' | 'message') => {
@@ -247,18 +229,21 @@ export default function SearchPage() {
                     {/* 标签按钮 */}
                     {item.app_tags && item.app_tags.length > 0 && (
                         <div className="flex flex-wrap gap-1 justify-end">
-                            {item.app_tags.map((tag: string) => (
-                                <span
-                                    key={tag}
-                                    className="px-2 py-0.5 text-xs font-medium rounded"
-                                    style={{
-                                        backgroundColor: appTagColors[tag]?.bg || '#F0F0F0',
-                                        color: appTagColors[tag]?.text || '#666666',
-                                    }}
-                                >
-                                    {appTagsMap[tag] || tag}
-                                </span>
-                            ))}
+                            {item.app_tags.map((tag: string) => {
+                                const tagColor = getAppTagColor(tag);
+                                return (
+                                    <span
+                                        key={tag}
+                                        className="px-2 py-0.5 text-xs font-medium rounded"
+                                        style={{
+                                            backgroundColor: tagColor.bg,
+                                            color: tagColor.text,
+                                        }}
+                                    >
+                                        {getAppTagLabel(tag, t)}
+                                    </span>
+                                );
+                            })}
                         </div>
                     )}
                 </div>

--- a/mobile/src/app/workbench/page.tsx
+++ b/mobile/src/app/workbench/page.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import { useTranslation } from '@/utils/i18n';
 import { getApplication } from '@/api/bot';
 import { getAvatar } from '@/utils/avatar';
+import { getAppTagColor, getAppTagLabel } from '@/constants/workbenchTags';
 
 type TabKey =
     | 'all'
@@ -110,25 +111,6 @@ export default function WorkbenchPage() {
         }
     }, [activeTab]);
 
-    // app_tags 映射
-    const appTagsMap: { [key: string]: string } = {
-        'routine_ops': t('workbench.routineOps'),
-        'monitor_alarm': t('workbench.monitorAlarm'),
-        'automation': t('workbench.automation'),
-        'security_audit': t('workbench.securityAudit'),
-        'performance_analysis': t('workbench.performanceAnalysis'),
-        'ops_plan': t('workbench.opsPlan'),
-    };
-
-    const appTagColors: { [key: string]: { bg: string; text: string } } = {
-        'routine_ops': { bg: '#E5F4FF', text: '#4A9EFF' },
-        'monitor_alarm': { bg: '#FFE5E5', text: '#FF6B9D' },
-        'automation': { bg: '#FFF4E5', text: '#FFB84D' },
-        'security_audit': { bg: '#E5FFE5', text: '#52C41A' },
-        'performance_analysis': { bg: '#F0E5FF', text: '#9B59B6' },
-        'ops_plan': { bg: '#E5F0FF', text: '#3498DB' },
-    };
-
     const handleTabChange = (key: string) => {
         setActiveTab(key as TabKey);
     };
@@ -182,18 +164,21 @@ export default function WorkbenchPage() {
                     {/* 标签按钮 */}
                     {item.app_tags && item.app_tags.length > 0 && (
                         <div className="flex flex-wrap gap-1 justify-end">
-                            {item.app_tags.map((tag: string) => (
-                                <span
-                                    key={tag}
-                                    className="px-2 py-0.5 text-xs font-medium rounded"
-                                    style={{
-                                        backgroundColor: appTagColors[tag]?.bg || '#F0F0F0',
-                                        color: appTagColors[tag]?.text || '#666666',
-                                    }}
-                                >
-                                    {appTagsMap[tag] || tag}
-                                </span>
-                            ))}
+                            {item.app_tags.map((tag: string) => {
+                                const tagColor = getAppTagColor(tag);
+                                return (
+                                    <span
+                                        key={tag}
+                                        className="px-2 py-0.5 text-xs font-medium rounded"
+                                        style={{
+                                            backgroundColor: tagColor.bg,
+                                            color: tagColor.text,
+                                        }}
+                                    >
+                                        {getAppTagLabel(tag, t)}
+                                    </span>
+                                );
+                            })}
                         </div>
                     )}
                 </div>

--- a/mobile/src/constants/workbenchTags.ts
+++ b/mobile/src/constants/workbenchTags.ts
@@ -1,0 +1,50 @@
+export const APP_TAGS = [
+    'routine_ops',
+    'monitor_alarm',
+    'automation',
+    'security_audit',
+    'performance_analysis',
+    'ops_plan',
+] as const;
+
+export type AppTagKey = typeof APP_TAGS[number];
+
+export interface AppTagColor {
+    bg: string;
+    text: string;
+}
+
+export const APP_TAG_LABEL_KEYS = {
+    'routine_ops': 'workbench.routineOps',
+    'monitor_alarm': 'workbench.monitorAlarm',
+    'automation': 'workbench.automation',
+    'security_audit': 'workbench.securityAudit',
+    'performance_analysis': 'workbench.performanceAnalysis',
+    'ops_plan': 'workbench.opsPlan',
+} satisfies Record<AppTagKey, string>;
+
+export const APP_TAG_COLORS = {
+    'routine_ops': { bg: '#E5F4FF', text: '#4A9EFF' },
+    'monitor_alarm': { bg: '#FFE5E5', text: '#FF6B9D' },
+    'automation': { bg: '#FFF4E5', text: '#FFB84D' },
+    'security_audit': { bg: '#E5FFE5', text: '#52C41A' },
+    'performance_analysis': { bg: '#F0E5FF', text: '#9B59B6' },
+    'ops_plan': { bg: '#E5F0FF', text: '#3498DB' },
+} satisfies Record<AppTagKey, AppTagColor>;
+
+const DEFAULT_APP_TAG_COLOR: AppTagColor = {
+    bg: '#F0F0F0',
+    text: '#666666',
+};
+
+const isAppTagKey = (tag: string): tag is AppTagKey => (
+    APP_TAGS.includes(tag as AppTagKey)
+);
+
+export const getAppTagColor = (tag: string): AppTagColor => (
+    isAppTagKey(tag) ? APP_TAG_COLORS[tag] : DEFAULT_APP_TAG_COLOR
+);
+
+export const getAppTagLabel = (tag: string, translate: (id: string) => string): string => (
+    isAppTagKey(tag) ? translate(APP_TAG_LABEL_KEYS[tag]) : tag
+);

--- a/mobile/tests/test_workbench_tag_config.py
+++ b/mobile/tests/test_workbench_tag_config.py
@@ -1,0 +1,37 @@
+import re
+import unittest
+from pathlib import Path
+
+
+MOBILE_ROOT = Path(__file__).resolve().parents[1]
+TAG_CONFIG = MOBILE_ROOT / "src/constants/workbenchTags.ts"
+TAG_CONSUMERS = (
+    MOBILE_ROOT / "src/app/workbench/page.tsx",
+    MOBILE_ROOT / "src/app/search/page.tsx",
+)
+
+
+class WorkbenchTagConfigTest(unittest.TestCase):
+    def test_pages_share_a_key_safe_tag_config(self):
+        config_source = TAG_CONFIG.read_text(encoding="utf-8")
+
+        self.assertIn("export const APP_TAGS", config_source)
+        self.assertIn("export type AppTagKey", config_source)
+        self.assertRegex(
+            config_source,
+            re.compile(r"APP_TAG_LABEL_KEYS[^=]*=.*satisfies Record<AppTagKey, string>", re.DOTALL),
+        )
+        self.assertRegex(
+            config_source,
+            re.compile(r"APP_TAG_COLORS[^=]*=.*satisfies Record<AppTagKey, AppTagColor>", re.DOTALL),
+        )
+
+        for consumer in TAG_CONSUMERS:
+            source = consumer.read_text(encoding="utf-8")
+            self.assertIn("@/constants/workbenchTags", source)
+            self.assertNotRegex(source, r"const appTagsMap\s*[:=]")
+            self.assertNotRegex(source, r"const appTagColors\s*[:=]")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

移动端工作台与搜索页本应对同一个应用标签呈现一致的文案和色卡，但两页各自维护完整映射。新增或调整标签时，单页更新不会被类型系统发现，另一入口会退回原始标签和默认颜色。

## 根因

标签键、国际化文案键和色卡没有共同的领域配置边界，页面组件直接持有宽泛字符串索引的字面量。这让同一展示契约分散成两个互不约束的副本。

## 怎么修的

- 建立共享标签配置，集中定义标签键联合类型、国际化文案键和色卡，并通过 `Record` 在编译期约束键集合完整一致。
- 两个页面统一通过共享 helper 获取标签文案和颜色。
- 保留未知标签显示原始 key、使用默认色卡的既有行为。

## 影响范围

改动仅触及 mobile 内部展示层，不调整接口、数据模型或标签值协议。服务端与 Web 端调用方无需适配，现有六个标签的文案 key、色值和未知标签回退均保持不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["WorkbenchPage / SearchPage\nmobile/src/app"]
    end

    D["API 返回 app_tags"]

    subgraph N["标签展示层"]
        F1["getAppTagColor\nworkbenchTags.ts"]
        F2["getAppTagLabel\nworkbenchTags.ts"]
    end

    subgraph C["未知标签兜底"]
        C1["原始 key + 默认色卡"]
    end

    T1 --> D --> F1
    D --> F2
    F1 -. "未知 key" .-> C1
    F2 -. "未知 key" .-> C1
```

## 验证

- `mobile/tests/test_workbench_tag_config.py`：1 passed。
- 测试直接约束两页必须消费共享配置、不得重新声明本地映射，并检查标签文案与色卡使用键安全的 `Record`；回退修复后该测试会失败。
