### PR TITLE
bugfix: 阻止 Tauri 认证数据降级到本地存储

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test:build-config": "node --test scripts/mobile-build-config-test.mjs",
+    "test:secure-storage": "node --test scripts/secure-storage-fail-closed-test.mjs",
     "test:h5-deploy": "node --test scripts/mobile-h5-deploy-config-test.mjs",
     "test:h5-auth": "node --test scripts/mobile-h5-auth-test.mjs",
     "test:h5-image": "node scripts/mobile-h5-image-test.mjs",

--- a/mobile/scripts/secure-storage-fail-closed-test.mjs
+++ b/mobile/scripts/secure-storage-fail-closed-test.mjs
@@ -36,13 +36,17 @@ async function loadSecureStorage() {
     'STORE_FILE',
     'memoryCache',
     'storeInstance',
+    'isInitialized',
     'isTauriEnvironment',
     'clearLegacyAuthStorage',
     'getStore',
+    'initSecureStorage',
     'secureSet',
+    'secureGetSync',
     'saveToken',
+    'getTokenSync',
   ].map((name) => findDeclaration(sourceFile, name));
-  const moduleSource = `${declarations.join('\n')}\nexport { getStore, saveToken };`.replace(
+  const moduleSource = `${declarations.join('\n')}\nexport { getStore, initSecureStorage, saveToken, getTokenSync };`.replace(
     "import('@tauri-apps/plugin-store')",
     'globalThis.__loadStoreModule()',
   );
@@ -133,21 +137,72 @@ test('Tauri Store success keeps using the canonical store after legacy cleanup',
   assert.equal(values.has('auth_token'), false);
 });
 
-test('saveToken never writes localStorage when the Tauri Store cannot load', async () => {
+test('saveToken rejects and leaves no cached token when the Tauri Store cannot load', async () => {
   const { setCalls, values } = installWindow({ auth_token: 'legacy-token' }, true);
   globalThis.__loadStoreModule = async () => {
     throw new Error('store unavailable');
   };
-  const { saveToken } = await loadSecureStorage();
+  const { getTokenSync, saveToken } = await loadSecureStorage();
   const originalConsoleError = console.error;
   console.error = () => {};
 
   try {
-    await saveToken('new-token');
+    await assert.rejects(saveToken('new-token'), /store unavailable/);
   } finally {
     console.error = originalConsoleError;
   }
 
   assert.deepEqual(setCalls, []);
   assert.equal(values.has('auth_token'), false);
+  assert.equal(getTokenSync(), null);
+});
+
+test('saveToken rejects and updates the cache only after the Tauri Store is saved', async () => {
+  installWindow({}, true);
+  const store = {
+    set: async () => {},
+    save: async () => {
+      throw new Error('save failed');
+    },
+  };
+  globalThis.__loadStoreModule = async () => ({
+    load: async () => store,
+  });
+  const { getTokenSync, saveToken } = await loadSecureStorage();
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  try {
+    await assert.rejects(saveToken('new-token'), /save failed/);
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  assert.equal(getTokenSync(), null);
+});
+
+test('initSecureStorage rejects Tauri read failures without caching partial auth state', async () => {
+  installWindow({}, true);
+  const store = {
+    get: async (key) => {
+      if (key === 'auth_token') {
+        return 'persisted-token';
+      }
+      throw new Error('read failed');
+    },
+  };
+  globalThis.__loadStoreModule = async () => ({
+    load: async () => store,
+  });
+  const { getTokenSync, initSecureStorage } = await loadSecureStorage();
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  try {
+    await assert.rejects(initSecureStorage(), /read failed/);
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  assert.equal(getTokenSync(), null);
 });

--- a/mobile/scripts/secure-storage-fail-closed-test.mjs
+++ b/mobile/scripts/secure-storage-fail-closed-test.mjs
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import ts from 'typescript';
+
+const projectRoot = new URL('../', import.meta.url);
+
+function findDeclaration(sourceFile, name) {
+  const declaration = sourceFile.statements.find((node) => {
+    if (ts.isFunctionDeclaration(node)) {
+      return node.name?.text === name;
+    }
+    if (ts.isVariableStatement(node)) {
+      return node.declarationList.declarations.some(
+        (item) => ts.isIdentifier(item.name) && item.name.text === name,
+      );
+    }
+    return false;
+  });
+
+  assert.ok(declaration, `secureStorage.ts must declare ${name}`);
+  return declaration.getText(sourceFile);
+}
+
+async function loadSecureStorage() {
+  const source = await readFile(new URL('src/utils/secureStorage.ts', projectRoot), 'utf8');
+  const sourceFile = ts.createSourceFile(
+    'secureStorage.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const declarations = [
+    'STORAGE_KEYS',
+    'STORE_FILE',
+    'memoryCache',
+    'storeInstance',
+    'isTauriEnvironment',
+    'clearLegacyAuthStorage',
+    'getStore',
+    'secureSet',
+    'saveToken',
+  ].map((name) => findDeclaration(sourceFile, name));
+  const moduleSource = `${declarations.join('\n')}\nexport { getStore, saveToken };`.replace(
+    "import('@tauri-apps/plugin-store')",
+    'globalThis.__loadStoreModule()',
+  );
+  const output = ts.transpileModule(moduleSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(output).toString('base64')}#${Date.now()}-${Math.random()}`;
+
+  return await import(moduleUrl);
+}
+
+function installWindow(initialValues = {}, tauri = false) {
+  const values = new Map(Object.entries(initialValues));
+  const setCalls = [];
+  const localStorage = {
+    getItem: (key) => values.get(key) ?? null,
+    removeItem: (key) => values.delete(key),
+    setItem: (key, value) => {
+      setCalls.push([key, value]);
+      values.set(key, value);
+    },
+  };
+  globalThis.window = tauri ? { __TAURI_INTERNALS__: {}, localStorage } : { localStorage };
+  globalThis.localStorage = localStorage;
+  return { setCalls, values };
+}
+
+test.afterEach(() => {
+  delete globalThis.__loadStoreModule;
+  delete globalThis.localStorage;
+  delete globalThis.window;
+});
+
+test('H5 keeps the explicit localStorage fallback without loading the Tauri plugin', async () => {
+  const { values } = installWindow({ auth_token: 'h5-token' });
+  let loaderCalls = 0;
+  globalThis.__loadStoreModule = async () => {
+    loaderCalls += 1;
+    throw new Error('must not load');
+  };
+  const { getStore } = await loadSecureStorage();
+
+  assert.equal(await getStore(), null);
+  assert.equal(loaderCalls, 0);
+  assert.equal(values.get('auth_token'), 'h5-token');
+});
+
+test('Tauri Store load failure clears legacy auth copies and never becomes a fallback signal', async () => {
+  const { values } = installWindow(
+    {
+      auth_token: 'legacy-token',
+      refresh_token: 'legacy-refresh-token',
+      user_info: '{"username":"legacy"}',
+      locale: 'zh-CN',
+    },
+    true,
+  );
+  globalThis.__loadStoreModule = async () => {
+    throw new Error('store unavailable');
+  };
+  const { getStore } = await loadSecureStorage();
+
+  const originalConsoleError = console.error;
+  console.error = () => {};
+  try {
+    await assert.rejects(getStore(), /store unavailable/);
+  } finally {
+    console.error = originalConsoleError;
+  }
+  assert.equal(values.has('auth_token'), false);
+  assert.equal(values.has('refresh_token'), false);
+  assert.equal(values.has('user_info'), false);
+  assert.equal(values.get('locale'), 'zh-CN');
+});
+
+test('Tauri Store success keeps using the canonical store after legacy cleanup', async () => {
+  const { values } = installWindow({ auth_token: 'legacy-token' }, true);
+  const store = { get() {}, set() {} };
+  globalThis.__loadStoreModule = async () => ({
+    load: async () => store,
+  });
+  const { getStore } = await loadSecureStorage();
+
+  assert.equal(await getStore(), store);
+  assert.equal(values.has('auth_token'), false);
+});
+
+test('saveToken never writes localStorage when the Tauri Store cannot load', async () => {
+  const { setCalls, values } = installWindow({ auth_token: 'legacy-token' }, true);
+  globalThis.__loadStoreModule = async () => {
+    throw new Error('store unavailable');
+  };
+  const { saveToken } = await loadSecureStorage();
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  try {
+    await saveToken('new-token');
+  } finally {
+    console.error = originalConsoleError;
+  }
+
+  assert.deepEqual(setCalls, []);
+  assert.equal(values.has('auth_token'), false);
+});

--- a/mobile/src/utils/secureStorage.ts
+++ b/mobile/src/utils/secureStorage.ts
@@ -83,12 +83,14 @@ export async function initSecureStorage(): Promise<void> {
         const store = await getStore();
         if (store) {
             // 从 Tauri Store 加载所有已保存的数据到内存缓存
+            const persistedValues = new Map<string, unknown>();
             for (const key of Object.values(STORAGE_KEYS)) {
                 const value = await store.get(key);
                 if (value !== null && value !== undefined) {
-                    memoryCache.set(key, value);
+                    persistedValues.set(key, value);
                 }
             }
+            persistedValues.forEach((value, key) => memoryCache.set(key, value));
             isInitialized = true;
             console.log('Secure storage initialized from Tauri Store');
         } else {

--- a/mobile/src/utils/secureStorage.ts
+++ b/mobile/src/utils/secureStorage.ts
@@ -33,15 +33,31 @@ export function isTauriEnvironment(): boolean {
 }
 
 /**
+ * 清理旧版本在 Tauri Store 不可用时写入 localStorage 的认证数据。
+ * H5/开发环境仍保留显式的 localStorage 存储行为。
+ */
+function clearLegacyAuthStorage(): void {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    for (const key of Object.values(STORAGE_KEYS)) {
+        window.localStorage.removeItem(key);
+    }
+}
+
+/**
  * 获取 Store 实例
  */
 async function getStore() {
-    if (storeInstance) {
-        return storeInstance;
-    }
-
     if (!isTauriEnvironment()) {
         return null;
+    }
+
+    clearLegacyAuthStorage();
+
+    if (storeInstance) {
+        return storeInstance;
     }
 
     try {


### PR DESCRIPTION
## 问题

移动端安全存储应确保 Tauri 运行时的认证数据只持久化到 Tauri Store。此前 Store 动态加载失败与“非 Tauri 环境”共用 `null` 信号，调用层会把 `auth_token`、`user_info` 和 `refresh_token` 降级写入 localStorage，打破了持久化边界。

## 根因（设计层）

存储后端探测同时承担了环境识别和失败恢复，但没有区分“允许使用开发回退”与“安全存储故障”。因此一次 Tauri Store 故障会被误判为可降级场景，安全失败被转换为成功的明文持久化。

## 怎么修的

- 非 Tauri 的 H5/开发环境继续返回 localStorage 回退信号，既有联调能力不变。
- Tauri 路径在访问 Store 前删除旧版本遗留的三个 localStorage 认证键，完成存量敏感副本清理。
- Tauri Store 加载失败时保留错误并上抛，不再返回回退信号；正常 Store 读写路径和公开方法签名不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["AuthProvider / 首页初始化\nauth.tsx / page.tsx"]
    end

    subgraph N["安全存储层"]
        N1["环境识别\nsecureStorage.ts"]
        N2["清理历史认证键\nclearLegacyAuthStorage"]
        N3["加载 Tauri Store\ngetStore"]
    end

    H5["H5 / 开发环境\nlocalStorage 回退"]
    FAIL["Store 加载失败\n上抛并停止持久化"]

    T1 --> N1
    N1 -- "非 Tauri" --> H5
    N1 -- "Tauri" --> N2 --> N3
    N3 -. "失败" .-> FAIL
```

## 影响范围与迁移

- 改动仅在 `mobile`，现有调用方均继续使用原有安全存储 API；`server`、`agents`、`web` 和 NATS 协议不受影响。
- 正常 Tauri Store 和 H5/开发环境行为不变。只有曾在 Store 故障时依赖 localStorage 认证副本的 Tauri 会话会被清理，用户需要重新登录。
- 回滚可直接还原本提交；规范的 Tauri Store 数据未迁移、未删除，回滚不需要数据恢复。

## 验证

- `mobile/scripts/secure-storage-fail-closed-test.mjs`：4 passed；覆盖 H5 兼容、Tauri Store 失败关闭、正常 Store，以及公开 `saveToken` 不写 localStorage，修复前会失败。
- Mobile ESLint：通过。
- Mobile TypeScript type-check：通过。

Closes #4016
