### PR TITLE
fix(monitor): preserve semantic dashboard return context

### DIFF
--- a/web/src/app/monitor/(pages)/integration/asset/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/page.tsx
@@ -374,7 +374,7 @@ const Asset = () => {
       row,
       resolveProfessionalDashboardUrl: getProfessionalDashboardUrl
     });
-    window.open(url, '_blank', 'noopener,noreferrer');
+    router.push(url);
   };
 
   const handleTableChange = (pagination: any) => {

--- a/web/src/app/monitor/(pages)/integration/asset/viewRoute.ts
+++ b/web/src/app/monitor/(pages)/integration/asset/viewRoute.ts
@@ -1,4 +1,5 @@
 import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
+import { withDashboardReturnContext } from '@/app/monitor/dashboards/shared/utils';
 
 type DashboardUrlResolver = (
   objectName?: string | null,
@@ -56,7 +57,12 @@ export const buildAssetViewUrl = ({
     instance_id_values: toParamValue(row.instance_id_values),
     instance_id_keys: resolveInstanceIdKeys(monitorItem?.instance_id_keys)
   });
-  const queryString = params.toString();
+  const dashboardParams = withDashboardReturnContext(params, {
+    objectId: toParamValue(objectId),
+    objectName: toParamValue(monitorItem?.display_name || monitorItem?.name),
+    source: 'integration'
+  });
+  const queryString = dashboardParams.toString();
   const professionalDashboardUrl =
     resolveProfessionalDashboardUrl?.(
       monitorItem?.name,

--- a/web/src/app/monitor/(pages)/view/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/view/detail/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import React, { useState } from 'react';
-import { Segmented } from 'antd';
+import { Breadcrumb, Segmented } from 'antd';
 import { useTranslation } from '@/utils/i18n';
 import { useSearchParams, useRouter } from 'next/navigation';
 import detailStyle from '../index.module.scss';
 import { ArrowLeftOutlined } from '@ant-design/icons';
 import Overview from './overview';
 import Metric from '@/app/monitor/components/metric-views';
+import { getDashboardReturnNavigation } from '@/app/monitor/dashboards/shared/utils';
+import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 
 const ViewDetail = () => {
   const { t } = useTranslation();
@@ -21,6 +23,8 @@ const ViewDetail = () => {
   const monitorObjectName: string = searchParams.get('name') || '';
   const instanceId: React.Key = searchParams.get('instance_id') || '';
   const instanceName: string = searchParams.get('instance_name') || '';
+  const detailTitle = `${monitorObjDisplayName || monitorObjectName || '监控对象'}指标详情`;
+  const returnNavigation = getDashboardReturnNavigation(searchParams, detailTitle);
   const idValues: string[] = (
     searchParams.get('instance_id_values') || ''
   ).split(',');
@@ -31,8 +35,7 @@ const ViewDetail = () => {
   };
 
   const onBackButtonClick = () => {
-    const targetUrl = `/monitor/view`;
-    router.push(targetUrl);
+    router.push(returnNavigation.href);
   };
 
   return (
@@ -74,14 +77,17 @@ const ViewDetail = () => {
             onChange={onTabChange}
           />
           <button
-            className="absolute bottom-4 left-4 flex items-center py-2 rounded-md text-sm"
+            className="absolute bottom-4 left-4 flex max-w-[168px] items-center py-2 rounded-md text-sm"
             onClick={onBackButtonClick}
+            title={returnNavigation.label}
           >
-            <ArrowLeftOutlined className="mr-2" />
+            <ArrowLeftOutlined className="mr-2 shrink-0" />
+            <EllipsisWithTooltip className="min-w-0 truncate" text={returnNavigation.label} />
           </button>
         </div>
       </div>
       <div className={detailStyle.rightSide}>
+        <Breadcrumb className="mb-4" items={returnNavigation.breadcrumbItems} />
         {activeMenu === 'metrics' ? (
           <Metric
             idValues={idValues}

--- a/web/src/app/monitor/(pages)/view/page.tsx
+++ b/web/src/app/monitor/(pages)/view/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Segmented } from 'antd';
+import { useRouter, useSearchParams } from 'next/navigation';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
 import { TreeItem, ObjectItem } from '@/app/monitor/types';
@@ -11,9 +12,12 @@ import ViewList from './viewList';
 import ViewHive from './viewHive';
 import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import { cloneDeep } from 'lodash';
+import { getMonitorViewObjectUrl } from '@/app/monitor/dashboards/shared/utils';
 
 const Integration = () => {
   const { isLoading } = useApiClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { getMonitorObject } = useMonitorApi();
   const [treeData, setTreeData] = useState<TreeItem[]>([]);
   const [objects, setObjects] = useState<ObjectItem[]>([]);
@@ -36,6 +40,9 @@ const Integration = () => {
   const handleObjectChange = async (id: string) => {
     setObjectId(id);
     setDisplayType('list');
+    if (searchParams.get('object_id') !== String(id)) {
+      router.replace(getMonitorViewObjectUrl(id));
+    }
   };
 
   const onDisplayTypeChange = async (value: string) => {
@@ -52,11 +59,18 @@ const Integration = () => {
       setTreeData(_treeData);
       if (type === 'update') return;
       setObjects(data);
-      setDefaultSelectObj(data[0]?.id);
     } finally {
       setTreeLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!objects.length) return;
+    const requestedObjectId = searchParams.get('object_id');
+    const selectedObject = objects.find((item) => String(item.id) === requestedObjectId) || objects[0];
+    setObjectId(selectedObject?.id || '');
+    setDefaultSelectObj(selectedObject?.id || '');
+  }, [objects, searchParams]);
 
   const getTreeData = (data: ObjectItem[]): TreeItem[] => {
     const groupedData = data.reduce((acc, item) => {

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -32,6 +32,7 @@ import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { ListItem } from '@/types';
 import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { getProfessionalDashboardUrl } from '@/app/monitor/dashboards/registry';
+import { withDashboardReturnContext } from '@/app/monitor/dashboards/shared/utils';
 import { getDerivativeObjectNames } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
 import { resolveViewColumns } from './viewColumnPreference';
@@ -616,7 +617,10 @@ const ViewList: React.FC<ViewListProps> = ({
         ? monitorItem.instance_id_keys.join(',')
         : 'instance_id'
     };
-    const params = new URLSearchParams(row);
+    const params = withDashboardReturnContext(new URLSearchParams(row), {
+      objectId: String(objectId || ''),
+      objectName: String(monitorItem?.display_name || monitorItem?.name || '')
+    });
     const professionalDashboardUrl = getProfessionalDashboardUrl(
       monitorItem?.name,
       monitorItem?.display_name,

--- a/web/src/app/monitor/(pages)/view/viewModal.tsx
+++ b/web/src/app/monitor/(pages)/view/viewModal.tsx
@@ -12,6 +12,7 @@ import MonitorAlarm from './monitorAlarm';
 import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { INIT_VIEW_MODAL_FORM } from '@/app/monitor/constants/view';
 import { getProfessionalDashboardUrl } from '@/app/monitor/dashboards/registry';
+import { withDashboardReturnContext } from '@/app/monitor/dashboards/shared/utils';
 
 const ViewModal = forwardRef<ModalRef, ViewModalProps>(
   ({ monitorObject, monitorName, plugins, metrics, objects = [] }, ref) => {
@@ -79,7 +80,10 @@ const ViewModal = forwardRef<ModalRef, ViewModalProps>(
             ? monitorItem.instance_id_keys.join(',')
             : 'instance_id'
       };
-      const params = new URLSearchParams(row);
+      const params = withDashboardReturnContext(new URLSearchParams(row), {
+        objectId: String(monitorObject || ''),
+        objectName: String(monitorItem?.display_name || monitorItem?.name || '')
+      });
       const professionalDashboardUrl = getProfessionalDashboardUrl(monitorName, monitorItem?.display_name, params.toString());
       const targetUrl = professionalDashboardUrl || `/monitor/view/detail?${params.toString()}`;
       router.push(targetUrl);

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
@@ -7,6 +7,7 @@ import useMonitorApi from '@/app/monitor/api';
 import { getProfessionalDashboardKey, getProfessionalDashboardUrl } from '../registry';
 import { normalizeDashboardKey } from '../shared/utils';
 import { preserveDashboardDisplayMode } from '../shared/utils/display-mode-route';
+import { preserveDashboardReturnContext } from '../shared/utils';
 import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import TreeSelector from '@/app/monitor/components/treeSelector';
 import { ObjectItem, TreeItem } from '@/app/monitor/types';
@@ -89,7 +90,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
     if (String(key) === String(selectedObjectId || '')) return;
 
     const monitorItem = objects.find((item) => String(item.id) === String(key));
-    const params = preserveDashboardDisplayMode(new URLSearchParams({
+    const params = preserveDashboardReturnContext(preserveDashboardDisplayMode(new URLSearchParams({
       monitorObjId: String(monitorItem?.id || key),
       name: monitorItem?.name || '',
       monitorObjDisplayName: monitorItem?.display_name || '',
@@ -97,7 +98,7 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
       instance_id_keys: Array.isArray(monitorItem?.instance_id_keys)
         ? monitorItem.instance_id_keys.join(',')
         : 'instance_id'
-    }), new URLSearchParams(searchParams.toString()));
+    }), new URLSearchParams(searchParams.toString())), searchParams);
     const dashboardUrl = getProfessionalDashboardUrl(
       monitorItem?.name,
       monitorItem?.display_name,

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -617,7 +617,6 @@ export const DashboardShell = ({
           onTimeChange={dashboard.onTimeChange}
           onFrequenceChange={dashboard.setFrequence}
           onRefresh={dashboard.onRefresh}
-          onBack={dashboard.onBack}
           showTimeSelector={false}
           styles={styles}
         />

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -816,7 +816,6 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     setTimeDefaultValue((prev) => ({ ...prev, rangePickerVaule: arr, selectValue: 0 }));
     setTimeValues({ timeRange: [start, end], originValue: 0 });
   };
-  const goBack = () => router.push('/monitor/view');
   const onInstanceChange = (value: string) => {
     const target = instanceOptions.find((item) => item.value === value);
     const params = new URLSearchParams(searchParams.toString());
@@ -876,7 +875,6 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     onTimeChange,
     onRefresh,
     onXRangeChange,
-    onBack: goBack,
     onInstanceChange,
     onClusterFilterChange
   };

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -40,6 +40,11 @@
   flex: 1;
 }
 
+.breadcrumb {
+  margin-bottom: 4px;
+  font-size: 12px;
+}
+
 .title {
   margin: 0;
   color: #182132;

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.tsx
@@ -69,7 +69,6 @@ export default function SimpleDashboard({ config }: { config: SimpleDashboardCon
     onTimeChange,
     onRefresh,
     onXRangeChange,
-    onBack,
     onInstanceChange
   } = useSimpleDashboardData(config);
 
@@ -85,7 +84,6 @@ export default function SimpleDashboard({ config }: { config: SimpleDashboardCon
             onTimeChange={onTimeChange}
             onFrequenceChange={setFrequence}
             onRefresh={onRefresh}
-            onBack={onBack}
             showTimeSelector={false}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -445,7 +445,6 @@ export default function K3sClusterDashboardPage() {
     params.set('instance_name', opt?.label || value);
     router.push(`?${params.toString()}`);
   };
-  const goBack = () => router.back();
   const onRefresh = () => {
     if (displayMode === 'dashboard') {
       loadAll();
@@ -468,7 +467,6 @@ export default function K3sClusterDashboardPage() {
             onTimeChange={onTimeChange}
             onFrequenceChange={setFrequence}
             onRefresh={onRefresh}
-            onBack={goBack}
             showTimeSelector={false}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -445,7 +445,6 @@ export default function K8sClusterDashboardPage() {
     params.set('instance_name', opt?.label || value);
     router.push(`?${params.toString()}`);
   };
-  const goBack = () => router.back();
   const onRefresh = () => {
     if (displayMode === 'dashboard') {
       loadAll();
@@ -468,7 +467,6 @@ export default function K8sClusterDashboardPage() {
             onTimeChange={onTimeChange}
             onFrequenceChange={setFrequence}
             onRefresh={onRefresh}
-            onBack={goBack}
             showTimeSelector={false}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -507,8 +507,6 @@ export default function MongoDashboardPage() {
   };
 
   const onFrequenceChange = (val: number) => setFrequence(val);
-  const goBack = () => router.push('/monitor/view');
-
   const onInstanceChange = (value: string) => {
     const target = instanceOptions.find((item) => item.value === value);
     const params = new URLSearchParams(searchParams.toString());
@@ -587,7 +585,6 @@ export default function MongoDashboardPage() {
             onTimeChange={onTimeChange}
             onFrequenceChange={onFrequenceChange}
             onRefresh={() => (isDashboardMode ? loadMetrics() : setMetricsRefreshSignal((value) => value + 1))}
-            onBack={goBack}
             showTimeSelector={false}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -929,10 +929,6 @@ export default function MysqlDashboardPage() {
     setFrequence(val);
   };
 
-  const goBack = () => {
-    router.push('/monitor/view');
-  };
-
   const onInstanceChange = (value: string) => {
     const target = instanceOptions.find((item) => item.value === value);
     const params = new URLSearchParams(searchParams.toString());
@@ -964,7 +960,6 @@ export default function MysqlDashboardPage() {
             onTimeChange={onTimeChange}
             onFrequenceChange={onFrequenceChange}
             onRefresh={() => (isDashboardMode ? loadMetrics() : setMetricsRefreshSignal((value) => value + 1))}
-            onBack={goBack}
             showTimeSelector={false}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/shared/utils/index.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/index.ts
@@ -9,6 +9,7 @@ export * from './metric-series';
 export * from './collection-status';
 export * from './concurrency';
 export * from './use-load-sequence';
+export * from './return-navigation';
 
 export const normalizeDashboardKey = (value?: string | null) => String(value || '').trim().toLowerCase();
 

--- a/web/src/app/monitor/dashboards/shared/utils/return-navigation.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/return-navigation.ts
@@ -1,0 +1,104 @@
+export const DASHBOARD_RETURN_OBJECT_ID_PARAM = 'return_object_id';
+export const DASHBOARD_RETURN_OBJECT_NAME_PARAM = 'return_object_name';
+export const DASHBOARD_RETURN_SOURCE_PARAM = 'return_source';
+
+export type DashboardReturnSource = 'view' | 'integration';
+
+type SearchParamsLike = Pick<URLSearchParams, 'get'>;
+
+export interface DashboardReturnContext {
+  objectId: string;
+  objectName: string;
+  source?: DashboardReturnSource;
+}
+
+/**
+ * Keep dashboard return navigation semantic and deterministic: it restores the
+ * monitor-object view that opened the dashboard instead of depending on the
+ * browser history stack.
+ */
+export const getDashboardReturnContext = (params: SearchParamsLike): DashboardReturnContext => ({
+  objectId: String(params.get(DASHBOARD_RETURN_OBJECT_ID_PARAM) || '').trim(),
+  objectName: String(params.get(DASHBOARD_RETURN_OBJECT_NAME_PARAM) || '').trim(),
+  source: params.get(DASHBOARD_RETURN_SOURCE_PARAM) === 'integration' ? 'integration' : 'view'
+});
+
+export const withDashboardReturnContext = (
+  params: URLSearchParams,
+  context: DashboardReturnContext
+) => {
+  const next = new URLSearchParams(params.toString());
+  if (context.objectId) {
+    next.set(DASHBOARD_RETURN_OBJECT_ID_PARAM, context.objectId);
+    if (context.objectName) {
+      next.set(DASHBOARD_RETURN_OBJECT_NAME_PARAM, context.objectName);
+    } else {
+      next.delete(DASHBOARD_RETURN_OBJECT_NAME_PARAM);
+    }
+    if (context.source === 'integration') {
+      next.set(DASHBOARD_RETURN_SOURCE_PARAM, 'integration');
+    } else {
+      next.delete(DASHBOARD_RETURN_SOURCE_PARAM);
+    }
+  } else {
+    next.delete(DASHBOARD_RETURN_OBJECT_ID_PARAM);
+    next.delete(DASHBOARD_RETURN_OBJECT_NAME_PARAM);
+    next.delete(DASHBOARD_RETURN_SOURCE_PARAM);
+  }
+  return next;
+};
+
+export const preserveDashboardReturnContext = (
+  nextParams: URLSearchParams,
+  currentParams: SearchParamsLike
+) => withDashboardReturnContext(nextParams, getDashboardReturnContext(currentParams));
+
+export const getMonitorViewObjectUrl = (objectId?: string | null) => {
+  const normalizedObjectId = String(objectId || '').trim();
+  return normalizedObjectId
+    ? `/monitor/view?object_id=${encodeURIComponent(normalizedObjectId)}`
+    : '/monitor/view';
+};
+
+export const getDashboardReturnUrl = (params: SearchParamsLike) => {
+  const { objectId, source } = getDashboardReturnContext(params);
+  if (source === 'integration' && objectId) {
+    return `/monitor/integration/asset?objId=${encodeURIComponent(objectId)}`;
+  }
+  return getMonitorViewObjectUrl(objectId);
+};
+
+export const getDashboardReturnLabel = (params: SearchParamsLike) => {
+  const { objectName, source } = getDashboardReturnContext(params);
+  if (source === 'integration') {
+    return objectName ? `返回${objectName}集成资产列表` : '返回集成资产列表';
+  }
+  return objectName ? `返回${objectName}视图列表` : '返回监控视图';
+};
+
+export const getDashboardBreadcrumbItems = (params: SearchParamsLike, title: string) => {
+  const { objectId, objectName, source } = getDashboardReturnContext(params);
+  if (source === 'integration') {
+    return [
+      { title: '集成', href: '/monitor/integration' },
+      { title: '资产', href: '/monitor/integration/asset' },
+      ...(objectName && objectId
+        ? [{ title: objectName, href: getDashboardReturnUrl(params) }]
+        : []),
+      { title }
+    ];
+  }
+  return [
+    { title: '监控视图', href: '/monitor/view' },
+    ...(objectName && objectId
+      ? [{ title: objectName, href: getDashboardReturnUrl(params) }]
+      : []),
+    { title }
+  ];
+};
+
+export const getDashboardReturnNavigation = (params: SearchParamsLike, title: string) => ({
+  href: getDashboardReturnUrl(params),
+  label: getDashboardReturnLabel(params),
+  breadcrumbItems: getDashboardBreadcrumbItems(params, title)
+});

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
-import { Button } from 'antd';
+import { Breadcrumb, Button } from 'antd';
 import { ArrowLeftOutlined } from '@ant-design/icons';
+import { useRouter, useSearchParams } from 'next/navigation';
 import TimeSelector from '@/components/time-selector';
+import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import { ListItem, TimeSelectorDefaultValue } from '@/types';
 import { DEFAULT_REFRESH_FREQUENCY_LIST } from '../utils';
+import {
+  getDashboardReturnNavigation
+} from '../utils/return-navigation';
 
 export interface DashboardPageHeaderStyles {
   readonly [key: string]: string | undefined;
@@ -18,7 +23,6 @@ export interface DashboardPageHeaderProps {
   onTimeChange: (val: number[], originValue: number | null) => void;
   onFrequenceChange: (val: number) => void;
   onRefresh: () => void;
-  onBack: () => void;
   /** 是否在标题行内渲染时间选择器；置 false 时由调用方自行放置（默认 true，保持原行为）。 */
   showTimeSelector?: boolean;
   styles: DashboardPageHeaderStyles;
@@ -33,13 +37,18 @@ export function DashboardPageHeader({
   onTimeChange,
   onFrequenceChange,
   onRefresh,
-  onBack,
   showTimeSelector = true,
   styles
 }: DashboardPageHeaderProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnNavigation = getDashboardReturnNavigation(searchParams, title);
+  const onBack = () => router.push(returnNavigation.href);
+
   return (
     <div className={styles.pageTitleRow}>
       <div className={styles.titleBlock}>
+        <Breadcrumb className={styles.breadcrumb} items={returnNavigation.breadcrumbItems} />
         <h1 className={styles.title}>{title}</h1>
       </div>
       <div className={styles.controlsWrap}>
@@ -72,10 +81,14 @@ export function DashboardPageHeader({
         ) : null}
         {styles.actionButtons ? (
           <div className={styles.actionButtons}>
-            <Button className={styles.toolbarBackBtn} icon={<ArrowLeftOutlined />} onClick={onBack}>返回</Button>
+            <Button className={`${styles.toolbarBackBtn} inline-flex max-w-[260px] items-center`} icon={<ArrowLeftOutlined />} onClick={onBack}>
+              <EllipsisWithTooltip className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap" text={returnNavigation.label} />
+            </Button>
           </div>
         ) : (
-          <Button className={styles.toolbarBackBtn} icon={<ArrowLeftOutlined />} onClick={onBack}>返回</Button>
+          <Button className={`${styles.toolbarBackBtn} inline-flex max-w-[260px] items-center`} icon={<ArrowLeftOutlined />} onClick={onBack}>
+            <EllipsisWithTooltip className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap" text={returnNavigation.label} />
+          </Button>
         )}
       </div>
     </div>

--- a/web/src/stories/monitor/dashboard-return-navigation.stories.tsx
+++ b/web/src/stories/monitor/dashboard-return-navigation.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useSearchParams } from '@storybook/nextjs/navigation.mock';
+import { DashboardPageHeader, type DashboardPageHeaderStyles } from '@/app/monitor/dashboards/shared/widgets/dashboard-page-header';
+
+const styles: DashboardPageHeaderStyles = {
+  pageTitleRow: 'flex flex-wrap items-center justify-between gap-4 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-4',
+  titleBlock: 'min-w-0',
+  breadcrumb: 'mb-1 text-xs',
+  title: 'm-0 text-base font-semibold text-[var(--color-text-1)]',
+  controlsWrap: 'flex flex-wrap items-center gap-3',
+  modeTabs: 'inline-flex items-center rounded-md bg-[var(--color-fill-1)] p-1',
+  modeTab: 'rounded px-3 py-1.5 text-sm text-[var(--color-text-2)]',
+  modeTabActive: 'bg-[var(--color-bg)] text-[var(--color-text-1)]',
+  toolbarBackBtn: '',
+  actionButtons: 'flex items-center'
+};
+
+interface DashboardReturnNavigationPreviewProps {
+  source: 'view' | 'integration';
+  objectName: string;
+}
+
+const DashboardReturnNavigationPreview = ({ source, objectName }: DashboardReturnNavigationPreviewProps) => {
+  const params = new URLSearchParams({
+    return_object_id: '16',
+    return_object_name: objectName,
+    ...(source === 'integration' ? { return_source: 'integration' } : {})
+  });
+  useSearchParams.mockImplementation(() => params as ReturnType<typeof useSearchParams>);
+
+  return <div className="max-w-[560px]">
+    <DashboardPageHeader
+      title={`${objectName}监控仪表盘`}
+      displayMode="dashboard"
+      onDisplayModeChange={() => undefined}
+      timeDefaultValue={{ selectValue: 15, rangePickerVaule: null }}
+      onTimeChange={() => undefined}
+      onFrequenceChange={() => undefined}
+      onRefresh={() => undefined}
+      styles={styles}
+    />
+  </div>;
+};
+
+const meta: Meta<typeof DashboardReturnNavigationPreview> = {
+  title: 'Monitor/Dashboard/Return Navigation',
+  component: DashboardReturnNavigationPreview,
+  parameters: { layout: 'padded' }
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardReturnNavigationPreview>;
+
+export const FromView: Story = {
+  args: { source: 'view', objectName: 'MongoDB' }
+};
+
+export const FromIntegrationAsset: Story = {
+  args: { source: 'integration', objectName: 'MongoDB' }
+};
+
+export const LongObjectNameInNarrowContainer: Story = {
+  args: { source: 'integration', objectName: '生产环境华南区域核心交易数据库集群' }
+};


### PR DESCRIPTION
## Summary
- preserve the originating view or integration asset list in dashboard URLs
- show source-aware breadcrumbs and return labels
- keep the selected monitor object after page refresh and open asset dashboards in the current page

## Validation
- `tsx scripts/dashboard-return-navigation-test.ts`
- scoped ESLint
- `git diff --check tencent-upstream/master...HEAD`

## Scope
- only dashboard navigation production files are included
- local regression test and handoff note are intentionally not committed