### PR TITLE
feat: refine JVM monitoring dashboard

### DIFF
--- a/web/src/app/monitor/dashboards/objects/common/object-dashboard-page.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/object-dashboard-page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import { DashboardShell, DetailSection, KpiSection, TrendSection } from './dashboard-components';
+import { useSimpleDashboardData, type SimpleDashboardConfig } from './simple-dashboard-core';
+
+interface TrendSectionConfig {
+  title: string;
+  chartTitles: string[];
+}
+
+export function ObjectDashboardPage({
+  config,
+  styles,
+  trendSections
+}: {
+  config: SimpleDashboardConfig;
+  styles: Record<string, string>;
+  trendSections?: TrendSectionConfig[];
+}) {
+  const dashboard = useSimpleDashboardData(config);
+  const sections = trendSections || [{ title: '关键趋势', chartTitles: dashboard.chartPanels.map(({ chart }) => chart.title) }];
+  return (
+    <DashboardShell dashboard={dashboard} styles={styles} dashboardContent={(
+      <>
+        <div className={styles.sectionLabel}>健康概览</div>
+        <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} styles={styles} />
+        {sections.map((section) => {
+          const charts = dashboard.chartPanels.filter(({ chart }) => section.chartTitles.includes(chart.title));
+          if (charts.length === 0) return null;
+          return (
+            <React.Fragment key={section.title}>
+              <div className={styles.sectionLabel}>{section.title}</div>
+              <TrendSection charts={charts} onXRangeChange={dashboard.onXRangeChange} loading={dashboard.loading} styles={styles} />
+            </React.Fragment>
+          );
+        })}
+        <div className={styles.sectionLabel}>诊断指标</div>
+        <DetailSection detailPanels={dashboard.detailPanels} styles={styles} />
+      </>
+    )} />
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/jvm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/jvm/config.ts
@@ -1,10 +1,4 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
-import type { MetricEnumMap } from '../../shared/types';
-
-const JMX_SCRAPE_ERROR_ENUM: MetricEnumMap = {
-  0: { label: '采集正常', color: '#27c274' },
-  1: { label: '采集报错', color: '#ff4d4f' }
-};
 
 export const JVM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'jvm',
@@ -31,15 +25,12 @@ export const JVM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     { name: 'bufferCapacity', display_name: 'NIO 缓冲容量', description: 'Java NIO 缓冲池总容量。', unit: 'bytes', query: 'sum(jvm_bufferpool_totalcapacity_value{__$labels__}) by (instance_id)', color: '#597ef7' },
     { name: 'physicalFree', display_name: '宿主可用内存', description: 'JVM 所在宿主机当前可用物理内存。', unit: 'bytes', query: 'jvm_os_memory_physical_free_value{__$labels__}', color: '#27c274' },
     { name: 'physicalTotal', display_name: '宿主总内存', description: 'JVM 所在宿主机物理内存总量。', unit: 'bytes', query: 'jvm_os_memory_physical_total_value{__$labels__}', color: '#9aa9bf' },
-    { name: 'swapFree', display_name: '可用交换空间', description: 'JVM 所在宿主机当前可用交换空间。', unit: 'bytes', query: 'jvm_os_memory_swap_free_value{__$labels__}', color: '#13c2c2' },
-    { name: 'scrapeDuration', display_name: '采集耗时', description: '最近一次 JMX 采集耗时。', unit: 's', query: 'jmx_scrape_duration_seconds_gauge{__$labels__}', color: '#597ef7' },
-    { name: 'scrapeError', display_name: '采集状态', description: 'JMX 采集状态，0 为正常、1 为报错。', unit: 'none', query: 'jmx_scrape_error_gauge{__$labels__}', color: '#ff4d4f' }
+    { name: 'swapFree', display_name: '可用交换空间', description: 'JVM 所在宿主机当前可用交换空间。', unit: 'bytes', query: 'jvm_os_memory_swap_free_value{__$labels__}', color: '#13c2c2' }
   ],
   summaryCards: [
     { title: '堆使用率', metric: 'heapUsageRatio', color: '#2f6bff', icon: 'memory', compare: true, compareFavorableDirection: 'down', guide: [{ label: '堆容量风险', detail: '持续逼近 100% 时，优先排查内存泄漏、堆配置和 GC 压力。' }], footer: [{ label: '已用', metric: 'heapUsed', unit: 'bytes' }, { label: '已提交', metric: 'heapCommitted', unit: 'bytes' }, { label: '上限', metric: 'heapMax', unit: 'bytes' }] },
     { title: 'GC 时间占比', metric: 'gcTimeRatio', color: '#ff4d4f', icon: 'clock', compare: true, compareFavorableDirection: 'down', guide: [{ label: 'GC 开销', detail: '最近五分钟内 GC 实际占用的时间比例；升高表示应用有效执行时间被回收挤占。' }], footer: [{ label: 'GC 频率', metric: 'gcCountRate', unit: 'cps' }] },
-    { title: '当前线程数', metric: 'threads', color: '#ff8a1f', icon: 'node', compare: true, compareFavorableDirection: 'down', guide: [{ label: '线程异常', detail: '持续高于历史水平时，结合守护线程和峰值线程判断请求堆积或线程泄漏。' }], footer: [{ label: '守护线程', metric: 'daemonThreads', unit: 'counts' }, { label: '历史峰值', metric: 'peakThreads', unit: 'counts' }] },
-    { title: 'JMX 采集状态', metric: 'scrapeError', color: '#27c274', icon: 'health', enumMap: JMX_SCRAPE_ERROR_ENUM, guide: [{ label: '数据可信度', detail: '采集报错时，当前页其余指标可能过期或缺失，应先恢复 JMX 连通性。' }], footer: [{ label: '采集耗时', metric: 'scrapeDuration', unit: 's' }] }
+    { title: '当前线程数', metric: 'threads', color: '#ff8a1f', icon: 'node', compare: true, compareFavorableDirection: 'down', guide: [{ label: '线程异常', detail: '持续高于历史水平时，结合守护线程和峰值线程判断请求堆积或线程泄漏。' }], footer: [{ label: '守护线程', metric: 'daemonThreads', unit: 'counts' }, { label: '历史峰值', metric: 'peakThreads', unit: 'counts' }] }
   ],
   charts: [
     { title: '堆容量趋势', subtitle: '已用、已提交与最大堆内存', metric: 'heapUsed', guide: [{ label: '堆容量', detail: '已用内存接近已提交或最大堆内存时，GC 压力与 OOM 风险上升；虚线为最大堆上限。' }], series: [{ metric: 'heapUsed', label: '已用', color: '#2f6bff', unit: 'bytes' }, { metric: 'heapCommitted', label: '已提交', color: '#13c2c2', unit: 'bytes' }, { metric: 'heapMax', label: '最大堆', color: '#9aa9bf', unit: 'bytes', style: 'limit' }] },

--- a/web/src/app/monitor/dashboards/objects/jvm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/jvm/config.ts
@@ -1,0 +1,54 @@
+import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+import type { MetricEnumMap } from '../../shared/types';
+
+const JMX_SCRAPE_ERROR_ENUM: MetricEnumMap = {
+  0: { label: '采集正常', color: '#27c274' },
+  1: { label: '采集报错', color: '#ff4d4f' }
+};
+
+export const JVM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
+  routeKey: 'jvm',
+  pageTitle: 'JVM 监控仪表盘',
+  objectFallbackName: 'JVM',
+  instanceType: 'jvm',
+  collectionStatusQuery: "count({instance_type='jvm', collect_type='jmx', __$labels__}) by (instance_id)",
+  metaItems: ['JVM-JMX', 'jmx'],
+  metrics: [
+    { name: 'heapUsageRatio', display_name: '堆使用率', description: 'JVM 已用堆内存占最大堆内存的比例。', unit: 'percent', query: '100 * jvm_memory_usage_used_value{__$labels__} / clamp_min(jvm_memory_usage_max_value{__$labels__}, 1)', color: '#2f6bff' },
+    { name: 'heapUsed', display_name: '堆已用内存', description: 'JVM 当前实际使用的堆内存。', unit: 'bytes', query: 'jvm_memory_usage_used_value{__$labels__}', color: '#2f6bff' },
+    { name: 'heapCommitted', display_name: '堆已提交内存', description: 'JVM 已向操作系统申请的堆内存。', unit: 'bytes', query: 'jvm_memory_usage_committed_value{__$labels__}', color: '#13c2c2' },
+    { name: 'heapMax', display_name: '最大堆内存', description: 'JVM 配置允许使用的最大堆内存。', unit: 'bytes', query: 'jvm_memory_usage_max_value{__$labels__}', color: '#8a5cff' },
+    { name: 'threads', display_name: '当前线程数', description: 'JVM 当前正在运行的线程数。', unit: 'counts', query: 'jvm_threads_count_value{__$labels__}', color: '#ff8a1f' },
+    { name: 'daemonThreads', display_name: '守护线程数', description: 'JVM 当前活跃的守护线程数。', unit: 'counts', query: 'jvm_threads_daemon_count_value{__$labels__}', color: '#13c2c2' },
+    { name: 'peakThreads', display_name: '峰值线程数', description: 'JVM 运行期间达到的线程数峰值。', unit: 'counts', query: 'jvm_threads_peak_count_value{__$labels__}', color: '#8a5cff' },
+    { name: 'totalStartedThreads', display_name: '累计启动线程数', description: 'JVM 启动以来创建并启动的线程总数。', unit: 'counts', query: 'jvm_threads_total_started_count_value{__$labels__}', color: '#597ef7' },
+    { name: 'gcTimeRatio', display_name: 'GC 时间占比', description: '最近五分钟内 GC 占用运行时间的比例。', unit: 'percent', query: '100 * sum(rate(jvm_gc_collectiontime_seconds_value{__$labels__}[5m])) by (instance_id)', color: '#ff4d4f' },
+    { name: 'gcCountRate', display_name: 'GC 频率', description: '最近五分钟内每秒执行的 GC 次数。', unit: 'cps', query: 'sum(rate(jvm_gc_collectioncount_value{__$labels__}[5m])) by (instance_id)', color: '#ff8a1f' },
+    { name: 'memoryPoolUsed', display_name: '内存池已用', description: 'JVM 内存池当前实际使用的内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_used_value{__$labels__}) by (instance_id)', color: '#8a5cff' },
+    { name: 'memoryPoolCommitted', display_name: '内存池已提交', description: 'JVM 内存池当前已提交的内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_committed_value{__$labels__}) by (instance_id)', color: '#2f6bff' },
+    { name: 'memoryPoolMax', display_name: '内存池上限', description: 'JVM 内存池允许使用的最大内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_max_value{__$labels__}) by (instance_id)', color: '#9aa9bf' },
+    { name: 'bufferUsed', display_name: 'NIO 缓冲已用', description: 'Java NIO 缓冲池当前已使用的内存。', unit: 'bytes', query: 'sum(jvm_bufferpool_memoryused_value{__$labels__}) by (instance_id)', color: '#13c2c2' },
+    { name: 'bufferCapacity', display_name: 'NIO 缓冲容量', description: 'Java NIO 缓冲池总容量。', unit: 'bytes', query: 'sum(jvm_bufferpool_totalcapacity_value{__$labels__}) by (instance_id)', color: '#597ef7' },
+    { name: 'physicalFree', display_name: '宿主可用内存', description: 'JVM 所在宿主机当前可用物理内存。', unit: 'bytes', query: 'jvm_os_memory_physical_free_value{__$labels__}', color: '#27c274' },
+    { name: 'physicalTotal', display_name: '宿主总内存', description: 'JVM 所在宿主机物理内存总量。', unit: 'bytes', query: 'jvm_os_memory_physical_total_value{__$labels__}', color: '#9aa9bf' },
+    { name: 'swapFree', display_name: '可用交换空间', description: 'JVM 所在宿主机当前可用交换空间。', unit: 'bytes', query: 'jvm_os_memory_swap_free_value{__$labels__}', color: '#13c2c2' },
+    { name: 'scrapeDuration', display_name: '采集耗时', description: '最近一次 JMX 采集耗时。', unit: 's', query: 'jmx_scrape_duration_seconds_gauge{__$labels__}', color: '#597ef7' },
+    { name: 'scrapeError', display_name: '采集状态', description: 'JMX 采集状态，0 为正常、1 为报错。', unit: 'none', query: 'jmx_scrape_error_gauge{__$labels__}', color: '#ff4d4f' }
+  ],
+  summaryCards: [
+    { title: '堆使用率', metric: 'heapUsageRatio', color: '#2f6bff', icon: 'memory', compare: true, compareFavorableDirection: 'down', guide: [{ label: '堆容量风险', detail: '持续逼近 100% 时，优先排查内存泄漏、堆配置和 GC 压力。' }], footer: [{ label: '已用', metric: 'heapUsed', unit: 'bytes' }, { label: '已提交', metric: 'heapCommitted', unit: 'bytes' }, { label: '上限', metric: 'heapMax', unit: 'bytes' }] },
+    { title: 'GC 时间占比', metric: 'gcTimeRatio', color: '#ff4d4f', icon: 'clock', compare: true, compareFavorableDirection: 'down', guide: [{ label: 'GC 开销', detail: '最近五分钟内 GC 实际占用的时间比例；升高表示应用有效执行时间被回收挤占。' }], footer: [{ label: 'GC 频率', metric: 'gcCountRate', unit: 'cps' }] },
+    { title: '当前线程数', metric: 'threads', color: '#ff8a1f', icon: 'node', compare: true, compareFavorableDirection: 'down', guide: [{ label: '线程异常', detail: '持续高于历史水平时，结合守护线程和峰值线程判断请求堆积或线程泄漏。' }], footer: [{ label: '守护线程', metric: 'daemonThreads', unit: 'counts' }, { label: '历史峰值', metric: 'peakThreads', unit: 'counts' }] },
+    { title: 'JMX 采集状态', metric: 'scrapeError', color: '#27c274', icon: 'health', enumMap: JMX_SCRAPE_ERROR_ENUM, guide: [{ label: '数据可信度', detail: '采集报错时，当前页其余指标可能过期或缺失，应先恢复 JMX 连通性。' }], footer: [{ label: '采集耗时', metric: 'scrapeDuration', unit: 's' }] }
+  ],
+  charts: [
+    { title: '堆容量趋势', subtitle: '已用、已提交与最大堆内存', metric: 'heapUsed', guide: [{ label: '堆容量', detail: '已用内存接近已提交或最大堆内存时，GC 压力与 OOM 风险上升；虚线为最大堆上限。' }], series: [{ metric: 'heapUsed', label: '已用', color: '#2f6bff', unit: 'bytes' }, { metric: 'heapCommitted', label: '已提交', color: '#13c2c2', unit: 'bytes' }, { metric: 'heapMax', label: '最大堆', color: '#9aa9bf', unit: 'bytes', style: 'limit' }] },
+    { title: '线程趋势', subtitle: '当前、守护与历史峰值线程数', metric: 'threads', guide: [{ label: '线程趋势', detail: '当前线程接近历史峰值或持续抬升时，排查线程池饱和、阻塞调用与线程泄漏。' }], series: [{ metric: 'threads', label: '当前线程', color: '#ff8a1f', unit: 'counts' }, { metric: 'daemonThreads', label: '守护线程', color: '#13c2c2', unit: 'counts' }, { metric: 'peakThreads', label: '历史峰值', color: '#9aa9bf', unit: 'counts', style: 'limit' }] },
+    { title: 'GC 开销趋势', subtitle: '最近五分钟 GC 时间占比', metric: 'gcTimeRatio', guide: [{ label: 'GC 开销', detail: '这是速率换算后的时间占比，不展示不可直接比较的累计 GC 时长。' }], series: [{ metric: 'gcTimeRatio', label: 'GC 时间占比', color: '#ff4d4f', unit: 'percent' }] },
+    { title: 'GC 频率趋势', subtitle: '最近五分钟每秒 GC 次数', metric: 'gcCountRate', guide: [{ label: 'GC 频率', detail: '频率与 GC 时间占比分开呈现；两者同时升高时，优先排查堆压力和对象分配。' }], series: [{ metric: 'gcCountRate', label: 'GC 频率', color: '#ff8a1f', unit: 'cps' }] }
+  ],
+  details: [
+    { title: '内存池与缓冲', subtitle: '定位堆外、内存池与 NIO 缓冲压力。', rows: [{ label: '内存池已用', metric: 'memoryPoolUsed', unit: 'bytes', tone: 'warning' }, { label: '内存池已提交', metric: 'memoryPoolCommitted', unit: 'bytes' }, { label: '内存池上限', metric: 'memoryPoolMax', unit: 'bytes' }, { label: 'NIO 缓冲已用', metric: 'bufferUsed', unit: 'bytes', tone: 'warning' }, { label: 'NIO 缓冲容量', metric: 'bufferCapacity', unit: 'bytes' }] },
+    { title: '宿主资源与线程生命周期', subtitle: '用于判断 JVM 压力是否受到宿主机资源约束。', rows: [{ label: '宿主可用内存', metric: 'physicalFree', unit: 'bytes', tone: 'warning' }, { label: '宿主总内存', metric: 'physicalTotal', unit: 'bytes' }, { label: '可用交换空间', metric: 'swapFree', unit: 'bytes', tone: 'warning' }, { label: '累计启动线程', metric: 'totalStartedThreads', unit: 'counts' }] }
+  ]
+};

--- a/web/src/app/monitor/dashboards/objects/jvm/config.ts
+++ b/web/src/app/monitor/dashboards/objects/jvm/config.ts
@@ -5,24 +5,23 @@ export const JVM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: 'JVM 监控仪表盘',
   objectFallbackName: 'JVM',
   instanceType: 'jvm',
-  collectionStatusQuery: "count({instance_type='jvm', collect_type='jmx', __$labels__}) by (instance_id)",
+  collectionStatusQuery: "max(1 - jmx_scrape_error_gauge{instance_type='jvm', __$labels__}) by (instance_id)",
   metaItems: ['JVM-JMX', 'jmx'],
   metrics: [
-    { name: 'heapUsageRatio', display_name: '堆使用率', description: 'JVM 已用堆内存占最大堆内存的比例。', unit: 'percent', query: '100 * jvm_memory_usage_used_value{__$labels__} / clamp_min(jvm_memory_usage_max_value{__$labels__}, 1)', color: '#2f6bff' },
-    { name: 'heapUsed', display_name: '堆已用内存', description: 'JVM 当前实际使用的堆内存。', unit: 'bytes', query: 'jvm_memory_usage_used_value{__$labels__}', color: '#2f6bff' },
-    { name: 'heapCommitted', display_name: '堆已提交内存', description: 'JVM 已向操作系统申请的堆内存。', unit: 'bytes', query: 'jvm_memory_usage_committed_value{__$labels__}', color: '#13c2c2' },
-    { name: 'heapMax', display_name: '最大堆内存', description: 'JVM 配置允许使用的最大堆内存。', unit: 'bytes', query: 'jvm_memory_usage_max_value{__$labels__}', color: '#8a5cff' },
+    { name: 'heapUsageRatio', display_name: '堆使用率', description: 'JVM 已用堆内存占最大堆内存的比例，不含非堆内存。', unit: 'percent', query: '100 * jvm_memory_usage_used_value{type="Heap",__$labels__} / clamp_min(jvm_memory_usage_max_value{type="Heap",__$labels__}, 1)', color: '#2f6bff' },
+    { name: 'heapUsed', display_name: '堆已用内存', description: 'JVM 当前实际使用的堆内存，不含非堆内存。', unit: 'bytes', query: 'jvm_memory_usage_used_value{type="Heap",__$labels__}', color: '#2f6bff' },
+    { name: 'heapCommitted', display_name: '堆已提交内存', description: 'JVM 已向操作系统申请的堆内存，不含非堆内存。', unit: 'bytes', query: 'jvm_memory_usage_committed_value{type="Heap",__$labels__}', color: '#13c2c2' },
+    { name: 'heapMax', display_name: '最大堆内存', description: 'JVM 配置允许使用的最大堆内存，不含非堆内存。', unit: 'bytes', query: 'jvm_memory_usage_max_value{type="Heap",__$labels__}', color: '#8a5cff' },
     { name: 'threads', display_name: '当前线程数', description: 'JVM 当前正在运行的线程数。', unit: 'counts', query: 'jvm_threads_count_value{__$labels__}', color: '#ff8a1f' },
     { name: 'daemonThreads', display_name: '守护线程数', description: 'JVM 当前活跃的守护线程数。', unit: 'counts', query: 'jvm_threads_daemon_count_value{__$labels__}', color: '#13c2c2' },
     { name: 'peakThreads', display_name: '峰值线程数', description: 'JVM 运行期间达到的线程数峰值。', unit: 'counts', query: 'jvm_threads_peak_count_value{__$labels__}', color: '#8a5cff' },
     { name: 'totalStartedThreads', display_name: '累计启动线程数', description: 'JVM 启动以来创建并启动的线程总数。', unit: 'counts', query: 'jvm_threads_total_started_count_value{__$labels__}', color: '#597ef7' },
     { name: 'gcTimeRatio', display_name: 'GC 时间占比', description: '最近五分钟内 GC 占用运行时间的比例。', unit: 'percent', query: '100 * sum(rate(jvm_gc_collectiontime_seconds_value{__$labels__}[5m])) by (instance_id)', color: '#ff4d4f' },
     { name: 'gcCountRate', display_name: 'GC 频率', description: '最近五分钟内每秒执行的 GC 次数。', unit: 'cps', query: 'sum(rate(jvm_gc_collectioncount_value{__$labels__}[5m])) by (instance_id)', color: '#ff8a1f' },
-    { name: 'memoryPoolUsed', display_name: '内存池已用', description: 'JVM 内存池当前实际使用的内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_used_value{__$labels__}) by (instance_id)', color: '#8a5cff' },
-    { name: 'memoryPoolCommitted', display_name: '内存池已提交', description: 'JVM 内存池当前已提交的内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_committed_value{__$labels__}) by (instance_id)', color: '#2f6bff' },
-    { name: 'memoryPoolMax', display_name: '内存池上限', description: 'JVM 内存池允许使用的最大内存。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_max_value{__$labels__}) by (instance_id)', color: '#9aa9bf' },
-    { name: 'bufferUsed', display_name: 'NIO 缓冲已用', description: 'Java NIO 缓冲池当前已使用的内存。', unit: 'bytes', query: 'sum(jvm_bufferpool_memoryused_value{__$labels__}) by (instance_id)', color: '#13c2c2' },
-    { name: 'bufferCapacity', display_name: 'NIO 缓冲容量', description: 'Java NIO 缓冲池总容量。', unit: 'bytes', query: 'sum(jvm_bufferpool_totalcapacity_value{__$labels__}) by (instance_id)', color: '#597ef7' },
+    { name: 'memoryPoolUsed', display_name: '内存池累计已用', description: '所有 JVM 内存池当前已用内存的合计。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_used_value{__$labels__}) by (instance_id)', color: '#8a5cff' },
+    { name: 'memoryPoolCommitted', display_name: '内存池累计已提交', description: '所有 JVM 内存池当前已提交内存的合计。', unit: 'bytes', query: 'sum(jvm_memorypool_usage_committed_value{__$labels__}) by (instance_id)', color: '#2f6bff' },
+    { name: 'bufferUsed', display_name: 'NIO 缓冲总已用', description: '所有 Java NIO 缓冲池当前已用内存的合计。', unit: 'bytes', query: 'sum(jvm_bufferpool_memoryused_value{__$labels__}) by (instance_id)', color: '#13c2c2' },
+    { name: 'bufferCapacity', display_name: 'NIO 缓冲总容量', description: '所有 Java NIO 缓冲池总容量的合计。', unit: 'bytes', query: 'sum(jvm_bufferpool_totalcapacity_value{__$labels__}) by (instance_id)', color: '#597ef7' },
     { name: 'physicalFree', display_name: '宿主可用内存', description: 'JVM 所在宿主机当前可用物理内存。', unit: 'bytes', query: 'jvm_os_memory_physical_free_value{__$labels__}', color: '#27c274' },
     { name: 'physicalTotal', display_name: '宿主总内存', description: 'JVM 所在宿主机物理内存总量。', unit: 'bytes', query: 'jvm_os_memory_physical_total_value{__$labels__}', color: '#9aa9bf' },
     { name: 'swapFree', display_name: '可用交换空间', description: 'JVM 所在宿主机当前可用交换空间。', unit: 'bytes', query: 'jvm_os_memory_swap_free_value{__$labels__}', color: '#13c2c2' }
@@ -39,7 +38,7 @@ export const JVM_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     { title: 'GC 频率趋势', subtitle: '最近五分钟每秒 GC 次数', metric: 'gcCountRate', guide: [{ label: 'GC 频率', detail: '频率与 GC 时间占比分开呈现；两者同时升高时，优先排查堆压力和对象分配。' }], series: [{ metric: 'gcCountRate', label: 'GC 频率', color: '#ff8a1f', unit: 'cps' }] }
   ],
   details: [
-    { title: '内存池与缓冲', subtitle: '定位堆外、内存池与 NIO 缓冲压力。', rows: [{ label: '内存池已用', metric: 'memoryPoolUsed', unit: 'bytes', tone: 'warning' }, { label: '内存池已提交', metric: 'memoryPoolCommitted', unit: 'bytes' }, { label: '内存池上限', metric: 'memoryPoolMax', unit: 'bytes' }, { label: 'NIO 缓冲已用', metric: 'bufferUsed', unit: 'bytes', tone: 'warning' }, { label: 'NIO 缓冲容量', metric: 'bufferCapacity', unit: 'bytes' }] },
+    { title: '内存池与缓冲', subtitle: '汇总观察内存池与 NIO 缓冲的总量压力。', rows: [{ label: '内存池累计已用', metric: 'memoryPoolUsed', unit: 'bytes', tone: 'warning' }, { label: '内存池累计已提交', metric: 'memoryPoolCommitted', unit: 'bytes' }, { label: 'NIO 缓冲总已用', metric: 'bufferUsed', unit: 'bytes', tone: 'warning' }, { label: 'NIO 缓冲总容量', metric: 'bufferCapacity', unit: 'bytes' }] },
     { title: '宿主资源与线程生命周期', subtitle: '用于判断 JVM 压力是否受到宿主机资源约束。', rows: [{ label: '宿主可用内存', metric: 'physicalFree', unit: 'bytes', tone: 'warning' }, { label: '宿主总内存', metric: 'physicalTotal', unit: 'bytes' }, { label: '可用交换空间', metric: 'swapFree', unit: 'bytes', tone: 'warning' }, { label: '累计启动线程', metric: 'totalStartedThreads', unit: 'counts' }] }
   ]
 };

--- a/web/src/app/monitor/dashboards/objects/jvm/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/jvm/index.module.scss
@@ -1,0 +1,1 @@
+@use '../common/simple-dashboard.module.scss'; .sectionLabel { margin: 2px 2px 4px; padding-bottom: 4px; border-bottom: 1px solid #eceff4; color: #8c95a8; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }

--- a/web/src/app/monitor/dashboards/objects/jvm/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/jvm/index.module.scss
@@ -1,1 +1,16 @@
-@use '../common/simple-dashboard.module.scss'; .sectionLabel { margin: 2px 2px 4px; padding-bottom: 4px; border-bottom: 1px solid #eceff4; color: #8c95a8; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+@use '../common/simple-dashboard.module.scss';
+
+.sectionLabel {
+  margin: 2px 2px 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--color-border-1);
+  color: var(--color-text-3);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 8px;
+}

--- a/web/src/app/monitor/dashboards/objects/jvm/index.ts
+++ b/web/src/app/monitor/dashboards/objects/jvm/index.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ObjectDashboardPage } from '../common/object-dashboard-page';
+import { JVM_DASHBOARD_CONFIG } from './config';
+import styles from './index.module.scss';
+
+const JVM_TREND_SECTIONS = [
+  { title: '运行趋势', chartTitles: ['堆容量趋势', '线程趋势'] },
+  { title: 'GC 专项', chartTitles: ['GC 开销趋势', 'GC 频率趋势'] }
+];
+
+export default function JvmDashboard() {
+  return React.createElement(ObjectDashboardPage, {
+    config: JVM_DASHBOARD_CONFIG,
+    styles,
+    trendSections: JVM_TREND_SECTIONS
+  });
+}

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -34,6 +34,7 @@ import AccessDashboard from './objects/access';
 import NetworkServiceDashboard from './objects/network_service';
 import ConsoleServerDashboard from './objects/console_server';
 import VoiceGatewayDashboard from './objects/voice_gateway';
+import JvmDashboard from './objects/jvm';
 import { ENTERPRISE_PROFESSIONAL_DASHBOARDS } from './objects/(enterprise)-registry';
 import { normalizeDashboardKey } from './shared/utils';
 
@@ -47,6 +48,7 @@ export const PROFESSIONAL_DASHBOARD_GROUPS = {
 } as const;
 
 const COMMUNITY_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
+  { key: 'jvm', groupKey: 'middleware', objectName: 'JVM', objectDisplayName: 'JVM', inheritedPermissionPath: '/monitor/view', component: JvmDashboard },
   {
     key: 'mysql',
     groupKey: 'database',


### PR DESCRIPTION
## 变更内容

- 新增 JVM 专用监控仪表盘，展示堆使用率、GC 时间占比和线程状态。
- 按运维语义拆分为运行趋势和 GC 专项：GC 开销与 GC 频率独立展示，不与线程数混用。
- 增加内存池、NIO 缓冲、宿主资源和线程生命周期诊断信息。

## 验证

- 定向 ESLint
- JVM 仪表盘结构断言
- `git diff --check`

## 范围

相对 `TencentBlueKing/bk-lite:master` 仅包含 5 个 JVM 仪表盘相关文件；未纳入工作区现有的测试、Patch Manager、图标、锁文件或本地生成物。