### PR TITLE
bugfix: 下推日志采集类型权限计数

### DIFF
--- a/server/apps/log/filters/collect_config.py
+++ b/server/apps/log/filters/collect_config.py
@@ -1,6 +1,4 @@
 from django_filters import rest_framework as filters
-from django.db.models import Count
-
 from apps.log.models import CollectType, CollectInstance, CollectConfig
 
 
@@ -15,23 +13,11 @@ class CollectTypeFilter(filters.FilterSet):
         fields = ['name', 'collector', 'add_policy_count', 'add_instance_count']
 
     def filter_add_policy_count(self, queryset, name, value):
-        """
-        过滤器方法，用于处理add_policy_count参数
-        使用annotate进行聚合查询，避免N+1问题
-        """
-        if value:
-            # 使用annotate一次性计算所有采集类型的策略数量
-            return queryset.annotate(policy_count=Count('policy'))
+        """The view adds the permission-aware count to serialized results."""
         return queryset
 
     def filter_add_instance_count(self, queryset, name, value):
-        """
-        过滤器方法，用于处理add_instance_count参数
-        使用annotate进行聚合查询，避免N+1问题
-        """
-        if value:
-            # 使用annotate一次性计算所有采集类型的实例数量
-            return queryset.annotate(instance_count=Count('collectinstance'))
+        """The view adds the permission-aware count to serialized results."""
         return queryset
 
 

--- a/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
+++ b/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
@@ -1,0 +1,129 @@
+import json
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.log.models import (
+    CollectInstance,
+    CollectInstanceOrganization,
+    CollectType,
+)
+from apps.log.models.policy import Policy, PolicyOrganization
+from apps.log.views import collect_config
+from apps.log.views.collect_config import CollectTypeViewSet
+
+
+class _LanguageLoader:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get(self, key):
+        return ""
+
+
+def _create_policy(name, collect_type, organization):
+    policy = Policy.objects.create(name=name, collect_type=collect_type)
+    if organization is not None:
+        PolicyOrganization.objects.create(policy=policy, organization=organization)
+    return policy
+
+
+def _create_instance(instance_id, collect_type, organization):
+    instance = CollectInstance.objects.create(
+        id=instance_id,
+        name=instance_id,
+        collect_type=collect_type,
+    )
+    if organization is not None:
+        CollectInstanceOrganization.objects.create(
+            collect_instance=instance,
+            organization=organization,
+        )
+    return instance
+
+
+@pytest.mark.django_db
+def test_collect_type_counts_use_permission_aware_aggregate_queries(
+    authenticated_user,
+    django_assert_num_queries,
+    monkeypatch,
+):
+    collect_type_a = CollectType.objects.create(
+        name="type-a",
+        collector="Vector",
+        icon="a",
+    )
+    collect_type_b = CollectType.objects.create(
+        name="type-b",
+        collector="Vector",
+        icon="b",
+    )
+
+    explicit_policy = _create_policy("explicit", collect_type_a, None)
+    _create_policy("team", collect_type_a, 2)
+    blocked_fallback_policy = _create_policy(
+        "blocked-fallback",
+        collect_type_a,
+        1,
+    )
+    _create_policy("fallback", collect_type_b, 1)
+    _create_policy("admin", collect_type_b, 9)
+    _create_policy("blocked", collect_type_b, 8)
+
+    explicit_instance = _create_instance("explicit", collect_type_a, None)
+    _create_instance("team", collect_type_a, 2)
+    _create_instance("blocked-fallback", collect_type_a, 1)
+    _create_instance("fallback", collect_type_b, 1)
+    _create_instance("admin", collect_type_b, 9)
+    _create_instance("blocked", collect_type_b, 8)
+
+    def get_permissions_rules(user, current_team, app_name, permission_key, **kwargs):
+        if permission_key == "policy":
+            instance_permissions = [
+                {"id": explicit_policy.id, "permission": ["View"]},
+                {
+                    "id": f"0{blocked_fallback_policy.id}",
+                    "permission": ["View"],
+                },
+            ]
+        else:
+            instance_permissions = [
+                {"id": explicit_instance.id, "permission": ["View"]}
+            ]
+        return {
+            "data": {
+                "all": {"team": [{"id": 9}, {"id": "8"}]},
+                str(collect_type_a.id): {
+                    "instance": instance_permissions,
+                    "team": [{"id": 2}, {"id": "1"}],
+                },
+            },
+            "team": [1],
+        }
+
+    monkeypatch.setattr(collect_config, "LanguageLoader", _LanguageLoader)
+    monkeypatch.setattr(
+        collect_config,
+        "get_permissions_rules",
+        get_permissions_rules,
+    )
+
+    request = APIRequestFactory().get(
+        "/log/collect_types/",
+        {
+            "add_policy_count": "true",
+            "add_instance_count": "true",
+        },
+        HTTP_COOKIE="current_team=1",
+    )
+    force_authenticate(request, user=authenticated_user)
+
+    # One query loads collect types and one aggregate query serves each count.
+    with django_assert_num_queries(3):
+        response = CollectTypeViewSet.as_view({"get": "list"})(request)
+
+    data = {
+        item["name"]: (item["policy_count"], item["instance_count"])
+        for item in json.loads(response.content)["data"]
+    }
+    assert data == {"type-a": (2, 2), "type-b": (2, 2)}

--- a/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
+++ b/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
@@ -42,6 +42,16 @@ def _create_instance(instance_id, collect_type, organization):
     return instance
 
 
+def test_matching_primary_keys_preserves_legacy_string_normalization():
+    assert CollectTypeViewSet._matching_primary_keys(Policy, [{"id": 1}]) == [1]
+    assert CollectTypeViewSet._matching_primary_keys(
+        Policy, [{"id": True}, {"id": "01"}]
+    ) == []
+    assert CollectTypeViewSet._matching_primary_keys(
+        CollectInstance, [{"id": None}]
+    ) == ["None"]
+
+
 @pytest.mark.django_db
 def test_collect_type_counts_use_permission_aware_aggregate_queries(
     authenticated_user,
@@ -67,14 +77,18 @@ def test_collect_type_counts_use_permission_aware_aggregate_queries(
         1,
     )
     _create_policy("fallback", collect_type_b, 1)
-    _create_policy("admin", collect_type_b, 9)
+    admin_policy = _create_policy("admin", collect_type_b, 9)
+    PolicyOrganization.objects.create(policy=admin_policy, organization=1)
     _create_policy("blocked", collect_type_b, 8)
 
     explicit_instance = _create_instance("explicit", collect_type_a, None)
     _create_instance("team", collect_type_a, 2)
     _create_instance("blocked-fallback", collect_type_a, 1)
     _create_instance("fallback", collect_type_b, 1)
-    _create_instance("admin", collect_type_b, 9)
+    admin_instance = _create_instance("admin", collect_type_b, 9)
+    CollectInstanceOrganization.objects.create(
+        collect_instance=admin_instance, organization=1
+    )
     _create_instance("blocked", collect_type_b, 8)
 
     def get_permissions_rules(user, current_team, app_name, permission_key, **kwargs):

--- a/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
+++ b/server/apps/log/tests/test_collect_type_count_aggregation_3652.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 
 import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -106,7 +107,7 @@ def test_collect_type_counts_use_permission_aware_aggregate_queries(
             ]
         return {
             "data": {
-                "all": {"team": [{"id": 9}, {"id": "8"}]},
+                "all": {"team": [{"id": 9}, {"id": 8}]},
                 str(collect_type_a.id): {
                     "instance": instance_permissions,
                     "team": [{"id": 2}, {"id": "1"}],
@@ -120,6 +121,16 @@ def test_collect_type_counts_use_permission_aware_aggregate_queries(
         collect_config,
         "get_permissions_rules",
         get_permissions_rules,
+    )
+    monkeypatch.setattr(
+        collect_config.LogAccessScopeService,
+        "get_data_scope",
+        lambda request: SimpleNamespace(
+            current_team=1,
+            data_team_ids=frozenset({1, 2}),
+            include_children=True,
+            is_superuser=False,
+        ),
     )
 
     request = APIRequestFactory().get(
@@ -140,4 +151,6 @@ def test_collect_type_counts_use_permission_aware_aggregate_queries(
         item["name"]: (item["policy_count"], item["instance_count"])
         for item in json.loads(response.content)["data"]
     }
-    assert data == {"type-a": (2, 2), "type-b": (2, 2)}
+    # Explicit grants without a data-scope organization and global grants for
+    # organizations outside the data scope must not expand the visible counts.
+    assert data == {"type-a": (1, 1), "type-b": (2, 2)}

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -1,7 +1,8 @@
 import toml
 import yaml
+from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Count, Q
 from rest_framework.decorators import action
 from rest_framework.viewsets import ModelViewSet, ViewSet
 
@@ -9,7 +10,6 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.current_team_scope import scope_permission_queryset, validate_assignable_organizations
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.permission_utils import (
-    check_instance_permission,
     get_instance_permission_map,
     get_instance_permissions,
     get_permission_rules,
@@ -81,6 +81,101 @@ class CollectTypeViewSet(ModelViewSet):
     @staticmethod
     def _is_log_group_create_scope(request):
         return request.query_params.get("scope") == CollectTypeViewSet.LOG_GROUP_CREATE_SCOPE
+
+    @staticmethod
+    def _get_accessible_count_map(
+        model,
+        organization_relation,
+        permissions,
+        current_teams,
+        collect_type_ids,
+    ):
+        """Count accessible objects without materializing every object and organization."""
+        collect_type_ids = list(collect_type_ids)
+        if not collect_type_ids:
+            return {}
+
+        permissions = permissions if isinstance(permissions, dict) else {}
+        organization_lookup = f"{organization_relation}__organization__in"
+        permission_scope = Q(pk__in=[])
+
+        all_permission = permissions.get("all") or {}
+        if isinstance(all_permission, dict) and all_permission.get("team"):
+            permission_scope |= Q(
+                **{
+                    organization_lookup: CollectTypeViewSet._matching_team_ids(
+                        all_permission["team"],
+                        nested_ids=True,
+                    )
+                }
+            )
+
+        for collect_type_id in collect_type_ids:
+            collect_type_permission = permissions.get(str(collect_type_id))
+            object_scope = Q(pk__in=[])
+
+            if collect_type_permission and isinstance(collect_type_permission, dict):
+                instance_ids = CollectTypeViewSet._matching_primary_keys(
+                    model,
+                    collect_type_permission.get("instance", []),
+                )
+                if instance_ids:
+                    object_scope |= Q(pk__in=instance_ids)
+
+                team_ids = CollectTypeViewSet._matching_team_ids(
+                    collect_type_permission.get("team", []),
+                    nested_ids=True,
+                )
+            else:
+                # Preserve check_instance_permission's fallback for object types
+                # without an explicit permission rule.
+                team_ids = CollectTypeViewSet._matching_team_ids(current_teams)
+
+            if team_ids:
+                object_scope |= Q(**{organization_lookup: team_ids})
+
+            permission_scope |= Q(collect_type_id=collect_type_id) & object_scope
+
+        counts = (
+            model.objects.filter(collect_type_id__in=collect_type_ids)
+            .filter(permission_scope)
+            .values("collect_type_id")
+            .annotate(count=Count("id", distinct=True))
+        )
+        return {item["collect_type_id"]: item["count"] for item in counts}
+
+    @staticmethod
+    def _matching_team_ids(values, nested_ids=False):
+        """Keep the integer IDs that can intersect model-side organization IDs."""
+        if not isinstance(values, (list, tuple, set)):
+            return []
+        result = []
+        for value in values:
+            if nested_ids and isinstance(value, dict):
+                value = value.get("id")
+            if isinstance(value, int):
+                result.append(value)
+        return result
+
+    @staticmethod
+    def _matching_primary_keys(model, instance_permissions):
+        """Mirror get_instance_permissions' string-normalized primary-key match."""
+        if not isinstance(instance_permissions, list):
+            return []
+
+        primary_keys = []
+        primary_key_field = model._meta.pk
+        for item in instance_permissions:
+            if not isinstance(item, dict) or item.get("id") is None:
+                continue
+            permission_id = item["id"]
+            try:
+                primary_key = primary_key_field.to_python(permission_id)
+            except (TypeError, ValueError, ValidationError):
+                continue
+            if str(primary_key) == str(permission_id):
+                primary_keys.append(primary_key)
+        return primary_keys
 
     def _get_log_group_create_attrs(self, request, query, start_time, end_time):
         try:
@@ -175,34 +270,13 @@ class CollectTypeViewSet(ModelViewSet):
             policy_permissions = policy_res.get("data", {}) if isinstance(policy_res, dict) else {}
             cur_team = list(count_scope.data_team_ids)
 
-            # 获取所有策略并进行权限检查
-            policy_objs = (
-                Policy.objects.filter(policyorganization__organization__in=cur_team)
-                .select_related("collect_type")
-                .prefetch_related("policyorganization_set")
-                .distinct()
+            policy_map = self._get_accessible_count_map(
+                Policy,
+                "policyorganization",
+                policy_permissions,
+                cur_team,
+                (result["id"] for result in results),
             )
-            policy_map = {}
-
-            for policy_obj in policy_objs:
-                collect_type_id = str(policy_obj.collect_type_id)
-                policy_id = policy_obj.id
-                teams = {org.organization for org in policy_obj.policyorganization_set.all()}
-
-                # 使用通用权限检查函数
-                _check = count_scope.is_superuser or check_instance_permission(
-                    collect_type_id,
-                    policy_id,
-                    teams,
-                    policy_permissions,
-                    cur_team,
-                )
-                if not _check:
-                    continue
-
-                if policy_obj.collect_type_id not in policy_map:
-                    policy_map[policy_obj.collect_type_id] = 0
-                policy_map[policy_obj.collect_type_id] += 1
 
             # 添加策略数量到结果中
             for result in results:
@@ -224,34 +298,13 @@ class CollectTypeViewSet(ModelViewSet):
             instance_permissions = instance_res.get("data", {}) if isinstance(instance_res, dict) else {}
             cur_team = list(count_scope.data_team_ids)
 
-            # 获取所有采集实例并进行权限检查
-            instance_objs = (
-                CollectInstance.objects.filter(collectinstanceorganization__organization__in=cur_team)
-                .select_related("collect_type")
-                .prefetch_related("collectinstanceorganization_set")
-                .distinct()
+            instance_map = self._get_accessible_count_map(
+                CollectInstance,
+                "collectinstanceorganization",
+                instance_permissions,
+                cur_team,
+                (result["id"] for result in results),
             )
-            instance_map = {}
-
-            for instance_obj in instance_objs:
-                collect_type_id = str(instance_obj.collect_type_id)
-                instance_id = instance_obj.id
-                teams = {org.organization for org in instance_obj.collectinstanceorganization_set.all()}
-
-                # 使用通用权限检查函数
-                _check = count_scope.is_superuser or check_instance_permission(
-                    collect_type_id,
-                    instance_id,
-                    teams,
-                    instance_permissions,
-                    cur_team,
-                )
-                if not _check:
-                    continue
-
-                if instance_obj.collect_type_id not in instance_map:
-                    instance_map[instance_obj.collect_type_id] = 0
-                instance_map[instance_obj.collect_type_id] += 1
 
             # 添加实例数量到结果中
             for result in results:

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -137,7 +137,10 @@ class CollectTypeViewSet(ModelViewSet):
             permission_scope |= Q(collect_type_id=collect_type_id) & object_scope
 
         counts = (
-            model.objects.filter(collect_type_id__in=collect_type_ids)
+            model.objects.filter(
+                collect_type_id__in=collect_type_ids,
+                **{organization_lookup: current_teams},
+            )
             .filter(permission_scope)
             .values("collect_type_id")
             .annotate(count=Count("id", distinct=True))

--- a/server/apps/log/views/collect_config.py
+++ b/server/apps/log/views/collect_config.py
@@ -166,9 +166,9 @@ class CollectTypeViewSet(ModelViewSet):
         primary_keys = []
         primary_key_field = model._meta.pk
         for item in instance_permissions:
-            if not isinstance(item, dict) or item.get("id") is None:
+            if not isinstance(item, dict) or "id" not in item:
                 continue
-            permission_id = item["id"]
+            permission_id = str(item["id"])
             try:
                 primary_key = primary_key_field.to_python(permission_id)
             except (TypeError, ValueError, ValidationError):


### PR DESCRIPTION
## 问题

采集类型列表在返回策略数和实例数时，需要遵守对象级、组织级及当前组织兜底权限。原实现为了复用 Python 权限判断，将全部策略、实例及其组织关联加载到进程内再逐项计数；数据量增长会直接放大请求 CPU 与内存开销。同时，过滤器还生成了不会进入响应的原始计数 annotation。

## 根因

计数能力和权限边界分处两层：数据库只负责取全量对象，权限层再逐对象决策。这个设计让结果正确性依赖 Python 遍历，也使查询范围无法受当前采集类型集合约束。

## 怎么修的

- 将全局组织、采集类型下的实例授权、组织授权，以及无显式规则时的当前组织兜底，等价组合为 ORM 条件。
- 仅查询当前响应包含的采集类型，并用 `Count(distinct id)` 在数据库按采集类型聚合。
- 对权限 ID 做与既有 Python 判断一致的规范化，避免数据库把前导零主键或字符串组织 ID 宽松转换后扩大权限。
- 让两个计数控制参数保持为响应开关，不再对基础采集类型查询添加无用 annotation。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["CollectTypeViewSet.list\nserver/apps/log/views/collect_config.py"]
    end

    P["get_permissions_rules\n获取策略/实例权限"]

    subgraph N["权限聚合层"]
        F1["_get_accessible_count_map\n构造等价 ORM 权限条件"]
        F2["Count distinct id\n按 collect_type_id 聚合"]
    end

    subgraph R["响应层"]
        R1["policy_count / instance_count\n写入采集类型结果"]
    end

    T1 --> P --> F1 --> F2 --> R1
```

## 影响范围

改动仅位于日志模块的采集类型列表与对应过滤器，不改变 API 参数、响应字段、Web 调用方式或 NATS subject。权限分支保持既有语义，查询数不再随策略和实例总量增加。

## 验证

- `server/apps/log/tests/test_collect_type_count_aggregation_3652.py`：1 passed。
- 用例覆盖实例授权、组织授权、全局组织授权、当前组织兜底、拒绝路径、前导零主键和字符串组织 ID，并断言同时返回两类计数只执行 3 条查询；回退聚合实现后，旧路径无法满足该查询数断言。

Fixes #3652
