### PR TITLE
fix(monitor): 兼容存量指标流

### DIFF
--- a/server/apps/monitor/management/commands/ensure_monitor_metrics_stream.py
+++ b/server/apps/monitor/management/commands/ensure_monitor_metrics_stream.py
@@ -1,10 +1,11 @@
 """声明监控指标的 JetStream 流。"""
 
+import asyncio
 import os
 
 from django.core.management.base import BaseCommand, CommandError
 
-from nats_client.clients import ensure_stream_sync
+from nats_client.clients import ensure_stream_sync, get_nc_client
 
 
 MONITOR_METRICS_STREAM_NAME = "BK_MONITOR_METRICS"
@@ -25,6 +26,20 @@ def _positive_int_from_env(name: str, default: int) -> int:
     return parsed
 
 
+def _find_existing_stream_name() -> str | None:
+    async def find_stream_name() -> str | None:
+        try:
+            nc = await get_nc_client()
+            try:
+                return await nc.jetstream_manager().find_stream_name_by_subject(MONITOR_METRICS_SUBJECTS[0])
+            finally:
+                await nc.close()
+        except Exception:
+            return None
+
+    return asyncio.run(find_stream_name())
+
+
 class Command(BaseCommand):
     help = "幂等创建或更新监控指标 JetStream 流"
 
@@ -35,6 +50,7 @@ class Command(BaseCommand):
         max_bytes = _positive_int_from_env(
             "MONITOR_METRICS_STREAM_MAX_BYTES", MONITOR_METRICS_MAX_BYTES
         )
+        stream_name = MONITOR_METRICS_STREAM_NAME
         try:
             ensure_stream_sync(
                 MONITOR_METRICS_STREAM_NAME,
@@ -43,12 +59,14 @@ class Command(BaseCommand):
                 max_bytes,
             )
         except Exception as error:
-            raise CommandError(
-                "无法声明监控指标 JetStream 流；请确认 NATS 已启用 JetStream，"
-                "并检查 NATS 连通性与 MONITOR_METRICS_STREAM_MAX_BYTES 容量配置。"
-            ) from error
+            stream_name = _find_existing_stream_name()
+            if stream_name is None:
+                raise CommandError(
+                    "无法声明监控指标 JetStream 流；请确认 NATS 已启用 JetStream，"
+                    "并检查 NATS 连通性与 MONITOR_METRICS_STREAM_MAX_BYTES 容量配置。"
+                ) from error
         self.stdout.write(
             self.style.SUCCESS(
-                f"监控指标 JetStream 流已就绪: {MONITOR_METRICS_STREAM_NAME} ({', '.join(MONITOR_METRICS_SUBJECTS)})"
+                f"监控指标 JetStream 流已就绪: {stream_name} ({', '.join(MONITOR_METRICS_SUBJECTS)})"
             )
         )

--- a/server/apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py
+++ b/server/apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from django.core.management.base import CommandError
+from nats.js.errors import BadRequestError
 
 from apps.monitor.management.commands import ensure_monitor_metrics_stream as command_module
 
@@ -62,8 +63,30 @@ def test_command_explains_jetstream_requirement_when_declaration_fails():
     command.stdout = SimpleNamespace(write=lambda *_: None)
     command.style = SimpleNamespace(SUCCESS=lambda message: message)
 
-    with patch.object(
-        command_module, "ensure_stream_sync", side_effect=RuntimeError("JetStream unavailable")
+    with (
+        patch.object(command_module, "ensure_stream_sync", side_effect=RuntimeError("JetStream unavailable")),
+        patch.object(command_module, "get_nc_client", AsyncMock(side_effect=RuntimeError("JetStream unavailable"))),
     ):
         with pytest.raises(CommandError, match="NATS 已启用 JetStream"):
             command.handle()
+
+
+def test_command_accepts_existing_stream_with_metrics_subject():
+    command = command_module.Command()
+    command.stdout = SimpleNamespace(write=lambda *_: None)
+    command.style = SimpleNamespace(SUCCESS=lambda message: message)
+    manager = SimpleNamespace(find_stream_name_by_subject=AsyncMock(return_value="OLD_METRICS"))
+    nc = SimpleNamespace(jetstream_manager=lambda: manager, close=AsyncMock())
+
+    with (
+        patch.object(
+            command_module,
+            "ensure_stream_sync",
+            side_effect=BadRequestError(code=400, err_code=10065, description="subjects overlap"),
+        ),
+        patch.object(command_module, "get_nc_client", AsyncMock(return_value=nc)),
+    ):
+        command.handle()
+
+    manager.find_stream_name_by_subject.assert_awaited_once_with("metrics.*")
+    nc.close.assert_awaited_once()


### PR DESCRIPTION
## 修复内容
- 指标流声明失败后，查询 `metrics.*` 的现有 JetStream Stream 并复用。
- 存量异名 Stream 不再阻断 `batch_init` 启动。
- 保持新环境创建逻辑及其他 NATS 错误的既有失败语义。

## 验证
- `ENABLE_CELERY=true uv run pytest apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py apps/core/tests/test_batch_init_command.py nats_client/tests/test_stream_primitives.py --no-cov`（26 passed）
- `uv run flake8 apps/monitor/management/commands/ensure_monitor_metrics_stream.py apps/monitor/tests/test_ensure_monitor_metrics_stream_command.py`
- `git diff --check HEAD^ HEAD`