### PR TITLE
fix: 修复节点安装后 CPU 架构缺失

### DIFF
--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -320,6 +320,26 @@ class Sidecar:
         return ""
 
     @staticmethod
+    def _cached_heartbeat_updates(node_id: str, node_details: dict) -> tuple[dict, str]:
+        """Build the bounded metadata update allowed on an ETag cache hit."""
+        request_data = dict(node_details)
+        missing_fields = [field for field in ("ip", "operating_system") if not request_data.get(field)]
+        if missing_fields:
+            existing_node = Node.objects.filter(id=node_id).values(*missing_fields).first() or {}
+            for field in missing_fields:
+                request_data[field] = existing_node.get(field, "")
+
+        updates = {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "status": node_details.get("status", {}),
+        }
+        cpu_architecture = Sidecar._fallback_cpu_architecture(node_id, request_data)
+        if cpu_architecture:
+            updates["cpu_architecture"] = cpu_architecture
+
+        return updates, request_data.get("ip", "")
+
+    @staticmethod
     def _default_collector_priority(collector_cpu_architecture: str, node_cpu_architecture: str) -> int:
         collector_arch = normalize_cpu_architecture(collector_cpu_architecture)
         node_arch = normalize_cpu_architecture(node_cpu_architecture)
@@ -380,17 +400,10 @@ class Sidecar:
 
         # 如果缓存的ETag存在且与客户端的相同，则返回304 Not Modified
         if cached_etag and cached_etag == if_none_match:
-            # 更新时间, 更新状态
-            node_status = request.data.get("node_details", {}).get("status", {})
-            Node.objects.filter(id=node_id).update(
-                updated_at=datetime.now(timezone.utc).isoformat(),
-                status=node_status,
-            )
-
-            node_ip = request.data.get("node_details", {}).get("ip", "")
-            if not node_ip:
-                node_ip = Node.objects.filter(id=node_id).values_list("ip", flat=True).first()
-            Sidecar.trigger_converge_tasks_if_needed(node_id, node_ip, node_status)
+            node_details = request.data.get("node_details", {})
+            updates, node_ip = Sidecar._cached_heartbeat_updates(node_id, node_details)
+            Node.objects.filter(id=node_id).update(**updates)
+            Sidecar.trigger_converge_tasks_if_needed(node_id, node_ip, updates["status"])
 
             response = HttpResponse(status=304)
             response["ETag"] = cached_etag

--- a/server/apps/node_mgmt/tests/test_b75_sidecar_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_sidecar_service.py
@@ -7,6 +7,7 @@ import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models import Collector, Node
 from apps.node_mgmt.models.cloud_region import CloudRegion
@@ -194,6 +195,78 @@ def test_get_collectors_returns_304_when_etag_matches(node):
         cache_mock.get.return_value = "cached-etag"
         resp = Sidecar.get_collectors(req)
     assert resp.status_code == 304
+
+
+@pytest.mark.django_db
+def test_update_node_client_304_refreshes_reported_node_metadata(node):
+    node.cpu_architecture = ""
+    node.install_method = ControllerConstants.AUTO
+    node.node_type = ControllerConstants.NODE_TYPE_HOST
+    node.save(update_fields=["cpu_architecture", "install_method", "node_type", "updated_at"])
+
+    request = SimpleNamespace(
+        headers={"If-None-Match": '"cached-etag"'},
+        META={},
+        data={
+            "node_name": node.name,
+            "node_details": {
+                "ip": node.ip,
+                "operating_system": "Linux",
+                "cpu_architecture": "amd64",
+                "status": {"status": 0},
+                "tags": [
+                    "zone:1",
+                    "group:1",
+                    "install_method:manual",
+                    "node_type:container",
+                ],
+            },
+        },
+    )
+
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache") as cache_mock,
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed"),
+    ):
+        cache_mock.get.return_value = "cached-etag"
+        response = Sidecar.update_node_client(request, node.id)
+
+    node.refresh_from_db()
+    assert response.status_code == 304
+    assert node.cpu_architecture == NodeConstants.X86_64_ARCH
+    assert node.install_method == ControllerConstants.AUTO
+    assert node.node_type == ControllerConstants.NODE_TYPE_HOST
+
+
+@pytest.mark.django_db
+def test_update_node_client_304_does_not_guess_missing_container_architecture(node):
+    node.cpu_architecture = ""
+    node.save(update_fields=["cpu_architecture", "updated_at"])
+
+    request = SimpleNamespace(
+        headers={"If-None-Match": '"cached-etag"'},
+        META={},
+        data={
+            "node_name": node.name,
+            "node_details": {
+                "ip": node.ip,
+                "operating_system": "Linux",
+                "status": {"status": 0},
+                "tags": ["node_type:container"],
+            },
+        },
+    )
+
+    with (
+        patch("apps.node_mgmt.services.sidecar.cache") as cache_mock,
+        patch.object(Sidecar, "trigger_converge_tasks_if_needed"),
+    ):
+        cache_mock.get.return_value = "cached-etag"
+        response = Sidecar.update_node_client(request, node.id)
+
+    node.refresh_from_db()
+    assert response.status_code == 304
+    assert node.cpu_architecture == ""
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## 问题

Sidecar 心跳命中 ETag 缓存后直接返回 304，仅刷新状态和时间，导致客户端已经上报的 CPU 架构没有写入节点记录。

## 修改

- 在 304 心跳分支同步规范化后的 `cpu_architecture`。
- 架构来源限定为心跳字段、架构标签或安装任务记录；没有可靠证据时保持为空，不猜测 x86_64。
- 不覆盖 `install_method`、`node_type` 等无关属性。
- 仅在心跳缺少 IP 或操作系统时查询节点信息，避免增加常态心跳查询。
- 增加 304 架构同步及未知架构保护的回归测试。

## 影响

- 手动和自动安装流程已上报架构时，节点管理可以在 304 心跳中正确落库。
- 不修改 `fusion-collector`、控制器安装脚本或运行时启动流程。

## 验证

- `pytest -q apps/node_mgmt/tests/test_b75_sidecar_service.py`：38 passed
- `git diff --check upstream/master...HEAD`：通过
