### PR TITLE
bugfix: 修复默认模型授权并发覆盖

### DIFF
--- a/server/apps/opspilot/nats_api.py
+++ b/server/apps/opspilot/nats_api.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 import nats_client
+from django.db import transaction
 from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.models import Bot, BotConversationHistory, BotWorkFlow, EmbedProvider, LLMModel, LLMSkill, OCRProvider, RerankProvider, SkillTools
 from apps.opspilot.models.bot_mgmt import BotWebChatSession
@@ -123,6 +124,16 @@ def _normalize_nats_trigger_input(message, team, user_ids, bot_id, node_id):
     }, None
 
 
+def _grant_provider_team_access(model, name, group_id):
+    provider = model.objects.select_for_update().get(name=name, is_build_in=True)
+    team = list(provider.team or [])
+    if group_id not in team:
+        team.append(group_id)
+        provider.team = team
+        provider.save(update_fields=["team"])
+    return provider
+
+
 @nats_client.register
 def get_opspilot_module_list():
     return [
@@ -180,37 +191,16 @@ def get_opspilot_module_data(module, child_module, page, page_size, group_id):
 
 @nats_client.register
 def get_guest_provider(group_id):
-    default_llm_model = LLMModel.objects.get(name="GPT-4o", is_build_in=True)
-    if group_id not in default_llm_model.team:
-        default_llm_model.team.append(group_id)
-        default_llm_model.save()
-    rerank_model = RerankProvider.objects.get(name="bce-reranker-base_v1", is_build_in=True)
-    if group_id not in rerank_model.team:
-        rerank_model.team.append(group_id)
-        rerank_model.save()
-
-    embed_model_1 = EmbedProvider.objects.get(name="bce-embedding-base_v1", is_build_in=True)
-    if group_id not in embed_model_1.team:
-        embed_model_1.team.append(group_id)
-        embed_model_1.save()
-    embed_model_2 = EmbedProvider.objects.get(name="FastEmbed(BAAI/bge-small-zh-v1.5)", is_build_in=True)
-    if group_id not in embed_model_2.team:
-        embed_model_2.team.append(group_id)
-        embed_model_2.save()
-
-    paddle_ocr = OCRProvider.objects.get(name="PaddleOCR", is_build_in=True)
-    if group_id not in paddle_ocr.team:
-        paddle_ocr.team.append(group_id)
-        paddle_ocr.save()
-
-    azure_ocr = OCRProvider.objects.get(name="AzureOCR", is_build_in=True)
-    if group_id not in azure_ocr.team:
-        azure_ocr.team.append(group_id)
-        azure_ocr.save()
-    olm_ocr = OCRProvider.objects.get(name="OlmOCR", is_build_in=True)
-    if group_id not in olm_ocr.team:
-        olm_ocr.team.append(group_id)
-        olm_ocr.save()
+    with transaction.atomic():
+        default_llm_model = _grant_provider_team_access(LLMModel, "GPT-4o", group_id)
+        rerank_model = _grant_provider_team_access(RerankProvider, "bce-reranker-base_v1", group_id)
+        embed_model_1 = _grant_provider_team_access(EmbedProvider, "bce-embedding-base_v1", group_id)
+        embed_model_2 = _grant_provider_team_access(
+            EmbedProvider, "FastEmbed(BAAI/bge-small-zh-v1.5)", group_id
+        )
+        paddle_ocr = _grant_provider_team_access(OCRProvider, "PaddleOCR", group_id)
+        azure_ocr = _grant_provider_team_access(OCRProvider, "AzureOCR", group_id)
+        olm_ocr = _grant_provider_team_access(OCRProvider, "OlmOCR", group_id)
     return {
         "result": True,
         "data": {

--- a/server/apps/opspilot/tests/test_nats_guest_provider_locking.py
+++ b/server/apps/opspilot/tests/test_nats_guest_provider_locking.py
@@ -1,0 +1,97 @@
+import ast
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+
+class _Provider:
+    def __init__(self, provider_id, name, team):
+        self.id = provider_id
+        self.name = name
+        self.team = team
+        self.saved_with = []
+
+    def save(self, **kwargs):
+        self.saved_with.append(kwargs)
+
+
+class _Manager:
+    def __init__(self, providers):
+        self.providers = {provider.name: provider for provider in providers}
+        self.lock_count = 0
+
+    def select_for_update(self):
+        self.lock_count += 1
+        return self
+
+    def get(self, *, name, is_build_in):
+        assert is_build_in is True
+        return self.providers[name]
+
+
+class _Atomic:
+    def __init__(self):
+        self.entries = 0
+        self.exits = 0
+
+    @contextmanager
+    def atomic(self):
+        self.entries += 1
+        try:
+            yield
+        finally:
+            self.exits += 1
+
+
+def _load_guest_provider_functions(namespace):
+    source_path = Path(__file__).parents[1] / "nats_api.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    functions = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"_grant_provider_team_access", "get_guest_provider"}
+    ]
+    assert {node.name for node in functions} == {"_grant_provider_team_access", "get_guest_provider"}
+    exec(compile(ast.Module(body=functions, type_ignores=[]), str(source_path), "exec"), namespace)
+
+
+def test_get_guest_provider_uses_one_transaction_and_locks_every_row():
+    llm = [_Provider(1, "GPT-4o", [3])]
+    rerank = [_Provider(2, "bce-reranker-base_v1", [])]
+    embeds = [
+        _Provider(3, "bce-embedding-base_v1", []),
+        _Provider(4, "FastEmbed(BAAI/bge-small-zh-v1.5)", []),
+    ]
+    ocrs = [
+        _Provider(5, "PaddleOCR", []),
+        _Provider(6, "AzureOCR", []),
+        _Provider(7, "OlmOCR", []),
+    ]
+    managers = {
+        "LLMModel": _Manager(llm),
+        "RerankProvider": _Manager(rerank),
+        "EmbedProvider": _Manager(embeds),
+        "OCRProvider": _Manager(ocrs),
+    }
+    transaction = _Atomic()
+    namespace = {
+        "nats_client": SimpleNamespace(register=lambda function: function),
+        "transaction": transaction,
+        **{name: SimpleNamespace(objects=manager) for name, manager in managers.items()},
+    }
+    _load_guest_provider_functions(namespace)
+
+    result = namespace["get_guest_provider"](group_id=7)
+
+    assert result["result"] is True
+    assert transaction.entries == transaction.exits == 1
+    assert managers["LLMModel"].lock_count == 1
+    assert managers["RerankProvider"].lock_count == 1
+    assert managers["EmbedProvider"].lock_count == 2
+    assert managers["OCRProvider"].lock_count == 3
+    for provider in rerank + embeds + ocrs:
+        assert provider.team == [7]
+        assert provider.saved_with == [{"update_fields": ["team"]}]
+    assert llm[0].team == [3, 7]
+    assert llm[0].saved_with == [{"update_fields": ["team"]}]

--- a/server/apps/opspilot/tests/test_nats_web_chat_exposure.py
+++ b/server/apps/opspilot/tests/test_nats_web_chat_exposure.py
@@ -1022,7 +1022,7 @@ def test_session_messages_missing_session_id_returns_400(bot):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_get_guest_provider_adds_team_to_models(bot, mocker):
+def test_get_guest_provider_adds_team_to_models(bot):
     """get_guest_provider：为默认 llm/rerank/embed/ocr 模型追加 group_id 到 team。"""
     from apps.opspilot import nats_api
     from apps.opspilot.models.model_provider_mgmt import EmbedProvider, LLMModel, OCRProvider, RerankProvider
@@ -1035,29 +1035,18 @@ def test_get_guest_provider_adds_team_to_models(bot, mocker):
     azure = OCRProvider.objects.create(name="AzureOCR", is_build_in=True, team=[])
     olm = OCRProvider.objects.create(name="OlmOCR", is_build_in=True, team=[])
 
-    def _fake_get(name=None, **kwargs):
-        mapping = {
-            "GPT-4o": llm,
-            "bce-reranker-base_v1": rerank,
-            "bce-embedding-base_v1": embed1,
-            "FastEmbed(BAAI/bge-small-zh-v1.5)": embed2,
-            "PaddleOCR": paddle,
-            "AzureOCR": azure,
-            "OlmOCR": olm,
-        }
-        return mapping[name]
-
-    mocker.patch.object(nats_api.LLMModel.objects, "get", side_effect=lambda **kw: _fake_get(name=kw.get("name")))
-    mocker.patch.object(nats_api.RerankProvider.objects, "get", side_effect=lambda **kw: _fake_get(name=kw.get("name")))
-    mocker.patch.object(nats_api.EmbedProvider.objects, "get", side_effect=lambda **kw: _fake_get(name=kw.get("name")))
-    mocker.patch.object(nats_api.OCRProvider.objects, "get", side_effect=lambda **kw: _fake_get(name=kw.get("name")))
-
     result = nats_api.get_guest_provider(group_id=1)
+    for provider in (llm, rerank, embed1, embed2, paddle, azure, olm):
+        provider.refresh_from_db()
+
     assert result["result"] is True
     assert 1 in llm.team
     assert 1 in rerank.team
     assert 1 in embed1.team
+    assert 1 in embed2.team
     assert 1 in paddle.team
+    assert 1 in azure.team
+    assert 1 in olm.team
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## 问题

`get_guest_provider` 的职责是为租户稳定授权全部默认 Provider。并发初始化时，每个请求都基于旧的 `team` JSON 快照读改写，后提交的请求可能覆盖先提交的组织授权，破坏默认模型授权的一致性。

## 根因

七条 Provider 记录原本分别查询、修改并保存，缺少共同事务和数据库行锁。设计上没有把“读取最新授权集合并追加组织”作为一个受并发保护的操作，因此不同请求能同时持有过期快照。

## 怎么修的

- 将七条默认 Provider 的授权更新纳入同一个事务。
- 按固定顺序使用 `select_for_update()` 重新读取每条记录，串行化冲突请求。
- 通过统一 helper 复制并幂等追加 `team`，仅保存 `team` 字段。
- 任何一条记录处理失败时整组回滚，避免只完成部分默认模型授权。

## 影响范围

改动仅涉及 opspilot 内部 NATS handler 及其测试；console_mgmt 的 RPC 调用参数和返回结构均未变化，agents 与 web 无此接口调用方。共享默认 Provider 在并发初始化时会短暂串行化，该路径不是高频请求。

风险：中。该修复涉及授权数据一致性，需 ⚠️ review 确认事务与锁策略。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["init_guest_role\napps/console_mgmt/management/commands/init_guest_role.py"]
        T2["OpsPilot.get_guest_provider\napps/rpc/opspilot.py"]
    end

    BU["transaction.atomic + select_for_update\napps/opspilot/nats_api.py"]

    subgraph N["核心处理层"]
        F1["get_guest_provider\napps/opspilot/nats_api.py"]
        F2["_grant_provider_team_access\napps/opspilot/nats_api.py"]
    end

    subgraph C["一致性保护"]
        C1["任一更新失败\n整组事务回滚"]
    end

    T1 --> T2 --> F1 --> BU --> F2
    F2 -. "失败时" .-> C1
```

## 验证

- `apps/opspilot/tests/test_nats_guest_provider_locking.py`：1 passed；直接执行实际实现，覆盖单事务、七次行锁、授权追加和限定字段保存。回退事务/行锁实现后该测试失败。
- `apps/opspilot/tests/test_nats_web_chat_exposure.py`：已适配真实 ORM 查询并覆盖七条 Provider；当前测试配置未启用 opspilot，collection 阶段被阻塞，未执行用例。

关联 Issue #3759。
