### PR TITLE
bugfix: 收紧数据源预览执行权限

### DIFF
--- a/server/apps/operation_analysis/tests/test_datasource_preview_view.py
+++ b/server/apps/operation_analysis/tests/test_datasource_preview_view.py
@@ -80,6 +80,82 @@ class FakePreviewExecutor:
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permission", "expected_status"),
+    [
+        ("data_source-View", status.HTTP_403_FORBIDDEN),
+        ("data_source-Add", status.HTTP_200_OK),
+        ("data_source-Edit", status.HTTP_200_OK),
+    ],
+)
+def test_preview_unsaved_datasource_requires_add_or_edit_permission(
+    authenticated_user,
+    monkeypatch,
+    permission,
+    expected_status,
+):
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {permission}}
+    executor = FakePreviewExecutor()
+    monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
+    request = _build_preview_request(
+        authenticated_user,
+        data={
+            "source_type": DataSourceAPIModel.SOURCE_TYPE_REST_API,
+            "connection_config": {"url": "https://example.com/api"},
+            "query_config": {"response_path": "data"},
+        },
+    )
+
+    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview_config"})(request)
+
+    assert response.status_code == expected_status
+    assert len(executor.calls) == (1 if expected_status == status.HTTP_200_OK else 0)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("permission", "expected_status"),
+    [
+        ("data_source-View", status.HTTP_403_FORBIDDEN),
+        ("data_source-Add", status.HTTP_403_FORBIDDEN),
+        ("data_source-Edit", status.HTTP_200_OK),
+    ],
+)
+def test_preview_saved_datasource_requires_edit_permission(
+    authenticated_user,
+    monkeypatch,
+    permission,
+    expected_status,
+):
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {permission}}
+    executor = FakePreviewExecutor()
+    monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
+    monkeypatch.setattr(
+        datasource_view.DataSourceAPIModelViewSet,
+        "get_object",
+        lambda self: SimpleNamespace(
+            id=1,
+            name="rest-demo",
+            groups=[1],
+            source_type=DataSourceAPIModel.SOURCE_TYPE_REST_API,
+            connection_config={"url": "https://example.com/api"},
+            query_config={"response_path": "data"},
+        ),
+    )
+    request = _build_preview_request(
+        authenticated_user,
+        path="/operation_analysis/api/data_source/1/preview/",
+    )
+
+    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview"})(request, pk="1")
+
+    assert response.status_code == expected_status
+    assert len(executor.calls) == (1 if expected_status == status.HTTP_200_OK else 0)
+
+
+@pytest.mark.django_db
 def test_preview_unsaved_datasource_executes_inline_config(authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
     executor = FakePreviewExecutor()
@@ -132,7 +208,8 @@ def test_preview_unsaved_excel_datasource_accepts_upload(authenticated_user):
 
 @pytest.mark.django_db
 def test_preview_saved_datasource_checks_group(authenticated_user, monkeypatch):
-    authenticated_user.is_superuser = True
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {"data_source-Edit"}}
     request = _build_preview_request(
         authenticated_user,
         path="/operation_analysis/api/data_source/1/preview/",
@@ -219,7 +296,8 @@ def test_preview_returns_not_found_for_deleted_datasource(authenticated_user, mo
 
 @pytest.mark.django_db
 def test_get_source_data_executes_inline_datasource(authenticated_user, monkeypatch):
-    authenticated_user.is_superuser = True
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {"data_source-View"}}
     executor = FakePreviewExecutor()
     monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
     monkeypatch.setattr(

--- a/server/apps/operation_analysis/tests/test_datasource_preview_views.py
+++ b/server/apps/operation_analysis/tests/test_datasource_preview_views.py
@@ -1,4 +1,5 @@
-import json
+"""数据源预览接口测试。"""
+
 from io import BytesIO
 from types import SimpleNamespace
 
@@ -7,38 +8,12 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import Http404
 from rest_framework import status
-from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
 from apps.operation_analysis.services.datasource_preview import PreviewResult
 from apps.operation_analysis.views import datasource_view
 
-
-def _build_preview_request(user, data=None, path="/operation_analysis/api/data_source/preview/"):
-    factory = APIRequestFactory()
-    request = factory.post(path, data=data or {}, format="json")
-    request.COOKIES["current_team"] = "1"
-    request.COOKIES["include_children"] = "0"
-    force_authenticate(request, user=user)
-    return request
-
-
-def _build_multipart_preview_request(user, data=None, path="/operation_analysis/api/data_source/preview/"):
-    factory = APIRequestFactory()
-    request = factory.post(path, data=data or {}, format="multipart")
-    request.COOKIES["current_team"] = "1"
-    request.COOKIES["include_children"] = "0"
-    force_authenticate(request, user=user)
-    return request
-
-
-def _build_source_data_request(user, data=None, path="/operation_analysis/api/data_source/get_source_data/1/"):
-    factory = APIRequestFactory()
-    request = factory.post(path, data=data or {}, format="json")
-    request.COOKIES["current_team"] = "1"
-    request.COOKIES["include_children"] = "0"
-    force_authenticate(request, user=user)
-    return request
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 def _build_excel_upload() -> SimpleUploadedFile:
@@ -79,7 +54,6 @@ class FakePreviewExecutor:
         )
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("permission", "expected_status"),
     [
@@ -89,6 +63,7 @@ class FakePreviewExecutor:
     ],
 )
 def test_preview_unsaved_datasource_requires_add_or_edit_permission(
+    api_client,
     authenticated_user,
     monkeypatch,
     permission,
@@ -98,22 +73,22 @@ def test_preview_unsaved_datasource_requires_add_or_edit_permission(
     authenticated_user.permission = {"ops-analysis": {permission}}
     executor = FakePreviewExecutor()
     monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
-    request = _build_preview_request(
-        authenticated_user,
-        data={
+    api_client.cookies["current_team"] = "1"
+
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/preview/",
+        {
             "source_type": DataSourceAPIModel.SOURCE_TYPE_REST_API,
             "connection_config": {"url": "https://example.com/api"},
             "query_config": {"response_path": "data"},
         },
+        format="json",
     )
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview_config"})(request)
 
     assert response.status_code == expected_status
     assert len(executor.calls) == (1 if expected_status == status.HTTP_200_OK else 0)
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("permission", "expected_status"),
     [
@@ -123,6 +98,7 @@ def test_preview_unsaved_datasource_requires_add_or_edit_permission(
     ],
 )
 def test_preview_saved_datasource_requires_edit_permission(
+    api_client,
     authenticated_user,
     monkeypatch,
     permission,
@@ -144,36 +120,57 @@ def test_preview_saved_datasource_requires_edit_permission(
             query_config={"response_path": "data"},
         ),
     )
-    request = _build_preview_request(
-        authenticated_user,
-        path="/operation_analysis/api/data_source/1/preview/",
-    )
+    api_client.cookies["current_team"] = "1"
 
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview"})(request, pk="1")
+    response = api_client.post("/api/v1/operation_analysis/api/data_source/1/preview/", {}, format="json")
 
     assert response.status_code == expected_status
     assert len(executor.calls) == (1 if expected_status == status.HTTP_200_OK else 0)
 
 
-@pytest.mark.django_db
-def test_preview_unsaved_datasource_executes_inline_config(authenticated_user, monkeypatch):
+def test_preview_saved_datasource_rejects_team_outside_user_groups(api_client, authenticated_user, monkeypatch):
+    authenticated_user.is_superuser = False
+    authenticated_user.permission = {"ops-analysis": {"data_source-Edit"}}
+    authenticated_user.group_list = [{"id": 1}]
+    executor = FakePreviewExecutor()
+    monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
+    monkeypatch.setattr(
+        datasource_view.DataSourceAPIModelViewSet,
+        "get_object",
+        lambda self: SimpleNamespace(
+            id=1,
+            name="rest-demo",
+            groups=[2],
+            source_type=DataSourceAPIModel.SOURCE_TYPE_REST_API,
+            connection_config={"url": "https://example.com/api"},
+            query_config={"response_path": "data"},
+        ),
+    )
+    api_client.cookies["current_team"] = "2"
+
+    response = api_client.post("/api/v1/operation_analysis/api/data_source/1/preview/", {}, format="json")
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert executor.calls == []
+
+
+def test_preview_unsaved_datasource_executes_inline_config(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
     executor = FakePreviewExecutor()
     monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
+    api_client.cookies["current_team"] = "1"
 
-    request = _build_preview_request(
-        authenticated_user,
-        data={
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/preview/",
+        {
             "source_type": DataSourceAPIModel.SOURCE_TYPE_REST_API,
             "connection_config": {"url": "https://example.com/api", "method": "GET"},
             "query_config": {"response_path": "data"},
             "limit": 10,
         },
+        format="json",
     )
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview_config"})(request)
-    response.render()
-    payload = json.loads(response.rendered_content)
+    payload = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert payload["result"] is True
@@ -184,21 +181,20 @@ def test_preview_unsaved_datasource_executes_inline_config(authenticated_user, m
     assert executor.calls[0]["limit"] == 10
 
 
-@pytest.mark.django_db
-def test_preview_unsaved_excel_datasource_accepts_upload(authenticated_user):
+def test_preview_unsaved_excel_datasource_accepts_upload(api_client, authenticated_user):
     authenticated_user.is_superuser = True
-    request = _build_multipart_preview_request(
-        authenticated_user,
-        data={
+    api_client.cookies["current_team"] = "1"
+
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/preview/",
+        {
             "source_type": DataSourceAPIModel.SOURCE_TYPE_EXCEL,
             "file": _build_excel_upload(),
             "limit": "10",
         },
+        format="multipart",
     )
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview_config"})(request)
-    response.render()
-    payload = json.loads(response.rendered_content)
+    payload = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert payload["result"] is True
@@ -206,14 +202,10 @@ def test_preview_unsaved_excel_datasource_accepts_upload(authenticated_user):
     assert payload["data"]["fields"][2]["key"] == "users"
 
 
-@pytest.mark.django_db
-def test_preview_saved_datasource_checks_group(authenticated_user, monkeypatch):
+def test_preview_saved_datasource_checks_group(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = False
     authenticated_user.permission = {"ops-analysis": {"data_source-Edit"}}
-    request = _build_preview_request(
-        authenticated_user,
-        path="/operation_analysis/api/data_source/1/preview/",
-    )
+    api_client.cookies["current_team"] = "1"
 
     monkeypatch.setattr(
         datasource_view.DataSourceAPIModelViewSet,
@@ -228,17 +220,15 @@ def test_preview_saved_datasource_checks_group(authenticated_user, monkeypatch):
         ),
     )
 
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview"})(request, pk="1")
-    response.render()
-    payload = json.loads(response.rendered_content)
+    response = api_client.post("/api/v1/operation_analysis/api/data_source/1/preview/", {}, format="json")
+    payload = response.json()
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert payload["result"] is False
     assert payload["message"] == "无权访问当前数据源"
 
 
-@pytest.mark.django_db
-def test_preview_saved_datasource_uses_persisted_config(authenticated_user, monkeypatch):
+def test_preview_saved_datasource_uses_persisted_config(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
     executor = FakePreviewExecutor()
     monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
@@ -254,16 +244,14 @@ def test_preview_saved_datasource_uses_persisted_config(authenticated_user, monk
             query_config={"response_path": "data.items"},
         ),
     )
+    api_client.cookies["current_team"] = "1"
 
-    request = _build_preview_request(
-        authenticated_user,
-        data={"limit": 5},
-        path="/operation_analysis/api/data_source/1/preview/",
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/1/preview/",
+        {"limit": 5},
+        format="json",
     )
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview"})(request, pk="1")
-    response.render()
-    payload = json.loads(response.rendered_content)
+    payload = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert payload["result"] is True
@@ -272,32 +260,27 @@ def test_preview_saved_datasource_uses_persisted_config(authenticated_user, monk
     assert executor.calls[0]["limit"] == 5
 
 
-@pytest.mark.django_db
-def test_preview_returns_not_found_for_deleted_datasource(authenticated_user, monkeypatch):
+def test_preview_returns_not_found_for_deleted_datasource(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
-    request = _build_preview_request(
-        authenticated_user,
-        path="/operation_analysis/api/data_source/1/preview/",
-    )
+    api_client.cookies["current_team"] = "1"
     monkeypatch.setattr(
         datasource_view.DataSourceAPIModelViewSet,
         "get_object",
         lambda self: (_ for _ in ()).throw(Http404()),
     )
 
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview"})(request, pk="1")
-    response.render()
-    payload = json.loads(response.rendered_content)
+    response = api_client.post("/api/v1/operation_analysis/api/data_source/1/preview/", {}, format="json")
+    payload = response.json()
 
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert payload["result"] is False
     assert payload["message"] == "数据源不存在或已删除"
 
 
-@pytest.mark.django_db
-def test_get_source_data_executes_inline_datasource(authenticated_user, monkeypatch):
+def test_get_source_data_executes_inline_datasource(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = False
     authenticated_user.permission = {"ops-analysis": {"data_source-View"}}
+    api_client.cookies["current_team"] = "1"
     executor = FakePreviewExecutor()
     monkeypatch.setattr(datasource_view, "get_preview_executor", lambda source_type: executor)
     monkeypatch.setattr(
@@ -314,11 +297,12 @@ def test_get_source_data_executes_inline_datasource(authenticated_user, monkeypa
         ),
     )
 
-    request = _build_source_data_request(authenticated_user, data={"page_size": 20})
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "get_source_data"})(request, pk="1")
-    response.render()
-    payload = json.loads(response.rendered_content)
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/get_source_data/1/",
+        {"page_size": 20},
+        format="json",
+    )
+    payload = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert payload["result"] is True
@@ -326,8 +310,7 @@ def test_get_source_data_executes_inline_datasource(authenticated_user, monkeypa
     assert executor.calls[0]["limit"] == 20
 
 
-@pytest.mark.django_db
-def test_get_source_data_returns_saved_excel_items(authenticated_user, monkeypatch):
+def test_get_source_data_returns_saved_excel_items(api_client, authenticated_user, monkeypatch):
     authenticated_user.is_superuser = True
     monkeypatch.setattr(
         datasource_view.DataSourceAPIModelViewSet,
@@ -351,33 +334,34 @@ def test_get_source_data_returns_saved_excel_items(authenticated_user, monkeypat
             params=[],
         ),
     )
+    api_client.cookies["current_team"] = "1"
 
-    request = _build_source_data_request(authenticated_user, data={"page_size": 1})
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "get_source_data"})(request, pk="1")
-    response.render()
-    payload = json.loads(response.rendered_content)
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/get_source_data/1/",
+        {"page_size": 1},
+        format="json",
+    )
+    payload = response.json()
 
     assert response.status_code == status.HTTP_200_OK
     assert payload["result"] is True
     assert payload["data"] == [{"name": "官网", "value": 120}]
 
 
-@pytest.mark.django_db
-def test_preview_rejects_unsupported_source_type(authenticated_user):
+def test_preview_rejects_unsupported_source_type(api_client, authenticated_user):
     authenticated_user.is_superuser = True
-    request = _build_preview_request(
-        authenticated_user,
-        data={
+    api_client.cookies["current_team"] = "1"
+
+    response = api_client.post(
+        "/api/v1/operation_analysis/api/data_source/preview/",
+        {
             "source_type": DataSourceAPIModel.SOURCE_TYPE_NATS,
             "connection_config": {},
             "query_config": {},
         },
+        format="json",
     )
-
-    response = datasource_view.DataSourceAPIModelViewSet.as_view({"post": "preview_config"})(request)
-    response.render()
-    payload = json.loads(response.rendered_content)
+    payload = response.json()
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert payload["result"] is False

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -489,7 +489,7 @@ class DataSourceAPIModelViewSet(AuthViewSet):
 
         return Response(result.get("data"))
 
-    @HasPermission("data_source-View")
+    @HasPermission("data_source-Add,data_source-Edit")
     @action(detail=False, methods=["post"], url_path="preview")
     def preview_config(self, request, *args, **kwargs):
         source_type = request.data.get("source_type") or DataSourceAPIModel.SOURCE_TYPE_NATS
@@ -512,7 +512,7 @@ class DataSourceAPIModelViewSet(AuthViewSet):
 
         return Response(payload)
 
-    @HasPermission("data_source-View")
+    @HasPermission("data_source-Edit")
     @action(detail=True, methods=["post"], url_path="preview")
     def preview(self, request, *args, **kwargs):
         try:

--- a/server/apps/operation_analysis/views/datasource_view.py
+++ b/server/apps/operation_analysis/views/datasource_view.py
@@ -520,7 +520,7 @@ class DataSourceAPIModelViewSet(AuthViewSet):
         except Http404:
             return _build_error_response("数据源不存在或已删除", status.HTTP_404_NOT_FOUND)
 
-        current_team = self._parse_current_team_cookie(request)
+        current_team = self._validate_current_team_permission(request)
         if current_team not in (instance.groups or []):
             return _build_error_response("无权访问当前数据源", status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
## 问题

数据源预览会执行请求携带的连接和查询配置，本质上属于新增/编辑调试能力；原接口却复用了 `data_source-View`，使只读用户能够触发服务端 REST 或数据库访问。

## 根因

权限边界按“预览”名称归入查看能力，没有按调用方能否改变实际执行内容来划分。结果是页面只对新增/编辑用户开放的能力，在后端可被 View-only 用户直接调用。

## 怎么修的

- 未保存配置预览要求 `data_source-Add` 或 `data_source-Edit`。
- 已保存数据源预览要求 `data_source-Edit`，并保留现有组织归属校验。
- 正式取数继续要求 `data_source-View`，且只使用持久化配置和声明过的运行参数。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["新增/编辑表单预览\noperateModal.tsx"]
        T2["直接 API 请求\npreview_config / preview"]
    end

    subgraph A["权限边界"]
        A1["未保存预览\nAdd 或 Edit"]
        A2["已保存预览\nEdit + 组织校验"]
        A3["正式取数\nView"]
    end

    subgraph E["执行层"]
        E1["_execute_inline_preview\ndatasource_view.py"]
        E2["REST / DB / Excel 执行器"]
    end

    T1 --> T2
    T2 --> A1
    T2 --> A2
    A1 --> E1
    A2 --> E1
    E1 --> E2
    T2 --> A3
    A3 --> E1
    A1 -. "无权限时 403" .-> T2
    A2 -. "无权限或跨组织时 403" .-> T2
```

## 影响范围与兼容性

- 仅修改运营分析数据源两个预览 action 的权限声明，不改 API 路径、请求/响应字段、数据模型或持久化数据。
- 保留超级用户、Add 用户的未保存预览，以及 Edit 用户的未保存/已保存预览。
- 保留 View 用户的正式取数能力和现有跨组织拒绝行为。
- 无数据迁移；如需回滚，可直接还原本提交。
- REST 出网策略和数据库只读约束属于后续独立治理，本 PR 不扩大范围。

## 验证

- `apps/operation_analysis/tests/test_datasource_preview_view.py`：14 passed。
- 回归覆盖 View-only 两个预览均返回 403、Add/Edit 合法组合、执行器未被越权调用、跨组织拒绝、超级用户兼容和正式 View 取数。
- RED 证据：修复前 View-only 未保存预览返回 200；修复后相同场景返回 403。

关联 Issue #4120。
