### PR TITLE
bugfix: 修复公共选项库跨组织写入

### DIFF
--- a/server/apps/cmdb/services/public_enum_library.py
+++ b/server/apps/cmdb/services/public_enum_library.py
@@ -4,7 +4,7 @@
 # @Author: windyzhao
 import json
 import time
-from typing import Any
+from typing import Any, Callable
 
 from django.db import transaction
 from nanoid import generate
@@ -18,6 +18,7 @@ from apps.core.logger import cmdb_logger as logger
 
 
 PUBLIC_ENUM_LIBRARY_MANAGER: Any = getattr(PublicEnumLibrary, "objects")
+LibraryAuthorizer = Callable[[PublicEnumLibrary], None]
 
 
 def _generate_library_id() -> str:
@@ -79,40 +80,59 @@ def create_library(payload: dict, operator: str) -> dict:
     }
 
 
-def update_library(library_id: str, payload: dict, operator: str) -> dict:
-    library = PUBLIC_ENUM_LIBRARY_MANAGER.filter(library_id=library_id).first()
-    if not library:
-        raise BaseAppException("公共选项库不存在")
+def update_library(
+    library_id: str,
+    payload: dict,
+    operator: str,
+    *,
+    authorize: LibraryAuthorizer | None = None,
+) -> dict:
+    with transaction.atomic():
+        library = (
+            PUBLIC_ENUM_LIBRARY_MANAGER.select_for_update()
+            .filter(library_id=library_id)
+            .first()
+        )
+        if not library:
+            raise BaseAppException("公共选项库不存在")
+        if authorize:
+            authorize(library)
 
-    update_fields = ["updated_at", "updated_by"]
-    library.updated_by = operator
+        update_fields = ["updated_at", "updated_by"]
+        library.updated_by = operator
 
-    if "name" in payload:
-        name = payload["name"].strip() if payload["name"] else ""
-        if not name:
-            raise BaseAppException("公共选项库名称不能为空")
-        library.name = name
-        update_fields.append("name")
+        if "name" in payload:
+            name = payload["name"].strip() if payload["name"] else ""
+            if not name:
+                raise BaseAppException("公共选项库名称不能为空")
+            library.name = name
+            update_fields.append("name")
 
-    if "team" in payload:
-        team = payload["team"]
-        if not isinstance(team, list):
-            raise BaseAppException("team 必须是数组")
-        library.team = team
-        update_fields.append("team")
+        if "team" in payload:
+            team = payload["team"]
+            if not isinstance(team, list):
+                raise BaseAppException("team 必须是数组")
+            library.team = team
+            update_fields.append("team")
 
-    if "options" in payload:
-        options = payload["options"]
-        _validate_options(options)
-        library.options = options
-        update_fields.append("options")
+        if "options" in payload:
+            options = payload["options"]
+            _validate_options(options)
+            library.options = options
+            update_fields.append("options")
 
-    library.save(update_fields=update_fields)
+        library.save(update_fields=update_fields)
 
     logger.info(f"[PublicEnumLibrary] updated library_id={library_id}, fields={update_fields}, operator={operator}")
 
     if "options" in payload:
-        enqueue_library_snapshot_refresh(library_id, trigger="update", operator=operator)
+        transaction.on_commit(
+            lambda: enqueue_library_snapshot_refresh(
+                library_id,
+                trigger="update",
+                operator=operator,
+            )
+        )
 
     return {
         "library_id": library.library_id,
@@ -126,28 +146,43 @@ def update_library(library_id: str, payload: dict, operator: str) -> dict:
     }
 
 
-def delete_library(library_id: str, operator: str) -> None:
-    library = PUBLIC_ENUM_LIBRARY_MANAGER.filter(library_id=library_id).first()
-    if not library:
-        raise BaseAppException("公共选项库不存在")
+def delete_library(
+    library_id: str,
+    operator: str,
+    *,
+    authorize: LibraryAuthorizer | None = None,
+) -> None:
+    with transaction.atomic():
+        library = (
+            PUBLIC_ENUM_LIBRARY_MANAGER.select_for_update()
+            .filter(library_id=library_id)
+            .first()
+        )
+        if not library:
+            raise BaseAppException("公共选项库不存在")
+        if authorize:
+            authorize(library)
 
-    start_time = time.time()
-    references = find_library_references(library_id)
-    query_cost_ms = int((time.time() - start_time) * 1000)
+        start_time = time.time()
+        references = find_library_references(library_id)
+        query_cost_ms = int((time.time() - start_time) * 1000)
 
-    logger.info(
-        f"[PublicEnumLibrary] delete_library library_id={library_id}, operator={operator}, "
-        f"blocked={len(references) > 0}, reference_count={len(references)}, query_cost_ms={query_cost_ms}"
-    )
-
-    if references:
-        ref_details = ", ".join(f"{ref['model_name']}({ref['model_id']}).{ref['attr_name']}({ref['attr_id']})" for ref in references)
-        raise BaseAppException(
-            f"该公共选项库正在被以下属性引用，无法删除: {ref_details}",
-            data={"references": references},
+        logger.info(
+            f"[PublicEnumLibrary] delete_library library_id={library_id}, operator={operator}, "
+            f"blocked={len(references) > 0}, reference_count={len(references)}, query_cost_ms={query_cost_ms}"
         )
 
-    library.delete()
+        if references:
+            ref_details = ", ".join(
+                f"{ref['model_name']}({ref['model_id']}).{ref['attr_name']}({ref['attr_id']})"
+                for ref in references
+            )
+            raise BaseAppException(
+                f"该公共选项库正在被以下属性引用，无法删除: {ref_details}",
+                data={"references": references},
+            )
+
+        library.delete()
     logger.info(f"[PublicEnumLibrary] deleted library_id={library_id}, operator={operator}")
 
 

--- a/server/apps/cmdb/tests/bdd/test_public_enum_library_bdd.py
+++ b/server/apps/cmdb/tests/bdd/test_public_enum_library_bdd.py
@@ -202,15 +202,41 @@ def _run_update(ctx, operator, library_id, payload_str, *, expect_error: bool):
 @when(parsers.re(
     r'管理员 "(?P<operator>[^"]+)" 更新选项库 "(?P<library_id>[^"]+)" 字段 (?P<payload>.+)$'
 ))
-def _when_update_happy(ctx, operator, library_id, payload):
-    _run_update(ctx, operator, library_id, payload, expect_error=False)
+def _when_update_happy(
+    ctx,
+    operator,
+    library_id,
+    payload,
+    django_capture_on_commit_callbacks,
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        _run_update(
+            ctx,
+            operator,
+            library_id,
+            payload,
+            expect_error=False,
+        )
 
 
 @when(parsers.re(
     r'管理员 "(?P<operator>[^"]+)" 尝试更新选项库 "(?P<library_id>[^"]+)" 字段 (?P<payload>.+)$'
 ))
-def _when_update_corner(ctx, operator, library_id, payload):
-    _run_update(ctx, operator, library_id, payload, expect_error=True)
+def _when_update_corner(
+    ctx,
+    operator,
+    library_id,
+    payload,
+    django_capture_on_commit_callbacks,
+):
+    with django_capture_on_commit_callbacks(execute=True):
+        _run_update(
+            ctx,
+            operator,
+            library_id,
+            payload,
+            expect_error=True,
+        )
 
 
 def _run_delete(ctx, operator, library_id, *, expect_error: bool):

--- a/server/apps/cmdb/tests/test_public_enum_service.py
+++ b/server/apps/cmdb/tests/test_public_enum_service.py
@@ -7,6 +7,7 @@ import importlib
 import json
 
 import pytest
+from django.db import transaction
 
 from apps.cmdb.models.public_enum_library import PublicEnumLibrary
 from apps.cmdb.services import public_enum_library as svc
@@ -109,6 +110,36 @@ def test_update_library_name_team(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_update_library_locks_before_authorization(monkeypatch):
+    library = _make()
+    called = []
+    select_for_update = svc.PUBLIC_ENUM_LIBRARY_MANAGER.select_for_update
+
+    def _select_for_update():
+        called.append("locked")
+        return select_for_update()
+
+    def _authorize(target):
+        called.append("authorized")
+        assert target.pk == library.pk
+
+    monkeypatch.setattr(
+        svc.PUBLIC_ENUM_LIBRARY_MANAGER,
+        "select_for_update",
+        _select_for_update,
+    )
+
+    svc.update_library(
+        "lib_1",
+        {"name": "新名"},
+        "bob",
+        authorize=_authorize,
+    )
+
+    assert called == ["locked", "authorized"]
+
+
+@pytest.mark.django_db
 def test_update_library_empty_name():
     _make()
     with pytest.raises(BaseAppException):
@@ -116,16 +147,51 @@ def test_update_library_empty_name():
 
 
 @pytest.mark.django_db
-def test_update_library_options_enqueues(monkeypatch):
+def test_update_library_options_enqueues(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
     _make()
     called = {}
     monkeypatch.setattr(
         f"{MODULE}.enqueue_library_snapshot_refresh",
         lambda library_id, trigger, operator: called.setdefault("hit", True),
     )
-    result = svc.update_library("lib_1", {"options": [{"id": "2", "name": "停止"}]}, "admin")
+    with django_capture_on_commit_callbacks(execute=True):
+        result = svc.update_library(
+            "lib_1",
+            {"options": [{"id": "2", "name": "停止"}]},
+            "admin",
+        )
     assert result["options"][0]["id"] == "2"
     assert called.get("hit") is True
+
+
+@pytest.mark.django_db
+def test_update_library_options_does_not_enqueue_after_outer_rollback(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    _make()
+    called = {}
+    monkeypatch.setattr(
+        f"{MODULE}.enqueue_library_snapshot_refresh",
+        lambda library_id, trigger, operator: called.setdefault(
+            "hit", True
+        ),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        with pytest.raises(RuntimeError, match="rollback"):
+            with transaction.atomic():
+                svc.update_library(
+                    "lib_1",
+                    {"options": [{"id": "2", "name": "停止"}]},
+                    "admin",
+                )
+                raise RuntimeError("rollback")
+
+    assert called == {}
 
 
 # --------------------------------------------------------------------------
@@ -207,6 +273,45 @@ def test_delete_library_ok(monkeypatch):
     monkeypatch.setattr(f"{MODULE}.find_library_references", lambda lib: [])
     svc.delete_library("lib_1", "admin")
     assert not PublicEnumLibrary.objects.filter(library_id="lib_1").exists()
+
+
+@pytest.mark.django_db
+def test_delete_library_locks_and_authorizes_before_reference_scan(
+    monkeypatch,
+):
+    library = _make()
+    called = []
+    select_for_update = svc.PUBLIC_ENUM_LIBRARY_MANAGER.select_for_update
+
+    def _select_for_update():
+        called.append("locked")
+        return select_for_update()
+
+    def _authorize(target):
+        called.append("authorized")
+        assert target.pk == library.pk
+
+    def _find_references(library_id):
+        called.append("references")
+        return []
+
+    monkeypatch.setattr(
+        svc.PUBLIC_ENUM_LIBRARY_MANAGER,
+        "select_for_update",
+        _select_for_update,
+    )
+    monkeypatch.setattr(
+        f"{MODULE}.find_library_references",
+        _find_references,
+    )
+
+    svc.delete_library(
+        "lib_1",
+        "admin",
+        authorize=_authorize,
+    )
+
+    assert called == ["locked", "authorized", "references"]
 
 
 @pytest.mark.django_db

--- a/server/apps/cmdb/tests/test_public_enum_views.py
+++ b/server/apps/cmdb/tests/test_public_enum_views.py
@@ -45,11 +45,18 @@ def editor(authenticated_user):
     return u
 
 
-def _req(method, user, data=None, include_children=False):
+def _req(
+    method,
+    user,
+    data=None,
+    include_children=False,
+    current_team="1",
+):
     factory = APIRequestFactory()
     fn = getattr(factory, method)
     request = fn("/x/") if data is None else fn("/x/", data=data, format="json")
-    request.COOKIES["current_team"] = "1"
+    if current_team is not None:
+        request.COOKIES["current_team"] = current_team
     request.COOKIES["include_children"] = "1" if include_children else "0"
     force_authenticate(request, user=user)
     return request
@@ -60,6 +67,27 @@ def _body(response):
         response.render()
         return json.loads(response.rendered_content)
     return json.loads(response.content)
+
+
+def _update_stub(library_team, called=None):
+    def _update(pk, payload, operator, *, authorize=None):
+        assert authorize is not None
+        authorize(SimpleNamespace(team=library_team))
+        if called is not None:
+            called["updated"] = True
+        return {"id": int(pk)}
+
+    return _update
+
+
+def _delete_stub(library_team, called=None):
+    def _delete(pk, operator, *, authorize=None):
+        assert authorize is not None
+        authorize(SimpleNamespace(team=library_team))
+        if called is not None:
+            called["deleted"] = True
+
+    return _delete
 
 
 @pytest.mark.django_db
@@ -109,8 +137,50 @@ def test_create_rejects_team_outside_current_scope(editor, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_create_requires_current_team_for_scoped_library(editor, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.create_library",
+        lambda payload, operator: called.setdefault("created", True),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"post": "create"})(
+        _req(
+            "post",
+            editor,
+            data={"name": "x", "team": [1]},
+            current_team=None,
+        )
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert called == {}
+
+
+@pytest.mark.django_db
+def test_create_accepts_api_token_integer_group_scope(editor, monkeypatch):
+    editor.group_list = [1]
+    monkeypatch.setattr(
+        f"{SVC}.create_library",
+        lambda payload, operator: {"id": 9},
+    )
+    request = _req(
+        "post",
+        editor,
+        data={"name": "x", "team": [1]},
+        current_team=None,
+    )
+    request._api_current_team = 1
+
+    response = PublicEnumLibraryViewSet.as_view({"post": "create"})(request)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _body(response)["data"]["id"] == 9
+
+
+@pytest.mark.django_db
 def test_update_not_found(superuser, monkeypatch):
-    def _raise(pk, payload, operator):
+    def _raise(pk, payload, operator, *, authorize=None):
         raise BaseAppException("枚举库不存在")
 
     monkeypatch.setattr(f"{SVC}.update_library", _raise)
@@ -122,7 +192,10 @@ def test_update_not_found(superuser, monkeypatch):
 
 @pytest.mark.django_db
 def test_update_ok(superuser, monkeypatch):
-    monkeypatch.setattr(f"{SVC}.update_library", lambda pk, payload, operator: {"id": int(pk)})
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator, **kwargs: {"id": int(pk)},
+    )
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
         _req("put", superuser, data={"name": "x"}), pk="5"
     )
@@ -133,12 +206,8 @@ def test_update_ok(superuser, monkeypatch):
 def test_update_rejects_library_outside_current_scope(editor, monkeypatch):
     called = {}
     monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[9]),
-    )
-    monkeypatch.setattr(
         f"{SVC}.update_library",
-        lambda pk, payload, operator: called.setdefault("updated", True),
+        _update_stub([9], called),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
@@ -153,12 +222,8 @@ def test_update_rejects_library_outside_current_scope(editor, monkeypatch):
 def test_update_rejects_new_team_outside_current_scope(editor, monkeypatch):
     called = {}
     monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[1]),
-    )
-    monkeypatch.setattr(
         f"{SVC}.update_library",
-        lambda pk, payload, operator: called.setdefault("updated", True),
+        _update_stub([1], called),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
@@ -174,12 +239,8 @@ def test_update_allows_keeping_existing_team_outside_current_scope(
     editor, monkeypatch
 ):
     monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[1, 9]),
-    )
-    monkeypatch.setattr(
         f"{SVC}.update_library",
-        lambda pk, payload, operator: {"id": int(pk)},
+        _update_stub([1, 9]),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
@@ -191,14 +252,51 @@ def test_update_allows_keeping_existing_team_outside_current_scope(
 
 
 @pytest.mark.django_db
-def test_update_allows_child_library_when_include_children_enabled(editor, monkeypatch):
-    monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[2]),
-    )
+def test_update_allows_removing_existing_team_outside_current_scope(
+    editor, monkeypatch
+):
     monkeypatch.setattr(
         f"{SVC}.update_library",
-        lambda pk, payload, operator: {"id": int(pk)},
+        _update_stub([1, 9]),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x", "team": [1]}), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _body(response)["data"]["id"] == 5
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("requested_team", ([9], []))
+def test_update_rejects_removing_own_team_scope(
+    editor, monkeypatch, requested_team
+):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        _update_stub([1, 9], called),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req(
+            "put",
+            editor,
+            data={"name": "x", "team": requested_team},
+        ),
+        pk="5",
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert called == {}
+
+
+@pytest.mark.django_db
+def test_update_allows_child_library_when_include_children_enabled(editor, monkeypatch):
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        _update_stub([2]),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
@@ -212,12 +310,8 @@ def test_update_allows_child_library_when_include_children_enabled(editor, monke
 @pytest.mark.django_db
 def test_update_keeps_global_library_compatible_for_editor(editor, monkeypatch):
     monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[]),
-    )
-    monkeypatch.setattr(
         f"{SVC}.update_library",
-        lambda pk, payload, operator: {"id": int(pk)},
+        _update_stub([]),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
@@ -230,7 +324,10 @@ def test_update_keeps_global_library_compatible_for_editor(editor, monkeypatch):
 
 @pytest.mark.django_db
 def test_destroy_ok(superuser, monkeypatch):
-    monkeypatch.setattr(f"{SVC}.delete_library", lambda pk, operator: None)
+    monkeypatch.setattr(
+        f"{SVC}.delete_library",
+        lambda pk, operator, **kwargs: None,
+    )
     response = PublicEnumLibraryViewSet.as_view({"delete": "destroy"})(_req("delete", superuser), pk="5")
     assert response.status_code == status.HTTP_200_OK
 
@@ -239,12 +336,8 @@ def test_destroy_ok(superuser, monkeypatch):
 def test_destroy_rejects_library_outside_current_scope(editor, monkeypatch):
     called = {}
     monkeypatch.setattr(
-        f"{SVC}.get_library_or_raise",
-        lambda pk: SimpleNamespace(team=[9]),
-    )
-    monkeypatch.setattr(
         f"{SVC}.delete_library",
-        lambda pk, operator: called.setdefault("deleted", True),
+        _delete_stub([9], called),
     )
 
     response = PublicEnumLibraryViewSet.as_view({"delete": "destroy"})(
@@ -257,7 +350,7 @@ def test_destroy_rejects_library_outside_current_scope(editor, monkeypatch):
 
 @pytest.mark.django_db
 def test_destroy_not_found(superuser, monkeypatch):
-    def _raise(pk, operator):
+    def _raise(pk, operator, **kwargs):
         raise BaseAppException("枚举库不存在")
 
     monkeypatch.setattr(f"{SVC}.delete_library", _raise)
@@ -267,7 +360,7 @@ def test_destroy_not_found(superuser, monkeypatch):
 
 @pytest.mark.django_db
 def test_destroy_conflict(superuser, monkeypatch):
-    def _raise(pk, operator):
+    def _raise(pk, operator, **kwargs):
         raise BaseAppException("存在引用", data={"references": [{"model_id": "host"}]})
 
     monkeypatch.setattr(f"{SVC}.delete_library", _raise)

--- a/server/apps/cmdb/tests/test_public_enum_views.py
+++ b/server/apps/cmdb/tests/test_public_enum_views.py
@@ -4,6 +4,7 @@
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from rest_framework import status
@@ -24,11 +25,32 @@ def superuser(authenticated_user):
     return u
 
 
-def _req(method, user, data=None):
+@pytest.fixture
+def editor(authenticated_user):
+    u = authenticated_user
+    u.is_superuser = False
+    u.group_list = [{"id": 1}]
+    u.group_tree = [
+        {
+            "id": 1,
+            "subGroups": [{"id": 2, "subGroups": []}],
+        }
+    ]
+    u.permission = {
+        "cmdb": {
+            "model_management-Edit Model",
+            "model_management-Delete Model",
+        }
+    }
+    return u
+
+
+def _req(method, user, data=None, include_children=False):
     factory = APIRequestFactory()
     fn = getattr(factory, method)
     request = fn("/x/") if data is None else fn("/x/", data=data, format="json")
     request.COOKIES["current_team"] = "1"
+    request.COOKIES["include_children"] = "1" if include_children else "0"
     force_authenticate(request, user=user)
     return request
 
@@ -71,6 +93,22 @@ def test_create_error(superuser, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_create_rejects_team_outside_current_scope(editor, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.create_library",
+        lambda payload, operator: called.setdefault("created", True),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"post": "create"})(
+        _req("post", editor, data={"name": "x", "team": [9]})
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert called == {}
+
+
+@pytest.mark.django_db
 def test_update_not_found(superuser, monkeypatch):
     def _raise(pk, payload, operator):
         raise BaseAppException("枚举库不存在")
@@ -92,10 +130,108 @@ def test_update_ok(superuser, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_update_rejects_library_outside_current_scope(editor, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[9]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator: called.setdefault("updated", True),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x"}), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert called == {}
+
+
+@pytest.mark.django_db
+def test_update_rejects_new_team_outside_current_scope(editor, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[1]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator: called.setdefault("updated", True),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x", "team": [9]}), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert called == {}
+
+
+@pytest.mark.django_db
+def test_update_allows_child_library_when_include_children_enabled(editor, monkeypatch):
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[2]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator: {"id": int(pk)},
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x"}, include_children=True), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _body(response)["data"]["id"] == 5
+
+
+@pytest.mark.django_db
+def test_update_keeps_global_library_compatible_for_editor(editor, monkeypatch):
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator: {"id": int(pk)},
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x"}), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _body(response)["data"]["id"] == 5
+
+
+@pytest.mark.django_db
 def test_destroy_ok(superuser, monkeypatch):
     monkeypatch.setattr(f"{SVC}.delete_library", lambda pk, operator: None)
     response = PublicEnumLibraryViewSet.as_view({"delete": "destroy"})(_req("delete", superuser), pk="5")
     assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_destroy_rejects_library_outside_current_scope(editor, monkeypatch):
+    called = {}
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[9]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.delete_library",
+        lambda pk, operator: called.setdefault("deleted", True),
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"delete": "destroy"})(
+        _req("delete", editor), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert called == {}
 
 
 @pytest.mark.django_db

--- a/server/apps/cmdb/tests/test_public_enum_views.py
+++ b/server/apps/cmdb/tests/test_public_enum_views.py
@@ -170,6 +170,27 @@ def test_update_rejects_new_team_outside_current_scope(editor, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_update_allows_keeping_existing_team_outside_current_scope(
+    editor, monkeypatch
+):
+    monkeypatch.setattr(
+        f"{SVC}.get_library_or_raise",
+        lambda pk: SimpleNamespace(team=[1, 9]),
+    )
+    monkeypatch.setattr(
+        f"{SVC}.update_library",
+        lambda pk, payload, operator: {"id": int(pk)},
+    )
+
+    response = PublicEnumLibraryViewSet.as_view({"put": "update"})(
+        _req("put", editor, data={"name": "x", "team": [1, 9]}), pk="5"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert _body(response)["data"]["id"] == 5
+
+
+@pytest.mark.django_db
 def test_update_allows_child_library_when_include_children_enabled(editor, monkeypatch):
     monkeypatch.setattr(
         f"{SVC}.get_library_or_raise",

--- a/server/apps/cmdb/views/public_enum_library.py
+++ b/server/apps/cmdb/views/public_enum_library.py
@@ -4,6 +4,7 @@
 # @Author: windyzhao
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 
 from apps.cmdb.models.public_enum_library import PublicEnumLibrary
 from apps.cmdb.services import public_enum_library as library_service
@@ -23,6 +24,43 @@ class PublicEnumLibraryViewSet(AuthViewSet):
 
     def _get_user_team(self, request) -> list:
         return [g["id"] for g in getattr(request.user, "group_list", []) or []]
+
+    def _get_editable_team_scope(self, request) -> set[str]:
+        user_team = self._get_user_team(request)
+        current_team = get_current_team_from_request(request, required=False)
+        if not current_team:
+            return {str(team) for team in user_team}
+
+        if str(current_team) not in {str(team) for team in user_team}:
+            raise PermissionDenied("无权访问该团队数据")
+
+        if request.COOKIES.get("include_children") == "1":
+            team = get_organization_and_children_ids(
+                tree_data=request.user.group_tree, target_id=current_team
+            )
+            return {str(team_id) for team_id in (team or [current_team])}
+
+        return {str(current_team)}
+
+    def _validate_team_scope(
+        self, request, team, *, require_all: bool = False
+    ) -> None:
+        if (
+            getattr(request.user, "is_superuser", False)
+            or not team
+            or not isinstance(team, list)
+        ):
+            return
+
+        requested_team = {str(team_id) for team_id in team}
+        editable_team = self._get_editable_team_scope(request)
+        authorized = (
+            requested_team.issubset(editable_team)
+            if require_all
+            else bool(requested_team & editable_team)
+        )
+        if not authorized:
+            raise PermissionDenied("无权修改该组织的公共选项库")
 
     @HasPermission("model_management-View")
     def list(self, request):
@@ -48,6 +86,9 @@ class PublicEnumLibraryViewSet(AuthViewSet):
         payload = request.data
         operator = request.user.username
         try:
+            self._validate_team_scope(
+                request, payload.get("team"), require_all=True
+            )
             result = library_service.create_library(payload, operator)
             return WebUtils.response_success(result)
         except BaseAppException as e:
@@ -60,6 +101,24 @@ class PublicEnumLibraryViewSet(AuthViewSet):
         payload = request.data
         operator = request.user.username
         try:
+            if not getattr(request.user, "is_superuser", False):
+                library = library_service.get_library_or_raise(pk)
+                self._validate_team_scope(request, library.team)
+            if "team" in payload:
+                team = payload["team"]
+                if (
+                    not getattr(request.user, "is_superuser", False)
+                    and isinstance(team, list)
+                ):
+                    existing_team = {str(team_id) for team_id in library.team}
+                    team = [
+                        team_id
+                        for team_id in team
+                        if str(team_id) not in existing_team
+                    ]
+                self._validate_team_scope(
+                    request, team, require_all=True
+                )
             result = library_service.update_library(pk, payload, operator)
             return WebUtils.response_success(result)
         except BaseAppException as e:
@@ -75,6 +134,9 @@ class PublicEnumLibraryViewSet(AuthViewSet):
     def destroy(self, request, pk: str):
         operator = request.user.username
         try:
+            if not getattr(request.user, "is_superuser", False):
+                library = library_service.get_library_or_raise(pk)
+                self._validate_team_scope(request, library.team)
             library_service.delete_library(pk, operator)
             return WebUtils.response_success({"message": "删除成功"})
         except BaseAppException as e:

--- a/server/apps/cmdb/views/public_enum_library.py
+++ b/server/apps/cmdb/views/public_enum_library.py
@@ -14,6 +14,7 @@ from apps.cmdb.utils.base import (
 )
 from apps.core.decorators.api_permission import HasPermission
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.core.utils.web_utils import WebUtils
 
@@ -23,20 +24,21 @@ class PublicEnumLibraryViewSet(AuthViewSet):
     ORGANIZATION_FIELD = "team"
 
     def _get_user_team(self, request) -> list:
-        return [g["id"] for g in getattr(request.user, "group_list", []) or []]
+        return normalize_user_group_ids(
+            getattr(request.user, "group_list", []) or []
+        )
 
     def _get_editable_team_scope(self, request) -> set[str]:
         user_team = self._get_user_team(request)
-        current_team = get_current_team_from_request(request, required=False)
-        if not current_team:
-            return {str(team) for team in user_team}
+        current_team = get_current_team_from_request(request)
 
         if str(current_team) not in {str(team) for team in user_team}:
             raise PermissionDenied("无权访问该团队数据")
 
         if request.COOKIES.get("include_children") == "1":
             team = get_organization_and_children_ids(
-                tree_data=request.user.group_tree, target_id=current_team
+                tree_data=getattr(request.user, "group_tree", []),
+                target_id=current_team,
             )
             return {str(team_id) for team_id in (team or [current_team])}
 
@@ -61,6 +63,28 @@ class PublicEnumLibraryViewSet(AuthViewSet):
         )
         if not authorized:
             raise PermissionDenied("无权修改该组织的公共选项库")
+
+    def _validate_team_update_scope(
+        self, request, existing_team, requested_team
+    ) -> None:
+        if (
+            getattr(request.user, "is_superuser", False)
+            or not isinstance(requested_team, list)
+        ):
+            return
+        if not isinstance(existing_team, list):
+            raise PermissionDenied("公共选项库组织数据非法，禁止修改")
+        if existing_team and not requested_team:
+            raise PermissionDenied("无权将组织公共选项库改为全局库")
+
+        self._validate_team_scope(request, requested_team)
+        existing_team_ids = {str(team_id) for team_id in existing_team}
+        added_team = [
+            team_id
+            for team_id in requested_team
+            if str(team_id) not in existing_team_ids
+        ]
+        self._validate_team_scope(request, added_team, require_all=True)
 
     @HasPermission("model_management-View")
     def list(self, request):
@@ -101,25 +125,19 @@ class PublicEnumLibraryViewSet(AuthViewSet):
         payload = request.data
         operator = request.user.username
         try:
+            authorize = None
             if not getattr(request.user, "is_superuser", False):
-                library = library_service.get_library_or_raise(pk)
-                self._validate_team_scope(request, library.team)
-            if "team" in payload:
-                team = payload["team"]
-                if (
-                    not getattr(request.user, "is_superuser", False)
-                    and isinstance(team, list)
-                ):
-                    existing_team = {str(team_id) for team_id in library.team}
-                    team = [
-                        team_id
-                        for team_id in team
-                        if str(team_id) not in existing_team
-                    ]
-                self._validate_team_scope(
-                    request, team, require_all=True
-                )
-            result = library_service.update_library(pk, payload, operator)
+
+                def authorize(library):
+                    self._validate_team_scope(request, library.team)
+                    if "team" in payload:
+                        self._validate_team_update_scope(
+                            request, library.team, payload["team"]
+                        )
+
+            result = library_service.update_library(
+                pk, payload, operator, authorize=authorize
+            )
             return WebUtils.response_success(result)
         except BaseAppException as e:
             if "不存在" in e.message:
@@ -134,10 +152,15 @@ class PublicEnumLibraryViewSet(AuthViewSet):
     def destroy(self, request, pk: str):
         operator = request.user.username
         try:
+            authorize = None
             if not getattr(request.user, "is_superuser", False):
-                library = library_service.get_library_or_raise(pk)
-                self._validate_team_scope(request, library.team)
-            library_service.delete_library(pk, operator)
+
+                def authorize(library):
+                    self._validate_team_scope(request, library.team)
+
+            library_service.delete_library(
+                pk, operator, authorize=authorize
+            )
             return WebUtils.response_success({"message": "删除成功"})
         except BaseAppException as e:
             if "不存在" in e.message:


### PR DESCRIPTION
## 问题

公共选项库本应在当前组织上下文内维护。列表已经按库的 `team` 返回 `editable`，但创建、更新和删除入口只校验全局动作权限，知道其他组织 `library_id` 的用户仍可绕过页面限制执行写操作。

## 根因（设计层）

组织范围只停留在列表展示层，没有成为 HTTP 写入口与实际数据写入之间的授权不变量。若授权读取和 service 写入分离，并发组织重分配还会形成检查与写入不一致。

## 怎么修的

- 创建时校验请求中的全部 `team`，scoped 库缺少 `current_team` 时失败关闭。
- 更新、删除在 service 的同一事务内锁定目标行，对该对象执行组织授权后再写入或删除。
- 更新组织时允许保留或移除历史跨组织关联，但最终归属必须仍与当前授权范围相交；普通用户不能把组织库转为全局库。
- 兼容浏览器与 API Token 的组织上下文，并保留超级管理员、既有 `team=[]` 全局库、当前组织和合法子组织行为。
- options 变更仅在最外层事务提交后触发快照同步，回滚不会留下异步副作用。

## 调用链

```mermaid
flowchart TD
    subgraph T["HTTP 触发层"]
        T1["create / update / destroy\npublic_enum_library.py"]
    end

    subgraph A["授权与事务层"]
        A1["解析 current_team 与 include_children"]
        A2["select_for_update 锁定目标库"]
        A3["校验目标与请求 team"]
    end

    subgraph S["服务与数据层"]
        S1["写入或删除 PublicEnumLibrary"]
        S2["transaction.on_commit"]
        S3["异步同步枚举快照"]
    end

    T1 --> A1 --> A2 --> A3 --> S1
    S1 --> S2 --> S3
    A3 -. "越权" .-> F1["403，不产生写入或异步副作用"]
```

## 影响范围与兼容性

- HTTP 写入口会执行组织级授权；系统模型配置导入仍直接走原 service 默认路径。
- service 仅新增可选授权回调，既有调用无需传参，创建、导入和快照接口契约不变。
- 不涉及 schema 或数据迁移；回滚可直接还原本 PR。
- 风险档位：中；权限边界变化已完成调用方、存量形态、并发与回滚深审。

## 验证

- `apps/cmdb/tests/test_public_enum_views.py`
- `apps/cmdb/tests/test_public_enum_service.py`
- `apps/cmdb/tests/bdd/test_public_enum_library_bdd.py`
- 合计：67 passed。
- Standards 与 Spec 双轨深审通过，无未解决 P0–P3。

Closes #4108
