### PR TITLE
bugfix: 收敛 system_mgmt 用户目录 NATS 入口

### DIFF
--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -17,7 +17,6 @@ def _is_persisted_superuser(user_obj):
     return Role.objects.filter(id__in=role_ids, name="admin").filter(Q(app="") | Q(app="system-manager")).exists()
 
 
-@nats_client.register
 def get_group_users(group=None, include_children=False):
     """
     获取组织下的用户列表
@@ -77,7 +76,6 @@ def _get_actor_user_scope(actor_context, include_children=False):
     return user_obj, authorized_groups
 
 
-@nats_client.register
 def get_group_users_scoped(actor_context, group=None, include_children=False):
     """
     在调用方授权范围内查询组织用户列表。
@@ -150,7 +148,6 @@ def get_assignable_groups(actor_context):
     return {"result": True, "data": groups}
 
 
-@nats_client.register
 def get_all_users():
     data = User.objects.all().values(*User.display_fields())
     return {"result": True, "data": list(data)}
@@ -162,7 +159,6 @@ def search_groups(query_params):
     return {"result": True, "data": list(groups)}
 
 
-@nats_client.register
 def search_users(query_params):
     page = int(query_params.get("page", 1))
     page_size = int(query_params.get("page_size", 10))

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers.py
@@ -69,6 +69,10 @@ def test_nats_api_compat_exports_local_and_nats_entrypoints():
         "_list_opspilot_nats_channels",
         "create_default_rule",
         "bk_lite_user_login",
+        "get_group_users",
+        "get_group_users_scoped",
+        "get_all_users",
+        "search_users",
     }
     registered_entrypoints = expected_entrypoints - local_only_entrypoints
 
@@ -77,8 +81,7 @@ def test_nats_api_compat_exports_local_and_nats_entrypoints():
 
     assert exported_entrypoints == expected_entrypoints
     assert registered_entrypoints <= actual_registered_entrypoints
-    assert "create_default_rule" not in actual_registered_entrypoints
-    assert "bk_lite_user_login" not in actual_registered_entrypoints
+    assert local_only_entrypoints.isdisjoint(actual_registered_entrypoints)
 
 
 def test_bk_lite_user_login_keeps_local_app_client_path(monkeypatch):

--- a/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
+++ b/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
@@ -1,0 +1,23 @@
+import nats_client
+
+from apps.system_mgmt import nats_api
+
+
+LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS = {
+    "get_group_users",
+    "get_group_users_scoped",
+    "get_all_users",
+    "search_users",
+}
+
+
+def test_user_directory_entrypoints_are_local_only():
+    exported_entrypoints = {
+        name for name in LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS if callable(getattr(nats_api, name, None))
+    }
+    registered_entrypoints = {
+        item["name"] for item in nats_client.registry.default_registry.registry.values()
+    }
+
+    assert exported_entrypoints == LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS
+    assert LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS.isdisjoint(registered_entrypoints)


### PR DESCRIPTION
## 问题

system_mgmt 的用户目录查询同时承担同进程服务能力和 NATS 远程入口。后者没有可信的调用服务身份绑定，导致拥有相应 subject 发布能力的客户端可直接枚举用户目录。

## 根因

本地服务函数与远程传输注册共用了同一组装饰器。调用方需要的是函数能力，但装饰器额外把它们暴露成远程 subject；现有 scoped 参数也来自消息体，不能替代可信的传输身份。

## 怎么修的

- 保留 `get_group_users`、`get_group_users_scoped`、`get_all_users`、`search_users` 的函数签名、查询和返回结构。
- 保留 `apps.system_mgmt.nats_api` 兼容导出与 `SystemMgmt` 的本地 `AppClient` 调用路径。
- 仅取消上述四个用户目录函数的 NATS 注册，使本地服务能力与远程入口分离。

## 影响范围

- 仓库内 server、agents、web 和部署样例扫描未发现远程消费者；现有仓内调用均走同进程 `AppClient`。
- 该变更会有意下架四个既有 NATS subject，部署侧若有仓库外消费者，需要在升级前完成迁移。
- 不涉及数据库、持久数据、HTTP API 或响应结构迁移；回滚可直接还原本提交。

## 调用链

```mermaid
flowchart TD
    subgraph L["本地调用链（保留）"]
        S["SystemMgmt\napps/rpc/system_mgmt.py"]
        A["AppClient\napps/rpc/base.py"]
        C["兼容导出\napps/system_mgmt/nats_api.py"]
        U["用户目录函数\napps/system_mgmt/nats/users.py"]
        S --> A --> C --> U
    end

    subgraph R["远程调用链（收口）"]
        N["NATS Listener"]
        G["NATS Registry"]
        N --> G
        G -. "不再注册用户目录 subject" .-> U
    end
```

## 验证

- `apps/system_mgmt/tests/test_nats_user_directory_registration.py` 与 `apps/rpc/tests/test_system_mgmt_forwarding.py`：合计 38 passed。
- 回退生产改动时，专项注册契约为 1 failed；恢复修复后通过。
- `git diff --check`：通过。

关联 Issue #3981。
