### PR TITLE
bugfix: 尊重 WinRM 证书校验显式设置

### DIFF
--- a/server/apps/job_mgmt/serializers/target.py
+++ b/server/apps/job_mgmt/serializers/target.py
@@ -64,7 +64,7 @@ class TargetSerializer(TeamSerializer):
         EncryptMixin.encrypt_field("ssh_password", validated_data)
         EncryptMixin.encrypt_field("ssh_key_passphrase", validated_data)
         EncryptMixin.encrypt_field("winrm_password", validated_data)
-        validated_data["winrm_cert_validation"] = False
+        validated_data.setdefault("winrm_cert_validation", False)
         return super().create(validated_data)
 
     def update(self, instance, validated_data):

--- a/server/apps/job_mgmt/tests/test_target_views.py
+++ b/server/apps/job_mgmt/tests/test_target_views.py
@@ -86,6 +86,38 @@ class TestTargetCrud:
         assert resp.status_code == 201
         assert Target.objects.filter(name="host1").exists()
 
+    @pytest.mark.parametrize(
+        ("submitted_value", "expected_value"),
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_create_windows_target_respects_explicit_cert_validation(self, su_client, submitted_value, expected_value):
+        resp = su_client.post(
+            URL,
+            self._payload(
+                os_type="windows",
+                winrm_user="administrator",
+                winrm_password="secret",
+                winrm_cert_validation=submitted_value,
+            ),
+            format="json",
+        )
+
+        assert resp.status_code == 201
+        assert Target.objects.get(name="host1").winrm_cert_validation is expected_value
+
+    def test_create_windows_target_keeps_legacy_default_without_cert_validation(self, su_client):
+        resp = su_client.post(
+            URL,
+            self._payload(os_type="windows", winrm_user="administrator", winrm_password="secret"),
+            format="json",
+        )
+
+        assert resp.status_code == 201
+        assert Target.objects.get(name="host1").winrm_cert_validation is False
+
     def test_create_missing_ssh_password_returns_400(self, su_client):
         resp = su_client.post(URL, self._payload(ssh_password=""), format="json")
         assert resp.status_code == 400

--- a/server/apps/job_mgmt/tests/test_target_views.py
+++ b/server/apps/job_mgmt/tests/test_target_views.py
@@ -9,12 +9,13 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.job_mgmt.models import Target
 from apps.job_mgmt.views import target as target_views
 
-pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+pytestmark = pytest.mark.django_db
 
 URL = "/api/v1/job_mgmt/api/target/"
 
 
 # ----------------------------- 纯函数 ----------------------------- #
+@pytest.mark.unit
 class TestParseSshTestResult:
     def test_string_success(self):
         ok, out, err, detail = target_views._parse_ssh_test_result("success")
@@ -33,6 +34,7 @@ class TestParseSshTestResult:
         assert ok is False and "未知返回类型" in err
 
 
+@pytest.mark.unit
 class TestBuildActorContext:
     def _req(self, current_team="1", include_children="0", superuser=False):
         user = SimpleNamespace(username="u", domain="domain.com", is_superuser=superuser)
@@ -57,6 +59,7 @@ class TestBuildActorContext:
             target_views._build_actor_context(self._req(current_team="abc"))
 
 
+@pytest.mark.unit
 class TestBuildSshTestFailureMessage:
     def test_merges_fallbacks(self):
         msg = target_views._build_ssh_test_failure_message({}, "err-detail", "stdout-detail")
@@ -64,6 +67,7 @@ class TestBuildSshTestFailureMessage:
 
 
 # ----------------------------- HTTP ----------------------------- #
+@pytest.mark.integration
 class TestTargetCrud:
     def _payload(self, **over):
         p = {
@@ -118,6 +122,32 @@ class TestTargetCrud:
         assert resp.status_code == 201
         assert Target.objects.get(name="host1").winrm_cert_validation is False
 
+    def test_update_windows_target_keeps_stored_false_without_cert_validation(self, su_client):
+        target = Target.objects.create(
+            name="windows-host",
+            ip="10.0.0.2",
+            os_type="windows",
+            winrm_cert_validation=False,
+            team=[1],
+        )
+
+        resp = su_client.put(
+            f"{URL}{target.id}/",
+            self._payload(
+                name="windows-host-renamed",
+                ip=target.ip,
+                os_type="windows",
+                winrm_user="administrator",
+                winrm_password="secret",
+            ),
+            format="json",
+        )
+
+        assert resp.status_code == 200
+        target.refresh_from_db()
+        assert target.name == "windows-host-renamed"
+        assert target.winrm_cert_validation is False
+
     def test_create_missing_ssh_password_returns_400(self, su_client):
         resp = su_client.post(URL, self._payload(ssh_password=""), format="json")
         assert resp.status_code == 400
@@ -130,6 +160,7 @@ class TestTargetCrud:
         assert resp.data["deleted_count"] == 2
 
 
+@pytest.mark.integration
 class TestQueryNodes:
     def test_query_nodes_success(self, su_client):
         with patch("apps.job_mgmt.views.target.SystemMgmt") as MSys, patch("apps.job_mgmt.views.target.NodeMgmt") as MNode, patch(
@@ -159,6 +190,7 @@ class TestQueryNodes:
         assert resp.status_code == 500
 
 
+@pytest.mark.integration
 class TestCloudRegions:
     def test_cloud_regions_success(self, su_client):
         with patch("apps.job_mgmt.views.target.NodeMgmt") as MNode:
@@ -174,6 +206,7 @@ class TestCloudRegions:
         assert resp.status_code == 500
 
 
+@pytest.mark.integration
 class TestTestConnection:
     def test_windows_not_supported(self, su_client):
         # windows + manual 需带 winrm 凭据才能过序列化器校验，进而到达视图的"暂不支持"分支


### PR DESCRIPTION
## 问题

Target 创建接口应保留调用方对 WinRM 服务端证书校验的显式选择，但创建序列化器会把该字段无条件覆盖为 `False`。因此即使调用方明确启用校验，执行时仍会关闭服务端身份验证。

## 根因（设计层）

创建层把兼容默认值和调用方选择混在同一次赋值里：为了兼容历史上未传字段的调用方，代码直接覆盖了所有请求，导致显式安全选择也无法穿过 API 边界。

## 怎么修的

- 仅在请求未提供 `winrm_cert_validation` 时补兼容默认值 `False`。
- 显式 `True` 与显式 `False` 原样进入模型，不改变更新接口的既有行为。
- 增加 REST 创建回归，覆盖显式开启、显式关闭和未传字段三种契约。

## 影响范围

- 仅涉及 `job_mgmt` 的 Target 创建序列化与对应测试。
- 不修改数据库结构、存量 Target、权限、API 字段、执行服务或 Ansible Executor 契约。
- 旧调用方未传字段时仍得到 `False`，显式关闭的调用方也不变；当前 Web 显式提交 `True` 时将按选择生效。
- 本 PR 是方案 2 的第一阶段，不翻转未传字段的历史默认行为；后续安全默认值切换仍需配套 CA 与存量环境迁移。
- 回滚可直接还原本提交，无数据回滚步骤。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["POST Target\nviews/target.py"]
        T2["Target 表单\npage.tsx"]
    end

    subgraph N["核心处理层"]
        N1["TargetSerializer.create\nserializers/target.py"]
        N2["Target 持久化\nmodels/target.py"]
    end

    subgraph E["执行层"]
        E1["_build_host_credentials\nexecution_base_service.py"]
        E2["WinRM inventory\nansible_runner.py"]
    end

    T2 --> T1 --> N1 --> N2
    N2 --> E1 --> E2
```

## 验证

- `apps/job_mgmt/tests/test_target_views.py`：23 passed。
- 回归测试在修复前对“显式 `True`”产生 1 个预期失败；修复后显式 `True`、显式 `False`、未传字段均通过真实 HTTP 与数据库断言。

关联 Issue #4130。
