### PR TITLE
bugfix: 避免代理日志泄露查询参数

### DIFF
--- a/web/scripts/proxy-log-redaction-test.ts
+++ b/web/scripts/proxy-log-redaction-test.ts
@@ -66,12 +66,22 @@ async function main() {
     /\[PROXY ERROR\] Request timeout: \$\{logTarget\}/,
     'timeout logs must use the query-free target',
   );
+  assert.match(
+    routeSource,
+    /\[PROXY ERROR\] Failed to proxy request: \$\{error\.name \|\| 'UnknownError'\} from \$\{logTarget\}/,
+    'generic fetch errors must not log an error message that can contain the full target URL',
+  );
 
   const proxyLogLines = routeSource.split('\n').filter((line) => line.includes('[PROXY'));
   assert.equal(
     proxyLogLines.some((line) => line.includes('${targetUrl}')),
     false,
     'no proxy log statement may interpolate the full forwarding URL',
+  );
+  assert.equal(
+    proxyLogLines.some((line) => line.includes('${error.message}')),
+    false,
+    'no proxy log statement may interpolate fetch error messages that can contain the full forwarding URL',
   );
 
   console.log('proxy log redaction tests passed');

--- a/web/scripts/proxy-log-redaction-test.ts
+++ b/web/scripts/proxy-log-redaction-test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type ProxyTargetModule = typeof import('../src/app/(core)/api/proxy/[...path]/proxyTarget');
+
+async function main() {
+  const moduleUrl = pathToFileURL(
+    path.resolve(process.cwd(), 'src/app/(core)/api/proxy/[...path]/proxyTarget.ts'),
+  );
+  const { buildProxyTargets } = await import(moduleUrl.href) as ProxyTargetModule;
+
+  const sensitiveSearch = '?poll_token=poll-secret&token=api-secret&code=oauth-code&state=oauth-state';
+  const sensitiveTargets = buildProxyTargets(
+    'https://api.example.com/api/v1',
+    '/core/api/login_auth_requests/request-id/status/',
+    sensitiveSearch,
+  );
+
+  assert.equal(
+    sensitiveTargets.targetUrl,
+    `https://api.example.com/api/v1/core/api/login_auth_requests/request-id/status/${sensitiveSearch}`,
+    'the forwarded request must retain its complete query string',
+  );
+  assert.equal(
+    sensitiveTargets.logTarget,
+    'https://api.example.com/api/v1/core/api/login_auth_requests/request-id/status/',
+    'the log target must contain only the destination origin and path',
+  );
+  for (const secret of ['poll-secret', 'api-secret', 'oauth-code', 'oauth-state']) {
+    assert.equal(sensitiveTargets.logTarget.includes(secret), false, `${secret} must not enter proxy logs`);
+  }
+
+  assert.deepEqual(
+    buildProxyTargets('https://api.example.com/api/v1', '/monitor/api/query/', ''),
+    {
+      targetUrl: 'https://api.example.com/api/v1/monitor/api/query/',
+      logTarget: 'https://api.example.com/api/v1/monitor/api/query/',
+    },
+    'requests without query parameters must keep their existing target representation',
+  );
+
+  const routeSource = readFileSync(
+    path.resolve(process.cwd(), 'src/app/(core)/api/proxy/[...path]/route.ts'),
+    'utf8',
+  );
+  assert.match(
+    routeSource,
+    /const \{targetUrl, logTarget\} = buildProxyTargets\(TARGET_SERVER, targetPath, req\.nextUrl\.search\);/,
+    'the proxy route must derive forwarding and logging targets together',
+  );
+  assert.match(routeSource, /fetch\(targetUrl, fetchOptions\)/, 'fetch must keep using the full target URL');
+  assert.match(
+    routeSource,
+    /\[PROXY\] Forwarding Request: \$\{req\.method\} \$\{logTarget\}/,
+    'forwarding logs must use the query-free target',
+  );
+  assert.match(
+    routeSource,
+    /\[PROXY\] Response Status: \$\{proxyResponse\.status\} from \$\{logTarget\}/,
+    'response logs must use the query-free target',
+  );
+  assert.match(
+    routeSource,
+    /\[PROXY ERROR\] Request timeout: \$\{logTarget\}/,
+    'timeout logs must use the query-free target',
+  );
+
+  const proxyLogLines = routeSource.split('\n').filter((line) => line.includes('[PROXY'));
+  assert.equal(
+    proxyLogLines.some((line) => line.includes('${targetUrl}')),
+    false,
+    'no proxy log statement may interpolate the full forwarding URL',
+  );
+
+  console.log('proxy log redaction tests passed');
+}
+
+void main();

--- a/web/src/app/(core)/api/proxy/[...path]/proxyTarget.ts
+++ b/web/src/app/(core)/api/proxy/[...path]/proxyTarget.ts
@@ -1,0 +1,12 @@
+export interface ProxyTargets {
+  targetUrl: string;
+  logTarget: string;
+}
+
+export function buildProxyTargets(targetServer: string, targetPath: string, search: string): ProxyTargets {
+  const logTarget = `${targetServer}${targetPath}`;
+  return {
+    targetUrl: `${logTarget}${search}`,
+    logTarget,
+  };
+}

--- a/web/src/app/(core)/api/proxy/[...path]/route.ts
+++ b/web/src/app/(core)/api/proxy/[...path]/route.ts
@@ -1,5 +1,7 @@
 import {NextRequest, NextResponse} from 'next/server';
 
+import {buildProxyTargets} from './proxyTarget';
+
 const TARGET_SERVER = process.env.NEXTAPI_URL + '/api/v1' || 'http://localhost:3000';
 
 // SSE 连接超时时间（5 分钟），与后端 Agent 总超时一致
@@ -68,16 +70,10 @@ async function handleProxy(req: NextRequest): Promise<NextResponse | Response> {
     targetPath += '/';
   }
 
-  // 构造完整的目标 URL
-  let targetUrl = `${TARGET_SERVER}${targetPath}`;
+  // 转发地址保留查询参数；日志地址仅保留 origin 与 path，避免凭据进入日志。
+  const {targetUrl, logTarget} = buildProxyTargets(TARGET_SERVER, targetPath, req.nextUrl.search);
 
-  // 拼接查询参数
-  const searchParams = req.nextUrl.search;
-  if (searchParams) {
-    targetUrl += searchParams;
-  }
-
-  console.log(`[PROXY] Forwarding Request: ${req.method} ${targetUrl}`);
+  console.log(`[PROXY] Forwarding Request: ${req.method} ${logTarget}`);
 
   // 复制原始请求头，追加 X-Forwarded-* 自定义请求头
   const headers = new Headers(req.headers);
@@ -104,7 +100,7 @@ async function handleProxy(req: NextRequest): Promise<NextResponse | Response> {
     const proxyResponse = await fetch(targetUrl, fetchOptions);
 
     // 转发响应及其内容
-    console.log(`[PROXY] Response Status: ${proxyResponse.status} from ${targetUrl}`);
+    console.log(`[PROXY] Response Status: ${proxyResponse.status} from ${logTarget}`);
 
     // 检测是否为 SSE 响应
     if (isSSEResponse(proxyResponse)) {
@@ -127,7 +123,7 @@ async function handleProxy(req: NextRequest): Promise<NextResponse | Response> {
 
     // 区分超时错误和其他错误
     if (error.name === 'AbortError') {
-      console.error(`[PROXY ERROR] Request timeout: ${targetUrl}`);
+      console.error(`[PROXY ERROR] Request timeout: ${logTarget}`);
       return NextResponse.json(
         { error: 'Gateway Timeout', message: 'Request timed out' },
         { status: 504 }

--- a/web/src/app/(core)/api/proxy/[...path]/route.ts
+++ b/web/src/app/(core)/api/proxy/[...path]/route.ts
@@ -130,7 +130,7 @@ async function handleProxy(req: NextRequest): Promise<NextResponse | Response> {
       );
     }
 
-    console.error(`[PROXY ERROR] Failed to proxy request: ${error.message}`);
+    console.error(`[PROXY ERROR] Failed to proxy request: ${error.name || 'UnknownError'} from ${logTarget}`);
     return NextResponse.json(
       { error: 'Proxy Failed', message: error.message },
       { status: 500 }


### PR DESCRIPTION
## 问题

通用代理需要完整保留查询参数转发请求，但日志不应携带认证凭据。原实现复用同一个完整目标地址执行转发和输出日志，导致 `poll_token`、`token`、`code`、`state` 等查询参数同时出现在请求、响应和超时日志中。

## 根因

转发地址与日志地址缺少独立边界：代码先把查询串拼入 `targetUrl`，随后既把它交给 `fetch`，又直接插入三处日志。只要合法调用方通过查询参数传递秘密，代理日志就会扩大秘密的可见范围。

## 怎么修的

- 新增 `buildProxyTargets`，一次生成完整转发地址 `targetUrl` 与仅含 origin/path 的 `logTarget`。
- `fetch` 继续使用完整 `targetUrl`，保持所有查询参数的转发行为不变。
- 请求、响应和超时日志统一改用 `logTarget`，查询参数默认不进入日志。

## 影响范围

- 仅触及 Web 通用代理及其聚焦回归脚本。
- 不改变代理 URL、请求方法、请求体、请求头、响应、SSE、超时或鉴权契约。
- 无查询参数的请求保持原有地址表示。
- 日志文本框架保持不变，仅移除目标地址中的查询串；回滚时可还原代码，但不建议恢复秘密参数明文日志。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["登录轮询/通用代理调用\nuseLoginAuthValidation.ts"]
    end

    B["buildProxyTargets\nproxyTarget.ts"]

    subgraph N["代理处理层"]
        F1["handleProxy\nroute.ts"]
        F2["fetch(targetUrl)\n保留完整查询串"]
    end

    subgraph L["日志边界"]
        L1["请求/响应/超时日志\n仅使用 logTarget"]
    end

    T1 --> F1 --> B
    B --> F2
    B --> L1
```

## 验证

- `web/scripts/proxy-log-redaction-test.ts`：父提交预期失败，当前提交通过；覆盖敏感查询串继续转发、日志地址不含凭据、无查询参数行为不变，以及请求/响应/超时三处日志。
- `web/src/app/(core)/api/proxy/[...path]/route.ts`、`web/src/app/(core)/api/proxy/[...path]/proxyTarget.ts`：定向 ESLint 0 错误。
- Web TypeScript 类型检查：通过。
- 差异空白检查：通过。

关联 Issue #4256。
