### PR TITLE
fix(monitor): initialize metrics JetStream stream

### DIFF
--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -114,6 +114,7 @@ class Command(BaseCommand):
         """监控资源初始化"""
         self.stdout.write("初始化监控资源...")
         call_command("plugin_init")
+        call_command("ensure_monitor_metrics_stream")
 
     def _init_node_mgmt(self):
         """节点管理初始化"""

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -52,10 +52,13 @@ class TestHandleDispatch:
         names = [c[0] for c in calls]
         assert names == ["node_init"]
 
-    def test_monitor_app_runs_plugin_init(self, calls):
+    def test_monitor_app_initializes_plugins_and_metrics_stream(self, calls):
         cmd = _make_command()
         cmd.handle(apps="monitor", continue_on_error=False)
-        assert [c[0] for c in calls] == ["plugin_init"]
+        assert [c[0] for c in calls] == [
+            "plugin_init",
+            "ensure_monitor_metrics_stream",
+        ]
 
     def test_multiple_apps_dispatched_in_order(self, calls):
         cmd = _make_command()
@@ -133,6 +136,24 @@ class TestErrorHandlingPolicy:
             cmd.handle(apps="monitor,log", continue_on_error=False)
         assert "log_init" not in calls
         assert any("ERR:" in m and "monitor" in m for m in cmd.stdout.messages)
+
+    def test_metrics_stream_failure_aborts_monitor_initialization(self, monkeypatch):
+        calls = []
+
+        def fake_call_command(name, *args, **kwargs):
+            calls.append(name)
+            if name == "ensure_monitor_metrics_stream":
+                raise RuntimeError("JetStream unavailable")
+
+        monkeypatch.setattr(bi, "call_command", fake_call_command)
+        monkeypatch.setattr(bi, "preload_language_cache", lambda *a, **k: {"loaded": [], "skipped": [], "failed": []})
+        cmd = _make_command()
+
+        with pytest.raises(RuntimeError, match="JetStream unavailable"):
+            cmd.handle(apps="monitor,log", continue_on_error=False)
+
+        assert calls == ["plugin_init", "ensure_monitor_metrics_stream"]
+        assert any("ERR:" in m and "初始化 monitor 失败: JetStream unavailable" in m for m in cmd.stdout.messages)
 
     def test_continue_on_error_runs_remaining_apps_and_reports_failures(self, monkeypatch):
         calls = []

--- a/server/apps/monitor/management/commands/ensure_monitor_metrics_stream.py
+++ b/server/apps/monitor/management/commands/ensure_monitor_metrics_stream.py
@@ -1,0 +1,54 @@
+"""声明监控指标的 JetStream 流。"""
+
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+
+from nats_client.clients import ensure_stream_sync
+
+
+MONITOR_METRICS_STREAM_NAME = "BK_MONITOR_METRICS"
+MONITOR_METRICS_SUBJECTS = ["metrics.*"]
+# 采集端短暂不可用时仍可回放；上限同时受 NATS 服务端总文件存储限制约束。
+MONITOR_METRICS_MAX_AGE_SECONDS = 3 * 24 * 60 * 60
+MONITOR_METRICS_MAX_BYTES = 1024 * 1024 * 1024
+
+
+def _positive_int_from_env(name: str, default: int) -> int:
+    value = os.getenv(name, str(default)).strip()
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        raise CommandError(f"{name} 必须是正整数，当前值: {value!r}") from error
+    if parsed <= 0:
+        raise CommandError(f"{name} 必须是正整数，当前值: {value!r}")
+    return parsed
+
+
+class Command(BaseCommand):
+    help = "幂等创建或更新监控指标 JetStream 流"
+
+    def handle(self, *args, **options):
+        max_age = _positive_int_from_env(
+            "MONITOR_METRICS_STREAM_MAX_AGE_SECONDS", MONITOR_METRICS_MAX_AGE_SECONDS
+        )
+        max_bytes = _positive_int_from_env(
+            "MONITOR_METRICS_STREAM_MAX_BYTES", MONITOR_METRICS_MAX_BYTES
+        )
+        try:
+            ensure_stream_sync(
+                MONITOR_METRICS_STREAM_NAME,
+                MONITOR_METRICS_SUBJECTS,
+                max_age,
+                max_bytes,
+            )
+        except Exception as error:
+            raise CommandError(
+                "无法声明监控指标 JetStream 流；请确认 NATS 已启用 JetStream，"
+                "并检查 NATS 连通性与 MONITOR_METRICS_STREAM_MAX_BYTES 容量配置。"
+            ) from error
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"监控指标 JetStream 流已就绪: {MONITOR_METRICS_STREAM_NAME} ({', '.join(MONITOR_METRICS_SUBJECTS)})"
+            )
+        )

--- a/server/apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py
+++ b/server/apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from apps.monitor.management.commands import ensure_monitor_metrics_stream as command_module
+
+
+pytestmark = pytest.mark.unit
+
+
+def test_command_declares_expected_metrics_stream():
+    command = command_module.Command()
+    command.stdout = SimpleNamespace(write=lambda *_: None)
+    command.style = SimpleNamespace(SUCCESS=lambda message: message)
+
+    with patch.object(command_module, "ensure_stream_sync") as ensure_stream:
+        command.handle()
+
+    ensure_stream.assert_called_once_with(
+        "BK_MONITOR_METRICS",
+        ["metrics.*"],
+        3 * 24 * 60 * 60,
+        1024 * 1024 * 1024,
+    )
+
+
+def test_command_allows_stream_retention_to_be_configured(monkeypatch):
+    monkeypatch.setenv("MONITOR_METRICS_STREAM_MAX_AGE_SECONDS", "3600")
+    monkeypatch.setenv("MONITOR_METRICS_STREAM_MAX_BYTES", "2097152")
+    command = command_module.Command()
+    command.stdout = SimpleNamespace(write=lambda *_: None)
+    command.style = SimpleNamespace(SUCCESS=lambda message: message)
+
+    with patch.object(command_module, "ensure_stream_sync") as ensure_stream:
+        command.handle()
+
+    ensure_stream.assert_called_once_with(
+        "BK_MONITOR_METRICS",
+        ["metrics.*"],
+        3600,
+        2097152,
+    )
+
+
+def test_command_rejects_non_positive_stream_capacity(monkeypatch):
+    monkeypatch.setenv("MONITOR_METRICS_STREAM_MAX_BYTES", "0")
+    command = command_module.Command()
+    command.stdout = SimpleNamespace(write=lambda *_: None)
+    command.style = SimpleNamespace(SUCCESS=lambda message: message)
+
+    with patch.object(command_module, "ensure_stream_sync") as ensure_stream:
+        with pytest.raises(CommandError, match="MONITOR_METRICS_STREAM_MAX_BYTES"):
+            command.handle()
+
+    ensure_stream.assert_not_called()
+
+
+def test_command_explains_jetstream_requirement_when_declaration_fails():
+    command = command_module.Command()
+    command.stdout = SimpleNamespace(write=lambda *_: None)
+    command.style = SimpleNamespace(SUCCESS=lambda message: message)
+
+    with patch.object(
+        command_module, "ensure_stream_sync", side_effect=RuntimeError("JetStream unavailable")
+    ):
+        with pytest.raises(CommandError, match="NATS 已启用 JetStream"):
+            command.handle()


### PR DESCRIPTION
## Summary

- Declare the `BK_MONITOR_METRICS` JetStream stream during monitor initialization.
- Keep the existing `metrics.*` JetStream contract and make retention/capacity configurable.
- Provide actionable startup errors for unavailable JetStream and cover failure handling.

## Root cause

Telegraf was configured to consume `metrics.*` from JetStream, but no stream was declared automatically. This made the monitoring ingestion pipeline fail on a fresh NATS deployment.

## Validation

- `22 passed` — isolated monitor Stream and batch initialization regression tests
- Python compilation and `git diff --check`
