### PR TITLE
fix(monitor): localize Docker endpoint placeholder

### DIFF
--- a/server/apps/monitor/services/ui_template_locale.py
+++ b/server/apps/monitor/services/ui_template_locale.py
@@ -36,7 +36,7 @@ _EN_FALLBACKS = {
     "选择 SNMP 版本": "Select SNMP Version",
     "选择安全级别": "Select Security Level",
     "主机地址": "Host Address",
-    "Docer守护进程连接地址，默认为 unix:///var/run/docker.sock": "Docker daemon address; defaults to unix:///var/run/docker.sock",
+    "Docker守护进程连接地址，默认为 unix:///var/run/docker.sock": "Docker daemon address; defaults to unix:///var/run/docker.sock",
     "IP地址": "IP Address",
     "数据库类型": "Database Type",
     "采样窗口": "Sampling Window",


### PR DESCRIPTION
## Summary
- Align the Docker endpoint placeholder fallback key with the current UI template text.
- Restore the English placeholder in the Docker integration form.

## Validation
- ENABLE_CELERY=true pytest apps/monitor/tests/test_ui_template_locale.py --no-cov -q (11 passed)
- python -m compileall -q apps/monitor/services/ui_template_locale.py
- git diff --check

## Scope
- Reviewed staged and base diffs: one production file, one-line replacement.
- Local regression test change is intentionally not committed under repository scope rules.