### PR TITLE
bugfix(operation_analysis): 消除目录模块列表 N+1 查询

### DIFF
--- a/server/apps/operation_analysis/services/directory_service.py
+++ b/server/apps/operation_analysis/services/directory_service.py
@@ -122,7 +122,7 @@ class DictDirectoryService:
             return {"count": 0, "items": []}
 
         result = []
-        queryset = model_class.objects.all()
+        queryset = model_class.objects.select_related("directory")
         filter_queryset = GroupPermissionMixin.apply_group_filter(queryset, group_id)
         queryset_count = filter_queryset.count()
         instances = filter_queryset[(page - 1) * page_size : page * page_size]

--- a/server/apps/operation_analysis/tests/test_directory_views.py
+++ b/server/apps/operation_analysis/tests/test_directory_views.py
@@ -288,6 +288,20 @@ def test_get_directory_modules_data_dashboard(authenticated_user):
 
 
 @pytest.mark.django_db
+def test_get_directory_modules_data_preloads_directories(authenticated_user, django_assert_num_queries):
+    first_directory = Directory.objects.create(name="目录一", groups=[1], created_by="testuser")
+    second_directory = Directory.objects.create(name="目录二", groups=[1], created_by="testuser")
+    Dashboard.objects.create(name="盘一", groups=[1], directory=first_directory, created_by="testuser")
+    Dashboard.objects.create(name="盘二", groups=[1], directory=second_directory, created_by="testuser")
+
+    with django_assert_num_queries(2):
+        result = DictDirectoryService.get_directory_modules_data("dashboard", page=1, page_size=10, group_id=1)
+
+    assert result["count"] == 2
+    assert {item["name"] for item in result["items"]} == {"【目录一】盘一", "【目录二】盘二"}
+
+
+@pytest.mark.django_db
 def test_get_directory_modules_data_unknown_module_returns_empty():
     result = DictDirectoryService.get_directory_modules_data("unknown", page=1, page_size=10, group_id=1)
     assert result == {"count": 0, "items": []}


### PR DESCRIPTION
## 问题

目录权限分页接口需要在固定查询次数内返回画布及所属目录名称。当前分页查询未预加载 `directory` 外键，循环拼接名称时会为每条记录追加一次查询，查询量随页面记录数线性增长。

## 根因

服务层把组织过滤、计数和分页建立在普通 queryset 上，但返回结构同时依赖关联目录名称。关联数据没有纳入分页查询计划，导致序列化循环越过了原有查询边界并触发惰性加载。

## 怎么修的

在进入组织过滤与分页前，通过 `select_related("directory")` 预加载单值外键。这样保留现有过滤、计数、分页和空目录处理语义，同时把关联目录读取合并进主查询。

## 影响范围

- 仅修改 `operation_analysis` 目录服务及其直接回归测试。
- 不改变 NATS/RPC 参数、返回结构、权限过滤或数据库结构。
- `CANVAS_TYPE_REGISTRY` 中各画布模型均使用同名 `directory` 外键，现有类型统一受益。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["权限选择器分页\nweb/src/app/system-manager/hooks/usePermissionData.ts"]
        T2["get_app_data\nserver/apps/system_mgmt/viewset/group_data_rule_viewset.py"]
    end

    subgraph R["RPC / NATS 层"]
        R1["OperationAnalysisRPC.get_module_data\nserver/apps/rpc/operation_analysis.py"]
        R2["get_operation_analysis_module_data\nserver/apps/operation_analysis/nats/nats.py"]
    end

    subgraph S["服务与数据库层"]
        S1["get_directory_modules_data\nserver/apps/operation_analysis/services/directory_service.py"]
        S2["count + select_related 分页查询"]
    end

    T1 --> T2 --> R1 --> R2 --> S1 --> S2
```

## 验证

- `apps/operation_analysis/tests/test_directory_views.py`：37 passed。
- 回归用例在修复前因实际 4 次查询而失败；修复后固定为 2 次查询并保持目录名称结果不变。

Closes #3401
