### PR TITLE
bugfix: 合并活跃屏蔽策略计数查询

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -560,8 +560,9 @@ class AlertSourceAdapter(ABC):
             from apps.alerts.models import AlertShield
 
             shields = AlertShield.objects.filter(is_active=True)
-            if shields.exists():
-                logger.debug("[AlertSource] 加载了 %s 个活跃屏蔽策略", shields.count())
+            shield_count = shields.count()
+            if shield_count:
+                logger.debug("[AlertSource] 加载了 %s 个活跃屏蔽策略", shield_count)
                 return shields
             return None
         except Exception as e:

--- a/server/apps/alerts/tests/test_issue_3391_shield_queries.py
+++ b/server/apps/alerts/tests/test_issue_3391_shield_queries.py
@@ -1,0 +1,20 @@
+import pytest
+
+from apps.alerts.common.source_adapter.base import AlertSourceAdapter
+from apps.alerts.models.alert_operator import AlertShield
+
+
+@pytest.mark.django_db
+def test_get_active_shields_uses_single_query(django_assert_num_queries):
+    AlertShield.objects.create(
+        name="active-shield",
+        match_type="all",
+        match_rules=[],
+        suppression_time={},
+    )
+
+    with django_assert_num_queries(1):
+        shields = AlertSourceAdapter.get_active_shields()
+
+    assert shields is not None
+    assert shields.count() == 1


### PR DESCRIPTION
## 问题

告警事件从 HTTP 接收器或 NATS handler 进入后，`event_operator()` 会先加载活跃屏蔽策略。这个入口需要同时完成“是否存在策略”的判断与日志计数，但不应为同一条件执行重复数据库查询。

## 根因（设计层）

`get_active_shields()` 把非空判断和可观测日志计数拆成了 `exists()`、`count()` 两次独立的 QuerySet 求值。日志参数会在调用前立即求值，因此即使 DEBUG 日志未输出，第二次查询也不会被跳过。

## 怎么修的

- 用一次 `count()` 的结果同时完成非空判断与日志计数。
- 保留原有 `QuerySet | None` 返回契约，不改变下游屏蔽匹配和批次处理方式。
- 增加真实数据库查询次数断言，确保活跃策略存在时该方法只执行一次查询。

## 影响范围

改动仅位于 `alerts` 模块，不涉及模型、接口或 NATS 协议变更。HTTP 告警接收和 `default.receive_alert_events` 两条入口都会减少一次冗余查询；无活跃策略和异常兜底语义保持不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        H["HTTP receiver\nreceiver.py"]
        N["receive_alert_events\nnats.py"]
    end

    subgraph P["事件处理层"]
        M["AlertSourceAdapter.main"]
        E["event_operator"]
    end

    subgraph S["屏蔽策略层"]
        G["get_active_shields\nbase.py"]
        C["单次 count 查询"]
        X["execute_shield_check_for_events"]
    end

    H --> M
    N --> M
    M --> E --> G --> C --> X
```

## 验证

- `apps/alerts/tests/test_issue_3391_shield_queries.py`：1 passed。
- 反向验证：还原旧实现后，同一测试以“期望 1 次、实际 2 次查询”失败；恢复修复后通过。
- `apps/alerts/tests/test_source_adapter.py`：#3391 对应目标用例通过；同文件另有 1 个由上游既有 `apps.alerts.apps.adapters` 测试漂移导致的预存失败，与本 PR diff 无关。

关联 Issue #3391。
