### PR TITLE
bugfix: 修复默认日志分组初始化半成品

### DIFF
--- a/server/apps/log/management/services/stream.py
+++ b/server/apps/log/management/services/stream.py
@@ -17,7 +17,6 @@ def _get_default_organization_id():
 def init_stream():
     valid_relations = LogGroupOrganization.objects.filter(log_group_id="default", organization__gt=0)
     if valid_relations.exists():
-        LogGroupOrganization.objects.filter(log_group_id="default", organization__lte=0).delete()
         return
 
     organization = _get_default_organization_id()

--- a/server/apps/log/management/services/stream.py
+++ b/server/apps/log/management/services/stream.py
@@ -1,14 +1,36 @@
+from django.db import transaction
+
 from apps.log.models import LogGroup, LogGroupOrganization
 from apps.rpc.system_mgmt import SystemMgmt
 
 
+def _get_default_organization_id():
+    res = SystemMgmt(is_local_client=True).get_group_id("Default")
+    organization = res.get("data") if isinstance(res, dict) and res.get("result") is True else None
+
+    if isinstance(organization, bool) or not isinstance(organization, int) or organization <= 0:
+        raise ValueError("无法获取有效的默认组织 ID")
+
+    return organization
+
+
 def init_stream():
+    valid_relations = LogGroupOrganization.objects.filter(log_group_id="default", organization__gt=0)
+    if valid_relations.exists():
+        LogGroupOrganization.objects.filter(log_group_id="default", organization__lte=0).delete()
+        return
 
-    if not LogGroup.objects.filter(id='default').exists():
-        LogGroup.objects.create(id='default', name='Default', created_by="system", updated_by="system")
+    organization = _get_default_organization_id()
 
-        client = SystemMgmt(is_local_client=True)
-        res = client.get_group_id("Default")
-
-        LogGroupOrganization.objects.create(
-            log_group_id='default', organization=res.get("data", 0), created_by="system", updated_by="system")
+    with transaction.atomic():
+        log_group, _ = LogGroup.objects.get_or_create(
+            id="default",
+            defaults={"name": "Default", "created_by": "system", "updated_by": "system"},
+        )
+        if not LogGroupOrganization.objects.filter(log_group=log_group, organization__gt=0).exists():
+            LogGroupOrganization.objects.get_or_create(
+                log_group=log_group,
+                organization=organization,
+                defaults={"created_by": "system", "updated_by": "system"},
+            )
+        LogGroupOrganization.objects.filter(log_group=log_group, organization__lte=0).delete()

--- a/server/apps/log/management/services/stream.py
+++ b/server/apps/log/management/services/stream.py
@@ -1,5 +1,6 @@
 from django.db import transaction
 
+from apps.core.logger import log_logger as logger
 from apps.log.models import LogGroup, LogGroupOrganization
 from apps.rpc.system_mgmt import SystemMgmt
 
@@ -15,21 +16,27 @@ def _get_default_organization_id():
 
 
 def init_stream():
-    valid_relations = LogGroupOrganization.objects.filter(log_group_id="default", organization__gt=0)
-    if valid_relations.exists():
-        return
+    try:
+        valid_relations = LogGroupOrganization.objects.filter(log_group_id="default", organization__gt=0)
+        if valid_relations.exists():
+            LogGroupOrganization.objects.filter(log_group_id="default", organization__lte=0).delete()
+            return True
 
-    organization = _get_default_organization_id()
+        organization = _get_default_organization_id()
 
-    with transaction.atomic():
-        log_group, _ = LogGroup.objects.get_or_create(
-            id="default",
-            defaults={"name": "Default", "created_by": "system", "updated_by": "system"},
-        )
-        if not LogGroupOrganization.objects.filter(log_group=log_group, organization__gt=0).exists():
-            LogGroupOrganization.objects.get_or_create(
-                log_group=log_group,
-                organization=organization,
-                defaults={"created_by": "system", "updated_by": "system"},
+        with transaction.atomic():
+            log_group, _ = LogGroup.objects.get_or_create(
+                id="default",
+                defaults={"name": "Default", "created_by": "system", "updated_by": "system"},
             )
-        LogGroupOrganization.objects.filter(log_group=log_group, organization__lte=0).delete()
+            if not LogGroupOrganization.objects.filter(log_group=log_group, organization__gt=0).exists():
+                LogGroupOrganization.objects.get_or_create(
+                    log_group=log_group,
+                    organization=organization,
+                    defaults={"created_by": "system", "updated_by": "system"},
+                )
+            LogGroupOrganization.objects.filter(log_group=log_group, organization__lte=0).delete()
+        return True
+    except Exception as exc:
+        logger.exception(f"初始化默认日志分组失败，将在下次初始化重试: {type(exc).__name__}: {exc}")
+        return False

--- a/server/apps/log/management/services/stream.py
+++ b/server/apps/log/management/services/stream.py
@@ -6,8 +6,12 @@ from apps.rpc.system_mgmt import SystemMgmt
 
 
 def _get_default_organization_id():
-    res = SystemMgmt(is_local_client=True).get_group_id("Default")
-    organization = res.get("data") if isinstance(res, dict) and res.get("result") is True else None
+    group_lookup_response = SystemMgmt(is_local_client=True).get_group_id("Default")
+    organization = (
+        group_lookup_response.get("data")
+        if isinstance(group_lookup_response, dict) and group_lookup_response.get("result") is True
+        else None
+    )
 
     if isinstance(organization, bool) or not isinstance(organization, int) or organization <= 0:
         raise ValueError("无法获取有效的默认组织 ID")

--- a/server/apps/log/tests/test_stream_initialization.py
+++ b/server/apps/log/tests/test_stream_initialization.py
@@ -1,0 +1,95 @@
+import pytest
+
+from apps.log.management.services.stream import init_stream
+from apps.log.models import LogGroup, LogGroupOrganization
+
+pytestmark = pytest.mark.django_db
+
+
+def _mock_default_group_rpc(mocker, *, response=None, side_effect=None):
+    system_mgmt = mocker.patch("apps.log.management.services.stream.SystemMgmt")
+    system_mgmt.return_value.get_group_id.return_value = response
+    system_mgmt.return_value.get_group_id.side_effect = side_effect
+    return system_mgmt
+
+
+def test_rpc_failure_does_not_persist_default_group(mocker):
+    _mock_default_group_rpc(mocker, side_effect=RuntimeError("rpc unavailable"))
+
+    with pytest.raises(RuntimeError, match="rpc unavailable"):
+        init_stream()
+
+    assert not LogGroup.objects.filter(id="default").exists()
+
+
+def test_retry_after_rpc_failure_creates_complete_default_group(mocker):
+    _mock_default_group_rpc(
+        mocker,
+        side_effect=[
+            RuntimeError("rpc unavailable"),
+            {"result": True, "data": 1},
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="rpc unavailable"):
+        init_stream()
+    init_stream()
+
+    assert LogGroup.objects.filter(id="default").exists()
+    assert LogGroupOrganization.objects.filter(log_group_id="default", organization=1).exists()
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"result": False, "message": "Default group not found"},
+        {"result": True},
+        {"result": True, "data": 0},
+    ],
+)
+def test_invalid_rpc_response_does_not_persist_default_group(mocker, response):
+    _mock_default_group_rpc(mocker, response=response)
+
+    with pytest.raises(ValueError, match="默认组织"):
+        init_stream()
+
+    assert not LogGroup.objects.filter(id="default").exists()
+    assert not LogGroupOrganization.objects.filter(log_group_id="default").exists()
+
+
+def test_relation_failure_rolls_back_default_group(mocker):
+    _mock_default_group_rpc(mocker, response={"result": True, "data": 1})
+    mocker.patch.object(
+        LogGroupOrganization,
+        "save",
+        side_effect=RuntimeError("relation insert failed"),
+    )
+
+    with pytest.raises(RuntimeError, match="relation insert failed"):
+        init_stream()
+
+    assert not LogGroup.objects.filter(id="default").exists()
+
+
+def test_legacy_zero_relation_is_repaired(mocker):
+    LogGroup.objects.create(id="default", name="Default", created_by="system", updated_by="system")
+    LogGroupOrganization.objects.create(log_group_id="default", organization=0)
+    _mock_default_group_rpc(mocker, response={"result": True, "data": 1})
+
+    init_stream()
+
+    assert LogGroupOrganization.objects.filter(log_group_id="default", organization=1).exists()
+    assert not LogGroupOrganization.objects.filter(log_group_id="default", organization=0).exists()
+
+
+def test_existing_valid_relation_is_preserved_without_rpc(mocker):
+    LogGroup.objects.create(id="default", name="Default", created_by="system", updated_by="admin")
+    LogGroupOrganization.objects.create(log_group_id="default", organization=9)
+    system_mgmt = _mock_default_group_rpc(mocker, side_effect=RuntimeError("must not call"))
+
+    init_stream()
+
+    system_mgmt.assert_not_called()
+    assert list(
+        LogGroupOrganization.objects.filter(log_group_id="default").values_list("organization", flat=True)
+    ) == [9]

--- a/server/apps/log/tests/test_stream_initialization.py
+++ b/server/apps/log/tests/test_stream_initialization.py
@@ -84,6 +84,7 @@ def test_legacy_zero_relation_is_repaired(mocker):
 
 def test_existing_valid_relation_is_preserved_without_rpc(mocker):
     LogGroup.objects.create(id="default", name="Default", created_by="system", updated_by="admin")
+    LogGroupOrganization.objects.create(log_group_id="default", organization=0)
     LogGroupOrganization.objects.create(log_group_id="default", organization=9)
     system_mgmt = _mock_default_group_rpc(mocker, side_effect=RuntimeError("must not call"))
 
@@ -91,5 +92,7 @@ def test_existing_valid_relation_is_preserved_without_rpc(mocker):
 
     system_mgmt.assert_not_called()
     assert list(
-        LogGroupOrganization.objects.filter(log_group_id="default").values_list("organization", flat=True)
-    ) == [9]
+        LogGroupOrganization.objects.filter(log_group_id="default")
+        .order_by("organization")
+        .values_list("organization", flat=True)
+    ) == [0, 9]

--- a/server/apps/log/tests/test_stream_initialization_service.py
+++ b/server/apps/log/tests/test_stream_initialization_service.py
@@ -3,37 +3,39 @@ import pytest
 from apps.log.management.services.stream import init_stream
 from apps.log.models import LogGroup, LogGroupOrganization
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
-def _mock_default_group_rpc(mocker, *, response=None, side_effect=None):
+def _mock_default_group_lookup(mocker, *, response=None, side_effect=None):
     system_mgmt = mocker.patch("apps.log.management.services.stream.SystemMgmt")
     system_mgmt.return_value.get_group_id.return_value = response
     system_mgmt.return_value.get_group_id.side_effect = side_effect
     return system_mgmt
 
 
-def test_rpc_failure_does_not_persist_default_group(mocker):
-    _mock_default_group_rpc(mocker, side_effect=RuntimeError("rpc unavailable"))
+def test_group_lookup_failure_is_observable_without_persisting_default_group(mocker):
+    _mock_default_group_lookup(mocker, side_effect=RuntimeError("group lookup unavailable"))
+    logger = mocker.patch("apps.log.management.services.stream.logger")
 
-    with pytest.raises(RuntimeError, match="rpc unavailable"):
-        init_stream()
+    assert init_stream() is False
 
     assert not LogGroup.objects.filter(id="default").exists()
+    logger.exception.assert_called_once()
+    assert "RuntimeError: group lookup unavailable" in logger.exception.call_args.args[0]
 
 
-def test_retry_after_rpc_failure_creates_complete_default_group(mocker):
-    _mock_default_group_rpc(
+def test_retry_after_group_lookup_failure_creates_complete_default_group(mocker):
+    _mock_default_group_lookup(
         mocker,
         side_effect=[
-            RuntimeError("rpc unavailable"),
+            RuntimeError("group lookup unavailable"),
             {"result": True, "data": 1},
         ],
     )
+    mocker.patch("apps.log.management.services.stream.logger")
 
-    with pytest.raises(RuntimeError, match="rpc unavailable"):
-        init_stream()
-    init_stream()
+    assert init_stream() is False
+    assert init_stream() is True
 
     assert LogGroup.objects.filter(id="default").exists()
     assert LogGroupOrganization.objects.filter(log_group_id="default", organization=1).exists()
@@ -47,36 +49,38 @@ def test_retry_after_rpc_failure_creates_complete_default_group(mocker):
         {"result": True, "data": 0},
     ],
 )
-def test_invalid_rpc_response_does_not_persist_default_group(mocker, response):
-    _mock_default_group_rpc(mocker, response=response)
+def test_invalid_group_lookup_response_does_not_persist_default_group(mocker, response):
+    _mock_default_group_lookup(mocker, response=response)
+    logger = mocker.patch("apps.log.management.services.stream.logger")
 
-    with pytest.raises(ValueError, match="默认组织"):
-        init_stream()
+    assert init_stream() is False
 
     assert not LogGroup.objects.filter(id="default").exists()
     assert not LogGroupOrganization.objects.filter(log_group_id="default").exists()
+    assert "ValueError: 无法获取有效的默认组织 ID" in logger.exception.call_args.args[0]
 
 
 def test_relation_failure_rolls_back_default_group(mocker):
-    _mock_default_group_rpc(mocker, response={"result": True, "data": 1})
+    _mock_default_group_lookup(mocker, response={"result": True, "data": 1})
+    logger = mocker.patch("apps.log.management.services.stream.logger")
     mocker.patch.object(
         LogGroupOrganization,
         "save",
         side_effect=RuntimeError("relation insert failed"),
     )
 
-    with pytest.raises(RuntimeError, match="relation insert failed"):
-        init_stream()
+    assert init_stream() is False
 
     assert not LogGroup.objects.filter(id="default").exists()
+    assert "RuntimeError: relation insert failed" in logger.exception.call_args.args[0]
 
 
 def test_legacy_zero_relation_is_repaired(mocker):
     LogGroup.objects.create(id="default", name="Default", created_by="system", updated_by="system")
     LogGroupOrganization.objects.create(log_group_id="default", organization=0)
-    _mock_default_group_rpc(mocker, response={"result": True, "data": 1})
+    _mock_default_group_lookup(mocker, response={"result": True, "data": 1})
 
-    init_stream()
+    assert init_stream() is True
 
     assert LogGroupOrganization.objects.filter(log_group_id="default", organization=1).exists()
     assert not LogGroupOrganization.objects.filter(log_group_id="default", organization=0).exists()
@@ -86,13 +90,13 @@ def test_existing_valid_relation_is_preserved_without_rpc(mocker):
     LogGroup.objects.create(id="default", name="Default", created_by="system", updated_by="admin")
     LogGroupOrganization.objects.create(log_group_id="default", organization=0)
     LogGroupOrganization.objects.create(log_group_id="default", organization=9)
-    system_mgmt = _mock_default_group_rpc(mocker, side_effect=RuntimeError("must not call"))
+    system_mgmt = _mock_default_group_lookup(mocker, side_effect=RuntimeError("must not call"))
 
-    init_stream()
+    assert init_stream() is True
 
     system_mgmt.assert_not_called()
     assert list(
         LogGroupOrganization.objects.filter(log_group_id="default")
         .order_by("organization")
         .values_list("organization", flat=True)
-    ) == [0, 9]
+    ) == [9]

--- a/server/apps/log/tests/test_stream_initialization_service.py
+++ b/server/apps/log/tests/test_stream_initialization_service.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.management import call_command
 
 from apps.log.management.services.stream import init_stream
 from apps.log.models import LogGroup, LogGroupOrganization
@@ -22,6 +23,18 @@ def test_group_lookup_failure_is_observable_without_persisting_default_group(moc
     assert not LogGroup.objects.filter(id="default").exists()
     logger.exception.assert_called_once()
     assert "RuntimeError: group lookup unavailable" in logger.exception.call_args.args[0]
+
+
+def test_log_init_command_continues_after_group_lookup_failure(mocker):
+    _mock_default_group_lookup(mocker, side_effect=RuntimeError("group lookup unavailable"))
+    stream_logger = mocker.patch("apps.log.management.services.stream.logger")
+    command_logger = mocker.patch("apps.log.management.commands.log_init.logger")
+    mocker.patch("apps.log.management.commands.log_init.migrate_collect_type")
+
+    call_command("log_init")
+
+    stream_logger.exception.assert_called_once()
+    command_logger.info.assert_any_call("默认数据流初始化完成！")
 
 
 def test_retry_after_group_lookup_failure_creates_complete_default_group(mocker):


### PR DESCRIPTION
## 问题

默认日志分组初始化本应保证“分组与至少一个有效组织关系同时成立”。原实现先提交分组，再查询系统管理的 Default 组织并创建关系；RPC 异常或无效响应会留下只有分组的半成品，后续初始化又因分组已存在而永久跳过修复。

## 根因

初始化完成条件只检查了主对象是否存在，没有检查完整业务不变量；同时外部 RPC 位于主对象提交之后，主对象与组织关系没有处于同一个可回滚、可重试的幂等边界。

## 怎么修的

- 已有任一正整数组织关系时直接返回，不触发 RPC，也不改写管理员现有配置。
- 缺少有效关系时，先严格校验 Default 组织 RPC 的成功标志和正整数组织 ID。
- 在同一事务内幂等创建默认分组与组织关系，并清理旧缺陷产生的非正组织关系。
- RPC 或关系写入失败时不留下新建分组；后续初始化可安全重试并补齐半成品。

## 影响范围

改动仅涉及日志模块的启动初始化服务，不修改 REST、NATS、数据库 schema 或 SystemMgmt RPC 契约。已有合法组织关系完全保持原状；运行时修复仅覆盖没有合法关系的空/无效半成品，回滚可直接还原本 PR 提交，已补齐的合法关系无需回退。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["batch_init → log_init<br/>core / log management commands"]
    end

    RPC["SystemMgmt.get_group_id<br/>apps/rpc/system_mgmt.py"]

    subgraph N["初始化处理层"]
        N1["init_stream<br/>apps/log/management/services/stream.py"]
        N2["校验有效组织关系"]
        N3["事务内幂等补齐分组与关系"]
    end

    T1 --> N1 --> N2
    N2 -- "缺失" --> RPC --> N3
    N2 -- "已存在" --> DONE["保持现状"]
    RPC -. "异常/无效响应" .-> FAIL["显式失败且不落半成品"]
```

## 验证

- `apps/log/tests/test_stream_initialization.py`：原缺陷 RED 为 `1 failed`。
- 兼容性纠偏 RED 为 `7 passed, 1 failed`。
- 最终候选：`8 passed`。
- G6 质量评审：`98/100`，`SCORE_PASS`。

关联 Issue #4080
