### PR TITLE
bugfix: 聚合异常向 Celery 上报

### DIFF
--- a/server/apps/alerts/tasks/tasks.py
+++ b/server/apps/alerts/tasks/tasks.py
@@ -46,6 +46,7 @@ def event_aggregation_alert():
             AggregationProcessor,
         )
 
+        aggregation_error = None
         try:
             processor = AggregationProcessor()
             processor.process_aggregation()
@@ -53,6 +54,7 @@ def event_aggregation_alert():
 
         except Exception as e:
             logger.exception("[AlertTask] 告警聚合任务执行失败: %s", e)
+            aggregation_error = e
 
         try:
             from apps.alerts.aggregation.recovery.timeout_checker import TimeoutChecker
@@ -62,6 +64,9 @@ def event_aggregation_alert():
         except Exception as e:
             logger.exception("[AlertTask] 聚合后会话超时检查失败: %s", e)
             raise
+
+        if aggregation_error is not None:
+            raise aggregation_error
     finally:
         cache.delete(AGGREGATION_LOCK_KEY)
 

--- a/server/apps/alerts/tests/test_aggregation_beat_lock.py
+++ b/server/apps/alerts/tests/test_aggregation_beat_lock.py
@@ -68,3 +68,17 @@ def test_aggregation_releases_lock_after_run(real_cache):
 
     # 锁已释放 → 能重新 add
     assert real_cache.add(LOCK_KEY, "x", 300) is True
+
+
+@pytest.mark.django_db
+def test_aggregation_reports_processor_failure_after_timeout_check(real_cache):
+    """聚合失败必须上报给 Celery，同时保留后续超时检查与锁释放。"""
+    from apps.alerts.tasks.tasks import event_aggregation_alert
+
+    error = RuntimeError("aggregation failed")
+    with mock.patch(_PROC, side_effect=error), mock.patch(_TIMEOUT, return_value=0) as m_timeout:
+        with pytest.raises(RuntimeError, match="aggregation failed"):
+            event_aggregation_alert()
+
+    m_timeout.assert_called_once_with()
+    assert real_cache.add(LOCK_KEY, "x", 300) is True


### PR DESCRIPTION
## 问题

告警聚合任务由 Celery Beat 每分钟触发。聚合处理器失败时，任务边界只记录异常却继续正常返回，导致 Celery 将实际失败的一轮聚合标记为 `SUCCESS`，故障无法通过任务状态被发现。

## 根因（设计层）

任务边界没有守住“后台任务失败必须向调度框架传播异常”的契约。同时，聚合与会话超时检查是同一周期内的两个独立步骤，直接在第一个异常点退出会削弱现有的超时恢复能力。

## 怎么修的

- 捕获并记录聚合异常后暂存该异常，继续执行会话超时检查。
- 超时检查完成后重新抛出聚合异常，使 Celery 正确记录失败状态。
- 保留外层 `finally` 释放聚合锁，确保下一周期仍可运行。

## 影响范围

改动仅涉及 `alerts` 的聚合定时任务和对应回归测试，不改变数据库结构、公共接口、NATS 协议或前端行为。正常执行路径保持不变；异常路径从错误的 `SUCCESS` 修正为 `FAILURE`，且仍会执行会话超时检查并释放锁。本次不引入自动重试，后续仍由既有 Beat 周期调度下一轮任务。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        B["Celery Beat\nalerts/config.py"]
        T1["event_aggregation_alert\ntasks/tasks.py"]
    end

    L["获取聚合单例锁"]

    subgraph N["核心处理层"]
        P["process_aggregation"]
        C["check_session_timeouts"]
    end

    subgraph E["失败报告与兜底层"]
        S["保存聚合异常"]
        R["向 Celery 重抛异常"]
        U["finally 释放聚合锁"]
    end

    B --> T1 --> L --> P --> C --> U
    P -. "失败时" .-> S --> C
    C --> R --> U
```

## 验证

- `apps/alerts/tests/test_aggregation_beat_lock.py`：4 passed。
- 新增用例覆盖聚合异常传播、后续超时检查继续执行及异常路径释放聚合锁；旧实现下该用例因未抛异常而失败。

关联 Issue #3390
