### PR TITLE
bugfix: 修复配置对比实时 YAML 请求契约

### DIFF
--- a/web/scripts/opspilot-diff-report-live-yaml-test.ts
+++ b/web/scripts/opspilot-diff-report-live-yaml-test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const helperPath = path.join(
+  process.cwd(),
+  'src/app/opspilot/components/custom-chat-sse/liveYamlRequest.ts'
+);
+
+assert.ok(
+  existsSync(helperPath),
+  'DiffReportCard should have a testable live YAML request contract'
+);
+
+async function main() {
+  const { buildLiveYamlRequest } = await import(pathToFileURL(helperPath).href);
+
+  const report = {
+    report_id: 'report-1',
+    title: 'Kubernetes Config Fix Preview',
+    cluster_name: 'prod-cluster',
+    skill_id: 42,
+    received_at: Date.now(),
+    items: [],
+  };
+  const item = {
+    workload_name: 'nginx-web Deployment',
+    workload_type: 'Deployment',
+    namespace: 'production',
+    severity: 'high' as const,
+    summary: 'Add resource limits',
+    before_yaml: 'resources: {}',
+    after_yaml: 'resources:\n  limits: {}',
+  };
+
+  assert.deepEqual(
+    buildLiveYamlRequest(report, item),
+    {
+      kind: 'request',
+      endpoint: '/opspilot/model_provider_mgmt/llm/fetch_k8s_deployment_yaml/',
+      payload: {
+        namespace: 'production',
+        name: 'nginx-web',
+        cluster_name: 'prod-cluster',
+        skill_id: 42,
+      },
+    },
+    'the current report-level skill_id contract should keep the concrete-namespace request compatible'
+  );
+
+  const legacyRequest = buildLiveYamlRequest(
+    { ...report, skill_id: undefined },
+    { ...item, skill_id: 7 }
+  );
+  assert.equal(legacyRequest?.kind, 'request');
+  assert.equal(
+    legacyRequest?.kind === 'request' ? legacyRequest.payload.skill_id : undefined,
+    7,
+    'legacy item-level skill_id reports should remain supported'
+  );
+
+  const currentRequest = buildLiveYamlRequest(report, { ...item, skill_id: 7 });
+  assert.equal(
+    currentRequest?.kind === 'request' ? currentRequest.payload.skill_id : undefined,
+    42,
+    'the current report-level contract should take precedence over the legacy item-level value'
+  );
+
+  const allNamespaces = buildLiveYamlRequest(report, { ...item, namespace: 'all' });
+  assert.equal(allNamespaces?.kind, 'unavailable');
+  assert.match(
+    allNamespaces?.kind === 'unavailable' ? allNamespaces.message : '',
+    /全部命名空间/,
+    'all must explain why a namespaced deployment cannot be fetched instead of sending an empty namespace'
+  );
+
+  assert.equal(
+    buildLiveYamlRequest({ ...report, skill_id: undefined }, item),
+    null,
+    'reports without either skill_id contract should keep the existing no-preview behavior'
+  );
+
+  const componentSource = readFileSync(
+    path.join(
+      process.cwd(),
+      'src/app/opspilot/components/custom-chat-sse/DiffReportCard.tsx'
+    ),
+    'utf8'
+  );
+
+  assert.match(componentSource, /useApiClient\(\)/, 'live YAML should use the shared authenticated request client');
+  assert.doesNotMatch(componentSource, /localStorage\.getItem\(['"]access_token['"]\)/);
+  assert.doesNotMatch(componentSource, /startsWith\(['"]access_token=['"]\)/);
+  assert.doesNotMatch(componentSource, /namespace:\s*selectedItem\.namespace\s*===\s*['"]all['"]\s*\?\s*['"]['"]/);
+  assert.match(componentSource, /let cancelled = false/, 'stale responses should not overwrite a newly selected report item');
+
+  for (const typePath of [
+    'src/app/opspilot/types/global.ts',
+    'src/app/opspilot/types/chat.ts',
+  ]) {
+    const typeSource = readFileSync(path.join(process.cwd(), typePath), 'utf8');
+    assert.match(
+      typeSource,
+      /skill_id\?:\s*number/,
+      `${typePath} should describe the report-level skill_id emitted by the backend`
+    );
+  }
+
+  console.log('OpsPilot DiffReportCard live YAML contract tests passed');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/opspilot/components/custom-chat-sse/DiffReportCard.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/DiffReportCard.tsx
@@ -5,6 +5,8 @@ import { Modal, Tag } from 'antd';
 import { FileTextOutlined, RightOutlined } from '@ant-design/icons';
 import { ConfigDiffReport, ConfigDiffItem } from '@/app/opspilot/types/global';
 import { getDiffReportItemPresentation } from './diffReportItemPresentation';
+import useApiClient, { isSilentRequestError } from '@/utils/request';
+import { buildLiveYamlRequest } from './liveYamlRequest';
 
 type DiffOp = 'equal' | 'add' | 'remove';
 interface DiffLine { op: DiffOp; text: string; leftNo?: number; rightNo?: number }
@@ -57,6 +59,7 @@ interface DiffReportCardProps {
 }
 
 const DiffReportCard: React.FC<DiffReportCardProps> = ({ report }) => {
+  const { post } = useApiClient();
   const [selectedItem, setSelectedItem] = useState<ConfigDiffItem | null>(null);
   const [fetchedYaml, setFetchedYaml] = useState<{ yaml: string; loading: boolean; error: string | null }>({
     yaml: '',
@@ -66,35 +69,36 @@ const DiffReportCard: React.FC<DiffReportCardProps> = ({ report }) => {
 
   // modal 一开就自动 fetch,没 skill_id 就跳过
   useEffect(() => {
-    if (!selectedItem?.skill_id) return;
+    if (!selectedItem) return;
+    const liveYamlRequest = buildLiveYamlRequest(report, selectedItem);
+    if (!liveYamlRequest) return;
+    if (liveYamlRequest.kind === 'unavailable') {
+      setFetchedYaml({ yaml: '', loading: false, error: liveYamlRequest.message });
+      return;
+    }
+
+    let cancelled = false;
     setFetchedYaml({ yaml: '', loading: true, error: null });
     (async () => {
       try {
-        const token = localStorage.getItem('access_token') ||
-          document.cookie.split('; ').find(c => c.startsWith('access_token='))?.split('=')[1] || '';
-        const apiBase = (window as any).__NEXT_DATA__?.props?.pageProps?.apiBase
-          || window.location.origin;
-        const res = await fetch(`${apiBase}/api/proxy/opspilot/model_provider_mgmt/llm/fetch_k8s_deployment_yaml/`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
-          body: JSON.stringify({
-            namespace: selectedItem.namespace === 'all' ? '' : selectedItem.namespace,
-            name: selectedItem.workload_name.split(' ')[0],
-            cluster_name: report.cluster_name,
-            skill_id: selectedItem.skill_id,
-          }),
-        });
-        const json = await res.json();
-        if (json.result && json.data?.yaml) {
-          setFetchedYaml({ yaml: json.data.yaml, loading: false, error: null });
-        } else {
-          setFetchedYaml({ yaml: '', loading: false, error: json.message || 'fetch failed' });
+        const data = await post<{ yaml: string }>(liveYamlRequest.endpoint, liveYamlRequest.payload);
+        if (!cancelled) {
+          setFetchedYaml({ yaml: data.yaml, loading: false, error: null });
         }
-      } catch (e: any) {
-        setFetchedYaml({ yaml: '', loading: false, error: e?.message || 'network error' });
+      } catch (error: unknown) {
+        if (!cancelled) {
+          const errorMessage = isSilentRequestError(error)
+            ? null
+            : error instanceof Error ? error.message : 'network error';
+          setFetchedYaml({ yaml: '', loading: false, error: errorMessage });
+        }
       }
     })();
-  }, [selectedItem?.skill_id, selectedItem?.namespace, selectedItem?.workload_name, report.cluster_name]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [post, report, selectedItem]);
   const a2uiComponent = report.a2ui?.component || 'config-diff-report';
   const a2uiVersion = report.a2ui?.version || 'legacy';
   const selectedPresentation = selectedItem ? getDiffReportItemPresentation(selectedItem) : null;
@@ -267,7 +271,7 @@ const DiffReportCard: React.FC<DiffReportCardProps> = ({ report }) => {
                 </div>
               )}
               {/* 真实 deployment YAML — modal 一开就自动 fetch,不再多点 */}
-              {selectedItem.skill_id && (
+              {(report.skill_id || selectedItem.skill_id) && (
                 <div className="px-4 py-3 border-t border-gray-200 bg-gray-50">
                   <div className="mb-1.5 flex items-center gap-2">
                     <span className="inline-flex h-6 items-center rounded-md bg-gray-100 px-2 text-xs font-medium text-gray-700 border border-gray-200">
@@ -275,8 +279,9 @@ const DiffReportCard: React.FC<DiffReportCardProps> = ({ report }) => {
                     </span>
                   </div>
                   <pre className="whitespace-pre-wrap break-words rounded-md bg-white border border-gray-200 p-3 text-xs font-mono text-gray-700 max-h-80 overflow-auto">
-                    {fetchedYaml.loading ? '加载中...'
-                    : fetchedYaml.error || fetchedYaml.yaml || '加载失败,请重试'}
+                    {fetchedYaml.loading
+                      ? '加载中...'
+                      : fetchedYaml.error || fetchedYaml.yaml || '加载失败,请重试'}
                   </pre>
                 </div>
               )}

--- a/web/src/app/opspilot/components/custom-chat-sse/liveYamlRequest.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/liveYamlRequest.ts
@@ -1,0 +1,54 @@
+import type { ConfigDiffItem, ConfigDiffReport } from '@/app/opspilot/types/global';
+
+export const LIVE_YAML_ENDPOINT = '/opspilot/model_provider_mgmt/llm/fetch_k8s_deployment_yaml/';
+
+interface LiveYamlRequest {
+  kind: 'request';
+  endpoint: typeof LIVE_YAML_ENDPOINT;
+  payload: {
+    namespace: string;
+    name: string;
+    cluster_name: string;
+    skill_id: number;
+  };
+}
+
+interface LiveYamlUnavailable {
+  kind: 'unavailable';
+  message: string;
+}
+
+export function buildLiveYamlRequest(
+  report: ConfigDiffReport,
+  item: ConfigDiffItem
+): LiveYamlRequest | LiveYamlUnavailable | null {
+  const skillId = report.skill_id ?? item.skill_id;
+  if (!skillId) return null;
+
+  const namespace = item.namespace.trim();
+  if (!namespace || namespace === 'all') {
+    return {
+      kind: 'unavailable',
+      message: '该报告覆盖全部命名空间，无法定位唯一的 deployment 实时 YAML。',
+    };
+  }
+
+  const name = item.workload_name.split(' ')[0]?.trim();
+  if (!name) {
+    return {
+      kind: 'unavailable',
+      message: '报告未提供可定位的 deployment 名称。',
+    };
+  }
+
+  return {
+    kind: 'request',
+    endpoint: LIVE_YAML_ENDPOINT,
+    payload: {
+      namespace,
+      name,
+      cluster_name: report.cluster_name,
+      skill_id: skillId,
+    },
+  };
+}

--- a/web/src/app/opspilot/types/chat.ts
+++ b/web/src/app/opspilot/types/chat.ts
@@ -61,6 +61,7 @@ export interface ConfigDiffReportValue {
   report_id: string;
   title: string;
   cluster_name: string;
+  skill_id?: number;
   a2ui?: A2UIReportContract;
   items: Array<{
     workload_name: string;

--- a/web/src/app/opspilot/types/chat.ts
+++ b/web/src/app/opspilot/types/chat.ts
@@ -71,6 +71,7 @@ export interface ConfigDiffReportValue {
     summary: string;
     before_yaml: string;
     after_yaml: string;
+    skill_id?: number;
   }>;
 }
 

--- a/web/src/app/opspilot/types/global.ts
+++ b/web/src/app/opspilot/types/global.ts
@@ -174,6 +174,7 @@ export interface ConfigDiffReport {
   report_id: string;
   title: string;
   cluster_name: string;
+  skill_id?: number;
   a2ui?: A2UIReportContract;
   items: ConfigDiffItem[];
   received_at: number;


### PR DESCRIPTION
## 问题

配置对比卡片的实时 YAML 预览绕过了 Web 统一请求层，自行读取已经退出登录契约的 `access_token`。正常会话因此可能发送空 Bearer。与此同时，后端当前把 `skill_id` 放在报告顶层，卡片却只读取条目内字段；覆盖全部命名空间的报告还会把 `all` 转成后端明确拒绝的空值。

## 根因（设计层）

该卡片没有复用项目既有的认证与错误处理边界，并且前后端对报告身份字段的落点缺少同一份类型契约。结果是 Session/AuthContext token、401/460 统一处理和报告级 `skill_id` 都无法生效；`all` 也被错误地当成可调用 namespaced API 的值。

## 怎么修的

- 通过 `useApiClient` 发起请求，复用当前 Session/AuthContext token 和统一会话失效处理。
- 以报告顶层 `skill_id` 为当前契约，同时兼容条目内 `skill_id`，避免历史消息失效。
- 抽出可测试的请求构造函数；只有具体 namespace 才调用既有接口。
- `all` 不再发送必然失败的请求，卡片直接说明无法定位唯一 deployment。
- 切换条目时忽略旧请求的迟到响应，避免旧 YAML 覆盖新选择。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["DiffReportCard 打开条目\nDiffReportCard.tsx"]
    end

    subgraph N["请求契约层"]
        N1["解析 report/item skill_id\nliveYamlRequest.ts"]
        N2["具体 namespace\nuseApiClient.post"]
        N3["all namespace\n显示不可定位说明"]
    end

    subgraph B["既有后端边界"]
        B1["Next API Proxy"]
        B2["AuthMiddleware + YAML action"]
    end

    T1 --> N1
    N1 -->|可定位| N2 --> B1 --> B2
    N1 -. "无法定位" .-> N3
    B2 -. "401/460" .-> N2
```

## 影响范围与兼容性

改动仅位于 Web 的 OpsPilot 配置对比卡片及其类型声明。后端 API、权限、默认可见范围、请求字段和 `current_team` cookie 转发均未改变。

具体 namespace 的旧请求体保持不变；当前报告级和历史条目级 `skill_id` 都可继续工作。`all` 从“发送空值并返回 400”改为前端明确说明，不会伪造跨 namespace 查询。需要回滚时可直接还原本 PR，不涉及数据迁移。

## 验证

- `web/scripts/opspilot-diff-report-live-yaml-test.ts`：通过；覆盖当前/历史 `skill_id`、具体 namespace、`all`、无 `skill_id`、统一请求层和快速切换。
- 本次触及生产 TS 文件：ESLint 通过，TypeScript 类型检查通过。
- 修复前测试因缺少实时 YAML 请求契约而失败，修复后通过。

仓库全量 lint/type-check 仍有本 PR 未触及的既有错误（包括旧 Storybook import 规则和 Markdown 测试缺少 `vitest` 类型）；本次 diff 未新增相关失败。

关联 Issue #4260
