### PR TITLE
bugfix: 修复日志策略补扫窗口断档

### DIFF
--- a/server/apps/core/fields/s3_json_field.py
+++ b/server/apps/core/fields/s3_json_field.py
@@ -15,7 +15,7 @@ import uuid
 from typing import Any, Optional
 
 from django.core.files.base import ContentFile
-from django.db import connections, models, transaction
+from django.db import models, transaction
 from django.db.models.signals import post_save
 from django_minio_backend import MinioBackend
 
@@ -182,20 +182,13 @@ class S3JSONField(models.CharField):
         if not self.delete_previous_on_update or not getattr(instance, "pk", None):
             return ""
 
-        meta = instance._meta
         db_alias = self._get_db_alias(instance)
-        connection = connections[db_alias]
-        quote_name = connection.ops.quote_name
-        query = f"SELECT {quote_name(self.column)} FROM {quote_name(meta.db_table)} WHERE {quote_name(meta.pk.column)} = %s"
-
-        with connection.cursor() as cursor:
-            cursor.execute(query, [instance.pk])
-            row = cursor.fetchone()
-
-        if not row:
-            return ""
-
-        value = row[0]
+        value = (
+            instance.__class__._base_manager.using(db_alias)
+            .filter(pk=instance.pk)
+            .values_list(self.attname, flat=True)
+            .first()
+        )
         return value if isinstance(value, str) else ""
 
     def _register_cleanup_task(self, instance, previous_path, current_path):

--- a/server/apps/core/tests/test_s3_json_field_service.py
+++ b/server/apps/core/tests/test_s3_json_field_service.py
@@ -218,6 +218,20 @@ class TestPreSave:
         with pytest.raises(RuntimeError):
             field.pre_save(inst, add=True)
 
+    def test_previous_path_is_loaded_through_model_manager(self, mocker):
+        field = S3JSONField(bucket_name="b1", delete_previous_on_update=True)
+        field.set_attributes_from_name("data")
+        manager = mocker.MagicMock()
+        manager.using.return_value.filter.return_value.values_list.return_value.first.return_value = "old/path.json.gz"
+        mocker.patch.object(_Instance, "_base_manager", manager, create=True)
+        inst = _Instance(pk=42)
+        inst._state.db = "replica"
+
+        assert field._get_raw_db_value(inst) == "old/path.json.gz"
+        manager.using.assert_called_once_with("replica")
+        manager.using.return_value.filter.assert_called_once_with(pk=42)
+        manager.using.return_value.filter.return_value.values_list.assert_called_once_with("data", flat=True)
+
 
 class TestDescriptor:
     def test_get_on_class_returns_descriptor(self):

--- a/server/apps/log/migrations/0018_alter_eventrawdata_data.py
+++ b/server/apps/log/migrations/0018_alter_eventrawdata_data.py
@@ -1,0 +1,24 @@
+import apps.core.fields.s3_json_field
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("log", "0017_systemvectorconfigstate_systemvectortoken_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="eventrawdata",
+            name="data",
+            field=apps.core.fields.s3_json_field.S3JSONField(
+                bucket_name="log-alert-raw-data",
+                compressed=True,
+                delete_previous_on_update=True,
+                help_text="自动压缩并存储到 MinIO/S3",
+                max_length=500,
+                upload_to=apps.core.fields.s3_json_field.s3_json_upload_path,
+                verbose_name="原始数据",
+            ),
+        ),
+    ]

--- a/server/apps/log/models/policy.py
+++ b/server/apps/log/models/policy.py
@@ -115,6 +115,7 @@ class EventRawData(models.Model):
     data = S3JSONField(
         bucket_name="log-alert-raw-data",
         compressed=True,
+        delete_previous_on_update=True,
         verbose_name="原始数据",
         help_text="自动压缩并存储到 MinIO/S3",
     )

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -61,7 +61,7 @@ def scan_log_policy_task(policy_id):
 
             backfill_count = int(gap_seconds // period_seconds)
 
-            if backfill_count <= 1:
+            if backfill_count == 0:
                 window_end_time = safe_time
                 window_start = int(window_end_time.timestamp()) - period_seconds
                 if overlap_seconds > 0:

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -20,25 +20,37 @@ def _execution_key(policy_id, cursor_time):
 
 
 def _advance_policy_cursor(policy_id, cursor_time, scan_time):
-    """用 CAS 单调推进游标；并发执行不能覆盖其他窗口的结果。"""
+    """用 CAS 单调推进游标，并将异常并发完成的窗口汇合到最晚时间。"""
     updated = Policy.objects.filter(id=policy_id, last_run_time=cursor_time).update(last_run_time=scan_time)
     if updated:
         return
+
+    # 正常生产入口由 celery-singleton 按 policy_id 排他。若锁被绕过，同一游标的
+    # 多个已完成窗口仍可能在副作用落库后竞争 CAS；接受这些窗口的并集并原子汇合到
+    # 最大 scan_time，避免“任务报错但副作用已发生”后用新 execution_key 重扫。
+    Policy.objects.filter(
+        id=policy_id,
+        last_run_time__lt=scan_time,
+    ).update(last_run_time=scan_time)
     current_cursor = Policy.objects.values_list("last_run_time", flat=True).get(id=policy_id)
-    if current_cursor != scan_time:
-        raise RuntimeError(f"日志策略 [{policy_id}] 扫描游标已被并发修改")
+    if current_cursor is None or current_cursor < scan_time:
+        raise RuntimeError(f"日志策略 [{policy_id}] 扫描游标无法单调推进")
 
 
-def _initialize_policy_cursor(policy_obj, safe_time, period_seconds):
-    """为首次扫描持久化一个有界左边界，失败重试不得移动该边界。"""
-    earliest = safe_time - timedelta(seconds=period_seconds)
-    created_at = min(policy_obj.created_at, safe_time)
-    initial_cursor = max(created_at, earliest)
-    updated = Policy.objects.filter(id=policy_obj.id, last_run_time__isnull=True).update(last_run_time=initial_cursor)
-    if not updated:
-        initial_cursor = Policy.objects.values_list("last_run_time", flat=True).get(id=policy_obj.id)
-    policy_obj.last_run_time = initial_cursor
-    return initial_cursor
+def _run_policy_window(policy_obj, cursor_time, scan_time, period_seconds, overlap_seconds):
+    """执行一个完整检测周期，并在成功后单调推进游标。"""
+    window_end = int(scan_time.timestamp())
+    window_start = max(window_end - period_seconds - overlap_seconds, 0)
+    LogPolicyScan(
+        policy_obj,
+        scan_time=scan_time,
+        window_start=window_start,
+        window_end=window_end,
+        execution_key=_execution_key(policy_obj.id, cursor_time),
+        cursor_time=cursor_time,
+    ).run()
+    _advance_policy_cursor(policy_obj.id, cursor_time, scan_time)
+    policy_obj.last_run_time = scan_time
 
 
 @shared_task(base=Singleton, raise_on_duplicate=False)
@@ -79,43 +91,60 @@ def scan_log_policy_task(policy_id):
         overlap_seconds = AlertConstants.WINDOW_OVERLAP_SECONDS
 
         if policy_obj.last_run_time is None:
-            _initialize_policy_cursor(policy_obj, safe_time, period_seconds)
-
-        gap_seconds = max((safe_time - policy_obj.last_run_time).total_seconds(), 0)
-        gap_seconds = min(gap_seconds, AlertConstants.MAX_BACKFILL_SECONDS)
-        backfill_count = int(gap_seconds // period_seconds)
-        if backfill_count == 0:
-            cursor_time = policy_obj.last_run_time
-            scan_time = safe_time
-            window_end = int(scan_time.timestamp())
-            window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
-            LogPolicyScan(
+            # 首次执行仍保持一个完整 period 的滚动窗口。游标只在成功后写入；
+            # 失败重试继续使用 initial 执行身份，可兼容复用升级前已落库的随机 UUID Event。
+            _run_policy_window(
                 policy_obj,
-                scan_time=scan_time,
-                window_start=window_start,
-                window_end=window_end,
-                execution_key=_execution_key(policy_id, cursor_time),
-                cursor_time=cursor_time,
-            ).run()
-            _advance_policy_cursor(policy_id, cursor_time, scan_time)
-        else:
-            backfill_count = min(backfill_count, AlertConstants.MAX_BACKFILL_COUNT)
-            logger.info(f"日志策略 [{policy_id}] 需要补偿 {backfill_count} 个周期")
+                cursor_time=None,
+                scan_time=safe_time,
+                period_seconds=period_seconds,
+                overlap_seconds=overlap_seconds,
+            )
+            duration = time.time() - start_time
+            logger.info(f"日志策略 [{policy_id}] 首次扫描完成，耗时: {duration:.2f}s")
+            return {"success": True, "duration": duration, "message": "执行成功"}
+
+        max_progress_seconds = min(
+            AlertConstants.MAX_BACKFILL_SECONDS,
+            AlertConstants.MAX_BACKFILL_COUNT * period_seconds,
+        )
+        effective_safe_time = min(
+            safe_time,
+            policy_obj.last_run_time + timedelta(seconds=max_progress_seconds),
+        )
+        gap_seconds = max((effective_safe_time - policy_obj.last_run_time).total_seconds(), 0)
+        backfill_count = int(gap_seconds // period_seconds)
+
+        if backfill_count:
+            logger.info(f"日志策略 [{policy_id}] 需要补偿 {backfill_count} 个完整周期")
             for index in range(backfill_count):
                 cursor_time = policy_obj.last_run_time
                 scan_time = cursor_time + timedelta(seconds=period_seconds)
-                window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
-                logger.info(f"开始执行日志策略 [{policy_id}] 的第 {index + 1}/{backfill_count} 次补偿扫描，" f"扫描时间点: {scan_time}")
-                LogPolicyScan(
+                logger.info(
+                    f"开始执行日志策略 [{policy_id}] 的第 {index + 1}/{backfill_count} 次补偿扫描，"
+                    f"扫描时间点: {scan_time}"
+                )
+                _run_policy_window(
                     policy_obj,
-                    scan_time=scan_time,
-                    window_start=window_start,
-                    window_end=int(scan_time.timestamp()),
-                    execution_key=_execution_key(policy_id, cursor_time),
                     cursor_time=cursor_time,
-                ).run()
-                policy_obj.last_run_time = scan_time
-                _advance_policy_cursor(policy_id, cursor_time, scan_time)
+                    scan_time=scan_time,
+                    period_seconds=period_seconds,
+                    overlap_seconds=overlap_seconds,
+                )
+
+        # 补偿完整周期后若已追到 safe_time 前不足一个周期，立即执行尾部滚动窗口。
+        # 查询宽度始终是 period（外加 overlap），避免 schedule < period 时缩短聚合语义。
+        remaining_gap = max((effective_safe_time - policy_obj.last_run_time).total_seconds(), 0)
+        if 0 < remaining_gap < period_seconds:
+            cursor_time = policy_obj.last_run_time
+            scan_time = effective_safe_time
+            _run_policy_window(
+                policy_obj,
+                cursor_time=cursor_time,
+                scan_time=scan_time,
+                period_seconds=period_seconds,
+                overlap_seconds=overlap_seconds,
+            )
 
         duration = time.time() - start_time
         logger.info(f"日志策略 [{policy_id}] 扫描完成，耗时: {duration:.2f}s")
@@ -137,13 +166,14 @@ def compensate_log_notice_task():
 
     产生事件复用 Event 的发送状态与重试次数；关闭事件复用 Alert 的状态、关闭时间与
     notice。
-    两类对象均限制在补偿窗口、最小落库年龄与批量上限内，通知语义为 at-least-once。
+    两类对象均限制在补偿窗口、最小落库年龄与批量上限内，通知语义为有界 best-effort；
+    发送成功但事务提交前退出时仍可能重放。
     """
     start_time = time.time()
     now = datetime.now(timezone.utc)
     window_start = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_WINDOW_SECONDS)
     # 仅补偿落库已超 MIN_AGE 的事件：等待本轮扫描的同步 notice() 完成，降低与首发并发双投的概率
-    # （门槛取值须大于 notice() 最坏耗时量级，见 AlertConstants 说明；通知语义为 at-least-once）
+    # （门槛取值须大于 notice() 最坏耗时量级，见 AlertConstants 说明）
     settle_before = now - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS)
 
     # closed 没有独立重试字段，仅扫描明确指向告警中心的策略。

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -1,16 +1,33 @@
+import time
+from datetime import datetime, timedelta, timezone
+
 from celery import shared_task
 from celery_singleton import Singleton
-from datetime import datetime, timedelta, timezone
-import time
+
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import celery_logger as logger
 from apps.log.constants.alert_policy import AlertConstants
 from apps.log.constants.database import DatabaseConstants
 from apps.log.models.policy import Alert, Event, Policy
-from apps.core.logger import celery_logger as logger
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
 from apps.log.tasks.services.policy_scan import LogPolicyScan
 from apps.log.tasks.utils.policy import period_to_seconds
 from apps.system_mgmt.models.channel import Channel, ChannelChoices
+
+
+def _execution_key(policy_id, cursor_time):
+    """同一成功游标后的所有重试共享执行身份。"""
+    return f"{policy_id}:{cursor_time.isoformat() if cursor_time else 'initial'}"
+
+
+def _advance_policy_cursor(policy_id, cursor_time, scan_time):
+    """用 CAS 单调推进游标；并发执行不能覆盖其他窗口的结果。"""
+    updated = Policy.objects.filter(id=policy_id, last_run_time=cursor_time).update(last_run_time=scan_time)
+    if updated:
+        return
+    current_cursor = Policy.objects.values_list("last_run_time", flat=True).get(id=policy_id)
+    if current_cursor != scan_time:
+        raise RuntimeError(f"日志策略 [{policy_id}] 扫描游标已被并发修改")
 
 
 @shared_task(base=Singleton, raise_on_duplicate=False)
@@ -50,52 +67,55 @@ def scan_log_policy_task(policy_id):
         safe_time = current_time - timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS)
         overlap_seconds = AlertConstants.WINDOW_OVERLAP_SECONDS
 
-        if not policy_obj.last_run_time:
-            policy_obj.last_run_time = safe_time
-            logger.info(f"日志策略 [{policy_id}] 首次执行，设置 last_run_time: {safe_time}")
-            LogPolicyScan(policy_obj, scan_time=safe_time).run()
-            Policy.objects.filter(id=policy_id).update(last_run_time=safe_time)
+        if policy_obj.last_run_time is None:
+            scan_time = safe_time
+            window_end = int(scan_time.timestamp())
+            window_start = max(int(policy_obj.created_at.timestamp()) - period_seconds, 0)
+            LogPolicyScan(
+                policy_obj,
+                scan_time=scan_time,
+                window_start=window_start,
+                window_end=window_end,
+                execution_key=_execution_key(policy_id, None),
+                cursor_time=None,
+            ).run()
+            _advance_policy_cursor(policy_id, None, scan_time)
         else:
             gap_seconds = max((safe_time - policy_obj.last_run_time).total_seconds(), 0)
             gap_seconds = min(gap_seconds, AlertConstants.MAX_BACKFILL_SECONDS)
-
             backfill_count = int(gap_seconds // period_seconds)
-
             if backfill_count == 0:
-                window_end_time = safe_time
-                window_start = int(window_end_time.timestamp()) - period_seconds
-                if overlap_seconds > 0:
-                    window_start = max(window_start - overlap_seconds, 0)
-
-                policy_obj.last_run_time = window_end_time
-                logger.info(f"开始执行日志策略 [{policy_id}] 的扫描逻辑")
+                cursor_time = policy_obj.last_run_time
+                scan_time = safe_time
+                window_end = int(scan_time.timestamp())
+                window_start = max(int(cursor_time.timestamp()) - period_seconds - overlap_seconds, 0)
                 LogPolicyScan(
                     policy_obj,
-                    scan_time=window_end_time,
+                    scan_time=scan_time,
                     window_start=window_start,
-                    window_end=int(window_end_time.timestamp()),
+                    window_end=window_end,
+                    execution_key=_execution_key(policy_id, cursor_time),
+                    cursor_time=cursor_time,
                 ).run()
-                Policy.objects.filter(id=policy_id).update(last_run_time=window_end_time)
+                _advance_policy_cursor(policy_id, cursor_time, scan_time)
             else:
                 backfill_count = min(backfill_count, AlertConstants.MAX_BACKFILL_COUNT)
                 logger.info(f"日志策略 [{policy_id}] 需要补偿 {backfill_count} 个周期")
-
-                for i in range(backfill_count):
-                    previous_success_time = policy_obj.last_run_time
-                    next_scan_time = policy_obj.last_run_time + timedelta(seconds=period_seconds)
-                    window_start = int(previous_success_time.timestamp())
-                    if overlap_seconds > 0:
-                        window_start = max(window_start - overlap_seconds, 0)
-
-                    policy_obj.last_run_time = next_scan_time
-                    logger.info(f"开始执行日志策略 [{policy_id}] 的第 {i + 1}/{backfill_count} 次补偿扫描，扫描时间点: {next_scan_time}")
+                for index in range(backfill_count):
+                    cursor_time = policy_obj.last_run_time
+                    scan_time = cursor_time + timedelta(seconds=period_seconds)
+                    window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
+                    logger.info(f"开始执行日志策略 [{policy_id}] 的第 {index + 1}/{backfill_count} 次补偿扫描，" f"扫描时间点: {scan_time}")
                     LogPolicyScan(
                         policy_obj,
-                        scan_time=next_scan_time,
+                        scan_time=scan_time,
                         window_start=window_start,
-                        window_end=int(next_scan_time.timestamp()),
+                        window_end=int(scan_time.timestamp()),
+                        execution_key=_execution_key(policy_id, cursor_time),
+                        cursor_time=cursor_time,
                     ).run()
-                    Policy.objects.filter(id=policy_id).update(last_run_time=policy_obj.last_run_time)
+                    policy_obj.last_run_time = scan_time
+                    _advance_policy_cursor(policy_id, cursor_time, scan_time)
 
         duration = time.time() - start_time
         logger.info(f"日志策略 [{policy_id}] 扫描完成，耗时: {duration:.2f}s")

--- a/server/apps/log/tasks/policy.py
+++ b/server/apps/log/tasks/policy.py
@@ -7,7 +7,6 @@ from celery_singleton import Singleton
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import celery_logger as logger
 from apps.log.constants.alert_policy import AlertConstants
-from apps.log.constants.database import DatabaseConstants
 from apps.log.models.policy import Alert, Event, Policy
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
 from apps.log.tasks.services.policy_scan import LogPolicyScan
@@ -28,6 +27,18 @@ def _advance_policy_cursor(policy_id, cursor_time, scan_time):
     current_cursor = Policy.objects.values_list("last_run_time", flat=True).get(id=policy_id)
     if current_cursor != scan_time:
         raise RuntimeError(f"日志策略 [{policy_id}] 扫描游标已被并发修改")
+
+
+def _initialize_policy_cursor(policy_obj, safe_time, period_seconds):
+    """为首次扫描持久化一个有界左边界，失败重试不得移动该边界。"""
+    earliest = safe_time - timedelta(seconds=period_seconds)
+    created_at = min(policy_obj.created_at, safe_time)
+    initial_cursor = max(created_at, earliest)
+    updated = Policy.objects.filter(id=policy_obj.id, last_run_time__isnull=True).update(last_run_time=initial_cursor)
+    if not updated:
+        initial_cursor = Policy.objects.values_list("last_run_time", flat=True).get(id=policy_obj.id)
+    policy_obj.last_run_time = initial_cursor
+    return initial_cursor
 
 
 @shared_task(base=Singleton, raise_on_duplicate=False)
@@ -68,54 +79,43 @@ def scan_log_policy_task(policy_id):
         overlap_seconds = AlertConstants.WINDOW_OVERLAP_SECONDS
 
         if policy_obj.last_run_time is None:
+            _initialize_policy_cursor(policy_obj, safe_time, period_seconds)
+
+        gap_seconds = max((safe_time - policy_obj.last_run_time).total_seconds(), 0)
+        gap_seconds = min(gap_seconds, AlertConstants.MAX_BACKFILL_SECONDS)
+        backfill_count = int(gap_seconds // period_seconds)
+        if backfill_count == 0:
+            cursor_time = policy_obj.last_run_time
             scan_time = safe_time
             window_end = int(scan_time.timestamp())
-            window_start = max(int(policy_obj.created_at.timestamp()) - period_seconds, 0)
+            window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
             LogPolicyScan(
                 policy_obj,
                 scan_time=scan_time,
                 window_start=window_start,
                 window_end=window_end,
-                execution_key=_execution_key(policy_id, None),
-                cursor_time=None,
+                execution_key=_execution_key(policy_id, cursor_time),
+                cursor_time=cursor_time,
             ).run()
-            _advance_policy_cursor(policy_id, None, scan_time)
+            _advance_policy_cursor(policy_id, cursor_time, scan_time)
         else:
-            gap_seconds = max((safe_time - policy_obj.last_run_time).total_seconds(), 0)
-            gap_seconds = min(gap_seconds, AlertConstants.MAX_BACKFILL_SECONDS)
-            backfill_count = int(gap_seconds // period_seconds)
-            if backfill_count == 0:
+            backfill_count = min(backfill_count, AlertConstants.MAX_BACKFILL_COUNT)
+            logger.info(f"日志策略 [{policy_id}] 需要补偿 {backfill_count} 个周期")
+            for index in range(backfill_count):
                 cursor_time = policy_obj.last_run_time
-                scan_time = safe_time
-                window_end = int(scan_time.timestamp())
-                window_start = max(int(cursor_time.timestamp()) - period_seconds - overlap_seconds, 0)
+                scan_time = cursor_time + timedelta(seconds=period_seconds)
+                window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
+                logger.info(f"开始执行日志策略 [{policy_id}] 的第 {index + 1}/{backfill_count} 次补偿扫描，" f"扫描时间点: {scan_time}")
                 LogPolicyScan(
                     policy_obj,
                     scan_time=scan_time,
                     window_start=window_start,
-                    window_end=window_end,
+                    window_end=int(scan_time.timestamp()),
                     execution_key=_execution_key(policy_id, cursor_time),
                     cursor_time=cursor_time,
                 ).run()
+                policy_obj.last_run_time = scan_time
                 _advance_policy_cursor(policy_id, cursor_time, scan_time)
-            else:
-                backfill_count = min(backfill_count, AlertConstants.MAX_BACKFILL_COUNT)
-                logger.info(f"日志策略 [{policy_id}] 需要补偿 {backfill_count} 个周期")
-                for index in range(backfill_count):
-                    cursor_time = policy_obj.last_run_time
-                    scan_time = cursor_time + timedelta(seconds=period_seconds)
-                    window_start = max(int(cursor_time.timestamp()) - overlap_seconds, 0)
-                    logger.info(f"开始执行日志策略 [{policy_id}] 的第 {index + 1}/{backfill_count} 次补偿扫描，" f"扫描时间点: {scan_time}")
-                    LogPolicyScan(
-                        policy_obj,
-                        scan_time=scan_time,
-                        window_start=window_start,
-                        window_end=int(scan_time.timestamp()),
-                        execution_key=_execution_key(policy_id, cursor_time),
-                        cursor_time=cursor_time,
-                    ).run()
-                    policy_obj.last_run_time = scan_time
-                    _advance_policy_cursor(policy_id, cursor_time, scan_time)
 
         duration = time.time() - start_time
         logger.info(f"日志策略 [{policy_id}] 扫描完成，耗时: {duration:.2f}s")
@@ -187,7 +187,6 @@ def compensate_log_notice_task():
         return {"success": True, "scanned": 0, "compensated": 0, "duration": duration}
 
     scanners = {}  # 按策略复用 scanner，避免重复构造
-    updated_events = []
     success_alert_ids = set()
 
     for event in pending:
@@ -195,8 +194,7 @@ def compensate_log_notice_task():
         # 普通渠道没有通知人时直接结束；告警中心 NATS 不依赖 notice_users。
         is_alert_center = policy.notice_type_id in alert_center_channel_ids
         if not policy.notice_users and not is_alert_center:
-            event.notified = True
-            updated_events.append(event)
+            Event.objects.filter(id=event.id, notified=False).update(notified=True)
             continue
 
         scanner = scanners.get(policy.id)
@@ -204,21 +202,12 @@ def compensate_log_notice_task():
             scanner = LogPolicyScan(policy)
             scanners[policy.id] = scanner
 
-        # 单次发送：补偿任务的周期回扫本身即外层重试，避免在 worker 内叠加内联 sleep 阻塞
-        is_notice, notice_result = scanner.send_notice(event, max_attempts=1)
-        event.notice_result = notice_result
-        event.notified = is_notice
-        event.notice_retry_count = (event.notice_retry_count or 0) + 1
-        updated_events.append(event)
-        if is_notice:
+        # notice() 以 Event 行锁领取发送；补偿任务只做单次尝试，避免与同步首发或
+        # 另一补偿 worker 同时持有旧对象后双投。
+        scanner.notice([event], max_attempts=1)
+        event.refresh_from_db(fields=["notified"])
+        if event.notified:
             success_alert_ids.add(event.alert_id)
-
-    if updated_events:
-        Event.objects.bulk_update(
-            updated_events,
-            ["notice_result", "notified", "notice_retry_count"],
-            batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
-        )
 
     if success_alert_ids:
         # 状态条件防止 created 的迟到回执覆盖并发关闭留下的补偿标记。

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -15,40 +15,77 @@ try:
 except ValueError:
     _MAX_ALERT_SNAPSHOTS = 500
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import celery_logger as logger
 from apps.log.constants.alert_policy import AlertConstants
 from apps.log.constants.database import DatabaseConstants
 from apps.log.constants.web import WebConstants
-
-from apps.log.models.policy import Alert, Event, EventRawData, AlertSnapshot
+from apps.log.models.policy import Alert, AlertSnapshot, Event, EventRawData
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
 from apps.log.tasks.utils.policy import period_to_seconds
-from apps.log.utils.query_log import VictoriaMetricsAPI
 from apps.log.utils.log_group import LogGroupQueryBuilder
+from apps.log.utils.query_log import VictoriaMetricsAPI
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
-from apps.core.logger import celery_logger as logger
 
 
 class LogPolicyScan:
     _ALERT_NAME_TOKEN_RE = re.compile(r"\$\{([^}]+)\}")
 
-    def __init__(self, policy, scan_time=None, window_start=None, window_end=None):
+    def __init__(self, policy, scan_time=None, window_start=None, window_end=None, execution_key=None, cursor_time=None):
         self.policy = policy
         self.vlogs_api = VictoriaMetricsAPI()
         self.scan_time = scan_time or policy.last_run_time
         self.window_start = window_start
         self.window_end = window_end
+        self.execution_key = execution_key
+        self.cursor_time = cursor_time
 
     def _get_scan_window(self):
-        if self.window_start is not None and self.window_end is not None:
-            return self.window_start, self.window_end
+        window_start = getattr(self, "window_start", None)
+        window_end = getattr(self, "window_end", None)
+        if window_start is not None and window_end is not None:
+            return window_start, window_end
 
         end_timestamp = int(self.scan_time.timestamp())
         period_seconds = period_to_seconds(self.policy.period)
         start_timestamp = end_timestamp - period_seconds
         return start_timestamp, end_timestamp
+
+    def _build_event_id(self, source_id):
+        execution_key = getattr(self, "execution_key", None)
+        if execution_key is None:
+            start_timestamp, end_timestamp = self._get_scan_window()
+            execution_key = f"{start_timestamp}:{end_timestamp}"
+        identity = f"{self.policy.id}:{execution_key}:{source_id}"
+        return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+
+    def _find_existing_events(self, event_ids, source_ids):
+        existing_by_id = {event.id: event for event in Event.objects.filter(id__in=event_ids).select_related("alert")}
+        missing_source_ids = {source_id for event_id, source_id in zip(event_ids, source_ids) if event_id not in existing_by_id}
+        if not missing_source_ids:
+            return existing_by_id, {}
+
+        legacy_events = Event.objects.filter(
+            policy_id=self.policy.id,
+            source_id__in=missing_source_ids,
+        ).select_related("alert")
+        cursor_time = getattr(self, "cursor_time", None)
+        if cursor_time is None:
+            # 旧版本首次扫描失败时不会推进 last_run_time，重试时 safe_time 可能已变化；
+            # 此时此前写入的随机 UUID Event 仍属于这次未完成的首次执行。
+            legacy_events = legacy_events.filter(event_time__lte=self.scan_time)
+        else:
+            legacy_events = legacy_events.filter(
+                event_time__gt=cursor_time,
+                event_time__lte=self.scan_time,
+            )
+
+        legacy_by_source = {}
+        for event in legacy_events.order_by("event_time"):
+            legacy_by_source[event.source_id] = event
+        return existing_by_id, legacy_by_source
 
     def _get_keyword_sample_limit(self, alert_condition):
         """获取关键字告警样本条数限制"""
@@ -233,8 +270,14 @@ class LogPolicyScan:
             futures = {
                 executor.submit(
                     self._fetch_group_sample,
-                    idx, group_values, total_count,
-                    final_query, start_timestamp, end_timestamp, sample_limit, group_by,
+                    idx,
+                    group_values,
+                    total_count,
+                    final_query,
+                    start_timestamp,
+                    end_timestamp,
+                    sample_limit,
+                    group_by,
                 ): idx
                 for idx, group_values, total_count in pending
             }
@@ -494,6 +537,7 @@ class LogPolicyScan:
                     context[f"log.{field}"] = value
 
         try:
+
             def replace_token(match):
                 token = match.group(1)
                 value = context.get(token, "")
@@ -678,13 +722,42 @@ class LogPolicyScan:
             alerts_to_update = []
             alerts_to_create = []
             create_events = []
-            create_raw_data = []
+            existing_event_objs = []
+            events_to_update = []
             # 建立 event_id 到原始数据的映射，用于后续快照创建
             event_id_to_raw_data = {}
+            source_ids = [event["source_id"] for event in events]
+            event_ids = [self._build_event_id(source_id) for source_id in source_ids]
+            existing_events, legacy_events = self._find_existing_events(event_ids, source_ids)
 
             for event in events:
-                event_id = uuid.uuid4().hex
+                event_id = self._build_event_id(event["source_id"])
                 source_id = event["source_id"]
+                existing_event = existing_events.get(event_id) or legacy_events.get(source_id)
+
+                if existing_event:
+                    alert_obj = existing_event.alert
+                    level_changed = existing_event.level != event["level"]
+                    if level_changed:
+                        alert_obj.notice = False
+                        existing_event.notified = False
+                        existing_event.notice_result = []
+                        existing_event.notice_retry_count = 0
+                    alert_obj.value = event.get("value", alert_obj.value)
+                    alert_obj.content = event["content"]
+                    alert_obj.level = event["level"]
+                    alert_obj.end_event_time = self.scan_time
+                    alerts_to_update.append(alert_obj)
+
+                    existing_event.event_time = self.scan_time
+                    existing_event.value = event.get("value")
+                    existing_event.level = event["level"]
+                    existing_event.content = event["content"]
+                    events_to_update.append(existing_event)
+                    existing_event_objs.append(existing_event)
+                    if event.get("raw_data"):
+                        event_id_to_raw_data[existing_event.id] = event["raw_data"]
+                    continue
 
                 if source_id in existing_alerts:
                     # 存在活跃告警，准备更新
@@ -740,47 +813,85 @@ class LogPolicyScan:
             # 避免"告警有、数据无"的孤儿记录。
             # 注意：S3JSONField.pre_save() 在 DB 写入前上传至 MinIO；若 MinIO 失败则抛异常
             # → 事务回滚，DB 保持一致。快照写入在事务外独立执行（各自已有 atomic 保护）。
-            with transaction.atomic():
-                # 批量创建新告警
-                if alerts_to_create:
-                    Alert.objects.bulk_create(alerts_to_create, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
-                    logger.debug(f"Created {len(alerts_to_create)} new alerts for policy {self.policy.id}")
+            try:
+                with transaction.atomic():
+                    # 批量创建新告警
+                    if alerts_to_create:
+                        Alert.objects.bulk_create(alerts_to_create, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
+                        logger.debug(f"Created {len(alerts_to_create)} new alerts for policy {self.policy.id}")
 
-                # 批量更新现有告警
-                if alerts_to_update:
-                    Alert.objects.bulk_update(
-                        alerts_to_update,
-                        ["value", "content", "level", "end_event_time", "notice"],
-                        batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
-                    )
-                    logger.debug(f"Updated {len(alerts_to_update)} existing alerts for policy {self.policy.id}")
+                    # 批量更新现有告警
+                    if alerts_to_update:
+                        Alert.objects.bulk_update(
+                            alerts_to_update,
+                            ["value", "content", "level", "end_event_time", "notice"],
+                            batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
+                        )
+                        logger.debug(f"Updated {len(alerts_to_update)} existing alerts for policy {self.policy.id}")
 
-                # 批量创建事件记录
-                event_objs = Event.objects.bulk_create(create_events, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
+                    if events_to_update:
+                        Event.objects.bulk_update(
+                            events_to_update,
+                            [
+                                "event_time",
+                                "value",
+                                "level",
+                                "content",
+                                "notified",
+                                "notice_result",
+                                "notice_retry_count",
+                            ],
+                            batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
+                        )
 
-                # 批量创建事件原始数据记录（关联到已创建的事件对象）
-                if event_id_to_raw_data:
-                    create_raw_data = []
-                    for event_obj in event_objs:
-                        if event_obj.id in event_id_to_raw_data:
-                            create_raw_data.append(
-                                EventRawData(
-                                    event=event_obj,  # 使用 event 字段，而不是 event_id
-                                    data=event_id_to_raw_data[event_obj.id],
+                    # 批量创建事件记录
+                    event_objs = Event.objects.bulk_create(create_events, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
+
+                    # 批量创建事件原始数据记录（关联到已创建的事件对象）
+                    if event_id_to_raw_data:
+                        create_raw_data = []
+                        for event_obj in event_objs:
+                            if event_obj.id in event_id_to_raw_data:
+                                create_raw_data.append(
+                                    EventRawData(
+                                        event=event_obj,  # 使用 event 字段，而不是 event_id
+                                        data=event_id_to_raw_data[event_obj.id],
+                                    )
                                 )
-                            )
 
-                    # 逐个保存原始数据记录以确保 S3JSONField 能正确上传数据
-                    for raw_data_obj in create_raw_data:
-                        raw_data_obj.save()
-                    logger.debug(f"Created {len(create_raw_data)} raw data records for policy {self.policy.id}")
+                        # 逐个保存原始数据记录以确保 S3JSONField 能正确上传数据
+                        for raw_data_obj in create_raw_data:
+                            raw_data_obj.save()
+                        logger.debug(f"Created {len(create_raw_data)} raw data records for policy {self.policy.id}")
+
+                    for event_obj in existing_event_objs:
+                        raw_data = event_id_to_raw_data.get(event_obj.id)
+                        if raw_data:
+                            raw_data_obj = EventRawData.objects.filter(event=event_obj).order_by("id").first()
+                            if raw_data_obj:
+                                raw_data_obj.data = raw_data
+                            else:
+                                raw_data_obj = EventRawData(event=event_obj, data=raw_data)
+                            raw_data_obj.save()
+            except IntegrityError:
+                # 相同执行并发越过“先查后写”时，事件主键是最终数据库幂等门禁。
+                # 只有全部目标事件均已由竞争方提交，才把冲突视为成功；其他约束错误保留原始异常。
+                recovered_events = {event.id: event for event in Event.objects.filter(id__in=event_ids).select_related("alert")}
+                if set(recovered_events) != set(event_ids):
+                    raise
+                if any(event.event_time != self.scan_time for event in recovered_events.values()):
+                    raise RuntimeError(f"policy {self.policy.id} concurrent scan window conflict")
+                event_objs = [recovered_events[event_id] for event_id in event_ids]
+                existing_event_objs = []
+                alerts_to_create = []
 
             # 为告警创建或更新快照（传递原始数据映射）
             # 快照写入在事务外执行：每条快照各自有 atomic 保护，且 S3JSONField 写 MinIO
             # 不应阻塞主事务；快照失败不影响告警/事件已提交的数据。
+            event_objs = existing_event_objs + event_objs
             self._create_snapshots_for_alerts(event_objs, alerts_to_create, events, event_id_to_raw_data)
 
-            logger.info(f"Created {len(event_objs)} events for policy {self.policy.id}")
+            logger.info(f"Prepared {len(event_objs)} idempotent events for policy {self.policy.id}")
             return event_objs
 
         except Exception as e:
@@ -874,18 +985,26 @@ class LogPolicyScan:
 
                 # 如果有事件数据，添加到snapshots列表末尾
                 if event_objs:
-                    # 优化：获取已存在的事件ID集合，避免重复查询
-                    existing_event_ids = {s.get("event_id") for s in snapshot_obj.snapshots if s.get("type") == "event" and s.get("event_id")}
+                    existing_snapshots = {
+                        item.get("event_id"): item for item in snapshot_obj.snapshots if item.get("type") == "event" and item.get("event_id")
+                    }
 
                     # 批量构建快照数据
                     new_snapshots = []
+                    snapshots_changed = False
                     for event_obj in event_objs:
-                        # 跳过已存在的事件
-                        if event_obj.id in existing_event_ids:
-                            continue
-
-                        # 获取事件的原始数据
                         raw_data = event_raw_data_map.get(event_obj.id, {})
+                        event_snapshot = existing_snapshots.get(event_obj.id)
+                        if event_snapshot:
+                            event_snapshot.update(
+                                {
+                                    "event_time": event_obj.event_time.isoformat() if event_obj.event_time else None,
+                                    "snapshot_time": snapshot_time.isoformat(),
+                                    "raw_data": raw_data,
+                                }
+                            )
+                            snapshots_changed = True
+                            continue
 
                         event_snapshot = {
                             "type": "event",
@@ -896,8 +1015,8 @@ class LogPolicyScan:
                         }
                         new_snapshots.append(event_snapshot)
 
-                    # 批量添加新快照，并裁剪至上限以防 S3 对象无限膨胀
-                    if new_snapshots:
+                    # 同一执行的重试覆盖快照；新执行追加，并裁剪至上限。
+                    if new_snapshots or snapshots_changed:
                         snapshot_obj.snapshots.extend(new_snapshots)
                         if len(snapshot_obj.snapshots) > _MAX_ALERT_SNAPSHOTS:
                             snapshot_obj.snapshots = snapshot_obj.snapshots[-_MAX_ALERT_SNAPSHOTS:]
@@ -967,7 +1086,9 @@ class LogPolicyScan:
                 # 检查发送结果
                 if result.get("result") is False:
                     last_result = result
-                    msg = f"send notice failed for policy {self.policy.id} (attempt {attempt}/{max_attempts}): {result.get('message', 'Unknown error')}"
+                    msg = (
+                        f"send notice failed for policy {self.policy.id} (attempt {attempt}/{max_attempts}): {result.get('message', 'Unknown error')}"
+                    )
                     logger.error(msg)
                 else:
                     logger.info(f"send notice success for policy {self.policy.id} (attempt {attempt}/{max_attempts})")
@@ -1020,6 +1141,10 @@ class LogPolicyScan:
             for event in event_objs:
                 # info级别事件不通知
                 if event.level == "info":
+                    continue
+                # Event 是 created 通知的持久化幂等边界；告警后续关闭时 notice 会重置，
+                # 不能据此重放已经成功的 created。
+                if event.notified:
                     continue
                 # 告警已成功通知过且未发生级别变化时不重复通知，避免持续命中导致每个扫描周期重复发送
                 if event.alert.notice:

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -736,6 +736,11 @@ class LogPolicyScan:
                 existing_event = existing_events.get(event_id) or legacy_events.get(source_id)
 
                 if existing_event:
+                    # 同一执行的旧 worker 可能在较新结果提交后才返回；旧结果只能复用，
+                    # 不得回退 Event/Alert/RawData/快照的时间与内容。
+                    if existing_event.event_time and self.scan_time and existing_event.event_time > self.scan_time:
+                        existing_event_objs.append(existing_event)
+                        continue
                     alert_obj = existing_event.alert
                     level_changed = existing_event.level != event["level"]
                     if level_changed:
@@ -1130,54 +1135,45 @@ class LogPolicyScan:
             end_event_time=closed_alert.end_event_time,
         ).update(notice=closed_success)
 
-    def notice(self, event_objs):
+    def notice(self, event_objs, max_attempts=None):
         """通知"""
         if not event_objs or not self.policy.notice:
             return
 
         try:
-            success_alert_ids = set()
-
             for event in event_objs:
-                # info级别事件不通知
-                if event.level == "info":
-                    continue
-                # Event 是 created 通知的持久化幂等边界；告警后续关闭时 notice 会重置，
-                # 不能据此重放已经成功的 created。
-                if event.notified:
-                    continue
-                # 告警已成功通知过且未发生级别变化时不重复通知，避免持续命中导致每个扫描周期重复发送
-                if event.alert.notice:
-                    event.notice_result = [{"result": True, "message": "skipped: alert already notified"}]
-                    # 去重跳过视为已结清：必须置 notified=True，否则补偿任务会把
-                    # 这些事件当作发送失败反复重投，去重就失效了（与 #3312 的语义对齐）
-                    event.notified = True
-                    continue
-                is_notice, notice_result = self.send_notice(event)
-                event.notice_result = notice_result
-                # 记录发送是否成功 + 累计尝试次数，供补偿任务（范围B）回扫 notified=False 的失败事件
-                event.notified = is_notice
-                event.notice_retry_count = (event.notice_retry_count or 0) + 1
+                with transaction.atomic():
+                    # 同步首发与补偿/并发扫描都以 Event 行锁领取通知；锁必须覆盖外部发送和
+                    # 回执落库，避免两个持有旧对象的 worker 同时看到 notified=False 后双投。
+                    current = Event.objects.select_for_update().select_related("alert").get(pk=event.pk)
+                    if current.level == "info" or current.notified:
+                        continue
+                    if current.alert.notice:
+                        current.notice_result = [{"result": True, "message": "skipped: alert already notified"}]
+                        current.notified = True
+                        current.save(update_fields=["notice_result", "notified", "updated_at"])
+                        continue
 
-                if is_notice:
-                    event.alert.notice = True
-                    success_alert_ids.add(event.alert_id)
+                    is_notice, notice_result = self.send_notice(current, max_attempts=max_attempts)
+                    current.notice_result = notice_result
+                    current.notified = is_notice
+                    current.notice_retry_count = (current.notice_retry_count or 0) + 1
+                    current.save(
+                        update_fields=[
+                            "notice_result",
+                            "notified",
+                            "notice_retry_count",
+                            "updated_at",
+                        ]
+                    )
+                    if is_notice:
+                        # 仅活跃告警接收 created 回执，避免覆盖并发关闭留下的补偿状态。
+                        Alert.objects.filter(
+                            id=current.alert_id,
+                            status=AlertConstants.STATUS_NEW,
+                        ).update(notice=True)
 
-            # 批量更新通知结果
-            Event.objects.bulk_update(
-                event_objs,
-                ["notice_result", "notified", "notice_retry_count"],
-                batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE,
-            )
             logger.info(f"Completed notification for {len(event_objs)} events")
-
-            # 批量更新告警的通知状态
-            if success_alert_ids:
-                # 仅活跃告警接收 created 回执，避免覆盖并发关闭留下的补偿状态。
-                Alert.objects.filter(
-                    id__in=success_alert_ids,
-                    status=AlertConstants.STATUS_NEW,
-                ).update(notice=True)
 
         except Exception as e:
             logger.error(f"notice failed for policy {self.policy.id}: {e}")

--- a/server/apps/log/tasks/services/policy_scan.py
+++ b/server/apps/log/tasks/services/policy_scan.py
@@ -16,6 +16,8 @@ except ValueError:
     _MAX_ALERT_SNAPSHOTS = 500
 
 from django.db import IntegrityError, transaction
+from django.utils import timezone as django_timezone
+from django.utils.dateparse import parse_datetime
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import celery_logger as logger
@@ -726,7 +728,6 @@ class LogPolicyScan:
             events_to_update = []
             # 建立 event_id 到原始数据的映射，用于后续快照创建
             event_id_to_raw_data = {}
-            source_ids = [event["source_id"] for event in events]
             event_ids = [self._build_event_id(source_id) for source_id in source_ids]
             existing_events, legacy_events = self._find_existing_events(event_ids, source_ids)
 
@@ -739,7 +740,6 @@ class LogPolicyScan:
                     # 同一执行的旧 worker 可能在较新结果提交后才返回；旧结果只能复用，
                     # 不得回退 Event/Alert/RawData/快照的时间与内容。
                     if existing_event.event_time and self.scan_time and existing_event.event_time > self.scan_time:
-                        existing_event_objs.append(existing_event)
                         continue
                     alert_obj = existing_event.alert
                     level_changed = existing_event.level != event["level"]
@@ -820,6 +820,81 @@ class LogPolicyScan:
             # → 事务回滚，DB 保持一致。快照写入在事务外独立执行（各自已有 atomic 保护）。
             try:
                 with transaction.atomic():
+                    # 分类阶段的查询可能早于并发 worker 提交。写入前按 Event → Alert 的
+                    # 固定顺序加行锁并重新判定时间，避免旧 worker 的陈旧对象反向覆盖。
+                    locked_events = {
+                        event.id: event
+                        for event in Event.objects.select_for_update()
+                        .filter(id__in=[event.id for event in events_to_update])
+                        .order_by("id")
+                    }
+                    locked_alerts = {
+                        alert.id: alert
+                        for alert in Alert.objects.select_for_update()
+                        .filter(id__in=[alert.id for alert in alerts_to_update])
+                        .order_by("id")
+                    }
+                    stale_alert_ids = {
+                        alert.id
+                        for alert in locked_alerts.values()
+                        if alert.status != AlertConstants.STATUS_NEW
+                        or (
+                            self.execution_key is not None
+                            and alert.end_event_time
+                            and self.scan_time
+                            and alert.end_event_time > self.scan_time
+                        )
+                    }
+
+                    refreshed_events = []
+                    refreshed_existing_event_objs = []
+                    for desired_event in events_to_update:
+                        current_event = locked_events[desired_event.id]
+                        if current_event.alert_id in stale_alert_ids or (
+                            current_event.event_time and self.scan_time and current_event.event_time > self.scan_time
+                        ):
+                            stale_alert_ids.add(current_event.alert_id)
+                            continue
+
+                        if current_event.level != desired_event.level:
+                            current_event.notified = False
+                            current_event.notice_result = []
+                            current_event.notice_retry_count = 0
+                        current_event.event_time = desired_event.event_time
+                        current_event.value = desired_event.value
+                        current_event.level = desired_event.level
+                        current_event.content = desired_event.content
+                        refreshed_events.append(current_event)
+                        refreshed_existing_event_objs.append(current_event)
+
+                    events_to_update = refreshed_events
+                    existing_event_objs = refreshed_existing_event_objs
+
+                    refreshed_alerts = {}
+                    for desired_alert in alerts_to_update:
+                        current_alert = locked_alerts[desired_alert.id]
+                        if current_alert.id in stale_alert_ids:
+                            continue
+                        if current_alert.level != desired_alert.level:
+                            current_alert.notice = False
+                        current_alert.value = desired_alert.value
+                        current_alert.content = desired_alert.content
+                        current_alert.level = desired_alert.level
+                        current_alert.end_event_time = desired_alert.end_event_time
+                        refreshed_alerts[current_alert.id] = current_alert
+                    alerts_to_update = list(refreshed_alerts.values())
+
+                    if stale_alert_ids:
+                        create_events = [event for event in create_events if event.alert_id not in stale_alert_ids]
+
+                    writable_event_ids = {event.id for event in create_events}
+                    writable_event_ids.update(event.id for event in existing_event_objs)
+                    event_id_to_raw_data = {
+                        event_id: raw_data
+                        for event_id, raw_data in event_id_to_raw_data.items()
+                        if event_id in writable_event_ids
+                    }
+
                     # 批量创建新告警
                     if alerts_to_create:
                         Alert.objects.bulk_create(alerts_to_create, batch_size=DatabaseConstants.DEFAULT_BATCH_SIZE)
@@ -1001,6 +1076,24 @@ class LogPolicyScan:
                         raw_data = event_raw_data_map.get(event_obj.id, {})
                         event_snapshot = existing_snapshots.get(event_obj.id)
                         if event_snapshot:
+                            # 主数据事务与快照事务刻意分离；旧 worker 可能晚于新 worker
+                            # 取得快照锁，只允许相同或更新的事件时间覆盖同一 event_id。
+                            persisted_time = parse_datetime(
+                                event_snapshot.get("event_time") or event_snapshot.get("snapshot_time") or ""
+                            )
+                            candidate_time = event_obj.event_time or snapshot_time
+                            if persisted_time and django_timezone.is_naive(persisted_time):
+                                persisted_time = django_timezone.make_aware(
+                                    persisted_time,
+                                    django_timezone.get_default_timezone(),
+                                )
+                            if candidate_time and django_timezone.is_naive(candidate_time):
+                                candidate_time = django_timezone.make_aware(
+                                    candidate_time,
+                                    django_timezone.get_default_timezone(),
+                                )
+                            if persisted_time and candidate_time and persisted_time > candidate_time:
+                                continue
                             event_snapshot.update(
                                 {
                                     "event_time": event_obj.event_time.isoformat() if event_obj.event_time else None,
@@ -1145,10 +1238,11 @@ class LogPolicyScan:
                 with transaction.atomic():
                     # 同步首发与补偿/并发扫描都以 Event 行锁领取通知；锁必须覆盖外部发送和
                     # 回执落库，避免两个持有旧对象的 worker 同时看到 notified=False 后双投。
-                    current = Event.objects.select_for_update().select_related("alert").get(pk=event.pk)
+                    current = Event.objects.select_for_update().get(pk=event.pk)
+                    current_alert = Alert.objects.select_for_update().get(pk=current.alert_id)
                     if current.level == "info" or current.notified:
                         continue
-                    if current.alert.notice:
+                    if current_alert.notice:
                         current.notice_result = [{"result": True, "message": "skipped: alert already notified"}]
                         current.notified = True
                         current.save(update_fields=["notice_result", "notified", "updated_at"])

--- a/server/apps/log/tests/test_create_events_atomic_3367.py
+++ b/server/apps/log/tests/test_create_events_atomic_3367.py
@@ -48,7 +48,7 @@ def _install_module(monkeypatch, name, **attrs):
 def _load_policy_scan_module(monkeypatch, transaction_mock):
     """加载 policy_scan.py，注入伪依赖（无 Django settings / ORM）。"""
     _install_module(monkeypatch, "django", db=types.SimpleNamespace(transaction=transaction_mock))
-    _install_module(monkeypatch, "django.db", transaction=transaction_mock)
+    _install_module(monkeypatch, "django.db", IntegrityError=Exception, transaction=transaction_mock)
 
     _install_module(monkeypatch, "apps.core.exceptions.base_app_exception", BaseAppException=Exception)
     _install_module(

--- a/server/apps/log/tests/test_policy_scan_db.py
+++ b/server/apps/log/tests/test_policy_scan_db.py
@@ -292,6 +292,39 @@ class TestCreateEvents:
         retry_event.refresh_from_db()
         assert retry_event.notified is True
 
+    def test_late_same_execution_cannot_overwrite_newer_event(self):
+        cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        source_id = f"policy_{policy.id}"
+        newer_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=4),
+            execution_key="same-execution",
+            cursor_time=cursor,
+        )
+        older_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=3),
+            execution_key="same-execution",
+            cursor_time=cursor,
+        )
+
+        newer_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "newer", "value": 4, "raw_data": []}]
+        )
+        older_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "older", "value": 3, "raw_data": []}]
+        )
+
+        event = Event.objects.get(policy=policy)
+        event.alert.refresh_from_db()
+        assert event.event_time == newer_scan.scan_time
+        assert event.content == "newer"
+        assert event.value == 4
+        assert event.alert.end_event_time == newer_scan.scan_time
+        assert event.alert.content == "newer"
+        assert event.alert.value == 4
+
     @pytest.mark.django_db(transaction=True)
     def test_concurrent_same_execution_recovers_event_conflict(self):
         policy = _make_policy()
@@ -686,6 +719,28 @@ class TestNotice:
         retry_event = Event.objects.select_related("alert").get(id=event.id)
 
         scan.notice([retry_event])
+
+        send.assert_called_once()
+
+    def test_stale_event_copy_does_not_resend_after_success(self, mocker):
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        alert = Alert.objects.create(
+            id="a-stale-notice",
+            policy=policy,
+            source_id="s",
+            level="warning",
+            status=AlertConstants.STATUS_NEW,
+            start_event_time=timezone.now(),
+            notice=False,
+        )
+        event = self._persist_event(policy, alert, level="warning")
+        first_copy = Event.objects.select_related("alert").get(id=event.id)
+        stale_copy = Event.objects.select_related("alert").get(id=event.id)
+        send = mocker.patch.object(LogPolicyScan, "send_notice", return_value=(True, {"result": True}))
+        scan = LogPolicyScan(policy)
+
+        scan.notice([first_copy])
+        scan.notice([stale_copy])
 
         send.assert_called_once()
 

--- a/server/apps/log/tests/test_policy_scan_db.py
+++ b/server/apps/log/tests/test_policy_scan_db.py
@@ -8,10 +8,12 @@
 DB（Policy/Alert/Event/AlertSnapshot）走真实，断言落库副作用。
 """
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier
+from copy import deepcopy
+from itertools import count
+from threading import Barrier, Event as ThreadEvent, Lock
 
 import pytest
-from django.db import close_old_connections
+from django.db import close_old_connections, connection
 from django.utils import timezone
 
 from apps.log.constants.alert_policy import AlertConstants
@@ -292,7 +294,34 @@ class TestCreateEvents:
         retry_event.refresh_from_db()
         assert retry_event.notified is True
 
-    def test_late_same_execution_cannot_overwrite_newer_event(self):
+    def test_event_and_alert_locks_do_not_require_for_update_of(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        source_id = f"policy_{policy.id}"
+        first_scan = LogPolicyScan(policy, scan_time=scan_time, execution_key="same-execution")
+        event = first_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "first", "value": 1, "raw_data": []}]
+        )[0]
+        mocker.patch.object(connection.features, "has_select_for_update_of", False)
+
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+        )
+        retry_event = retry_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "retry", "value": 2, "raw_data": []}]
+        )[0]
+        send = mocker.patch.object(LogPolicyScan, "send_notice", return_value=(True, {"result": True}))
+
+        retry_scan.notice([retry_event])
+
+        send.assert_called_once()
+        event.refresh_from_db()
+        assert event.event_time == retry_scan.scan_time
+        assert event.notified is True
+
+    def test_late_same_execution_cannot_overwrite_newer_event(self, mocker):
         cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
         policy = _make_policy(last_run_time=cursor)
         source_id = f"policy_{policy.id}"
@@ -310,20 +339,93 @@ class TestCreateEvents:
         )
 
         newer_scan.create_events(
-            [{"source_id": source_id, "level": "warning", "content": "newer", "value": 4, "raw_data": []}]
+            [{"source_id": source_id, "level": "warning", "content": "newer", "value": 4, "raw_data": [{"version": 4}]}]
         )
-        older_scan.create_events(
-            [{"source_id": source_id, "level": "warning", "content": "older", "value": 3, "raw_data": []}]
+        snapshot_update = mocker.spy(older_scan, "_create_snapshots_for_alerts")
+        older_result = older_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "older", "value": 3, "raw_data": [{"version": 3}]}]
         )
 
         event = Event.objects.get(policy=policy)
         event.alert.refresh_from_db()
+        assert older_result == []
+        assert snapshot_update.call_args.args[0] == []
         assert event.event_time == newer_scan.scan_time
         assert event.content == "newer"
         assert event.value == 4
         assert event.alert.end_event_time == newer_scan.scan_time
         assert event.alert.content == "newer"
         assert event.alert.value == 4
+
+    def test_same_execution_retry_does_not_modify_closed_alert(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy()
+        source_id = f"policy_{policy.id}"
+        first_scan = LogPolicyScan(policy, scan_time=scan_time, execution_key="same-execution")
+        event = first_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "first", "value": 1, "raw_data": []}]
+        )[0]
+        closed_at = scan_time + timezone.timedelta(minutes=2)
+        Alert.objects.filter(id=event.alert_id).update(
+            status=AlertConstants.STATUS_CLOSED,
+            end_event_time=closed_at,
+            content="closed",
+            notice=True,
+        )
+
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time + timezone.timedelta(minutes=3),
+            execution_key="same-execution",
+        )
+        snapshot_update = mocker.spy(retry_scan, "_create_snapshots_for_alerts")
+        retry_result = retry_scan.create_events(
+            [{"source_id": source_id, "level": "critical", "content": "retry", "value": 2, "raw_data": []}]
+        )
+
+        event.alert.refresh_from_db()
+        assert retry_result == []
+        assert snapshot_update.call_args.args[0] == []
+        assert event.alert.status == AlertConstants.STATUS_CLOSED
+        assert event.alert.end_event_time == closed_at
+        assert event.alert.content == "closed"
+        assert event.alert.level == "warning"
+        assert event.alert.notice is True
+
+    @pytest.mark.django_db(transaction=True)
+    def test_same_execution_raw_data_update_deletes_previous_s3_object(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy()
+        source_id = f"policy_{policy.id}"
+        raw_paths = iter(["raw-v1.json.gz", "raw-v2.json.gz"])
+
+        def upload(instance, data):
+            if isinstance(instance, EventRawData):
+                return next(raw_paths)
+            return f"snapshot-{instance.pk}.json.gz"
+
+        mocker.patch("apps.core.fields.s3_json_field.S3JSONField._upload_to_s3", side_effect=upload)
+        raw_field = EventRawData._meta.get_field("data")
+        snapshot_field = AlertSnapshot._meta.get_field("snapshots")
+        raw_storage = mocker.MagicMock()
+        snapshot_storage = mocker.MagicMock()
+        mocker.patch.object(raw_field, "_minio_storage", raw_storage)
+        mocker.patch.object(snapshot_field, "_minio_storage", snapshot_storage)
+
+        first_scan = LogPolicyScan(policy, scan_time=scan_time, execution_key="same-execution")
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+        )
+        first_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "first", "value": 1, "raw_data": [{"version": 1}]}]
+        )
+        retry_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "retry", "value": 2, "raw_data": [{"version": 2}]}]
+        )
+
+        raw_storage.delete.assert_called_once_with("raw-v1.json.gz")
 
     @pytest.mark.django_db(transaction=True)
     def test_concurrent_same_execution_recovers_event_conflict(self):
@@ -410,6 +512,197 @@ class TestCreateEvents:
         assert [outcome[0] for outcome in outcomes].count("retry") == 1
         assert Event.objects.filter(policy=policy).count() == 1
         assert Alert.objects.filter(policy=policy).count() == 1
+
+    @pytest.mark.django_db(transaction=True)
+    def test_concurrent_existing_event_cannot_be_overwritten_by_late_worker(self):
+        cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        source_id = f"policy_{policy.id}"
+        initial_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+            cursor_time=cursor,
+        )
+        initial_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "initial", "value": 1, "raw_data": []}]
+        )
+        barrier = Barrier(2)
+
+        class CoordinatedScan(LogPolicyScan):
+            def _find_existing_events(self, event_ids, source_ids):
+                existing = super()._find_existing_events(event_ids, source_ids)
+                barrier.wait(timeout=5)
+                return existing
+
+        def update_once(scan_time, content, value):
+            close_old_connections()
+            try:
+                return CoordinatedScan(
+                    Policy.objects.get(id=policy.id),
+                    scan_time=scan_time,
+                    execution_key="same-execution",
+                    cursor_time=cursor,
+                ).create_events(
+                    [{"source_id": source_id, "level": "warning", "content": content, "value": value, "raw_data": []}]
+                )
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(update_once, cursor + timezone.timedelta(minutes=3), "older", 3),
+                executor.submit(update_once, cursor + timezone.timedelta(minutes=4), "newer", 4),
+            ]
+            [future.result() for future in futures]
+
+        event = Event.objects.get(policy=policy)
+        event.alert.refresh_from_db()
+        assert event.event_time == cursor + timezone.timedelta(minutes=4)
+        assert event.content == "newer"
+        assert event.value == 4
+        assert event.alert.end_event_time == cursor + timezone.timedelta(minutes=4)
+        assert event.alert.content == "newer"
+        assert event.alert.value == 4
+
+    @pytest.mark.django_db(transaction=True)
+    def test_late_worker_cannot_regress_raw_data_or_snapshot_after_newer_commit(self, mocker):
+        cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        source_id = f"policy_{policy.id}"
+        raw_field = EventRawData._meta.get_field("data")
+        snapshot_field = AlertSnapshot._meta.get_field("snapshots")
+        object_store = {}
+        object_counter = count()
+        object_lock = Lock()
+
+        def configure_memory_storage(field, prefix):
+            def upload(instance, value):
+                with object_lock:
+                    path = f"{prefix}-{next(object_counter)}.json.gz"
+                    object_store[path] = deepcopy(value)
+                    return path
+
+            def load(path):
+                with object_lock:
+                    return deepcopy(object_store[path])
+
+            mocker.patch.object(field, "_upload_to_s3", side_effect=upload)
+            mocker.patch.object(field, "_load_from_s3", side_effect=load)
+            mocker.patch.object(field, "_minio_storage", mocker.MagicMock())
+
+        configure_memory_storage(raw_field, "raw")
+        configure_memory_storage(snapshot_field, "snapshot")
+
+        initial_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+            cursor_time=cursor,
+        )
+        initial_scan.create_events(
+            [
+                {
+                    "source_id": source_id,
+                    "level": "warning",
+                    "content": "initial",
+                    "value": 1,
+                    "raw_data": [{"version": 1}],
+                }
+            ]
+        )
+
+        older_snapshot_ready = ThreadEvent()
+        release_older_snapshot = ThreadEvent()
+
+        class CoordinatedScan(LogPolicyScan):
+            def _create_snapshots_for_alerts(self, *args, **kwargs):
+                if self.scan_time == cursor + timezone.timedelta(minutes=3):
+                    older_snapshot_ready.set()
+                    assert release_older_snapshot.wait(timeout=5)
+                return super()._create_snapshots_for_alerts(*args, **kwargs)
+
+        def update_older():
+            close_old_connections()
+            try:
+                return CoordinatedScan(
+                    Policy.objects.get(id=policy.id),
+                    scan_time=cursor + timezone.timedelta(minutes=3),
+                    execution_key="same-execution",
+                    cursor_time=cursor,
+                ).create_events(
+                    [
+                        {
+                            "source_id": source_id,
+                            "level": "warning",
+                            "content": "older",
+                            "value": 3,
+                            "raw_data": [{"version": 3}],
+                        }
+                    ]
+                )
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            older_future = executor.submit(update_older)
+            assert older_snapshot_ready.wait(timeout=5)
+            newer_scan = LogPolicyScan(
+                Policy.objects.get(id=policy.id),
+                scan_time=cursor + timezone.timedelta(minutes=4),
+                execution_key="same-execution",
+                cursor_time=cursor,
+            )
+            newer_scan.create_events(
+                [
+                    {
+                        "source_id": source_id,
+                        "level": "warning",
+                        "content": "newer",
+                        "value": 4,
+                        "raw_data": [{"version": 4}],
+                    }
+                ]
+            )
+            release_older_snapshot.set()
+            older_future.result()
+
+        event = Event.objects.get(policy=policy)
+        raw_data = EventRawData.objects.get(event=event)
+        snapshot = AlertSnapshot.objects.get(alert=event.alert)
+        event_snapshot = next(item for item in snapshot.snapshots if item.get("event_id") == event.id)
+        assert event.event_time == cursor + timezone.timedelta(minutes=4)
+        assert event.content == "newer"
+        assert raw_data.data == [{"version": 4}]
+        assert event_snapshot["event_time"] == event.event_time.isoformat()
+        assert event_snapshot["raw_data"] == [{"version": 4}]
+
+    def test_stale_create_events_does_not_reset_successful_notification(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        source_id = f"policy_{policy.id}"
+        scan = LogPolicyScan(policy, scan_time=scan_time, execution_key="same-execution")
+        event = scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "first", "value": 1, "raw_data": []}]
+        )[0]
+        stale_existing = scan._find_existing_events([event.id], [source_id])
+        send = mocker.patch.object(LogPolicyScan, "send_notice", return_value=(True, {"result": True}))
+        scan.notice([event])
+
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+        )
+        mocker.patch.object(retry_scan, "_find_existing_events", return_value=stale_existing)
+        retry_event = retry_scan.create_events(
+            [{"source_id": source_id, "level": "warning", "content": "retry", "value": 2, "raw_data": []}]
+        )[0]
+        retry_scan.notice([retry_event])
+
+        retry_event.refresh_from_db()
+        assert retry_event.notified is True
+        send.assert_called_once()
 
 
 class TestSendNotice:

--- a/server/apps/log/tests/test_policy_scan_db.py
+++ b/server/apps/log/tests/test_policy_scan_db.py
@@ -7,7 +7,11 @@
 
 DB（Policy/Alert/Event/AlertSnapshot）走真实，断言落库副作用。
 """
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
 import pytest
+from django.db import close_old_connections
 from django.utils import timezone
 
 from apps.log.constants.alert_policy import AlertConstants
@@ -221,13 +225,15 @@ class TestCreateEvents:
             start_event_time=timezone.now(),
             end_event_time=timezone.now(),
         )
-        events = [{
-            "source_id": f"policy_{policy.id}",
-            "level": "critical",
-            "content": "新内容",
-            "value": 9,
-            "raw_data": [],
-        }]
+        events = [
+            {
+                "source_id": f"policy_{policy.id}",
+                "level": "critical",
+                "content": "新内容",
+                "value": 9,
+                "raw_data": [],
+            }
+        ]
         scan.create_events(events)
         existing.refresh_from_db()
         assert existing.content == "新内容"
@@ -236,6 +242,140 @@ class TestCreateEvents:
         # 级别变化导致 notice 重置为 False
         assert existing.notice is False
         # 没有创建新告警
+        assert Alert.objects.filter(policy=policy).count() == 1
+
+    def test_same_execution_level_change_resets_event_notification(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        first_scan = LogPolicyScan(policy, scan_time=scan_time, execution_key="same-execution")
+        first_event = first_scan.create_events(
+            [
+                {
+                    "source_id": f"policy_{policy.id}",
+                    "level": "warning",
+                    "content": "首次命中",
+                    "value": 1,
+                    "raw_data": [],
+                }
+            ]
+        )[0]
+        Event.objects.filter(id=first_event.id).update(notified=True)
+        Alert.objects.filter(id=first_event.alert_id).update(notice=True)
+
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time + timezone.timedelta(minutes=1),
+            execution_key="same-execution",
+        )
+        retry_event = retry_scan.create_events(
+            [
+                {
+                    "source_id": f"policy_{policy.id}",
+                    "level": "critical",
+                    "content": "升级命中",
+                    "value": 2,
+                    "raw_data": [],
+                }
+            ]
+        )[0]
+
+        retry_event.refresh_from_db()
+        retry_event.alert.refresh_from_db()
+        assert retry_event.id == first_event.id
+        assert retry_event.notified is False
+        assert retry_event.alert.notice is False
+
+        send = mocker.patch.object(LogPolicyScan, "send_notice", return_value=(True, {"result": True}))
+        retry_scan.notice([retry_event])
+
+        send.assert_called_once()
+        retry_event.refresh_from_db()
+        assert retry_event.notified is True
+
+    @pytest.mark.django_db(transaction=True)
+    def test_concurrent_same_execution_recovers_event_conflict(self):
+        policy = _make_policy()
+        events = [
+            {
+                "source_id": f"policy_{policy.id}",
+                "level": "warning",
+                "content": "并发命中",
+                "value": 1,
+                "raw_data": [],
+            }
+        ]
+        barrier = Barrier(2)
+
+        class CoordinatedScan(LogPolicyScan):
+            def _find_existing_events(self, event_ids, source_ids):
+                existing = super()._find_existing_events(event_ids, source_ids)
+                barrier.wait(timeout=5)
+                return existing
+
+        def create_once():
+            close_old_connections()
+            try:
+                return CoordinatedScan(
+                    Policy.objects.get(id=policy.id),
+                    execution_key="same-execution",
+                ).create_events(events)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(lambda _: create_once(), range(2)))
+
+        assert [len(result) for result in results] == [1, 1]
+        assert Event.objects.filter(policy=policy).count() == 1
+        assert Alert.objects.filter(policy=policy).count() == 1
+
+    @pytest.mark.django_db(transaction=True)
+    def test_concurrent_different_windows_force_loser_to_retry(self):
+        policy = _make_policy()
+        events = [
+            {
+                "source_id": f"policy_{policy.id}",
+                "level": "warning",
+                "content": "并发命中",
+                "value": 1,
+                "raw_data": [],
+            }
+        ]
+        barrier = Barrier(2)
+        scan_times = [
+            timezone.datetime(2026, 7, 24, 0, 2, tzinfo=timezone.utc),
+            timezone.datetime(2026, 7, 24, 0, 3, tzinfo=timezone.utc),
+        ]
+
+        class CoordinatedScan(LogPolicyScan):
+            def _find_existing_events(self, event_ids, source_ids):
+                existing = super()._find_existing_events(event_ids, source_ids)
+                barrier.wait(timeout=5)
+                return existing
+
+        def create_once(scan_time):
+            close_old_connections()
+            try:
+                return CoordinatedScan(
+                    Policy.objects.get(id=policy.id),
+                    scan_time=scan_time,
+                    execution_key="same-execution",
+                ).create_events(events)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(create_once, scan_time) for scan_time in scan_times]
+            outcomes = []
+            for future in futures:
+                try:
+                    outcomes.append(("success", future.result()))
+                except RuntimeError as exc:
+                    outcomes.append(("retry", str(exc)))
+
+        assert [outcome[0] for outcome in outcomes].count("success") == 1
+        assert [outcome[0] for outcome in outcomes].count("retry") == 1
+        assert Event.objects.filter(policy=policy).count() == 1
         assert Alert.objects.filter(policy=policy).count() == 1
 
 
@@ -475,7 +615,9 @@ class TestNotice:
 
     def test_already_notified_alert_skipped(self, mocker):
         policy = _make_policy(notice=True, notice_users=["u1"])
-        alert = Alert.objects.create(id="a-noticed", policy=policy, source_id="s", level="warning", status="new", start_event_time=timezone.now(), notice=True)
+        alert = Alert.objects.create(
+            id="a-noticed", policy=policy, source_id="s", level="warning", status="new", start_event_time=timezone.now(), notice=True
+        )
         ev = self._persist_event(policy, alert, level="warning")
         send = mocker.patch.object(LogPolicyScan, "send_notice")
         LogPolicyScan(policy).notice([ev])
@@ -485,7 +627,9 @@ class TestNotice:
 
     def test_successful_notice_marks_alert(self, mocker):
         policy = _make_policy(notice=True, notice_users=["u1"])
-        alert = Alert.objects.create(id="a-send", policy=policy, source_id="s", level="warning", status="new", start_event_time=timezone.now(), notice=False)
+        alert = Alert.objects.create(
+            id="a-send", policy=policy, source_id="s", level="warning", status="new", start_event_time=timezone.now(), notice=False
+        )
         ev = self._persist_event(policy, alert, level="warning")
         mocker.patch.object(LogPolicyScan, "send_notice", return_value=(True, {"result": True}))
         LogPolicyScan(policy).notice([ev])
@@ -516,8 +660,198 @@ class TestNotice:
         assert event.notified is True
         assert alert.notice is False
 
+    def test_retry_does_not_resend_event_already_notified_before_alert_closed(self, mocker):
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        alert = Alert.objects.create(
+            id="a-notified-before-close",
+            policy=policy,
+            source_id="s",
+            level="warning",
+            status=AlertConstants.STATUS_NEW,
+            start_event_time=timezone.now(),
+            notice=False,
+        )
+        event = self._persist_event(policy, alert, level="warning")
+
+        def send_then_close(*args, **kwargs):
+            Alert.objects.filter(id=alert.id).update(
+                status=AlertConstants.STATUS_CLOSED,
+                notice=False,
+            )
+            return True, {"result": True}
+
+        send = mocker.patch.object(LogPolicyScan, "send_notice", side_effect=send_then_close)
+        scan = LogPolicyScan(policy)
+        scan.notice([event])
+        retry_event = Event.objects.select_related("alert").get(id=event.id)
+
+        scan.notice([retry_event])
+
+        send.assert_called_once()
+
+    def test_retry_resends_event_whose_notice_failed(self, mocker):
+        policy = _make_policy(notice=True, notice_users=["u1"])
+        alert = Alert.objects.create(
+            id="a-notice-retry",
+            policy=policy,
+            source_id="s",
+            level="warning",
+            status=AlertConstants.STATUS_NEW,
+            start_event_time=timezone.now(),
+            notice=False,
+        )
+        event = self._persist_event(policy, alert, level="warning")
+        send = mocker.patch.object(
+            LogPolicyScan,
+            "send_notice",
+            side_effect=[
+                (False, {"result": False}),
+                (True, {"result": True}),
+            ],
+        )
+        scan = LogPolicyScan(policy)
+
+        scan.notice([event])
+        retry_event = Event.objects.select_related("alert").get(id=event.id)
+        scan.notice([retry_event])
+
+        assert send.call_count == 2
+        retry_event.refresh_from_db()
+        assert retry_event.notified is True
+
 
 class TestRun:
+    def test_retrying_same_scan_does_not_duplicate_event(self, mocker):
+        scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=scan_time)
+        scan = LogPolicyScan(policy, scan_time=scan_time)
+        mocker.patch.object(
+            scan.vlogs_api,
+            "query",
+            side_effect=[
+                [{"_msg": "err"}],
+                [{"total_count": "2"}],
+                [{"_msg": "err"}],
+                [{"total_count": "2"}],
+            ],
+        )
+
+        scan.run()
+        first_event_id = Event.objects.get(policy=policy).id
+
+        scan.run()
+
+        assert list(Event.objects.filter(policy=policy).values_list("id", flat=True)) == [first_event_id]
+
+    def test_retrying_from_same_cursor_is_idempotent_when_safe_time_moves(self, mocker):
+        cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        first_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=2),
+            window_start=int(cursor.timestamp()) - 180,
+            window_end=int(cursor.timestamp()) + 120,
+            execution_key=cursor.isoformat(),
+        )
+        retry_scan = LogPolicyScan(
+            policy,
+            scan_time=cursor + timezone.timedelta(minutes=3),
+            window_start=int(cursor.timestamp()) - 120,
+            window_end=int(cursor.timestamp()) + 180,
+            execution_key=cursor.isoformat(),
+        )
+        for scan in (first_scan, retry_scan):
+            mocker.patch.object(
+                scan.vlogs_api,
+                "query",
+                side_effect=[[{"_msg": "err"}], [{"total_count": "2"}]],
+            )
+
+        first_scan.run()
+        retry_scan.run()
+
+        assert Event.objects.filter(policy=policy).count() == 1
+        event = Event.objects.get(policy=policy)
+        assert event.event_time == retry_scan.scan_time
+        assert event.value == 2
+        assert event.content == "报错: 检测到 2 条匹配日志"
+
+    def test_retry_reuses_legacy_uuid_event_created_before_upgrade(self, mocker):
+        cursor = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        scan_time = cursor + timezone.timedelta(minutes=5)
+        policy = _make_policy(last_run_time=cursor)
+        alert = Alert.objects.create(
+            id="legacy-alert",
+            policy=policy,
+            source_id=f"policy_{policy.id}",
+            level="warning",
+            status=AlertConstants.STATUS_NEW,
+            start_event_time=scan_time,
+        )
+        legacy_event = Event.objects.create(
+            id="legacy-random-uuid",
+            policy=policy,
+            alert=alert,
+            source_id=f"policy_{policy.id}",
+            event_time=scan_time,
+            level="warning",
+            content="旧版本已提交",
+        )
+        scan = LogPolicyScan(
+            policy,
+            scan_time=scan_time,
+            window_start=int(cursor.timestamp()),
+            window_end=int(scan_time.timestamp()),
+            execution_key="new-version-execution",
+            cursor_time=cursor,
+        )
+        mocker.patch.object(
+            scan.vlogs_api,
+            "query",
+            side_effect=[[{"_msg": "err"}], [{"total_count": "2"}]],
+        )
+
+        scan.run()
+
+        assert list(Event.objects.filter(policy=policy).values_list("id", flat=True)) == [legacy_event.id]
+
+    def test_first_retry_reuses_legacy_uuid_event_when_safe_time_moves(self, mocker):
+        first_scan_time = timezone.datetime(2026, 7, 24, tzinfo=timezone.utc)
+        retry_scan_time = first_scan_time + timezone.timedelta(minutes=1)
+        policy = _make_policy(last_run_time=None)
+        alert = Alert.objects.create(
+            id="legacy-first-alert",
+            policy=policy,
+            source_id=f"policy_{policy.id}",
+            level="warning",
+            status=AlertConstants.STATUS_NEW,
+            start_event_time=first_scan_time,
+        )
+        legacy_event = Event.objects.create(
+            id="legacy-first-random-uuid",
+            policy=policy,
+            alert=alert,
+            source_id=f"policy_{policy.id}",
+            event_time=first_scan_time,
+            level="warning",
+            content="旧版本首次扫描已提交",
+        )
+        scan = LogPolicyScan(
+            policy,
+            scan_time=retry_scan_time,
+            execution_key="new-version-first-execution",
+            cursor_time=None,
+        )
+        mocker.patch.object(
+            scan.vlogs_api,
+            "query",
+            side_effect=[[{"_msg": "err"}], [{"total_count": "2"}]],
+        )
+
+        scan.run()
+
+        assert list(Event.objects.filter(policy=policy).values_list("id", flat=True)) == [legacy_event.id]
+
     def test_keyword_run_full_flow(self, mocker):
         policy = _make_policy(notice=False)
         scan = LogPolicyScan(policy)

--- a/server/apps/log/tests/test_tasks_policy.py
+++ b/server/apps/log/tests/test_tasks_policy.py
@@ -73,7 +73,7 @@ class TestScanLogPolicyTask:
         assert policy.last_run_time is not None
 
     def test_single_window_run(self, mocker):
-        # last_run_time 接近 now → backfill_count <= 1 单周期分支
+        # last_run_time 接近 now → backfill_count == 0 单周期分支
         recent = datetime.now(timezone.utc) - timedelta(seconds=120)
         policy = _make_policy(last_run_time=recent)
         run = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
@@ -83,6 +83,28 @@ class TestScanLogPolicyTask:
         run.assert_called_once()
         _, kwargs = run.call_args
         assert "window_start" in kwargs and "window_end" in kwargs
+
+    def test_one_and_half_period_delay_keeps_window_continuous(self, mocker):
+        period_seconds = 5 * 60
+        last_run_time = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_time = last_run_time + timedelta(seconds=period_seconds * 1.5)
+        current_time = safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS)
+        policy = _make_policy(last_run_time=last_run_time)
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = current_time
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        scan.assert_called_once_with(
+            mocker.ANY,
+            scan_time=last_run_time + timedelta(seconds=period_seconds),
+            window_start=int(last_run_time.timestamp()),
+            window_end=int(last_run_time.timestamp()) + period_seconds,
+        )
+        scan.return_value.run.assert_called_once_with()
+        policy.refresh_from_db()
+        assert policy.last_run_time == last_run_time + timedelta(seconds=period_seconds)
 
     def test_backfill_multiple_windows(self, mocker):
         # last_run_time 远早于 now → 多周期补偿

--- a/server/apps/log/tests/test_tasks_policy.py
+++ b/server/apps/log/tests/test_tasks_policy.py
@@ -46,7 +46,7 @@ class TestScanLogPolicyTask:
     @pytest.mark.parametrize(
         ("delay_periods", "expected_windows", "expected_cursor_periods"),
         [
-            (0.5, [(-1, 0.5)], 0.5),
+            (0.5, [(0, 0.5)], 0.5),
             (1, [(0, 1)], 1),
             (1.5, [(0, 1)], 1),
             (2, [(0, 1), (1, 2)], 2),
@@ -121,6 +121,36 @@ class TestScanLogPolicyTask:
         policy.refresh_from_db()
         assert policy.last_run_time is not None
 
+    def test_first_run_failure_persists_bounded_retry_window(self, mocker):
+        period_seconds = 5 * 60
+        first_safe_time = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        retry_safe_time = first_safe_time + timedelta(seconds=period_seconds // 4)
+        policy = _make_policy(last_run_time=None)
+        Policy.objects.filter(id=policy.id).update(created_at=first_safe_time - timedelta(days=30))
+        mocker.patch("apps.log.tasks.policy.datetime").now.side_effect = [
+            first_safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS),
+            retry_safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS),
+        ]
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+        scan.return_value.run.side_effect = [RuntimeError("worker lost"), None]
+
+        with pytest.raises(RuntimeError, match="worker lost"):
+            scan_log_policy_task(policy.id)
+        policy.refresh_from_db()
+        initial_cursor = first_safe_time - timedelta(seconds=period_seconds)
+        assert policy.last_run_time == initial_cursor
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(initial_cursor.timestamp()), int(first_safe_time.timestamp())),
+            (int(initial_cursor.timestamp()), int(first_safe_time.timestamp())),
+        ]
+        assert scan.call_args_list[0].kwargs["execution_key"] == scan.call_args_list[1].kwargs["execution_key"]
+        policy.refresh_from_db()
+        assert policy.last_run_time == first_safe_time
+
     def test_single_window_run(self, mocker):
         # last_run_time 接近 now → backfill_count == 0 单周期分支
         recent = datetime.now(timezone.utc) - timedelta(seconds=120)
@@ -181,9 +211,9 @@ class TestScanLogPolicyTask:
         assert result["success"] is True
         assert scan.call_args_list[0].kwargs["execution_key"] == scan.call_args_list[1].kwargs["execution_key"]
         assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
-            (int(cursor.timestamp()) - period_seconds, int(cursor.timestamp()) + period_seconds // 2),
+            (int(cursor.timestamp()), int(cursor.timestamp()) + period_seconds // 2),
             (
-                int(cursor.timestamp()) - period_seconds,
+                int(cursor.timestamp()),
                 int(cursor.timestamp()) + period_seconds * 3 // 4,
             ),
         ]

--- a/server/apps/log/tests/test_tasks_policy.py
+++ b/server/apps/log/tests/test_tasks_policy.py
@@ -13,7 +13,7 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.log.constants.alert_policy import AlertConstants
 from apps.log.models.policy import Alert, Event, Policy
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
-from apps.log.tasks.policy import compensate_log_notice_task, scan_log_policy_task
+from apps.log.tasks.policy import _advance_policy_cursor, compensate_log_notice_task, scan_log_policy_task
 from apps.system_mgmt.models.channel import Channel
 
 pytestmark = pytest.mark.django_db
@@ -43,6 +43,55 @@ def _make_policy(**overrides):
 
 
 class TestScanLogPolicyTask:
+    @pytest.mark.parametrize(
+        ("delay_periods", "expected_windows", "expected_cursor_periods"),
+        [
+            (0.5, [(-1, 0.5)], 0.5),
+            (1, [(0, 1)], 1),
+            (1.5, [(0, 1)], 1),
+            (2, [(0, 1), (1, 2)], 2),
+        ],
+    )
+    def test_scan_window_boundaries(self, mocker, delay_periods, expected_windows, expected_cursor_periods):
+        period_seconds = 5 * 60
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_time = cursor + timedelta(seconds=period_seconds * delay_periods)
+        policy = _make_policy(last_run_time=cursor)
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS)
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (
+                int(cursor.timestamp() + start_period * period_seconds),
+                int(cursor.timestamp() + end_period * period_seconds),
+            )
+            for start_period, end_period in expected_windows
+        ]
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * expected_cursor_periods)
+
+    def test_backfill_overlap_does_not_break_cursor_continuity(self, mocker):
+        period_seconds = 5 * 60
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        safe_time = cursor + timedelta(seconds=period_seconds * 2)
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS)
+        mocker.patch.object(AlertConstants, "WINDOW_OVERLAP_SECONDS", 30)
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(cursor.timestamp()) - 30, int(cursor.timestamp()) + period_seconds),
+            (int(cursor.timestamp()) + period_seconds - 30, int(cursor.timestamp()) + period_seconds * 2),
+        ]
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * 2)
+
     def test_missing_policy_raises(self):
         with pytest.raises(BaseAppException, match="未找到"):
             scan_log_policy_task(999999)
@@ -101,10 +150,88 @@ class TestScanLogPolicyTask:
             scan_time=last_run_time + timedelta(seconds=period_seconds),
             window_start=int(last_run_time.timestamp()),
             window_end=int(last_run_time.timestamp()) + period_seconds,
+            execution_key=mocker.ANY,
+            cursor_time=last_run_time,
         )
         scan.return_value.run.assert_called_once_with()
         policy.refresh_from_db()
         assert policy.last_run_time == last_run_time + timedelta(seconds=period_seconds)
+
+    def test_failed_partial_window_reuses_cursor_identity_when_safe_time_moves(self, mocker):
+        period_seconds = 5 * 60
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_times = [
+            cursor + timedelta(seconds=period_seconds * 0.5),
+            cursor + timedelta(seconds=period_seconds * 0.75),
+        ]
+        policy = _make_policy(last_run_time=cursor)
+        mocker.patch("apps.log.tasks.policy.datetime").now.side_effect = [
+            safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS) for safe_time in safe_times
+        ]
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+        scan.return_value.run.side_effect = [RuntimeError("worker lost"), None]
+
+        with pytest.raises(RuntimeError, match="worker lost"):
+            scan_log_policy_task(policy.id)
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert scan.call_args_list[0].kwargs["execution_key"] == scan.call_args_list[1].kwargs["execution_key"]
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(cursor.timestamp()) - period_seconds, int(cursor.timestamp()) + period_seconds // 2),
+            (
+                int(cursor.timestamp()) - period_seconds,
+                int(cursor.timestamp()) + period_seconds * 3 // 4,
+            ),
+        ]
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * 0.75)
+
+    def test_backfill_resumes_from_second_window_after_mid_run_failure(self, mocker):
+        period_seconds = 5 * 60
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_times = [
+            cursor + timedelta(seconds=period_seconds * 2),
+            cursor + timedelta(seconds=period_seconds * 2.5),
+        ]
+        policy = _make_policy(last_run_time=cursor)
+        mocker.patch("apps.log.tasks.policy.datetime").now.side_effect = [
+            safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS) for safe_time in safe_times
+        ]
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+        scan.return_value.run.side_effect = [None, RuntimeError("second window failed"), None]
+
+        with pytest.raises(RuntimeError, match="second window failed"):
+            scan_log_policy_task(policy.id)
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds)
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(cursor.timestamp()), int(cursor.timestamp()) + period_seconds),
+            (int(cursor.timestamp()) + period_seconds, int(cursor.timestamp()) + period_seconds * 2),
+            (int(cursor.timestamp()) + period_seconds, int(cursor.timestamp()) + period_seconds * 2),
+        ]
+        assert scan.call_args_list[1].kwargs["execution_key"] == scan.call_args_list[2].kwargs["execution_key"]
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * 2)
+
+    def test_cursor_compare_and_swap_rejects_different_concurrent_window(self):
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        newer_scan_time = cursor + timedelta(minutes=4)
+
+        _advance_policy_cursor(policy.id, cursor, newer_scan_time)
+
+        with pytest.raises(RuntimeError, match="并发修改"):
+            _advance_policy_cursor(policy.id, cursor, cursor + timedelta(minutes=3))
+        policy.refresh_from_db()
+        assert policy.last_run_time == newer_scan_time
 
     def test_backfill_multiple_windows(self, mocker):
         # last_run_time 远早于 now → 多周期补偿
@@ -207,7 +334,9 @@ class TestCompensateLogNoticeTask:
 
     def test_successful_resend_marks_alert(self, mocker):
         policy = _make_policy(notice=True, enable=True, notice_users=["u1"])
-        alert = Alert.objects.create(id="a-c2", policy=policy, source_id="s", level="warning", status="new", start_event_time=dj_timezone.now(), notice=False)
+        alert = Alert.objects.create(
+            id="a-c2", policy=policy, source_id="s", level="warning", status="new", start_event_time=dj_timezone.now(), notice=False
+        )
         ev = self._make_event(policy, alert, id="ev-resend")
         mocker.patch(
             "apps.log.tasks.services.policy_scan.LogPolicyScan.send_notice",
@@ -223,7 +352,9 @@ class TestCompensateLogNoticeTask:
 
     def test_failed_resend_increments_retry(self, mocker):
         policy = _make_policy(notice=True, enable=True, notice_users=["u1"])
-        alert = Alert.objects.create(id="a-c3", policy=policy, source_id="s", level="warning", status="new", start_event_time=dj_timezone.now(), notice=False)
+        alert = Alert.objects.create(
+            id="a-c3", policy=policy, source_id="s", level="warning", status="new", start_event_time=dj_timezone.now(), notice=False
+        )
         ev = self._make_event(policy, alert, id="ev-fail")
         mocker.patch(
             "apps.log.tasks.services.policy_scan.LogPolicyScan.send_notice",
@@ -266,9 +397,7 @@ class TestCompensateLogNoticeTask:
             notice_type="nats",
             notice_type_id=channel.id,
         )
-        closed_at = dj_timezone.now() - timedelta(
-            seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS + 60
-        )
+        closed_at = dj_timezone.now() - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS + 60)
         alert = Alert.objects.create(
             id="a-closed-compensate",
             policy=policy,
@@ -300,9 +429,7 @@ class TestCompensateLogNoticeTask:
             notice_type="nats",
             notice_type_id=channel.id,
         )
-        closed_at = dj_timezone.now() - timedelta(
-            seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS + 60
-        )
+        closed_at = dj_timezone.now() - timedelta(seconds=AlertConstants.NOTICE_COMPENSATE_MIN_AGE_SECONDS + 60)
         alert = Alert.objects.create(
             id="a-closed-fail",
             policy=policy,

--- a/server/apps/log/tests/test_tasks_policy.py
+++ b/server/apps/log/tests/test_tasks_policy.py
@@ -4,16 +4,19 @@ LogPolicyScan 整体作为协作边界 mock（其内部逻辑已在 policy_scan 
 聚焦任务编排：启用判断、首次执行、单周期、补偿循环、last_run_time 落库、通知补偿筛选。
 S3 边界 stub。
 """
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from threading import Barrier
 
 import pytest
+from django.db import close_old_connections
 from django.utils import timezone as dj_timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.log.constants.alert_policy import AlertConstants
 from apps.log.models.policy import Alert, Event, Policy
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
-from apps.log.tasks.policy import _advance_policy_cursor, compensate_log_notice_task, scan_log_policy_task
+from apps.log.tasks.policy import _advance_policy_cursor, _run_policy_window, compensate_log_notice_task, scan_log_policy_task
 from apps.system_mgmt.models.channel import Channel
 
 pytestmark = pytest.mark.django_db
@@ -46,9 +49,9 @@ class TestScanLogPolicyTask:
     @pytest.mark.parametrize(
         ("delay_periods", "expected_windows", "expected_cursor_periods"),
         [
-            (0.5, [(0, 0.5)], 0.5),
+            (0.5, [(-0.5, 0.5)], 0.5),
             (1, [(0, 1)], 1),
-            (1.5, [(0, 1)], 1),
+            (1.5, [(0, 1), (0.5, 1.5)], 1.5),
             (2, [(0, 1), (1, 2)], 2),
         ],
     )
@@ -92,6 +95,57 @@ class TestScanLogPolicyTask:
         policy.refresh_from_db()
         assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * 2)
 
+    def test_backfill_tail_respects_24_hour_progress_limit(self, mocker):
+        period_seconds = 20 * 3600
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_time = cursor + timedelta(hours=39)
+        policy = _make_policy(
+            period={"type": "hour", "value": 20},
+            last_run_time=cursor,
+        )
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = safe_time + timedelta(
+            seconds=AlertConstants.INGEST_DELAY_SECONDS
+        )
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(cursor.timestamp()), int(cursor.timestamp()) + period_seconds),
+            (
+                int(cursor.timestamp()) + 4 * 3600,
+                int(cursor.timestamp()) + AlertConstants.MAX_BACKFILL_SECONDS,
+            ),
+        ]
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(seconds=AlertConstants.MAX_BACKFILL_SECONDS)
+
+    def test_backfill_tail_does_not_exceed_window_count_limit(self, mocker):
+        period_seconds = 3600
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_time = cursor + timedelta(hours=AlertConstants.MAX_BACKFILL_COUNT + 0.5)
+        policy = _make_policy(
+            period={"type": "hour", "value": 1},
+            last_run_time=cursor,
+        )
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = safe_time + timedelta(
+            seconds=AlertConstants.INGEST_DELAY_SECONDS
+        )
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert scan.call_count == AlertConstants.MAX_BACKFILL_COUNT
+        assert scan.call_args_list[-1].kwargs["window_end"] == int(
+            cursor.timestamp() + AlertConstants.MAX_BACKFILL_COUNT * period_seconds
+        )
+        policy.refresh_from_db()
+        assert policy.last_run_time == cursor + timedelta(
+            seconds=AlertConstants.MAX_BACKFILL_COUNT * period_seconds
+        )
+
     def test_missing_policy_raises(self):
         with pytest.raises(BaseAppException, match="未找到"):
             scan_log_policy_task(999999)
@@ -121,7 +175,7 @@ class TestScanLogPolicyTask:
         policy.refresh_from_db()
         assert policy.last_run_time is not None
 
-    def test_first_run_failure_persists_bounded_retry_window(self, mocker):
+    def test_first_run_failure_keeps_bounded_retry_window_without_advancing_cursor(self, mocker):
         period_seconds = 5 * 60
         first_safe_time = datetime(2026, 7, 24, tzinfo=timezone.utc)
         retry_safe_time = first_safe_time + timedelta(seconds=period_seconds // 4)
@@ -137,19 +191,26 @@ class TestScanLogPolicyTask:
         with pytest.raises(RuntimeError, match="worker lost"):
             scan_log_policy_task(policy.id)
         policy.refresh_from_db()
-        initial_cursor = first_safe_time - timedelta(seconds=period_seconds)
-        assert policy.last_run_time == initial_cursor
+        assert policy.last_run_time is None
 
         result = scan_log_policy_task(policy.id)
 
         assert result["success"] is True
         assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
-            (int(initial_cursor.timestamp()), int(first_safe_time.timestamp())),
-            (int(initial_cursor.timestamp()), int(first_safe_time.timestamp())),
+            (
+                int(first_safe_time.timestamp()) - period_seconds,
+                int(first_safe_time.timestamp()),
+            ),
+            (
+                int(retry_safe_time.timestamp()) - period_seconds,
+                int(retry_safe_time.timestamp()),
+            ),
         ]
         assert scan.call_args_list[0].kwargs["execution_key"] == scan.call_args_list[1].kwargs["execution_key"]
+        assert scan.call_args_list[0].kwargs["cursor_time"] is None
+        assert scan.call_args_list[1].kwargs["cursor_time"] is None
         policy.refresh_from_db()
-        assert policy.last_run_time == first_safe_time
+        assert policy.last_run_time == retry_safe_time
 
     def test_single_window_run(self, mocker):
         # last_run_time 接近 now → backfill_count == 0 单周期分支
@@ -175,17 +236,16 @@ class TestScanLogPolicyTask:
         result = scan_log_policy_task(policy.id)
 
         assert result["success"] is True
-        scan.assert_called_once_with(
-            mocker.ANY,
-            scan_time=last_run_time + timedelta(seconds=period_seconds),
-            window_start=int(last_run_time.timestamp()),
-            window_end=int(last_run_time.timestamp()) + period_seconds,
-            execution_key=mocker.ANY,
-            cursor_time=last_run_time,
-        )
-        scan.return_value.run.assert_called_once_with()
+        assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
+            (int(last_run_time.timestamp()), int(last_run_time.timestamp()) + period_seconds),
+            (
+                int(safe_time.timestamp()) - period_seconds,
+                int(safe_time.timestamp()),
+            ),
+        ]
+        assert scan.return_value.run.call_count == 2
         policy.refresh_from_db()
-        assert policy.last_run_time == last_run_time + timedelta(seconds=period_seconds)
+        assert policy.last_run_time == safe_time
 
     def test_failed_partial_window_reuses_cursor_identity_when_safe_time_moves(self, mocker):
         period_seconds = 5 * 60
@@ -211,10 +271,13 @@ class TestScanLogPolicyTask:
         assert result["success"] is True
         assert scan.call_args_list[0].kwargs["execution_key"] == scan.call_args_list[1].kwargs["execution_key"]
         assert [(call.kwargs["window_start"], call.kwargs["window_end"]) for call in scan.call_args_list] == [
-            (int(cursor.timestamp()), int(cursor.timestamp()) + period_seconds // 2),
             (
-                int(cursor.timestamp()),
-                int(cursor.timestamp()) + period_seconds * 3 // 4,
+                int(safe_times[0].timestamp()) - period_seconds,
+                int(safe_times[0].timestamp()),
+            ),
+            (
+                int(safe_times[1].timestamp()) - period_seconds,
+                int(safe_times[1].timestamp()),
             ),
         ]
         policy.refresh_from_db()
@@ -232,7 +295,7 @@ class TestScanLogPolicyTask:
             safe_time + timedelta(seconds=AlertConstants.INGEST_DELAY_SECONDS) for safe_time in safe_times
         ]
         scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
-        scan.return_value.run.side_effect = [None, RuntimeError("second window failed"), None]
+        scan.return_value.run.side_effect = [None, RuntimeError("second window failed"), None, None]
 
         with pytest.raises(RuntimeError, match="second window failed"):
             scan_log_policy_task(policy.id)
@@ -246,22 +309,99 @@ class TestScanLogPolicyTask:
             (int(cursor.timestamp()), int(cursor.timestamp()) + period_seconds),
             (int(cursor.timestamp()) + period_seconds, int(cursor.timestamp()) + period_seconds * 2),
             (int(cursor.timestamp()) + period_seconds, int(cursor.timestamp()) + period_seconds * 2),
+            (
+                int(safe_times[1].timestamp()) - period_seconds,
+                int(safe_times[1].timestamp()),
+            ),
         ]
         assert scan.call_args_list[1].kwargs["execution_key"] == scan.call_args_list[2].kwargs["execution_key"]
         policy.refresh_from_db()
-        assert policy.last_run_time == cursor + timedelta(seconds=period_seconds * 2)
+        assert policy.last_run_time == safe_times[1]
 
-    def test_cursor_compare_and_swap_rejects_different_concurrent_window(self):
+    def test_cursor_compare_and_swap_converges_to_latest_completed_window(self):
         cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
         policy = _make_policy(last_run_time=cursor)
-        newer_scan_time = cursor + timedelta(minutes=4)
+        earlier_scan_time = cursor + timedelta(minutes=3)
+        later_scan_time = cursor + timedelta(minutes=4)
 
-        _advance_policy_cursor(policy.id, cursor, newer_scan_time)
+        _advance_policy_cursor(policy.id, cursor, earlier_scan_time)
+        _advance_policy_cursor(policy.id, cursor, later_scan_time)
+        _advance_policy_cursor(policy.id, cursor, earlier_scan_time)
 
-        with pytest.raises(RuntimeError, match="并发修改"):
-            _advance_policy_cursor(policy.id, cursor, cursor + timedelta(minutes=3))
         policy.refresh_from_db()
-        assert policy.last_run_time == newer_scan_time
+        assert policy.last_run_time == later_scan_time
+
+    def test_local_backfill_sequence_does_not_jump_to_concurrent_db_cursor(self, mocker):
+        period_seconds = 5 * 60
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        safe_time = cursor + timedelta(seconds=period_seconds * 2)
+        remote_cursor = cursor + timedelta(seconds=period_seconds * 4)
+        policy = _make_policy(last_run_time=cursor)
+        mocker.patch("apps.log.tasks.policy.datetime").now.return_value = safe_time + timedelta(
+            seconds=AlertConstants.INGEST_DELAY_SECONDS
+        )
+        scan = mocker.patch("apps.log.tasks.policy.LogPolicyScan")
+        run_count = 0
+
+        def advance_remote_cursor():
+            nonlocal run_count
+            run_count += 1
+            if run_count == 1:
+                Policy.objects.filter(id=policy.id).update(last_run_time=remote_cursor)
+
+        scan.return_value.run.side_effect = advance_remote_cursor
+
+        result = scan_log_policy_task(policy.id)
+
+        assert result["success"] is True
+        assert [call.kwargs["scan_time"] for call in scan.call_args_list] == [
+            cursor + timedelta(seconds=period_seconds),
+            safe_time,
+        ]
+        policy.refresh_from_db()
+        assert policy.last_run_time == remote_cursor
+
+    @pytest.mark.django_db(transaction=True)
+    def test_concurrent_disjoint_windows_keep_side_effects_and_converge_cursor(self, mocker):
+        cursor = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        policy = _make_policy(last_run_time=cursor)
+        scan_times = [
+            cursor + timedelta(minutes=3),
+            cursor + timedelta(minutes=4),
+        ]
+        barrier = Barrier(2)
+        side_effects = []
+
+        class DisjointSourceScan:
+            def __init__(self, policy_obj, *, scan_time, **kwargs):
+                self.scan_time = scan_time
+
+            def run(self):
+                side_effects.append(f"source-{self.scan_time.minute}")
+                barrier.wait(timeout=5)
+
+        mocker.patch("apps.log.tasks.policy.LogPolicyScan", DisjointSourceScan)
+
+        def run_window(scan_time):
+            close_old_connections()
+            try:
+                _run_policy_window(
+                    Policy.objects.get(id=policy.id),
+                    cursor_time=cursor,
+                    scan_time=scan_time,
+                    period_seconds=5 * 60,
+                    overlap_seconds=0,
+                )
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(run_window, scan_time) for scan_time in scan_times]
+            [future.result() for future in futures]
+
+        policy.refresh_from_db()
+        assert sorted(side_effects) == ["source-3", "source-4"]
+        assert policy.last_run_time == max(scan_times)
 
     def test_backfill_multiple_windows(self, mocker):
         # last_run_time 远早于 now → 多周期补偿


### PR DESCRIPTION
## 关联问题

Fixes #4082

## 问题

日志策略任务延迟后，旧逻辑只执行当前调度点的一次扫描，`last_run_time` 与实际查询窗口又没有形成可靠的逐窗提交关系，可能漏掉延迟期间的数据。失败重试、并发执行和生命周期通知还可能产生游标前进但数据未完成、旧结果覆盖新结果或重复通知。

## 修复

- 以 `last_run_time` 为成功游标，按完整 `period` 逐窗补扫；不足一个周期时执行一个以有效安全时间为终点、宽度仍为完整 `period` 的尾部滚动窗口。
- 单轮进度同时受“最多 10 个窗口”和“最多 24 小时”限制，尾部窗口也不能绕过上限。
- 每个窗口成功后才推进游标；正常生产入口继续由 `celery-singleton` 按 `policy_id` 排他。若排他锁被绕过，已完成窗口通过数据库原子更新单调汇合到最大游标，不再出现“副作用已发生但任务因 CAS 失败而重扫”。
- 同一游标的重试使用稳定执行身份和稳定 Event ID，并兼容升级前已写入的随机 UUID Event。
- Event、Alert、RawData 和 Snapshot 均按事件时间单调更新；关闭告警不会被旧扫描重新打开或覆盖，旧 worker 晚提交快照时不会回退较新数据。
- 更新与通知统一按 Event → Alert 顺序加行锁，不依赖仅部分数据库支持的 `FOR UPDATE OF` 语法。
- EventRawData 更新后在事务提交时清理旧 S3 对象；迁移 `0018_alter_eventrawdata_data` 只同步字段状态，不改写现有业务数据。
- 通知以 Event 行锁领取，成功状态在同级重试中保留；告警中心 created 成功后会对账并补发并发发生的 closed。通道发送语义为有界 best-effort，极端的“发送成功但事务提交前进程退出”仍可能重放。

## 验证

- 相关 Server 回归：129 passed。
- 覆盖 0.5P / 1P / 1.5P / 2P、首次失败、补扫中途失败、24 小时与 10 窗口上限、同游标并发汇合、本地补扫不越过自身安全时间。
- 覆盖不支持 `FOR UPDATE OF` 的后端特性、关闭告警保护、通知领取、旧 worker 反序提交以及 Event / Alert / RawData / Snapshot 最终保持较新版本。
- `makemigrations --check --dry-run`：No changes detected。

## 风险与回滚

- 查询量仍受原有单轮补扫上限约束；尾部窗口保持完整 `period` 聚合语义。
- 对象存储清理由 `transaction.on_commit` 触发，数据库回滚时不会误删旧对象。
- 如需回滚，可整体回退本 PR；迁移不包含数据转换。
