### PR TITLE
ci: 新增 server migrate 校验 workflow

### DIFF
--- a/.github/workflows/server-migrate-check.yml
+++ b/.github/workflows/server-migrate-check.yml
@@ -1,0 +1,76 @@
+name: Server Migrate Check
+
+on:
+  pull_request:
+    paths:
+      - 'server/apps/**/migrations/**'
+      - 'server/apps/**/models/**'
+      - 'server/apps/**/models.py'
+      - 'server/config/**'
+      - 'server/pyproject.toml'
+      - 'server/settings.py'
+  push:
+    branches: [master]
+    paths:
+      - 'server/apps/**/migrations/**'
+      - 'server/apps/**/models/**'
+      - 'server/apps/**/models.py'
+      - 'server/config/**'
+      - 'server/pyproject.toml'
+      - 'server/settings.py'
+  workflow_dispatch:
+
+jobs:
+  migrate-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: migrate-check
+          POSTGRES_DB: migrate_check
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DB_ENGINE: postgresql
+      DB_NAME: migrate_check
+      DB_USER: postgres
+      DB_PASSWORD: migrate-check
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+      SECRET_KEY: github-actions-migrate-check
+      ENABLE_CELERY: "true"
+      MINIO_ENDPOINT: 127.0.0.1:9000
+      MINIO_ACCESS_KEY: migrate-check
+      MINIO_SECRET_KEY: migrate-check
+      MINIO_USE_HTTPS: "false"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: server/pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[cmdb,dev,mlops,opspilot]"
+
+      - name: Run migrate against empty PostgreSQL
+        run: python manage.py migrate --no-input
+
+      - name: Check for missing migrations
+        run: python manage.py makemigrations --check --dry-run


### PR DESCRIPTION
## 背景

alerts.0024 数据迁移的缺陷（历史模型上 `AlertSource.objects` 不存在）只有对真实数据库执行 migrate 才会暴露，单测和代码审查都拦不住，最终在部署环境炸出。参考 #4287。

## 改动

新增 `.github/workflows/server-migrate-check.yml`：

- PR / master push 触及 server 模型、migration、配置相关路径时触发；
- 起 postgres:15 service 容器，对**空库全量执行** `manage.py migrate --no-input`；
- 追加 `makemigrations --check --dry-run`，拦截「改了模型没生成 migration」的漂移；
- 依赖安装与 release 镜像一致（`pip install -e ".[cmdb,dev,mlops,opspilot]"`），启用 pip 缓存。

## 验证

两项检查已在本地 PostgreSQL 15.18 + 当前 master 验证通过：416 个 migration 全部应用成功，`makemigrations --check` 无漂移。

🤖 Generated with [Claude Code](https://claude.com/claude-code)