### PR TITLE
feat(监控): 支持主机磁盘文件系统过滤

### DIFF
--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -366,6 +366,11 @@ async def windows_wmi_metrics(request):
     password = request.headers.get("password")
     namespace = request.headers.get("namespace", "root\\cimv2")
     metrics_modules = request.headers.get("metrics_modules", "cpu,mem,disk,diskio,net,processes,system")
+    disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
+    disk_exclude_fstypes = request.headers.get(
+        "disk_exclude_fstypes",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+    )
     raw_timeout = request.headers.get("timeout", "60")
     instance_id = request.headers.get("instance_id")
     instance_type = request.headers.get("instance_type", "os")
@@ -391,6 +396,8 @@ async def windows_wmi_metrics(request):
         "password": password,
         "namespace": namespace,
         "metrics_modules": metrics_modules,
+        "disk_include_fstypes": disk_include_fstypes,
+        "disk_exclude_fstypes": disk_exclude_fstypes,
         "timeout": timeout,
         "tags": {
             "instance_id": instance_id,
@@ -437,6 +444,11 @@ async def host_metrics(request):
     password = request.headers.get("password")
     port = request.headers.get("port", "22" if os_type == "linux" else "5986")
     metrics_modules = request.headers.get("metrics_modules", "cpu,mem,disk,diskio,net,processes,system")
+    disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
+    disk_exclude_fstypes = request.headers.get(
+        "disk_exclude_fstypes",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+    )
     ansible_node_id = request.headers.get("ansible_node_id", "")
 
     agent_id = request.headers.get("agent_id", "")
@@ -482,6 +494,8 @@ async def host_metrics(request):
             "password": password,
             "port": port,
             "metrics_modules": metrics_modules,
+            "disk_include_fstypes": disk_include_fstypes,
+            "disk_exclude_fstypes": disk_exclude_fstypes,
             "ansible_node_id": ansible_node_id,
             "tags": {
                 "agent_id": agent_id,

--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -369,7 +369,7 @@ async def windows_wmi_metrics(request):
     disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
     disk_exclude_fstypes = request.headers.get(
         "disk_exclude_fstypes",
-        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
     )
     raw_timeout = request.headers.get("timeout", "60")
     instance_id = request.headers.get("instance_id")
@@ -447,7 +447,7 @@ async def host_metrics(request):
     disk_include_fstypes = request.headers.get("disk_include_fstypes", "")
     disk_exclude_fstypes = request.headers.get(
         "disk_exclude_fstypes",
-        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+        "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
     )
     ansible_node_id = request.headers.get("ansible_node_id", "")
 

--- a/agents/stargazer/tasks/collectors/disk_filter.py
+++ b/agents/stargazer/tasks/collectors/disk_filter.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+
+def _parse_fstypes(value: Any) -> set[str]:
+    if isinstance(value, (list, tuple, set)):
+        values = value
+    else:
+        values = str(value or "").split(",")
+    return {str(item).strip().lower() for item in values if str(item).strip()}
+
+
+def should_collect_disk(
+    fstype: Any,
+    *,
+    include_fstypes: Any = None,
+    exclude_fstypes: Any = None,
+) -> bool:
+    """Return whether a disk passes the configured filesystem-type rules.
+
+    A non-empty include list is an allowlist. The exclude list is always
+    evaluated afterwards, so it has priority when a type occurs in both lists.
+    """
+    normalized_fstype = str(fstype or "").strip().lower()
+    includes = _parse_fstypes(include_fstypes)
+    excludes = _parse_fstypes(exclude_fstypes)
+    return (not includes or normalized_fstype in includes) and normalized_fstype not in excludes

--- a/agents/stargazer/tasks/collectors/host_collector.py
+++ b/agents/stargazer/tasks/collectors/host_collector.py
@@ -7,6 +7,7 @@ from typing import Dict, Any, List
 from urllib.parse import unquote
 
 from .base_collector import BaseCollector
+from .disk_filter import should_collect_disk
 
 logger = logging.getLogger("stargazer.host_collector")
 
@@ -29,19 +30,25 @@ def _url_decode_secret(value: Any, credential_encoding: Any = "url") -> str:
     return unquote(str(value))
 
 SCRIPTS_DIR = Path(__file__).parent / "scripts"
+MONITOR_SCRIPTS_DIR = Path(__file__).parent / "monitor_scripts"
 
 VALID_MODULES = {"cpu", "mem", "disk", "net", "diskio", "processes", "system"}
 HOST_REMOTE_CALLBACK_REQUEST_TIMEOUT = 60
 LINUX_SCRIPT_WRAPPER_EOF = "STARGAZER_HOST_COLLECT_EOF"
 
 
-def build_script(os_type: str, modules: List[str]) -> str:
+def build_script(os_type: str, modules: List[str], monitor_type: str | None = None) -> str:
     base_dir = SCRIPTS_DIR / ("linux" if os_type == "linux" else "windows")
+    monitor_base_dir = MONITOR_SCRIPTS_DIR / ("linux" if os_type == "linux" else "windows")
     ext = ".sh" if os_type == "linux" else ".ps1"
 
     parts = [_read_script(base_dir / f"header{ext}")]
     for mod in modules:
         script_file = base_dir / f"{mod}{ext}"
+        if monitor_type == "host" and mod == "disk":
+            monitor_script_file = monitor_base_dir / f"{mod}{ext}"
+            if monitor_script_file.exists():
+                script_file = monitor_script_file
         if script_file.exists():
             parts.append(_read_script(script_file))
     parts.append(_read_script(base_dir / f"footer{ext}"))
@@ -137,7 +144,13 @@ def _append_gauge(lines: List[str], name: str, labels: str, value: Any, timestam
 
 
 def parse_metrics_to_prometheus(
-    data: Dict[str, Any], instance_id: str, os_type: str, timestamp: int | None = None
+    data: Dict[str, Any],
+    instance_id: str,
+    os_type: str,
+    timestamp: int | None = None,
+    *,
+    disk_include_fstypes: Any = None,
+    disk_exclude_fstypes: Any = None,
 ) -> str:
     lines = []
     timestamp = int(timestamp) if timestamp is not None else int(time.time() * 1000)
@@ -185,7 +198,15 @@ def parse_metrics_to_prometheus(
         if isinstance(disks, list):
             for disk in disks:
                 mount = disk.get("mount", "unknown")
-                disk_labels = f"{base_labels},{_format_prometheus_labels(mount=mount)}"
+                path = disk.get("path") or mount
+                fstype = disk.get("fstype") or ""
+                if not should_collect_disk(
+                    fstype,
+                    include_fstypes=disk_include_fstypes,
+                    exclude_fstypes=disk_exclude_fstypes,
+                ):
+                    continue
+                disk_labels = f"{base_labels},{_format_prometheus_labels(mount=mount, path=path, fstype=fstype)}"
                 total = disk.get("total_bytes", 0)
                 used = disk.get("used_bytes", 0)
                 free = _metric_value(disk, "free_bytes", "available_bytes", default=max(float(total or 0) - float(used or 0), 0))
@@ -279,7 +300,7 @@ class HostCollector(BaseCollector):
 
         logger.info(f"[Host Collector] host={host}, os={os_type}, modules={modules}")
 
-        script = build_script(os_type, modules)
+        script = build_script(os_type, modules, monitor_type=self.params.get("monitor_type"))
 
         connection = "ssh" if os_type == "linux" else "winrm"
         module = "raw" if os_type == "linux" else "win_shell"
@@ -404,6 +425,8 @@ class HostCollector(BaseCollector):
             instance_id,
             os_type,
             timestamp=callback_timestamp,
+            disk_include_fstypes=self.params.get("disk_include_fstypes"),
+            disk_exclude_fstypes=self.params.get("disk_exclude_fstypes"),
         )
 
         logger.info(f"[Host Collector] Completed: host={host}, metrics_size={len(prometheus_metrics)}")

--- a/agents/stargazer/tasks/collectors/host_wmi/metrics.py
+++ b/agents/stargazer/tasks/collectors/host_wmi/metrics.py
@@ -1,6 +1,8 @@
 import time
 from typing import Any
 
+from ..disk_filter import should_collect_disk
+
 
 def _escape_label(value: Any) -> str:
     return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
@@ -29,6 +31,8 @@ def wmi_results_to_prometheus(
     *,
     host: str,
     timestamp: int | None = None,
+    disk_include_fstypes: Any = None,
+    disk_exclude_fstypes: Any = None,
 ) -> str:
     timestamp = timestamp or int(time.time() * 1000)
     base_labels = {
@@ -55,7 +59,19 @@ def wmi_results_to_prometheus(
     _append_gauge(lines, "mem_used_percent_gauge", base_labels, mem.get("used_percent"), timestamp)
 
     for disk in results.get("disk") or []:
-        disk_labels = {**base_labels, "device": disk.get("device")}
+        fstype = disk.get("fstype") or ""
+        if not should_collect_disk(
+            fstype,
+            include_fstypes=disk_include_fstypes,
+            exclude_fstypes=disk_exclude_fstypes,
+        ):
+            continue
+        disk_labels = {
+            **base_labels,
+            "device": disk.get("device"),
+            "path": disk.get("path") or disk.get("device"),
+            "fstype": fstype,
+        }
         _append_gauge(lines, "host_disk_total_bytes_gauge", disk_labels, disk.get("total_bytes"), timestamp)
         _append_gauge(lines, "host_disk_free_bytes_gauge", disk_labels, disk.get("free_bytes"), timestamp)
         _append_gauge(lines, "host_disk_used_bytes_gauge", disk_labels, disk.get("used_bytes"), timestamp)

--- a/agents/stargazer/tasks/collectors/host_wmi/modules.py
+++ b/agents/stargazer/tasks/collectors/host_wmi/modules.py
@@ -56,7 +56,7 @@ class DiskModule(WmiModule):
     name = "disk"
 
     def collect(self, client):
-        rows = client.query("SELECT DeviceID, Size, FreeSpace FROM Win32_LogicalDisk WHERE DriveType=3")
+        rows = client.query("SELECT DeviceID, FileSystem, Size, FreeSpace FROM Win32_LogicalDisk WHERE DriveType=3")
         disks = []
         for row in rows:
             total = int(row.get("Size") or 0)
@@ -65,6 +65,8 @@ class DiskModule(WmiModule):
             disks.append(
                 {
                     "device": str(row.get("DeviceID") or ""),
+                    "path": str(row.get("DeviceID") or ""),
+                    "fstype": str(row.get("FileSystem") or ""),
                     "total_bytes": total,
                     "free_bytes": free,
                     "used_bytes": used,

--- a/agents/stargazer/tasks/collectors/host_wmi_collector.py
+++ b/agents/stargazer/tasks/collectors/host_wmi_collector.py
@@ -77,6 +77,8 @@ class WindowsWmiCollector(BaseCollector):
             results,
             self.params.get("tags") or {},
             host=self.params["host"],
+            disk_include_fstypes=self.params.get("disk_include_fstypes"),
+            disk_exclude_fstypes=self.params.get("disk_exclude_fstypes"),
         )
         duration_ms = int((time.monotonic() - started) * 1000)
         logger.info("event=wmi_collect_success duration_ms=%s %s", duration_ms, context)

--- a/agents/stargazer/tasks/collectors/monitor_scripts/linux/disk.sh
+++ b/agents/stargazer/tasks/collectors/monitor_scripts/linux/disk.sh
@@ -1,0 +1,33 @@
+# Host Remote 监控专属磁盘采集：保留文件系统类型，供监控白黑名单过滤。
+if [ $_first_module -eq 0 ]; then echo ','; fi; _first_module=0
+echo '"disk":['
+_disk_first=1
+disk_number_or_zero() {
+  case "$1" in
+    ''|*[!0-9]*)
+      echo 0
+      ;;
+    *)
+      echo "$1"
+      ;;
+  esac
+}
+df -PT -B1 -x tmpfs -x devtmpfs -x squashfs 2>/dev/null | tail -n +2 | while read fs fstype size used avail pct mount; do
+  case "$fs:$mount" in
+    overlay:*|*:/var/lib/docker/overlay2/*/merged|*:/data/lib/docker/overlay2/*/merged|*:/run/containerd/*)
+      continue
+      ;;
+  esac
+  if [ $_disk_first -eq 0 ]; then echo ','; fi; _disk_first=0
+  used_pct=$(echo "$pct" | tr -d '%')
+  size=$(disk_number_or_zero "$size")
+  used=$(disk_number_or_zero "$used")
+  avail=$(disk_number_or_zero "$avail")
+  used_pct=$(disk_number_or_zero "$used_pct")
+  mount_json=$(json_escape "$mount")
+  fstype_json=$(json_escape "$fstype")
+  inode_pct=$(df -Pi "$mount" 2>/dev/null | tail -n 1 | awk '{print $5}' | tr -d '%')
+  inode_pct=$(disk_number_or_zero "$inode_pct")
+  echo "{\"mount\":\"$mount_json\",\"path\":\"$mount_json\",\"fstype\":\"$fstype_json\",\"total_bytes\":$size,\"free_bytes\":$avail,\"used_bytes\":$used,\"used_percent\":$used_pct,\"inodes_used_percent\":${inode_pct:-0}}"
+done
+echo ']'

--- a/agents/stargazer/tasks/collectors/monitor_scripts/linux/disk.sh
+++ b/agents/stargazer/tasks/collectors/monitor_scripts/linux/disk.sh
@@ -12,12 +12,7 @@ disk_number_or_zero() {
       ;;
   esac
 }
-df -PT -B1 -x tmpfs -x devtmpfs -x squashfs 2>/dev/null | tail -n +2 | while read fs fstype size used avail pct mount; do
-  case "$fs:$mount" in
-    overlay:*|*:/var/lib/docker/overlay2/*/merged|*:/data/lib/docker/overlay2/*/merged|*:/run/containerd/*)
-      continue
-      ;;
-  esac
+df -PT -B1 2>/dev/null | tail -n +2 | while read fs fstype size used avail pct mount; do
   if [ $_disk_first -eq 0 ]; then echo ','; fi; _disk_first=0
   used_pct=$(echo "$pct" | tr -d '%')
   size=$(disk_number_or_zero "$size")

--- a/agents/stargazer/tasks/collectors/monitor_scripts/windows/disk.ps1
+++ b/agents/stargazer/tasks/collectors/monitor_scripts/windows/disk.ps1
@@ -1,0 +1,20 @@
+# Host Remote 监控专属磁盘采集：保留文件系统类型，供监控白黑名单过滤。
+$disks = Get-MetricData 'Win32_LogicalDisk' | Where-Object { $_.DriveType -eq 3 }
+$diskArr = @()
+foreach ($d in $disks) {
+    $total = [int64]$d.Size
+    $free = [int64]$d.FreeSpace
+    $used = $total - $free
+    $pct = if ($total -gt 0) { [math]::Round($used / $total * 100, 2) } else { 0 }
+    $diskArr += @{
+        mount = $d.DeviceID
+        path = $d.DeviceID
+        fstype = $d.FileSystem
+        total_bytes = $total
+        free_bytes = $free
+        used_bytes = $used
+        used_percent = $pct
+        inodes_used_percent = 0
+    }
+}
+$result['disk'] = $diskArr

--- a/agents/stargazer/tests/test_api_http_layer.py
+++ b/agents/stargazer/tests/test_api_http_layer.py
@@ -483,6 +483,37 @@ class TestMonitorEndpointLogic:
         assert task_params["monitor_type"] == "windows_wmi"
         assert task_params["metrics_modules"] == FULL_HOST_MODULES
 
+    async def test_host_metrics_passes_disk_fstype_filters_to_collector(self):
+        await self.mod.host_metrics(self._req(
+            headers={
+                "host": "10.0.0.10",
+                "username": "root",
+                "password": "pass",
+                "ansible_node_id": "node-1",
+                "disk_include_fstypes": "ext4,xfs",
+                "disk_exclude_fstypes": "vfat,exfat",
+            }
+        ))
+
+        task_params = self.task_queue.enqueue_collect_task.call_args.args[0]
+        assert task_params["disk_include_fstypes"] == "ext4,xfs"
+        assert task_params["disk_exclude_fstypes"] == "vfat,exfat"
+
+    async def test_windows_wmi_metrics_passes_disk_fstype_filters_to_collector(self):
+        await self.mod.windows_wmi_metrics(self._req(
+            headers={
+                "host": "10.0.0.20",
+                "username": "DOMAIN\\monitor",
+                "password": "pass",
+                "disk_include_fstypes": "NTFS,ReFS",
+                "disk_exclude_fstypes": "FAT32,exFAT",
+            }
+        ))
+
+        task_params = self.task_queue.enqueue_collect_task.call_args.args[0]
+        assert task_params["disk_include_fstypes"] == "NTFS,ReFS"
+        assert task_params["disk_exclude_fstypes"] == "FAT32,exFAT"
+
 
 # ---------------------------------------------------------------------------
 # health.py — HTTP handler 逻辑测试

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -321,12 +321,17 @@ class TestBuildScript:
         assert "cpu_user_2" in script
         assert "used_delta" in script
 
-    def test_linux_disk_script_filters_container_overlay_mounts(self):
-        script = build_script("linux", ["disk"])
+    def test_monitor_linux_disk_script_leaves_filesystem_filtering_to_collector(self):
+        script = build_script("linux", ["disk"], monitor_type="host")
 
-        assert "overlay:*" in script
-        assert "/var/lib/docker/overlay2/*/merged" in script
-        assert "/data/lib/docker/overlay2/*/merged" in script
+        assert "df -PT -B1" in script
+        assert " -x " not in script
+        assert "overlay:*" not in script
+        assert "/var/lib/docker/overlay2/" not in script
+        assert "/data/lib/docker/overlay2/" not in script
+        assert "/run/containerd/" not in script
+        assert '\\"path\\":\\"$mount_json\\"' in script
+        assert '\\"fstype\\":\\"$fstype_json\\"' in script
 
     def test_linux_header_script_provides_json_escape_helper(self):
         script = build_script("linux", ["disk"])

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -349,10 +349,10 @@ class TestBuildScript:
         fake_df = bin_dir / "df"
         fake_df.write_text(
             """#!/bin/sh
-if [ "$1" = "-P" ] && [ "$2" = "-B1" ]; then
+if [ "$1" = "-PT" ] && [ "$2" = "-B1" ]; then
   cat <<'DATA'
-Filesystem 1B-blocks Used Available Capacity Mounted on
-/dev/sda1 100 50 50 50% /
+Filesystem Type 1B-blocks Used Available Capacity Mounted on
+/dev/sda1 ext4 100 50 50 50% /
 DATA
   exit 0
 fi
@@ -371,7 +371,7 @@ exit 1
         env = {**os.environ, "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}"}
 
         result = subprocess.run(
-            ["bash", "-c", build_script("linux", ["disk"])],
+            ["bash", "-c", build_script("linux", ["disk"], monitor_type="host")],
             check=True,
             env=env,
             capture_output=True,
@@ -380,6 +380,24 @@ exit 1
 
         payload = json.loads(result.stdout)
         assert payload["disk"][0]["inodes_used_percent"] == 0
+        assert payload["disk"][0]["path"] == "/"
+        assert payload["disk"][0]["fstype"] == "ext4"
+
+    def test_monitor_disk_metadata_is_isolated_from_generic_host_script(self):
+        generic_script = build_script("linux", ["disk"])
+        monitor_script = build_script("linux", ["disk"], monitor_type="host")
+
+        assert "df -P -B1" in generic_script
+        assert "df -PT -B1" not in generic_script
+        assert "df -PT -B1" in monitor_script
+        assert '\\"fstype\\":\\"$fstype_json\\"' in monitor_script
+
+    def test_windows_monitor_disk_metadata_is_isolated_from_generic_host_script(self):
+        generic_script = build_script("windows", ["disk"])
+        monitor_script = build_script("windows", ["disk"], monitor_type="host")
+
+        assert "fstype = $d.FileSystem" not in generic_script
+        assert "fstype = $d.FileSystem" in monitor_script
 
     def test_linux_net_script_filters_virtual_interfaces(self):
         script = build_script("linux", ["net"])
@@ -498,6 +516,28 @@ class TestParseMetricsToPrometheus:
         assert 'mount="/"' in result
         assert 'mount="/data"' in result
         assert "host_disk_used_percent" in result
+
+    def test_disk_metrics_filter_by_fstype_and_keep_path_labels(self):
+        data = {
+            "disk": [
+                {"mount": "/", "path": "/", "fstype": "ext4", "total_bytes": 100, "used_bytes": 50, "used_percent": 50},
+                {"mount": "/media/usb", "path": "/media/usb", "fstype": "vfat", "total_bytes": 100, "used_bytes": 50, "used_percent": 50},
+                {"mount": "/data", "path": "/data", "fstype": "xfs", "total_bytes": 100, "used_bytes": 50, "used_percent": 50},
+            ]
+        }
+
+        result = parse_metrics_to_prometheus(
+            data,
+            "inst1",
+            "linux",
+            disk_include_fstypes=" ext4, vfat ",
+            disk_exclude_fstypes="vfat",
+        )
+
+        assert 'path="/"' in result
+        assert 'fstype="ext4"' in result
+        assert "/media/usb" not in result
+        assert "/data" not in result
 
     def test_disk_metrics_escape_prometheus_label_values(self):
         data = {

--- a/agents/stargazer/tests/test_windows_wmi_collector.py
+++ b/agents/stargazer/tests/test_windows_wmi_collector.py
@@ -53,6 +53,8 @@ def test_wmi_results_to_prometheus_emits_host_metrics():
             "disk": [
                 {
                     "device": "C:",
+                    "path": "C:",
+                    "fstype": "NTFS",
                     "total_bytes": 1000,
                     "free_bytes": 250,
                     "used_bytes": 750,
@@ -74,7 +76,38 @@ def test_wmi_results_to_prometheus_emits_host_metrics():
     assert f"host_cpu_usage_percent_gauge{{{base}}} 12.5 1700000000000" in output
     assert f"host_cpu_core_count_gauge{{{base}}} 4 1700000000000" in output
     assert f"host_mem_used_percent_gauge{{{base}}} 50 1700000000000" in output
-    assert f'host_disk_used_percent_gauge{{{base},device="C:"}} 75 1700000000000' in output
+    assert f'host_disk_used_percent_gauge{{{base},device="C:",path="C:",fstype="NTFS"}} 75 1700000000000' in output
+
+
+def test_wmi_disk_metrics_filter_fstype_and_emit_path_labels():
+    output = wmi_results_to_prometheus(
+        {
+            "disk": [
+                {"device": "C:", "path": "C:", "fstype": "NTFS", "total_bytes": 1000, "free_bytes": 250, "used_bytes": 750, "used_percent": 75},
+                {"device": "E:", "path": "E:", "fstype": "FAT32", "total_bytes": 1000, "free_bytes": 250, "used_bytes": 750, "used_percent": 75},
+            ]
+        },
+        {"instance_id": "region_os_10.0.0.8"},
+        host="10.0.0.8",
+        timestamp=1700000000000,
+        disk_include_fstypes="NTFS,FAT32",
+        disk_exclude_fstypes="FAT32",
+    )
+
+    assert 'device="C:",path="C:",fstype="NTFS"' in output
+    assert 'device="E:"' not in output
+
+
+def test_wmi_disk_module_exposes_filesystem_as_fstype():
+    class DiskClient:
+        def query(self, _query):
+            return [{"DeviceID": "C:", "FileSystem": "NTFS", "Size": 1000, "FreeSpace": 250}]
+
+    disks = wmi_modules.DiskModule().collect(DiskClient())
+
+    assert disks == [
+        {"device": "C:", "path": "C:", "fstype": "NTFS", "total_bytes": 1000, "free_bytes": 250, "used_bytes": 750, "used_percent": 75.0}
+    ]
 
 
 def test_wmi_modules_collect_telegraf_aligned_host_metrics():

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
@@ -98,6 +98,7 @@
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs。",
       "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
+      "guide_short": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "ext4,xfs"
       },
@@ -114,6 +115,7 @@
       "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
       "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
@@ -91,6 +91,36 @@
       "label_en": "Metric Type"
     },
     {
+      "name": "disk_include_fstypes",
+      "label": "仅采集的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "",
+      "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs。",
+      "widget_props": {
+        "placeholder": "ext4,xfs"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.disk_include_fstypes"
+      },
+      "label_en": "Included Filesystem Types"
+    },
+    {
+      "name": "disk_exclude_fstypes",
+      "label": "排除的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
+      "widget_props": {
+        "placeholder": "vfat,exfat,ntfs"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.disk_exclude_fstypes"
+      },
+      "label_en": "Excluded Filesystem Types"
+    },
+    {
       "name": "interval",
       "label": "间隔",
       "type": "inputNumber",

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/UI.json
@@ -97,6 +97,7 @@
       "required": false,
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs。",
+      "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "ext4,xfs"
       },
@@ -110,8 +111,9 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
@@ -1,6 +1,6 @@
 [[inputs.disk]]
     startup_error_behavior = "retry"
-    ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs"]
+    ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "vfat", "exfat", "fat", "fat32"]
     interval = "{{ interval }}s"
     [inputs.disk.tags]
         instance_id = "{{ instance_id }}"
@@ -25,4 +25,4 @@ def apply(metric):
 
     [processors.starlark.constants]
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
@@ -24,4 +24,4 @@ def apply(metric):
 
     [processors.starlark.constants]
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') | replace('\\', '\\\\') | replace('"', '\\"') }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
@@ -7,3 +7,22 @@
         instance_type = "{{ instance_type }}"
         collect_type = "host"
         config_type = "disk"
+
+[[processors.starlark]]
+    namepass = ["disk"]
+    source = '''
+def _parse_fstypes(value):
+    return [item.strip().lower() for item in value.split(",") if item.strip()]
+
+def apply(metric):
+    fstype = metric.tags.get("fstype", "").strip().lower()
+    includes = _parse_fstypes(disk_include_fstypes)
+    excludes = _parse_fstypes(disk_exclude_fstypes)
+    if (includes and fstype not in includes) or fstype in excludes:
+        return None
+    return metric
+'''
+
+    [processors.starlark.constants]
+        disk_include_fstypes = "{{ disk_include_fstypes | default('', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) | replace('\\', '\\\\') | replace('"', '\\"') }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/disk.child.toml.j2
@@ -1,6 +1,5 @@
 [[inputs.disk]]
     startup_error_behavior = "retry"
-    ignore_fs = ["tmpfs", "devtmpfs", "devfs", "iso9660", "overlay", "aufs", "squashfs", "vfat", "exfat", "fat", "fat32"]
     interval = "{{ interval }}s"
     [inputs.disk.tags]
         instance_id = "{{ instance_id }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/metrics.json
@@ -248,7 +248,7 @@
     {
       "metric_group": "Disk",
       "name": "disk_total",
-      "query": "any(disk_total{instance_type=\"os\", __$labels__}) by (instance_id, device)",
+      "query": "any(disk_total{instance_type=\"os\", __$labels__}) by (instance_id, device, path, fstype)",
       "display_name": "Disk Total",
       "data_type": "Number",
       "unit": "bytes",
@@ -256,6 +256,14 @@
         {
           "name": "device",
           "description": "磁盘设备"
+        },
+        {
+          "name": "path",
+          "description": "挂载路径"
+        },
+        {
+          "name": "fstype",
+          "description": "文件系统类型"
         }
       ],
       "instance_id_keys": ["instance_id"],
@@ -264,7 +272,7 @@
     {
       "metric_group": "Disk",
       "name": "disk_free",
-      "query": "any(disk_free{instance_type=\"os\", __$labels__}) by (instance_id, device)",
+      "query": "any(disk_free{instance_type=\"os\", __$labels__}) by (instance_id, device, path, fstype)",
       "display_name": "Disk Free",
       "data_type": "Number",
       "unit": "bytes",
@@ -272,6 +280,14 @@
         {
           "name": "device",
           "description": "磁盘设备"
+        },
+        {
+          "name": "path",
+          "description": "挂载路径"
+        },
+        {
+          "name": "fstype",
+          "description": "文件系统类型"
         }
       ],
       "instance_id_keys": ["instance_id"],
@@ -280,7 +296,7 @@
     {
       "metric_group": "Disk",
       "name": "disk_used_percent",
-      "query": "any(disk_used_percent{instance_type=\"os\", __$labels__}) by (instance_id, device)",
+      "query": "any(disk_used_percent{instance_type=\"os\", __$labels__}) by (instance_id, device, path, fstype)",
       "display_name": "Disk Usage",
       "data_type": "Number",
       "unit": "percent",
@@ -288,6 +304,14 @@
         {
           "name": "device",
           "description": "磁盘设备"
+        },
+        {
+          "name": "path",
+          "description": "挂载路径"
+        },
+        {
+          "name": "fstype",
+          "description": "文件系统类型"
         }
       ],
       "instance_id_keys": ["instance_id"],
@@ -296,7 +320,7 @@
     {
       "metric_group": "Disk",
       "name": "disk_inodes_used_percent",
-      "query": "any(disk_inodes_used_percent{instance_type=\"os\", __$labels__}) by (instance_id, device)",
+      "query": "any(disk_inodes_used_percent{instance_type=\"os\", __$labels__}) by (instance_id, device, path, fstype)",
       "display_name": "Inode Usage",
       "data_type": "Number",
       "unit": "percent",
@@ -304,6 +328,14 @@
         {
           "name": "device",
           "description": "磁盘设备"
+        },
+        {
+          "name": "path",
+          "description": "挂载路径"
+        },
+        {
+          "name": "fstype",
+          "description": "文件系统类型"
         }
       ],
       "instance_id_keys": ["instance_id"],
@@ -656,6 +688,5 @@
     }
   ]
 }
-
 
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
@@ -78,6 +78,7 @@
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs 或 NTFS,ReFS。",
       "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
+      "guide_short": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "ext4,xfs"
       },
@@ -94,6 +95,7 @@
       "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
       "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
@@ -71,6 +71,36 @@
       }
     },
     {
+      "name": "disk_include_fstypes",
+      "label": "仅采集的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "",
+      "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs 或 NTFS,ReFS。",
+      "widget_props": {
+        "placeholder": "ext4,xfs"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.http_headers.disk_include_fstypes"
+      },
+      "label_en": "Included Filesystem Types"
+    },
+    {
+      "name": "disk_exclude_fstypes",
+      "label": "排除的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
+      "widget_props": {
+        "placeholder": "vfat,exfat,ntfs"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.http_headers.disk_exclude_fstypes"
+      },
+      "label_en": "Excluded Filesystem Types"
+    },
+    {
       "name": "username",
       "label": "用户名",
       "type": "input",

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/UI.json
@@ -77,6 +77,7 @@
       "required": false,
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 ext4,xfs 或 NTFS,ReFS。",
+      "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "ext4,xfs"
       },
@@ -90,8 +91,9 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 vfat,exfat,ntfs。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "vfat,exfat,ntfs"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
@@ -17,7 +17,7 @@
         port = "{{ port | default('', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) }}"
         winrm_scheme = "{{ winrm_scheme | default('https', true) }}"
         winrm_transport = "{{ winrm_transport | default('ntlm', true) }}"
         winrm_cert_validation = "{{ winrm_cert_validation | default('false', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
@@ -17,7 +17,7 @@
         port = "{{ port | default('', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') }}"
         winrm_scheme = "{{ winrm_scheme | default('https', true) }}"
         winrm_transport = "{{ winrm_transport | default('ntlm', true) }}"
         winrm_cert_validation = "{{ winrm_cert_validation | default('false', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/host.child.toml.j2
@@ -16,6 +16,8 @@
         auth_type = "{{ auth_type | default('password', true) }}"
         port = "{{ port | default('', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
+        disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) }}"
         winrm_scheme = "{{ winrm_scheme | default('https', true) }}"
         winrm_transport = "{{ winrm_transport | default('ntlm', true) }}"
         winrm_cert_validation = "{{ winrm_cert_validation | default('false', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/metrics.json
@@ -148,7 +148,7 @@
       "display_name": "Disk Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [{"name": "mount"}],
+      "dimensions": [{"name": "mount"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Total disk space in bytes per mount"
     },
@@ -159,7 +159,7 @@
       "display_name": "Disk Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [{"name": "mount"}],
+      "dimensions": [{"name": "mount"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Used disk space in bytes per mount"
     },
@@ -170,7 +170,7 @@
       "display_name": "Disk Usage",
       "data_type": "Number",
       "unit": "%",
-      "dimensions": [{"name": "mount"}],
+      "dimensions": [{"name": "mount"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Disk usage percentage per mount"
     },
@@ -445,7 +445,7 @@
       "display_name": "Disk Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [{"name": "mount"}],
+      "dimensions": [{"name": "mount"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Free disk space in bytes"
     },
@@ -456,7 +456,7 @@
       "display_name": "Disk Inodes Usage",
       "data_type": "Number",
       "unit": "%",
-      "dimensions": [{"name": "mount"}],
+      "dimensions": [{"name": "mount"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Disk inode usage percentage"
     },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
@@ -92,6 +92,36 @@
       }
     },
     {
+      "name": "disk_include_fstypes",
+      "label": "仅采集的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "",
+      "description": "逗号分隔；留空表示不限制类型，例如 NTFS,ReFS。",
+      "widget_props": {
+        "placeholder": "NTFS,ReFS"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.http_headers.disk_include_fstypes"
+      },
+      "label_en": "Included Filesystem Types"
+    },
+    {
+      "name": "disk_exclude_fstypes",
+      "label": "排除的文件系统类型",
+      "type": "input",
+      "required": false,
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "description": "逗号分隔；黑名单优先于仅采集列表，例如 FAT,FAT32,exFAT。",
+      "widget_props": {
+        "placeholder": "FAT,FAT32,exFAT"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.http_headers.disk_exclude_fstypes"
+      },
+      "label_en": "Excluded Filesystem Types"
+    },
+    {
       "name": "timeout",
       "label": "超时",
       "type": "inputNumber",

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
@@ -98,6 +98,7 @@
       "required": false,
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 NTFS,ReFS。",
+      "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "NTFS,ReFS"
       },
@@ -111,8 +112,9 @@
       "label": "排除的文件系统类型",
       "type": "input",
       "required": false,
-      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs",
+      "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 FAT,FAT32,exFAT。",
+      "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "FAT,FAT32,exFAT"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/UI.json
@@ -99,6 +99,7 @@
       "default_value": "",
       "description": "逗号分隔；留空表示不限制类型，例如 NTFS,ReFS。",
       "tooltip": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
+      "guide_short": "推荐仅采集 Linux 的 ext4、xfs、btrfs，或 Windows 的 NTFS、ReFS；留空表示不按类型限制。",
       "widget_props": {
         "placeholder": "NTFS,ReFS"
       },
@@ -115,6 +116,7 @@
       "default_value": "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
       "description": "逗号分隔；黑名单优先于仅采集列表，例如 FAT,FAT32,exFAT。",
       "tooltip": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
+      "guide_short": "临时盘/容器盘：tmpfs、devtmpfs、overlay、aufs、squashfs；光盘：iso9660；常见 U 盘：vfat、exfat、fat、fat32。黑名单优先于仅采集列表；不默认排除 ntfs。",
       "widget_props": {
         "placeholder": "FAT,FAT32,exFAT"
       },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/metrics.json
@@ -49,7 +49,7 @@
       "display_name": "Disk Usage",
       "data_type": "Number",
       "unit": "%",
-      "dimensions": [{"name": "device"}],
+      "dimensions": [{"name": "device"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Disk usage percentage per logical disk"
     },
@@ -82,7 +82,7 @@
       "display_name": "Disk Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [{"name": "device"}],
+      "dimensions": [{"name": "device"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Total disk space in bytes per logical disk"
     },
@@ -93,7 +93,7 @@
       "display_name": "Disk Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [{"name": "device"}],
+      "dimensions": [{"name": "device"}, {"name": "path"}, {"name": "fstype"}],
       "instance_id_keys": ["instance_id"],
       "description": "Free disk space in bytes per logical disk"
     },

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
@@ -11,6 +11,8 @@
         password = "${PASSWORD__{{ config_id }}}"
         namespace = "{{ namespace | default('root\\cimv2', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
+        disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) }}"
         timeout = "{{ timeout | default(60, true) }}"
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type | default('os', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
@@ -12,7 +12,7 @@
         namespace = "{{ namespace | default('root\\cimv2', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32') }}"
         timeout = "{{ timeout | default(60, true) }}"
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type | default('os', true) }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/windows_wmi.child.toml.j2
@@ -12,7 +12,7 @@
         namespace = "{{ namespace | default('root\\cimv2', true) }}"
         metrics_modules = "{{ metrics_modules | default('cpu,mem,disk,diskio,net,processes,system', true) }}"
         disk_include_fstypes = "{{ disk_include_fstypes | default('', true) }}"
-        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs', true) }}"
+        disk_exclude_fstypes = "{{ disk_exclude_fstypes | default('tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32', true) }}"
         timeout = "{{ timeout | default(60, true) }}"
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type | default('os', true) }}"

--- a/server/apps/monitor/tests/test_host_disk_metric_contract.py
+++ b/server/apps/monitor/tests/test_host_disk_metric_contract.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "support-files" / "plugins" / "Telegraf"
+
+PLUGIN_PATHS = {
+    "host": PLUGIN_ROOT / "host" / "os",
+    "windows_wmi": PLUGIN_ROOT / "http" / "windows_wmi",
+    "host_remote": PLUGIN_ROOT / "http" / "host",
+}
+
+
+def _disk_metrics(plugin_path: Path) -> list[dict]:
+    metrics = json.loads((plugin_path / "metrics.json").read_text())
+    return [metric for metric in metrics["metrics"] if metric["metric_group"] == "Disk"]
+
+
+def test_all_host_templates_expose_fstype_allow_and_deny_lists():
+    for plugin_path in PLUGIN_PATHS.values():
+        ui = json.loads((plugin_path / "UI.json").read_text())
+        fields = {field["name"] for field in ui["form_fields"]}
+        template_text = "\n".join(path.read_text() for path in plugin_path.glob("*.child.toml.j2"))
+
+        assert {"disk_include_fstypes", "disk_exclude_fstypes"} <= fields
+        assert "disk_include_fstypes" in template_text
+        assert "disk_exclude_fstypes" in template_text
+
+
+def test_host_telegraf_template_filters_only_disk_measurements_by_fstype():
+    template = (PLUGIN_PATHS["host"] / "disk.child.toml.j2").read_text()
+
+    assert "[[processors.starlark]]" in template
+    assert 'namepass = ["disk"]' in template
+    assert 'metric.tags.get("fstype", "")' in template
+    assert "return None" in template
+
+
+def test_all_disk_metrics_keep_path_and_fstype_dimensions():
+    for plugin_path in PLUGIN_PATHS.values():
+        for metric in _disk_metrics(plugin_path):
+            dimensions = {dimension["name"] for dimension in metric["dimensions"]}
+            assert {"path", "fstype"} <= dimensions, metric["name"]
+
+
+def test_host_disk_aggregation_keeps_path_and_fstype():
+    for metric in _disk_metrics(PLUGIN_PATHS["host"]):
+        assert "by (instance_id, device, path, fstype)" in metric["query"], metric["name"]

--- a/server/apps/monitor/tests/test_host_disk_metric_contract.py
+++ b/server/apps/monitor/tests/test_host_disk_metric_contract.py
@@ -10,6 +10,9 @@ PLUGIN_PATHS = {
     "host_remote": PLUGIN_ROOT / "http" / "host",
 }
 
+DEFAULT_EXCLUDE_FSTYPES = "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32"
+API_MONITOR_PATH = Path(__file__).resolve().parents[4] / "agents" / "stargazer" / "api" / "monitor.py"
+
 
 def _disk_metrics(plugin_path: Path) -> list[dict]:
     metrics = json.loads((plugin_path / "metrics.json").read_text())
@@ -46,3 +49,28 @@ def test_all_disk_metrics_keep_path_and_fstype_dimensions():
 def test_host_disk_aggregation_keeps_path_and_fstype():
     for metric in _disk_metrics(PLUGIN_PATHS["host"]):
         assert "by (instance_id, device, path, fstype)" in metric["query"], metric["name"]
+
+
+def test_all_host_disk_configs_default_exclude_usb_filesystems_and_explain_filtering():
+    for plugin_path in PLUGIN_PATHS.values():
+        ui = json.loads((plugin_path / "UI.json").read_text())
+        fields = {field["name"]: field for field in ui["form_fields"]}
+        template_text = "\n".join(path.read_text() for path in plugin_path.glob("*.child.toml.j2"))
+
+        exclude_types = set(fields["disk_exclude_fstypes"]["default_value"].split(","))
+        assert DEFAULT_EXCLUDE_FSTYPES.split(",") == fields["disk_exclude_fstypes"]["default_value"].split(",")
+        assert {"vfat", "exfat", "fat", "fat32"} <= exclude_types
+        assert "ntfs" not in exclude_types
+        assert fields["disk_include_fstypes"]["tooltip"]
+        assert fields["disk_exclude_fstypes"]["tooltip"]
+        assert DEFAULT_EXCLUDE_FSTYPES in template_text
+
+    assert API_MONITOR_PATH.read_text().count(DEFAULT_EXCLUDE_FSTYPES) == 2
+
+
+if __name__ == "__main__":
+    test_all_host_templates_expose_fstype_allow_and_deny_lists()
+    test_host_telegraf_template_filters_only_disk_measurements_by_fstype()
+    test_all_disk_metrics_keep_path_and_fstype_dimensions()
+    test_host_disk_aggregation_keeps_path_and_fstype()
+    test_all_host_disk_configs_default_exclude_usb_filesystems_and_explain_filtering()

--- a/server/apps/monitor/tests/test_host_disk_metric_contract.py
+++ b/server/apps/monitor/tests/test_host_disk_metric_contract.py
@@ -33,6 +33,7 @@ def test_all_host_templates_expose_fstype_allow_and_deny_lists():
 def test_host_telegraf_template_filters_only_disk_measurements_by_fstype():
     template = (PLUGIN_PATHS["host"] / "disk.child.toml.j2").read_text()
 
+    assert "ignore_fs" not in template
     assert "[[processors.starlark]]" in template
     assert 'namepass = ["disk"]' in template
     assert 'metric.tags.get("fstype", "")' in template

--- a/server/apps/monitor/tests/test_host_disk_metric_contract.py
+++ b/server/apps/monitor/tests/test_host_disk_metric_contract.py
@@ -64,6 +64,8 @@ def test_all_host_disk_configs_default_exclude_usb_filesystems_and_explain_filte
         assert "ntfs" not in exclude_types
         assert fields["disk_include_fstypes"]["tooltip"]
         assert fields["disk_exclude_fstypes"]["tooltip"]
+        assert fields["disk_include_fstypes"]["guide_short"]
+        assert fields["disk_exclude_fstypes"]["guide_short"]
         assert DEFAULT_EXCLUDE_FSTYPES in template_text
         assert f"disk_exclude_fstypes | default('{DEFAULT_EXCLUDE_FSTYPES}')" in template_text
         assert f"disk_exclude_fstypes | default('{DEFAULT_EXCLUDE_FSTYPES}', true)" not in template_text

--- a/server/apps/monitor/tests/test_host_disk_metric_contract.py
+++ b/server/apps/monitor/tests/test_host_disk_metric_contract.py
@@ -65,6 +65,8 @@ def test_all_host_disk_configs_default_exclude_usb_filesystems_and_explain_filte
         assert fields["disk_include_fstypes"]["tooltip"]
         assert fields["disk_exclude_fstypes"]["tooltip"]
         assert DEFAULT_EXCLUDE_FSTYPES in template_text
+        assert f"disk_exclude_fstypes | default('{DEFAULT_EXCLUDE_FSTYPES}')" in template_text
+        assert f"disk_exclude_fstypes | default('{DEFAULT_EXCLUDE_FSTYPES}', true)" not in template_text
 
     assert API_MONITOR_PATH.read_text().count(DEFAULT_EXCLUDE_FSTYPES) == 2
 

--- a/server/apps/monitor/tests/test_plugin_controller.py
+++ b/server/apps/monitor/tests/test_plugin_controller.py
@@ -3,6 +3,8 @@
 聚焦 TOML 转义/内联表、模板上下文归一化、Jinja 模板渲染、模板按采集器分组。
 """
 
+from pathlib import Path
+
 import pytest
 
 from apps.core.exceptions.base_app_exception import BaseAppException
@@ -102,6 +104,26 @@ class TestRenderTemplate:
         )
         assert isinstance(out, str)
         assert out.startswith("expect = ")
+
+    def test_host_os_disk_template_uses_defaults_when_fstype_config_is_missing(self):
+        """回归：Host/OS 磁盘模板缺省文件系统过滤配置时仍可通过 default 渲染。"""
+        template_path = (
+            Path(__file__).resolve().parents[1]
+            / "support-files/plugins/Telegraf/host/os/disk.child.toml.j2"
+        )
+        template_content = template_path.read_text()
+
+        out = Controller({}).render_template(
+            template_content,
+            {
+                "instance_id": "('host-1',)",
+                "instance_type": "host",
+                "interval": "60",
+            },
+        )
+
+        assert 'disk_include_fstypes = ""' in out
+        assert 'disk_exclude_fstypes = "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32"' in out
 
 
 @pytest.mark.django_db

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -36,6 +36,8 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "credential_encoding",
     "database",
     "dbname",
+    "disk_exclude_fstypes",
+    "disk_include_fstypes",
     "endpoint",
     "expect",
     "host",

--- a/web/scripts/monitor-config-renderer-tooltip-test.mjs
+++ b/web/scripts/monitor-config-renderer-tooltip-test.mjs
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const rendererPath = path.join(
+  process.cwd(),
+  'src/app/monitor/hooks/integration/useConfigRenderer.tsx'
+);
+const source = fs.readFileSync(rendererPath, 'utf8');
+
+const expectations = [
+  [
+    /guide_short\s*,\s*tooltip/,
+    'UI.json 的 tooltip 字段应被配置表单读取'
+  ],
+  [
+    /const guideTip = guide_short \|\| tooltip;/,
+    'tooltip 应作为 guide_short 的兼容兜底'
+  ],
+  [
+    /<FieldGuideTip short=\{guideTip\} \/>/,
+    '字段标签应将 tooltip 内容传给悬浮指引组件'
+  ]
+];
+
+const failures = expectations
+  .filter(([pattern]) => !pattern.test(source))
+  .map(([, message]) => message);
+
+if (failures.length) {
+  console.error(failures.map((failure) => `- ${failure}`).join('\n'));
+  process.exit(1);
+}
+
+console.log('monitor config renderer tooltip support OK');

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -33,9 +33,11 @@ export const useConfigRenderer = () => {
       rules = [],
       description,
       editable,
-      guide_short
+      guide_short,
+      tooltip
     } = fieldConfig;
-    const hasGuideTip = Boolean(guide_short);
+    const guideTip = guide_short || tooltip;
+    const hasGuideTip = Boolean(guideTip);
 
     if (type === 'hidden') {
       return (
@@ -235,7 +237,7 @@ export const useConfigRenderer = () => {
                   hasGuideTip ? (
                     <span className="inline-flex items-center">
                       {label}
-                      <FieldGuideTip short={guide_short} />
+                      <FieldGuideTip short={guideTip} />
                     </span>
                   ) : (
                     label
@@ -274,7 +276,7 @@ export const useConfigRenderer = () => {
           hasGuideTip ? (
             <span className="inline-flex items-center">
               {label}
-              <FieldGuideTip short={guide_short} />
+              <FieldGuideTip short={guideTip} />
             </span>
           ) : (
             label


### PR DESCRIPTION
## 变更说明

- 三种主机采集模板新增文件系统类型白名单和黑名单，黑名单优先。
- Disk 指标增加 path、fstype 维度，并更新聚合维度。
- Host Remote 使用监控专属磁盘采集片段；未修改通用 disk.sh、disk.ps1。

## 验证

- 107 项 Stargazer 定向回归通过。
- 主机三模板指标/配置静态契约通过。
- Python 编译检查通过。