### PR TITLE
bugfix: 修复 MLOps 父子资源组织集合校验

### DIFF
--- a/server/apps/mlops/tests/test_group_scope_pure.py
+++ b/server/apps/mlops/tests/test_group_scope_pure.py
@@ -68,7 +68,8 @@ def test_get_allowed_team_ids_no_group_list_empty():
 # ---------- validate_requested_teams ----------
 
 def test_validate_requested_teams_normalizes():
-    assert gs.validate_requested_teams(_req(), [1, "2", 3]) == [1, 2, 3]
+    user = SimpleNamespace(is_superuser=False, group_list=[1, 2, 3])
+    assert gs.validate_requested_teams(_req(user=user), [1, "2", 3]) == [1, 2, 3]
 
 
 def test_validate_requested_teams_empty_raises():
@@ -120,6 +121,18 @@ def test_assert_team_ownership_none_team_raises():
 def test_assert_parent_team_matches_equal_ok():
     owner = SimpleNamespace(team=[1, 2])
     parent = SimpleNamespace(team=[1, 2])
+    gs.assert_parent_team_matches(owner, parent, "ds")
+
+
+def test_assert_parent_team_matches_equivalent_order_ok():
+    owner = SimpleNamespace(team=[1, 2])
+    parent = SimpleNamespace(team=[2, 1])
+    gs.assert_parent_team_matches(owner, parent, "ds")
+
+
+def test_assert_parent_team_matches_equivalent_duplicates_ok():
+    owner = SimpleNamespace(team=[1, 1, 2])
+    parent = SimpleNamespace(team=[2, 1])
     gs.assert_parent_team_matches(owner, parent, "ds")
 
 

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -129,7 +129,7 @@ def assert_parent_team_matches(team_owned_obj, parent_obj, field_name):
     """Raise ``ValidationError`` when a root-owned object does not match its parent's team."""
     owner_team = getattr(team_owned_obj, "team", None) or []
     parent_team = getattr(parent_obj, "team", None) or []
-    if owner_team != parent_team:
+    if set(owner_team) != set(parent_team):
         raise serializers.ValidationError({field_name: "关联资源与当前对象的组归属不一致"})
 
 


### PR DESCRIPTION
## 问题

MLOps 的六类训练与服务资源使用 `team` 表示可访问组织。父子资源关联时应校验组织 ID 集合一致，但现有实现比较 JSON 列表的具体表示，导致 `[1, 2]` 与 `[2, 1]` 或含重复 ID 的等价范围被误判为不同，合法请求返回 400。

## 根因

组织归属的授权语义是集合，而校验边界复用了列表的顺序与重复次数语义。展示/存储表示因此泄漏到了授权一致性判断中。

## 怎么修的

- 父子资源归属校验改为比较组织 ID 集合。
- 保留 `validate_requested_teams` 的整数归一化、所属组织子集校验和返回顺序。
- 补充乱序、重复值回归用例，并修正既有纯函数用例的合法用户组织上下文。

## 影响范围

- 六类 MLOps serializer 共用该校验，行为同步修复。
- 不修改数据库、JSON 存储、响应顺序、API 字段或错误结构。
- 旧同序调用继续通过；不同组织集合仍按原错误拒绝。
- 回滚只需回退本提交，不涉及数据迁移。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["六类 MLOps serializer\nserver/apps/mlops/serializers"]
    end

    subgraph N["组织校验层"]
        F1["validate_team / validate\n父子资源关联"]
        F2["assert_parent_team_matches\ngroup_scope.py"]
        F3["组织 ID 集合比较"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -- "集合不同" --> E["ValidationError"]
```

## 验证

- `apps/mlops/tests/test_group_scope_pure.py`：25 passed。
- 回归用例在修复前稳定失败，修复后通过；同序、乱序、重复和不同集合路径均已覆盖。

Closes #4250
