### PR TITLE
bugfix: 批量查询导入预检冲突

### DIFF
--- a/server/apps/operation_analysis/services/import_export/precheck_service.py
+++ b/server/apps/operation_analysis/services/import_export/precheck_service.py
@@ -343,8 +343,11 @@ class PrecheckService:
         all_actions = [ConflictAction.SKIP.value, ConflictAction.OVERWRITE.value, ConflictAction.RENAME.value]
         rename_only = [ConflictAction.RENAME.value]
 
+        existing_namespace_names = set(
+            NameSpace.objects.filter(name__in=[ns.name for ns in doc.namespaces]).values_list("name", flat=True)
+        )
         for ns in doc.namespaces:
-            if NameSpace.objects.filter(name=ns.name).exists():
+            if ns.name in existing_namespace_names:
                 conflicts.append(
                     {
                         "object_key": ns.key,
@@ -354,8 +357,14 @@ class PrecheckService:
                     }
                 )
 
+        datasource_keys = {(ds.name, ds.rest_api) for ds in doc.datasources}
+        existing_datasources = {
+            (datasource.name, datasource.rest_api): datasource
+            for datasource in DataSourceAPIModel.objects.filter(name__in={name for name, _ in datasource_keys})
+            if (datasource.name, datasource.rest_api) in datasource_keys
+        }
         for ds in doc.datasources:
-            existing = DataSourceAPIModel.objects.filter(name=ds.name, rest_api=ds.rest_api).first()
+            existing = existing_datasources.get((ds.name, ds.rest_api))
             if existing:
                 has_permission = cls._check_group_permission(existing, current_team)
                 conflicts.append(
@@ -377,8 +386,11 @@ class PrecheckService:
         ]
 
         for canvas_list, obj_type, model in canvas_checks:
+            existing_canvases = {
+                canvas.name: canvas for canvas in model.objects.filter(name__in=[item.name for item in canvas_list])
+            }
             for canvas in canvas_list:
-                existing = model.objects.filter(name=canvas.name).first()
+                existing = existing_canvases.get(canvas.name)
                 if existing:
                     has_permission = cls._check_group_permission(existing, current_team)
                     conflicts.append(

--- a/server/apps/operation_analysis/tests/test_precheck_service_conflicts.py
+++ b/server/apps/operation_analysis/tests/test_precheck_service_conflicts.py
@@ -1,0 +1,90 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
+from apps.operation_analysis.models.models import Architecture, Dashboard, Directory, NetworkTopology, Report, Screen, Topology
+from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
+
+
+@pytest.mark.django_db
+def test_identify_conflicts_batches_database_queries_by_object_type(django_assert_num_queries):
+    directory = Directory.objects.create(name="issue-3399-directory", groups=[1])
+
+    namespaces = []
+    datasources = []
+    dashboards = []
+    topologies = []
+    architectures = []
+    screens = []
+    reports = []
+    network_topologies = []
+
+    for index in range(2):
+        namespace_name = f"issue-3399-namespace-{index}"
+        NameSpace.objects.create(
+            name=namespace_name,
+            account="admin",
+            password="secret",
+            domain="127.0.0.1:4222",
+        )
+        namespaces.append(SimpleNamespace(key=f"namespace::{index}", name=namespace_name))
+
+        datasource_name = f"issue-3399-datasource-{index}"
+        rest_api = f"monitor/query/{index}"
+        DataSourceAPIModel.objects.create(name=datasource_name, rest_api=rest_api, groups=[1])
+        datasources.append(
+            SimpleNamespace(key=f"datasource::{index}", name=datasource_name, rest_api=rest_api)
+        )
+
+        canvas_models = (
+            (Dashboard, dashboards, "dashboard", {"view_sets": []}),
+            (Topology, topologies, "topology", {"view_sets": []}),
+            (Architecture, architectures, "architecture", {"view_sets": []}),
+            (Screen, screens, "screen", {"view_sets": {}}),
+            (Report, reports, "report", {"view_sets": {}}),
+        )
+        for model, items, object_type, defaults in canvas_models:
+            name = f"issue-3399-{object_type}-{index}"
+            model.objects.create(name=name, groups=[1], **defaults)
+            items.append(SimpleNamespace(key=f"{object_type}::{index}", name=name))
+
+        network_topology_name = f"issue-3399-network-topology-{index}"
+        NetworkTopology.objects.create(
+            name=network_topology_name,
+            directory=directory,
+            base_url="https://example.com",
+            groups=[1],
+        )
+        network_topologies.append(
+            SimpleNamespace(key=f"network-topology::{index}", name=network_topology_name)
+        )
+
+    doc = SimpleNamespace(
+        namespaces=namespaces,
+        datasources=datasources,
+        dashboards=dashboards,
+        topologies=topologies,
+        architectures=architectures,
+        screens=screens,
+        reports=reports,
+        network_topologies=network_topologies,
+    )
+
+    with django_assert_num_queries(8):
+        conflicts = PrecheckService.identify_conflicts(doc, current_team=1)
+
+    assert {conflict["object_key"] for conflict in conflicts} == {
+        item.key
+        for items in (
+            namespaces,
+            datasources,
+            dashboards,
+            topologies,
+            architectures,
+            screens,
+            reports,
+            network_topologies,
+        )
+        for item in items
+    }


### PR DESCRIPTION
## 问题

运营分析的 YAML 导入预检需要判断各类对象是否已存在。这个检查的数据库往返次数应受对象类型数量约束，但当前实现对每个对象单独查询，导入规模增大时会线性放大请求延迟和数据库压力。

## 根因

冲突识别层直接在对象遍历中执行存在性查询，没有先建立当前批次的现存对象索引。业务键本身已有唯一约束，却未被用于批量加载，导致同一类型的对象重复穿越 ORM/数据库边界。

## 怎么修的

- 命名空间按名称集合一次性查询，并用名称集合判断冲突。
- 数据源按名称批量加载，再按 `(name, rest_api)` 唯一业务键建立索引。
- 六类画布分别按名称批量加载，并在原遍历顺序中查表生成冲突结果。
- 保留原有冲突类型、权限判断、建议动作和输出顺序。

## 影响范围

改动仅限 `operation_analysis` 的导入预检服务，不修改 API、数据模型、权限规则或导入执行逻辑。后台接口与 OpenAPI 共用该服务，agents、web 和 NATS 协议均不受影响。数据库查询由“每个对象一次”收敛为“每个非空对象类型一次”。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["import_precheck / import_submit\nimport_export_view.py"]
        T2["OpenAPI precheck / submit\nopenapi_import_export_view.py"]
    end

    subgraph N["核心处理层"]
        F1["PrecheckService.precheck\nprecheck_service.py"]
        F2["identify_conflicts\n按对象类型批量查询"]
        F3["内存业务键索引\n生成冲突结果"]
    end

    DB["数据库\n每个非空类型一次查询"]

    T1 --> F1
    T2 --> F1
    F1 --> F2 --> DB --> F3
```

## 验证

- `apps/operation_analysis/tests/test_precheck_service_conflicts.py`：修复前回归测试以“期望 8 次、实际 16 次查询”失败；修复后通过。
- `apps/operation_analysis/tests/test_precheck_service_conflicts.py`、`apps/operation_analysis/tests/test_import_export_auth.py`：20 passed。

Closes #3399
