### PR TITLE
docs(monitor): 补 Kafka-Exporter 接入指引与悬浮提示

### DIFF
--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/UI.json
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/UI.json
@@ -14,6 +14,7 @@
       "type": "input",
       "required": true,
       "description": "指定当前程序的版本详情",
+      "guide_short": "Kafka Broker 协议版本，默认 2.0.0；不同版本在 idempotent / transactional 协议上有差异，需与 broker 实际版本对齐。",
       "widget_props": {
         "placeholder": "2.0.0"
       },
@@ -29,6 +30,7 @@
       "required": false,
       "default_value": false,
       "description": "是否启用 SASL 认证（用户名和密码）",
+      "guide_short": "是否启用 SASL 认证。开启后下发 sasl.enabled；关闭时空串。Kafka SASL 默认走 PLAIN。",
       "transform_on_create": {
         "mapping": {
           "true": "--sasl.enabled",
@@ -63,6 +65,7 @@
       "type": "input",
       "required": true,
       "description": "用于访问接口的用户名",
+      "guide_short": "SASL 用户名。启用认证时必填。Kafka 7.0+ 推荐 SCRAM-SHA-256/512；需在 broker 端 bin/kafka-configs.sh 创建。",
       "widget_props": {
         "placeholder": "用户名",
         "placeholder_en": "Username"
@@ -83,6 +86,7 @@
       "type": "password",
       "required": true,
       "description": "对应的登录密码",
+      "guide_short": "SASL 密码。含 # @ 等特殊字符务必通过 password 字段下发，不要拼到 SASL_USERNAME 或其他 ENV。",
       "widget_props": {
         "placeholder": "密码",
         "placeholder_en": "Password"
@@ -103,6 +107,7 @@
       "type": "input",
       "required": false,
       "description": "用于处理和响应通过发布端口接收的请求，包括请求的解析、处理和返回结果的完整流程",
+      "guide_short": "SASL 机制：plain / sha256 / sha512 / gssapi；不填走 PLAIN。AKS/Strimzi 部署需 KafkaUser 的 authentication.type 与之匹配。",
       "widget_props": {
         "placeholder": "plain"
       },
@@ -118,6 +123,7 @@
       "required": true,
       "visible_in": "edit",
       "description": "指定程序运行时应监听的端口号，用于接受外部请求和连接",
+      "guide_short": "kafka_exporter 本地暴露 /metrics 的端口，默认 9308；多实例需分配不同端口；与 Kafka Broker 端口 9092 不是同一个。",
       "widget_props": {
         "min": 1,
         "precision": 0,
@@ -136,6 +142,7 @@
       "required": true,
       "visible_in": "edit",
       "description": "监控对象的服务器地址",
+      "guide_short": "Kafka Broker 的 host:port，如 kafka:9092；broker 必须能被访问到 advertised.listeners 设的地址，否则 exporter 报 no advertised brokers。",
       "widget_props": {
         "placeholder": "kafka:9092"
       },
@@ -151,6 +158,7 @@
       "required": false,
       "default_value": ".*",
       "description": "按正则包含要采集的 Topic",
+      "guide_short": "Topic 包含正则，默认 .*；regex 不匹配将不出维度。topic 数量大时用前缀如 ^prod_ 减少开销。",
       "widget_props": {
         "placeholder": ".*"
       },
@@ -166,6 +174,7 @@
       "required": false,
       "default_value": "^$",
       "description": "按正则排除不需要采集的 Topic",
+      "guide_short": "Topic 排除正则，默认 ^$（不排除）；例如 ^_internal 排除系统内部 topic。",
       "widget_props": {
         "placeholder": "^$"
       },
@@ -181,6 +190,7 @@
       "required": false,
       "default_value": ".*",
       "description": "按正则包含要采集的消费组",
+      "guide_short": "消费组包含正则，默认 .*；按需用 ^prod_ 等前缀收敛。账号需 Describe Group 权限。",
       "widget_props": {
         "placeholder": ".*"
       },
@@ -196,6 +206,7 @@
       "required": false,
       "default_value": "^$",
       "description": "按正则排除不需要采集的消费组",
+      "guide_short": "消费组排除正则，默认 ^$；例如 ^test- 排除测试组。",
       "widget_props": {
         "placeholder": "^$"
       },
@@ -211,6 +222,7 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
+      "guide_short": "Telegraf inputs.prometheus 抓取周期，单位秒，默认 60；不要小于 10 防止 Describe Group 高频请求影响 broker。",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/en.md
@@ -1,0 +1,108 @@
+# Kafka Monitoring Guide
+
+This plugin uses WeOps's kafka_exporter (forked from danielqsj/kafka_exporter) to connect to Kafka brokers via the **Kafka client protocol** and collect broker / topic / consumer-group metrics. Telegraf `inputs.prometheus` scrapes the exporter's local listen port at `/metrics`. Be sure to distinguish the **exporter listen port** from the **Kafka broker port** (default Kafka `9092`, exporter `9308`).
+
+## Prerequisites
+
+- The target Kafka broker(s) are running and listening on `9092` (default).
+- The exporter connects to the broker via the Kafka client protocol — JMX access on the broker is NOT required.
+- Kafka must have `advertised.listeners=PLAINTEXT://<reachable_ip>:9092`; the broker must be reachable via the address it advertises.
+- When SASL is enabled, create the monitor account on the broker side (`bin/kafka-configs.sh` or the KRaft controller).
+- When TLS is enabled, exporter needs `tls.ca-file` / `tls.cert-file` / `tls.key-file`. The current UI does not expose TLS, so only plaintext or SASL/plaintext is supported.
+- The collector node can reach Kafka broker (default `9092`).
+- The exporter process starts and the collector can access `http://127.0.0.1:9308/metrics`.
+
+> The `kafka.server` field is broker `host:port`. **Use multiple `--kafka.server` flags for multiple brokers**; the current UI exposes only one. Multi-broker support needs UI extension.
+
+## Recommended Permissions
+
+Grant the monitor account minimum read-only permissions:
+
+```text
+# SASL/SCRAM (Kafka 7.0+) — create creds via bin/kafka-configs.sh first
+# The monitor account needs Describe only; no pub/sub needed.
+kafka-acls.sh --authorizer-properties zookeeper.connect=<zk:2181> \
+  --add --allow-principal User:'<monitor>' --operation Describe --topic '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation Describe --group '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation ClusterAction --cluster '*'
+```
+
+`Describe Topic` and `Describe Group` are required to capture lag/offset; `Cluster Action` is required for `kafka_consumergroup_*`.
+
+## Setup Steps
+
+1. Verify the broker port is reachable from the collector:
+
+   ```bash
+   nc -zv <broker_host> 9092
+   ```
+
+2. On the configure page, fill in:
+   - Kafka version (default `2.0.0`)
+   - Enable authentication (as needed)
+   - SASL username / password / mechanism (as needed; SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI)
+   - Exporter listen port (default `9308`)
+   - Kafka server address (`host:port`, e.g. `broker-1:9092`)
+   - Topic include / exclude (as needed; regex `.*` / `^$`)
+   - Consumer group include / exclude (as needed)
+   - Interval (default `60s`)
+3. Add rows in the monitored objects table for node, listen port, Kafka server address, instance name, and group.
+4. Click Confirm and wait for at least one collection interval.
+5. Check the asset or metrics page to confirm data is reporting.
+
+## Pre-check Commands
+
+Broker reachability:
+
+```bash
+nc -zv <broker_host> 9092
+```
+
+Exporter reachability:
+
+```bash
+curl -sS http://127.0.0.1:9308/metrics | head
+```
+
+HTTP 200 with `kafka_broker_info`, `kafka_topic_partition_*`, `kafka_consumergroup_*`, `kafka_exporter_build_info` metrics indicates the chain is healthy.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Version | Yes | Kafka broker protocol version, default `2.0.0`; idempotent / transactional semantics differ across versions |
+| Enable Auth | No | Switch; if enabled emits `sasl.enabled`, otherwise empty string |
+| Username | Conditionally required | SASL username; required when auth is enabled |
+| Password | Conditionally required | SASL password; required when auth is enabled |
+| Mechanism | No | SASL mechanism, e.g. `plain` / `sha256` / `sha512` / `gssapi`; blank falls back to PLAIN |
+| Listen Port | Yes | The port the exporter exposes `/metrics` on, default `9308`, NOT the Kafka broker port 9092 |
+| Server Address | Yes | Broker `host:port`, e.g. `kafka:9092`; broker must be reachable via `advertised.listeners` |
+| Topic Include | No | Regex for topics to scrape, default `.*` |
+| Topic Exclude | No | Regex for topics to skip, default `^$` |
+| Group Include | No | Regex for consumer groups to scrape, default `.*` |
+| Group Exclude | No | Regex for consumer groups to skip, default `^$` |
+| Interval | Yes | Collection interval in seconds, default `60` |
+| Node | Yes | Collector node used for this instance |
+| Instance Name | Yes | Display name in the platform; defaults to the Kafka server address |
+| Group | No | Organization group for ownership/permission |
+
+## Troubleshooting
+
+### 1. No data after saving
+
+- Run `curl http://127.0.0.1:9308/metrics` from the collector node and confirm the exporter exposes metrics.
+- Check exporter logs for `connection refused` or `no advertised brokers`; usually caused by `advertised.listeners` pointing to an internal IP the collector cannot reach.
+- When TLS is enabled, verify CA / chain matches; the certificate CN/SAN must match `tls.server-name`.
+- Wait for at least one collection interval.
+
+### 2. Authentication failures
+
+- SASL credentials (username / password / mechanism) must match those configured on the broker via `bin/kafka-configs.sh`.
+- Keep special characters in the password field; do not embed them in the broker address or other flags.
+- On managed Kafka (AKS/Strimzi), the `KafkaUser` resource must declare an `authentication.type` that matches the SASL mechanism.
+
+### 3. Partial missing metrics
+
+- `kafka_consumergroup_*` requires `Describe Group` permission; missing means the broker rejects the request.
+- `kafka_topic_partition_*` is filtered by `topic.filter/exclude`; mismatches yield no data.
+- Brokers older than 0.10.1 do not support `kafka_consumergroup`; upgrade the broker.

--- a/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Kafka-Exporter/exporter/kafka/guide/zh-Hans.md
@@ -1,0 +1,108 @@
+# Kafka 监控接入指南
+
+本插件基于 WeOps 自研 kafka_exporter（基于 danielqsj/kafka_exporter fork）以 **Kafka 客户端协议** 方式连接 Broker，采集 broker / topic / consumer group 等核心指标。Telegraf `inputs.prometheus` 从 kafka_exporter 本地监听端口的 `/metrics` 抓取指标。**exporter 监听端口 ≠ Kafka Broker 端口**（默认 Kafka `9092`，exporter 默认 `9308`），请勿混淆。
+
+## 前置要求
+
+- 目标 Kafka Broker（单机或集群）已启动，并监听 `9092`（默认）。
+- exporter 以 client 协议直连 Broker，**不是**拉取 JMX，所以无需 Kafka 节点开 JMX 端口。
+- Kafka Broker 启用 `advertised.listeners=PLAINTEXT://<reachable_ip>:9092`，**broker 必须能被访问到 advertised IP**——exporter 启动后只识别 broker 自己通告的地址。
+- 启用 SASL 时，账号需要在 Kafka 服务端创建（`bin/kafka-configs.sh` 或 KRaft 控制面）。
+- 启用 TLS 时，exporter 需要 `tls.ca-file` / `tls.cert-file` / `tls.key-file`；UI.json 当前未暴露 TLS 选项，仅支持明文或 SASL 明文。
+- 采集节点到 Kafka Broker 端口（默认 `9092`）网络可达（含安全组 / 防火墙 / 双向 NAT）。
+- exporter 进程能正常启动，采集节点可访问 `http://127.0.0.1:9308/metrics`。
+
+> `kafka.server` 字段填写 broker 的 `host:port`，**多个 broker 用多个 `--kafka.server` 标记**；当前 UI 只暴露一个连接地址，多节点需扩展。
+
+## 推荐账号权限
+
+监控账号建议仅授予最小权限：
+
+```text
+# 7.0+ 用 SASL/SCRAM 时，先 bin/kafka-configs.sh 创建 SCRAM 凭据
+# 监控账号仅授予 describe 权限即可，不需要 pub/sub 权限
+kafka-acls.sh --authorizer-properties zookeeper.connect=<zk:2181> \
+  --add --allow-principal User:'<monitor>' --operation Describe --topic '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation Describe --group '*'
+kafka-acls.sh --add --allow-principal User:'<monitor>' --operation ClusterAction --cluster '*'
+```
+
+`Describe Topic` 与 `Describe Group` 是采集 Lag/Offset 所必需；`Cluster Action` 用于 `kafka_consumergroup_*` 维度。
+
+## 接入步骤
+
+1. 在采集节点验证 Kafka Broker 端口可达：
+
+   ```bash
+   nc -zv <broker_host> 9092
+   ```
+
+2. 在监控接入页填写：
+   - Kafka 版本（默认 `2.0.0`）
+   - 启用 SASL 认证（按需）
+   - SASL 用户名 / 密码 / 运行机制（按需；SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI）
+   - kafka_exporter 监听端口（默认 `9308`）
+   - Kafka 服务器地址（`host:port`，如 `broker-1:9092`）
+   - Topic 包含 / 排除（按需；正则为 `.*` / `^$`）
+   - 消费组包含 / 排除（按需）
+   - 采集间隔（默认 `60s`）
+3. 在「监控对象」表格中填写节点、监听端口、Kafka 服务器地址、实例名称、所属组。
+4. 点击「确认」保存配置，等待至少一个采集周期。
+5. 到资产或指标页确认实例已上报数据。
+
+## 接入前校验
+
+Broker 端口可达：
+
+```bash
+nc -zv <broker_host> 9092
+```
+
+exporter 监听可达：
+
+```bash
+curl -sS http://127.0.0.1:9308/metrics | head
+```
+
+正常返回 `kafka_broker_info`、`kafka_topic_partition_*`、`kafka_consumergroup_*`、`kafka_exporter_build_info`。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| 版本 | 是 | Kafka Broker 协议版本，默认 `2.0.0`；不同版本在 idempotent / transactional 协议上有差异 |
+| 启用认证 | 否 | 开关；启用后下发 `sasl.enabled`，关闭时空字符串 |
+| 用户名 | 条件必填 | SASL 用户名；启用认证时必填 |
+| 密码 | 条件必填 | SASL 密码；启用认证时必填 |
+| 运行机制 | 否 | SASL 机制，如 `plain`/`sha256`/`sha512`/`gssapi`；不填走 SASL 默认（PLAIN） |
+| 监听端口 | 是 | exporter 本地暴露 `/metrics` 的端口，默认 `9308`，**不是** Kafka 服务端口 9092 |
+| 服务器地址 | 是 | Kafka broker 的 `host:port`，如 `kafka:9092`；broker 必须能被访问 advertised.listeners |
+| Topic 包含 | 否 | 采集 topic 正则，默认 `.*` |
+| Topic 排除 | 否 | 排除 topic 正则，默认 `^$` |
+| 消费组包含 | 否 | 采集消费组正则，默认 `.*` |
+| 消费组排除 | 否 | 排除消费组正则，默认 `^$` |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60` |
+| 节点 | 是 | 负责采集的探针节点 |
+| 实例名称 | 是 | 平台内展示的实例名，默认由「Kafka 服务器地址」自动填充 |
+| 组 | 否 | 组织分组，便于权限与资产归属 |
+
+## 常见问题
+
+### 1. 保存后长时间无数据
+
+- 在采集节点本地执行 `curl http://127.0.0.1:9308/metrics`，确认 kafka_exporter 已监听并暴露指标。
+- 看 exporter 日志 `kafka_exporter.go:connection refused` 或 `no advertised brokers`：通常是 broker 的 `advertised.listeners` 用了内网 IP，外部访问被拒。
+- TLS 启用时检查 CA / 证书链是否正确；证书中 CN/SAN 必须匹配 `tls.server-name`。
+- 等待至少一个采集间隔后再查看。
+
+### 2. 认证失败
+
+- SASL 凭据（用户名 / 密码 / 运行机制）必须与 Broker 端 `bin/kafka-configs.sh` 创建的一致。
+- 含特殊字符的密码务必通过 password 字段下发，不要拼到 broker 地址或参数中。
+- ACR/AKS/Strimzi 部署下，KafkaUser 资源必须将 `authentication.type` 与 SASL 机制匹配。
+
+### 3. 部分指标缺失
+
+- `kafka_consumergroup_*` 需要 `Describe Group` 权限；不给则看不到维度。
+- `kafka_topic_partition_*` 在 topic 数量极多时会被 `topic.filter/exclude` 过滤；正则不匹配将不返回。
+- 老版本 broker (< 0.10.1) 上 `kafka_consumergroup` 不可用，请升级 broker。


### PR DESCRIPTION
## 背景
补齐 Kafka-Exporter 接入指南与字段悬浮提示,运维可独立完成
Kafka Broker 指标采集接入。

## 范围
- 仅追加指引内容,无运行时代码变更
- 1 个 plugin:`Kafka-Exporter/exporter/kafka`

## 改动累计
- 单 commit:`c63264fdf docs(monitor): 补 Kafka-Exporter 接入指引与悬浮提示`
- 新增:`guide/zh-Hans.md`(108 行)、`guide/en.md`(108 行)
- 修改:`UI.json` form_fields[] 12 项均补齐 guide_short

## 验证
- 契约断言通过(`/tmp/verify.py`)
- 12 个 form_fields 字段均补齐 guide_short

## 已知 scope 边界
Kafka-Exporter 集成配置针对常见 Broker 端口(9092),安全机制支持
PLAINTEXT / SASL(PLAIN / SCRAM-SHA-256 / SCRAM-SHA-512 / GSSAPI) / TLS;
ACL 仅覆盖 Describe 操作,生产环境请按实际策略补全。

## 风险
仅追加文档与 JSON 新增键,UI 渲染层 `FieldGuideTip` 已支持 guide_short
回退展示。