### PR TITLE
bugfix: 收紧数据源标签读取权限

### DIFF
--- a/server/apps/operation_analysis/tests/test_datasource_view.py
+++ b/server/apps/operation_analysis/tests/test_datasource_view.py
@@ -429,9 +429,10 @@ def test_datasource_tag_read_blocked_without_permission(authenticated_user, acti
 
 
 @pytest.mark.django_db
-def test_datasource_tag_list_allowed_with_permission(authenticated_user):
-    """拥有 data_source-View 权限的用户仍可读取标签列表。"""
-    datasource_view.DataSourceTag.objects.create(
+@pytest.mark.parametrize("action", ["list", "retrieve"])
+def test_datasource_tag_read_allowed_with_permission(authenticated_user, action):
+    """拥有 data_source-View 权限的用户仍可读取标签列表和详情。"""
+    tag = datasource_view.DataSourceTag.objects.create(
         tag_id="cmdb",
         name="CMDB",
         created_by="system",
@@ -443,8 +444,9 @@ def test_datasource_tag_list_allowed_with_permission(authenticated_user):
     factory = APIRequestFactory()
     request = factory.get("/operation_analysis/api/tag/")
     force_authenticate(request, user=authenticated_user)
-    view = datasource_view.DataSourceTagModelViewSet.as_view({"get": "list"})
+    view = datasource_view.DataSourceTagModelViewSet.as_view({"get": action})
 
-    response = view(request)
+    kwargs = {"pk": str(tag.pk)} if action == "retrieve" else {}
+    response = view(request, **kwargs)
 
     assert response.status_code == status.HTTP_200_OK

--- a/server/apps/operation_analysis/tests/test_datasource_view.py
+++ b/server/apps/operation_analysis/tests/test_datasource_view.py
@@ -399,3 +399,52 @@ def test_namespace_partial_update_allowed_with_permission(authenticated_user, mo
 
     assert update_called, "update() must be called when user has namespace-Edit permission"
     assert response.status_code != 403, "User with namespace-Edit permission must not be blocked"
+
+
+# --- Tests for issue #3393: DataSourceTagModelViewSet read permission enforcement ---
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("action", ["list", "retrieve"])
+def test_datasource_tag_read_blocked_without_permission(authenticated_user, action):
+    """标签列表和详情必须拒绝缺少 data_source-View 权限的用户。"""
+    tag = datasource_view.DataSourceTag.objects.create(
+        tag_id="security",
+        name="Security",
+        created_by="system",
+        updated_by="system",
+    )
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": set()}
+
+    factory = APIRequestFactory()
+    request = factory.get("/operation_analysis/api/tag/")
+    force_authenticate(request, user=authenticated_user)
+    view = datasource_view.DataSourceTagModelViewSet.as_view({"get": action})
+
+    kwargs = {"pk": str(tag.pk)} if action == "retrieve" else {}
+    response = view(request, **kwargs)
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_datasource_tag_list_allowed_with_permission(authenticated_user):
+    """拥有 data_source-View 权限的用户仍可读取标签列表。"""
+    datasource_view.DataSourceTag.objects.create(
+        tag_id="cmdb",
+        name="CMDB",
+        created_by="system",
+        updated_by="system",
+    )
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {"data_source-View"}}
+
+    factory = APIRequestFactory()
+    request = factory.get("/operation_analysis/api/tag/")
+    force_authenticate(request, user=authenticated_user)
+    view = datasource_view.DataSourceTagModelViewSet.as_view({"get": "list"})
+
+    response = view(request)
+
+    assert response.status_code == status.HTTP_200_OK

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -301,6 +301,14 @@ class DataSourceTagModelViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = DataSourceTagModelFilter
     pagination_class = CustomPageNumberPagination
 
+    @HasPermission("data_source-View")
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+    @HasPermission("data_source-View")
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
 
 class NameSpaceModelViewSet(ModelViewSet):
     """


### PR DESCRIPTION
## 问题

数据源标签是运营分析的数据源分类元数据，读取它应与数据源查看权限保持同一边界。现有标签列表和详情直接继承 DRF 只读行为，导致只有登录态、但没有 `data_source-View` 权限的用户也能读取全部标签。

## 根因

标签 ViewSet 没有接入运营分析模块既有的细粒度权限守卫，因此请求在全局登录校验后直接进入全量查询。标签模型本身是全局分类模型、没有组织字段，所以这里应收紧动作权限，而不是引入并不存在的组织过滤语义。

## 怎么修的

- 为标签 `list` 和 `retrieve` 动作统一增加 `data_source-View` 权限守卫。
- 保持模型、路由、序列化响应和过滤行为不变。
- 补充无权限拒绝与有权限放行的回归测试。

## 影响范围

改动仅限 `operation_analysis` 的数据源标签读取。Web 中的两个标签消费点都与已受 `data_source-View` 保护的数据源读取或配置链配套；远程 Agent 和 NATS 没有该接口的调用方。未授权请求由 200 收紧为 403，已有权限的请求保持原行为。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GET 标签列表或详情\ndatasource_view.py"]
    end

    subgraph N["权限与处理层"]
        P1["HasPermission\ndata_source-View"]
        F1["DataSourceTagModelViewSet\nlist / retrieve"]
        S1["标签序列化与分页\nDataSourceTag queryset"]
    end

    subgraph C["拒绝路径"]
        C1["缺少权限\n返回 403"]
    end

    T1 --> P1 --> F1 --> S1
    P1 -. "校验失败" .-> C1
```

## 验证

- `apps/operation_analysis/tests/test_datasource_view.py`：20 passed。
- 回归测试已验证：移除权限守卫时，无权限标签列表会返回 200，目标用例失败。

Fixes #3393
