### PR TITLE
bugfix: 修正 IP 发现插件加载路径

### DIFF
--- a/agents/stargazer/plugins/inputs/ip/plugin.yml
+++ b/agents/stargazer/plugins/inputs/ip/plugin.yml
@@ -15,7 +15,7 @@ executors:
     type: protocol
     timeout: 600
     collector:
-      module: plugins.inputs.ip_discovery.ip_discovery_scanner
+      module: plugins.inputs.ip.ip_discovery_scanner
       class: IPDiscoveryScanner
 
 default_executor: protocol

--- a/agents/stargazer/tests/test_ip_discovery_scanner.py
+++ b/agents/stargazer/tests/test_ip_discovery_scanner.py
@@ -1,9 +1,10 @@
 # -- coding: utf-8 --
 """IP 发现 collector：TCP 判活、ICMP 判活、并发聚合、best-effort MAC。规格 §13.2/§13.3。"""
 import asyncio
+import importlib
 import pytest
 from unittest.mock import patch
-from plugins.inputs.ip_discovery.ip_discovery_scanner import IPDiscoveryScanner
+from plugins.inputs.ip.ip_discovery_scanner import IPDiscoveryScanner
 
 pytestmark = pytest.mark.unit
 
@@ -92,9 +93,11 @@ class TestScanner:
 
 def test_plugin_yml_loads_and_points_to_scanner():
     import os, yaml
-    path = os.path.join(os.path.dirname(__file__), "..", "plugins", "inputs", "ip_discovery", "plugin.yml")
+    path = os.path.join(os.path.dirname(__file__), "..", "plugins", "inputs", "ip", "plugin.yml")
     cfg = yaml.safe_load(open(os.path.abspath(path), encoding="utf-8"))
     assert cfg["metadata"]["model_id"] == "ip"
     proto = cfg["executors"]["protocol"]
     assert proto["collector"]["class"] == "IPDiscoveryScanner"
-    assert proto["collector"]["module"].endswith("ip_discovery_scanner")
+    assert proto["collector"]["module"] == "plugins.inputs.ip.ip_discovery_scanner"
+    collector_module = importlib.import_module(proto["collector"]["module"])
+    assert getattr(collector_module, proto["collector"]["class"]) is IPDiscoveryScanner

--- a/agents/stargazer/tests/test_ip_discovery_targets.py
+++ b/agents/stargazer/tests/test_ip_discovery_targets.py
@@ -1,7 +1,7 @@
 # -- coding: utf-8 --
 """子网 -> 扫描目标地址：排除网络号/广播/网关。规格 §13.1。"""
 import pytest
-from plugins.inputs.ip_discovery.scan_targets import derive_targets
+from plugins.inputs.ip.scan_targets import derive_targets
 
 pytestmark = pytest.mark.unit
 


### PR DESCRIPTION
## 问题

IP 发现插件的清单是动态加载器与 collector 实现之间的注册契约。目录迁移到 `plugins.inputs.ip` 后，清单和相关测试仍保留旧包名，导致标准调度在实例化扫描器之前抛出 `ModuleNotFoundError`，IP 发现无法进入探测阶段。

关联 Issue #4281。

## 根因

插件目录迁移时只移动了实现文件，没有同步更新声明式清单与测试导入。原测试只校验模块名后缀，没有验证清单中的完整模块路径确实可导入，因此未能守住动态加载契约。

## 怎么修的

- 将 OSS IP 插件清单指向实际存在的 `plugins.inputs.ip.ip_discovery_scanner`。
- 同步两份 IP 发现测试的包路径。
- 将清单断言收紧为完整模块名，并实际导入声明的 collector class，防止目录与清单再次漂移。

## 影响范围

改动仅限 Stargazer 的 OSS IP 发现插件及其测试。未修改 `PluginSourceResolver`、`PluginExecutor`、enterprise 覆盖与回退规则，也不改变 API、权限、输入参数、扫描行为或结果结构。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["CollectionService.collect\nservice/collection_service.py"]
    end

    subgraph N["插件解析与执行层"]
        N1["PluginYamlReader\ncore/yaml_reader.py"]
        N2["PluginExecutor._load_collector\ncore/plugin_executor.py"]
        N3["IPDiscoveryScanner\nplugins/inputs/ip/ip_discovery_scanner.py"]
    end

    T1 --> N1 --> N2 --> N3
```

## 验证

- `agents/stargazer/tests/test_ip_discovery_scanner.py`、`agents/stargazer/tests/test_ip_discovery_targets.py`：9 passed。
- RED 阶段在仅更新测试后，清单完整路径断言稳定失败（1 failed、8 passed）；修正清单后转为 9 passed，满足 revert-fail 准则。
- `git diff --check` 通过。
