### PR TITLE
bugfix: 合并保存查询同键在途请求

### DIFF
--- a/web/scripts/monitor-saved-query-inflight-dedup-test.ts
+++ b/web/scripts/monitor-saved-query-inflight-dedup-test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import type React from 'react';
+
+import type { MetricItem } from '../src/app/monitor/types';
+
+const run = async () => {
+const queryPanelSource = readFileSync(
+  new URL(
+    '../src/app/monitor/(pages)/search/queryPanel.tsx',
+    import.meta.url
+  ),
+  'utf8'
+);
+
+assert.match(
+  queryPanelSource,
+  /loadSavedQueryResources/,
+  '保存查询加载路径应通过共享资源编排合并同键在途请求'
+);
+
+const { loadSavedQueryResources } = await import(
+  '../src/app/monitor/(pages)/search/savedQueryLoading.ts'
+);
+
+const makeGroup = (id: string, plugin: number | null = 6) => ({
+  id,
+  name: `查询条件 ${id}`,
+  object: 8,
+  plugin,
+  instanceIds: ['host-1'],
+  metric: null,
+  legacyMetricName: 'cpu_usage_total',
+  aggregation: 'AVG',
+  conditions: [],
+  collapsed: false
+});
+
+const makeMetric = (id: number, name = 'cpu_usage_total'): MetricItem => ({
+  id,
+  metric_group: 1,
+  metric_object: 8,
+  name,
+  type: 'gauge',
+  dimensions: []
+});
+
+const getResourceKey = (objectId: React.Key, pluginId: React.Key | null) =>
+  pluginId !== null && pluginId !== undefined && pluginId !== ''
+    ? `${objectId}_${pluginId}`
+    : String(objectId);
+
+const duplicateGroups = Array.from({ length: 50 }, (_, index) =>
+  makeGroup(`g${index + 1}`)
+);
+const beforeRequestCount = 1 + duplicateGroups.length * 3;
+assert.equal(beforeRequestCount, 151);
+
+let pluginLoads = 0;
+let metricLoads = 0;
+let instanceLoads = 0;
+const result = await loadSavedQueryResources({
+  queryGroups: duplicateGroups,
+  pluginsMap: {},
+  metricsMap: {},
+  instancesMap: {},
+  loadPlugins: async () => {
+    pluginLoads += 1;
+    return [{ id: 6, name: 'Host' }];
+  },
+  loadMetrics: async () => {
+    metricLoads += 1;
+    return [makeMetric(125)];
+  },
+  loadInstances: async () => {
+    instanceLoads += 1;
+    return [
+      {
+        instance_id: 'host-1',
+        instance_name: 'Host 1',
+        instance_id_values: ['host-1']
+      }
+    ];
+  },
+  getResourceKey,
+  resolvePlugin: (plugins, group) =>
+    group.plugin || (plugins.length === 1 ? plugins[0].id : null),
+  resolveLegacyMetric: (metrics, legacyName) =>
+    metrics.find((metric) => metric.name === legacyName) || null
+});
+
+const afterRequestCount = pluginLoads + metricLoads * 2 + instanceLoads;
+assert.equal(afterRequestCount, 4);
+assert.deepEqual(
+  result.queryGroups.map((group) => group.id),
+  duplicateGroups.map((group) => group.id),
+  '合并请求不能改变查询组顺序'
+);
+assert.ok(result.queryGroups.every((group) => group.metric === 125));
+assert.ok(
+  result.queryGroups.every((group) => group.legacyMetricName === null),
+  '每个重复组都应独立完成 legacy metric 解析'
+);
+
+const distinctGroups = [makeGroup('host', 6), makeGroup('remote', 30)];
+let distinctMetricLoads = 0;
+let distinctInstanceLoads = 0;
+const distinctResult = await loadSavedQueryResources({
+  queryGroups: distinctGroups,
+  pluginsMap: { '8': [{ id: 6 }, { id: 30 }] },
+  metricsMap: {},
+  instancesMap: {},
+  loadPlugins: async () => {
+    throw new Error('已有 plugin 缓存时不应再次加载');
+  },
+  loadMetrics: async (_objectId, pluginId) => {
+    distinctMetricLoads += 1;
+    return [makeMetric(Number(pluginId))];
+  },
+  loadInstances: async () => {
+    distinctInstanceLoads += 1;
+    return [];
+  },
+  getResourceKey,
+  resolvePlugin: (_plugins, group) => group.plugin,
+  resolveLegacyMetric: (metrics) => metrics[0] || null
+});
+assert.equal(distinctMetricLoads, 2, '不同 object/plugin 键不能被错误合并');
+assert.equal(distinctInstanceLoads, 2, '不同 object/plugin 键不能被错误合并');
+assert.deepEqual(Object.keys(distinctResult.metricsMap).sort(), ['8_30', '8_6']);
+
+const missingPluginGroup = makeGroup('missing', null);
+let missingMetricKey = '';
+await loadSavedQueryResources({
+  queryGroups: [missingPluginGroup],
+  pluginsMap: { '8': [] },
+  metricsMap: {},
+  instancesMap: {},
+  loadPlugins: async () => [],
+  loadMetrics: async (objectId, pluginId) => {
+    missingMetricKey = `${objectId}:${String(pluginId)}`;
+    return [];
+  },
+  loadInstances: async () => [],
+  getResourceKey,
+  resolvePlugin: () => null,
+  resolveLegacyMetric: () => null
+});
+assert.equal(
+  missingMetricKey,
+  '8:null',
+  '缺失 plugin 时保持原有按 object 加载行为'
+);
+
+let attempts = 0;
+const retryArgs: Parameters<typeof loadSavedQueryResources>[0] = {
+  queryGroups: [makeGroup('retry')],
+  pluginsMap: { '8': [{ id: 6 }] },
+  metricsMap: {},
+  instancesMap: {},
+  loadPlugins: async () => [{ id: 6 }],
+  loadMetrics: async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error('temporary failure');
+    return [makeMetric(125)];
+  },
+  loadInstances: async () => [],
+  getResourceKey,
+  resolvePlugin: (_plugins, group) => group.plugin,
+  resolveLegacyMetric: (metrics, legacyName) =>
+    metrics.find((metric) => metric.name === legacyName) || null
+};
+await assert.rejects(() => loadSavedQueryResources(retryArgs));
+await loadSavedQueryResources(retryArgs);
+assert.equal(attempts, 2, '失败后再次加载必须发起新请求');
+
+console.log(
+  `monitor saved query in-flight dedup passed: requests ${beforeRequestCount} -> ${afterRequestCount}`
+);
+};
+
+void run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/src/app/monitor/(pages)/search/queryPanel.tsx
+++ b/web/src/app/monitor/(pages)/search/queryPanel.tsx
@@ -48,6 +48,7 @@ import {
 import { cloneDeep } from 'lodash';
 import SavedQueryDrawer from './savedQueryDrawer';
 import SaveQueryModal from './saveQueryModal';
+import { loadSavedQueryResources } from './savedQueryLoading';
 import {
   generateSearchId,
   getMetricsMapKey,
@@ -606,63 +607,24 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     };
 
     const handleLoadSavedQuery = async (savedQueryGroups: QueryGroup[]) => {
-      const objectIds = [
-        ...new Set(savedQueryGroups.map((g) => g.object).filter(Boolean))
-      ];
-      const loadedPluginsMap: Record<string, PluginItem[]> = { ...pluginsMap };
-      const loadedMetricsMap: Record<string, MetricItem[]> = { ...metricsMap };
-      const loadedInstancesMap: Record<string, InstanceItem[]> = {
-        ...instancesMap
-      };
-      await Promise.all(
-        objectIds.map(async (objectId) => {
-          const key = String(objectId);
-          const plugins = pluginsMap[key] || (await getPlugins(objectId));
-          loadedPluginsMap[key] = plugins;
-          const groupsForObject = savedQueryGroups.filter(
-            (group) => group.object === objectId
-          );
-          await Promise.all(
-            groupsForObject.map(async (group) => {
-              const pluginId =
-                group.plugin ||
-                resolveInitialPlugin(plugins) ||
-                (group.legacyMetricName ? plugins[0]?.id : null);
-              if (pluginId && !group.plugin) {
-                group.plugin = pluginId;
-              }
-              const mapKey = getMetricsMapKey(objectId, pluginId);
-              const metricsPromise = loadedMetricsMap[mapKey]
-                ? Promise.resolve(loadedMetricsMap[mapKey])
-                : getMetrics(
-                  objectId,
-                  pluginId,
-                  group.id,
-                  group.legacyMetricName
-                );
-              const instancesPromise = loadedInstancesMap[mapKey]
-                ? Promise.resolve(loadedInstancesMap[mapKey])
-                : getInstList(objectId, pluginId);
-              const [metrics, instances] = await Promise.all([
-                metricsPromise,
-                instancesPromise
-              ]);
-              if (group.legacyMetricName && !group.metric) {
-                const legacyMetric = resolveMetricSelection(
-                  metrics,
-                  group.legacyMetricName
-                );
-                if (legacyMetric) {
-                  group.metric = legacyMetric.id;
-                  group.legacyMetricName = null;
-                }
-              }
-              loadedMetricsMap[mapKey] = metrics;
-              loadedInstancesMap[mapKey] = instances;
-            })
-          );
-        })
-      );
+      const loadedResources = await loadSavedQueryResources({
+        queryGroups: savedQueryGroups,
+        pluginsMap,
+        metricsMap,
+        instancesMap,
+        loadPlugins: getPlugins,
+        loadMetrics: (objectId, pluginId) => getMetrics(objectId, pluginId),
+        loadInstances: getInstList,
+        getResourceKey: getMetricsMapKey,
+        resolvePlugin: (plugins, group) =>
+          group.plugin ||
+          resolveInitialPlugin(plugins) ||
+          (group.legacyMetricName ? plugins[0]?.id : null),
+        resolveLegacyMetric: resolveMetricSelection
+      });
+      const loadedPluginsMap = loadedResources.pluginsMap;
+      const loadedMetricsMap = loadedResources.metricsMap;
+      const loadedInstancesMap = loadedResources.instancesMap;
       setPluginsMap(loadedPluginsMap);
       setQueryGroups(savedQueryGroups);
       const canSearchNow = savedQueryGroups.some(

--- a/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
+++ b/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
@@ -1,0 +1,131 @@
+import type React from 'react';
+
+import type { MetricItem } from '@/app/monitor/types';
+import type {
+  InstanceItem,
+  PluginItem,
+  QueryGroup
+} from '@/app/monitor/types/search';
+
+interface LoadSavedQueryResourcesArgs {
+  queryGroups: QueryGroup[];
+  pluginsMap: Record<string, PluginItem[]>;
+  metricsMap: Record<string, MetricItem[]>;
+  instancesMap: Record<string, InstanceItem[]>;
+  loadPlugins: (objectId: React.Key) => Promise<PluginItem[]>;
+  loadMetrics: (
+    objectId: React.Key,
+    pluginId: React.Key | null
+  ) => Promise<MetricItem[]>;
+  loadInstances: (
+    objectId: React.Key,
+    pluginId: React.Key | null
+  ) => Promise<InstanceItem[]>;
+  getResourceKey: (
+    objectId: React.Key,
+    pluginId: React.Key | null
+  ) => string;
+  resolvePlugin: (
+    plugins: PluginItem[],
+    group: QueryGroup
+  ) => React.Key | null;
+  resolveLegacyMetric: (
+    metrics: MetricItem[],
+    legacyName: string
+  ) => MetricItem | null;
+}
+
+interface LoadSavedQueryResourcesResult {
+  queryGroups: QueryGroup[];
+  pluginsMap: Record<string, PluginItem[]>;
+  metricsMap: Record<string, MetricItem[]>;
+  instancesMap: Record<string, InstanceItem[]>;
+}
+
+const getOrCreateRequest = <T>(
+  requests: Map<string, Promise<T>>,
+  key: string,
+  load: () => Promise<T>
+) => {
+  const inFlight = requests.get(key);
+  if (inFlight) return inFlight;
+  const request = load().finally(() => requests.delete(key));
+  requests.set(key, request);
+  return request;
+};
+
+export const loadSavedQueryResources = async ({
+  queryGroups,
+  pluginsMap,
+  metricsMap,
+  instancesMap,
+  loadPlugins,
+  loadMetrics,
+  loadInstances,
+  getResourceKey,
+  resolvePlugin,
+  resolveLegacyMetric
+}: LoadSavedQueryResourcesArgs): Promise<LoadSavedQueryResourcesResult> => {
+  const loadedPluginsMap = { ...pluginsMap };
+  const loadedMetricsMap = { ...metricsMap };
+  const loadedInstancesMap = { ...instancesMap };
+  const metricRequests = new Map<string, Promise<MetricItem[]>>();
+  const instanceRequests = new Map<string, Promise<InstanceItem[]>>();
+  const objectIds = [
+    ...new Set(queryGroups.map((group) => group.object).filter(Boolean))
+  ];
+
+  await Promise.all(
+    objectIds.map(async (objectId) => {
+      const objectKey = String(objectId);
+      const plugins =
+        loadedPluginsMap[objectKey] || (await loadPlugins(objectId));
+      loadedPluginsMap[objectKey] = plugins;
+      const groupsForObject = queryGroups.filter(
+        (group) => group.object === objectId
+      );
+
+      await Promise.all(
+        groupsForObject.map(async (group) => {
+          const pluginId = resolvePlugin(plugins, group);
+          if (pluginId && !group.plugin) group.plugin = pluginId;
+          const resourceKey = getResourceKey(objectId, pluginId);
+          const metricsPromise = loadedMetricsMap[resourceKey]
+            ? Promise.resolve(loadedMetricsMap[resourceKey])
+            : getOrCreateRequest(metricRequests, resourceKey, () =>
+              loadMetrics(objectId, pluginId)
+            );
+          const instancesPromise = loadedInstancesMap[resourceKey]
+            ? Promise.resolve(loadedInstancesMap[resourceKey])
+            : getOrCreateRequest(instanceRequests, resourceKey, () =>
+              loadInstances(objectId, pluginId)
+            );
+          const [metrics, instances] = await Promise.all([
+            metricsPromise,
+            instancesPromise
+          ]);
+
+          if (group.legacyMetricName && !group.metric) {
+            const legacyMetric = resolveLegacyMetric(
+              metrics,
+              group.legacyMetricName
+            );
+            if (legacyMetric) {
+              group.metric = legacyMetric.id;
+              group.legacyMetricName = null;
+            }
+          }
+          loadedMetricsMap[resourceKey] = metrics;
+          loadedInstancesMap[resourceKey] = instances;
+        })
+      );
+    })
+  );
+
+  return {
+    queryGroups,
+    pluginsMap: loadedPluginsMap,
+    metricsMap: loadedMetricsMap,
+    instancesMap: loadedInstancesMap
+  };
+};


### PR DESCRIPTION
## 问题

保存查询加载应当按数据键复用相同的监控元数据结果。此前多个查询组使用相同 object/plugin 时，每个组都会在完成值写入缓存前分别发起指标与实例请求；后发请求还会通过共享 AbortController 取消先发请求。

## 根因（设计层）

加载流程只有“已完成值缓存”，缺少“在途请求缓存”。同一批并发查询组会同时观察到缓存未命中，因此请求量随查询组数增长，而不是随唯一数据键数增长。

## 怎么修的

- 提取保存查询资源加载编排，按既有 object/plugin key 共享 metrics 与 instances 的在途 Promise。
- Promise 完成或失败后移除在途项，后续加载仍可重试。
- 共享结果返回后，仍逐组解析 legacy metric，保持各查询组的独立选择语义。

## 影响范围

改动仅位于 Web 监控搜索页的保存查询加载路径，不改后端 API、权限、租户、响应结构或 UI 交互。查询组顺序、plugin fallback、缺失 plugin 的既有加载行为、不同 key 并发及自动搜索条件保持不变。

## 性能结果

以 50 个相同 object/plugin 的冷加载查询组为同一输入：

| 指标 | 优化前 | 优化后 |
|---|---:|---:|
| plugin 请求 | 1 | 1 |
| metrics 请求（两个 API） | 100 | 2 |
| instance 请求 | 50 | 1 |
| 总请求数 | 151 | 4 |

网络请求复杂度由 `O(G)` 收敛为 `O(U)`，其中 G 为查询组数，U 为唯一 object/plugin 键数。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["SavedQueryDrawer.handleLoad\nsavedQueryDrawer.tsx"]
    end

    subgraph N["核心处理层"]
        N1["handleLoadSavedQuery\nqueryPanel.tsx"]
        N2["loadSavedQueryResources\nsavedQueryLoading.ts"]
        N3["keyed in-flight Promise\nobject/plugin"]
        N4["getMetrics + getInstList\n唯一键一次"]
    end

    subgraph C["完成与失败"]
        C1["逐组 legacy metric 解析"]
        C2["清除在途项，允许重试"]
    end

    T1 --> N1 --> N2 --> N3 --> N4 --> C1
    N4 -. "完成或失败" .-> C2
```

## 验证

- `web/scripts/monitor-saved-query-inflight-dedup-test.ts`：通过，50 组同键请求数 `151 -> 4`；覆盖重复键、不同键、组顺序、legacy metric、缺失 plugin 与失败重试。
- 上述测试在基线实现上因未合并生产加载路径而失败，接入修复后通过。
- 三个触及文件 ESLint：0 error。
- 三个触及文件定向 TypeScript 检查：通过。
- `git diff --check`：通过。

## 残余风险

本次计数在真实加载编排与 API loader 边界完成，未额外启动浏览器录制 Network；上线后仍可通过相同 50 组保存查询在 Network 面板确认总请求数为 4。


