### PR TITLE
bugfix: 降低 ASGI 模型下载峰值内存

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-4244-asgi-model-download.md
+++ b/docs/superpowers/plans/2026-07-23-issue-4244-asgi-model-download.md
@@ -1,0 +1,75 @@
+# Issue #4244 ASGI 模型下载 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让六类模型下载在 Uvicorn ASGI 下以 64 KiB 分块发送，归档和响应阶段均不全量占用 Python 堆。
+
+**Architecture:** `download_model_artifact` 继续返回磁盘临时 ZIP；共享响应构造器用仅支持异步迭代的文件包装器交给 `StreamingHttpResponse`，显式保留长度与下载头。六类 ViewSet 只负责授权、命名和调用共享构造器。
+
+**Tech Stack:** Python 3.12、Django 4.2、asgiref、pytest、tracemalloc
+
+## Global Constraints
+
+- 保持 URL、权限、run 归属、文件名、`Content-Disposition`、`Content-Type` 和 ZIP 内容。
+- 64 KiB 分块读取；响应关闭必须关闭底层 `TemporaryFile`。
+- 只运行本 PR 修改的具体测试文件。
+
+---
+
+### Task 1: ASGI RED 回归
+
+**Files:**
+- Modify: `server/apps/mlops/tests/test_model_download_memory.py`
+- Modify: `server/apps/mlops/tests/test_views_actions_param.py`
+
+**Interfaces:**
+- Consumes: 六类既有 `download_model` action。
+- Produces: 对异步迭代、端到端堆峰值和关闭清理的回归约束。
+
+- [ ] **Step 1: 六类响应测试断言 `response.is_async` 并通过 `response.__aiter__()` 完整消费**
+- [ ] **Step 2: 增加 4 MiB 响应完整消费的 `tracemalloc` 测试，断言峰值低于输入大小**
+- [ ] **Step 3: 增加未消费即 `response.close()` 仍关闭底层临时文件的测试**
+- [ ] **Step 4: 运行两份具体测试，确认旧同步 `FileResponse` 因 `is_async=False` 或缺少共享构造器而 RED**
+
+### Task 2: 共享异步文件响应
+
+**Files:**
+- Modify: `server/apps/mlops/utils/mlflow_service.py`
+
+**Interfaces:**
+- Produces: `build_model_download_response(zip_stream: BinaryIO, filename: str) -> StreamingHttpResponse`。
+
+- [ ] **Step 1: 实现仅支持 `__aiter__`/`__anext__` 的 64 KiB 文件包装器，读取通过 `sync_to_async` 在线程中执行**
+- [ ] **Step 2: 实现响应构造器，显式设置长度、内容类型和 Django 标准下载头**
+- [ ] **Step 3: 让响应资源关闭器持有包装器的 `close()`，保持幂等关闭**
+- [ ] **Step 4: 运行内存与共享工具具体测试，确认 GREEN**
+
+### Task 3: 六类调用方统一
+
+**Files:**
+- Modify: `server/apps/mlops/views/anomaly_detection.py`
+- Modify: `server/apps/mlops/views/classification.py`
+- Modify: `server/apps/mlops/views/log_clustering.py`
+- Modify: `server/apps/mlops/views/timeseries_predict.py`
+- Modify: `server/apps/mlops/views/image_classification.py`
+- Modify: `server/apps/mlops/views/object_detection.py`
+
+**Interfaces:**
+- Consumes: `mlflow_service.build_model_download_response`。
+
+- [ ] **Step 1: 六类 action 用共享构造器替代各自的 `FileResponse`**
+- [ ] **Step 2: 保留各自既有文件名生成与异常响应**
+- [ ] **Step 3: 运行 `test_views_actions_param.py`，确认六类异步内容、头和关闭语义 GREEN**
+
+### Task 4: 验证、提交与评审
+
+**Files:**
+- Verify: `weops/master...HEAD` 的全部变更文件。
+
+**Interfaces:**
+- Produces: clean commit、精确测试证据和 G6 分数。
+
+- [ ] **Step 1: 运行 `git diff --check` 与三份修改测试**
+- [ ] **Step 2: 提交实现并在新 commit 上重跑相同测试**
+- [ ] **Step 3: 独立 G6 复评；低于 70 分则按意见继续修正**
+- [ ] **Step 4: 公开文本 lint 后 push、创建带 `auto-pr` 的 PR，并回填 Issue**

--- a/docs/superpowers/specs/2026-07-23-issue-4244-asgi-model-download-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-4244-asgi-model-download-design.md
@@ -1,0 +1,38 @@
+# Issue #4244 ASGI 模型下载设计
+
+## 目标
+
+六类 MLOps 模型下载在生产 Uvicorn ASGI 链路中以固定大小分块发送，避免归档和响应阶段将完整 ZIP 物化到 Python 堆，同时保持现有 HTTP、权限和 ZIP 契约。
+
+## 事实与约束
+
+- 六类 ViewSet 共用 `download_model_artifact`，生产入口由 Uvicorn ASGI 承载。
+- Django 4.2 对同步 `FileResponse` 的 ASGI 消费会先把所有分块收集为列表，不能作为端到端流式方案。
+- URL、权限、run 归属、文件名、`Content-Disposition`、`Content-Type`、ZIP 条目和内容必须保持不变。
+- 归档异常和临时盘失败继续进入现有异常处理；不得新增兼容开关或协议版本。
+
+## 方案
+
+在 `mlflow_service` 共享层保留磁盘 `TemporaryFile` 归档，并增加 64 KiB 异步文件迭代器与响应构造器。迭代器通过线程桥接执行阻塞读取，只暴露异步迭代协议，使 Django ASGI 逐块消费；响应显式设置文件长度和下载头，并登记底层临时文件的关闭回调。
+
+六类 ViewSet 统一调用该响应构造器，不各自管理 Django 响应类型。这样响应完成或 ASGI 断连触发 `response.close()` 时，底层临时 ZIP 被关闭；归档过程中失败仍由 `download_model_artifact` 立即关闭。
+
+## 数据流
+
+1. ViewSet 完成既有对象授权和 run 归属校验。
+2. `download_model_artifact` 下载 artifact 并把 ZIP 写入磁盘临时文件。
+3. 共享响应构造器计算剩余长度、设置下载头，并返回异步流式响应。
+4. ASGI handler 以 64 KiB 分块发送；完成或断连后关闭响应及临时文件。
+
+## 测试
+
+- RED：旧同步 `FileResponse` 经 `response.__aiter__()` 完整消费时产生迭代器类型告警，且 Python 堆峰值随输入增长。
+- GREEN：相同输入经异步响应消费不出现同步迭代告警，峰值低于输入大小。
+- 六类下载入口验证状态、文件名、内容类型、长度、ZIP 字节、异步迭代和 `close()` 清理。
+- 共享工具继续覆盖目录、单文件、路径不存在及归档异常关闭。
+
+## 风险与回滚
+
+- 风险从内存转移到临时盘容量；磁盘满继续按既有 500 错误契约返回，不改变 API。
+- WSGI 同步消费异步响应会回退为全量消费，但当前生产部署为 ASGI；行为不差于旧实现。
+- 回滚可整体还原共享响应构造器和六类调用点，不涉及数据迁移。

--- a/server/apps/mlops/tests/test_mlflow_service_utils.py
+++ b/server/apps/mlops/tests/test_mlflow_service_utils.py
@@ -6,7 +6,6 @@ MLflow 客户端 / mlflow 模块为真实外部边界，统一打桩；其余命
 """
 import pydantic.root_model  # noqa
 
-from io import BytesIO
 from types import SimpleNamespace
 import zipfile
 
@@ -278,14 +277,16 @@ def test_download_model_artifact_zips_directory(tmp_path, mocker):
     client = SimpleNamespace(download_artifacts=lambda run_id, artifact_path, dst_path: str(model_dir))
     mocker.patch("apps.mlops.utils.mlflow_service.get_mlflow_client", return_value=client)
 
-    buffer = ms.download_model_artifact("r1", "model")
-
-    assert isinstance(buffer, BytesIO)
-    with zipfile.ZipFile(buffer) as zf:
-        names = set(zf.namelist())
-    # 相对父目录归档，含目录前缀
-    assert "model/model.pkl" in names
-    assert "model/MLmodel" in names
+    archive = ms.download_model_artifact("r1", "model")
+    try:
+        assert archive.fileno() >= 0
+        with zipfile.ZipFile(archive) as zf:
+            names = set(zf.namelist())
+        # 相对父目录归档，含目录前缀
+        assert "model/model.pkl" in names
+        assert "model/MLmodel" in names
+    finally:
+        archive.close()
 
 
 def test_download_model_artifact_zips_single_file(tmp_path, mocker):
@@ -295,12 +296,14 @@ def test_download_model_artifact_zips_single_file(tmp_path, mocker):
     client = SimpleNamespace(download_artifacts=lambda run_id, artifact_path, dst_path: str(single))
     mocker.patch("apps.mlops.utils.mlflow_service.get_mlflow_client", return_value=client)
 
-    buffer = ms.download_model_artifact("r1", "model.pkl")
-
-    with zipfile.ZipFile(buffer) as zf:
-        names = zf.namelist()
-    # 单文件场景：仅以文件名归档
-    assert names == ["model.pkl"]
+    archive = ms.download_model_artifact("r1", "model.pkl")
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            names = zf.namelist()
+        # 单文件场景：仅以文件名归档
+        assert names == ["model.pkl"]
+    finally:
+        archive.close()
 
 
 def test_download_model_artifact_missing_path_raises(mocker):

--- a/server/apps/mlops/tests/test_model_download_memory.py
+++ b/server/apps/mlops/tests/test_model_download_memory.py
@@ -20,6 +20,12 @@ async def _consume_response(response):
     return total_size
 
 
+async def _consume_one_chunk_then_disconnect(response):
+    iterator = response.__aiter__()
+    await iterator.__anext__()
+    await iterator.aclose()
+
+
 def _measure_asgi_response(response):
     tracemalloc.start()
     streamed_size = asyncio.run(_consume_response(response))
@@ -85,5 +91,28 @@ def test_model_download_response_close_cleans_unconsumed_archive():
 
     response = ms.build_model_download_response(archive, "model_r1.zip")
     response.close()
+
+    assert archive.closed
+
+
+def test_model_download_response_preserves_file_response_basename():
+    archive = tempfile.TemporaryFile(mode="w+b")
+    archive.write(b"zipdata")
+    archive.seek(0)
+
+    response = ms.build_model_download_response(archive, "team/model_r1.zip")
+    try:
+        assert response["Content-Disposition"] == 'attachment; filename="model_r1.zip"'
+    finally:
+        response.close()
+
+
+def test_model_download_response_disconnect_closes_archive():
+    archive = tempfile.TemporaryFile(mode="w+b")
+    archive.write(b"x" * (128 * 1024))
+    archive.seek(0)
+
+    response = ms.build_model_download_response(archive, "model_r1.zip")
+    asyncio.run(_consume_one_chunk_then_disconnect(response))
 
     assert archive.closed

--- a/server/apps/mlops/tests/test_model_download_memory.py
+++ b/server/apps/mlops/tests/test_model_download_memory.py
@@ -1,12 +1,31 @@
 """模型归档的大输入内存边界回归测试。"""
 
+import asyncio
 import random
+import tempfile
 import tracemalloc
 from types import SimpleNamespace
 
 import pydantic.root_model  # noqa
+import pytest
+from django.http import FileResponse
 
 from apps.mlops.utils import mlflow_service as ms
+
+
+async def _consume_response(response):
+    total_size = 0
+    async for chunk in response:
+        total_size += len(chunk)
+    return total_size
+
+
+def _measure_asgi_response(response):
+    tracemalloc.start()
+    streamed_size = asyncio.run(_consume_response(response))
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return streamed_size, peak_bytes
 
 
 def test_download_model_artifact_keeps_large_zip_off_heap(tmp_path, mocker):
@@ -26,3 +45,45 @@ def test_download_model_artifact_keeps_large_zip_off_heap(tmp_path, mocker):
         assert peak_bytes < input_size, f"4 MiB 输入的 Python 堆峰值为 {peak_bytes} bytes"
     finally:
         archive.close()
+
+
+def test_model_download_response_keeps_asgi_stream_off_heap():
+    input_size = 4 * 1024 * 1024
+    payload = random.Random(4244).randbytes(input_size)
+
+    baseline_archive = tempfile.TemporaryFile(mode="w+b")
+    baseline_archive.write(payload)
+    baseline_archive.seek(0)
+    baseline_response = FileResponse(baseline_archive, content_type="application/zip")
+    with pytest.warns(Warning, match="consume synchronous"):
+        baseline_size, baseline_peak_bytes = _measure_asgi_response(baseline_response)
+    baseline_response.close()
+
+    archive = tempfile.TemporaryFile(mode="w+b")
+    archive.write(payload)
+    archive.seek(0)
+
+    response = ms.build_model_download_response(archive, "model_r1.zip")
+    streamed_size, peak_bytes = _measure_asgi_response(response)
+
+    try:
+        assert response.is_async
+        assert baseline_size == input_size
+        assert streamed_size == input_size
+        assert baseline_peak_bytes >= input_size
+        assert peak_bytes < input_size, f"4 MiB ASGI 响应的 Python 堆峰值为 {peak_bytes} bytes"
+    finally:
+        response.close()
+
+    assert archive.closed
+
+
+def test_model_download_response_close_cleans_unconsumed_archive():
+    archive = tempfile.TemporaryFile(mode="w+b")
+    archive.write(b"zipdata")
+    archive.seek(0)
+
+    response = ms.build_model_download_response(archive, "model_r1.zip")
+    response.close()
+
+    assert archive.closed

--- a/server/apps/mlops/tests/test_model_download_memory.py
+++ b/server/apps/mlops/tests/test_model_download_memory.py
@@ -1,0 +1,28 @@
+"""模型归档的大输入内存边界回归测试。"""
+
+import random
+import tracemalloc
+from types import SimpleNamespace
+
+import pydantic.root_model  # noqa
+
+from apps.mlops.utils import mlflow_service as ms
+
+
+def test_download_model_artifact_keeps_large_zip_off_heap(tmp_path, mocker):
+    input_size = 4 * 1024 * 1024
+    model_file = tmp_path / "model.bin"
+    model_file.write_bytes(random.Random(4244).randbytes(input_size))
+
+    client = SimpleNamespace(download_artifacts=lambda run_id, artifact_path, dst_path: str(model_file))
+    mocker.patch("apps.mlops.utils.mlflow_service.get_mlflow_client", return_value=client)
+
+    tracemalloc.start()
+    archive = ms.download_model_artifact("r1", "model.bin")
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    try:
+        assert peak_bytes < input_size, f"4 MiB 输入的 Python 堆峰值为 {peak_bytes} bytes"
+    finally:
+        archive.close()

--- a/server/apps/mlops/tests/test_views_actions_param.py
+++ b/server/apps/mlops/tests/test_views_actions_param.py
@@ -7,6 +7,7 @@ external boundaries: ``mlflow_service`` (MLflow tracking server),
 ``WebhookClient`` (webhookd / docker), ``requests`` (predict HTTP call) and the
 config helpers (env vars).
 """
+import asyncio
 import importlib
 import types
 from io import BytesIO
@@ -25,6 +26,10 @@ from apps.mlops.utils.webhook_client import WebhookError
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 factory = APIRequestFactory()
+
+
+async def _consume_streaming_response(response):
+    return b"".join([chunk async for chunk in response])
 
 
 # Each tuple: (module suffix, MLflow prefix, model module, class basename)
@@ -610,7 +615,8 @@ def test_download_model_success(monkeypatch, superuser, suffix, prefix, model_mo
     assert resp["Content-Length"] == "7"
     assert ".zip" in resp["Content-Disposition"]
     assert resp.streaming
-    assert b"".join(resp.streaming_content) == b"zipdata"
+    assert resp.is_async
+    assert asyncio.run(_consume_streaming_response(resp)) == b"zipdata"
     resp.close()
     assert archive.closed
 

--- a/server/apps/mlops/tests/test_views_actions_param.py
+++ b/server/apps/mlops/tests/test_views_actions_param.py
@@ -595,17 +595,24 @@ def test_download_model_run_not_found(monkeypatch, superuser, suffix, prefix, mo
 def test_download_model_success(monkeypatch, superuser, suffix, prefix, model_module, basename):
     tj = _make_train_job(model_module, basename)
     mod = _view_module(suffix)
+    archive = BytesIO(b"zipdata")
     _patch_mlflow(
         monkeypatch, suffix,
         get_experiment_by_name=lambda name: types.SimpleNamespace(experiment_id="1"),
         get_experiment_runs=lambda eid, **kw: _runs_frame([{"run_id": "r1"}]),
-        download_model_artifact=lambda run_id, artifact_path=None: BytesIO(b"zipdata"),
+        download_model_artifact=lambda run_id, artifact_path=None: archive,
     )
     view = getattr(mod, f"{basename}TrainJobViewSet").as_view({"get": "download_model"})
     request = factory.get(f"/{suffix}_train_jobs/x/runs/r1/download_model/")
     resp = _call(view, request, superuser, pk=tj.id, run_id="r1")
     assert resp.status_code == status.HTTP_200_OK
     assert resp["Content-Type"] == "application/zip"
+    assert resp["Content-Length"] == "7"
+    assert ".zip" in resp["Content-Disposition"]
+    assert resp.streaming
+    assert b"".join(resp.streaming_content) == b"zipdata"
+    resp.close()
+    assert archive.closed
 
 
 # =========================================================================

--- a/server/apps/mlops/utils/mlflow_service.py
+++ b/server/apps/mlops/utils/mlflow_service.py
@@ -7,8 +7,7 @@ MLflow 工具函数集合
 import os
 import tempfile
 import zipfile
-from io import BytesIO
-from typing import List, Optional, Tuple
+from typing import BinaryIO, List, Optional, Tuple
 from pathlib import Path
 
 import mlflow
@@ -376,7 +375,7 @@ def resolve_model_uri(model_name: str, version: str = "latest") -> str:
         raise
 
 
-def download_model_artifact(run_id: str, artifact_path: str = "model") -> BytesIO:
+def download_model_artifact(run_id: str, artifact_path: str = "model") -> BinaryIO:
     """
     从 MLflow 下载模型并打包为 ZIP 流
 
@@ -385,11 +384,12 @@ def download_model_artifact(run_id: str, artifact_path: str = "model") -> BytesI
         artifact_path: artifact 路径，默认 "model"
 
     Returns:
-        BytesIO: ZIP 文件流
+        BinaryIO: 位于磁盘临时文件中的 ZIP 文件流，由调用方负责关闭
 
     Raises:
         Exception: 下载或打包失败时抛出
     """
+    zip_stream: Optional[BinaryIO] = None
     try:
         client = get_mlflow_client()
 
@@ -404,9 +404,9 @@ def download_model_artifact(run_id: str, artifact_path: str = "model") -> BytesI
                 logger.error(error_msg)
                 raise FileNotFoundError(error_msg)
 
-            # 打包为 ZIP
-            zip_buffer = BytesIO()
-            with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zip_file:
+            # 打包到磁盘临时文件，避免 ZIP 大小直接叠加到 Web 进程内存。
+            zip_stream = tempfile.TemporaryFile(mode="w+b")
+            with zipfile.ZipFile(zip_stream, "w", zipfile.ZIP_DEFLATED) as zip_file:
                 if model_dir.is_file():
                     # 单文件
                     zip_file.write(model_dir, model_dir.name)
@@ -417,13 +417,15 @@ def download_model_artifact(run_id: str, artifact_path: str = "model") -> BytesI
                             arcname = file_path.relative_to(model_dir.parent)
                             zip_file.write(file_path, arcname)
 
-            zip_buffer.seek(0)
-            zip_size = len(zip_buffer.getvalue())
+            zip_size = zip_stream.tell()
+            zip_stream.seek(0)
             logger.info(f"模型打包完成 [run_id: {run_id}, size: {zip_size} bytes]")
 
-            return zip_buffer
+            return zip_stream
 
     except Exception as e:
+        if zip_stream is not None:
+            zip_stream.close()
         logger.error(
             f"下载模型失败 [run_id: {run_id}, artifact: {artifact_path}]: {e}",
             exc_info=True,

--- a/server/apps/mlops/utils/mlflow_service.py
+++ b/server/apps/mlops/utils/mlflow_service.py
@@ -13,6 +13,9 @@ from pathlib import Path
 import mlflow
 import pandas as pd
 import numpy as np
+from asgiref.sync import sync_to_async
+from django.http import StreamingHttpResponse
+from django.utils.http import content_disposition_header
 from mlflow.tracking import MlflowClient
 
 from config.components.mlflow import MLFLOW_TRACKER_URL
@@ -373,6 +376,44 @@ def resolve_model_uri(model_name: str, version: str = "latest") -> str:
             exc_info=True,
         )
         raise
+
+
+class _AsyncFileIterator:
+    """以异步迭代协议分块读取同步临时文件。"""
+
+    def __init__(self, file_stream: BinaryIO, block_size: int = 64 * 1024):
+        self.file_stream = file_stream
+        self.block_size = block_size
+        self._read = sync_to_async(file_stream.read, thread_sensitive=False)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        chunk = await self._read(self.block_size)
+        if chunk:
+            return chunk
+        raise StopAsyncIteration
+
+    def close(self):
+        self.file_stream.close()
+
+
+def build_model_download_response(zip_stream: BinaryIO, filename: str) -> StreamingHttpResponse:
+    """构造适配 ASGI 的异步分块模型下载响应。"""
+    initial_position = zip_stream.tell()
+    zip_stream.seek(0, os.SEEK_END)
+    content_length = zip_stream.tell() - initial_position
+    zip_stream.seek(initial_position)
+
+    response = StreamingHttpResponse(
+        _AsyncFileIterator(zip_stream),
+        content_type="application/zip",
+    )
+    response["Content-Length"] = content_length
+    if disposition := content_disposition_header(True, filename):
+        response["Content-Disposition"] = disposition
+    return response
 
 
 def download_model_artifact(run_id: str, artifact_path: str = "model") -> BinaryIO:

--- a/server/apps/mlops/utils/mlflow_service.py
+++ b/server/apps/mlops/utils/mlflow_service.py
@@ -393,10 +393,21 @@ class _AsyncFileIterator:
         chunk = await self._read(self.block_size)
         if chunk:
             return chunk
+        self.close()
         raise StopAsyncIteration
+
+    async def aclose(self):
+        self.close()
 
     def close(self):
         self.file_stream.close()
+
+
+class _AsyncFileStreamingHttpResponse(StreamingHttpResponse):
+    """让 ASGIHandler 的 aclosing 直接关闭底层异步文件迭代器。"""
+
+    def __aiter__(self):
+        return self._iterator
 
 
 def build_model_download_response(zip_stream: BinaryIO, filename: str) -> StreamingHttpResponse:
@@ -406,11 +417,12 @@ def build_model_download_response(zip_stream: BinaryIO, filename: str) -> Stream
     content_length = zip_stream.tell() - initial_position
     zip_stream.seek(initial_position)
 
-    response = StreamingHttpResponse(
+    response = _AsyncFileStreamingHttpResponse(
         _AsyncFileIterator(zip_stream),
         content_type="application/zip",
     )
     response["Content-Length"] = content_length
+    filename = os.path.basename(filename)
     if disposition := content_disposition_header(True, filename):
         response["Content-Disposition"] = disposition
     return response

--- a/server/apps/mlops/views/anomaly_detection.py
+++ b/server/apps/mlops/views/anomaly_detection.py
@@ -592,12 +592,7 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
             filename = f"AnomalyDetection_{run_name}_{run_id[:8]}.zip"
 
             # 返回文件
-            response = FileResponse(
-                zip_buffer,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_buffer, filename)
 
             logger.info(f"模型下载请求完成: {filename}")
             return response

--- a/server/apps/mlops/views/classification.py
+++ b/server/apps/mlops/views/classification.py
@@ -1282,12 +1282,7 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
             filename = f"Classification_{run_name}_{run_id[:8]}.zip"
 
             # 返回文件
-            response = FileResponse(
-                zip_buffer,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_buffer, filename)
 
             return response
 

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -554,19 +554,20 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
             logger.info(f"开始下载模型: run_id={run_id}")
 
             # 下载模型并打包为 ZIP
-            zip_buffer = mlflow_service.download_model_artifact(run_id=run_id, artifact_path="model")
+            zip_stream = mlflow_service.download_model_artifact(run_id=run_id, artifact_path="model")
 
             # 构造文件名
             filename = f"model_{run_id}.zip"
 
             # 返回文件响应
-            from django.http import HttpResponse
+            response = FileResponse(
+                zip_stream,
+                content_type="application/zip",
+                as_attachment=True,
+                filename=filename,
+            )
 
-            response = HttpResponse(zip_buffer.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = f'attachment; filename="{filename}"'
-            response["Content-Length"] = len(zip_buffer.getvalue())
-
-            logger.info(f"模型下载成功: run_id={run_id}, size={len(zip_buffer.getvalue())} bytes")
+            logger.info(f"模型下载成功: run_id={run_id}, size={response['Content-Length']} bytes")
             return response
 
         except Exception as e:

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -560,12 +560,7 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
             filename = f"model_{run_id}.zip"
 
             # 返回文件响应
-            response = FileResponse(
-                zip_stream,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_stream, filename)
 
             logger.info(f"模型下载成功: run_id={run_id}, size={response['Content-Length']} bytes")
             return response

--- a/server/apps/mlops/views/log_clustering.py
+++ b/server/apps/mlops/views/log_clustering.py
@@ -610,12 +610,7 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
             filename = f"mlflow_model_{safe_run_name}_{run_id[:8]}.zip"
 
             # 返回文件响应
-            response = FileResponse(
-                zip_buffer,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_buffer, filename)
 
             logger.info(f"模型下载完成 [run_id: {run_id}, filename: {filename}]")
             return response

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -540,12 +540,7 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
             filename = f"model_{run_id}.zip"
 
             # 返回文件响应
-            response = FileResponse(
-                zip_stream,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_stream, filename)
 
             logger.info(f"模型下载成功: run_id={run_id}, size={response['Content-Length']} bytes")
             return response

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -534,19 +534,20 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
             logger.info(f"开始下载模型: run_id={run_id}")
 
             # 下载模型并打包为 ZIP
-            zip_buffer = mlflow_service.download_model_artifact(run_id=run_id, artifact_path="model")
+            zip_stream = mlflow_service.download_model_artifact(run_id=run_id, artifact_path="model")
 
             # 构造文件名
             filename = f"model_{run_id}.zip"
 
             # 返回文件响应
-            from django.http import HttpResponse
+            response = FileResponse(
+                zip_stream,
+                content_type="application/zip",
+                as_attachment=True,
+                filename=filename,
+            )
 
-            response = HttpResponse(zip_buffer.getvalue(), content_type="application/zip")
-            response["Content-Disposition"] = f'attachment; filename="{filename}"'
-            response["Content-Length"] = len(zip_buffer.getvalue())
-
-            logger.info(f"模型下载成功: run_id={run_id}, size={len(zip_buffer.getvalue())} bytes")
+            logger.info(f"模型下载成功: run_id={run_id}, size={response['Content-Length']} bytes")
             return response
 
         except Exception as e:

--- a/server/apps/mlops/views/timeseries_predict.py
+++ b/server/apps/mlops/views/timeseries_predict.py
@@ -613,12 +613,7 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
             filename = f"mlflow_model_{safe_run_name}_{run_id[:8]}.zip"
 
             # 返回文件响应
-            response = FileResponse(
-                zip_buffer,
-                content_type="application/zip",
-                as_attachment=True,
-                filename=filename,
-            )
+            response = mlflow_service.build_model_download_response(zip_buffer, filename)
 
             logger.info(f"模型下载完成 [run_id: {run_id}, filename: {filename}]")
             return response


### PR DESCRIPTION
## 问题

六类 MLOps 模型下载本应在生产 ASGI 链路中按块传输，但原实现先把完整 ZIP 写入 Python 内存；其中图像分类和目标检测还会再复制一次响应内容。大模型或并发下载会让 Web worker 的堆内存随模型总大小线性增长。

## 根因

归档阶段以 `BytesIO` 为边界，响应阶段又使用同步文件迭代器。Django 4.2 在 ASGI 下会先完整消费同步迭代器再发送，因此仅替换归档介质仍不足以形成端到端回压。

## 怎么修的

- 将 ZIP 写入磁盘临时文件，归档阶段不再持有完整内存副本。
- 新增 64 KiB 异步文件迭代响应，六类下载入口统一复用。
- 响应正常完成、显式关闭或客户端断连时关闭临时文件。
- 复刻 `FileResponse` 的 basename、文件长度和下载头语义。

## 影响范围

改动仅涉及 `server/apps/mlops` 的六类模型下载入口及共享 MLflow 工具。下载 URL、权限、run 归属、文件名、`Content-Disposition`、`Content-Type`、ZIP 条目和内容保持不变；没有数据迁移或配置变更。临时盘会同时容纳 MLflow 下载目录和 ZIP，磁盘不足仍沿用现有 500 错误契约。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["六类 download_model\nserver/apps/mlops/views"]
    end

    subgraph N["核心处理层"]
        F1["download_model_artifact\nmlflow_service.py"]
        F2["磁盘 TemporaryFile ZIP"]
        F3["64 KiB 异步文件迭代响应"]
    end

    subgraph C["资源清理层"]
        C1["正常完成 / close / 断连\n关闭临时文件"]
    end

    T1 --> F1 --> F2 --> F3
    F3 -. "结束或中断" .-> C1
```

## 验证

- `apps/mlops/tests/test_model_download_memory.py`：5 passed
- `apps/mlops/tests/test_mlflow_service_utils.py`：33 passed
- `apps/mlops/tests/test_views_actions_param.py`：280 passed, 14 skipped
- 8 MiB 相同响应输入下，Python 堆峰值从 8,557,501 bytes 降至 153,744 bytes，发送字节一致，下降 98.20%。

关联 Issue #4244。
