### PR TITLE
fix(monitor): 移除私有 SNMP 表根 OID

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/arris.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/arris.child.toml.j2
@@ -50,7 +50,6 @@
 
     # ARRIS Cadant E6 equipment health from CADANT-CMTS-EQUIPMENT-MIB.
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4998.1.1.10.1.4.12.1"
         name = "device_card"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -61,7 +60,6 @@
         name = "temperature_level"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4998.1.1.10.1.4.14.1"
         name = "device_disk"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -72,7 +70,6 @@
         name = "usage"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4998.1.1.10.1.4.17.1"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -80,7 +77,6 @@
         name = "celsius"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4998.1.1.10.1.4.18.1"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/nateks.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/nateks.child.toml.j2
@@ -50,7 +50,6 @@
 
     # NATEKS-MIB health: board temperature is reported in 1/1000 Celsius.
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4249.2.5.6.2"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -62,7 +61,6 @@
         name = "celsius"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.4249.2.5.8.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/raisecom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/raisecom.child.toml.j2
@@ -74,7 +74,6 @@
         name = "celsius"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.8886.1.1.5.2.2.1"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -82,7 +81,6 @@
         name = "state"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.8886.1.24.2.1.1"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/zdns.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/zdns.child.toml.j2
@@ -108,7 +108,6 @@
 
     # ---- F5 BIG-IP LTM availability states reused by the local ZDNS profile. ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3375.2.2.10.1.2.1"
         name = "network_service_virtual_server"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -120,7 +119,6 @@
         name = "state"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3375.2.2.4.3.2.1"
         name = "network_service_node"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -132,7 +130,6 @@
         name = "state"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3375.2.2.5.5.2.1"
         name = "network_service_pool"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -144,7 +141,6 @@
         name = "state"
 
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3375.2.2.5.6.2.1"
         name = "network_service_pool_member"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/benu.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/benu.child.toml.j2
@@ -57,7 +57,6 @@
         name = "ifHCOutOctets"
     # ---- Benu chassis temperature sensors: keep only sensor type temparature(1) ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.39406.1.1.1.4.1"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -73,7 +72,6 @@
         name = "celsius"
     # ---- Benu fan sensors: sensor type fan(4), sensor state normal(1) -> 1, every other code -> 2 ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.39406.1.1.1.4.1"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -89,7 +87,6 @@
         name = "state"
     # ---- Benu power supply: present yes(1) and powered(1) are healthy; every other state is abnormal ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.39406.1.1.1.7.1"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
@@ -48,7 +48,6 @@
     # ---- LANCOM 温度 (LCOS-MIB lcsStatusHardwareInfoTemperatureDegrees, 每传感器 ℃, 表, PEN 2356) ----
     # 待现网核验：1.3.6.1.4.1.2356.11.1.47.20（硬件温度℃，按列 walk 所有传感器，max by instance）。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.2356.11.1.47.20"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
@@ -48,8 +48,8 @@
         oid = "1.3.6.1.2.1.31.1.1.1.10"
         name = "ifHCOutOctets"
     # ---- 3Com CPU (A3COM-HUAWEI-LswDEVM-MIB hwCpuCostRatePer1Min, 近1分钟占用率%, 每板卡表, PEN 43；3com.snmprec 实测 34/99, avg by instance) ----
+    # 不设置私有表根 OID：collector 未安装厂商 MIB 时，Telegraf 无法将其识别为 table；直接 walk 数值列 OID。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.43.45.1.6.1.1"
         name = "device_cpu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -58,7 +58,6 @@
     # ---- 3Com 内存 (hwMemSize 总量 + hwMemFree 空闲, 字节, 每板卡表；usage = (total-free)/total) ----
     # 待现网核验：hwMemSize .43.45.1.6.1.2.1.1.2(总量) / hwMemFree .43.45.1.6.1.2.1.1.3(空闲)；snmprec total=36212352 free=21029498。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.43.45.1.6.1.2"
         name = "device_memory"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
@@ -54,7 +54,6 @@
     # 表按 npCpuUtilizationIndex(...4.2.1.1) 固定 3 行：1=过去5秒/2=过去1分钟/3=过去5分钟 的同一主 CPU 平均值。
     # telegraf inputs.snmp 不支持行级过滤，三行均为合法的同设备 CPU 读数 → 共享盘 max() by instance_id 取代表值。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.278.107.1.1.4.2"
         name = "device_cpu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -65,7 +64,6 @@
     # 表按 npTemperatureUnitId(...1.1.1)/npTemperatureIndex(...1.1.2) 索引；NP4000 系列每装置 1 个温度传感器。
     # 共享盘 device_temperature_celsius max() by instance_id（多传感器机型取最热）。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.278.107.1.1.1"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -76,7 +74,6 @@
     # 厂商码已是 1=正常/2=异常，与共享盘 device_fan_state(1=正常,>1=异常) 一致，processors.enum 显式归一保险。
     # 行名 npFanIndex(...2.1.2)，共享盘 max() by instance_id 取最差风扇行。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.278.107.1.1.2"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -91,7 +88,6 @@
     # 行名 npPowerIndex(...3.1.2)；inOperation(1)→1 正常，failed(2)→2 异常，empty(3)=未安装非故障→1 正常。
     # 共享盘 device_psu_state(1=正常,>1=异常) max() by instance_id 取最差电源行。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.278.107.1.1.3"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
@@ -62,7 +62,6 @@
     # 待现网核验：used 列 1.3.6.1.4.1.3320.9.48.1.1.1.5 / free 列 ...1.1.1.6（按 pool index 走表）。
     # 利用率共享盘按 used/(used+free) 计算。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3320.9.48.1.1"
         name = "device_memory"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -74,7 +73,6 @@
     # ---- BDCOM card temperature (BDCOM-SYS nmscardTemperature, °C, per-card table) ----
     # 待现网核验：列 OID 1.3.6.1.4.1.3320.3.6.10.1.13（专用温度列）。device_temperature_celsius max()。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3320.3.6.10.1"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
@@ -78,7 +78,6 @@
     # ---- Edgecore/Accton ECS 电源状态表 (.259.10.1.24.1.1.4.1.1.2, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.259.10.1.24.1.1.4.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
@@ -77,7 +77,6 @@
     # ---- Enterasys 电源状态表 (etsysChassisPowerSupplyState .5624.1.2.16.1.1.1.3, 每电源 normal(1)/notOperational(2)...) ----
     # 待现网核验：原始码 normal=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.5624.1.2.16.1.1.1.3"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/etherwan.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/etherwan.child.toml.j2
@@ -63,7 +63,6 @@
     # 待现网核验：列 OID 1.3.6.1.4.1.2736.1.1.21.1.1.4（原始码 0=up 正常/1=down 失电或缺省），行名 ewnPowerSupplyName ...21.1.1.2（Power1/Power2）。
     # 下方 processors.enum 归一为 1=正常/2=异常（0 up→1，1 down→2）。共享盘 device_psu_state 约定 1=正常,>1=异常，故 max() by instance_id 取最差电源行。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.2736.1.1.21"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
@@ -78,7 +78,6 @@
     # ---- GarretCom 电源状态表 (.14778.1.2.1.5.1.1.3, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.14778.1.2.1.5.1.1.3"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
@@ -76,7 +76,6 @@
     # ---- Hirschmann 电源状态 (hmPSState 表 .248.14.1.2.1.3, 每电源 ok(1)/failed(2)/notInstalled(3)/unknown(4)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.248.14.1.2.1.3"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
@@ -80,7 +80,6 @@
     # ---- Maipu 电源状态表 (.5651.1.1.1.1.5.1.1.2, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.5651.1.1.1.1.5.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
@@ -80,7 +80,6 @@
     # ---- MICROSENS 冗余电源状态表 (.3181.10.6.1.6.1.1.2, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3181.10.6.1.6.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
@@ -50,14 +50,12 @@
     # ---- Nokia OmniSwitch CPU/Memory health (ALCATEL-IND1-HEALTH-MIB healthModuleTable, 企业号 6486, 直接 %) ----
     # 待现网核验：healthModuleCpuLatest 1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1.13 / healthModuleMemoryLatest ...1.14（0-100%，按模块行）。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1"
         name = "device_cpu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1.13"
         name = "usage"
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1"
         name = "device_memory"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -66,7 +64,6 @@
     # ---- Nokia OmniSwitch chassis temperature (ALCATEL-IND1-CHASSIS-MIB chasChassisTemp, ℃) ----
     # 待现网核验：chasChassisTempCurrent 1.3.6.1.4.1.6486.800.1.1.1.3.1.1.4.1（℃，按机箱）。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.6486.800.1.1.1.3.1.1.4"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -75,14 +72,12 @@
     # ---- Nokia OmniSwitch fan/psu operational status (chasEntPhysOperStatus, up(1)/down(2)等) ----
     # 待现网核验：chasEntPhysOperStatus 表，风扇/电源实体行；原始 up(1)→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.6486.800.1.1.1.1.1.1.1.2"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.1.1.1.1.1.1.2"
         name = "state"
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.6486.800.1.1.1.4.1.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
@@ -78,7 +78,6 @@
     # ---- PLANET 电源状态表 (.10456.1.999.1.4.1.1.2, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.10456.1.999.1.4.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
@@ -80,7 +80,6 @@
     # ---- RuggedCOM 冗余电源状态表 (.15004.4.2.3.1.1.2, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.15004.4.2.3.1.1.2"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
@@ -78,7 +78,6 @@
     # ---- Westermo 电源状态表 (.16177.1.5.1.6.1.1.3, 每电源 ok(1)/failed(2)) ----
     # 待现网核验：原始码 ok=1；下方 enum 归一 1→1(正常),其余→2(异常)。
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.16177.1.5.1.6.1.1.3"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/hubersuhner.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/hubersuhner.child.toml.j2
@@ -57,7 +57,6 @@
         name = "ifHCOutOctets"
     # ---- Cubo Mini transceiver temperature: tenths of Celsius -> query divides by 10 ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.27894.11.241.1.9.5"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -65,7 +64,6 @@
         name = "celsius"
     # ---- Cubo Mini fan-card status: ok(3) -> 1, every other code -> 2 ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.27894.11.241.1.3.1"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/siae.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/siae.child.toml.j2
@@ -57,7 +57,6 @@
         name = "ifHCOutOctets"
     # ---- SIAE equipment temperature: sensorTempValue, degrees Celsius ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.3373.1103.77.2.1"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/xkl.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/xkl.child.toml.j2
@@ -57,7 +57,6 @@
         name = "ifHCOutOctets"
     # ---- XKL hardware sensor temperature (XKL-MIB, PEN 21150) ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.21150.1.1.13"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -69,7 +68,6 @@
         name = "celsius"
     # ---- XKL fan controller status: normal(2) -> 1, every other code -> 2 ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.21150.1.1.5"
         name = "device_fan"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -77,7 +75,6 @@
         name = "state"
     # ---- XKL power supply status: normal(2) -> 1, every other code -> 2 ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.21150.1.1.9"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/zenitel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/zenitel.child.toml.j2
@@ -50,7 +50,6 @@
 
     # ---- Zenitel VS-DEVICE-MIB temperature sensors (tempCurrentValue, Celsius) ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.26122.3.2.2"
         name = "device_temperature"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]
@@ -63,7 +62,6 @@
 
     # ---- Zenitel VS-DEVICE-MIB powerStatus: unknown(1), notConnected(2), connected(3) ----
     [[inputs.snmp.table]]
-        oid = "1.3.6.1.4.1.26122.3.5.1"
         name = "device_psu"
         inherit_tags = ["source"]
     [[inputs.snmp.table.field]]


### PR DESCRIPTION
## 变更内容

移除内置 Telegraf SNMP 模板中 47 处厂商私有 `1.3.6.1.4.1.*` table 根 OID，保留所有数值列 OID、指标名称、标签和处理器。

## 原因

私有 table 根会要求 fusion-collector 在运行时安装对应厂商 MIB 才能完成表解析；改为仅 walk 已配置的数值列 OID，避免此运行时依赖。

## 范围

- 修改 24 个 SNMP 模板
- 保留标准 `1.3.6.1.2.1.*` MIB-II/IF-MIB 表根，未改 Huawei 标准接口表
- 未包含测试、计划文件或其他本地改动

## 验证

- 私有 table 根 OID 全仓检索为 0
- `git diff --check` 通过
- 未执行 collector 运行时验证：本机 Docker runtime 不可访问