### PR TITLE
bugfix: 收敛导入重命名查询

### DIFF
--- a/server/apps/operation_analysis/services/import_export/import_service.py
+++ b/server/apps/operation_analysis/services/import_export/import_service.py
@@ -172,10 +172,19 @@ class ImportService:
 
         规则：{original_name}_copy，若仍冲突则继续追加_copy
         """
-        new_name = f"{original_name}{RENAME_SUFFIX}"
-        while model.objects.filter(name=new_name).exists():
-            new_name = f"{new_name}{RENAME_SUFFIX}"
-        return new_name
+        name_max_length = model._meta.get_field("name").max_length
+        max_suffixes = (name_max_length - len(original_name)) // len(RENAME_SUFFIX)
+        candidates = [
+            f"{original_name}{RENAME_SUFFIX * count}"
+            for count in range(1, max_suffixes + 1)
+        ]
+        existing_names = set(model.objects.filter(name__in=candidates).values_list("name", flat=True))
+
+        for candidate in candidates:
+            if candidate not in existing_names:
+                return candidate
+
+        raise ValueError(f"名称 {original_name} 已无可用的重命名空间")
 
     def _record_result(
         self,

--- a/server/apps/operation_analysis/tests/test_import_service.py
+++ b/server/apps/operation_analysis/tests/test_import_service.py
@@ -503,3 +503,15 @@ def test_generate_rename_name_increments_on_repeated_conflict():
     svc = _service(_doc())
     new_name = svc._generate_rename_name("ns-a", NameSpace)
     assert new_name == "ns-a_copy_copy"
+
+
+@pytest.mark.django_db
+def test_generate_rename_name_uses_one_query_for_conflict_chain():
+    for name in ("ns-a_copy", "ns-a_copy_copy", "ns-a_copy_copy_copy"):
+        NameSpace.objects.create(name=name, domain="d", account="a", password="p")
+
+    with CaptureQueriesContext(connection) as queries:
+        new_name = _service(_doc())._generate_rename_name("ns-a", NameSpace)
+
+    assert new_name == "ns-a_copy_copy_copy_copy"
+    assert len(queries) == 1, queries.captured_queries


### PR DESCRIPTION
## 问题

导入冲突选择“重命名”时，本应以受模型字段约束的固定成本找到下一个可用名称。原实现却把每次 `_copy` 探测都变成一次数据库往返，已有名称链越长，单次导入发出的查询越多。

## 根因

重命名算法把候选名遍历与数据库存在性查询耦合在一起，导致数据库成本由可被导入用户构造的冲突链长度直接决定，破坏了导入服务应有的资源边界。

## 怎么修的

- 按模型 `name` 字段的最大长度一次生成全部合法候选名，候选数量天然有界。
- 使用一次精确的 `name__in` 查询取得已占用名称，再在内存中选择第一个可用候选。
- 保持既有 `原名_copy_copy...` 命名顺序与冲突语义不变。

## 影响范围

改动集中在运营分析导入服务，覆盖命名空间、数据源及画布对象的重命名路径。登录态导入与 Open API 导入复用同一服务，因此同时受益；不涉及数据库结构、接口参数、NATS 协议或前端契约变更。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["import_submit\nimport_export_view.py / openapi_import_export_view.py"]
    end

    subgraph N["导入处理层"]
        F1["ImportService.execute\nimport_service.py"]
        F2["_import_namespace / _import_datasource / _import_canvas"]
        F3["_generate_rename_name\n生成有界候选集合"]
    end

    DB["单次 name__in 查询"]
    R["内存选择首个可用名称"]

    T1 --> F1 --> F2 --> F3 --> DB --> R
```

## 验证

- `apps/operation_analysis/tests/test_import_service.py`：25 passed。
- 回归用例验证相同冲突链下结果仍为 `_copy` 顺序，数据库查询数由 4 次收敛为 1 次；回退实现后该用例会失败。

Fixes #3397
