### PR TITLE
fix(monitor): resolve storage detail brand icons

### DIFF
--- a/web/scripts/prepare-enterprise.mjs
+++ b/web/scripts/prepare-enterprise.mjs
@@ -447,7 +447,7 @@ export const prepareEnterpriseRoutes = async () => {
 /**
  * 解析 EE 端 web/src/app/monitor/utils/common.tsx 的 `export const enterpriseBrands`
  * 数组,写 CE 端 web/public/__enterprise-brands.js。运行时由 next layout.tsx
- * 注入 <Script src="/__enterprise-brands.js" strategy="afterInteractive" />,
+ * 注入 <Script src="/__enterprise-brands.js" strategy="beforeInteractive" />,
  * 加载后 window.__ENTERPRISE_BRANDS = [...]。CE 端 utils/common.tsx 的
  * getPluginBrandIcon/getBrandLabel 拼接该数组。
  * 失败降级:文件不存在 / 解析失败 → 写空数组,getPluginBrandIcon 走纯 CE BRANDS。

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -240,7 +240,7 @@ export default function RootLayout({
         {/* cache bust: prepare-enterprise.mjs 重写该文件但 next dev 模式 HMR 不重发 script,
             浏览器可能缓存旧版(空数组)→ 22 卡片全显示 VTrak 占位。
             ?v=Date.now() 强制浏览器每次重拉,避免陈旧 brand 数据 */}
-        <Script src={`/__enterprise-brands.js?v=${Date.now()}`} strategy="afterInteractive" />
+        <Script src={`/__enterprise-brands.js?v=${Date.now()}`} strategy="beforeInteractive" />
       </head>
       <body>
         {/* 全局 Context Provider 配置 */}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -237,10 +237,8 @@ export default function RootLayout({
         <title>BlueKing Lite</title>
         <link rel="icon" href="/logo-site.png" type="image/png" data-portal-favicon="true" />
         <Script src="/iconfont.js" strategy="afterInteractive"/>
-        {/* cache bust: prepare-enterprise.mjs 重写该文件但 next dev 模式 HMR 不重发 script,
-            浏览器可能缓存旧版(空数组)→ 22 卡片全显示 VTrak 占位。
-            ?v=Date.now() 强制浏览器每次重拉,避免陈旧 brand 数据 */}
-        <Script src={`/__enterprise-brands.js?v=${Date.now()}`} strategy="beforeInteractive" />
+        {/* 企业品牌映射必须在 hydration 前加载；src 保持稳定，避免 SSR/客户端生成不同地址。 */}
+        <Script src="/__enterprise-brands.js" strategy="beforeInteractive" />
       </head>
       <body>
         {/* 全局 Context Provider 配置 */}

--- a/web/src/app/monitor/(pages)/integration/list/detail/layout.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/layout.tsx
@@ -6,6 +6,7 @@ import WithSideMenuLayout from '@/components/sub-layout';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslation } from '@/utils/i18n';
 import type { MenuItem } from '@/types';
+import { getPluginBrandIcon } from '@/app/monitor/utils/common';
 
 const IntegrationDetailLayout = ({
   children
@@ -19,6 +20,8 @@ const IntegrationDetailLayout = ({
   const desc = searchParams.get('plugin_description');
   const objId = searchParams.get('id') || '';
   const icon = searchParams.get('icon');
+  const pluginName = searchParams.get('plugin_name') || '';
+  const resolvedIcon = getPluginBrandIcon(pluginName) || icon || 'cc-default_默认';
   const templateType = searchParams.get('template_type') || '';
 
   const handleBackButtonClick = () => {
@@ -31,7 +34,7 @@ const IntegrationDetailLayout = ({
     <div className="p-4 rounded-md w-full min-h-[95px] flex items-start bg-[var(--color-bg-2)]">
       <div className="w-[72px] h-[72px] mr-[10px] min-w-[72px] rounded-lg flex items-center justify-center bg-[var(--color-fill-1)]">
         <img
-          src={`/assets/icons/${icon}.svg`}
+          src={`/assets/icons/${resolvedIcon}.svg`}
           alt="icon"
           className="w-[60px] h-[60px]"
           onError={(e) => {

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -304,7 +304,7 @@ const Integration = () => {
     }
     const row: TableDataItem = {
       id: objectInfo.id || '',
-      icon: objectInfo.icon || OBJECT_DEFAULT_ICON,
+      icon: getPluginBrandIcon(app?.name) || objectInfo.icon || OBJECT_DEFAULT_ICON,
       name: objectInfo.name || '',
       plugin_name: app?.name,
       plugin_id: app?.id,

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -551,7 +551,7 @@ export const getIconByObjectName = (objectName = '', objects: ObjectItem[]) => {
 // 品牌专属采集模板/实例（如思科交换机）的品牌识别：按名称匹配 → 提供品牌标签（及可选 logo 图标）。
 // icon 可选：未提供时集成卡片回退到监控对象默认图标，仪表盘头部仍展示品牌文字标签。
 const BRANDS: { match: RegExp; label: string; icon?: string }[] = [
-  { match: /cisco/i, label: 'Cisco', icon: 'mm-cisco_思科' },
+  { match: /^(?!.*san_cisco).*cisco/i, label: 'Cisco', icon: 'mm-cisco_思科' },
   { match: /huawei/i, label: 'Huawei', icon: 'mm-huawei_华为' },
   { match: /aruba/i, label: 'Aruba', icon: 'mm-aruba_aruba' },
   { match: /juniper/i, label: 'Juniper', icon: 'mm-juniper_juniper' },
@@ -805,7 +805,7 @@ const getEnterpriseBrands = (): Array<{ match: RegExp; label: string; icon?: str
 // 按插件名取品牌 logo 图标;命中 CE BRANDS 或运行时注入的 EE __ENTERPRISE_BRANDS 任一即返回。
 // 失败降级:都未命中 → undefined,调用方回退到监控对象 icon。
 export const getPluginBrandIcon = (pluginName = ''): string | undefined => {
-  const all = [...getEnterpriseBrands(), ...BRANDS];
+  const all = [...BRANDS, ...getEnterpriseBrands()];
   return all.find((brand) => brand.match.test(pluginName))?.icon;
 };
 

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -805,7 +805,7 @@ const getEnterpriseBrands = (): Array<{ match: RegExp; label: string; icon?: str
 // 按插件名取品牌 logo 图标;命中 CE BRANDS 或运行时注入的 EE __ENTERPRISE_BRANDS 任一即返回。
 // 失败降级:都未命中 → undefined,调用方回退到监控对象 icon。
 export const getPluginBrandIcon = (pluginName = ''): string | undefined => {
-  const all = [...BRANDS, ...getEnterpriseBrands()];
+  const all = [...getEnterpriseBrands(), ...BRANDS];
   return all.find((brand) => brand.match.test(pluginName))?.icon;
 };
 


### PR DESCRIPTION
## Summary
- Resolve the storage brand icon from the integration plugin name in the detail page.
- Pass the resolved brand icon when navigating from the integration list.
- Load enterprise brand mappings before hydration so the detail header resolves its first render.

## Validation
- Verified the detail brand-icon flow statically.
- Verified the GPFS integration detail page renders `mm-gpfs_gpfs.svg` in the local browser.