### PR TITLE
bugfix: 修复日志异常段跨窗口查询

### DIFF
--- a/server/apps/log/nats/log.py
+++ b/server/apps/log/nats/log.py
@@ -2,6 +2,8 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import nats_client
+from django.db.models import Q
+
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.current_team_scope import _normalize_organization_ids
 from apps.core.utils.permission_utils import check_instance_permission, get_permission_rules, get_permissions_rules, permission_filter
@@ -385,7 +387,10 @@ def query_log_alert_segments(query_data: dict, *args, **kwargs):
         }
 
     queryset = Alert.objects.filter(collect_type_id=collect_type_id, policy_id__in=policy_ids)
-    queryset = queryset.filter(start_event_time__lte=end_dt, created_at__gte=start_dt)
+    queryset = queryset.filter(
+        Q(end_event_time__isnull=True) | Q(end_event_time__gte=start_dt),
+        start_event_time__lte=end_dt,
+    )
 
     if source_ids:
         queryset = queryset.filter(source_id__in=source_ids)

--- a/server/apps/log/tests/test_nats_log_pure.py
+++ b/server/apps/log/tests/test_nats_log_pure.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pydantic.root_model  # noqa
 import pytest
+from django.db.models import Q
 
 from apps.log.nats import log as nats_log
 
@@ -501,3 +502,30 @@ def test_query_log_alert_segments_propagates_policy_error(mocker):
         }
     )
     assert out == err
+
+
+def test_query_log_alert_segments_filters_by_overlapping_event_time(mocker):
+    mocker.patch.object(nats_log, "_get_log_policy_ids", return_value=(["policy-1"], None))
+    queryset = mocker.MagicMock()
+    filtered_queryset = queryset.filter.return_value
+    mocker.patch.object(nats_log.Alert.objects, "filter", return_value=queryset)
+    mocker.patch.object(
+        nats_log,
+        "_build_paginated_alert_segments",
+        return_value={"count": 0, "page": 1, "page_size": 100, "items": []},
+    )
+
+    out = nats_log.query_log_alert_segments(
+        {
+            "collect_type_id": "ct",
+            "start": "2024-01-01 01:00:00",
+            "end": "2024-01-01 02:00:00",
+        }
+    )
+
+    assert out["result"] is True
+    queryset.filter.assert_called_once_with(
+        Q(end_event_time__isnull=True) | Q(end_event_time__gte=datetime(2024, 1, 1, 1, 0, 0)),
+        start_event_time__lte=datetime(2024, 1, 1, 2, 0, 0),
+    )
+    nats_log._build_paginated_alert_segments.assert_called_once_with(filtered_queryset, 1, 100)


### PR DESCRIPTION
## 问题

日志异常段查询应返回与指定时间窗口相交的业务异常段。此前查询用记录创建时间作为下界，导致异常在窗口前创建、但在窗口内仍持续时被静默遗漏。

## 根因

查询边界混用了持久化记录时间与异常业务时间：上界按 `start_event_time` 判断，下界却按 `created_at` 判断，两个条件不能共同表达区间重叠。

## 怎么修的

- 保留“异常开始时间不晚于窗口结束时间”的上界。
- 下界改为“异常尚未结束，或结束时间不早于窗口开始时间”。
- 边界相等继续视为重叠；权限、分页、排序与可选筛选保持不变。

## 影响范围

改动仅涉及日志异常段 NATS handler 的 ORM 过滤及对应回归测试，不修改 RPC 入参、响应结构、权限模型、数据库结构或存量数据。调用方无需迁移，回滚可直接还原本提交。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["LogOperationAnaRpc.query_log_alert_segments\nserver/apps/rpc/log.py"]
    end

    subgraph N["日志处理层"]
        N1["query_log_alert_segments\nserver/apps/log/nats/log.py"]
        N2["Alert ORM 区间重叠过滤\nstart <= window_end"]
        N3["分页与异常段序列化\n_build_paginated_alert_segments"]
    end

    T1 --> N1 --> N2 --> N3
```

## 验证

- `apps/log/tests/test_nats_log_pure.py`：RED 为 1 failed / 43 passed，恢复实现会准确触发新增回归失败。
- `apps/log/tests/test_nats_log_pure.py`：GREEN 为 44 passed。
- G6 质量复核：96/100，无 Critical 或 Important 问题。

关联 Issue #4088。
