### PR TITLE
bugfix: 批量解析导入数据源关联

### DIFF
--- a/server/apps/operation_analysis/services/import_export/import_service.py
+++ b/server/apps/operation_analysis/services/import_export/import_service.py
@@ -97,6 +97,7 @@ class ImportService:
         # 导入过程中的映射表：YAML key -> DB ID
         self.namespace_key_to_id: dict[str, int] = {}
         self.datasource_key_to_id: dict[str, int] = {}
+        self.tag_name_to_id: dict[str, int] = {}
 
         # 导入结果统计
         self.results: list[dict] = []
@@ -323,23 +324,14 @@ class ImportService:
         action = self._get_conflict_action(ds_item.key)
 
         # 解析关联的命名空间ID
-        namespace_ids = []
-        for ns_key in ds_item.namespace_keys:
-            ns_id = self.namespace_key_to_id.get(ns_key)
-            if ns_id:
-                namespace_ids.append(ns_id)
-            else:
-                # 尝试从数据库查找
-                ns = NameSpace.objects.filter(name=ns_key).first()
-                if ns:
-                    namespace_ids.append(ns.id)
+        namespace_ids = [
+            self.namespace_key_to_id[ns_key]
+            for ns_key in ds_item.namespace_keys
+            if ns_key in self.namespace_key_to_id
+        ]
 
         # 解析tags
-        tag_ids = []
-        for tag_name in ds_item.tags:
-            tag = DataSourceTag.objects.filter(name=tag_name).first()
-            if tag:
-                tag_ids.append(tag.id)
+        tag_ids = [self.tag_name_to_id[tag_name] for tag_name in ds_item.tags if tag_name in self.tag_name_to_id]
 
         if existing:
             if action == ConflictAction.SKIP.value:
@@ -606,6 +598,19 @@ class ImportService:
                 return rollback_result
 
             # Step 2: 导入数据源
+            namespace_keys = {
+                ns_key
+                for ds_item in self.doc.datasources
+                for ns_key in ds_item.namespace_keys
+                if ns_key not in self.namespace_key_to_id
+            }
+            self.namespace_key_to_id.update(
+                NameSpace.objects.filter(name__in=namespace_keys).values_list("name", "id")
+            )
+            tag_names = {tag_name for ds_item in self.doc.datasources for tag_name in ds_item.tags}
+            self.tag_name_to_id.update(
+                DataSourceTag.objects.filter(name__in=tag_names).values_list("name", "id")
+            )
             for ds_item in self.doc.datasources:
                 ds_id = self._import_datasource(ds_item)
                 if ds_id:

--- a/server/apps/operation_analysis/tests/test_import_service.py
+++ b/server/apps/operation_analysis/tests/test_import_service.py
@@ -5,6 +5,8 @@
 """
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from pydantic import ValidationError
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -197,6 +199,38 @@ def test_import_datasource_links_namespace_and_tags():
     ds = DataSourceAPIModel.objects.get(name="ds-a")
     assert ds.namespaces.count() == 1
     assert ds.tag.count() == 1
+
+
+@pytest.mark.django_db
+def test_import_datasource_relation_queries_do_not_grow_with_datasource_count():
+    NameSpace.objects.create(name="shared-ns", domain="d", account="a", password="p")
+    DataSourceTag.objects.create(tag_id="shared", name="Shared", created_by="s", updated_by="s")
+    doc = _doc(
+        datasources=[
+            _ds_section(key="ds1", name="ds-1", namespace_keys=["shared-ns"], tags=["Shared"]),
+            _ds_section(key="ds2", name="ds-2", namespace_keys=["shared-ns"], tags=["Shared"]),
+        ]
+    )
+
+    with CaptureQueriesContext(connection) as queries:
+        result = _service(doc).execute()
+
+    relation_tables = {
+        connection.ops.quote_name(NameSpace._meta.db_table),
+        connection.ops.quote_name(DataSourceTag._meta.db_table),
+    }
+    relation_selects = [
+        query["sql"]
+        for query in queries.captured_queries
+        if " INNER JOIN " not in query["sql"]
+        and any(f"FROM {table}" in query["sql"] for table in relation_tables)
+    ]
+    assert result["success"] is True
+    assert len(relation_selects) == 2, relation_selects
+    assert (
+        DataSourceAPIModel.objects.filter(namespaces__name="shared-ns", tag__name="Shared").distinct().count()
+        == 2
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

配置包导入本应在一个批次内解析数据源关联，但现有实现把 namespace 与 tag 的名称解析放在逐数据源循环中。相同关联被多个数据源复用时，基础表查询会随数据源数量线性增长，并延长导入事务。

## 根因

关系解析缺少“批次级名称到 ID 映射”边界：namespace 仅缓存本次已导入对象，tag 完全没有缓存，导致既有 namespace 和所有 tag 都退化为循环内单条查询。

## 怎么修的

- namespace 导入完成后，汇总所有 datasource 引用但尚未缓存的 namespace，一次查询并合并到现有映射。
- 汇总所有 datasource 引用的 tag，一次查询生成名称到 ID 映射。
- `_import_datasource` 只从映射取 ID，保留缺失关联静默忽略及 ManyToMany 写入语义。

## 影响范围

改动仅限 `operation_analysis` 的 YAML 导入服务及其测试，不改变提交接口、OpenAPI、内置画布初始化入口、数据模型或导入包格式。namespace 与 tag 名称字段均有唯一约束，因此批量映射与原逐条查询的匹配语义一致。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["import/submit\nimport_export_view.py"]
        T2["OpenAPI import/submit\nopenapi_import_export_view.py"]
        T3["内置画布初始化\ninit_builtin_canvases.py"]
    end

    TX["transaction.atomic\nImportService.execute"]

    subgraph N["批次关系解析层"]
        N1["批量加载 namespace 映射\nimport_service.py"]
        N2["批量加载 tag 映射\nimport_service.py"]
        N3["字典解析关系 ID\n_import_datasource"]
    end

    DB["ManyToMany 关联写入"]

    T1 --> TX
    T2 --> TX
    T3 --> TX
    TX --> N1
    TX --> N2
    N1 --> N3
    N2 --> N3
    N3 --> DB
```

## 验证

- `apps/operation_analysis/tests/test_import_service.py`：24 passed。
- 回归用例在修复前观察到两个 datasource 的基础关系解析查询为 4 次，修复后固定为 2 次；同时验证两个 datasource 均保持正确关联。

关联 #3400
