### PR TITLE
bugfix: 防止过期语言请求覆盖最新状态

### DIFF
--- a/web/scripts/locale-latest-request-test.ts
+++ b/web/scripts/locale-latest-request-test.ts
@@ -11,69 +11,76 @@ interface LatestRequestGuard {
 
 type GuardFactory = () => LatestRequestGuard;
 
-let createLatestRequestGuard: GuardFactory | undefined;
-try {
-  ({ createLatestRequestGuard } = await import('../src/context/latestRequestGuard.ts'));
-} catch {
-  // RED 阶段模块尚不存在，由下方行为断言给出明确失败。
+async function main() {
+  let createLatestRequestGuard: GuardFactory | undefined;
+  try {
+    ({ createLatestRequestGuard } = await import('../src/context/latestRequestGuard.ts'));
+  } catch {
+    // RED 阶段模块尚不存在，由下方行为断言给出明确失败。
+  }
+
+  assert.equal(
+    typeof createLatestRequestGuard,
+    'function',
+    '应提供可复用的 latest request guard',
+  );
+
+  const guard = createLatestRequestGuard!();
+  const commits: string[] = [];
+  const olderRequest = guard.begin();
+  const latestRequest = guard.begin();
+
+  assert.equal(
+    guard.commitIfCurrent(olderRequest, () => commits.push('older')),
+    false,
+    '旧请求不得提交状态',
+  );
+  assert.equal(
+    guard.commitIfCurrent(latestRequest, () => commits.push('latest')),
+    true,
+    '最新请求应提交状态',
+  );
+  assert.deepEqual(commits, ['latest']);
+
+  guard.invalidate();
+  assert.equal(
+    guard.commitIfCurrent(latestRequest, () => commits.push('after-unmount')),
+    false,
+    'Provider 卸载后在途请求不得提交状态',
+  );
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const localeSource = readFileSync(resolve(here, '../src/context/locale.tsx'), 'utf8');
+  const menusSource = readFileSync(resolve(here, '../src/context/menus.tsx'), 'utf8');
+
+  for (const [name, source, setter] of [
+    ['LocaleProvider', localeSource, 'setMessages'],
+    ['MenusProvider', menusSource, 'setConfigMenus'],
+  ] as const) {
+    assert.match(source, /createLatestRequestGuard/, `${name} 应创建 latest request guard`);
+    assert.match(source, /requestGuard\.begin\(\)/, `${name} 应为每次请求生成代次`);
+    assert.match(
+      source,
+      new RegExp(`requestGuard\\.commitIfCurrent\\([\\s\\S]*?${setter}\\(`),
+      `${name} 只能让最新请求提交 ${setter}`,
+    );
+    assert.match(
+      source,
+      /return\s*\(\)\s*=>\s*requestGuard\.invalidate\(\)/,
+      `${name} 卸载时应使在途请求失效`,
+    );
+  }
+
+  assert.match(
+    menusSource,
+    /requestGuard\.commitIfCurrent\([\s\S]*?setLoading\(false\)/,
+    'MenusProvider 只能由最新请求结束 loading',
+  );
+
+  console.log('locale latest request test passed');
 }
 
-assert.equal(
-  typeof createLatestRequestGuard,
-  'function',
-  '应提供可复用的 latest request guard',
-);
-
-const guard = createLatestRequestGuard!();
-const commits: string[] = [];
-const olderRequest = guard.begin();
-const latestRequest = guard.begin();
-
-assert.equal(
-  guard.commitIfCurrent(olderRequest, () => commits.push('older')),
-  false,
-  '旧请求不得提交状态',
-);
-assert.equal(
-  guard.commitIfCurrent(latestRequest, () => commits.push('latest')),
-  true,
-  '最新请求应提交状态',
-);
-assert.deepEqual(commits, ['latest']);
-
-guard.invalidate();
-assert.equal(
-  guard.commitIfCurrent(latestRequest, () => commits.push('after-unmount')),
-  false,
-  'Provider 卸载后在途请求不得提交状态',
-);
-
-const here = dirname(fileURLToPath(import.meta.url));
-const localeSource = readFileSync(resolve(here, '../src/context/locale.tsx'), 'utf8');
-const menusSource = readFileSync(resolve(here, '../src/context/menus.tsx'), 'utf8');
-
-for (const [name, source, setter] of [
-  ['LocaleProvider', localeSource, 'setMessages'],
-  ['MenusProvider', menusSource, 'setConfigMenus'],
-] as const) {
-  assert.match(source, /createLatestRequestGuard/, `${name} 应创建 latest request guard`);
-  assert.match(source, /requestGuard\.begin\(\)/, `${name} 应为每次请求生成代次`);
-  assert.match(
-    source,
-    new RegExp(`requestGuard\\.commitIfCurrent\\([\\s\\S]*?${setter}\\(`),
-    `${name} 只能让最新请求提交 ${setter}`,
-  );
-  assert.match(
-    source,
-    /return\s*\(\)\s*=>\s*requestGuard\.invalidate\(\)/,
-    `${name} 卸载时应使在途请求失效`,
-  );
-}
-
-assert.match(
-  menusSource,
-  /requestGuard\.commitIfCurrent\([\s\S]*?setLoading\(false\)/,
-  'MenusProvider 只能由最新请求结束 loading',
-);
-
-console.log('locale latest request test passed');
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/scripts/locale-latest-request-test.ts
+++ b/web/scripts/locale-latest-request-test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+interface LatestRequestGuard {
+  begin: () => number;
+  commitIfCurrent: (requestId: number, commit: () => void) => boolean;
+  invalidate: () => void;
+}
+
+type GuardFactory = () => LatestRequestGuard;
+
+let createLatestRequestGuard: GuardFactory | undefined;
+try {
+  ({ createLatestRequestGuard } = await import('../src/context/latestRequestGuard.ts'));
+} catch {
+  // RED 阶段模块尚不存在，由下方行为断言给出明确失败。
+}
+
+assert.equal(
+  typeof createLatestRequestGuard,
+  'function',
+  '应提供可复用的 latest request guard',
+);
+
+const guard = createLatestRequestGuard!();
+const commits: string[] = [];
+const olderRequest = guard.begin();
+const latestRequest = guard.begin();
+
+assert.equal(
+  guard.commitIfCurrent(olderRequest, () => commits.push('older')),
+  false,
+  '旧请求不得提交状态',
+);
+assert.equal(
+  guard.commitIfCurrent(latestRequest, () => commits.push('latest')),
+  true,
+  '最新请求应提交状态',
+);
+assert.deepEqual(commits, ['latest']);
+
+guard.invalidate();
+assert.equal(
+  guard.commitIfCurrent(latestRequest, () => commits.push('after-unmount')),
+  false,
+  'Provider 卸载后在途请求不得提交状态',
+);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const localeSource = readFileSync(resolve(here, '../src/context/locale.tsx'), 'utf8');
+const menusSource = readFileSync(resolve(here, '../src/context/menus.tsx'), 'utf8');
+
+for (const [name, source, setter] of [
+  ['LocaleProvider', localeSource, 'setMessages'],
+  ['MenusProvider', menusSource, 'setConfigMenus'],
+] as const) {
+  assert.match(source, /createLatestRequestGuard/, `${name} 应创建 latest request guard`);
+  assert.match(source, /requestGuard\.begin\(\)/, `${name} 应为每次请求生成代次`);
+  assert.match(
+    source,
+    new RegExp(`requestGuard\\.commitIfCurrent\\([\\s\\S]*?${setter}\\(`),
+    `${name} 只能让最新请求提交 ${setter}`,
+  );
+  assert.match(
+    source,
+    /return\s*\(\)\s*=>\s*requestGuard\.invalidate\(\)/,
+    `${name} 卸载时应使在途请求失效`,
+  );
+}
+
+assert.match(
+  menusSource,
+  /requestGuard\.commitIfCurrent\([\s\S]*?setLoading\(false\)/,
+  'MenusProvider 只能由最新请求结束 loading',
+);
+
+console.log('locale latest request test passed');

--- a/web/src/context/latestRequestGuard.ts
+++ b/web/src/context/latestRequestGuard.ts
@@ -1,0 +1,24 @@
+export interface LatestRequestGuard {
+  begin: () => number;
+  commitIfCurrent: (requestId: number, commit: () => void) => boolean;
+  invalidate: () => void;
+}
+
+export const createLatestRequestGuard = (): LatestRequestGuard => {
+  let currentRequestId = 0;
+
+  return {
+    begin: () => ++currentRequestId,
+    commitIfCurrent: (requestId, commit) => {
+      if (requestId !== currentRequestId) {
+        return false;
+      }
+
+      commit();
+      return true;
+    },
+    invalidate: () => {
+      currentRequestId += 1;
+    },
+  };
+};

--- a/web/src/context/locale.tsx
+++ b/web/src/context/locale.tsx
@@ -5,6 +5,7 @@ import { IntlProvider } from 'react-intl';
 import { useTranslation } from '@/utils/i18n';
 import Spin from '@/components/spin';
 import { getStoredLocale, normalizeLocale, persistLocale } from '@/utils/userPreferences';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 
 const LocaleContext = createContext<{
   locale: string;
@@ -15,6 +16,7 @@ export const LocaleProvider = ({ children }: { children: ReactNode }) => {
   const [locale, setLocale] = useState('en');
   const [messages, setMessages] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
+  const [requestGuard] = useState(createLatestRequestGuard);
 
   useEffect(() => {
     const savedLocale = getStoredLocale();
@@ -23,14 +25,19 @@ export const LocaleProvider = ({ children }: { children: ReactNode }) => {
     fetchLocaleMessages(savedLocale).finally(() => setIsLoading(false));
   }, []);
 
+  useEffect(() => {
+    return () => requestGuard.invalidate();
+  }, [requestGuard]);
+
   const fetchLocaleMessages = async (locale: string) => {
+    const requestId = requestGuard.begin();
     try {
       const response = await fetch(`/api/locales?locale=${locale}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch locale ${locale} from api`);
       }
       const data = await response.json();
-      setMessages(data);
+      requestGuard.commitIfCurrent(requestId, () => setMessages(data));
     } catch (error) {
       console.error('Failed to load locale messages form api:', error);
     }

--- a/web/src/context/menus.tsx
+++ b/web/src/context/menus.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { MenuItem } from '@/types/index';
 import { useLocale } from '@/context/locale';
+import { createLatestRequestGuard } from '@/context/latestRequestGuard';
 import { normalizeLocale } from '@/utils/userPreferences';
 
 interface MenusContextType {
@@ -13,10 +14,12 @@ const MenusContext = createContext<MenusContextType>({ configMenus: [], loading:
 export const MenusProvider = ({ children }: { children: ReactNode }) => {
   const [loading, setLoading] = useState<boolean>(false);
   const [configMenus, setConfigMenus] = useState<MenuItem[]>([]);
+  const [requestGuard] = useState(createLatestRequestGuard);
   const { locale } = useLocale();
 
   useEffect(() => {
     const fetchMenus = async () => {
+      const requestId = requestGuard.begin();
       const nextLocale = normalizeLocale(locale);
       setLoading(true);
       try {
@@ -25,16 +28,17 @@ export const MenusProvider = ({ children }: { children: ReactNode }) => {
           throw new Error('Failed to fetch menus');
         }
         const menus = await response.json();
-        setConfigMenus(menus);
+        requestGuard.commitIfCurrent(requestId, () => setConfigMenus(menus));
       } catch (error) {
         console.error('Failed to fetch menus:', error);
       } finally {
-        setLoading(false);
+        requestGuard.commitIfCurrent(requestId, () => setLoading(false));
       }
     };
 
     fetchMenus();
-  }, [locale]);
+    return () => requestGuard.invalidate();
+  }, [locale, requestGuard]);
 
   return (
     <MenusContext.Provider value={{configMenus, loading}}>


### PR DESCRIPTION
## 问题

语言切换的全局状态应遵循 latest-wins：用户最后选择的语言必须同时决定正文消息与菜单标题。此前语言包和菜单各自发起异步请求，响应完成后无条件写入状态；较早请求若较晚返回，会把新选择覆盖成旧语言，并可能让正文与菜单互相错配。

## 根因（设计层）

两个 Provider 都把“发起请求”和“允许提交全局状态”视为同一件事，缺少跨请求的单调提交边界。请求完成顺序由网络和文件读取决定，不能代表用户选择顺序；组件卸载时也没有统一失效在途请求。

## 怎么修的

- 新增无 React 依赖的请求代次守卫，统一提供 `begin`、`commitIfCurrent`、`invalidate`。
- 语言包与菜单请求开始时取得代次，只有当前代次可以提交消息、菜单和菜单 loading 状态。
- locale 变化或 Provider 卸载时使旧代次失效，避免在途响应继续回写。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["LocaleProvider.changeLocale\nweb/src/context/locale.tsx"]
        T2["MenusProvider locale effect\nweb/src/context/menus.tsx"]
    end

    subgraph N["请求与提交层"]
        G1["requestGuard.begin\nlatestRequestGuard.ts"]
        F1["fetch locale/menu API"]
        G2["commitIfCurrent\n仅最新代次提交"]
    end

    subgraph C["生命周期边界"]
        C1["requestGuard.invalidate\n切换或卸载"]
    end

    T1 --> G1 --> F1 --> G2
    T2 --> G1
    C1 -. "旧请求失效" .-> G2
```

## 影响范围

- 仅触及 Web 全局语言/菜单 Provider 及其内部共享守卫。
- 不修改 `/api/locales`、`/api/menu`、locale 持久化、Provider 对外接口或服务端/Agent 契约。
- 错误请求仍保留原有失败处理；本次只阻止过期请求提交状态。
- 回滚时还原本 PR 的四个文件即可，不涉及数据迁移。

## 验证

- `web/scripts/locale-latest-request-test.ts`：通过；覆盖旧请求拒绝、最新请求提交、卸载失效和两个 Provider 接线。
- `web/scripts/locale-provider-switch-flash-test.ts`：通过；保持切换语言不卸载整页的既有契约。
- `web/scripts/signin-language-toggle-test.ts`：通过；保持登录页语言切换入口契约。
- 本 PR 触及的 TypeScript/TSX 文件：ESLint 与定向类型检查均为 0 error。
- 回归测试在守卫缺失、Provider 未接线两个 RED 阶段分别失败，接线后转绿。

Closes #4259
