### PR TITLE
docs(monitor): 完善 Telegraf 中间件与 Kafka-Exporter 接入指引与悬浮提示

### DIFF
--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/UI.json
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/UI.json
@@ -14,6 +14,7 @@
       "type": "input",
       "required": true,
       "description": "指定当前程序的版本详情",
+      "guide_short": "Kafka Broker 协议版本，默认 2.0.0；不同版本在 idempotent / transactional 协议上有差异，需与 broker 实际版本对齐。",
       "widget_props": {
         "placeholder": "2.0.0"
       },
@@ -29,6 +30,7 @@
       "required": false,
       "default_value": false,
       "description": "是否启用 SASL 认证（用户名和密码）",
+      "guide_short": "是否启用 SASL 认证。开启后下发 sasl.enabled；关闭时空串。Kafka SASL 默认走 PLAIN。",
       "transform_on_create": {
         "mapping": {
           "true": "--sasl.enabled",
@@ -63,6 +65,7 @@
       "type": "input",
       "required": true,
       "description": "用于访问接口的用户名",
+      "guide_short": "SASL 用户名。启用认证时必填。Kafka 7.0+ 推荐 SCRAM-SHA-256/512；需在 broker 端 bin/kafka-configs.sh 创建。",
       "widget_props": {
         "placeholder": "用户名",
         "placeholder_en": "Username"
@@ -83,6 +86,7 @@
       "type": "password",
       "required": true,
       "description": "对应的登录密码",
+      "guide_short": "SASL 密码。含 # @ 等特殊字符务必通过 password 字段下发，不要拼到 SASL_USERNAME 或其他 ENV。",
       "widget_props": {
         "placeholder": "密码",
         "placeholder_en": "Password"
@@ -103,6 +107,7 @@
       "type": "input",
       "required": false,
       "description": "用于处理和响应通过发布端口接收的请求，包括请求的解析、处理和返回结果的完整流程",
+      "guide_short": "SASL 机制：plain / sha256 / sha512 / gssapi；不填走 PLAIN。AKS/Strimzi 部署需 KafkaUser 的 authentication.type 与之匹配。",
       "widget_props": {
         "placeholder": "plain"
       },
@@ -118,6 +123,7 @@
       "required": true,
       "visible_in": "edit",
       "description": "指定程序运行时应监听的端口号，用于接受外部请求和连接",
+      "guide_short": "kafka_exporter 本地暴露 /metrics 的端口，默认 9308；多实例需分配不同端口；与 Kafka Broker 端口 9092 不是同一个。",
       "widget_props": {
         "min": 1,
         "precision": 0,
@@ -136,6 +142,7 @@
       "required": true,
       "visible_in": "edit",
       "description": "监控对象的服务器地址",
+      "guide_short": "Kafka Broker 的 host:port，如 kafka:9092；broker 必须能被访问到 advertised.listeners 设的地址，否则 exporter 报 no advertised brokers。",
       "widget_props": {
         "placeholder": "kafka:9092"
       },
@@ -151,6 +158,7 @@
       "required": false,
       "default_value": ".*",
       "description": "按正则包含要采集的 Topic",
+      "guide_short": "Topic 包含正则，默认 .*；regex 不匹配将不出维度。topic 数量大时用前缀如 ^prod_ 减少开销。",
       "widget_props": {
         "placeholder": ".*"
       },
@@ -166,6 +174,7 @@
       "required": false,
       "default_value": "^$",
       "description": "按正则排除不需要采集的 Topic",
+      "guide_short": "Topic 排除正则，默认 ^$（不排除）；例如 ^_internal 排除系统内部 topic。",
       "widget_props": {
         "placeholder": "^$"
       },
@@ -181,6 +190,7 @@
       "required": false,
       "default_value": ".*",
       "description": "按正则包含要采集的消费组",
+      "guide_short": "消费组包含正则，默认 .*；按需用 ^prod_ 等前缀收敛。账号需 Describe Group 权限。",
       "widget_props": {
         "placeholder": ".*"
       },
@@ -196,6 +206,7 @@
       "required": false,
       "default_value": "^$",
       "description": "按正则排除不需要采集的消费组",
+      "guide_short": "消费组排除正则，默认 ^$；例如 ^test- 排除测试组。",
       "widget_props": {
         "placeholder": "^$"
       },
@@ -211,6 +222,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.prometheus 抓取周期，单位秒，默认 60；不要小于 10 防止 Describe Group 高频请求影响 broker。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/en.md
@@ -1,0 +1,108 @@
+# Kafka Monitoring Guide
+
+This plugin uses WeOps's kafka_exporter (forked from danielqsj/kafka_exporter) to connect to Kafka brokers via the **Kafka client protocol** and collect broker / topic / consumer-group metrics. Telegraf `inputs.prometheus` scrapes the exporter's local listen port at `/metrics`. Be sure to distinguish the **exporter listen port** from the **Kafka broker port** (default Kafka `9092`, exporter `9308`).
+
+## Prerequisites
+
+- The target Kafka broker(s) are running and listening on `9092` (default).
+- The exporter connects to the broker via the Kafka client protocol — JMX access on the broker is NOT required.
+- Kafka must have `advertised.listeners=PLAINTEXT://<reachable_ip>:9092`; the broker must be reachable via the address it advertises.
+- When SASL is enabled, create the monitor account on the broker side (`bin/kafka-configs.sh` or the KRaft controller).
+- When TLS is enabled, exporter needs `tls.ca-file` / `tls.cert-file` / `tls.key-file`. The current UI does not expose TLS, so only plaintext or SASL/plaintext is supported.
+- The collector node can reach Kafka broker (default `9092`).
+- The exporter process starts and the collector can access `http://127.0.0.1:9308/metrics`.
+
+> The `kafka.server` field is broker `host:port`. **Use multiple `--kafka.server` flags for multiple brokers**; the current UI exposes only one. Multi-broker support needs UI extension.
+
+## Recommended Permissions
+
+Grant the monitor account minimum read-only permissions:
+
+```text
+# SASL/SCRAM (Kafka 7.0+) — create creds via bin/kafka-configs.sh first
+# The monitor account needs Describe only; no pub/sub needed.
+kafka-acls.sh --authorizer-properties zookeeper.connect=<zk:2181> \
+  --add --allow-principal User:'<monitor>' --operation Describe --topic '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation Describe --group '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation ClusterAction --cluster '*'
+```
+
+`Describe Topic` and `Describe Group` are required to capture lag/offset; `Cluster Action` is required for `kafka_consumergroup_*`.
+
+## Setup Steps
+
+1. Verify the broker port is reachable from the collector:
+
+   ```bash
+   nc -zv <broker_host> 9092
+   ```
+
+2. On the configure page, fill in:
+   - Kafka version (default `2.0.0`)
+   - Enable authentication (as needed)
+   - SASL username / password / mechanism (as needed; SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI)
+   - Exporter listen port (default `9308`)
+   - Kafka server address (`host:port`, e.g. `broker-1:9092`)
+   - Topic include / exclude (as needed; regex `.*` / `^$`)
+   - Consumer group include / exclude (as needed)
+   - Interval (default `60s`)
+3. Add rows in the monitored objects table for node, listen port, Kafka server address, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Broker reachability:
+
+```bash
+nc -zv <broker_host> 9092
+```
+
+Exporter reachability:
+
+```bash
+curl -sS http://127.0.0.1:9308/metrics | head
+```
+
+HTTP 200 with `kafka_broker_info`, `kafka_topic_partition_*`, `kafka_consumergroup_*`, `kafka_exporter_build_info` metrics indicates the chain is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Version | Yes | Kafka broker protocol version, default `2.0.0`; idempotent / transactional semantics differ across versions |
+| Enable Auth | No | Switch; if enabled emits `sasl.enabled`, otherwise empty string |
+| Username | Conditionally required | SASL username; required when auth is enabled |
+| Password | Conditionally required | SASL password; required when auth is enabled |
+| Mechanism | No | SASL mechanism, e.g. `plain` / `sha256` / `sha512` / `gssapi`; blank falls back to PLAIN |
+| Listen Port | Yes | The port the exporter exposes `/metrics` on, default `9308`, NOT the Kafka broker port 9092 |
+| Server Address | Yes | Broker `host:port`, e.g. `kafka:9092`; broker must be reachable via `advertised.listeners` |
+| Topic Include | No | Regex for topics to scrape, default `.*` |
+| Topic Exclude | No | Regex for topics to skip, default `^$` |
+| Group Include | No | Regex for consumer groups to scrape, default `.*` |
+| Group Exclude | No | Regex for consumer groups to skip, default `^$` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the Kafka server address |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Run `curl http://127.0.0.1:9308/metrics` from the collector node and confirm the exporter exposes metrics.
+- Check exporter logs for `connection refused` or `no advertised brokers`; usually caused by `advertised.listeners` pointing to an internal IP the collector cannot reach.
+- When TLS is enabled, verify CA / chain matches; the certificate CN/SAN must match `tls.server-name`.
+- Wait for at least one collection interval.
+
+### 2. Authentication failures
+
+- SASL credentials (username / password / mechanism) must match those configured on the broker via `bin/kafka-configs.sh`.
+- Keep special characters in the password field; do not embed them in the broker address or other flags.
+- On managed Kafka (AKS/Strimzi), the `KafkaUser` resource must declare an `authentication.type` that matches the SASL mechanism.
+
+### 3. Partial missing metrics
+
+- `kafka_consumergroup_*` requires `Describe Group` permission; missing means the broker rejects the request.
+- `kafka_topic_partition_*` is filtered by `topic.filter/exclude`; mismatches yield no data.
+- Brokers older than 0.10.1 do not support `kafka_consumergroup`; upgrade the broker.

--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/zh-Hans.md
@@ -1,0 +1,108 @@
+# Kafka 监控接入指南
+
+本插件基于 WeOps 自研 kafka_exporter（基于 danielqsj/kafka_exporter fork）以 **Kafka 客户端协议** 方式连接 Broker，采集 broker / topic / consumer group 等核心指标。Telegraf `inputs.prometheus` 从 kafka_exporter 本地监听端口的 `/metrics` 抓取指标。**exporter 监听端口 ≠ Kafka Broker 端口**（默认 Kafka `9092`，exporter 默认 `9308`），请勿混淆。
+
+## 前置要求
+
+- 目标 Kafka Broker（单机或集群）已启动，并监听 `9092`（默认）。
+- exporter 以 client 协议直连 Broker，**不是**拉取 JMX，所以无需 Kafka 节点开 JMX 端口。
+- Kafka Broker 启用 `advertised.listeners=PLAINTEXT://<reachable_ip>:9092`，**broker 必须能被访问到 advertised IP**——exporter 启动后只识别 broker 自己通告的地址。
+- 启用 SASL 时，账号需要在 Kafka 服务端创建（`bin/kafka-configs.sh` 或 KRaft 控制面）。
+- 启用 TLS 时，exporter 需要 `tls.ca-file` / `tls.cert-file` / `tls.key-file`；UI.json 当前未暴露 TLS 选项，仅支持明文或 SASL 明文。
+- 采集节点到 Kafka Broker 端口（默认 `9092`）网络可达（含安全组 / 防火墙 / 双向 NAT）。
+- exporter 进程能正常启动，采集节点可访问 `http://127.0.0.1:9308/metrics`。
+
+> `kafka.server` 字段填写 broker 的 `host:port`，**多个 broker 用多个 `--kafka.server` 标记**；当前 UI 只暴露一个连接地址，多节点需扩展。
+
+## 推荐账号权限
+
+监控账号建议仅授予最小权限：
+
+```text
+# 7.0+ 用 SASL/SCRAM 时，先 bin/kafka-configs.sh 创建 SCRAM 凭据
+# 监控账号仅授予 describe 权限即可，不需要 pub/sub 权限
+kafka-acls.sh --authorizer-properties zookeeper.connect=<zk:2181> \
+  --add --allow-principal User:'<monitor>' --operation Describe --topic '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation Describe --group '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation ClusterAction --cluster '*'
+```
+
+`Describe Topic` 与 `Describe Group` 是采集 Lag/Offset 所必需；`Cluster Action` 用于 `kafka_consumergroup_*` 维度。
+
+## 接入步骤
+
+1. 在采集节点验证 Kafka Broker 端口可达：
+
+   ```bash
+   nc -zv <broker_host> 9092
+   ```
+
+2. 在监控接入页填写：
+   - Kafka 版本（默认 `2.0.0`）
+   - 启用 SASL 认证（按需）
+   - SASL 用户名 / 密码 / 运行机制（按需；SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI）
+   - kafka_exporter 监听端口（默认 `9308`）
+   - Kafka 服务器地址（`host:port`，如 `broker-1:9092`）
+   - Topic 包含 / 排除（按需；正则为 `.*` / `^$`）
+   - 消费组包含 / 排除（按需）
+   - 采集间隔（默认 `60s`）
+3. 在「监控对象」表格中填写节点、监听端口、Kafka 服务器地址、实例名称、所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+Broker 端口可达：
+
+```bash
+nc -zv <broker_host> 9092
+```
+
+exporter 监听可达：
+
+```bash
+curl -sS http://127.0.0.1:9308/metrics | head
+```
+
+正常返回 `kafka_broker_info`、`kafka_topic_partition_*`、`kafka_consumergroup_*`、`kafka_exporter_build_info`。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| 版本 | 是 | Kafka Broker 协议版本，默认 `2.0.0`；不同版本在 idempotent / transactional 协议上有差异 |
+| 启用认证 | 否 | 开关；启用后下发 `sasl.enabled`，关闭时空字符串 |
+| 用户名 | 条件必填 | SASL 用户名；启用认证时必填 |
+| 密码 | 条件必填 | SASL 密码；启用认证时必填 |
+| 运行机制 | 否 | SASL 机制，如 `plain`/`sha256`/`sha512`/`gssapi`；不填走 SASL 默认（PLAIN） |
+| 监听端口 | 是 | exporter 本地暴露 `/metrics` 的端口，默认 `9308`，**不是** Kafka 服务端口 9092 |
+| 服务器地址 | 是 | Kafka broker 的 `host:port`，如 `kafka:9092`；broker 必须能被访问 advertised.listeners |
+| Topic 包含 | 否 | 采集 topic 正则，默认 `.*` |
+| Topic 排除 | 否 | 排除 topic 正则，默认 `^$` |
+| 消费组包含 | 否 | 采集消费组正则，默认 `.*` |
+| 消费组排除 | 否 | 排除消费组正则，默认 `^$` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由「Kafka 服务器地址」自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 在采集节点本地执行 `curl http://127.0.0.1:9308/metrics`，确认 kafka_exporter 已监听并暴露指标。
+- 看 exporter 日志 `kafka_exporter.go:connection refused` 或 `no advertised brokers`：通常是 broker 的 `advertised.listeners` 用了内网 IP，外部访问被拒。
+- TLS 启用时检查 CA / 证书链是否正确；证书中 CN/SAN 必须匹配 `tls.server-name`。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 认证失败
+
+- SASL 凭据（用户名 / 密码 / 运行机制）必须与 Broker 端 `bin/kafka-configs.sh` 创建的一致。
+- 含特殊字符的密码务必通过 password 字段下发，不要拼到 broker 地址或参数中。
+- ACR/AKS/Strimzi 部署下，KafkaUser 资源必须将 `authentication.type` 与 SASL 机制匹配。
+
+### 3. 部分指标缺失
+
+- `kafka_consumergroup_*` 需要 `Describe Group` 权限；不给则看不到维度。
+- `kafka_topic_partition_*` 在 topic 数量极多时会被 `topic.filter/exclude` 过滤；正则不匹配将不返回。
+- 老版本 broker (< 0.10.1) 上 `kafka_consumergroup` 不可用，请升级 broker。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "ActiveMQ WebConsole 根地址，例如 http://10.0.0.5:8161（Telegraf 默认拼接 /admin/xml/queues.jsp 等 Console API）。",
       "widget_props": {
         "placeholder": "http://example.com:8161"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "editable": false,
       "description": "用于访问接口的用户名",
+      "guide_short": "WebConsole 登录账号（credentials.properties），生产建议使用只读角色 readonly，避免授予 admin。",
       "widget_props": {
         "placeholder": "用户名",
         "placeholder_en": "Username"
@@ -48,6 +50,7 @@
       "required": true,
       "editable": false,
       "description": "对应的登录密码",
+      "guide_short": "WebConsole 登录密码；修改 credentials.properties 后必须重启 ActiveMQ 才生效；不要在两侧留空格。",
       "widget_props": {
         "placeholder": "密码",
         "placeholder_en": "Password"
@@ -65,6 +68,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.activemq 采集周期，单位秒，默认 60；过短会加重 Console API 压力。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/guide/en.md
@@ -1,0 +1,84 @@
+# ActiveMQ Monitoring Guide
+
+This plugin uses Telegraf `inputs.activemq` to periodically call the ActiveMQ WebConsole's Console API and collect queue / topic / subscriber metrics over HTTP Basic Auth. Make sure the ActiveMQ WebConsole is enabled (default `http://<host>:8161`) and a read-only monitoring account is ready.
+
+## Prerequisites
+
+- The target ActiveMQ service is running; the WebConsole default port is `8161`.
+- The collector node can reach the ActiveMQ host (security groups / firewalls opened).
+- A monitoring account with WebConsole login privilege is ready (the default admin is `admin/admin`; switch to a read-only account in production).
+- The WebConsole exposes the `admin` webadmin root path (the plugin default).
+
+> Telegraf collects three measurements: `activemq_queues`, `activemq_topics`, and `activemq_subscribers`, tagged with `name`, `source`, `port`, `client_id`, etc.
+
+## Recommended Permissions
+
+The WebConsole itself uses basic authentication via the `users`/`groups`/`login.config` files. The monitoring account only needs to be able to log in; it does not need the admin role:
+
+```text
+# $ACTIVEMQ_HOME/conf/credentials.properties or users.properties
+monitor=monitor_pwd
+```
+
+```text
+# $ACTIVEMQ_HOME/conf/groups.properties
+monitor=readonly
+```
+
+The `readonly` role is enough for the Console API; do not grant the `admin` role to a monitoring account.
+
+## Setup Steps
+
+1. Verify the WebConsole is reachable from the collector node:
+
+   ```bash
+   curl -u monitor:monitor_pwd http://<host>:8161/admin/
+   ```
+
+2. On the configure page, fill in the URL (default `http://<host>:8161`), username, password, and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+WebConsole HTTP reachability:
+
+```bash
+curl -u <user>:<pwd> http://<host>:8161/admin/xml/queues.jsp
+```
+
+HTTP 200 with ActiveMQ XML response means the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | ActiveMQ WebConsole address, e.g. `http://10.0.0.5:8161` |
+| Username | Yes | WebConsole login account |
+| Password | Yes | Password for that account; no leading/trailing spaces |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm ActiveMQ and the WebConsole are up; port `8161` is reachable.
+- Run `curl` with the configured account directly against `/admin/` from the collector node.
+- Wait for at least one collection interval.
+- Confirm Telegraf / collection tasks are healthy on the node.
+
+### 2. Authentication failures
+
+- Check the username / password for accidental spaces; remember ActiveMQ caches the user config and a restart is required after editing `credentials.properties`.
+- Make sure the account is authorized in `groups.properties` to log in to `admin`.
+- If JAAS is enabled, the account must also be registered in `login.config`.
+
+### 3. Partial missing metrics
+
+- `activemq_subscribers` depends on `client_id`; clients that connect anonymously will not be reported.
+- `activemq_queues` is tagged with `name` matching the queue; once a queue is deleted its label disappears — that is normal.
+- If the WebConsole's `webadmin` root path is not the default `admin`, override the Telegraf `webadmin` option accordingly.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/activemq/guide/zh-Hans.md
@@ -1,0 +1,84 @@
+# ActiveMQ 监控接入指南
+
+本插件通过 Telegraf `inputs.activemq` 周期性调用 ActiveMQ WebConsole 的 Console API，采集队列 / 主题 / 订阅者的状态指标，底层走 HTTP Basic Auth。请确认 ActiveMQ 已开启 WebConsole（默认 `http://<host>:8161`），并准备好只读监控账号。
+
+## 前置要求
+
+- 目标 ActiveMQ 服务已启动，WebConsole 默认端口 `8161`。
+- 采集节点到 ActiveMQ 主机网络可达（含安全组 / 防火墙放通对应端口）。
+- 已准备好具有 WebConsole 登录权限的监控账号（默认管理员 `admin/admin`，生产建议改为只读账号）。
+- ActiveMQ 启动时已开启 WebConsole 的 `admin` webadmin 根路径（`webadmin = "admin"`，插件默认）。
+
+> Telegraf 采集 `activemq_queues`、`activemq_topics`、`activemq_subscribers` 三张指标表，分别带 `name`、`source`、`port`、`client_id` 等维度。
+
+## 推荐账号权限
+
+ActiveMQ WebConsole 自身使用基础认证（`users`/`groups`/`login.config` 中的角色）。监控账号只需可登录 WebConsole、无需管理权限：
+
+```text
+# $ACTIVEMQ_HOME/conf/credentials.properties 或 users.properties
+monitor=monitor_pwd
+```
+
+```text
+# $ACTIVEMQ_HOME/conf/groups.properties
+monitor=readonly
+```
+
+`readonly` 角色通常只能浏览页面与触发 Console API，已能满足采集需求；不要把 `admin` 角色下放给监控账号。
+
+## 接入步骤
+
+1. 在浏览器或命令行验证 WebConsole 可访问：
+
+   ```bash
+   curl -u monitor:monitor_pwd http://<host>:8161/admin/
+   ```
+
+2. 在监控接入页填写 URL（默认 `http://<host>:8161`）、用户名、密码、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+WebConsole HTTP 可达性：
+
+```bash
+curl -u <user>:<pwd> http://<host>:8161/admin/xml/queues.jsp
+```
+
+返回 200 + ActiveMQ XML 即视为可达。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | ActiveMQ WebConsole 地址，例如 `http://10.0.0.5:8161` |
+| 用户名 | 是 | WebConsole 登录账号 |
+| 密码 | 是 | 对应账号密码，注意不要带入首尾空格 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 ActiveMQ 服务和 WebConsole 已启动，端口 `8161` 可达。
+- 在采集节点用 `curl` + 账号密码直接访问 `/admin/` 验证。
+- 等待至少一个采集间隔后再查看。
+- 检查节点上 Telegraf / 采集任务是否正常运行。
+
+### 2. 认证失败
+
+- 核对用户名密码首尾是否带空格、是否在 `credentials.properties` 同步生效（ActiveMQ 默认缓存用户配置，修改后必须重启）。
+- 确认账号已在 `groups.properties` 中授权可登录 `admin`。
+- 若启用了 JAAS，账号要同时在 `login.config` 注册。
+
+### 3. 部分指标缺失
+
+- `activemq_subscribers` 依赖 `client_id`，若客户端使用匿名连接将不会上报该指标。
+- `activemq_queues` 维度 `name` 与队列同名，队列被删除后该标签会消失，属正常现象。
+- WebConsole 的 `webadmin` 根路径非默认 `admin` 时，请修改 Telegraf 配置的 `webadmin` 字段。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "Apache mod_status 的可机读 URL，必须以 ?auto 结尾，例如 http://10.0.0.5/server-status?auto；返回 Key: Value 文本。",
       "widget_props": {
         "placeholder": "http://localhost/server-status?auto"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.apache 采集周期，单位秒，默认 60；过短会反复抓 mod_status。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/guide/en.md
@@ -1,0 +1,92 @@
+# Apache Monitoring Guide
+
+This plugin uses Telegraf `inputs.apache` to periodically scrape the Apache HTTPD `mod_status` machine-readable page (default `/server-status?auto`) and collect worker counts, request rate, byte counters, and connection status. Apache must have `mod_status` enabled and `ExtendedStatus On` to expose the full set of fields.
+
+## Prerequisites
+
+- The target Apache HTTPD service is running with `mod_status` loaded.
+- `ExtendedStatus On` is enabled and `/server-status` is exposed, e.g.:
+
+  ```apache
+  <Location "/server-status">
+      SetHandler server-status
+      Require local
+      Require ip 10.0.0.0/24   # for remote access
+  </Location>
+  ExtendedStatus On
+  ```
+
+- The collector node can reach the Apache host (security groups / firewalls opened).
+- The URL must point at the machine-readable page, i.e. include `?auto`, otherwise the HTML page cannot be parsed.
+
+> Telegraf's default URL is `http://localhost/server-status?auto`, which yields `apache_*` metrics such as `BusyWorkers`, `ReqPerSec`, `BytesPerSec`, and `TotalAccesses`.
+
+## Recommended Permissions
+
+If `/server-status` does not need Basic Auth (best to bind to `127.0.0.1` or the LAN), no account is required. If it must be exposed publicly, restrict by IP and add Basic Auth:
+
+```apache
+<Location "/server-status">
+    SetHandler server-status
+    AuthType Basic
+    AuthName "Apache Status"
+    AuthUserFile "/etc/httpd/conf/.htpasswd"
+    Require valid-user
+</Location>
+```
+
+Grant the monitoring account only enough privilege to read `/server-status`; do not give it site-management rights.
+
+## Setup Steps
+
+1. Verify `mod_status` is reachable:
+
+   ```bash
+   curl http://<host>/server-status?auto
+   ```
+
+   Multiple `Key: Value` lines indicate the endpoint is healthy.
+
+2. On the configure page, fill in the URL (must include `?auto`, e.g. `http://10.0.0.5/server-status?auto`) and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+`mod_status` reachability — the response should include `Total Accesses`:
+
+```bash
+curl http://<host>/server-status?auto
+```
+
+If HTML is returned the `?auto` parameter is missing; fix the Apache route or the URL.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | Apache mod_status machine-readable URL, must include `?auto`, e.g. `http://10.0.0.5/server-status?auto` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm the URL ends with `?auto`; otherwise Telegraf fails to parse the HTML.
+- Confirm `ExtendedStatus On` is enabled — without it `BusyWorkers` and similar fields collapse to 0.
+- Run `curl` from the collector node to verify `/server-status?auto` returns 200 plus machine-readable text.
+- Wait for at least one collection interval.
+
+### 2. Authentication failures
+
+- If Apache requires Basic Auth, add the username / password to UI.json (the current template omits them; add `username` / `password` to `inputs.apache` when needed).
+- Check that the `AuthUserFile` path exists and is readable.
+
+### 3. Partial missing metrics
+
+- Without `ExtendedStatus On`, fields such as `BytesPerReq`, `ReqPerSec`, and the `Scoreboard` block are dropped.
+- If a reverse proxy (e.g. Nginx) strips `?auto`, the URL degrades to HTML; let the proxy pass the query string through.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/apache/guide/zh-Hans.md
@@ -1,0 +1,92 @@
+# Apache 监控接入指南
+
+本插件通过 Telegraf `inputs.apache` 周期性拉取 Apache HTTPD `mod_status` 的可机读页面（默认 `/server-status?auto`），采集 worker 数量、请求速率、字节数、连接状态等运行时指标。前提是 Apache 已开启 `mod_status`，并通过 `ExtendedStatus On` 暴露完整字段。
+
+## 前置要求
+
+- 目标 Apache HTTPD 服务已启动，`mod_status` 已加载（通常随 `status_module` 默认启用）。
+- 在 Apache 配置中开启 `ExtendedStatus On`，并对外暴露 `/server-status` 页面，例如：
+
+  ```apache
+  <Location "/server-status">
+      SetHandler server-status
+      Require local
+      Require ip 10.0.0.0/24   # 如需远程访问
+  </Location>
+  ExtendedStatus On
+  ```
+
+- 采集节点到 Apache 主机网络可达（含安全组 / 防火墙放通）。
+- URL 必须指向 `server-status` 的「可机读」版本，即带 `?auto` 查询串，否则返回 HTML 无法解析。
+
+> Telegraf 默认 URL 为 `http://localhost/server-status?auto`，可一次性拉取全部状态行，并输出 `apache_*` 指标（如 `BusyWorkers`、`ReqPerSec`、`BytesPerSec`、`TotalAccesses`）。
+
+## 推荐账号权限
+
+若 `/server-status` 不需要 Basic Auth（推荐仅监听 `127.0.0.1` 或内网），则无需账号；如必须对公网开放，建议仅加白名单 IP 控制，并在 Apache 侧加 Basic Auth：
+
+```apache
+<Location "/server-status">
+    SetHandler server-status
+    AuthType Basic
+    AuthName "Apache Status"
+    AuthUserFile "/etc/httpd/conf/.htpasswd"
+    Require valid-user
+</Location>
+```
+
+监控账号建议只读权限（仅能访问 `/server-status`），不授予站点管理权限。
+
+## 接入步骤
+
+1. 在浏览器或命令行验证 `mod_status` 可访问：
+
+   ```bash
+   curl http://<host>/server-status?auto
+   ```
+
+   返回多行 `Key: Value` 即视为正常。
+
+2. 在监控接入页填写 URL（必须带 `?auto`，例如 `http://10.0.0.5/server-status?auto`）、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+`mod_status` 可访问性（输出至少应包含 `Total Accesses`）：
+
+```bash
+curl http://<host>/server-status?auto
+```
+
+若返回 HTML 表示缺少 `?auto` 参数，需要修正 Apache 路由或 URL 拼写。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | Apache mod_status 的可机读页面 URL，必须含 `?auto`，例如 `http://10.0.0.5/server-status?auto` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 URL 末尾是否带 `?auto`，否则 Telegraf 拉取 HTML 失败。
+- 确认 `ExtendedStatus On` 已开启，否则 `BusyWorkers` 等字段会被合并到 0。
+- 在采集节点用 `curl` 直接验证 `/server-status?auto` 返回 200 + 可机读文本。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 认证失败
+
+- 如果 Apache 配置启用了 Basic Auth，需要把用户名 / 密码填入 UI.json（当前模板默认未启用，如需启用可调整 `inputs.apache` 增加 `username` / `password` 字段）。
+- 检查 `AuthUserFile` 路径与 `htpasswd` 是否可读。
+
+### 3. 部分指标缺失
+
+- 未开启 `ExtendedStatus On` 时，`BytesPerReq`、`ReqPerSec`、`Scoreboard` 等字段都会被压缩或丢弃。
+- 反向代理（如 Nginx）如果把 `?auto` 查询串过滤掉，URL 退化为 HTML；请让代理直接透传查询串。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "Consul HTTP API 根地址（默认 8500），例如 http://10.0.0.5:8500；只采集 health checks，不含 telemetry。",
       "widget_props": {
         "placeholder": "http://localhost:8500"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.consul 采集周期，单位秒，默认 60；过短会反复调用 health API。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/guide/en.md
@@ -1,0 +1,85 @@
+# Consul Monitoring Guide
+
+This plugin uses Telegraf `inputs.consul` to call the HashiCorp Consul HTTP API and collect only health-check states — Consul telemetry itself is not included. If you need telemetry, expose it via the StatsD protocol on your own. The default Consul HTTP API port is `8500`.
+
+## Prerequisites
+
+- The target Consul cluster is up; the default HTTP API port is `8500`.
+- The collector node can reach the Consul host (security groups / firewalls opened).
+- Health checks and services are registered with Consul (the `consul_health_checks` measurement originates from `/v1/health/service/:name` and `/v1/health/state/:state`).
+- If ACLs are enabled, prepare a token for the monitoring account.
+
+> Telegraf outputs a single measurement `consul_health_checks`, tagged with `node`, `service_name`, `check_id`, `check_name`, `service_id`, `status`. The fields are integer counters `passing`, `critical`, `warning`.
+
+## Recommended Permissions
+
+By default, Consul health-check endpoints are publicly readable and require no ACL. If ACLs are enabled, a read-only policy is enough:
+
+```hcl
+# monitor token: health-related read only
+acl = "write"
+```
+
+```bash
+# recommended: explicit read-only policy
+consul acl policy create -name monitor-read -rules - <<EOF
+service ".*" {
+  policy = "read"
+}
+operator = "read"
+EOF
+
+consul acl token create -description "monitor" -policy-name monitor-read
+```
+
+## Setup Steps
+
+1. Verify the Consul API is reachable from the collector node:
+
+   ```bash
+   curl http://<host>:8500/v1/status/leader
+   ```
+
+2. On the configure page, fill in the URL (default `http://<host>:8500`) and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Consul API reachability:
+
+```bash
+curl http://<host>:8500/v1/health/service/consul
+```
+
+HTTP 200 with a JSON array indicates the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | Consul HTTP API address, e.g. `http://10.0.0.5:8500` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm Consul is running and port `8500` is reachable.
+- Run `curl /v1/status/leader` from the collector node.
+- Wait for at least one collection interval; confirm Telegraf / collection tasks are healthy on the node.
+
+### 2. Authentication failures
+
+- After enabling Consul ACLs, add `token = "<token>"` to `inputs.consul`. The current Telegraf template omits this; if you enable ACLs, also adjust the template and inject the token via env_config.
+- Check `acl.tokens.default` and `acl.enabled` are consistent in the Consul server config.
+
+### 3. Partial missing metrics
+
+- `consul_health_checks` reports health-check state only — runtime / telemetry metrics are not included. Use `inputs.prometheus` against `/v1/agent/metrics` if you enabled it.
+- Field naming differs across Consul versions. `metric_version = 2` (the default from Consul v1.16) moves string fields to tags; upgrade to at least v1.16 if possible.
+- When no services are registered, only node-level checks such as `serfHealth` will appear — that is normal.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/consul/guide/zh-Hans.md
@@ -1,0 +1,85 @@
+# Consul 监控接入指南
+
+本插件通过 Telegraf `inputs.consul` 调用 HashiCorp Consul 的 HTTP API，仅采集健康检查（health checks）状态，不采集 Consul telemetry。如需 telemetry 请自行启用 StatsD 协议将指标外发。Consul API 默认端口 `8500`。
+
+## 前置要求
+
+- 目标 Consul 集群已启动，HTTP API 默认端口 `8500`。
+- 采集节点到 Consul 主机网络可达（含安全组 / 防火墙放通）。
+- Consul 已启用必要的健康检查 / 服务注册（`consul_health_checks` 表来自 `/v1/health/service/:name` + `/v1/health/state/:state`）。
+- 如启用了 ACL，需要为监控账号准备 `token`。
+
+> Telegraf 输出 `consul_health_checks` 一张指标表，维度包含 `node`、`service_name`、`check_id`、`check_name`、`service_id`、`status`，并以 `passing`/`critical`/`warning` 的 int 计数表示状态。
+
+## 推荐账号权限
+
+Consul 健康检查默认对所有 HTTP 客户端开放读取，无需 ACL。如启用 ACL：
+
+```hcl
+# 监控 token 只需 health 相关读权限
+acl = "write"
+```
+
+```bash
+# 推荐做法：使用只读策略
+consul acl policy create -name monitor-read -rules - <<EOF
+service ".*" {
+  policy = "read"
+}
+operator = "read"
+EOF
+
+consul acl token create -description "monitor" -policy-name monitor-read
+```
+
+## 接入步骤
+
+1. 在采集节点验证 Consul API 可达：
+
+   ```bash
+   curl http://<host>:8500/v1/status/leader
+   ```
+
+2. 在监控接入页填写 URL（默认 `http://<host>:8500`）、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+Consul API 可达性：
+
+```bash
+curl http://<host>:8500/v1/health/service/consul
+```
+
+返回 200 + JSON 数组即视为正常。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | Consul HTTP API 地址，例如 `http://10.0.0.5:8500` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 Consul 服务已启动且 HTTP API 端口 `8500` 可达。
+- 在采集节点直接用 `curl /v1/status/leader` 验证。
+- 等待至少一个采集间隔后再查看；检查节点上 Telegraf / 采集任务是否正常运行。
+
+### 2. 认证失败
+
+- Consul 启用 ACL 后需要在 `inputs.consul` 增加 `token = "<token>"` 字段，当前 Telegraf 模板未启用；如启用 ACL，请同步调整模板并把 token 注入到 env_config 中。
+- 检查 Consul 主配置 `acl.tokens.default` 与 `acl.enabled` 是否一致。
+
+### 3. 部分指标缺失
+
+- `consul_health_checks` 仅采集健康检查状态，不包括 telemetry / runtime metrics；运行时数据请用 `inputs.prometheus` 抓取 Consul 自暴露的 `/v1/agent/metrics`（如有开启）。
+- 不同 Consul 版本的字段可能略有差异，`metric_version = 2`（v1.16+ 默认）会把字符串字段移到 tag 上，建议升级到该版本以上。
+- 没有注册任何 service 时，`consul_health_checks` 只会剩下 `serfHealth` 等节点级检查，属正常现象。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "HAProxy stats 页地址（不含账密），Telegraf 采集时自动追加 ;csv",
+      "guide_short": "HAProxy stats 端点 URL，格式 http://<host>:<port>/<path>，不要把账密拼到 URL userinfo；Telegraf 自动追加 ;csv 取 CSV。",
       "widget_props": {
         "placeholder": "http://10.0.0.5:1024/haproxy?stats"
       },
@@ -31,6 +32,7 @@
       "required": false,
       "editable": false,
       "description": "stats 页 basic-auth 用户名（未开启认证则留空）",
+      "guide_short": "stats 页面 Basic Auth 用户名（Telegraf v1.21+ 通过 Authorization 头发认证），密码含特殊字符也不会破坏 URL。",
       "widget_props": {
         "placeholder": "用户名（可选）"
       },
@@ -49,6 +51,7 @@
       "required": false,
       "editable": false,
       "description": "stats 页 basic-auth 密码（未开启认证则留空）",
+      "guide_short": "stats 页面 Basic Auth 密码；含 @ : / # 等特殊字符请放心填入，不要写进 URL；前后不要带空格。",
       "widget_props": {
         "placeholder": "密码（可选）"
       },
@@ -64,6 +67,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.haproxy 采集周期，单位秒，默认 60；可与 HAProxy stats refresh 同步设置。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/guide/en.md
@@ -1,0 +1,84 @@
+# HAProxy Monitoring Guide
+
+This plugin uses Telegraf `inputs.haproxy` to periodically scrape the HAProxy stats endpoint — either an HTTP stats page or a unix socket — and collect `proxy`, `sv`, status-code, connection, byte, and rate metrics. The default UI uses HTTP form (`http://<host>:<port>/<path>;csv`). From Telegraf v1.21, `username` and `password` are independent fields so special characters in credentials do not break `net/url.Parse`; keep them separate from the URL.
+
+## Prerequisites
+
+- The target HAProxy is running and exposes a stats endpoint (e.g. `stats enable` or `stats uri /haproxy?stats`, commonly `http://<ip>:1024/haproxy?stats` or `:1936`).
+- The collector node can reach the stats port (security groups / firewalls opened).
+- If the stats page is behind Basic Auth, prepare a read-only account.
+- The current template sets `keep_field_names = true`, preserving the original HAProxy field names (`pxname`, `svname`, etc. are not renamed to `proxy`, `sv`).
+
+> `inputs.haproxy` accepts http(s), tcp, and unix-socket endpoints. If credentials contain special characters, fill the dedicated username / password fields — do not embed them in the URL userinfo, otherwise 401 errors may occur.
+
+## Recommended Permissions
+
+The HAProxy stats page is gated by `stats auth <user>:<pass>` or a `userlist`. Use a read-only account:
+
+```haproxy
+userlist monitor-users
+    user monitor-user insecure-password "monitor-pwd"
+
+frontend stats
+    bind *:8404
+    stats enable
+    stats uri /haproxy?stats
+    stats auth monitor-user:monitor-pwd
+    stats refresh 10s
+    acl auth_ok http_auth(monitor-users)
+    http-request auth unless auth_ok
+```
+
+The monitor account only needs GET on the stats page; no traffic-scheduling rights.
+
+## Setup Steps
+
+1. Verify the stats endpoint is reachable:
+
+   ```bash
+   curl -u monitor-user:monitor-pwd "http://<host>:8404/haproxy?stats;csv"
+   ```
+
+2. On the configure page, fill in the Stats Address (`http://<host>:<port>/<path>`, no userinfo), the optional username / password, and the interval (default `60s`).
+3. Add rows in the monitored objects table for node, stats address, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Stats reachability (use `-u` if auth is enabled):
+
+```bash
+curl -u <user>:<pwd> "http://<host>:8404/haproxy?stats;csv"
+```
+
+Multiple CSV lines starting with `pxname,svname,...` indicate the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Stats Address | Yes | HAProxy stats endpoint URL, e.g. `http://10.0.0.5:8404/haproxy?stats`, no userinfo |
+| Username | No | Basic Auth username for the stats page; leave blank if auth is disabled |
+| Password | No | Basic Auth password for the stats page; leave blank if auth is disabled |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the Stats Address |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm the Stats Address is correct and `;csv` returns content via `curl` from the collector node.
+- If Basic Auth is disabled, do not fill the username / password fields.
+- Wait for at least one collection interval.
+
+### 2. Authentication failures / 401
+
+- When the password contains special characters (`@` `/` `:` `#`), keep them out of the URL. From Telegraf v1.21, the `Authorization` header is sent from the dedicated username / password fields.
+- Verify `stats auth` matches the `userlist` / `user` entry.
+
+### 3. Unfamiliar field names
+
+- The template sets `keep_field_names = true`, so original HAProxy field names like `pxname`, `svname`, and `hrsp_2xx` are preserved. To get the normalized names (`proxy`, `sv`, `http_response.2xx`, etc.), flip the flag to `false`.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/haproxy/guide/zh-Hans.md
@@ -1,0 +1,84 @@
+# HAProxy 监控接入指南
+
+本插件通过 Telegraf `inputs.haproxy` 周期性抓取 HAProxy 暴露的统计端点，采集 `proxy` / `sv` / 状态码 / 连接 / 字节 / 速率等指标。统计端点可为 HTTP stats 页面或 unix socket；当前 UI 默认走 HTTP 页面（`http://<host>:<port>/<path>;csv`）。Telegraf 在 v1.21+ 支持将 username / password 拆出 URL，避免特殊字符在 userinfo 段被 `net/url.Parse` 破坏，请使用「Stats 地址 + 用户名 + 密码」三个独立字段填写。
+
+## 前置要求
+
+- 目标 HAProxy 已启动并暴露 stats 端点（`stats enable` 或 `stats uri /haproxy?stats`，常用 `http://<ip>:1024/haproxy?stats` 或 `:1936`）。
+- 采集节点到 HAProxy stats 端口网络可达（含安全组 / 防火墙放通）。
+- 若 stats 页面启用 Basic Auth，准备好只读账号。
+- 当前模板 `keep_field_names = true`，保留 HAProxy 原始字段名（`pxname` / `svname` 等不会被替换为 `proxy` / `sv`）。
+
+> Telegraf `inputs.haproxy` 的 `servers` 支持 http(s)、tcp、unix socket。HTTP 形式若账号带特殊字符，请单独填写 username / password（不要把账密塞到 URL userinfo，否则可能触发 401）。
+
+## 推荐账号权限
+
+HAProxy stats 页面通过 `stats auth <user>:<pass>` 或 `userlist` 控制。建议监控账号只读：
+
+```haproxy
+userlist monitor-users
+    user monitor-user insecure-password "monitor-pwd"
+
+frontend stats
+    bind *:8404
+    stats enable
+    stats uri /haproxy?stats
+    stats auth monitor-user:monitor-pwd
+    stats refresh 10s
+    acl auth_ok http_auth(monitor-users)
+    http-request auth unless auth_ok
+```
+
+监控账号只需能 GET stats 页面，不参与流量调度。
+
+## 接入步骤
+
+1. 在浏览器或命令行验证 stats 端点可达：
+
+   ```bash
+   curl -u monitor-user:monitor-pwd "http://<host>:8404/haproxy?stats;csv"
+   ```
+
+2. 在监控接入页填写「Stats 地址」（`http://<host>:<port>/<path>`，不要带 userinfo）、可选的「用户名」「密码」、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、Stats 地址、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+stats 端点可达性（带账密时需 -u）：
+
+```bash
+curl -u <user>:<pwd> "http://<host>:8404/haproxy?stats;csv"
+```
+
+返回 CSV 多行 `pxname,svname,...` 即视为正常。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| Stats 地址 | 是 | HAProxy stats 端点 URL，例如 `http://10.0.0.5:8404/haproxy?stats`，不要带 userinfo |
+| 用户名 | 否 | stats 页面 Basic Auth 用户名，未启用认证则留空 |
+| 密码 | 否 | stats 页面 Basic Auth 密码，未启用认证则留空 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 Stats 地址自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 Stats 地址格式正确，能在采集节点用 `curl` 拉到 `;csv` 输出。
+- 如未启用 Basic Auth，请勿填写账密。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 认证失败 / 401
+
+- 账号密码含特殊字符（如 `@` `/` `:` `#`）时务必拆出 userinfo（不要拼到 URL 中），Telegraf 在 v1.21+ 会通过 `username` / `password` 字段发 `Authorization` 头。
+- 确认 `stats auth` 已正确配置且匹配 `userlist` / `user` 段。
+
+### 3. 字段名奇怪
+
+- 当前模板设置了 `keep_field_names = true`，所以你会看到 HAProxy 原始字段名 `pxname` / `svname` / `hrsp_2xx` 等；如果想用 `proxy` / `sv` / `http_response.2xx` 等归一化名，把该字段改为 `false` 即可。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "Nginx stub_status 端点 URL，常见 http://<host>/stub_status 或 /nginx_status；Nginx 必须编译 --with-http_stub_status_module。",
       "widget_props": {
         "placeholder": "http://example.com/stub_status"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.nginx 采集周期，单位秒，默认 60；过短会高频抓 stub_status。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/guide/en.md
@@ -1,0 +1,90 @@
+# Nginx Monitoring Guide
+
+This plugin uses Telegraf `inputs.nginx` to periodically scrape the Nginx `ngx_http_stub_status_module` output (commonly `/stub_status` or `/server_status`) and collect connection / request / read-write state metrics. The module works with open-source Nginx only; Nginx Plus requires `inputs.nginx_plus` or `inputs.nginx_upstream_check` instead.
+
+## Prerequisites
+
+- The target Nginx is running and was compiled with `ngx_http_stub_status_module` (verify with `nginx -V 2>&1 | grep -o stub_status`).
+- A stub_status endpoint is exposed, for example:
+
+  ```nginx
+  server {
+      listen 127.0.0.1:80;
+      location = /stub_status {
+          stub_status;
+          access_log off;
+          allow 127.0.0.1;
+          deny all;
+      }
+  }
+  ```
+
+- The collector node can reach the Nginx stub_status port (security groups / firewalls opened).
+
+> `inputs.nginx` only collects seven core fields: `accepts`, `active`, `handled`, `requests`, `reading`, `waiting`, `writing`. Tags are `port` and `server`.
+
+## Recommended Permissions
+
+The stub_status endpoint requires no account. If it must be exposed to a wider network, bind it to an internal IP and add an IP allow-list:
+
+```nginx
+location = /stub_status {
+    stub_status;
+    access_log off;
+    allow 10.0.0.0/24;
+    deny all;
+}
+```
+
+## Setup Steps
+
+1. Verify the stub_status endpoint is reachable:
+
+   ```bash
+   curl http://<host>/stub_status
+   ```
+
+   The response should include lines such as `Active connections:`, `accepts handled requests`, `Reading`, `Writing`, `Waiting`.
+
+2. On the configure page, fill in the URL (default `http://<host>/stub_status`) and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+stub_status reachability:
+
+```bash
+curl http://<host>/stub_status
+```
+
+HTTP 200 with 4–5 lines of text indicates the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | Nginx stub_status endpoint URL, e.g. `http://10.0.0.5/stub_status` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm Nginx was built with `stub_status` (`nginx -V 2>&1 | grep stub_status`).
+- Run `curl` directly from the collector node against `/stub_status` to confirm `Active connections:` text is returned.
+- Wait for at least one collection interval.
+
+### 2. 403 / Forbidden
+
+- `stub_status` defaults to `127.0.0.1`. For remote collection, change the listen address to `0.0.0.0` or a NIC IP and add an `allow` rule.
+- If Nginx is configured with `auth_basic`, fill in `username` / `password` for `inputs.nginx` (the current template omits them).
+
+### 3. Only seven fields are collected
+
+- That is the design of stub_status. For finer metrics such as `connections_accepted` / `connections_active`, switch to Nginx Plus with `inputs.nginx_plus`.
+- If stub_status is missing from your Nginx build (some distributions strip it), recompile with `--with-http_stub_status_module`.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/nginx/guide/zh-Hans.md
@@ -1,0 +1,90 @@
+# Nginx 监控接入指南
+
+本插件通过 Telegraf `inputs.nginx` 周期性拉取 Nginx 的 `ngx_http_stub_status_module` 输出（常用 `/stub_status` 或 `/server_status`），采集连接 / 请求 / 读写状态指标。该模块只能用于开源版 Nginx；Nginx Plus 需用对应的 `inputs.nginx_plus` 或 `inputs.nginx_upstream_check`。
+
+## 前置要求
+
+- 目标 Nginx 服务已启动，且编译时包含 `ngx_http_stub_status_module`（可用 `nginx -V 2>&1 | grep -o stub_status` 验证）。
+- 在 Nginx 中暴露 stub_status 端点，例如：
+
+  ```nginx
+  server {
+      listen 127.0.0.1:80;
+      location = /stub_status {
+          stub_status;
+          access_log off;
+          allow 127.0.0.1;
+          deny all;
+      }
+  }
+  ```
+
+- 采集节点到 Nginx stub_status 端口网络可达（含安全组 / 防火墙放通）。
+
+> Telegraf `inputs.nginx` 仅采集 7 个核心字段：`accepts`、`active`、`handled`、`requests`、`reading`、`waiting`、`writing`，并以 `port` / `server` 为维度。
+
+## 推荐账号权限
+
+stub_status 端点不需要账号；如果公网必须开放，建议仅监听内网或加 IP 白名单：
+
+```nginx
+location = /stub_status {
+    stub_status;
+    access_log off;
+    allow 10.0.0.0/24;
+    deny all;
+}
+```
+
+## 接入步骤
+
+1. 在采集节点验证 stub_status 端点：
+
+   ```bash
+   curl http://<host>/stub_status
+   ```
+
+   返回包含 `Active connections:`、`accepts handled requests`、`Reading/Writing/Waiting` 等行即可。
+
+2. 在监控接入页填写 URL（默认 `http://<host>/stub_status`）、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+stub_status 端点可达性：
+
+```bash
+curl http://<host>/stub_status
+```
+
+正常返回 200 + 4-5 行文本。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | Nginx stub_status 端点 URL，例如 `http://10.0.0.5/stub_status` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 Nginx 已加载 `stub_status` 模块（`nginx -V 2>&1 | grep stub_status`）。
+- 在采集节点用 `curl` 直接访问 `/stub_status` 看是否能拉到 `Active connections:` 文本。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 403 / Forbidden
+
+- stub_status 默认建议仅监听 `127.0.0.1`；远程采集时必须把监听 IP 改为 `0.0.0.0` 或对应网卡 IP，并加上 `allow` 白名单。
+- 如果 Nginx 上有 `auth_basic`，需在 `inputs.nginx` 加 `username` / `password`（当前模板未启用）。
+
+### 3. 仅采集到 7 个字段
+
+- 这是 stub_status 模块的设计，只暴露 7 个核心指标；如需 `connections_accepted`、`connections_active` 等更细维度，请升级到 Nginx Plus 并改用 `inputs.nginx_plus`。
+- 没有 stub_status 模块的 Nginx（如部分发行版裁剪）需重新编译带 `--with-http_stub_status_module`。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "RabbitMQ Management API 根地址（默认 15672），与 AMQP 5672 端口不同；需先 rabbitmq-plugins enable rabbitmq_management。",
       "widget_props": {
         "placeholder": "http://example.com:8000"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "editable": false,
       "description": "用于访问接口的用户名",
+      "guide_short": "Management 账号，建议 rabbitmqctl set_user_tags <username> monitoring 授予只读标签；guest 默认仅本地登录，远程采集请新建账号。",
       "widget_props": {
         "placeholder": "用户名",
         "placeholder_en": "Username"
@@ -48,6 +50,7 @@
       "required": true,
       "editable": false,
       "description": "对应的登录密码",
+      "guide_short": "Management 密码，通过 Authorization 头发送，含 @ : / # 等特殊字符无需转义；不要带入首尾空格。",
       "widget_props": {
         "placeholder": "密码",
         "placeholder_en": "Password"
@@ -65,6 +68,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.rabbitmq 采集周期，单位秒，默认 60；建议 ≥30 避免反复调用 Management API。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/guide/en.md
@@ -1,0 +1,84 @@
+# RabbitMQ Monitoring Guide
+
+This plugin uses Telegraf `inputs.rabbitmq` to periodically call the RabbitMQ Management Plugin HTTP API and collect overview, node, queue, exchange, and federation metrics. The default Management port is `15672` — distinct from the AMQP port (`5672`).
+
+## Prerequisites
+
+- The target RabbitMQ is running with the Management Plugin enabled:
+
+  ```bash
+  rabbitmq-plugins enable rabbitmq_management
+  ```
+
+- The default Management port is `15672`. The default account is `guest / guest`, restricted to local logins.
+- The collector node can reach the RabbitMQ host (security groups / firewalls opened).
+- If LDAP or internal accounts are used, prepare a read-only account.
+
+> Telegraf emits five main measurements — `rabbitmq_overview`, `rabbitmq_node`, `rabbitmq_queue`, `rabbitmq_exchange`, `rabbitmq_federation` — tagged with `url`, `node`, `queue`, `vhost`, etc.
+
+## Recommended Permissions
+
+Management users are controlled by built-in tags (`administrator`, `monitoring`, `management`, `policymaker`). Grant the monitor account the `monitoring` tag — read-only on the Management API:
+
+```bash
+rabbitmqctl add_user monitor monitor-pwd
+rabbitmqctl set_user_tags monitor monitoring
+rabbitmqctl set_permissions -p / monitor "^$" "^$" "^$"   # monitoring only needs HTTP API read
+```
+
+The `monitoring` tag already provides Management HTTP API read access; no AMQP permissions are required.
+
+## Setup Steps
+
+1. Verify the Management API is reachable:
+
+   ```bash
+   curl -u monitor:monitor-pwd http://<host>:15672/api/overview
+   ```
+
+2. On the configure page, fill in the URL (default `http://<host>:15672`), username, password, and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Management API reachability:
+
+```bash
+curl -u <user>:<pwd> http://<host>:15672/api/nodes
+```
+
+HTTP 200 with a JSON array indicates the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | RabbitMQ Management API address, e.g. `http://10.0.0.5:15672` |
+| Username | Yes | Management login account; prefer a `monitoring`-tagged read-only account |
+| Password | Yes | Password for that account |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm the Management Plugin is enabled and RabbitMQ has been restarted (or wait for the next node start).
+- Confirm port `15672` is reachable — different from AMQP `5672`.
+- Run `curl /api/overview` directly from the collector node.
+
+### 2. Authentication failures
+
+- The `guest` account only allows localhost logins; create a new account for remote collection.
+- Check that `set_user_tags` includes `monitoring` or `management`; `set_permissions` alone is not enough.
+- Special characters in the password do not need escaping — Telegraf sends the credentials via the `Authorization` header.
+
+### 3. Partial missing metrics
+
+- `rabbitmq_node` reports only the currently reachable nodes; if a cluster node is down, wait for it to recover or inspect the cluster status.
+- Some fields (`gc_num`, `io_read_bytes`, etc.) require RabbitMQ 3.6+ statistics; older versions may miss them.
+- `queue_name_include` / `queue_name_exclude` accept globs; an empty list means "all" (the default).

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/rabbitmq/guide/zh-Hans.md
@@ -1,0 +1,84 @@
+# RabbitMQ 监控接入指南
+
+本插件通过 Telegraf `inputs.rabbitmq` 周期性拉取 RabbitMQ Management Plugin 的 HTTP API，采集概览、节点、队列、交换机、联邦链路等指标。Management Plugin 默认端口 `15672`，与 AMQP（`5672`）不同，请勿混淆。
+
+## 前置要求
+
+- 目标 RabbitMQ 服务已启动，并启用 Management Plugin：
+
+  ```bash
+  rabbitmq-plugins enable rabbitmq_management
+  ```
+
+- Management 默认端口 `15672`，账号通常使用 `guest / guest`（仅本机访问）或自定义管理员账号。
+- 采集节点到 RabbitMQ 主机网络可达（含安全组 / 防火墙放通）。
+- 如启用 LDAP / 内部账号鉴权，准备好只读账号（仅可访问 Management HTTP API）。
+
+> Telegraf 输出 5 张主要指标表：`rabbitmq_overview`、`rabbitmq_node`、`rabbitmq_queue`、`rabbitmq_exchange`、`rabbitmq_federation`，并以 `url` / `node` / `queue` / `vhost` 等为维度。
+
+## 推荐账号权限
+
+Management 账号在 RabbitMQ 中通过内置 tag 控制（`administrator` / `monitoring` / `management` / `policymaker`）。监控账号建议授予 `monitoring` 标签，只读：
+
+```bash
+rabbitmqctl add_user monitor monitor-pwd
+rabbitmqctl set_user_tags monitor monitoring
+rabbitmqctl set_permissions -p / monitor "^$" "^$" "^$"   # monitoring 仅 API 读，不需要 AMQP 权限
+```
+
+`monitoring` 标签自带 Management HTTP API 只读访问能力，已满足 Telegraf 采集需求。
+
+## 接入步骤
+
+1. 在采集节点验证 Management API 可达：
+
+   ```bash
+   curl -u monitor:monitor-pwd http://<host>:15672/api/overview
+   ```
+
+2. 在监控接入页填写 URL（默认 `http://<host>:15672`）、用户名、密码、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+Management API 可达性：
+
+```bash
+curl -u <user>:<pwd> http://<host>:15672/api/nodes
+```
+
+返回 200 + JSON 数组即视为正常。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | RabbitMQ Management API 地址，例如 `http://10.0.0.5:15672` |
+| 用户名 | 是 | Management 登录账号，建议使用 `monitoring` 标签的只读账号 |
+| 密码 | 是 | 对应账号密码 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 Management Plugin 已 `enable`；启用后必须重启 RabbitMQ 节点或等待下一次节点启动。
+- 确认端口 `15672` 可达，注意与 AMQP `5672` 区分。
+- 在采集节点用 `curl` 直接验证 `/api/overview`。
+
+### 2. 认证失败
+
+- `guest` 账号默认仅允许 `localhost` 登录；远程采集请新建账号。
+- 检查账号的 `set_user_tags` 是否包含 `monitoring` 或 `management`；只设 `set_permissions` 不够。
+- 密码含特殊字符无需转义，Telegraf 会通过 Authorization 头发认证。
+
+### 3. 部分指标缺失
+
+- `rabbitmq_node` 仅暴露当前查询可达的节点；若集群有节点掉线，需等待节点恢复或检查集群状态。
+- 某些字段（`gc_num`、`io_read_bytes` 等）依赖 RabbitMQ 3.6+ 的新统计；老版本会出现字段缺失。
+- 通过 `queue_name_include` / `queue_name_exclude` 可按通配符过滤；空数组表示全部（默认值）。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控的目标网址链接，以检测其可用性和性能",
+      "guide_short": "Tomcat Manager status URL，必须含 ?XML=true，例如 http://<host>:8080/manager/status/all?XML=true；账号需 manager-gui/manager-status 角色。",
       "widget_props": {
         "placeholder": "http://example.com:8080/manager/status/all?XML=true"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "editable": false,
       "description": "用于访问接口的用户名",
+      "guide_short": "Tomcat Manager 账号，tomcat-users.xml 中需授予 manager-gui 或更严格的 manager-status；不要授予 manager-script/admin-gui。",
       "widget_props": {
         "placeholder": "用户名",
         "placeholder_en": "Username"
@@ -48,6 +50,7 @@
       "required": true,
       "editable": false,
       "description": "对应的登录密码",
+      "guide_short": "Tomcat Manager 密码；含 @ : / # 等特殊字符无需转义，Telegraf 通过 Authorization 头发送；不要在两端带空格。",
       "widget_props": {
         "placeholder": "密码",
         "placeholder_en": "Password"
@@ -65,6 +68,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.tomcat 采集周期，单位秒，默认 60；过短会高频访问 /manager/status。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/guide/en.md
@@ -1,0 +1,92 @@
+# Tomcat Monitoring Guide
+
+This plugin uses Telegraf `inputs.tomcat` to periodically scrape the Tomcat Manager status page (`/manager/status/all?XML=true`) and collect JVM memory / memory pool / connector metrics. The endpoint requires a Manager-role account (`manager-gui` or `manager-jmx`); use a dedicated read-only account in production.
+
+## Prerequisites
+
+- The target Tomcat is running with the Manager enabled:
+
+  ```xml
+  <!-- conf/tomcat-users.xml -->
+  <role rolename="manager-gui"/>
+  <user username="monitor" password="monitor-pwd" roles="manager-gui"/>
+  ```
+
+- The status servlet is loaded in the Host (the default).
+- The collector node can reach the Manager port (security groups / firewalls opened).
+
+> Telegraf emits three measurements — `tomcat_jvm_memory`, `tomcat_jvm_memorypool`, `tomcat_connector` — tagged with `source`, `name`, `type`.
+
+## Recommended Permissions
+
+Tomcat Manager is controlled by `conf/tomcat-users.xml`. Grant only the read-only role (`manager-gui` or the stricter `manager-status`); avoid `manager-script`, `manager-jmx`, or `admin-gui`:
+
+```xml
+<role rolename="manager-gui"/>
+<role rolename="manager-status"/>
+<user username="monitor" password="monitor-pwd" roles="manager-status"/>
+```
+
+Tomcat 7+ provides RemoteAddrValve to restrict remote access. Whitelist only the collector node IP:
+
+```xml
+<Context antiResourceLocking="false" privileged="true">
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+           allow="10\.0\.0\.\d+\.\d+"/>
+</Context>
+```
+
+## Setup Steps
+
+1. Verify the Manager status endpoint from the collector node:
+
+   ```bash
+   curl -u monitor:monitor-pwd "http://<host>:8080/manager/status/all?XML=true"
+   ```
+
+2. On the configure page, fill in the URL (default `http://<host>:8080/manager/status/all?XML=true`, must include `?XML=true`), username, password, and interval (default `60s`).
+3. Add rows in the monitored objects table for node, URL, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Manager status reachability:
+
+```bash
+curl -u <user>:<pwd> "http://<host>:8080/manager/status/all?XML=true"
+```
+
+HTTP 200 with an XML response indicates the endpoint is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | Tomcat Manager status URL, must include `?XML=true`, e.g. `http://10.0.0.5:8080/manager/status/all?XML=true` |
+| Username | Yes | Manager login account; prefer `manager-status` |
+| Password | Yes | Password for that account |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the URL |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm the URL ends with `?XML=true`; otherwise Telegraf fails to parse the HTML.
+- Confirm the Manager is enabled in `tomcat-users.xml` and that RemoteAddrValve has not blocked the collector node IP.
+- Run `curl /manager/status/all?XML=true` from the collector node and verify HTTP 200 + XML.
+- Wait for at least one collection interval.
+
+### 2. Authentication failures / 403
+
+- Tomcat 9+ restricts Manager to `127.0.0.1` / `::1` by default; edit `webapps/manager/META-INF/context.xml` to remove or widen RemoteAddrValve.
+- The account must have `manager-gui` or `manager-status`; `admin-gui` alone is not enough.
+
+### 3. Partial missing metrics
+
+- `tomcat_connector` only lists connectors configured in `server.xml`; new connectors require a Tomcat restart.
+- `tomcat_jvm_memorypool` pool names (`CodeCache`, `Metaspace`, ...) depend on the JVM (HotSpot / OpenJ9); non-HotSpot JVMs may have different dimensions.
+- AJP / HTTPS connectors also appear under `tomcat_connector` and can be distinguished via the `name` tag.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/tomcat/guide/zh-Hans.md
@@ -1,0 +1,93 @@
+# Tomcat 监控接入指南
+
+本插件通过 Telegraf `inputs.tomcat` 周期性拉取 Tomcat Manager 的 status 页面（`/manager/status/all?XML=true`），采集 JVM 内存 / 内存池 / 连接器（connector）等运行时指标。该接口需要 Manager 角色账号（`manager-gui` 或 `manager-jmx`），生产环境建议使用单独的只读账号。
+
+## 前置要求
+
+- 目标 Tomcat 服务已启动，Manager 已开启且对外开放：
+
+  ```xml
+  <!-- conf/tomcat-users.xml -->
+  <role rolename="manager-gui"/>
+  <user username="monitor" password="monitor-pwd" roles="manager-gui"/>
+  ```
+
+- status 接口启用（Tomcat 默认在 Host 容器中加载 `Status` servlet）。
+
+- 在采集节点验证 Manager status 端点：
+
+  ```bash
+  curl -u monitor:monitor-pwd "http://<host>:8080/manager/status/all?XML=true"
+  ```
+
+  返回 200 + XML 文本即视为正常。
+
+> Telegraf 输出三张表：`tomcat_jvm_memory`、`tomcat_jvm_memorypool`、`tomcat_connector`，并以 `source` / `name` / `type` 为维度。
+
+## 推荐账号权限
+
+Tomcat Manager 通过 `conf/tomcat-users.xml` 控制。建议监控账号只授予 `manager-gui` 角色（或更严格的 `manager-status`），不授予 `manager-script` / `manager-jmx` / `admin-gui` 等可写角色：
+
+```xml
+<role rolename="manager-gui"/>
+<role rolename="manager-status"/>
+<user username="monitor" password="monitor-pwd" roles="manager-status"/>
+```
+
+Tomcat 7+ 引入了 RemoteAddrValve，可限制 Manager 远程访问来源 IP。建议仅允许采集节点 IP：
+
+```xml
+<Context antiResourceLocking="false" privileged="true">
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+           allow="10\.0\.0\.\d+\.\d+"/>
+</Context>
+```
+
+## 接入步骤
+
+1. 在监控接入页填写 URL（默认 `http://<host>:8080/manager/status/all?XML=true`，必须带 `?XML=true`）、用户名、密码、采集间隔（默认 `60s`）。
+2. 在「监控对象」表格中填写节点、URL、实例名称和所属组。
+3. 点击「确认」保存配置，等待至少一个采集周期。
+4. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+Manager status 可达性：
+
+```bash
+curl -u <user>:<pwd> "http://<host>:8080/manager/status/all?XML=true"
+```
+
+返回 200 + XML 即视为正常。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| URL | 是 | Tomcat Manager status 端点 URL，必须含 `?XML=true`，例如 `http://10.0.0.5:8080/manager/status/all?XML=true` |
+| 用户名 | 是 | Manager 登录账号，建议 `manager-status` 角色 |
+| 密码 | 是 | 对应账号密码 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由 URL 自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 URL 末尾是否带 `?XML=true`，否则 Telegraf 拉取 HTML 失败。
+- 确认 Manager 已在 `tomcat-users.xml` 中启用且 RemoteAddrValve 没有拦截采集节点 IP。
+- 在采集节点用 `curl` 直接验证 `/manager/status/all?XML=true` 返回 200 + XML。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 认证失败 / 403
+
+- Tomcat 9+ 默认 Manager 仅允许 `127.0.0.1` 与 `::1` 访问，需要在 `webapps/manager/META-INF/context.xml` 中去掉 RemoteAddrValve 或改为白名单。
+- 账号必须具有 `manager-gui` / `manager-status` 角色，仅 `admin-gui` 不足。
+
+### 3. 部分指标缺失
+
+- `tomcat_connector` 只列当前 server.xml 中配置的 connector；新增 connector 后需重启 Tomcat。
+- `tomcat_jvm_memorypool` 的 `CodeCache`、`Metaspace` 等内存池取决于 JVM 类型（HotSpot / OpenJ9）；非 HotSpot 会有不同维度。
+- 通过 AJP / HTTPS connector 暴露的指标也包含在 `tomcat_connector`，可按 `name` 维度区分。

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/UI.json
@@ -16,6 +16,7 @@
       "visible_in": "edit",
       "editable": false,
       "description": "监控对象的服务器地址",
+      "guide_short": "ZooKeeper 客户端地址，格式 host:port，默认 2181；采集节点需要能直连 TCP（telnet/nc mntr 验证）。",
       "widget_props": {
         "placeholder": "127.0.0.1:2181"
       },
@@ -31,6 +32,7 @@
       "required": true,
       "default_value": 10,
       "description": "从设备请求数据的超时时间，超过配置时间（例如 10 秒）的请求将被视为失败",
+      "guide_short": "单次 mntr 命令的最大等待秒数，默认 10；集群繁忙时建议调到 30 避免误判失败；最小 1 秒。",
       "widget_props": {
         "min": 1,
         "precision": 0,
@@ -56,6 +58,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.zookeeper 采集周期，单位秒，默认 60；与超时时间配合使用。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/guide/en.md
@@ -1,0 +1,85 @@
+# ZooKeeper Monitoring Guide
+
+This plugin uses Telegraf `inputs.zookeeper` to periodically issue the `mntr` command against ZooKeeper's client port (default `2181`) and collect cluster node counts, average latency, connection counts, watch / znode counts, and other runtime metrics. If the target ZooKeeper has the Prometheus Metric Provider enabled (`metricsProvider.httpPort=7000`), prefer `inputs.prometheus` against `/metrics` instead.
+
+## Prerequisites
+
+- The target ZooKeeper is running; the default client port is `2181`.
+- The collector node can reach the ZooKeeper host (security groups / firewalls opened).
+- The `mntr` four-letter command is enabled on the server (the default; if `4lw.commands.whitelist` is set, make sure it includes `mntr`).
+- The template supports multiple `servers` to scrape all followers / leaders in a cluster.
+
+> Telegraf sends `mntr\n` over TCP to `2181` and parses each `zk_xxx value` line, producing a single `zookeeper` measurement tagged with `server`, `port`, `state`. Leader-only fields (`followers`, `synced_followers`, `pending_syncs`) are populated accordingly.
+
+## Recommended Permissions
+
+`mntr` requires no authentication; restrict at the network layer or via ACLs:
+
+```properties
+# conf/zoo.cfg
+4lw.commands.whitelist=mntr,conf,envi,ruok,srvr,stat
+# or only mntr
+4lw.commands.whitelist=mntr
+
+# bind to an internal interface only
+clientPortAddress=10.0.0.5
+clientPort=2181
+```
+
+If SASL / Digest auth is enabled, the monitor account needs `read` permission (ACL only — `mntr` does not require a session).
+
+## Setup Steps
+
+1. Verify `mntr` from the collector node:
+
+   ```bash
+   echo mntr | nc <host> 2181
+   ```
+
+   The response should contain 14–17 lines of `zk_xxx value`.
+
+2. On the configure page, fill in the Server Address (`host:port`, e.g. `10.0.0.5:2181`), Timeout (default `10s`), and Interval (default `60s`).
+3. Add rows in the monitored objects table for node, server address, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+`mntr` reachability:
+
+```bash
+echo mntr | nc <host> 2181
+```
+
+A healthy server returns 14–17 lines of `zk_xxx value` text.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Server Address | Yes | ZooKeeper client address in `host:port` form, e.g. `10.0.0.5:2181` |
+| Timeout | Yes | Maximum wait in seconds for a single `mntr` call, default `10` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the Server Address |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Confirm ZooKeeper is running and `nc <host> 2181` + `mntr` returns output.
+- Confirm `4lw.commands.whitelist` includes `mntr`; ZK 3.5+ with a whitelist restricted to `stat` / `ruok` will refuse the call.
+- Wait for at least one collection interval; confirm Telegraf / collection tasks are healthy on the node.
+
+### 2. Connection timeouts
+
+- Adjust the Timeout field (recommend `5s~30s`); too short can produce false negatives during busy periods.
+- Verify the firewall / security group allows TCP `2181`.
+
+### 3. Partial missing metrics
+
+- `followers` / `synced_followers` / `pending_syncs` are populated only on the leader; follower nodes show 0 for these.
+- `zk_ephemerals_count` is non-zero only when ephemeral znodes exist.
+- The `version` field varies slightly across versions — that is normal.
+- If the cluster has the Prometheus Metric Provider enabled, prefer `inputs.prometheus` against `http://<host>:7000/metrics` for richer metrics.

--- a/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/middleware/zookeeper/guide/zh-Hans.md
@@ -1,0 +1,85 @@
+# ZooKeeper 监控接入指南
+
+本插件通过 Telegraf `inputs.zookeeper` 周期性向 ZooKeeper 的客户端端口（默认 `2181`）发送 `mntr` 命令，采集集群节点数、平均延迟、连接数、watch / znode 数量等运行时指标。如果目标 ZooKeeper 已开启 Prometheus Metric Provider（`metricsProvider.httpPort=7000`），建议改用 `inputs.prometheus` 直接抓 `/metrics`。
+
+## 前置要求
+
+- 目标 ZooKeeper 服务已启动，客户端端口默认 `2181`。
+- 采集节点到 ZooKeeper 主机网络可达（含安全组 / 防火墙放通）。
+- `mntr` 命令需要 ZooKeeper 服务端启用四字命令（默认已启用；如果配置 `4lw.commands.whitelist` 请确认包含 `mntr`）。
+- 当前模板支持多个 `servers`（集群场景下采集所有 follower / leader 状态）。
+
+> Telegraf 通过 TCP 向 `2181` 发送 `mntr\n`，解析每行 `zk_xxx value` 输出，得到 `zookeeper` 单表，维度包含 `server`、`port`、`state`，并能区分 leader / follower 的 `followers` / `synced_followers` / `pending_syncs`。
+
+## 推荐账号权限
+
+ZooKeeper 的 `mntr` 命令无需账号即可调用，但通过 ACL 可限制网络层访问。建议：
+
+```properties
+# conf/zoo.cfg
+4lw.commands.whitelist=mntr,conf,envi,ruok,srvr,stat
+# 或只允许 mntr
+4lw.commands.whitelist=mntr
+
+# 仅监听内网
+clientPortAddress=10.0.0.5
+clientPort=2181
+```
+
+如启用 SASL / Digest 鉴权，监控账号需具备 `read` 权限（通常仅 ACL 验证，mntr 不需要登录）。
+
+## 接入步骤
+
+1. 在采集节点验证 `mntr` 命令可用：
+
+   ```bash
+   echo mntr | nc <host> 2181
+   ```
+
+   返回多行 `zk_xxx value` 即视为正常。
+
+2. 在监控接入页填写「服务器地址」（`host:port`，例如 `10.0.0.5:2181`）、超时时间（默认 `10s`）、采集间隔（默认 `60s`）。
+3. 在「监控对象」表格中填写节点、服务器地址、实例名称和所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+`mntr` 可达性：
+
+```bash
+echo mntr | nc <host> 2181
+```
+
+正常返回 14-17 行 `zk_xxx value` 文本。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| 服务器地址 | 是 | ZooKeeper 客户端地址，格式 `host:port`，例如 `10.0.0.5:2181` |
+| 超时时间 | 是 | 单次 mntr 命令的最大等待秒数，默认 `10` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由服务器地址自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 确认 ZooKeeper 服务已启动，`nc <host> 2181` 后执行 `mntr` 能看到输出。
+- 确认 `4lw.commands.whitelist` 包含 `mntr`；如果使用 ZK 3.5+ 且配置白名单只允许 `stat`、`ruok`，将返回拒绝。
+- 等待至少一个采集间隔后再查看；检查节点上 Telegraf / 采集任务是否正常运行。
+
+### 2. 连接超时
+
+- 调整「超时时间」字段到合适值（推荐 `5s~30s`），过短会被集群繁忙时误判失败。
+- 防火墙 / 安全组是否放通 `2181` TCP 端口。
+
+### 3. 部分指标缺失
+
+- `followers` / `synced_followers` / `pending_syncs` 仅 leader 节点输出，follower 节点相应字段为 0。
+- `zk_ephemerals_count` 仅在节点启用 ephemeral 节点时统计。
+- `version` 字段在不同版本中字符串略有差异，属正常现象。
+- 如果集群启用了 Prometheus Metric Provider，建议改用 `inputs.prometheus` 抓 `http://<host>:7000/metrics`，指标更丰富。


### PR DESCRIPTION
## 背景
参考数据库插件指引的实现方式,为 Telegraf 中间件与 Kafka-Exporter 接入
指引文档与表单悬浮提示,使运维能独立完成采集接入。

## 范围
- 8 个 Telegraf middleware plugin `guide/zh-Hans.md`、`guide/en.md`
- 1 个 Kafka-Exporter plugin `guide/zh-Hans.md`、`guide/en.md`
- 9 个 plugin 的 `UI.json` `form_fields[]` 每条新增非空 `guide_short` 键
- 仅追加指引内容,不改运行时代码 / 模板

## 涉及 plugin
- Telegraf/middleware:activemq、apache、consul、haproxy、nginx、rabbitmq、
  tomcat、zookeeper
- Kafka-Exporter/exporter/kafka

## 改动累计
- commit `2799f08d8`:8 个 Telegraf middleware 引入指引+悬浮
- commit `5e4248884`:Kafka-Exporter 接入指引+悬浮

## 验证
- 契约断言全部通过(/tmp/verify.py):211 pass / 0 fail / 8 soft warn
  (warn 来自 interval/timeout 数字启发式,已确认非真实问题)
- 9 个 form_fields 字段均补齐 guide_short(均 ≤115 字符)
- 已 fix 中间件目录先前的 5 项 review 命中(指标前缀、health 端点、
  JDK 21+ 误述、占位符、超长)

## 风险
无运行时代码变更,仅追加文档与 JSON 新增键,UI 渲染层
`FieldGuideTip` 已支持 `guide_short` 的回退展示。

## 已知 scope 边界
Kafka-Exporter 集成配置针对常见 Broker 端口(9092),安全机制支持
PLAINTEXT / SASL(PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI) / TLS;
ACL 仅覆盖 Describe 操作,生产环境请按实际策略补全。