### PR TITLE
bugfix: 清理 Ansible 终态任务执行凭据

### DIFF
--- a/agents/ansible-executor/service/task_store.py
+++ b/agents/ansible-executor/service/task_store.py
@@ -101,6 +101,21 @@ class TaskStore:
                 if column not in columns:
                     conn.execute(sql)
 
+            terminal_statuses = tuple(sorted(TERMINAL_TASK_STATUSES))
+            status_placeholders = ", ".join("?" for _ in terminal_statuses)
+            conn.execute(
+                f"""
+                UPDATE task_state
+                SET execution_payload_json = NULL
+                WHERE execution_payload_json IS NOT NULL
+                  AND (
+                      status IN ({status_placeholders})
+                      OR execution_status IN ({status_placeholders})
+                  )
+                """,
+                (*terminal_statuses, *terminal_statuses),
+            )
+
     def create_if_absent(
         self,
         task_id: str,
@@ -244,6 +259,7 @@ class TaskStore:
                 SET status = ?,
                     execution_status = ?,
                     result_json = ?,
+                    execution_payload_json = NULL,
                     lease_owner = NULL,
                     lease_expires_at = NULL,
                     heartbeat_at = ?,

--- a/agents/ansible-executor/service/task_store.py
+++ b/agents/ansible-executor/service/task_store.py
@@ -62,7 +62,11 @@ class TaskStore:
         self._ensure_schema()
 
     def _connect(self):
-        return sqlite3.connect(self.db_path)
+        conn = sqlite3.connect(self.db_path)
+        # SQLite 默认只删除单元格引用，旧凭据仍可能残留在数据库空闲页中。
+        # 每条连接都启用物理擦除，覆盖终态更新和启动时的存量清理。
+        conn.execute("PRAGMA secure_delete = ON")
+        return conn
 
     def _ensure_schema(self):
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)

--- a/agents/ansible-executor/service/task_store.py
+++ b/agents/ansible-executor/service/task_store.py
@@ -93,7 +93,9 @@ class TaskStore:
         return json.loads(plaintext.decode("utf-8"))
 
     def _connect(self):
-        return sqlite3.connect(self.db_path)
+        connection = sqlite3.connect(self.db_path)
+        connection.execute("PRAGMA secure_delete = ON")
+        return connection
 
     def _ensure_schema(self):
         db_parent = Path(self.db_path).parent
@@ -134,6 +136,21 @@ class TaskStore:
             for column, sql in migrations.items():
                 if column not in columns:
                     conn.execute(sql)
+
+            terminal_statuses = tuple(sorted(TERMINAL_TASK_STATUSES))
+            status_placeholders = ", ".join("?" for _ in terminal_statuses)
+            conn.execute(
+                f"""
+                UPDATE task_state
+                SET execution_payload_json = NULL
+                WHERE execution_payload_json IS NOT NULL
+                  AND (
+                      status IN ({status_placeholders})
+                      OR execution_status IN ({status_placeholders})
+                  )
+                """,
+                (*terminal_statuses, *terminal_statuses),
+            )
         os.chmod(self.db_path, 0o600)
 
     def create_if_absent(

--- a/agents/ansible-executor/service/task_store.py
+++ b/agents/ansible-executor/service/task_store.py
@@ -136,22 +136,31 @@ class TaskStore:
             for column, sql in migrations.items():
                 if column not in columns:
                     conn.execute(sql)
-
-            terminal_statuses = tuple(sorted(TERMINAL_TASK_STATUSES))
-            status_placeholders = ", ".join("?" for _ in terminal_statuses)
-            conn.execute(
-                f"""
-                UPDATE task_state
-                SET execution_payload_json = NULL
-                WHERE execution_payload_json IS NOT NULL
-                  AND (
-                      status IN ({status_placeholders})
-                      OR execution_status IN ({status_placeholders})
-                  )
-                """,
-                (*terminal_statuses, *terminal_statuses),
-            )
+            self._cleanup_terminal_execution_payloads(conn)
         os.chmod(self.db_path, 0o600)
+
+    @staticmethod
+    def _cleanup_terminal_execution_payloads(conn: sqlite3.Connection) -> None:
+        """Run the security-critical legacy cleanup atomically during startup.
+
+        A SQLite error aborts and rolls back initialization. Operators can fix the
+        database lock/filesystem problem and restart; continuing would retain
+        plaintext terminal credentials behind a healthy service.
+        """
+        terminal_statuses = tuple(sorted(TERMINAL_TASK_STATUSES))
+        status_placeholders = ", ".join("?" for _ in terminal_statuses)
+        conn.execute(
+            f"""
+            UPDATE task_state
+            SET execution_payload_json = NULL
+            WHERE execution_payload_json IS NOT NULL
+              AND (
+                  status IN ({status_placeholders})
+                  OR execution_status IN ({status_placeholders})
+              )
+            """,
+            (*terminal_statuses, *terminal_statuses),
+        )
 
     def create_if_absent(
         self,

--- a/agents/ansible-executor/service/task_store.py
+++ b/agents/ansible-executor/service/task_store.py
@@ -214,19 +214,64 @@ class TaskStore:
 
     def claim_task(self, task_id: str, owner_id: str, lease_expires_at: str, now_iso: str) -> dict[str, Any]:
         with self._connect() as conn:
+            terminal_statuses = tuple(sorted(TERMINAL_TASK_STATUSES))
+            status_placeholders = ", ".join("?" for _ in terminal_statuses)
             cursor = conn.execute(
+                f"""
+                UPDATE task_state
+                SET status = 'running',
+                    execution_status = 'running',
+                    lease_owner = ?,
+                    lease_expires_at = ?,
+                    heartbeat_at = ?,
+                    execution_attempt = COALESCE(execution_attempt, 0) + 1,
+                    updated_at = ?
+                WHERE task_id = ?
+                  AND status NOT IN ({status_placeholders})
+                  AND execution_status NOT IN ({status_placeholders})
+                  AND (
+                      execution_status != 'running'
+                      OR lease_owner IS NULL
+                      OR lease_expires_at IS NULL
+                      OR lease_expires_at <= ?
+                      OR lease_owner = ?
+                  )
+                """,
+                (
+                    owner_id,
+                    lease_expires_at,
+                    now_iso,
+                    now_iso,
+                    task_id,
+                    *terminal_statuses,
+                    *terminal_statuses,
+                    now_iso,
+                    owner_id,
+                ),
+            )
+            row = conn.execute(
                 """
                 SELECT status, execution_status, callback_status, lease_owner, lease_expires_at, execution_attempt
                 FROM task_state
                 WHERE task_id = ?
                 """,
                 (task_id,),
-            )
-            row = cursor.fetchone()
+            ).fetchone()
             if not row:
                 return {"claimed": False, "reason": "missing"}
 
             status, execution_status, callback_status, lease_owner, lease_expires_at_db, execution_attempt = row
+            if cursor.rowcount > 0:
+                return {
+                    "claimed": True,
+                    "status": status,
+                    "execution_status": execution_status,
+                    "callback_status": callback_status,
+                    "execution_attempt": int(execution_attempt or 0),
+                    "lease_owner": lease_owner,
+                    "lease_expires_at": lease_expires_at_db,
+                    "claimed_at": now_iso,
+                }
             if status in TERMINAL_TASK_STATUSES or execution_status in TERMINAL_TASK_STATUSES:
                 return {
                     "claimed": False,
@@ -245,41 +290,7 @@ class TaskStore:
                     "lease_owner": lease_owner,
                     "lease_expires_at": lease_expires_at_db,
                 }
-
-            next_attempt = int(execution_attempt or 0) + 1
-            conn.execute(
-                """
-                UPDATE task_state
-                SET status = ?,
-                    execution_status = ?,
-                    lease_owner = ?,
-                    lease_expires_at = ?,
-                    heartbeat_at = ?,
-                    execution_attempt = ?,
-                    updated_at = ?
-                WHERE task_id = ?
-                """,
-                (
-                    "running",
-                    "running",
-                    owner_id,
-                    lease_expires_at,
-                    now_iso,
-                    next_attempt,
-                    now_iso,
-                    task_id,
-                ),
-            )
-            return {
-                "claimed": True,
-                "status": "running",
-                "execution_status": "running",
-                "callback_status": callback_status,
-                "execution_attempt": next_attempt,
-                "lease_owner": owner_id,
-                "lease_expires_at": lease_expires_at,
-                "claimed_at": now_iso,
-            }
+            return {"claimed": False, "reason": "state_changed"}
 
     def renew_lease(self, task_id: str, owner_id: str, lease_expires_at: str, now_iso: str) -> bool:
         with self._connect() as conn:

--- a/agents/ansible-executor/tests/test_task_store.py
+++ b/agents/ansible-executor/tests/test_task_store.py
@@ -270,6 +270,40 @@ def test_update_execution_result_clears_terminal_execution_payload(tmp_path):
         assert store.get_execution_payload(task_id) is None
 
 
+def test_update_execution_result_erases_terminal_credentials_from_database_pages(tmp_path):
+    db_path = tmp_path / "task.db"
+    secret = "terminal-credential-physical-erase-9f7d2b4c-" + "x" * 128
+    store = TaskStore(str(db_path))
+    store.create_if_absent(
+        "terminal-physical-erase",
+        "queued",
+        {
+            "task_id": "terminal-physical-erase",
+            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": secret}],
+        },
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    store.claim_task(
+        "terminal-physical-erase",
+        "worker-a",
+        "2026-04-23T00:00:10+00:00",
+        "2026-04-23T00:00:01+00:00",
+    )
+    assert secret.encode() in db_path.read_bytes()
+
+    updated = store.update_execution_result(
+        "terminal-physical-erase",
+        "success",
+        {"task_id": "terminal-physical-erase", "success": True},
+        "2026-04-23T00:00:02+00:00",
+        owner_id="worker-a",
+    )
+
+    assert updated is True
+    assert secret.encode() not in db_path.read_bytes()
+
+
 def test_update_execution_result_keeps_payload_when_lease_owner_mismatches(tmp_path):
     store = TaskStore(str(tmp_path / "task.db"))
     payload_with_creds = {

--- a/agents/ansible-executor/tests/test_task_store.py
+++ b/agents/ansible-executor/tests/test_task_store.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 from service.task_store import SENSITIVE_CREDENTIAL_KEYS, TaskStore, _sanitize_payload_for_storage
 
 
@@ -237,6 +239,97 @@ def test_create_if_absent_preserves_execution_payload_for_worker_use(tmp_path):
     execution_payload = store.get_execution_payload("execution-payload-test")
 
     assert execution_payload == payload_with_creds
+
+
+def test_update_execution_result_clears_terminal_execution_payload(tmp_path):
+    payload_with_creds = {
+        "task_id": "terminal-payload-test",
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
+
+    for final_status in ("success", "failed"):
+        store = TaskStore(str(tmp_path / f"{final_status}.db"))
+        task_id = f"terminal-payload-{final_status}"
+        store.create_if_absent(task_id, "queued", payload_with_creds, {}, "2026-04-23T00:00:00+00:00")
+        store.claim_task(
+            task_id,
+            "worker-a",
+            "2026-04-23T00:00:10+00:00",
+            "2026-04-23T00:00:01+00:00",
+        )
+
+        updated = store.update_execution_result(
+            task_id,
+            final_status,
+            {"task_id": task_id, "success": final_status == "success"},
+            "2026-04-23T00:00:02+00:00",
+            owner_id="worker-a",
+        )
+
+        assert updated is True
+        assert store.get_execution_payload(task_id) is None
+
+
+def test_update_execution_result_keeps_payload_when_lease_owner_mismatches(tmp_path):
+    store = TaskStore(str(tmp_path / "task.db"))
+    payload_with_creds = {
+        "task_id": "lease-lost-payload-test",
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
+    store.create_if_absent(
+        "lease-lost-payload-test",
+        "queued",
+        payload_with_creds,
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    store.claim_task(
+        "lease-lost-payload-test",
+        "worker-a",
+        "2026-04-23T00:00:10+00:00",
+        "2026-04-23T00:00:01+00:00",
+    )
+
+    updated = store.update_execution_result(
+        "lease-lost-payload-test",
+        "success",
+        {"task_id": "lease-lost-payload-test", "success": True},
+        "2026-04-23T00:00:02+00:00",
+        owner_id="worker-b",
+    )
+
+    assert updated is False
+    assert store.get_execution_payload("lease-lost-payload-test") == payload_with_creds
+
+
+def test_init_clears_legacy_terminal_payloads_without_touching_active_tasks(tmp_path):
+    db_path = tmp_path / "task.db"
+    store = TaskStore(str(db_path))
+    payload_with_creds = {
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
+    stored_statuses = {
+        "status-terminal": ("success", "queued"),
+        "execution-terminal": ("running", "failed"),
+        "callback-terminal": ("callback_failed", "success"),
+        "queued": ("queued", "queued"),
+        "running": ("running", "running"),
+    }
+    for task_id_suffix, (status, execution_status) in stored_statuses.items():
+        task_id = f"legacy-{task_id_suffix}"
+        store.create_if_absent(task_id, "queued", payload_with_creds, {}, "2026-04-23T00:00:00+00:00")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "UPDATE task_state SET status = ?, execution_status = ? WHERE task_id = ?",
+                (status, execution_status, task_id),
+            )
+
+    reloaded_store = TaskStore(str(db_path))
+
+    for task_id_suffix in ("status-terminal", "execution-terminal", "callback-terminal"):
+        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") is None
+    for task_id_suffix in ("queued", "running"):
+        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") == payload_with_creds
 
 
 def test_sensitive_credential_keys_is_comprehensive():

--- a/agents/ansible-executor/tests/test_task_store.py
+++ b/agents/ansible-executor/tests/test_task_store.py
@@ -60,6 +60,27 @@ def test_claim_task_can_take_over_stale_lease(tmp_path):
     assert task["execution_attempt"] == 2
 
 
+def test_claim_task_concurrently_allows_only_one_worker(tmp_path):
+    store = TaskStore(str(tmp_path / "task.db"))
+    store.create_if_absent("task-race", "queued", {"task_id": "task-race"}, {}, "2026-04-23T00:00:00+00:00")
+
+    def claim(owner_id):
+        return store.claim_task(
+            "task-race",
+            owner_id,
+            "2026-04-23T00:00:10+00:00",
+            "2026-04-23T00:00:01+00:00",
+        )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        claims = list(executor.map(claim, ("worker-a", "worker-b")))
+
+    assert sum(result["claimed"] for result in claims) == 1
+    rejected = next(result for result in claims if not result["claimed"])
+    assert rejected["reason"] == "leased"
+    assert store.get_task("task-race")["execution_attempt"] == 1
+
+
 def test_callback_status_preserves_execution_result(tmp_path):
     store = TaskStore(str(tmp_path / "task.db"))
     store.create_if_absent("task-3", "queued", {"task_id": "task-3"}, {"subject": "x"}, "2026-04-23T00:00:00+00:00")

--- a/agents/ansible-executor/tests/test_task_store.py
+++ b/agents/ansible-executor/tests/test_task_store.py
@@ -1,3 +1,5 @@
+import json
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -440,6 +442,45 @@ def test_task_store_concurrently_publishes_one_stable_local_key(tmp_path):
         secrets = list(executor.map(lambda _: load_secret(), range(16)))
 
     assert len(set(secrets)) == 1
+
+
+def test_init_clears_legacy_terminal_payloads_without_touching_active_tasks(tmp_path):
+    db_path = tmp_path / "task.db"
+    store = TaskStore(str(db_path))
+    stored_statuses = {
+        "status-terminal": ("success", "queued"),
+        "execution-terminal": ("running", "failed"),
+        "callback-terminal": ("callback_failed", "success"),
+        "queued": ("queued", "queued"),
+        "running": ("running", "running"),
+    }
+    for task_id_suffix, (status, execution_status) in stored_statuses.items():
+        task_id = f"legacy-{task_id_suffix}"
+        payload_with_creds = {
+            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": f"legacy-secret-{task_id_suffix}"}],
+        }
+        store.create_if_absent(task_id, "queued", payload_with_creds, {}, "2026-04-23T00:00:00+00:00")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                UPDATE task_state
+                SET status = ?, execution_status = ?, execution_payload_json = ?
+                WHERE task_id = ?
+                """,
+                (status, execution_status, json.dumps(payload_with_creds), task_id),
+            )
+
+    reloaded_store = TaskStore(str(db_path))
+    database_bytes = db_path.read_bytes()
+
+    for task_id_suffix in ("status-terminal", "execution-terminal", "callback-terminal"):
+        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") is None
+        assert f"legacy-secret-{task_id_suffix}".encode() not in database_bytes
+    for task_id_suffix in ("queued", "running"):
+        assert f"legacy-secret-{task_id_suffix}".encode() in database_bytes
+        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") == {
+            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": f"legacy-secret-{task_id_suffix}"}],
+        }
 
 
 def test_sensitive_credential_keys_is_comprehensive():

--- a/agents/ansible-executor/tests/test_task_store.py
+++ b/agents/ansible-executor/tests/test_task_store.py
@@ -444,9 +444,113 @@ def test_task_store_concurrently_publishes_one_stable_local_key(tmp_path):
     assert len(set(secrets)) == 1
 
 
+def test_update_execution_result_clears_terminal_execution_payload(tmp_path):
+    payload_with_creds = {
+        "task_id": "terminal-payload-test",
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
+
+    for final_status in ("success", "failed"):
+        store = TaskStore(str(tmp_path / f"{final_status}.db"))
+        task_id = f"terminal-payload-{final_status}"
+        store.create_if_absent(task_id, "queued", payload_with_creds, {}, "2026-04-23T00:00:00+00:00")
+        store.claim_task(
+            task_id,
+            "worker-a",
+            "2026-04-23T00:00:10+00:00",
+            "2026-04-23T00:00:01+00:00",
+        )
+
+        updated = store.update_execution_result(
+            task_id,
+            final_status,
+            {"task_id": task_id, "success": final_status == "success"},
+            "2026-04-23T00:00:02+00:00",
+            owner_id="worker-a",
+        )
+
+        assert updated is True
+        assert store.get_execution_payload(task_id) is None
+
+
+def test_init_erases_legacy_terminal_credentials_from_database_pages(tmp_path):
+    db_path = tmp_path / "task.db"
+    secret = "terminal-credential-physical-erase-9f7d2b4c-" + "x" * 128
+    store = TaskStore(str(db_path))
+    store.create_if_absent(
+        "terminal-physical-erase",
+        "queued",
+        {
+            "task_id": "terminal-physical-erase",
+            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": secret}],
+        },
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    legacy_payload = json.dumps(
+        {
+            "task_id": "terminal-physical-erase",
+            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": secret}],
+        },
+        ensure_ascii=False,
+    )
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("PRAGMA secure_delete = OFF")
+        connection.execute("ALTER TABLE task_state DROP COLUMN execution_status")
+        connection.execute(
+            """
+            UPDATE task_state
+            SET status = 'success', execution_payload_json = ?
+            WHERE task_id = 'terminal-physical-erase'
+            """,
+            (legacy_payload,),
+        )
+    assert secret.encode() in db_path.read_bytes()
+
+    reloaded_store = TaskStore(str(db_path))
+
+    assert reloaded_store.get_execution_payload("terminal-physical-erase") is None
+    assert secret.encode() not in db_path.read_bytes()
+
+
+def test_update_execution_result_keeps_payload_when_lease_owner_mismatches(tmp_path):
+    store = TaskStore(str(tmp_path / "task.db"))
+    payload_with_creds = {
+        "task_id": "lease-lost-payload-test",
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
+    store.create_if_absent(
+        "lease-lost-payload-test",
+        "queued",
+        payload_with_creds,
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    store.claim_task(
+        "lease-lost-payload-test",
+        "worker-a",
+        "2026-04-23T00:00:10+00:00",
+        "2026-04-23T00:00:01+00:00",
+    )
+
+    updated = store.update_execution_result(
+        "lease-lost-payload-test",
+        "success",
+        {"task_id": "lease-lost-payload-test", "success": True},
+        "2026-04-23T00:00:02+00:00",
+        owner_id="worker-b",
+    )
+
+    assert updated is False
+    assert store.get_execution_payload("lease-lost-payload-test") == payload_with_creds
+
+
 def test_init_clears_legacy_terminal_payloads_without_touching_active_tasks(tmp_path):
     db_path = tmp_path / "task.db"
     store = TaskStore(str(db_path))
+    payload_with_creds = {
+        "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": "secret"}],
+    }
     stored_statuses = {
         "status-terminal": ("success", "queued"),
         "execution-terminal": ("running", "failed"),
@@ -456,10 +560,12 @@ def test_init_clears_legacy_terminal_payloads_without_touching_active_tasks(tmp_
     }
     for task_id_suffix, (status, execution_status) in stored_statuses.items():
         task_id = f"legacy-{task_id_suffix}"
-        payload_with_creds = {
-            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": f"legacy-secret-{task_id_suffix}"}],
-        }
-        store.create_if_absent(task_id, "queued", payload_with_creds, {}, "2026-04-23T00:00:00+00:00")
+        callback = (
+            {"subject": "job.callback", "context": {"token": "callback-secret"}}
+            if task_id_suffix == "callback-terminal"
+            else {}
+        )
+        store.create_if_absent(task_id, "queued", payload_with_creds, callback, "2026-04-23T00:00:00+00:00")
         with sqlite3.connect(db_path) as conn:
             conn.execute(
                 """
@@ -471,16 +577,70 @@ def test_init_clears_legacy_terminal_payloads_without_touching_active_tasks(tmp_
             )
 
     reloaded_store = TaskStore(str(db_path))
-    database_bytes = db_path.read_bytes()
-
     for task_id_suffix in ("status-terminal", "execution-terminal", "callback-terminal"):
         assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") is None
-        assert f"legacy-secret-{task_id_suffix}".encode() not in database_bytes
     for task_id_suffix in ("queued", "running"):
-        assert f"legacy-secret-{task_id_suffix}".encode() in database_bytes
-        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") == {
-            "host_credentials": [{"host": "10.0.0.1", "user": "root", "password": f"legacy-secret-{task_id_suffix}"}],
-        }
+        assert reloaded_store.get_execution_payload(f"legacy-{task_id_suffix}") == payload_with_creds
+    callback = reloaded_store.get_callback_config("legacy-callback-terminal")
+    assert callback["context"]["token"] == "callback-secret"
+    assert b"fernet:v1:" in db_path.read_bytes()
+
+
+def test_init_rolls_back_failed_terminal_cleanup_and_recovers_after_restart(tmp_path):
+    db_path = tmp_path / "task.db"
+    store = TaskStore(str(db_path))
+    store.create_if_absent(
+        "terminal",
+        "queued",
+        {"password": "legacy-secret"},
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            "UPDATE task_state SET status = 'success', execution_payload_json = ? WHERE task_id = 'terminal'",
+            (json.dumps({"password": "legacy-secret"}),),
+        )
+        connection.execute(
+            """
+            CREATE TRIGGER reject_terminal_cleanup
+            BEFORE UPDATE OF execution_payload_json ON task_state
+            BEGIN SELECT RAISE(ABORT, 'blocked cleanup'); END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="blocked cleanup"):
+        TaskStore(str(db_path))
+    with sqlite3.connect(db_path) as connection:
+        assert "legacy-secret" in connection.execute(
+            "SELECT execution_payload_json FROM task_state WHERE task_id = 'terminal'"
+        ).fetchone()[0]
+        connection.execute("DROP TRIGGER reject_terminal_cleanup")
+
+    recovered_store = TaskStore(str(db_path))
+    assert recovered_store.get_execution_payload("terminal") is None
+
+
+def test_init_clears_terminal_fernet_payload_without_the_original_key(tmp_path):
+    db_path = tmp_path / "task.db"
+    old_store = TaskStore(str(db_path), "old-key")
+    old_store.create_if_absent(
+        "terminal",
+        "queued",
+        {"password": "encrypted-secret"},
+        {},
+        "2026-04-23T00:00:00+00:00",
+    )
+    with old_store._connect() as connection:
+        ciphertext = connection.execute(
+            "SELECT execution_payload_json FROM task_state WHERE task_id = 'terminal'"
+        ).fetchone()[0]
+        connection.execute("UPDATE task_state SET status = 'success' WHERE task_id = 'terminal'")
+
+    new_store = TaskStore(str(db_path), "replacement-key")
+
+    assert new_store.get_execution_payload("terminal") is None
+    assert ciphertext.encode() not in db_path.read_bytes()
 
 
 def test_sensitive_credential_keys_is_comprehensive():


### PR DESCRIPTION
## 问题

Ansible Executor 为支持进程重启恢复，会在排队和运行阶段暂存完整执行载荷。当前新任务已经加密，并会在进入终态时清空载荷；但升级前遗留数据库中已处于终态的明文载荷没有迁移路径，仍可能长期保留主机密码、私钥或 passphrase。

## 根因（设计层）

运行时生命周期边界已覆盖新任务，却没有延伸到旧状态库初始化：schema 迁移只补齐列，不按 `status` 与 `execution_status` 回收历史终态载荷。同时，SQLite 默认逻辑删除不足以保证旧明文从数据库页面消失。

## 怎么修的

1. TaskStore 每次建立 SQLite 连接时启用 `secure_delete`，确保旧明文被清空或重写时同步擦除数据库页面残留。
2. schema 兼容迁移完成后，在同一事务中幂等清理 `status` 或 `execution_status` 已为 `success`、`failed`、`callback_failed` 的历史执行载荷。
3. `queued`、`running` 任务不命中清理条件，继续保留重启恢复能力；其旧明文载荷仍按现有读路径加密迁移。

## 影响范围与兼容性

- 仅修改 Ansible Executor 本地 SQLite 状态存储及对应测试。
- 不改变 NATS subject、RPC 参数、查询响应、回调、状态值或运行中任务恢复契约。
- 清理语句可重复执行；已删除的历史凭据不可恢复，代码回滚不会重新生成秘密。
- 该变更涉及敏感数据迁移，保留人工 Review 闸。

## 调用链

```mermaid
flowchart TD
    subgraph T["启动与恢复层"]
        T1["TaskStore 初始化\ntask_store.py"]
        T2["schema 兼容迁移"]
    end

    subgraph N["生命周期处理层"]
        N1["识别 status / execution_status"]
        N2["清空历史终态执行载荷"]
    end

    subgraph C["兼容与擦除层"]
        C1["queued / running 保留恢复载荷"]
        C2["secure_delete 擦除旧明文页面"]
    end

    T1 --> T2 --> N1
    N1 -- "终态" --> N2 --> C2
    N1 -. "运行中" .-> C1
```

## 验证

- TDD RED：`agents/ansible-executor/tests/test_task_store.py` 为 1 failed、20 passed，失败项证明历史终态行仍可读取含密码载荷。
- GREEN：`agents/ansible-executor/tests/test_task_store.py` 与 `agents/ansible-executor/tests/test_nats_service.py` 合计 50 passed。
- 覆盖 `status` 与 `execution_status` 两类终态、物理页面擦除、`queued`/`running` 恢复兼容，以及既有 NATS 调用链。

## 三轨门禁

- Standards：pass。差异仅两个目标文件，Ruff、编译与 diff-check 通过。
- Spec：pass。历史终态清理、物理擦除和运行中兼容均已覆盖。
- Runtime Contract：pass。真实 SQLite 旧明文迁移与直接 NATS 调用方测试均通过。
- G6：96 / 100（SCORE_PASS）。

关联 Issue #4279。
