### PR TITLE
bugfix: 更新 MLOps NATS 数据测试鉴权契约

### DIFF
--- a/server/apps/mlops/tests/test_nats_module_data.py
+++ b/server/apps/mlops/tests/test_nats_module_data.py
@@ -12,6 +12,14 @@ from apps.mlops.models.anomaly_detection import (
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
+@pytest.fixture
+def actor_context():
+    def build(*group_ids, is_superuser=False):
+        return {"is_superuser": is_superuser, "group_list": list(group_ids)}
+
+    return build
+
+
 def test_get_mlops_module_data_unknown_module():
     result = nats_api.get_mlops_module_data("nope", "x", 1, 10, 1)
     assert result["result"] is False
@@ -24,20 +32,23 @@ def test_get_mlops_module_data_unknown_child():
     assert "未知子模块" in result["message"]
 
 
-def test_get_mlops_module_data_root_filters_by_group():
+def test_get_mlops_module_data_root_filters_by_group(actor_context):
     AnomalyDetectionDataset.objects.create(name="d1", description="", team=[1])
     AnomalyDetectionDataset.objects.create(name="d2", description="", team=[2])
-    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 10, 1)
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 10, 1, actor_context=actor_context(1)
+    )
     assert result["result"] is True
     assert result["count"] == 1
     assert result["items"][0]["name"] == "d1"
 
 
-def test_get_mlops_module_data_pagination():
+def test_get_mlops_module_data_pagination(actor_context):
     for i in range(5):
         AnomalyDetectionDataset.objects.create(name=f"d{i}", description="", team=[1])
-    page1 = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 2, 1)
-    page2 = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 2, 2, 1)
+    context = actor_context(1)
+    page1 = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 2, 1, actor_context=context)
+    page2 = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 2, 2, 1, actor_context=context)
     assert page1["count"] == 5
     assert len(page1["items"]) == 2
     assert len(page2["items"]) == 2
@@ -47,34 +58,67 @@ def test_get_mlops_module_data_pagination():
     assert ids1.isdisjoint(ids2)
 
 
-def test_get_mlops_module_data_page_size_clamped_to_max(monkeypatch):
+def test_get_mlops_module_data_page_size_clamped_to_max(monkeypatch, actor_context):
     monkeypatch.setattr(nats_api, "MAX_PAGE_SIZE", 3)
     for i in range(5):
         AnomalyDetectionDataset.objects.create(name=f"d{i}", description="", team=[1])
-    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 999, 1)
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 999, 1, actor_context=actor_context(1)
+    )
     assert result["count"] == 5
     assert len(result["items"]) == 3
 
 
-def test_get_mlops_module_data_page_size_floor_one():
+def test_get_mlops_module_data_page_size_floor_one(actor_context):
     AnomalyDetectionDataset.objects.create(name="d", description="", team=[1])
-    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 0, 1)
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 0, 1, actor_context=actor_context(1)
+    )
     # page_size floored to 1
     assert len(result["items"]) == 1
 
 
-def test_get_mlops_module_data_inherited_child_uses_dataset_team():
+def test_get_mlops_module_data_inherited_child_uses_dataset_team(actor_context):
     ds1 = AnomalyDetectionDataset.objects.create(name="parent1", description="", team=[1])
     ds2 = AnomalyDetectionDataset.objects.create(name="parent2", description="", team=[2])
     AnomalyDetectionTrainData.objects.create(name="t-in", dataset=ds1, is_train_data=True)
     AnomalyDetectionTrainData.objects.create(name="t-out", dataset=ds2, is_train_data=True)
-    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_train_data", 1, 10, 1)
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_train_data", 1, 10, 1, actor_context=actor_context(1)
+    )
     assert result["count"] == 1
     assert result["items"][0]["name"] == "t-in"
 
 
-def test_get_mlops_module_data_empty_result():
-    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 10, 999)
+def test_get_mlops_module_data_empty_result(actor_context):
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 10, 999, actor_context=actor_context(999)
+    )
     assert result["result"] is True
     assert result["count"] == 0
     assert result["items"] == []
+
+
+def test_get_mlops_module_data_rejects_missing_actor_context():
+    result = nats_api.get_mlops_module_data("dataset", "anomaly_detection_dataset", 1, 10, 1)
+
+    assert result == {"result": False, "message": "缺少调用方上下文"}
+
+
+def test_get_mlops_module_data_rejects_group_outside_actor_scope(actor_context):
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 10, 2, actor_context=actor_context(1)
+    )
+
+    assert result == {"result": False, "message": "无权访问该组织"}
+
+
+def test_get_mlops_module_data_allows_superuser_group(actor_context):
+    AnomalyDetectionDataset.objects.create(name="d2", description="", team=[2])
+    result = nats_api.get_mlops_module_data(
+        "dataset", "anomaly_detection_dataset", 1, 10, 2, actor_context=actor_context(is_superuser=True)
+    )
+
+    assert result["result"] is True
+    assert result["count"] == 1
+    assert result["items"][0]["name"] == "d2"


### PR DESCRIPTION
## 问题

MLOps 模块数据查询已经要求可信的 `actor_context` 来约束组织范围，但主集成测试仍按旧的无上下文契约调用。结果是合法查询路径在进入 ORM 前即被拒绝，门禁无法同时守住“合法调用成功”和“越权调用失败”两侧契约。

## 根因

组织授权收口落地时，生产入口与 NATS handler 已完成上下文传递和校验，但覆盖筛选、分页、页大小边界、继承资源及空结果的集成测试没有同步迁移。测试契约因此落后于真实调用链。

## 怎么修的

- 增加与真实调用方结构一致的 `actor_context` 测试 fixture。
- 将六条合法查询路径迁移为显式携带授权组织上下文。
- 增加缺少上下文、越组访问和超管访问用例，确保拒绝与放行边界都有持续验证。
- 保持生产 handler、RPC、数据库查询和既有接口行为不变。

## 影响范围

仅修改 MLOps 的一份测试文件，不改生产代码、权限默认值、公共接口或存量数据。普通用户仍只能查询授权组织，超管仍可按目标组织查询，无上下文调用仍被明确拒绝。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_app_data\nsystem_mgmt viewset"]
        T2["test_nats_module_data.py\n集成测试"]
    end

    subgraph N["核心处理层"]
        N1["_build_actor_context\n构造调用方上下文"]
        N2["get_mlops_module_data\nMLOps NATS handler"]
        N3["_validate_actor_group\n校验组织范围"]
    end

    DB["QuerySet.filter\n按 team 查询"]
    R["拒绝：缺上下文或越组"]

    T1 --> N1 --> N2
    T2 --> N2
    N2 --> N3
    N3 --> DB
    N3 -. "校验失败" .-> R
```

## 验证

- `apps/mlops/tests/test_nats_module_data.py`：修复前 1 failed、2 passed，旧成功路径因缺少上下文失败。
- `apps/mlops/tests/test_nats_module_data.py`：修复后 11 passed。

关联 Issue #4251。
