### PR TITLE
bugfix: 训练数据提交后再清理旧文件

### DIFF
--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -36,48 +36,58 @@ class TrainDataFileCleanupMixin:
         This method:
         1. Detects if we're updating an existing record (pk exists)
         2. Compares old and new file paths
-        3. Deletes the old file from storage if path changed
-        4. Calls the parent save() method
+        3. Saves the database record while holding a row lock
+        4. Deletes the old file after the surrounding transaction commits
         """
-        from django.db import transaction
+        from django.db import router, transaction
         from apps.core.logger import mlops_logger as logger
 
         file_field_name = self._file_field_name
+        update_fields = kwargs.get("update_fields")
 
-        # Only perform cleanup on updates (not on new records)
-        if self.pk:
-            with transaction.atomic():
-                try:
-                    # Use select_for_update to prevent race conditions
-                    old_instance = self.__class__.objects.select_for_update().get(
-                        pk=self.pk
-                    )
-                    old_file = getattr(old_instance, file_field_name)
-                    new_file = getattr(self, file_field_name)
+        # New records and partial saves that exclude the file keep normal Model.save semantics.
+        if not self.pk or (
+            update_fields is not None and file_field_name not in update_fields
+        ):
+            super().save(*args, **kwargs)
+            return
 
-                    # Extract file paths (handle FieldFile objects and None)
-                    old_path = old_file.name if old_file else None
-                    new_path = new_file.name if new_file else None
+        using = kwargs.get("using") or router.db_for_write(
+            self.__class__, instance=self
+        )
+        with transaction.atomic(using=using):
+            try:
+                old_instance = (
+                    self.__class__.objects.using(using)
+                    .select_for_update()
+                    .get(pk=self.pk)
+                )
+                old_file = getattr(old_instance, file_field_name)
+                old_path = old_file.name if old_file else None
+            except self.__class__.DoesNotExist:
+                old_file = None
+                old_path = None
 
-                    # Delete old file if it exists and path has changed (including when cleared)
-                    if old_path and old_path != new_path:
-                        try:
-                            old_file.delete(save=False)
-                            logger.info(
-                                f"Deleted old {file_field_name} file for {self.__class__.__name__} {self.pk}: "
-                                f"old={old_path}, new={new_path or 'None'}"
-                            )
-                        except Exception as delete_err:
-                            logger.warning(
-                                f"Failed to delete old file '{old_path}': {delete_err}"
-                            )
+            new_file = getattr(self, file_field_name)
+            new_path = new_file.name if new_file else None
 
-                except self.__class__.DoesNotExist:
-                    pass
-                except Exception as e:
-                    logger.warning(f"Failed to check old {file_field_name} file: {e}")
+            super().save(*args, **kwargs)
 
-        super().save(*args, **kwargs)
+            if old_path and old_path != new_path:
+
+                def delete_old_file():
+                    try:
+                        old_file.storage.delete(old_path)
+                        logger.info(
+                            f"Deleted old {file_field_name} file for {self.__class__.__name__} {self.pk}: "
+                            f"old={old_path}, new={new_path or 'None'}"
+                        )
+                    except Exception as delete_err:
+                        logger.warning(
+                            f"Failed to delete old file '{old_path}': {delete_err}"
+                        )
+
+                transaction.on_commit(delete_old_file, using=using)
 
 
 class TrainJobConfigSyncMixin:

--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -28,6 +28,16 @@ class TrainDataFileCleanupMixin:
 
     # Subclasses can override this to use a different file field name
     _file_field_name = "train_data"
+    _loaded_file_path_missing = object()
+
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        file_field_name = cls._file_field_name
+        if file_field_name in field_names:
+            file_value = getattr(instance, file_field_name)
+            instance._loaded_file_path = file_value.name if file_value else None
+        return instance
 
     def save(self, *args, **kwargs):
         """
@@ -46,9 +56,12 @@ class TrainDataFileCleanupMixin:
         update_fields = kwargs.get("update_fields")
 
         # New records and partial saves that exclude the file keep normal Model.save semantics.
-        if not self.pk or (
-            update_fields is not None and file_field_name not in update_fields
-        ):
+        if not self.pk:
+            super().save(*args, **kwargs)
+            file_value = getattr(self, file_field_name)
+            self._loaded_file_path = file_value.name if file_value else None
+            return
+        if update_fields is not None and file_field_name not in update_fields:
             super().save(*args, **kwargs)
             return
 
@@ -70,16 +83,44 @@ class TrainDataFileCleanupMixin:
 
             new_file = getattr(self, file_field_name)
             new_path = new_file.name if new_file else None
+            loaded_path = getattr(
+                self, "_loaded_file_path", self._loaded_file_path_missing
+            )
+
+            # A stale instance that did not change the file must not overwrite a
+            # replacement committed by another request.
+            if (
+                loaded_path is not self._loaded_file_path_missing
+                and new_path == loaded_path
+                and old_path != loaded_path
+            ):
+                setattr(self, file_field_name, old_file)
+                new_path = old_path
 
             super().save(*args, **kwargs)
+            self._loaded_file_path = new_path
 
             if old_path and old_path != new_path:
+                model_class = self.__class__
+                instance_pk = self.pk
+                storage = old_file.storage
 
                 def delete_old_file():
                     try:
-                        old_file.storage.delete(old_path)
+                        current_path = (
+                            model_class.objects.using(using)
+                            .values_list(file_field_name, flat=True)
+                            .filter(pk=instance_pk)
+                            .first()
+                        )
+                        if current_path == old_path:
+                            logger.info(
+                                f"Skipped deleting referenced {file_field_name} file for {model_class.__name__} {instance_pk}: {old_path}"
+                            )
+                            return
+                        storage.delete(old_path)
                         logger.info(
-                            f"Deleted old {file_field_name} file for {self.__class__.__name__} {self.pk}: "
+                            f"Deleted old {file_field_name} file for {model_class.__name__} {instance_pk}: "
                             f"old={old_path}, new={new_path or 'None'}"
                         )
                     except Exception as delete_err:

--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -101,32 +101,49 @@ class TrainDataFileCleanupMixin:
             self._loaded_file_path = new_path
 
             if old_path and old_path != new_path:
-                model_class = self.__class__
-                instance_pk = self.pk
-                storage = old_file.storage
+                cleanup_kwargs = {
+                    "model_label": self.__class__._meta.label,
+                    "instance_pk": self.pk,
+                    "file_field_name": file_field_name,
+                    "old_path": old_path,
+                    "using": using,
+                }
 
                 def delete_old_file():
+                    from apps.mlops.services.train_data_file_cleanup import (
+                        delete_unreferenced_train_data_file,
+                    )
+
                     try:
-                        current_path = (
-                            model_class.objects.using(using)
-                            .values_list(file_field_name, flat=True)
-                            .filter(pk=instance_pk)
-                            .first()
-                        )
-                        if current_path == old_path:
-                            logger.info(
-                                f"Skipped deleting referenced {file_field_name} file for {model_class.__name__} {instance_pk}: {old_path}"
-                            )
-                            return
-                        storage.delete(old_path)
-                        logger.info(
-                            f"Deleted old {file_field_name} file for {model_class.__name__} {instance_pk}: "
-                            f"old={old_path}, new={new_path or 'None'}"
-                        )
+                        delete_unreferenced_train_data_file(**cleanup_kwargs)
                     except Exception as delete_err:
                         logger.warning(
-                            f"Failed to delete old file '{old_path}': {delete_err}"
+                            "Failed to delete old file '%s'; scheduling retry: %s",
+                            old_path,
+                            delete_err,
                         )
+                        try:
+                            from apps.mlops.tasks.file_cleanup import (
+                                cleanup_train_data_file,
+                            )
+
+                            cleanup_train_data_file.apply_async(
+                                kwargs=cleanup_kwargs,
+                                delivery_mode=2,
+                                retry=True,
+                                retry_policy={
+                                    "max_retries": 3,
+                                    "interval_start": 0,
+                                    "interval_step": 1,
+                                    "interval_max": 3,
+                                },
+                            )
+                        except Exception as publish_err:
+                            logger.error(
+                                "Failed to publish cleanup retry for '%s': %s",
+                                old_path,
+                                publish_err,
+                            )
 
                 transaction.on_commit(delete_old_file, using=using)
 

--- a/server/apps/mlops/services/train_data_file_cleanup.py
+++ b/server/apps/mlops/services/train_data_file_cleanup.py
@@ -1,0 +1,41 @@
+from django.apps import apps
+
+from apps.core.logger import mlops_logger as logger
+
+
+def delete_unreferenced_train_data_file(
+    *,
+    model_label,
+    instance_pk,
+    file_field_name,
+    old_path,
+    using="default",
+):
+    """Delete an old training file only when the database no longer references it."""
+    model_class = apps.get_model(model_label)
+    current_path = (
+        model_class.objects.using(using)
+        .filter(pk=instance_pk)
+        .values_list(file_field_name, flat=True)
+        .first()
+    )
+    if current_path == old_path:
+        logger.info(
+            "Skipped deleting referenced %s file for %s %s: %s",
+            file_field_name,
+            model_class.__name__,
+            instance_pk,
+            old_path,
+        )
+        return "referenced"
+
+    storage = model_class._meta.get_field(file_field_name).storage
+    storage.delete(old_path)
+    logger.info(
+        "Deleted old %s file for %s %s: %s",
+        file_field_name,
+        model_class.__name__,
+        instance_pk,
+        old_path,
+    )
+    return "deleted"

--- a/server/apps/mlops/tasks/__init__.py
+++ b/server/apps/mlops/tasks/__init__.py
@@ -21,6 +21,7 @@ from .object_detection import (
     publish_dataset_release_async as object_detection_publish_dataset_release_async,
 )
 from .poll_train_job_status import poll_train_job_status  # noqa: F401
+from .file_cleanup import cleanup_train_data_file
 
 __all__ = [
     "timeseries_publish_dataset_release_async",
@@ -30,4 +31,5 @@ __all__ = [
     "image_classification_publish_dataset_release_async",
     "object_detection_publish_dataset_release_async",
     "poll_train_job_status",
+    "cleanup_train_data_file",
 ]

--- a/server/apps/mlops/tasks/file_cleanup.py
+++ b/server/apps/mlops/tasks/file_cleanup.py
@@ -1,0 +1,31 @@
+from celery import shared_task
+
+from apps.mlops.services.train_data_file_cleanup import (
+    delete_unreferenced_train_data_file,
+)
+
+
+@shared_task(
+    acks_late=True,
+    reject_on_worker_lost=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_jitter=True,
+    max_retries=5,
+)
+def cleanup_train_data_file(
+    *,
+    model_label,
+    instance_pk,
+    file_field_name,
+    old_path,
+    using="default",
+):
+    """Retry an idempotent old-file cleanup after a transient storage failure."""
+    return delete_unreferenced_train_data_file(
+        model_label=model_label,
+        instance_pk=instance_pk,
+        file_field_name=file_field_name,
+        old_path=old_path,
+        using=using,
+    )

--- a/server/apps/mlops/tests/test_train_data_file_cleanup_mixin.py
+++ b/server/apps/mlops/tests/test_train_data_file_cleanup_mixin.py
@@ -1,0 +1,198 @@
+from unittest.mock import Mock
+
+import pytest
+from django.db import IntegrityError, models, transaction
+
+from apps.mlops.models.anomaly_detection import (
+    AnomalyDetectionDataset,
+    AnomalyDetectionTrainData,
+)
+from apps.mlops.models.classification import (
+    ClassificationDataset,
+    ClassificationTrainData,
+)
+from apps.mlops.models.image_classification import (
+    ImageClassificationDataset,
+    ImageClassificationTrainData,
+)
+from apps.mlops.models.log_clustering import (
+    LogClusteringDataset,
+    LogClusteringTrainData,
+)
+from apps.mlops.models.object_detection import (
+    ObjectDetectionDataset,
+    ObjectDetectionTrainData,
+)
+from apps.mlops.models.timeseries_predict import (
+    TimeSeriesPredictDataset,
+    TimeSeriesPredictTrainData,
+)
+
+pytestmark = [pytest.mark.django_db(transaction=True), pytest.mark.integration]
+
+TRAIN_DATA_MODELS = [
+    (AnomalyDetectionDataset, AnomalyDetectionTrainData),
+    (ClassificationDataset, ClassificationTrainData),
+    (ImageClassificationDataset, ImageClassificationTrainData),
+    (LogClusteringDataset, LogClusteringTrainData),
+    (ObjectDetectionDataset, ObjectDetectionTrainData),
+    (TimeSeriesPredictDataset, TimeSeriesPredictTrainData),
+]
+
+
+def _create_train_data(dataset_model, train_data_model):
+    dataset = dataset_model.objects.create(name="dataset", description="", team=[1])
+    return train_data_model.objects.create(
+        name="train-data",
+        dataset=dataset,
+        train_data="old/train-data.bin",
+        is_train_data=True,
+    )
+
+
+def _mock_storage_delete(monkeypatch, train_data_model, *, side_effect=None):
+    delete = Mock(side_effect=side_effect)
+    storage = train_data_model._meta.get_field("train_data").storage
+    monkeypatch.setattr(storage, "delete", delete)
+    return delete
+
+
+@pytest.mark.parametrize(("dataset_model", "train_data_model"), TRAIN_DATA_MODELS)
+def test_database_save_failure_preserves_old_file(
+    monkeypatch,
+    dataset_model,
+    train_data_model,
+):
+    instance = _create_train_data(dataset_model, train_data_model)
+    delete = _mock_storage_delete(monkeypatch, train_data_model)
+    instance.train_data = "new/train-data.bin"
+    monkeypatch.setattr(
+        models.Model,
+        "save",
+        Mock(side_effect=IntegrityError("database save failed")),
+    )
+
+    with pytest.raises(IntegrityError, match="database save failed"):
+        instance.save()
+
+    delete.assert_not_called()
+    assert (
+        train_data_model.objects.values_list("train_data", flat=True).get(pk=instance.pk)
+        == "old/train-data.bin"
+    )
+
+
+def test_outer_transaction_rollback_preserves_old_file(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    with pytest.raises(RuntimeError, match="rollback caller transaction"):
+        with transaction.atomic():
+            instance.train_data = "new/train-data.bin"
+            instance.save()
+            raise RuntimeError("rollback caller transaction")
+
+    delete.assert_not_called()
+    assert (
+        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
+            pk=instance.pk
+        )
+        == "old/train-data.bin"
+    )
+
+
+def test_committed_replacement_deletes_old_file(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    instance.train_data = "new/train-data.bin"
+    instance.save()
+
+    delete.assert_called_once_with("old/train-data.bin")
+    assert (
+        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
+            pk=instance.pk
+        )
+        == "new/train-data.bin"
+    )
+
+
+def test_committed_clear_deletes_old_file(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    instance.train_data = None
+    instance.save()
+
+    delete.assert_called_once_with("old/train-data.bin")
+    assert (
+        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
+            pk=instance.pk
+        )
+        == ""
+    )
+
+
+def test_unchanged_file_is_not_deleted(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    instance.name = "renamed"
+    instance.save()
+
+    delete.assert_not_called()
+
+
+def test_update_fields_without_file_keeps_persisted_file(monkeypatch):
+    instance = _create_train_data(
+        ImageClassificationDataset,
+        ImageClassificationTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, ImageClassificationTrainData)
+
+    instance.train_data = "not-persisted/train-data.bin"
+    instance.metadata = {"classes": ["cat"]}
+    instance.save(update_fields=["metadata"])
+
+    delete.assert_not_called()
+    assert (
+        ImageClassificationTrainData.objects.values_list("train_data", flat=True).get(
+            pk=instance.pk
+        )
+        == "old/train-data.bin"
+    )
+
+
+def test_cleanup_failure_does_not_rollback_committed_database_update(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(
+        monkeypatch,
+        AnomalyDetectionTrainData,
+        side_effect=OSError("object storage unavailable"),
+    )
+
+    instance.train_data = "new/train-data.bin"
+    instance.save()
+
+    delete.assert_called_once_with("old/train-data.bin")
+    assert (
+        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
+            pk=instance.pk
+        )
+        == "new/train-data.bin"
+    )

--- a/server/apps/mlops/tests/test_train_data_file_cleanup_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_data_file_cleanup_mixin_service.py
@@ -57,6 +57,12 @@ def _mock_storage_delete(monkeypatch, train_data_model, *, side_effect=None):
     return delete
 
 
+def _persisted_train_data_path(train_data_model, instance):
+    return train_data_model.objects.values_list("train_data", flat=True).get(
+        pk=instance.pk
+    )
+
+
 @pytest.mark.parametrize(("dataset_model", "train_data_model"), TRAIN_DATA_MODELS)
 def test_database_save_failure_preserves_old_file(
     monkeypatch,
@@ -76,10 +82,7 @@ def test_database_save_failure_preserves_old_file(
         instance.save()
 
     delete.assert_not_called()
-    assert (
-        train_data_model.objects.values_list("train_data", flat=True).get(pk=instance.pk)
-        == "old/train-data.bin"
-    )
+    assert _persisted_train_data_path(train_data_model, instance) == "old/train-data.bin"
 
 
 def test_outer_transaction_rollback_preserves_old_file(monkeypatch):
@@ -97,9 +100,7 @@ def test_outer_transaction_rollback_preserves_old_file(monkeypatch):
 
     delete.assert_not_called()
     assert (
-        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
-            pk=instance.pk
-        )
+        _persisted_train_data_path(AnomalyDetectionTrainData, instance)
         == "old/train-data.bin"
     )
 
@@ -116,9 +117,7 @@ def test_committed_replacement_deletes_old_file(monkeypatch):
 
     delete.assert_called_once_with("old/train-data.bin")
     assert (
-        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
-            pk=instance.pk
-        )
+        _persisted_train_data_path(AnomalyDetectionTrainData, instance)
         == "new/train-data.bin"
     )
 
@@ -134,12 +133,7 @@ def test_committed_clear_deletes_old_file(monkeypatch):
     instance.save()
 
     delete.assert_called_once_with("old/train-data.bin")
-    assert (
-        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
-            pk=instance.pk
-        )
-        == ""
-    )
+    assert _persisted_train_data_path(AnomalyDetectionTrainData, instance) == ""
 
 
 def test_unchanged_file_is_not_deleted(monkeypatch):
@@ -168,9 +162,7 @@ def test_update_fields_without_file_keeps_persisted_file(monkeypatch):
 
     delete.assert_not_called()
     assert (
-        ImageClassificationTrainData.objects.values_list("train_data", flat=True).get(
-            pk=instance.pk
-        )
+        _persisted_train_data_path(ImageClassificationTrainData, instance)
         == "old/train-data.bin"
     )
 
@@ -191,8 +183,47 @@ def test_cleanup_failure_does_not_rollback_committed_database_update(monkeypatch
 
     delete.assert_called_once_with("old/train-data.bin")
     assert (
-        AnomalyDetectionTrainData.objects.values_list("train_data", flat=True).get(
-            pk=instance.pk
-        )
+        _persisted_train_data_path(AnomalyDetectionTrainData, instance)
         == "new/train-data.bin"
     )
+
+
+def test_stale_instance_non_file_save_preserves_committed_replacement(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    stale_instance = AnomalyDetectionTrainData.objects.get(pk=instance.pk)
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    instance.train_data = "new/train-data.bin"
+    instance.save()
+
+    stale_instance.name = "renamed by concurrent request"
+    stale_instance.save()
+
+    assert (
+        _persisted_train_data_path(AnomalyDetectionTrainData, stale_instance)
+        == "new/train-data.bin"
+    )
+    delete.assert_called_once_with("old/train-data.bin")
+
+
+def test_multiple_replacements_in_outer_transaction_keep_final_file(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+
+    with transaction.atomic():
+        instance.train_data = "intermediate/train-data.bin"
+        instance.save()
+        instance.train_data = "old/train-data.bin"
+        instance.save()
+
+    assert (
+        _persisted_train_data_path(AnomalyDetectionTrainData, instance)
+        == "old/train-data.bin"
+    )
+    delete.assert_called_once_with("intermediate/train-data.bin")

--- a/server/apps/mlops/tests/test_train_data_file_cleanup_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_data_file_cleanup_mixin_service.py
@@ -27,8 +27,9 @@ from apps.mlops.models.timeseries_predict import (
     TimeSeriesPredictDataset,
     TimeSeriesPredictTrainData,
 )
+from apps.mlops.tasks.file_cleanup import cleanup_train_data_file
 
-pytestmark = [pytest.mark.django_db(transaction=True), pytest.mark.integration]
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 TRAIN_DATA_MODELS = [
     (AnomalyDetectionDataset, AnomalyDetectionTrainData),
@@ -85,18 +86,22 @@ def test_database_save_failure_preserves_old_file(
     assert _persisted_train_data_path(train_data_model, instance) == "old/train-data.bin"
 
 
-def test_outer_transaction_rollback_preserves_old_file(monkeypatch):
+def test_outer_transaction_rollback_preserves_old_file(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
     )
     delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
 
-    with pytest.raises(RuntimeError, match="rollback caller transaction"):
-        with transaction.atomic():
-            instance.train_data = "new/train-data.bin"
-            instance.save()
-            raise RuntimeError("rollback caller transaction")
+    with django_capture_on_commit_callbacks(execute=True):
+        with pytest.raises(RuntimeError, match="rollback caller transaction"):
+            with transaction.atomic():
+                instance.train_data = "new/train-data.bin"
+                instance.save()
+                raise RuntimeError("rollback caller transaction")
 
     delete.assert_not_called()
     assert (
@@ -105,15 +110,19 @@ def test_outer_transaction_rollback_preserves_old_file(monkeypatch):
     )
 
 
-def test_committed_replacement_deletes_old_file(monkeypatch):
+def test_committed_replacement_deletes_old_file(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
     )
     delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
 
-    instance.train_data = "new/train-data.bin"
-    instance.save()
+    with django_capture_on_commit_callbacks(execute=True):
+        instance.train_data = "new/train-data.bin"
+        instance.save()
 
     delete.assert_called_once_with("old/train-data.bin")
     assert (
@@ -122,15 +131,19 @@ def test_committed_replacement_deletes_old_file(monkeypatch):
     )
 
 
-def test_committed_clear_deletes_old_file(monkeypatch):
+def test_committed_clear_deletes_old_file(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
     )
     delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
 
-    instance.train_data = None
-    instance.save()
+    with django_capture_on_commit_callbacks(execute=True):
+        instance.train_data = None
+        instance.save()
 
     delete.assert_called_once_with("old/train-data.bin")
     assert _persisted_train_data_path(AnomalyDetectionTrainData, instance) == ""
@@ -167,7 +180,10 @@ def test_update_fields_without_file_keeps_persisted_file(monkeypatch):
     )
 
 
-def test_cleanup_failure_does_not_rollback_committed_database_update(monkeypatch):
+def test_cleanup_failure_schedules_retry_without_rolling_back_database_update(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
@@ -177,18 +193,41 @@ def test_cleanup_failure_does_not_rollback_committed_database_update(monkeypatch
         AnomalyDetectionTrainData,
         side_effect=OSError("object storage unavailable"),
     )
+    apply_async = Mock()
+    monkeypatch.setattr(cleanup_train_data_file, "apply_async", apply_async)
 
-    instance.train_data = "new/train-data.bin"
-    instance.save()
+    with django_capture_on_commit_callbacks(execute=True):
+        instance.train_data = "new/train-data.bin"
+        instance.save()
 
     delete.assert_called_once_with("old/train-data.bin")
+    apply_async.assert_called_once_with(
+        kwargs={
+            "model_label": "mlops.AnomalyDetectionTrainData",
+            "instance_pk": instance.pk,
+            "file_field_name": "train_data",
+            "old_path": "old/train-data.bin",
+            "using": "default",
+        },
+        delivery_mode=2,
+        retry=True,
+        retry_policy={
+            "max_retries": 3,
+            "interval_start": 0,
+            "interval_step": 1,
+            "interval_max": 3,
+        },
+    )
     assert (
         _persisted_train_data_path(AnomalyDetectionTrainData, instance)
         == "new/train-data.bin"
     )
 
 
-def test_stale_instance_non_file_save_preserves_committed_replacement(monkeypatch):
+def test_stale_instance_non_file_save_preserves_committed_replacement(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
@@ -196,8 +235,9 @@ def test_stale_instance_non_file_save_preserves_committed_replacement(monkeypatc
     stale_instance = AnomalyDetectionTrainData.objects.get(pk=instance.pk)
     delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
 
-    instance.train_data = "new/train-data.bin"
-    instance.save()
+    with django_capture_on_commit_callbacks(execute=True):
+        instance.train_data = "new/train-data.bin"
+        instance.save()
 
     stale_instance.name = "renamed by concurrent request"
     stale_instance.save()
@@ -209,21 +249,52 @@ def test_stale_instance_non_file_save_preserves_committed_replacement(monkeypatc
     delete.assert_called_once_with("old/train-data.bin")
 
 
-def test_multiple_replacements_in_outer_transaction_keep_final_file(monkeypatch):
+def test_multiple_replacements_in_outer_transaction_keep_final_file(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     instance = _create_train_data(
         AnomalyDetectionDataset,
         AnomalyDetectionTrainData,
     )
     delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
 
-    with transaction.atomic():
-        instance.train_data = "intermediate/train-data.bin"
-        instance.save()
-        instance.train_data = "old/train-data.bin"
-        instance.save()
+    with django_capture_on_commit_callbacks(execute=True):
+        with transaction.atomic():
+            instance.train_data = "intermediate/train-data.bin"
+            instance.save()
+            instance.train_data = "old/train-data.bin"
+            instance.save()
 
     assert (
         _persisted_train_data_path(AnomalyDetectionTrainData, instance)
         == "old/train-data.bin"
     )
     delete.assert_called_once_with("intermediate/train-data.bin")
+
+
+def test_retry_task_rechecks_current_database_reference(monkeypatch):
+    instance = _create_train_data(
+        AnomalyDetectionDataset,
+        AnomalyDetectionTrainData,
+    )
+    delete = _mock_storage_delete(monkeypatch, AnomalyDetectionTrainData)
+    cleanup_kwargs = {
+        "model_label": "mlops.AnomalyDetectionTrainData",
+        "instance_pk": instance.pk,
+        "file_field_name": "train_data",
+        "old_path": "old/train-data.bin",
+        "using": "default",
+    }
+
+    assert cleanup_train_data_file.run(**cleanup_kwargs) == "referenced"
+    delete.assert_not_called()
+
+    AnomalyDetectionTrainData.objects.filter(pk=instance.pk).update(
+        train_data="new/train-data.bin"
+    )
+    assert cleanup_train_data_file.run(**cleanup_kwargs) == "deleted"
+    delete.assert_called_once_with("old/train-data.bin")
+    assert cleanup_train_data_file.max_retries == 5
+    assert cleanup_train_data_file.acks_late is True
+    assert cleanup_train_data_file.reject_on_worker_lost is True


### PR DESCRIPTION
## 问题

六类 TrainData 更新共享旧文件清理入口。原实现会在数据库保存前删除 MinIO 旧对象；数据库保存失败或外层事务回滚后，已提交记录会指向不存在的文件。

## 修复

- 按模型实际数据库别名开启事务，在同一事务内锁定旧行并完成保存。
- 仅在外围事务最终提交后清理旧对象；保存失败或任一外层事务回滚都会取消清理。
- 陈旧实例未修改文件字段时，不再覆盖另一请求已提交的新路径。
- 每次清理前复查数据库最终引用，避免同一外层事务 A→B→A 或并发更新误删最终文件。
- MinIO 同步删除失败时投递 durable Celery 消息；发布阶段重试，Worker 最多重试 5 次，并使用 `acks_late` 与 `reject_on_worker_lost` 保证异常退出后重新入队。

## 兼容性

- 六个 HTTP 更新入口、NATS 读取契约、字段、bucket 和对象键不变。
- `update_fields` 未包含 `train_data` 时保持局部保存行为。
- 不修改 schema，不迁移或重新解释存量数据；回滚只需还原本 PR。
- 已经处于“数据库行指向缺失对象”的历史数据不在本次自动恢复范围。

## 验证

- `apps/mlops/tests/test_train_data_file_cleanup_mixin_service.py`
- `apps/mlops/tests/test_signals_cleanup.py`
- `apps/mlops/tests/test_tasks_wrappers_param.py`
- 合计 41 passed。

覆盖六类模型、保存失败、外层事务回滚、替换、清空、路径不变、局部字段保存、陈旧实例、A→B→A、对象存储失败补偿、任务最终引用复查及 Worker 重投配置。

Closes #4241
