### PR TITLE
bugfix: 公共枚举快照部分失败时重试

### DIFF
--- a/server/apps/cmdb/services/public_enum_library.py
+++ b/server/apps/cmdb/services/public_enum_library.py
@@ -293,7 +293,7 @@ def sync_library_snapshots(library_id: str, trigger: str, operator: str | None =
     )
 
     return {
-        "result": True,
+        "result": not failed_items,
         "library_id": library_id,
         "affected_models": len(affected_models),
         "affected_attrs": affected_attrs,

--- a/server/apps/cmdb/services/public_enum_library.py
+++ b/server/apps/cmdb/services/public_enum_library.py
@@ -283,8 +283,19 @@ def sync_library_snapshots(library_id: str, trigger: str, operator: str | None =
                     )
                     affected_models.add(model_id)
                 except Exception as e:
-                    logger.error(f"[SyncPublicEnumSnapshots] failed to update model={model_id}, error={e}")
-                    failed_items.append({"model_id": model_id, "error": str(e)})
+                    logger.exception(
+                        "[SyncPublicEnumSnapshots] failed to update model=%s, error_type=%s, error=%s",
+                        model_id,
+                        type(e).__name__,
+                        e,
+                    )
+                    failed_items.append(
+                        {
+                            "model_id": model_id,
+                            "error_type": type(e).__name__,
+                            "error": str(e),
+                        }
+                    )
 
     logger.info(
         f"[SyncPublicEnumSnapshots] completed library_id={library_id}, "

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -31,12 +31,28 @@ _COLLECT_TERMINAL_STATUSES = (
     CollectRunStatusType.PARTIAL_SUCCESS,
 )
 
-PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES = max(
-    0, int(os.getenv("CMDB_PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES", "3"))
+
+def _read_bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int:
+    raw_value = os.getenv(name)
+    try:
+        value = default if raw_value is None else int(raw_value)
+    except (TypeError, ValueError):
+        logger.warning("%s must be an integer; using default=%s", name, default)
+        return default
+
+    bounded_value = min(max(value, minimum), maximum)
+    if bounded_value != value:
+        logger.warning("%s is outside [%s, %s]; using %s", name, minimum, maximum, bounded_value)
+    return bounded_value
+
+
+PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES = _read_bounded_int_env(
+    "CMDB_PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES", 3, 0, 10
 )
-PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS = max(
-    1, int(os.getenv("CMDB_PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS", "10"))
+PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS = _read_bounded_int_env(
+    "CMDB_PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS", 10, 1, 3600
 )
+PUBLIC_ENUM_SNAPSHOT_RETRY_MAX_SECONDS = 3600
 
 
 def _is_unhelpful_error_message(message: str) -> bool:
@@ -628,20 +644,27 @@ def sync_public_enum_library_snapshots_task(
         return result
 
     retry_number = int(self.request.retries)
+    failure_summary = "; ".join(
+        f"model_id={item.get('model_id')}, error_type={item.get('error_type', 'UnknownError')}, error={item.get('error', '')}"
+        for item in result.get("failed_items", [])
+    )
     error = RuntimeError(
-        f"公共枚举快照同步存在失败项: library_id={library_id}, failed_count={failed_count}"
+        f"公共枚举快照同步存在失败项: library_id={library_id}, failed_count={failed_count}, failures=[{failure_summary}]"
     )
     if retry_number >= self.max_retries:
         logger.error(
-            "[SyncPublicEnumSnapshots] retries exhausted library_id=%s, "
-            "failed_count=%s, attempts=%s",
+            "[SyncPublicEnumSnapshots] retries exhausted library_id=%s, failed_count=%s, attempts=%s, failures=%s",
             library_id,
             failed_count,
             retry_number + 1,
+            failure_summary,
         )
         raise error
 
-    countdown = PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS * (2**retry_number)
+    countdown = min(
+        PUBLIC_ENUM_SNAPSHOT_RETRY_MAX_SECONDS,
+        PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS * (2**retry_number),
+    )
     logger.warning(
         "[SyncPublicEnumSnapshots] retry partial failure library_id=%s, "
         "failed_count=%s, attempt=%s, countdown=%s",

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -31,6 +31,13 @@ _COLLECT_TERMINAL_STATUSES = (
     CollectRunStatusType.PARTIAL_SUCCESS,
 )
 
+PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES = max(
+    0, int(os.getenv("CMDB_PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES", "3"))
+)
+PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS = max(
+    1, int(os.getenv("CMDB_PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS", "10"))
+)
+
 
 def _is_unhelpful_error_message(message: str) -> bool:
     text = str(message or "").strip()
@@ -608,12 +615,42 @@ def execute_collect_tool_debug_task(debug_id: str, payload: dict, service_name: 
         return result
 
 
-@shared_task
-def sync_public_enum_library_snapshots_task(library_id: str, trigger: str, operator: str | None = None) -> dict:
+@shared_task(bind=True, max_retries=PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES)
+def sync_public_enum_library_snapshots_task(
+    self, library_id: str, trigger: str, operator: str | None = None
+) -> dict:
     from apps.cmdb.services.public_enum_library import sync_library_snapshots
 
     logger.info(f"[SyncPublicEnumSnapshots] task started library_id={library_id}, trigger={trigger}, operator={operator}")
-    return sync_library_snapshots(library_id, trigger, operator)
+    result = sync_library_snapshots(library_id, trigger, operator)
+    failed_count = int(result.get("failed_count") or 0)
+    if not failed_count:
+        return result
+
+    retry_number = int(self.request.retries)
+    error = RuntimeError(
+        f"公共枚举快照同步存在失败项: library_id={library_id}, failed_count={failed_count}"
+    )
+    if retry_number >= self.max_retries:
+        logger.error(
+            "[SyncPublicEnumSnapshots] retries exhausted library_id=%s, "
+            "failed_count=%s, attempts=%s",
+            library_id,
+            failed_count,
+            retry_number + 1,
+        )
+        raise error
+
+    countdown = PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS * (2**retry_number)
+    logger.warning(
+        "[SyncPublicEnumSnapshots] retry partial failure library_id=%s, "
+        "failed_count=%s, attempt=%s, countdown=%s",
+        library_id,
+        failed_count,
+        retry_number + 1,
+        countdown,
+    )
+    raise self.retry(exc=error, countdown=countdown)
 
 
 @shared_task

--- a/server/apps/cmdb/tests/test_public_enum_service.py
+++ b/server/apps/cmdb/tests/test_public_enum_service.py
@@ -243,3 +243,137 @@ def test_sync_library_snapshots_ok(patch_parse, fake_graph):
     assert result["result"] is True
     assert result["affected_attrs"] == 1
     assert any(c[0] == "set_entity_properties" for c in fg.calls)
+
+
+@pytest.mark.django_db
+def test_sync_library_snapshots_reports_partial_graph_failure(patch_parse, fake_graph):
+    _make(options=[{"id": "2", "name": "停止"}])
+    models = [
+        {
+            "model_id": model_id,
+            "_id": model_db_id,
+            "attrs": json.dumps(
+                [
+                    {
+                        "attr_id": "status",
+                        "attr_type": "enum",
+                        "enum_rule_type": "public_library",
+                        "public_library_id": "lib_1",
+                        "option": [],
+                    }
+                ]
+            ),
+        }
+        for model_id, model_db_id in (("host", 1), ("service", 2))
+    ]
+
+    def _set_entity_properties(_label, ids, *_args):
+        if ids == [2]:
+            raise RuntimeError("graph unavailable")
+        return {}
+
+    fake_graph(
+        MODULE,
+        query_entity=(models, 2),
+        set_entity_properties=_set_entity_properties,
+    )
+
+    result = svc.sync_library_snapshots("lib_1", "update", "admin")
+
+    assert result["result"] is False
+    assert result["affected_models"] == 1
+    assert result["failed_count"] == 1
+    assert result["failed_items"] == [
+        {"model_id": "service", "error": "graph unavailable"}
+    ]
+
+
+def test_snapshot_task_retries_partial_graph_failure(mocker):
+    from celery.canvas import Signature
+    from celery.exceptions import Retry
+
+    from apps.cmdb.tasks import celery_tasks
+
+    mocker.patch(
+        f"{MODULE}.sync_library_snapshots",
+        return_value={
+            "result": False,
+            "library_id": "lib_1",
+            "failed_count": 1,
+            "failed_items": [{"model_id": "service", "error": "graph unavailable"}],
+        },
+    )
+    apply_async = mocker.patch.object(Signature, "apply_async", autospec=True)
+    task = celery_tasks.sync_public_enum_library_snapshots_task
+    task.push_request(
+        args=("lib_1", "update", "admin"),
+        kwargs={},
+        id="public-enum-snapshot-retry-1",
+        retries=0,
+        called_directly=False,
+        is_eager=False,
+    )
+    try:
+        with pytest.raises(Retry) as retry_error:
+            task.run("lib_1", "update", "admin")
+    finally:
+        task.pop_request()
+
+    scheduled_signature = apply_async.call_args.args[0]
+    expected_countdown = celery_tasks.PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS
+    assert retry_error.value.when == expected_countdown
+    assert scheduled_signature.options["countdown"] == expected_countdown
+    assert scheduled_signature.options["retries"] == 1
+    assert task.max_retries == celery_tasks.PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES
+
+
+def test_snapshot_task_raises_after_partial_failure_retries_exhausted(mocker):
+    from apps.cmdb.tasks import celery_tasks
+
+    mocker.patch(
+        f"{MODULE}.sync_library_snapshots",
+        return_value={
+            "result": False,
+            "library_id": "lib_1",
+            "failed_count": 1,
+            "failed_items": [{"model_id": "service", "error": "graph unavailable"}],
+        },
+    )
+    task = celery_tasks.sync_public_enum_library_snapshots_task
+    task.push_request(
+        args=("lib_1", "update", "admin"),
+        kwargs={},
+        id="public-enum-snapshot-retry-exhausted",
+        retries=task.max_retries,
+        called_directly=False,
+        is_eager=False,
+    )
+    try:
+        with pytest.raises(RuntimeError, match=r"failed_count=1"):
+            task.run("lib_1", "update", "admin")
+    finally:
+        task.pop_request()
+
+
+def test_snapshot_task_preserves_success_result(mocker):
+    from apps.cmdb.tasks import celery_tasks
+
+    expected = {
+        "result": True,
+        "library_id": "lib_1",
+        "affected_models": 2,
+        "affected_attrs": 2,
+        "failed_count": 0,
+        "failed_items": [],
+    }
+    mocker.patch(f"{MODULE}.sync_library_snapshots", return_value=expected)
+    retry = mocker.patch.object(
+        celery_tasks.sync_public_enum_library_snapshots_task, "retry"
+    )
+
+    result = celery_tasks.sync_public_enum_library_snapshots_task.run(
+        "lib_1", "update", "admin"
+    )
+
+    assert result == expected
+    retry.assert_not_called()

--- a/server/apps/cmdb/tests/test_public_enum_service.py
+++ b/server/apps/cmdb/tests/test_public_enum_service.py
@@ -3,6 +3,7 @@
 对照 specs/capabilities/legacy-prd-cmdb-模型管理.md：公共选项库 CRUD、选项校验、引用扫描、快照同步。
 """
 
+import importlib
 import json
 
 import pytest
@@ -246,7 +247,7 @@ def test_sync_library_snapshots_ok(patch_parse, fake_graph):
 
 
 @pytest.mark.django_db
-def test_sync_library_snapshots_reports_partial_graph_failure(patch_parse, fake_graph):
+def test_sync_library_snapshots_reports_partial_graph_failure(patch_parse, fake_graph, mocker):
     _make(options=[{"id": "2", "name": "停止"}])
     models = [
         {
@@ -272,6 +273,7 @@ def test_sync_library_snapshots_reports_partial_graph_failure(patch_parse, fake_
             raise RuntimeError("graph unavailable")
         return {}
 
+    log_exception = mocker.patch.object(svc.logger, "exception")
     fake_graph(
         MODULE,
         query_entity=(models, 2),
@@ -284,8 +286,85 @@ def test_sync_library_snapshots_reports_partial_graph_failure(patch_parse, fake_
     assert result["affected_models"] == 1
     assert result["failed_count"] == 1
     assert result["failed_items"] == [
-        {"model_id": "service", "error": "graph unavailable"}
+        {
+            "model_id": "service",
+            "error_type": "RuntimeError",
+            "error": "graph unavailable",
+        }
     ]
+    log_exception.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_sync_library_snapshots_repeated_run_is_idempotent_and_converges(patch_parse, fake_graph):
+    options = [{"id": "2", "name": "停止"}]
+    _make(options=options)
+    models = [
+        {
+            "model_id": model_id,
+            "_id": model_db_id,
+            "attrs": json.dumps(
+                [
+                    {
+                        "attr_id": "status",
+                        "attr_type": "enum",
+                        "enum_rule_type": "public_library",
+                        "public_library_id": "lib_1",
+                        "option": [],
+                    }
+                ]
+            ),
+        }
+        for model_id, model_db_id in (("host", 1), ("service", 2))
+    ]
+    writes = {}
+    service_attempts = 0
+
+    def _set_entity_properties(_label, ids, properties, *_args):
+        nonlocal service_attempts
+        model_db_id = ids[0]
+        if model_db_id == 2:
+            service_attempts += 1
+            if service_attempts == 1:
+                raise RuntimeError("transient graph error")
+        writes.setdefault(model_db_id, []).append(properties["attrs"])
+        return {}
+
+    fake_graph(MODULE, query_entity=(models, 2), set_entity_properties=_set_entity_properties)
+
+    first_result = svc.sync_library_snapshots("lib_1", "update", "admin")
+    second_result = svc.sync_library_snapshots("lib_1", "update", "admin")
+
+    assert first_result["result"] is False
+    assert second_result["result"] is True
+    assert len(writes[1]) == 2
+    assert writes[1][0] == writes[1][1]
+    assert all(
+        json.loads(model_writes[-1])[0]["option"] == options
+        for model_writes in writes.values()
+    )
+
+
+def test_snapshot_retry_settings_invalid_values_do_not_break_task_import(monkeypatch):
+    from apps.cmdb.tasks import celery_tasks
+
+    with monkeypatch.context() as env:
+        env.setenv("CMDB_PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES", "invalid")
+        env.setenv("CMDB_PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS", "invalid")
+        reloaded_tasks = importlib.reload(celery_tasks)
+        assert reloaded_tasks.PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES == 3
+        assert reloaded_tasks.PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS == 10
+
+    importlib.reload(celery_tasks)
+
+
+def test_snapshot_retry_settings_are_bounded(monkeypatch):
+    from apps.cmdb.tasks import celery_tasks
+
+    monkeypatch.setenv("SNAPSHOT_RETRY_TEST", "999999")
+    assert celery_tasks._read_bounded_int_env("SNAPSHOT_RETRY_TEST", 3, 0, 10) == 10
+    monkeypatch.setenv("SNAPSHOT_RETRY_TEST", "-1")
+    assert celery_tasks._read_bounded_int_env("SNAPSHOT_RETRY_TEST", 10, 1, 3600) == 1
 
 
 def test_snapshot_task_retries_partial_graph_failure(mocker):
@@ -300,7 +379,13 @@ def test_snapshot_task_retries_partial_graph_failure(mocker):
             "result": False,
             "library_id": "lib_1",
             "failed_count": 1,
-            "failed_items": [{"model_id": "service", "error": "graph unavailable"}],
+            "failed_items": [
+                {
+                    "model_id": "service",
+                    "error_type": "RuntimeError",
+                    "error": "graph unavailable",
+                }
+            ],
         },
     )
     apply_async = mocker.patch.object(Signature, "apply_async", autospec=True)
@@ -336,7 +421,13 @@ def test_snapshot_task_raises_after_partial_failure_retries_exhausted(mocker):
             "result": False,
             "library_id": "lib_1",
             "failed_count": 1,
-            "failed_items": [{"model_id": "service", "error": "graph unavailable"}],
+            "failed_items": [
+                {
+                    "model_id": "service",
+                    "error_type": "RuntimeError",
+                    "error": "graph unavailable",
+                }
+            ],
         },
     )
     task = celery_tasks.sync_public_enum_library_snapshots_task
@@ -349,7 +440,7 @@ def test_snapshot_task_raises_after_partial_failure_retries_exhausted(mocker):
         is_eager=False,
     )
     try:
-        with pytest.raises(RuntimeError, match=r"failed_count=1"):
+        with pytest.raises(RuntimeError, match=r"RuntimeError.*graph unavailable"):
             task.run("lib_1", "update", "admin")
     finally:
         task.pop_request()


### PR DESCRIPTION
## 问题

公共枚举库更新 options 后，会异步把新选项写入各引用模型的 attrs 快照。这条链路本应保证：只要有一个模型写入失败，任务就不能继续报告全部成功。

此前批处理虽然收集了单模型失败明细，却始终返回 `result=true`；Celery 包装器又直接返回该结果，导致中央选项已更新、部分模型仍保留旧快照，而任务状态显示成功。

## 根因

服务层把“批量处理完成”与“全部写入成功”混成了同一个成功状态，任务层也没有把 `failed_count` 转换为可观测、可恢复的失败控制流。因此单项异常只能进入日志和返回明细，无法驱动重试或最终失败。

## 怎么修的

- 服务层仅在没有失败项时返回成功，仍完整保留 `failed_count` 和 `failed_items`。
- Celery 任务只对部分图写失败执行有限指数退避重试；默认最多重试 3 次，基准间隔 10 秒。
- 重试耗尽后抛出明确异常，让任务进入失败状态，不再静默成功。
- 重试参数可通过 `CMDB_PUBLIC_ENUM_SNAPSHOT_MAX_RETRIES` 和 `CMDB_PUBLIC_ENUM_SNAPSHOT_RETRY_BASE_SECONDS` 调整。

## 影响范围与兼容性

- 仅触及 CMDB 公共枚举快照同步服务和对应 Celery 任务。
- 更新接口、模型导入入口、成功结果、数据库结构和快照内容均不变。
- 未改动 Web、Agent、NATS、权限或公共 API；现有调用方仍使用同一任务参数。
- 变化只发生在原本已部分失败的任务：由“错误成功”改为有限重试，耗尽后明确失败。
- 重试会重新读取最新公共库和模型 attrs，再覆盖相同的选项快照，重复执行保持幂等。
- 无数据迁移；如需回滚，直接还原本提交即可恢复原任务行为。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["update_library / 模型导入\npublic_enum_library.py"]
        T2["enqueue_library_snapshot_refresh\npublic_enum_library.py"]
    end

    subgraph N["核心处理层"]
        N1["sync_public_enum_library_snapshots_task\ncelery_tasks.py"]
        N2["sync_library_snapshots\npublic_enum_library.py"]
        N3["GraphClient.set_entity_properties\n图数据库覆盖写"]
    end

    subgraph C["失败控制层"]
        C1["failed_count > 0\n有限指数退避重试"]
        C2["重试耗尽\n任务明确失败"]
    end

    T1 --> T2 --> N1 --> N2 --> N3
    N3 -. "单模型失败" .-> C1
    C1 --> N1
    C1 -. "达到上限" .-> C2
```

## 验证

- `apps/cmdb/tests/test_public_enum_service.py`：27 passed。
- 新回归在旧实现上以 `result` 仍为 true 失败，确认覆盖了本次缺陷。
- 覆盖部分成功/部分失败、首次重试调度、重试耗尽、成功结果兼容四类行为。

关联 Issue #4111。
