### PR TITLE
ci: 新增 server 全量 import 冒烟检查

### DIFF
--- a/.github/workflows/server-import-check.yml
+++ b/.github/workflows/server-import-check.yml
@@ -1,0 +1,48 @@
+name: Server Import Check
+
+on:
+  pull_request:
+    paths:
+      - 'server/**'
+  push:
+    branches: [master]
+    paths:
+      - 'server/**'
+  workflow_dispatch:
+
+jobs:
+  import-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+
+    # 轻量 import 冒烟：用 sqlite 免去外部服务，只验证全量 app 能完成
+    # django.setup() 与系统检查，专拦"import 了未提交/不存在的模块"这类
+    # 启动即崩的破坏。migrate 与迁移一致性仍由 Server Migrate Check 负责。
+    env:
+      DB_ENGINE: sqlite
+      DB_NAME: ":memory:"
+      SECRET_KEY: github-actions-import-check
+      ENABLE_CELERY: "true"
+      MINIO_ENDPOINT: 127.0.0.1:9000
+      MINIO_ACCESS_KEY: import-check
+      MINIO_SECRET_KEY: import-check-secret
+      MINIO_USE_HTTPS: "false"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: server/pyproject.toml
+
+      - name: Install dependencies
+        run: pip install -e ".[cmdb,dev,mlops,opspilot]"
+
+      - name: Django import smoke check
+        run: python manage.py check

--- a/.github/workflows/server-import-check.yml
+++ b/.github/workflows/server-import-check.yml
@@ -1,9 +1,10 @@
 name: Server Import Check
 
+# pull_request 不做 paths 过滤：本 check 计划设为 required status check，
+# 带 paths 的 workflow 在未命中的 PR 上不会报告状态，required 会永远
+# 卡在 Expected 导致无法合并。sqlite + pip 缓存下全量跑成本约 2-3 分钟。
 on:
   pull_request:
-    paths:
-      - 'server/**'
   push:
     branches: [master]
     paths:


### PR DESCRIPTION
## 背景

7327d2a8e（7-27 22:09）在 `server/apps/cmdb/services/model.py` 引入 `from apps.cmdb.services.model_visibility import BusinessModelVisibility`，但 `model_visibility.py` 文件漏提交，master 进入启动即崩状态（`ModuleNotFoundError: No module named 'apps.cmdb.services.model_visibility'`），直到 f171762c3（7-28 10:09）补齐文件，坏窗口约 12 小时；期间构建的 `server:latest` 镜像启动失败。

Server Migrate Check 未拦截的原因：其 `paths` 过滤只监听 `migrations/**`、`models/**`、`models.py`、`config/**` 等路径，该提交改动全部落在 `services/`、`serializers/`、`nats/` 等目录，workflow 根本未触发。

## 变更

新增 `Server Import Check` workflow：

- 触发范围覆盖 `server/**` 全路径（PR + push master + 手动）；
- 使用 sqlite 内存库，不依赖 PostgreSQL 等外部 service，成本远低于 migrate 校验；
- 仅执行 `python manage.py check`——完成全量 INSTALLED_APPS 的 `django.setup()` 导入与系统检查，专拦“import 先行、文件未提交”类启动即崩破坏；
- migrate 与迁移一致性校验仍由 Server Migrate Check 负责，二者职责不重叠。

## 验证

本地以与 CI 相同的 extras（`cmdb,dev,mlops,opspilot`）和环境变量组合验证：

- ✅ 正向：当前 master（含 f171762c3 修复）`manage.py check` 通过（`System check identified no issues`）；
- ✅ 负向：临时移除 `model_visibility.py` 复刻 7327d2a8e 状态，`manage.py check` 准确报出与生产事故完全一致的 `ModuleNotFoundError`，随后已还原。

🤖 Generated with [Claude Code](https://claude.com/claude-code)