### PR TITLE
bugfix: 目录树校验当前组织上下文

### DIFF
--- a/server/apps/operation_analysis/services/directory_service.py
+++ b/server/apps/operation_analysis/services/directory_service.py
@@ -2,6 +2,8 @@
 # @File: directory_service.py
 # @Time: 2025/11/3 16:22
 # @Author: windyzhao
+from rest_framework.exceptions import ValidationError
+
 from apps.core.utils.team_utils import get_current_team
 from apps.operation_analysis.constants.constants import PERMISSION_DATASOURCE, PERMISSION_DIRECTORY
 from apps.operation_analysis.filters.base_filters import GroupPermissionMixin
@@ -38,7 +40,10 @@ class DictDirectoryService:
         获取目录树形结构,目录和仪表盘统一作为树节点
         """
         # 验证用户组织权限，构建组织ID列表（支持 include_children）
-        current_team = int(get_current_team(request))
+        try:
+            current_team = int(get_current_team(request))
+        except (TypeError, ValueError):
+            raise ValidationError({"detail": "current_team cookie 缺失或格式错误，请重新登录或刷新页面"})
         group_ids = [current_team]
         if request.COOKIES.get("include_children", "0") == "1":
             from apps.core.utils.viewset_utils import GenericViewSetFun

--- a/server/apps/operation_analysis/tests/test_directory_views.py
+++ b/server/apps/operation_analysis/tests/test_directory_views.py
@@ -24,7 +24,8 @@ def _request(method, path, user, data=None, team="1", include_children="0"):
         request = fn(path)
     else:
         request = fn(path, data=data, format="json")
-    request.COOKIES["current_team"] = team
+    if team is not None:
+        request.COOKIES["current_team"] = team
     request.COOKIES["include_children"] = include_children
     force_authenticate(request, user=user)
     return request
@@ -270,6 +271,19 @@ def test_tree_endpoint_builds_nested_structure(authenticated_user):
     assert root_node["type"] == "directory"
     child_node = next(c for c in root_node["children"] if c["data_id"] == child.id)
     assert any(g["type"] == "dashboard" for g in child_node["children"])
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("team", [None, "not-a-number"])
+def test_tree_endpoint_rejects_missing_or_invalid_current_team(authenticated_user, team):
+    user = _superuser(authenticated_user)
+    request = _request("get", "/directory/tree/", user, team=team)
+
+    response = view_module.DirectoryModelViewSet.as_view({"get": "tree"})(request)
+    payload = _render(response)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "current_team cookie 缺失或格式错误" in payload["message"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

运营分析目录树端点依赖当前组织上下文来执行组织隔离。浏览器未携带 `current_team`，或该值无法解析为组织 ID 时，服务端不应让类型转换异常冒泡成 500，而应返回可识别的请求校验错误。

## 根因（设计层）

统一组织读取函数同时支持浏览器 Cookie 与 API Key 注入，并允许在两种来源都不存在时返回空值。目录树服务直接把这个可空结果转换为整数，绕过了服务边界的输入校验，也没有遵循项目自定义响应渲染器要求的结构化错误详情契约。

## 怎么修的

- 在目录树服务进入组织过滤前统一解析组织 ID。
- 将缺失值和非法数字映射为结构化 DRF 校验错误，由现有响应层返回 HTTP 400 与明确提示。
- 使用真实 ViewSet 请求覆盖 Cookie 缺失与非法数字两个回归场景。

## 影响范围

改动仅涉及 `operation_analysis` 的目录树服务和既有端点测试。合法组织 Cookie 的查询、目录组织过滤、Web 调用地址、RPC 与 NATS 接口均保持不变；变化仅是异常输入由 500 收敛为 400。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GET directory/tree\nviews/view.py"]
    end

    subgraph N["核心处理层"]
        N1["DirectoryModelViewSet.tree"]
        N2["DictDirectoryService.get_dict_trees"]
        N3["解析并校验 current_team"]
    end

    DB["Directory.objects.filter\n组织过滤"]

    subgraph E["错误响应层"]
        E1["结构化 ValidationError\nHTTP 400"]
    end

    T1 --> N1 --> N2 --> N3 --> DB
    N3 -. "缺失或非法" .-> E1
```

## 验证

- `apps/operation_analysis/tests/test_directory_views.py`：39 passed。
- 撤回生产防护时，新增回归用例会以原始 `int(None)` 异常失败；恢复防护后通过。

关联 Issue #3396。
