### PR TITLE
bugfix: 限制网络拓扑运行态请求并发

### DIFF
--- a/web/scripts/ops-analysis-network-topology-runtime-request-pool-test.ts
+++ b/web/scripts/ops-analysis-network-topology-runtime-request-pool-test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+
+import {
+  NETWORK_TOPOLOGY_RUNTIME_CONCURRENCY,
+  indexRuntimeNodes,
+  runRuntimeTasks,
+  selectLinkEndpointNodes,
+} from '../src/app/ops-analysis/(pages)/view/networkTopology/runtimeRequestPool.ts';
+
+const nodeCount = 100;
+const linkCount = 150;
+const nodes = Array.from({ length: nodeCount }, (_, index) => ({
+  id: `node-${index}`,
+}));
+const nodeIndex = indexRuntimeNodes(nodes);
+
+assert.deepEqual(
+  selectLinkEndpointNodes(nodeIndex, {
+    source_node_id: 'node-2',
+    target_node_id: 'node-99',
+  }).map((node) => node.id),
+  ['node-2', 'node-99'],
+  'link runtime payload should contain only the two endpoint nodes',
+);
+
+assert.deepEqual(
+  selectLinkEndpointNodes(nodeIndex, {
+    source_node_id: 'node-2',
+    target_node_id: 'missing-node',
+  }).map((node) => node.id),
+  ['node-2'],
+  'missing endpoints should not add undefined payload entries',
+);
+
+const main = async () => {
+  let activeRequests = 0;
+  let peakRequests = 0;
+  let startedRequests = 0;
+  const requestCount = nodeCount + linkCount;
+  const tasks = Array.from({ length: requestCount }, (_, index) => async () => {
+    startedRequests += 1;
+    activeRequests += 1;
+    peakRequests = Math.max(peakRequests, activeRequests);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    activeRequests -= 1;
+    if (index === 17) throw new Error('single request failed');
+  });
+
+  const results = await runRuntimeTasks(tasks);
+
+  assert.equal(startedRequests, requestCount, 'a failed request should not stop queued runtime tasks');
+  assert.equal(
+    peakRequests,
+    NETWORK_TOPOLOGY_RUNTIME_CONCURRENCY,
+    'large canvases should never exceed the fixed runtime request concurrency',
+  );
+  assert.equal(
+    results.filter((result) => result.status === 'rejected').length,
+    1,
+    'the scheduler should preserve per-request settled results',
+  );
+
+  let current = true;
+  let staleStartedRequests = 0;
+  const staleResults = await runRuntimeTasks(
+    Array.from({ length: 10 }, () => async () => {
+      staleStartedRequests += 1;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      current = false;
+    }),
+    { concurrency: 2, isActive: () => current },
+  );
+  assert.equal(staleStartedRequests, 2, 'generation changes should discard queued stale requests');
+  assert.equal(staleResults.length, 2, 'settled results should include only tasks that actually started');
+
+  const baselineSerializedNodes = nodeCount * linkCount;
+  const optimizedSerializedNodes = 2 * linkCount;
+  assert.equal(baselineSerializedNodes, 15_000);
+  assert.equal(optimizedSerializedNodes, 300);
+
+  console.log(
+    JSON.stringify({
+      input: { nodeCount, linkCount },
+      before: {
+        requests: requestCount,
+        peakConcurrency: requestCount,
+        serializedLinkNodes: baselineSerializedNodes,
+      },
+      after: {
+        requests: requestCount,
+        peakConcurrency: peakRequests,
+        serializedLinkNodes: optimizedSerializedNodes,
+      },
+    }),
+  );
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/web/scripts/ops-analysis-network-topology-runtime-request-pool-test.ts
+++ b/web/scripts/ops-analysis-network-topology-runtime-request-pool-test.ts
@@ -33,6 +33,24 @@ assert.deepEqual(
 );
 
 const main = async () => {
+  assert.deepEqual(
+    await runRuntimeTasks([]),
+    [],
+    'an empty canvas should complete without starting workers',
+  );
+
+  let singleTaskCalls = 0;
+  const singleTaskResults = await runRuntimeTasks([
+    async () => {
+      singleTaskCalls += 1;
+      return 'single-result';
+    },
+  ]);
+  assert.equal(singleTaskCalls, 1, 'a one-item canvas should start exactly one task');
+  assert.deepEqual(singleTaskResults, [
+    { status: 'fulfilled', value: 'single-result' },
+  ]);
+
   let activeRequests = 0;
   let peakRequests = 0;
   let startedRequests = 0;
@@ -73,10 +91,20 @@ const main = async () => {
   assert.equal(staleStartedRequests, 2, 'generation changes should discard queued stale requests');
   assert.equal(staleResults.length, 2, 'settled results should include only tasks that actually started');
 
-  const baselineSerializedNodes = nodeCount * linkCount;
-  const optimizedSerializedNodes = 2 * linkCount;
-  assert.equal(baselineSerializedNodes, 15_000);
-  assert.equal(optimizedSerializedNodes, 300);
+  const links = Array.from({ length: linkCount }, (_, index) => ({
+    source_node_id: `node-${index % nodeCount}`,
+    target_node_id: `node-${(index + 1) % nodeCount}`,
+  }));
+  const baselineSerializedNodes = nodeCount * links.length;
+  const optimizedSerializedNodes = links.reduce(
+    (total, link) => total + selectLinkEndpointNodes(nodeIndex, link).length,
+    0,
+  );
+  assert.equal(
+    optimizedSerializedNodes,
+    300,
+    'endpoint selection should serialize two nodes per valid link',
+  );
 
   console.log(
     JSON.stringify({

--- a/web/scripts/ops-analysis-network-topology-test.ts
+++ b/web/scripts/ops-analysis-network-topology-test.ts
@@ -1069,8 +1069,8 @@ assert.match(
 );
 assert.match(
   topologyIndexSource,
-  /api\s*\.\s*getLinkRuntime\(\s*String\(canvasId\),\s*\{\s*link:\s*nextLink,\s*nodes:\s*prev\.nodes\s*\}/,
-  'committing link interfaces should request local link runtime with the current unsaved node list',
+  /api\s*\.\s*getLinkRuntime\(\s*String\(canvasId\),\s*\{\s*link:\s*nextLink,\s*nodes:\s*selectLinkEndpointNodes\(indexRuntimeNodes\(prev\.nodes\),\s*nextLink\),?\s*\}/,
+  'committing link interfaces should send only endpoint nodes from the current unsaved node list',
 );
 assert.doesNotMatch(
   topologyIndexSource,
@@ -1131,6 +1131,21 @@ assert.match(
   topologyIndexSource,
   /runtimeConfig\.links[\s\S]*api\.getLinkRuntime/,
   'configured links should load independently after the canvas config is available',
+);
+assert.match(
+  topologyIndexSource,
+  /\.map\(\(node\) => async \(\) =>[\s\S]*\.map\(\(link\) => async \(\) =>/,
+  'configured runtime requests should stay lazy until the bounded pool starts each task',
+);
+assert.match(
+  topologyIndexSource,
+  /runRuntimeTasks\(\[\.\.\.nodeTasks, \.\.\.linkTasks\], \{ isActive: isCurrent \}\)/,
+  'configured runtime requests should use the bounded pool and stop queued stale generations',
+);
+assert.match(
+  topologyIndexSource,
+  /nodes:\s*selectLinkEndpointNodes\(runtimeNodeIndex, link\)/,
+  'configured link refreshes should send only endpoint nodes from the prebuilt index',
 );
 
 console.log('ops-analysis-network-topology-test passed');

--- a/web/src/app/ops-analysis/(pages)/view/networkTopology/index.tsx
+++ b/web/src/app/ops-analysis/(pages)/view/networkTopology/index.tsx
@@ -33,6 +33,11 @@ import NetworkEdgeDrawer from './components/networkEdgeDrawer';
 import MonitorSourcePickerModal from './components/modals/monitorSourcePickerModal';
 import ConfirmDeleteModal from './components/modals/confirmDeleteModal';
 import {
+  indexRuntimeNodes,
+  runRuntimeTasks,
+  selectLinkEndpointNodes,
+} from './runtimeRequestPool';
+import {
   buildLinkDetailPortRows,
   buildLinkInterfaceMetricRows,
   buildNodeDetailMetricRows,
@@ -238,10 +243,11 @@ const NetworkTopology = forwardRef<NetworkTopologyRef, NetworkTopologyProps>(
 
         const generation = ++runtimeLoadGenerationRef.current;
         const isCurrent = () => runtimeLoadGenerationRef.current === generation;
+        const runtimeNodeIndex = indexRuntimeNodes(runtimeConfig.nodes);
 
         const nodeTasks = runtimeConfig.nodes
           .filter((node) => node.metrics.length > 0)
-          .map(async (node) => {
+          .map((node) => async () => {
             const metrics = node.metrics;
             const metricRequests = metrics.map((metric) => {
               const requestId = buildMetricRuntimeRequestId(node.id, metric);
@@ -325,11 +331,11 @@ const NetworkTopology = forwardRef<NetworkTopologyRef, NetworkTopologyProps>(
 
         const linkTasks = runtimeConfig.links
           .filter((link) => !link.is_draft && link.port_pairs.length > 0)
-          .map(async (link) => {
+          .map((link) => async () => {
             try {
               const res = await api.getLinkRuntime(runtimeCanvasId, {
                 link,
-                nodes: runtimeConfig.nodes,
+                nodes: selectLinkEndpointNodes(runtimeNodeIndex, link),
               });
               if (!isCurrent()) return;
               if (res?.link) {
@@ -350,7 +356,7 @@ const NetworkTopology = forwardRef<NetworkTopologyRef, NetworkTopologyProps>(
             }
           });
 
-        const task = Promise.allSettled([...nodeTasks, ...linkTasks])
+        const task = runRuntimeTasks([...nodeTasks, ...linkTasks], { isActive: isCurrent })
           .then(() => undefined)
           .finally(() => {
             if (runtimeRefreshPromiseRef.current?.promise === task) {
@@ -1012,7 +1018,10 @@ const NetworkTopology = forwardRef<NetworkTopologyRef, NetworkTopologyProps>(
           return;
         }
         void api
-          .getLinkRuntime(String(canvasId), { link: nextLink, nodes: prev.nodes })
+          .getLinkRuntime(String(canvasId), {
+            link: nextLink,
+            nodes: selectLinkEndpointNodes(indexRuntimeNodes(prev.nodes), nextLink),
+          })
           .then((res) => {
             if (res?.link) {
               setRuntimeLinkOverrides((prevOverrides) => ({

--- a/web/src/app/ops-analysis/(pages)/view/networkTopology/runtimeRequestPool.ts
+++ b/web/src/app/ops-analysis/(pages)/view/networkTopology/runtimeRequestPool.ts
@@ -1,0 +1,63 @@
+export const NETWORK_TOPOLOGY_RUNTIME_CONCURRENCY = 4;
+
+interface RuntimeLinkEndpoints {
+  source_node_id?: string;
+  target_node_id?: string;
+}
+
+interface RuntimeTaskPoolOptions {
+  concurrency?: number;
+  isActive?: () => boolean;
+}
+
+export const indexRuntimeNodes = <T extends { id: string }>(
+  nodes: T[],
+): Map<string, T> => new Map(nodes.map((node) => [node.id, node]));
+
+export const selectLinkEndpointNodes = <T>(
+  nodesById: ReadonlyMap<string, T>,
+  link: RuntimeLinkEndpoints,
+): T[] => {
+  const result: T[] = [];
+  const sourceNode = link.source_node_id
+    ? nodesById.get(link.source_node_id)
+    : undefined;
+  const targetNode = link.target_node_id
+    ? nodesById.get(link.target_node_id)
+    : undefined;
+  if (sourceNode) result.push(sourceNode);
+  if (targetNode && targetNode !== sourceNode) result.push(targetNode);
+  return result;
+};
+
+export const runRuntimeTasks = async <T>(
+  tasks: Array<() => Promise<T>>,
+  options: RuntimeTaskPoolOptions = {},
+): Promise<Array<PromiseSettledResult<T>>> => {
+  const {
+    concurrency = NETWORK_TOPOLOGY_RUNTIME_CONCURRENCY,
+    isActive = () => true,
+  } = options;
+  const results = new Array<PromiseSettledResult<T>>(tasks.length);
+  const workerCount = Math.min(Math.max(concurrency, 1), tasks.length);
+  let cursor = 0;
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (cursor < tasks.length && isActive()) {
+        const index = cursor;
+        cursor += 1;
+        try {
+          results[index] = {
+            status: 'fulfilled',
+            value: await tasks[index](),
+          };
+        } catch (reason) {
+          results[index] = { status: 'rejected', reason };
+        }
+      }
+    }),
+  );
+
+  return results.filter((result) => result !== undefined);
+};


### PR DESCRIPTION
## 问题

网络拓扑查看态需要渐进展示每个节点和连线的运行结果，同时保证单项失败不阻塞其他结果。原实现虽然保留了局部失败语义，但在每轮刷新时立即启动全部节点与连线请求，使并发峰值随画布规模线性增长；每条连线还重复携带整张画布的节点数据。

## 根因

逐项加载任务直接以已启动的 Promise 表示，汇合层只能等待，无法控制请求何时进入网络层。连线预览也没有在客户端收窄其真实依赖，只把完整节点集合交给后端筛选。

## 怎么修的

- 将运行态请求改为惰性任务，由并发上限为 4 的任务池领取执行。
- 保留逐项 settled 结果和单项错误隔离；画布代次失效后不再启动排队的旧请求。
- 预建节点索引，刷新和单条编辑都只为连线发送源端、目标端节点。
- 增加真实 100 节点、150 连线规模测量和生产接线回归。

## 影响范围与兼容性

仅触及运营分析网络拓扑前端，不修改后端接口、权限、鉴权、allowlist、默认画布范围、持久化结构或响应契约。节点和连线仍独立更新，局部失败仍保留旧值或错误态，手动刷新、周期刷新和同画布 in-flight 去重保持不变。回滚可直接还原本 PR 提交。

同一组 100 节点、150 连线输入下，请求总数保持 250，峰值并发由 250 降为 4；连线请求累计携带的节点项由 15000 降为 300，客户端端点查找由 O(N×E) 收敛为 O(N+E)。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["首次加载 / 手动刷新 / 周期刷新\nnetworkTopology/index.tsx"]
    end

    subgraph N["有界调度层"]
        N1["构造惰性节点与连线任务"]
        N2["runRuntimeTasks\n并发上限 4"]
        N3["generation 门禁\n丢弃排队旧请求"]
    end

    subgraph P["代理请求层"]
        P1["节点 metric_values"]
        P2["连线 link_runtime\n仅源端与目标端节点"]
    end

    T1 --> N1 --> N2 --> N3
    N3 --> P1
    N3 --> P2
    P1 -. "单项失败" .-> N2
    P2 -. "单项失败" .-> N2
```

## 验证

- `web/scripts/ops-analysis-network-topology-runtime-request-pool-test.ts`：通过；100+150 输入峰值并发 250→4、连线节点项 15000→300，并覆盖单项失败与失效代次。
- `web/scripts/ops-analysis-network-topology-test.ts`：通过；覆盖惰性任务、任务池接线、generation 门禁及刷新/编辑两条端点裁剪路径。
- 触及 helper 与测试的定向 ESLint、严格 TypeScript 检查、diff-check：通过。

关联 Issue #4257。
