### PR TITLE
fix: 统一监控图表显示精度

### DIFF
--- a/web/src/app/monitor/dashboards/shared/widgets/chart-display-precision.ts
+++ b/web/src/app/monitor/dashboards/shared/widgets/chart-display-precision.ts
@@ -1,0 +1,12 @@
+const DEFAULT_DECIMAL_PLACES = 2;
+
+export const roundChartValueToDisplayPrecision = (
+  value: number | null,
+  decimalPlaces = DEFAULT_DECIMAL_PLACES
+): number | null => {
+  if (value == null || !Number.isFinite(value)) return value;
+
+  const factor = 10 ** decimalPlaces;
+  const rounded = Math.sign(value) * Math.round((Math.abs(value) + Number.EPSILON) * factor) / factor;
+  return Object.is(rounded, -0) ? 0 : rounded;
+};

--- a/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/echarts-line-chart.tsx
@@ -9,6 +9,7 @@ import { formatMetricValue } from '../utils/format';
 import { MetricUnit } from '../types';
 import { normalizeGapIntervals } from '@/app/monitor/utils/gapIntervals';
 import { CHART_COLORS } from '@/app/monitor/constants';
+import { roundChartValueToDisplayPrecision } from './chart-display-precision';
 
 export interface EChartsLineChartProps {
   data: ChartData[];
@@ -103,6 +104,9 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
 
     const yAxisUnit = seriesStyles[0]?.unit || unit || '';
     const needsBinaryScale = yAxisUnit in BINARY_SCALE_CONFIG;
+    const displayValues = data.flatMap((point) => areaKeys.map((key) => point[key] as number | null));
+    const allSeriesValuesAreZero = displayValues.some((value) => value != null)
+      && displayValues.every((value) => value == null || roundChartValueToDisplayPrecision(value) === 0);
 
     let scaleDivisor = 1;
     let scaleDisplayUnit = yAxisUnit;
@@ -151,7 +155,8 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
         data: data.map((d) => {
           const v = d[key] as number | null;
           if (v == null) return [d.time, null];
-          return [d.time, scaleDivisor > 1 ? v / scaleDivisor : v];
+          const scaledValue = scaleDivisor > 1 ? v / scaleDivisor : v;
+          return [d.time, roundChartValueToDisplayPrecision(scaledValue)];
         }),
         smooth: false,
         symbol: 'none',
@@ -202,8 +207,10 @@ const EChartsLineChart: React.FC<EChartsLineChartProps> = ({
       },
       yAxis: {
         type: 'value' as const,
+        min: allSeriesValuesAreZero ? 0 : undefined,
+        max: allSeriesValuesAreZero ? 1 : undefined,
         axisLabel: {
-          formatter: (val: number) => formatAxisNumber(val),
+          formatter: (val: number) => allSeriesValuesAreZero && val !== 0 ? '' : formatAxisNumber(val),
           fontSize: 11,
           color: '#8c8c8c'
         },


### PR DESCRIPTION
## 变更
- 按两位显示精度归零折线图数据，低于 0.005 的值绘制为 0。
- 当全部展示值归零时，固定 Y 轴为 0 至 1，并仅保留一个 0 刻度，避免多条曲线视觉悬浮。
- 同步 tooltip 使用归零后的序列值；负数临界值按对称规则舍入。

## 验证
- `pnpm exec tsx scripts/monitor-dashboard-display-precision-test.ts`
- `pnpm lint`
- Chrome：MSSQL 三条不同的原始等待 rate 均小于 0.005，15 分钟图三线贴底、Y 轴仅 0、tooltip 三项均为 0 ms。

## 已知环境项
- `pnpm type-check` 被既有 CMDB 缺失依赖及 TongLink `Bps` 类型错误阻断，与本 PR 无关。

提交范围已复核：仅 2 个生产文件；本地回归脚本和 mock 数据未提交。