### PR TITLE
fix(stargazer): 调整镜像构建的依赖安装路径

### DIFF
--- a/agents/stargazer/support-files/docker/Dockerfile
+++ b/agents/stargazer/support-files/docker/Dockerfile
@@ -21,17 +21,6 @@ RUN if [ -n "$NEXUS_PYTHON_REPOSITY" ]; then \
     pip3 config set global.trusted-host "$(echo $NEXUS_PYTHON_REPOSITY | sed -E 's|^https?://([^/:]+).*|\1|')"; \
     fi
 
-RUN pip3 install uv==0.8.16
-
-RUN if [ -n "$NEXUS_PYTHON_REPOSITY" ]; then \
-    uv sync --locked --all-groups --all-extras \
-        --default-index "$NEXUS_PYTHON_REPOSITY" \
-        --allow-insecure-host "$(echo $NEXUS_PYTHON_REPOSITY | sed -E 's|^https?://([^/:]+).*|\1|')"; \
-    else \
-    uv sync --locked --all-groups --all-extras; \
-    fi
-
-ENV PATH="/app/.venv/bin:$PATH"
-
-RUN apt-get reinstall -y supervisor
+RUN pip3 install -e ".[dev,aliyun,qcloud,huawei,vmware,openstack,qingyun,snmp]"
+RUN apt-get reinstall -y supervisor 
 CMD ["supervisord", "-n"]

--- a/agents/stargazer/tests/test_dependency_lock_contract.py
+++ b/agents/stargazer/tests/test_dependency_lock_contract.py
@@ -1,7 +1,4 @@
 import importlib
-import os
-import subprocess
-import sys
 import warnings
 from importlib.metadata import version
 from pathlib import Path
@@ -41,16 +38,17 @@ def test_lock_contains_the_approved_tracerite_version() -> None:
     assert [package["version"] for package in tracerite_packages] == ["1.1.3"]
 
 
-def test_dockerfile_installs_the_locked_uv_environment() -> None:
+def test_dockerfile_installs_pinned_dependencies_via_pip() -> None:
     dockerfile = _logical_dockerfile()
 
-    assert "pip3 install uv==0.8.16" in dockerfile
-    assert 'ENV PATH="/app/.venv/bin:$PATH"' in dockerfile
-    assert dockerfile.count("uv sync ") == 2
-    assert dockerfile.count("uv sync --locked --all-groups --all-extras") == 2
-    assert '--default-index "$NEXUS_PYTHON_REPOSITY"' in dockerfile
-    assert '--allow-insecure-host "$(echo $NEXUS_PYTHON_REPOSITY' in dockerfile
-    assert "pip3 install -e" not in dockerfile
+    assert (
+        'pip3 install -e ".[dev,aliyun,qcloud,huawei,vmware,openstack,qingyun,snmp]"'
+        in dockerfile
+    )
+    assert 'pip3 config set global.index-url "$NEXUS_PYTHON_REPOSITY"' in dockerfile
+    # uv sync --locked 会把 index 地址纳入锁校验，与 Nexus 私有源冲突，
+    # 不得回到镜像构建路径（TencentBlueKing/bk-lite#4287）
+    assert "uv sync" not in dockerfile
 
 
 def test_docker_context_and_runbook_expose_task_queue_cleanup_cli() -> None:
@@ -79,54 +77,6 @@ def test_runbook_documents_startup_orphan_cleanup_toggle() -> None:
     assert "分布式锁" in readme
     assert "status=warning" in readme
     assert "脱敏" in readme
-
-
-def test_locked_sync_rejects_stale_lockfile_offline(tmp_path: Path) -> None:
-    uv_environment = {
-        **os.environ,
-        "UV_CACHE_DIR": str(tmp_path / ".uv-cache"),
-    }
-    uv_environment.pop("VIRTUAL_ENV", None)
-    pyproject_path = tmp_path / "pyproject.toml"
-    pyproject_path.write_text(
-        """\
-[project]
-name = "dependency-lock-contract"
-version = "0.1.1"
-requires-python = ">=3.12"
-dependencies = []
-
-[tool.uv]
-package = false
-""",
-        encoding="utf-8",
-    )
-    (tmp_path / "uv.lock").write_text(
-        """\
-version = 1
-revision = 3
-requires-python = ">=3.12"
-
-[[package]]
-name = "dependency-lock-contract"
-version = "0.1.0"
-source = { virtual = "." }
-""",
-        encoding="utf-8",
-    )
-
-    locked_sync = subprocess.run(
-        ["uv", "sync", "--locked", "--offline", "--python", sys.executable],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=uv_environment,
-    )
-    output = f"{locked_sync.stdout}\n{locked_sync.stderr}".lower()
-
-    assert locked_sync.returncode != 0
-    assert "needs to be updated, but `--locked` was provided" in output
 
 
 def test_sanic_imports_with_the_approved_tracerite_api() -> None:


### PR DESCRIPTION
## 背景

stargazer 镜像近期从 `pip3 install -e` 迁移到了 `uv sync --locked`。`--locked` 校验会把 index 地址视为锁内容的一部分，而部署环境通过 `--default-index` 指定私有 PyPI 源（`NEXUS_PYTHON_REPOSITY` 构建参数），与 `uv.lock` 中记录的官方 PyPI 地址不一致，导致该部署路径下镜像构建失败：

```
The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

## 改动

- `support-files/docker/Dockerfile` 恢复为迁移前的 `pip3 install -e` 安装逻辑（通过 pip.conf 使用私有源）；
- `tests/test_dependency_lock_contract.py` 同步调整：Dockerfile 契约改为断言 pip 安装路径且不含 `uv sync`，删除仅验证 uv 自身行为的离线锁校验用例；
- 保留 `pyproject.toml` 的 `tracerite==1.1.3` 钉定（pip 安装同样生效，原 sanic/tracerite 兼容性问题不会回归）。

## 验证

- `pytest tests/test_dependency_lock_contract.py` → 6 passed；
- 回退后的 Dockerfile 与迁移前最后一次可正常构建的版本逐字一致；
- 已在本地用镜像内同版本 uv 0.8.16 复现原失败并确认回退后不再触发。

Closes #4287

🤖 Generated with [Claude Code](https://claude.com/claude-code)