### PR TITLE
feat(monitor): add MSSQL diagnostic metrics

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/en.yaml
@@ -108,8 +108,8 @@ monitor_object_metric:
         concurrent load and connection pool usage. Too many connections may lead to
         resource contention.
     sqlserver_lock_wait_time_rate:
-      name: Lock Wait Time
-      desc: Rate of lock wait time, reflecting concurrency contention. High values
+      name: Lock Waits Rate
+      desc: Rate of lock waits, reflecting concurrency contention. High values
         may indicate blocking or lock contention issues that require transaction design
         optimization.
     sqlserver_requests_cpu_time_ms_rate:

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/en.yaml
@@ -52,6 +52,45 @@ monitor_object_metric:
       desc: Rate of batch requests processed by SQL Server, measuring overall database
         throughput and load pressure. High request rates indicate the database is
         processing a large volume of queries.
+    sqlserver_checkpoint_pages_rate:
+      name: Checkpoint Pages Rate
+      desc: Rate at which the checkpoint process flushes dirty buffer pages to disk. Interpret it with write latency and lazy writes to assess write-back pressure.
+    sqlserver_lazy_writes_rate:
+      name: Lazy Writes Rate
+      desc: Rate at which the lazy writer flushes pages to make buffer-pool space available. Sustained growth with low page life expectancy indicates memory pressure.
+    sqlserver_memory_grants_pending:
+      name: Memory Grants Pending
+      desc: Current number of queries waiting for execution-memory grants. A sustained nonzero value indicates query-workspace memory pressure.
+    sqlserver_processes_blocked:
+      name: Blocked Processes
+      desc: Current number of blocked SQL Server processes. Investigate blocking sessions, transaction scope, and lock contention when it persists.
+    sqlserver_deadlocks_rate:
+      name: Deadlocks Rate
+      desc: Rate of SQL Server deadlocks. A sustained nonzero rate requires investigation of transaction order, isolation level, and indexing.
+    sqlserver_sql_compilations_rate:
+      name: SQL Compilations Rate
+      desc: Rate of SQL statement compilations. Compare it with batch requests and recompilations to assess plan-cache efficiency.
+    sqlserver_sql_recompilations_rate:
+      name: SQL Re-Compilations Rate
+      desc: Rate of SQL statement recompilations. A high rate relative to compilations can increase CPU cost and reveal unstable plans or frequent schema changes.
+    sqlserver_memory_grants_outstanding:
+      name: Memory Grants Outstanding
+      desc: Current number of granted query-workspace memory requests that have not completed. Interpret it with pending grants to distinguish active workload from memory pressure.
+    sqlserver_memory_target_server_memory_kb:
+      name: Target Server Memory
+      desc: SQL Server target memory. Compare it with total server memory to determine whether the buffer pool has reached its configured target.
+    sqlserver_memory_total_server_memory_kb:
+      name: Total Server Memory
+      desc: Current SQL Server committed memory. A persistent gap below target can indicate memory pressure or a recent workload change.
+    sqlserver_tempdb_free_space_kb:
+      name: TempDB Free Space
+      desc: Current free space in TempDB. Low free space can affect sorting, hashing, row versioning, and temporary-object workloads.
+    sqlserver_tempdb_version_store_size_kb:
+      name: TempDB Version Store Size
+      desc: Current TempDB version-store size. Growth can indicate long-running snapshot or read-committed snapshot transactions.
+    sqlserver_log_flushes_rate:
+      name: Transaction Log Flushes Rate
+      desc: Rate of transaction-log flushes. Interpret it with database write latency to identify write-intensive workloads and log I/O pressure.
     sqlserver_page_life_expectancy:
       name: Page Life Expectancy
       desc: Average time data pages stay in the buffer pool, reflecting memory pressure.

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/zh-Hans.yaml
@@ -83,8 +83,8 @@ monitor_object_metric:
       name: 用户连接数
       desc: 当前连接到SQL Server实例的用户数量，反映数据库的并发负载和连接池使用情况。连接数过多可能导致资源争用。
     sqlserver_lock_wait_time_rate:
-      name: 锁等待时间
-      desc: 锁等待时间的速率，反映数据库的并发争用情况。高值可能表明存在阻塞或锁竞争问题，需要优化事务设计。
+      name: 锁等待速率
+      desc: 锁等待发生速率，反映数据库的并发争用情况。高值可能表明存在阻塞或锁竞争问题，需要优化事务设计。
     sqlserver_requests_cpu_time_ms_rate:
       name: 请求CPU时间速率
       desc: 请求消耗CPU时间的速率，用于识别高CPU消耗的查询和语句，帮助进行性能优化和资源分配决策。

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/language/zh-Hans.yaml
@@ -34,6 +34,45 @@ monitor_object_metric:
     sqlserver_performance_value_rate:
       name: 批处理请求速率
       desc: SQL Server批处理请求的速率，衡量数据库整体吞吐量和负载压力。高请求率表示数据库处理大量查询。
+    sqlserver_checkpoint_pages_rate:
+      name: 检查点写页速率
+      desc: 检查点进程将脏页刷写到磁盘的速率，反映写回压力；应结合写入延迟和惰性写入速率判断。
+    sqlserver_lazy_writes_rate:
+      name: 惰性写入速率
+      desc: 惰性写入器为腾出缓冲池空间而刷写页面的速率。持续升高且页生命周期较低时，通常表示内存压力。
+    sqlserver_memory_grants_pending:
+      name: 等待内存授予的请求数
+      desc: 当前等待执行内存授予的查询数量。持续非零表示查询工作区内存不足，应结合并发和大排序或哈希操作排查。
+    sqlserver_processes_blocked:
+      name: 阻塞进程数
+      desc: 当前被阻塞的 SQL Server 进程数量。持续存在时应检查阻塞会话、事务范围和锁竞争。
+    sqlserver_deadlocks_rate:
+      name: 死锁速率
+      desc: SQL Server 死锁发生速率。持续非零时应检查事务访问顺序、隔离级别和索引设计。
+    sqlserver_sql_compilations_rate:
+      name: SQL 编译速率
+      desc: SQL 语句编译速率。结合批处理请求速率和重编译速率，可评估计划缓存效率。
+    sqlserver_sql_recompilations_rate:
+      name: SQL 重编译速率
+      desc: SQL 语句重编译速率。相对编译速率持续偏高会增加 CPU 消耗，并可能反映计划不稳定或频繁架构变更。
+    sqlserver_memory_grants_outstanding:
+      name: 已授予内存的请求数
+      desc: 当前已获得查询工作区内存但尚未完成的请求数。应结合等待内存授予的请求数，区分活跃负载与内存压力。
+    sqlserver_memory_target_server_memory_kb:
+      name: 目标 Server Memory
+      desc: SQL Server 目标内存大小。结合当前总 Server Memory 判断缓冲池是否达到配置目标。
+    sqlserver_memory_total_server_memory_kb:
+      name: 当前 Server Memory
+      desc: SQL Server 当前已提交的内存大小。长期低于目标内存可能表示内存压力或负载刚发生变化。
+    sqlserver_tempdb_free_space_kb:
+      name: TempDB 可用空间
+      desc: TempDB 当前可用空间。空间不足会影响排序、哈希、行版本和临时对象等工作负载。
+    sqlserver_tempdb_version_store_size_kb:
+      name: TempDB 版本存储大小
+      desc: TempDB 当前版本存储大小。持续增长可能表示长时间运行的快照隔离或读已提交快照事务。
+    sqlserver_log_flushes_rate:
+      name: 事务日志刷写速率
+      desc: 事务日志刷写速率。结合数据库写入延迟，可识别写密集负载和日志 I/O 压力。
     sqlserver_page_life_expectancy:
       name: 页生命周期期望
       desc: 数据页在缓冲池中的平均停留时间，反映内存压力。值过低表明内存不足，可能导致频繁的物理IO，影响性能。

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
@@ -9,7 +9,15 @@
   "default_metric": "any({instance_type='mssql'}) by (instance_id)",
   "instance_id_keys": ["instance_id"],
   "supplementary_indicators": ["sqlserver_database_io_read_latency_ms", "sqlserver_waitstats_wait_time_ms_rate", "sqlserver_volume_space_available_space_bytes"],
-  "display_fields": [{"name":"进程CPU使用率","sort_order":0,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_cpu_sqlserver_process_cpu_avg"}]}, {"name":"缓冲区缓存命中率","sort_order":1,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_buffer_cache_hit_ratio"}]}, {"name":"批处理请求速率","sort_order":2,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_performance_value_rate"}]}, {"name":"数据库读取延迟","sort_order":3,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_database_io_read_latency_ms"}]}, {"name":"用户连接数","sort_order":4,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_user_connections_rate"}]}],
+  "display_fields": [
+    {"name":"进程CPU使用率","sort_order":0,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_cpu_sqlserver_process_cpu_avg"}]},
+    {"name":"缓冲区缓存命中率","sort_order":1,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_buffer_cache_hit_ratio"}]},
+    {"name":"批处理请求速率","sort_order":2,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_performance_value_rate"}]},
+    {"name":"数据库读取延迟","sort_order":3,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_database_io_read_latency_ms"}]},
+    {"name":"用户连接数","sort_order":4,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_user_connections_rate"}]},
+    {"name":"阻塞进程数","sort_order":5,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_processes_blocked"}]},
+    {"name":"等待内存授予的请求数","sort_order":6,"metrics":[{"plugin":"MSSQL","metric":"sqlserver_memory_grants_pending"}]}
+  ],
   "metrics": [
     {
       "metric_group": "Base",
@@ -109,6 +117,149 @@
       "dimensions": [],
       "description": "Rate of batch requests processed by SQL Server, measuring overall database throughput and load pressure. High request rates indicate the database is processing a large volume of queries.",
       "query": "rate(sqlserver_performance_value{counter=~\"Batch Requests/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_checkpoint_pages_rate",
+      "display_name": "Checkpoint Pages Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate at which the checkpoint process flushes dirty buffer pages to disk. It reflects write-back pressure and should be interpreted together with write latency and lazy writes.",
+      "query": "rate(sqlserver_performance_value{counter=\"Checkpoint pages/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_lazy_writes_rate",
+      "display_name": "Lazy Writes Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate at which the lazy writer flushes pages to make buffer-pool space available. Sustained growth together with low page life expectancy indicates memory pressure.",
+      "query": "rate(sqlserver_performance_value{counter=\"Lazy writes/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_memory_grants_pending",
+      "display_name": "Memory Grants Pending",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Current number of queries waiting for execution-memory grants. A nonzero sustained value indicates query-workspace memory pressure.",
+      "query": "sqlserver_performance_value{counter=\"Memory Grants Pending\", __$labels__}"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_processes_blocked",
+      "display_name": "Blocked Processes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Current number of blocked SQL Server processes. Sustained values require checking blocking sessions, transaction scope, and lock contention.",
+      "query": "sqlserver_performance_value{counter=\"Processes blocked\", __$labels__}"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_deadlocks_rate",
+      "display_name": "Deadlocks Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate of SQL Server deadlocks. Any sustained nonzero rate requires investigation of transaction order, isolation level, and indexing.",
+      "query": "rate(sqlserver_performance_value{counter=\"Number of Deadlocks/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_sql_compilations_rate",
+      "display_name": "SQL Compilations Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate of SQL statement compilations. It helps assess plan-cache efficiency when compared with batch request and recompilation rates.",
+      "query": "rate(sqlserver_performance_value{counter=\"SQL Compilations/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_sql_recompilations_rate",
+      "display_name": "SQL Re-Compilations Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate of SQL statement recompilations. A high rate relative to compilations can increase CPU cost and reveal unstable plans or frequent schema changes.",
+      "query": "rate(sqlserver_performance_value{counter=\"SQL Re-Compilations/sec\", __$labels__}[5m])"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_memory_grants_outstanding",
+      "display_name": "Memory Grants Outstanding",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Current number of granted query-workspace memory requests that have not yet completed. Interpret it with pending grants to distinguish active workload from memory pressure.",
+      "query": "sqlserver_performance_value{counter=\"Memory Grants Outstanding\", __$labels__}"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_memory_target_server_memory_kb",
+      "display_name": "Target Server Memory",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "kibibytes",
+      "dimensions": [],
+      "description": "SQL Server target memory in KiB. Compare it with total server memory to determine whether the buffer pool has reached its configured target.",
+      "query": "sqlserver_performance_value{counter=\"Target Server Memory (KB)\", __$labels__}"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_memory_total_server_memory_kb",
+      "display_name": "Total Server Memory",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "kibibytes",
+      "dimensions": [],
+      "description": "Current SQL Server memory committed in KiB. A persistent gap below target can indicate memory pressure or a recent workload change.",
+      "query": "sqlserver_performance_value{counter=\"Total Server Memory (KB)\", __$labels__}"
+    },
+    {
+      "metric_group": "Storage",
+      "name": "sqlserver_tempdb_free_space_kb",
+      "display_name": "TempDB Free Space",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "kibibytes",
+      "dimensions": [],
+      "description": "Current free space in TempDB in KiB. Low free space can cause failures in sorting, hashing, row versioning, and temporary-object workloads.",
+      "query": "sqlserver_performance_value{counter=\"Free Space in tempdb (KB)\", __$labels__}"
+    },
+    {
+      "metric_group": "Storage",
+      "name": "sqlserver_tempdb_version_store_size_kb",
+      "display_name": "TempDB Version Store Size",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "kibibytes",
+      "dimensions": [],
+      "description": "Current TempDB version-store size in KiB. Growth can indicate long-running snapshot or read-committed snapshot transactions.",
+      "query": "sqlserver_performance_value{counter=\"Version Store Size (KB)\", __$labels__}"
+    },
+    {
+      "metric_group": "Performance",
+      "name": "sqlserver_log_flushes_rate",
+      "display_name": "Transaction Log Flushes Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Rate of transaction-log flushes. Interpret it with database write latency to identify write-intensive workloads and log I/O pressure.",
+      "query": "rate(sqlserver_performance_value{counter=\"Log Flushes/sec\", __$labels__}[5m])"
     },
     {
       "metric_group": "Performance",

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/mssql/metrics.json
@@ -292,18 +292,18 @@
       "unit": "counts",
       "dimensions": [],
       "description": "Number of users currently connected to the SQL Server instance, reflecting concurrent load and connection pool usage. Too many connections may lead to resource contention.",
-      "query": "rate(sqlserver_performance_value{counter=~\"User Connections\", __$labels__}[5m])"
+      "query": "sqlserver_performance_value{counter=\"User Connections\", __$labels__}"
     },
     {
       "metric_group": "Performance",
       "name": "sqlserver_lock_wait_time_rate",
-      "display_name": "Lock Wait Time",
+      "display_name": "Lock Waits Rate",
       "instance_id_keys": ["instance_id"],
       "data_type": "Number",
-      "unit": "ms",
+      "unit": "counts",
       "dimensions": [{"name": "instance", "description": "锁资源类型"}],
-      "description": "Rate of lock wait time, reflecting concurrency contention. High values may indicate blocking or lock contention issues that require transaction design optimization.",
-      "query": "rate(sqlserver_performance_value{counter=~\"Lock Waits/sec\", __$labels__}[5m])"
+      "description": "Rate of lock waits, reflecting concurrency contention. High values may indicate blocking or lock contention that requires transaction design optimization.",
+      "query": "rate(sqlserver_performance_value{counter=\"Lock Waits/sec\", __$labels__}[5m])"
     },
     {
       "metric_group": "Performance",

--- a/web/src/app/monitor/dashboards/objects/mssql/config.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/config.ts
@@ -81,6 +81,110 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#27c274'
     },
     {
+      name: 'sqlserver_checkpoint_pages_rate',
+      display_name: '检查点写页速率',
+      description: '检查点进程将脏页刷写到磁盘的速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="Checkpoint pages/sec", __$labels__}[5m])',
+      color: '#2f6bff'
+    },
+    {
+      name: 'sqlserver_lazy_writes_rate',
+      display_name: '惰性写入速率',
+      description: '惰性写入器为腾出缓冲池空间而刷写页面的速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="Lazy writes/sec", __$labels__}[5m])',
+      color: '#8a5cff'
+    },
+    {
+      name: 'sqlserver_memory_grants_pending',
+      display_name: '等待内存授予的请求数',
+      description: '当前等待执行内存授予的查询数量。',
+      unit: 'counts',
+      query: 'sqlserver_performance_value{counter="Memory Grants Pending", __$labels__}',
+      color: '#ff8a1f'
+    },
+    {
+      name: 'sqlserver_memory_grants_outstanding',
+      display_name: '已授予内存的请求数',
+      description: '当前已获得查询工作区内存但尚未完成的请求数。',
+      unit: 'counts',
+      query: 'sqlserver_performance_value{counter="Memory Grants Outstanding", __$labels__}',
+      color: '#2f6bff'
+    },
+    {
+      name: 'sqlserver_memory_target_server_memory_kb',
+      display_name: '目标 Server Memory',
+      description: 'SQL Server 目标内存大小。',
+      unit: 'kibibytes',
+      query: 'sqlserver_performance_value{counter="Target Server Memory (KB)", __$labels__}',
+      color: '#9aa9bf'
+    },
+    {
+      name: 'sqlserver_memory_total_server_memory_kb',
+      display_name: '当前 Server Memory',
+      description: 'SQL Server 当前已提交的内存大小。',
+      unit: 'kibibytes',
+      query: 'sqlserver_performance_value{counter="Total Server Memory (KB)", __$labels__}',
+      color: '#8a5cff'
+    },
+    {
+      name: 'sqlserver_tempdb_free_space_kb',
+      display_name: 'TempDB 可用空间',
+      description: 'TempDB 当前可用空间。',
+      unit: 'kibibytes',
+      query: 'sqlserver_performance_value{counter="Free Space in tempdb (KB)", __$labels__}',
+      color: '#27c274'
+    },
+    {
+      name: 'sqlserver_tempdb_version_store_size_kb',
+      display_name: 'TempDB 版本存储大小',
+      description: 'TempDB 当前版本存储大小。',
+      unit: 'kibibytes',
+      query: 'sqlserver_performance_value{counter="Version Store Size (KB)", __$labels__}',
+      color: '#faad14'
+    },
+    {
+      name: 'sqlserver_log_flushes_rate',
+      display_name: '事务日志刷写速率',
+      description: '事务日志刷写速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="Log Flushes/sec", __$labels__}[5m])',
+      color: '#13c2c2'
+    },
+    {
+      name: 'sqlserver_processes_blocked',
+      display_name: '阻塞进程数',
+      description: '当前被阻塞的 SQL Server 进程数量。',
+      unit: 'counts',
+      query: 'sqlserver_performance_value{counter="Processes blocked", __$labels__}',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'sqlserver_deadlocks_rate',
+      display_name: '死锁速率',
+      description: 'SQL Server 死锁发生速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="Number of Deadlocks/sec", __$labels__}[5m])',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'sqlserver_sql_compilations_rate',
+      display_name: 'SQL 编译速率',
+      description: 'SQL 语句编译速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="SQL Compilations/sec", __$labels__}[5m])',
+      color: '#13c2c2'
+    },
+    {
+      name: 'sqlserver_sql_recompilations_rate',
+      display_name: 'SQL 重编译速率',
+      description: 'SQL 语句重编译速率。',
+      unit: 'cps',
+      query: 'rate(sqlserver_performance_value{counter="SQL Re-Compilations/sec", __$labels__}[5m])',
+      color: '#faad14'
+    },
+    {
       name: 'sqlserver_page_life_expectancy',
       display_name: '页面生命周期',
       description: '数据页在缓冲池中平均停留时间。',
@@ -253,7 +357,10 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       compare: true,
       compareFavorableDirection: 'up',
       guide: [{ label: '缓存命中率', detail: '缓冲池满足数据页读取的比例，低值说明内存或缓存压力偏高。' }],
-      footer: [{ label: '页面生命周期', metric: 'sqlserver_page_life_expectancy', unit: 's' }]
+      footer: [
+        { label: '页面生命周期', metric: 'sqlserver_page_life_expectancy', unit: 's' },
+        { label: '内存授予等待', metric: 'sqlserver_memory_grants_pending', unit: 'counts' }
+      ]
     },
     {
       title: '读延迟',
@@ -345,6 +452,83 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { metric: 'sqlserver_waitstats_wait_time_ms_rate', label: '总等待', color: '#8a5cff', unit: 'ms' },
         { metric: 'sqlserver_waitstats_signal_wait_time_ms_rate', label: '信号等待', color: '#ff8a1f', unit: 'ms' },
         { metric: 'sqlserver_waitstats_resource_wait_ms', label: '资源等待', color: '#faad14', unit: 'ms' }
+      ]
+    },
+    {
+      title: '缓冲池写回压力',
+      subtitle: '检查点与惰性写入',
+      metric: 'sqlserver_checkpoint_pages_rate',
+      guide: [
+        { label: '检查点写页', detail: '检查点进程将脏页写入磁盘的速率；应结合写延迟观察。' },
+        { label: '惰性写入', detail: '惰性写入器为缓冲池腾出空间的速率；持续升高且页生命周期下降时表示内存压力。' }
+      ],
+      series: [
+        { metric: 'sqlserver_checkpoint_pages_rate', label: '检查点写页', color: '#2f6bff', unit: 'cps' },
+        { metric: 'sqlserver_lazy_writes_rate', label: '惰性写入', color: '#8a5cff', unit: 'cps' }
+      ]
+    },
+    {
+      title: '并发与内存压力',
+      subtitle: '阻塞进程与内存授予等待',
+      metric: 'sqlserver_processes_blocked',
+      guide: [
+        { label: '阻塞进程', detail: '当前被锁或资源争用阻塞的进程数。' },
+        { label: '内存授予等待', detail: '等待查询工作区内存的请求数，持续非零应排查大排序、哈希和并发。' }
+      ],
+      series: [
+        { metric: 'sqlserver_processes_blocked', label: '阻塞进程', color: '#ff4d4f', unit: 'counts' },
+        { metric: 'sqlserver_memory_grants_pending', label: '内存授予等待', color: '#ff8a1f', unit: 'counts' },
+        { metric: 'sqlserver_memory_grants_outstanding', label: '已授予内存', color: '#2f6bff', unit: 'counts' }
+      ]
+    },
+    {
+      title: 'Server Memory',
+      subtitle: '当前内存与目标内存',
+      metric: 'sqlserver_memory_total_server_memory_kb',
+      guide: [
+        { label: '当前内存', detail: 'SQL Server 当前已提交的内存大小。' },
+        { label: '目标内存', detail: 'SQL Server 配置的目标内存大小；长期差距需结合内存授予等待排查。' }
+      ],
+      series: [
+        { metric: 'sqlserver_memory_total_server_memory_kb', label: '当前内存', color: '#8a5cff', unit: 'kibibytes' },
+        { metric: 'sqlserver_memory_target_server_memory_kb', label: '目标内存', color: '#9aa9bf', unit: 'kibibytes' }
+      ]
+    },
+    {
+      title: 'TempDB 健康度',
+      subtitle: '可用空间与版本存储',
+      metric: 'sqlserver_tempdb_free_space_kb',
+      guide: [
+        { label: '可用空间', detail: 'TempDB 当前剩余空间，过低会影响排序、哈希与临时对象。' },
+        { label: '版本存储', detail: '长事务或快照读会推动版本存储增长。' }
+      ],
+      series: [
+        { metric: 'sqlserver_tempdb_free_space_kb', label: '可用空间', color: '#27c274', unit: 'kibibytes' },
+        { metric: 'sqlserver_tempdb_version_store_size_kb', label: '版本存储', color: '#faad14', unit: 'kibibytes' }
+      ]
+    },
+    {
+      title: '事务日志刷写',
+      subtitle: '事务日志 I/O 负载',
+      metric: 'sqlserver_log_flushes_rate',
+      guide: [{ label: '日志刷写', detail: '事务日志刷写速率；应结合数据库写延迟判断日志 I/O 压力。' }],
+      series: [
+        { metric: 'sqlserver_log_flushes_rate', label: '日志刷写', color: '#13c2c2', unit: 'cps' }
+      ]
+    },
+    {
+      title: '计划缓存与死锁',
+      subtitle: '编译、重编译与死锁',
+      metric: 'sqlserver_sql_compilations_rate',
+      guide: [
+        { label: 'SQL 编译', detail: 'SQL 语句编译速率，需结合批量请求速率判断计划缓存效率。' },
+        { label: 'SQL 重编译', detail: 'SQL 语句重编译速率，相对编译速率持续偏高会增加 CPU 成本。' },
+        { label: '死锁', detail: '死锁发生速率，持续非零应检查事务访问顺序和隔离级别。' }
+      ],
+      series: [
+        { metric: 'sqlserver_sql_compilations_rate', label: 'SQL 编译', color: '#13c2c2', unit: 'cps' },
+        { metric: 'sqlserver_sql_recompilations_rate', label: 'SQL 重编译', color: '#faad14', unit: 'cps' },
+        { metric: 'sqlserver_deadlocks_rate', label: '死锁', color: '#ff4d4f', unit: 'cps' }
       ]
     },
     {

--- a/web/src/app/monitor/dashboards/objects/mssql/config.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/config.ts
@@ -202,10 +202,10 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     },
     {
       name: 'sqlserver_user_connections_rate',
-      display_name: '用户连接变化',
-      description: '用户连接数变化速率。',
-      unit: 'cps',
-      query: 'rate(sqlserver_performance_value{counter=~"User Connections", __$labels__}[5m])',
+      display_name: '用户连接数',
+      description: '当前连接到 SQL Server 实例的用户数量。',
+      unit: 'counts',
+      query: 'sqlserver_performance_value{counter="User Connections", __$labels__}',
       color: '#597ef7'
     },
     {
@@ -213,7 +213,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '锁等待速率',
       description: '锁等待发生速率。',
       unit: 'cps',
-      query: 'rate(sqlserver_performance_value{counter=~"Lock Waits/sec", __$labels__}[5m])',
+      query: 'rate(sqlserver_performance_value{counter="Lock Waits/sec", __$labels__}[5m])',
       color: '#ff8a1f'
     },
     {
@@ -347,7 +347,7 @@ export const MSSQL_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#27c274',
       icon: 'thunder',
       guide: [{ label: '批量请求', detail: '每秒处理的 SQL 批量请求数(次/秒),无固定阈值,按业务基线看突增突降。' }],
-      footer: [{ label: '锁等待', metric: 'sqlserver_lock_wait_time_rate', unit: 'cps' }]
+      footer: [{ label: '当前连接', metric: 'sqlserver_user_connections_rate', unit: 'counts' }]
     },
     {
       title: '缓存命中率',


### PR DESCRIPTION
## Summary

- add MSSQL diagnostic metrics and dashboard panels for checkpoint/lazy writes, memory grants, blocking/deadlocks, SQL compilation, server memory, TempDB, and log flushes
- correct the `User Connections` query to use its current gauge value
- correct `Lock Waits/sec` metadata from milliseconds to a count rate

## Validation

- MSSQL metric contract, JSON/YAML parsing, and `git diff --check`
- `pnpm eslint src/app/monitor/dashboards/objects/mssql/config.ts`
- `pnpm lint && pnpm type-check`
- live MSSQL 2022 Telegraf 1.29.5 `--test` counter verification

## Scope

This PR contains only the four MSSQL plugin metadata, localization, and dashboard files. Unrelated local workspace changes are excluded.