### PR TITLE
bugfix: 图像数据集发布改为分块下载

### DIFF
--- a/server/apps/mlops/tasks/image_classification.py
+++ b/server/apps/mlops/tasks/image_classification.py
@@ -11,11 +11,15 @@ from django_minio_backend import MinioBackend, iso_date_prefix
 import tempfile
 import zipfile
 import json
+import shutil
 from pathlib import Path
 from collections import defaultdict
 
 from apps.core.logger import mlops_logger as logger
 from apps.mlops.tasks.base import mark_release_as_failed
+
+
+ZIP_COPY_CHUNK_SIZE = 64 * 1024
 
 
 @shared_task(
@@ -106,16 +110,16 @@ def publish_dataset_release_async(release_id, train_file_id, val_file_id, test_f
                 if data_obj.train_data and data_obj.train_data.name:
                     logger.info(f"处理 {split_name} 数据: {data_obj.name}")
 
-                    # 下载 ZIP
-                    with data_obj.train_data.open("rb") as f:
-                        zip_content = f.read()
-
                     # 解压到临时目录（扁平化）
                     temp_extract = temp_path / f"{split_name}_extract"
                     temp_extract.mkdir()
                     temp_zip = temp_path / f"{split_name}_temp.zip"
-                    with open(temp_zip, "wb") as f:
-                        f.write(zip_content)
+                    with data_obj.train_data.open("rb") as source, open(
+                        temp_zip, "wb"
+                    ) as target:
+                        shutil.copyfileobj(
+                            source, target, length=ZIP_COPY_CHUNK_SIZE
+                        )
 
                     with zipfile.ZipFile(temp_zip, "r") as zipf:
                         zipf.extractall(temp_extract)

--- a/server/apps/mlops/tasks/object_detection.py
+++ b/server/apps/mlops/tasks/object_detection.py
@@ -11,12 +11,16 @@ from django_minio_backend import MinioBackend, iso_date_prefix
 import tempfile
 import zipfile
 import json
+import shutil
 import yaml
 from pathlib import Path
 from collections import defaultdict
 
 from apps.core.logger import mlops_logger as logger
 from apps.mlops.tasks.base import mark_release_as_failed
+
+
+ZIP_COPY_CHUNK_SIZE = 64 * 1024
 
 
 def prepare_class_mappings(
@@ -297,16 +301,16 @@ def publish_dataset_release_async(release_id, train_file_id, val_file_id, test_f
                 if data_obj.train_data and data_obj.train_data.name:
                     logger.info(f"处理 {split_name} 数据: {data_obj.name}")
 
-                    # 下载 ZIP
-                    with data_obj.train_data.open("rb") as f:
-                        zip_content = f.read()
-
                     # 解压到临时目录
                     temp_extract = temp_path / f"{split_name}_extract"
                     temp_extract.mkdir()
                     temp_zip = temp_path / f"{split_name}_temp.zip"
-                    with open(temp_zip, "wb") as f:
-                        f.write(zip_content)
+                    with data_obj.train_data.open("rb") as source, open(
+                        temp_zip, "wb"
+                    ) as target:
+                        shutil.copyfileobj(
+                            source, target, length=ZIP_COPY_CHUNK_SIZE
+                        )
 
                     with zipfile.ZipFile(temp_zip, "r") as zipf:
                         zipf.extractall(temp_extract)

--- a/server/apps/mlops/tests/test_issue_4245_streaming_zip.py
+++ b/server/apps/mlops/tests/test_issue_4245_streaming_zip.py
@@ -1,0 +1,196 @@
+import io
+import zipfile
+
+import pytest
+
+from apps.mlops.tasks import image_classification as image_task
+from apps.mlops.tasks import object_detection as object_task
+
+
+pytestmark = pytest.mark.unit
+
+_CHUNK_SIZE = 64 * 1024
+_IMAGE_BYTES = bytes(range(256)) * 768
+
+
+def _make_zip() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("sample.jpg", _IMAGE_BYTES)
+    return buffer.getvalue()
+
+
+class _ShortReadStream(io.BytesIO):
+    def __init__(self, content: bytes):
+        super().__init__(content)
+        self.requested_sizes = []
+
+    def read(self, size=-1):
+        self.requested_sizes.append(size)
+        if size >= 0:
+            size = min(size, 8192)
+        return super().read(size)
+
+
+class _FakeFieldFile:
+    name = "datasets/sample.zip"
+
+    def __init__(self, content: bytes, opened_streams: list[_ShortReadStream]):
+        self._content = content
+        self._opened_streams = opened_streams
+
+    def open(self, mode="rb"):
+        assert mode == "rb"
+        stream = _ShortReadStream(self._content)
+        self._opened_streams.append(stream)
+        return stream
+
+
+def _patch_storage(monkeypatch, module):
+    uploaded = {}
+
+    class _FakeStorage:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def save(self, path, content):
+            uploaded["path"] = path
+            uploaded["content"] = content.read()
+            return path
+
+        def url(self, path):
+            return f"https://storage.invalid/{path}"
+
+    monkeypatch.setattr(module, "MinioBackend", _FakeStorage)
+    return uploaded
+
+
+def _assert_streamed(opened_streams):
+    assert len(opened_streams) == 3
+    assert all(stream.requested_sizes for stream in opened_streams)
+    requested_sizes = [stream.requested_sizes for stream in opened_streams]
+    assert all(
+        0 < requested_size <= _CHUNK_SIZE
+        for stream_sizes in requested_sizes
+        for requested_size in stream_sizes
+    ), requested_sizes
+
+
+@pytest.mark.django_db
+def test_image_publish_streams_each_source_zip_in_bounded_chunks(monkeypatch):
+    from apps.mlops.models.image_classification import (
+        ImageClassificationDataset,
+        ImageClassificationDatasetRelease,
+        ImageClassificationTrainData,
+    )
+
+    dataset = ImageClassificationDataset.objects.create(
+        name="image-dataset", description="", team=[1]
+    )
+    release = ImageClassificationDatasetRelease.objects.create(
+        name="release",
+        description="",
+        dataset=dataset,
+        version="v1",
+        dataset_file="placeholder.zip",
+        status="pending",
+        metadata={},
+        file_size=0,
+    )
+    train_data = [
+        ImageClassificationTrainData.objects.create(
+            name=name,
+            dataset=dataset,
+            metadata={"labels": {"sample.jpg": "cat"}, "classes": ["cat"]},
+        )
+        for name in ("train", "val", "test")
+    ]
+
+    source_zip = _make_zip()
+    opened_streams = []
+    original_get = ImageClassificationTrainData.objects.get
+
+    def fake_get(*args, **kwargs):
+        data = original_get(*args, **kwargs)
+        data.train_data = _FakeFieldFile(source_zip, opened_streams)
+        return data
+
+    monkeypatch.setattr(ImageClassificationTrainData.objects, "get", fake_get)
+    uploaded = _patch_storage(monkeypatch, image_task)
+
+    result = image_task.publish_dataset_release_async.run(
+        release.id, *(data.id for data in train_data)
+    )
+
+    assert result["result"] is True
+    _assert_streamed(opened_streams)
+    with zipfile.ZipFile(io.BytesIO(uploaded["content"])) as archive:
+        assert archive.read("train/cat/sample.jpg") == _IMAGE_BYTES
+        assert archive.read("val/cat/sample.jpg") == _IMAGE_BYTES
+        assert archive.read("test/cat/sample.jpg") == _IMAGE_BYTES
+
+
+@pytest.mark.django_db
+def test_object_publish_streams_each_source_zip_in_bounded_chunks(monkeypatch):
+    from apps.mlops.models.object_detection import (
+        ObjectDetectionDataset,
+        ObjectDetectionDatasetRelease,
+        ObjectDetectionTrainData,
+    )
+
+    dataset = ObjectDetectionDataset.objects.create(
+        name="object-dataset", description="", team=[1]
+    )
+    release = ObjectDetectionDatasetRelease.objects.create(
+        name="release",
+        description="",
+        dataset=dataset,
+        version="v1",
+        dataset_file="placeholder.zip",
+        status="pending",
+        metadata={},
+        file_size=0,
+    )
+    metadata = {
+        "classes": ["cat"],
+        "labels": {
+            "sample.jpg": [
+                {
+                    "class_id": 0,
+                    "x_center": 0.5,
+                    "y_center": 0.5,
+                    "width": 0.25,
+                    "height": 0.25,
+                }
+            ]
+        },
+    }
+    train_data = [
+        ObjectDetectionTrainData.objects.create(
+            name=name, dataset=dataset, metadata=metadata
+        )
+        for name in ("train", "val", "test")
+    ]
+
+    source_zip = _make_zip()
+    opened_streams = []
+    original_get = ObjectDetectionTrainData.objects.get
+
+    def fake_get(*args, **kwargs):
+        data = original_get(*args, **kwargs)
+        data.train_data = _FakeFieldFile(source_zip, opened_streams)
+        return data
+
+    monkeypatch.setattr(ObjectDetectionTrainData.objects, "get", fake_get)
+    uploaded = _patch_storage(monkeypatch, object_task)
+
+    result = object_task.publish_dataset_release_async.run(
+        release.id, *(data.id for data in train_data)
+    )
+
+    assert result["result"] is True
+    _assert_streamed(opened_streams)
+    with zipfile.ZipFile(io.BytesIO(uploaded["content"])) as archive:
+        assert archive.read("images/train/sample.jpg") == _IMAGE_BYTES
+        assert archive.read("images/val/sample.jpg") == _IMAGE_BYTES
+        assert archive.read("images/test/sample.jpg") == _IMAGE_BYTES


### PR DESCRIPTION
## 问题

图片分类与目标检测的数据集发布任务需要把 train、val、test 的源 ZIP 下载到临时目录后再解压重组。原实现对每个远程文件执行无参数 `read()`，使合法大数据集的额外内存随单包大小线性增长，可能耗尽 Celery worker。

## 根因（设计层）

远程对象与本地临时文件之间缺少有界的流式复制边界：任务虽然最终从磁盘解压，却先把完整对象物化为单个字节串，抵消了临时文件本应提供的内存隔离。

## 怎么修的

- 图片分类与目标检测两条专用任务均以 64 KiB 块从 FieldFile 复制到临时 ZIP。
- 继续使用原有临时目录、解压、数据重组、重新打包和上传流程。
- 回归测试模拟每次最多返回 8 KiB 的短读，验证复制会持续到 EOF，且三份源 ZIP 的每次读取请求都不超过 64 KiB。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["DatasetRelease serializer\nserver/apps/mlops/serializers"]
        T2["Celery publish task\nimage_classification.py / object_detection.py"]
    end

    subgraph N["核心处理层"]
        N1["64 KiB 分块复制\nFieldFile → 临时 ZIP"]
        N2["解压并重组\nImageFolder / YOLO"]
        N3["重新打包并上传\nMinioBackend.save"]
    end

    subgraph C["失败处理层"]
        C1["标记 release failed\nmark_release_as_failed"]
    end

    T1 --> T2 --> N1 --> N2 --> N3
    T2 -. "读取、解压或处理失败" .-> C1
```

## 影响范围

- 仅修改 MLOps 图片分类与目标检测发布任务，不改 API、权限、模型或数据库结构。
- ZIP 内容、目录结构、类别排序、发布状态和异常处理沿用原契约。
- 单个活跃源文件的复制阶段额外内存由 O(单包大小) 收敛为 O(64 KiB)；总传输时间仍为 O(文件大小)。
- 回滚只需还原本 PR，不涉及数据迁移。

## 验证

- `apps/mlops/tests/test_issue_4245_streaming_zip.py`：2 passed。修复前相同输入的两条链均记录到三次无界读取并失败；修复后块大小、短读和最终 ZIP 字节一致性通过。
- `apps/mlops/tests/test_tasks_image_object.py`、`apps/mlops/tests/test_tasks_image_object_reorg.py`、`apps/mlops/tests/test_dataset_release_serializer.py`：85 passed。
- 合计：87 passed。

Fixes #4245
