### PR TITLE
优化网站/Ping/TCP 拨测监控仪表盘

### DIFF
--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -11,6 +11,10 @@ monitor_object_type:
   Tencent Cloud: Tencent Cloud
   Other: Other
 
+# Fallback display name when plugin i18n is missing: show TCP, not TCPPort
+monitor_object:
+  TCPPort: TCP
+
 flow_onboarding_ui:
   accessAsset: Access Asset
   accessGuide: Access Guide

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -11,6 +11,10 @@ monitor_object_type:
   Tencent Cloud: 腾讯云
   Other: 其他
 
+# 对象展示名兜底：插件语言未合并时仍显示「TCP」而非技术名 TCPPort
+monitor_object:
+  TCPPort: TCP
+
 flow_onboarding_ui:
   accessAsset: 接入资产
   accessGuide: 接入指引

--- a/web/src/app/monitor/(pages)/view/page.tsx
+++ b/web/src/app/monitor/(pages)/view/page.tsx
@@ -13,6 +13,7 @@ import ViewHive from './viewHive';
 import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
 import { cloneDeep } from 'lodash';
 import { getMonitorViewObjectUrl } from '@/app/monitor/dashboards/shared/utils';
+import { getProfessionalObjectDisplayName } from '@/app/monitor/dashboards/registry';
 
 const Integration = () => {
   const { isLoading } = useApiClient();
@@ -82,7 +83,7 @@ const Integration = () => {
         };
       }
       acc[item.type].children.push({
-        title: item.display_name || '--',
+        title: getProfessionalObjectDisplayName(item.name, item.display_name) || '--',
         label: item.name || '--',
         key: item.id,
         icon: item.icon,

--- a/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
+++ b/web/src/app/monitor/dashboards/components/dashboard-sidebar.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
-import { getProfessionalDashboardKey, getProfessionalDashboardUrl } from '../registry';
+import { getProfessionalDashboardKey, getProfessionalDashboardUrl, getProfessionalObjectDisplayName } from '../registry';
 import { normalizeDashboardKey } from '../shared/utils';
 import { preserveDashboardDisplayMode } from '../shared/utils/display-mode-route';
 import { preserveDashboardReturnContext } from '../shared/utils';
@@ -27,7 +27,7 @@ const buildMonitorObjectTree = (objects: ObjectItem[]): TreeItem[] => {
       };
     }
     acc[item.type].children.push({
-      title: item.display_name || '--',
+      title: getProfessionalObjectDisplayName(item.name, item.display_name) || '--',
       label: item.name || '--',
       key: item.id,
       icon: item.icon,
@@ -90,10 +90,11 @@ export const DashboardSidebar = ({ currentObjectKey }: DashboardSidebarProps) =>
     if (String(key) === String(selectedObjectId || '')) return;
 
     const monitorItem = objects.find((item) => String(item.id) === String(key));
+    const displayName = getProfessionalObjectDisplayName(monitorItem?.name, monitorItem?.display_name);
     const params = preserveDashboardReturnContext(preserveDashboardDisplayMode(new URLSearchParams({
       monitorObjId: String(monitorItem?.id || key),
       name: monitorItem?.name || '',
-      monitorObjDisplayName: monitorItem?.display_name || '',
+      monitorObjDisplayName: displayName || '',
       icon: monitorItem?.icon || '',
       instance_id_keys: Array.isArray(monitorItem?.instance_id_keys)
         ? monitorItem.instance_id_keys.join(',')

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -374,7 +374,7 @@ export const InsightSection = ({
   return (
     <section className={styles.dashboardSection}>
       <div className={styles.sectionGrid}>
-        {rings.map(({ panel, data, centerValue, isEmpty }, index) => (
+        {rings.map(({ panel, data, centerValue, isEmpty, emptyDescription }, index) => (
           <RingChartPanel
             key={panel.title}
             title={panel.title}
@@ -384,17 +384,20 @@ export const InsightSection = ({
             centerValue={centerValue}
             centerCaption={panel.centerCaption}
             isEmpty={isEmpty}
+            emptyDescription={emptyDescription}
             className={`${styles.panel} ${ringSpanClass ? ringSpanClass(index, rings.length) : defaultSpan}`}
             styles={styles}
           />
         ))}
-        {bars.map(({ panel, items }, index) => (
+        {bars.map(({ panel, items, isEmpty, emptyDescription }, index) => (
           <HorizontalBarPanel
             key={panel.title}
             title={panel.title}
             subtitle={panel.subtitle}
             guide={panel.guide}
             items={items}
+            isEmpty={isEmpty}
+            emptyDescription={emptyDescription}
             className={`${styles.panel} ${barSpanClass ? barSpanClass(index, bars.length) : defaultSpan}`}
             styles={styles}
           />

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -128,6 +128,12 @@ export interface RingPanelConfig {
   centerUnit?: SimpleMetricUnit;
   centerFormatter?: 'duration';
   segments: RingSegmentConfig[];
+  /**
+   * 全部分段无数据或数值均为 0 时视为空态（如拨测尚未拿到 HTTP 状态码）。
+   */
+  emptyWhenAllZero?: boolean;
+  /** 空态说明；缺省「暂无数据」。 */
+  emptyDescription?: string;
 }
 
 export interface BarPanelConfig {
@@ -137,6 +143,13 @@ export interface BarPanelConfig {
   items: Array<{ label: string; metric: string; color: string; unit?: SimpleMetricUnit }>;
   /** true 时每行渲染 sparkline 趋势(速率/计数类);缺省保留进度条(分布/对比类)。 */
   showTrend?: boolean;
+  /**
+   * 全部 item 无数据或数值均为 0 时视为空态，展示 emptyDescription。
+   * 用于拨测状态码等「全 0 ≠ 健康、可能尚未拿到该维度样本」的归因图。
+   */
+  emptyWhenAllZero?: boolean;
+  /** 空态说明；缺省「暂无数据」。 */
+  emptyDescription?: string;
 }
 
 /** A binary/flag signal shown as a status row (dot + state badge) rather than a value bar.
@@ -212,11 +225,14 @@ export interface PreparedRingPanel {
   data: Array<{ name: string; value: number; color: string; display: string }>;
   centerValue: string;
   isEmpty: boolean;
+  emptyDescription?: string;
 }
 
 export interface PreparedBarPanel {
   panel: BarPanelConfig;
   items: Array<{ label: string; value: number; display: string; color: string; max: number; trend?: ChartData[] }>;
+  isEmpty: boolean;
+  emptyDescription?: string;
 }
 
 export interface PreparedStatusPanel {
@@ -608,8 +624,9 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     const value = getLatest(field.metric);
     if (!hasMetricData(field.metric)) return '--';
     if (field.formatter === 'duration') return formatDuration(value);
-    if (field.formatter === 'enumHealth') return formatClusterHealth(value).value;
+    // enumMap 优先：拨测结果码等业务枚举；无 enumMap 时 enumHealth 才走集群健康三态。
     if (field.enumMap) return formatMappedEnum(value, field.enumMap).value;
+    if (field.formatter === 'enumHealth') return formatClusterHealth(value).value;
     if (field.formatter === 'startedAt') {
       if (!Number.isFinite(value) || value < 0) return '--';
       return dayjs().subtract(Math.floor(value), 'second').format('YYYY-MM-DD HH:mm:ss');
@@ -632,7 +649,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
 
   const summaryCards = useMemo<PreparedSummaryCard[]>(() => (
     config.summaryCards.map((card) => {
-      const healthResult = card.formatter === 'enumHealth' && hasMetricData(card.metric)
+      const healthResult = card.formatter === 'enumHealth' && !card.enumMap && hasMetricData(card.metric)
         ? formatClusterHealth(getLatest(card.metric))
         : null;
       const enumResult = card.enumMap && hasMetricData(card.metric)
@@ -694,21 +711,30 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   ), [config.charts, config.metrics, metricMap]);
 
   const ringPanels = useMemo<PreparedRingPanel[]>(() => (
-    (config.ringPanels || []).map((panel) => ({
-      panel,
-      data: panel.segments.map((item) => ({
+    (config.ringPanels || []).map((panel) => {
+      const data = panel.segments.map((item) => ({
         name: item.label,
         value: getTransformedValue(item.metric, item.transform),
         color: item.color,
         display: formatTransformedValue(item.metric, item.unit, item.transform)
-      })),
-      centerValue: hasMetricData(panel.centerMetric)
-        ? panel.centerFormatter === 'duration'
-          ? formatDuration(getLatest(panel.centerMetric))
-          : formatTransformedValue(panel.centerMetric, panel.centerUnit)
-        : '--',
-      isEmpty: !hasMetricData(panel.centerMetric) && panel.segments.every((item) => !hasMetricData(item.metric))
-    }))
+      }));
+      const anySegmentData = panel.segments.some((item) => hasMetricData(item.metric));
+      const allZero = data.every((item) => item.value <= 0);
+      const isEmpty =
+        (!hasMetricData(panel.centerMetric) && !anySegmentData) ||
+        Boolean(panel.emptyWhenAllZero && allZero);
+      return {
+        panel,
+        data,
+        centerValue: hasMetricData(panel.centerMetric)
+          ? panel.centerFormatter === 'duration'
+            ? formatDuration(getLatest(panel.centerMetric))
+            : formatTransformedValue(panel.centerMetric, panel.centerUnit)
+          : '--',
+        isEmpty,
+        emptyDescription: panel.emptyDescription
+      };
+    })
   ), [config.ringPanels, formatTransformedValue, getLatest, getTransformedValue, hasMetricData]);
 
   const barPanels = useMemo<PreparedBarPanel[]>(() => (
@@ -729,7 +755,15 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         };
       });
       const max = Math.max(...items.map((item) => item.value), 1);
-      return { panel, items: items.map((item) => ({ ...item, max })) };
+      const anyData = panel.items.some((item) => hasMetricData(item.metric));
+      const allZero = items.every((item) => item.value <= 0);
+      const isEmpty = !anyData || Boolean(panel.emptyWhenAllZero && allZero);
+      return {
+        panel,
+        items: items.map((item) => ({ ...item, max })),
+        isEmpty,
+        emptyDescription: panel.emptyDescription
+      };
     })
   ), [config.barPanels, getLatest, hasMetricData, metricMap]);
 

--- a/web/src/app/monitor/dashboards/objects/ping/config.ts
+++ b/web/src/app/monitor/dashboards/objects/ping/config.ts
@@ -43,38 +43,58 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       name: 'ping_success_rate_avg',
       display_name: '连通成功率',
-      description: 'Ping 探测节点的平均连通成功率。',
+      description: '由丢包率换算的连通成功率（100−丢包率）。',
       unit: 'percent',
       query: 'clamp_max(100 - avg(ping_percent_packet_loss{__$labels__}), 100)',
       color: '#27c274'
     },
     {
-      name: 'ping_ttl_avg',
-      display_name: '平均 TTL',
-      description: 'Ping 探测节点的平均 TTL。',
-      unit: 'counts',
-      query: 'avg(ping_ttl{__$labels__})',
-      color: '#597ef7'
+      name: 'ping_result_success_rate',
+      display_name: '成功占比',
+      description: 'result_code=0 的探测占比。',
+      unit: 'percent',
+      query: 'avg(ping_result_code{__$labels__} == bool 0) * 100',
+      color: '#27c274'
     },
     {
-      name: 'ping_result_code_max',
-      display_name: '最差结果码',
-      description: 'Ping 探测节点当前最差结果码。',
-      unit: 'none',
-      query: 'max(ping_result_code{__$labels__})',
-      color: '#8a5cff'
+      name: 'ping_result_error_rate',
+      display_name: '错误占比',
+      description: 'result_code=1 的探测占比。',
+      unit: 'percent',
+      query: 'avg(ping_result_code{__$labels__} == bool 1) * 100',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'ping_result_resolve_fail_rate',
+      display_name: '无法解析占比',
+      description: 'result_code=2 的探测占比。',
+      unit: 'percent',
+      query: 'avg(ping_result_code{__$labels__} == bool 2) * 100',
+      color: '#ff7875'
     }
   ],
+  // Layer0 + A 丢包（原生）+ B 延迟；C 结果码进分布环
   summaryCards: [
     {
-      title: '连通成功率',
-      metric: 'ping_success_rate_avg',
-      color: '#27c274',
+      title: '平均丢包率',
+      metric: 'ping_packet_loss_avg',
+      color: '#ff4d4f',
       icon: 'api',
       compare: true,
-      compareFavorableDirection: 'up',
-      guide: [{ label: '连通成功率', detail: '由丢包率换算；低于基线或持续下跌时优先查链路、中间设备与目标可达性。' }],
-      footer: [{ label: '平均丢包率', metric: 'ping_packet_loss_avg', unit: 'percent' }]
+      compareFavorableDirection: 'down',
+      guide: [
+        {
+          label: '平均丢包率',
+          detail: 'ICMP 丢包百分比，Ping 可用性的原生指标。非零表示链路不稳；持续升高优先查拥塞、错包与对端可达性。'
+        },
+        {
+          label: '连通成功率',
+          detail: '由 100−丢包率换算，与丢包互为镜像，故不单独占主卡。'
+        }
+      ],
+      footer: [
+        { label: '连通成功率', metric: 'ping_success_rate_avg', unit: 'percent' }
+      ]
     },
     {
       title: '平均延迟',
@@ -83,79 +103,53 @@ export const PING_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       icon: 'clock',
       compare: true,
       guide: [{ label: '平均延迟', detail: '往返时延均值；持续升高结合最大延迟判断是整体变慢还是尖刺抖动。' }],
-      footer: [{ label: '最大延迟', metric: 'ping_latency_max', unit: 'ms' }]
-    },
-    {
-      title: '平均丢包率',
-      metric: 'ping_packet_loss_avg',
-      color: '#ff4d4f',
-      icon: 'api',
-      compare: true,
-      compareFavorableDirection: 'down',
-      guide: [{ label: '平均丢包率', detail: '非零丢包表示链路不稳；持续升高优先查拥塞、错包与对端负载。' }],
-      footer: [{ label: '平均 TTL', metric: 'ping_ttl_avg', unit: 'counts' }],
-    },
-    {
-      title: '平均 TTL',
-      metric: 'ping_ttl_avg',
-      unit: 'counts',
-      color: '#597ef7',
-      icon: 'api',
-      compare: true,
-      guide: [{ label: '平均 TTL', detail: '回包剩余 TTL(路由跳数计数);数值突变常意味路由路径改变。' }],
-      footer: [{ label: '最差结果码', metric: 'ping_result_code_max', unit: 'none' }]
+      footer: [
+        { label: '最大延迟', metric: 'ping_latency_max', unit: 'ms' },
+        { label: '最小延迟', metric: 'ping_latency_min', unit: 'ms' }
+      ]
     }
   ],
   charts: [
     {
-      title: '延迟趋势',
-      subtitle: '平均、最小与最大',
-      metric: 'ping_latency_avg',
-      guide: [{ label: '延迟趋势', detail: '观察 Ping 平均、最小和最大延迟变化。' }],
-      series: [
-        { metric: 'ping_latency_avg', label: '平均延迟', color: '#2f6bff', unit: 'ms' },
-        { metric: 'ping_latency_min', label: '最小延迟', color: '#13c2c2', unit: 'ms' },
-        { metric: 'ping_latency_max', label: '最大延迟', color: '#ff8a1f', unit: 'ms' }
-      ]
-    },
-    {
       title: '丢包率趋势',
-      subtitle: '丢包率变化',
+      subtitle: '链路稳定性',
       metric: 'ping_packet_loss_avg',
-      guide: [{ label: '丢包趋势', detail: '观察 Ping 丢包率随时间变化。' }],
+      guide: [{ label: '丢包趋势', detail: '丢包升高时对照延迟与结果码分布；持续高位优先查链路与目标可达性。' }],
       series: [{ metric: 'ping_packet_loss_avg', label: '平均丢包率', color: '#ff4d4f', unit: 'percent' }]
     },
     {
-      title: 'TTL 趋势',
-      subtitle: 'TTL 变化',
-      metric: 'ping_ttl_avg',
-      guide: [{ label: 'TTL 趋势', detail: '回包剩余 TTL(路由跳数计数);数值突变常意味路由路径改变。' }],
-      series: [{ metric: 'ping_ttl_avg', label: '平均 TTL', color: '#597ef7', unit: 'counts' }]
+      title: '延迟趋势',
+      subtitle: '平均与最大',
+      metric: 'ping_latency_avg',
+      guide: [{ label: '延迟趋势', detail: '对比平均与最大延迟，判断整体变慢还是尖刺抖动。' }],
+      series: [
+        { metric: 'ping_latency_avg', label: '平均延迟', color: '#2f6bff', unit: 'ms' },
+        { metric: 'ping_latency_max', label: '最大延迟', color: '#ff8a1f', unit: 'ms' }
+      ]
     }
   ],
   ringPanels: [
     {
-      title: '连通质量分布',
-      subtitle: '成功与丢包占比',
-      centerMetric: 'ping_success_rate_avg',
-      centerCaption: '连通成功率',
+      title: '结果码分布',
+      subtitle: '失败形态归因',
+      guide: [
+        {
+          label: '结果码分布',
+          detail: '按 Telegraf ping result_code：成功、错误、无法解析。丢包升高时用于区分对端不可达与域名解析失败。'
+        }
+      ],
+      centerMetric: 'ping_result_success_rate',
+      centerCaption: '成功占比',
       centerUnit: 'percent',
-      guide: [{ label: '连通质量', detail: '展示 Ping 成功率与丢包率的当前结构。' }],
+      emptyWhenAllZero: true,
+      emptyDescription: '当前窗口无 Ping 探测结果码样本',
       segments: [
-        { label: '成功占比', metric: 'ping_success_rate_avg', color: '#27c274', unit: 'percent' },
-        { label: '丢包占比', metric: 'ping_packet_loss_avg', color: '#ffccc7', unit: 'percent' }
+        { label: '成功', metric: 'ping_result_success_rate', color: '#27c274', unit: 'percent' },
+        { label: '错误', metric: 'ping_result_error_rate', color: '#ff4d4f', unit: 'percent' },
+        { label: '无法解析', metric: 'ping_result_resolve_fail_rate', color: '#ff7875', unit: 'percent' }
       ]
     }
   ],
   barPanels: [],
-  details: [
-    {
-      title: '探测质量细节',
-      subtitle: '延迟下界与失败结果码',
-      rows: [
-        { label: '最小延迟', metric: 'ping_latency_min', unit: 'ms' },
-        { label: '最差结果码', metric: 'ping_result_code_max', unit: 'none' }
-      ]
-    }
-  ]
+  details: []
 };

--- a/web/src/app/monitor/dashboards/objects/ping/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/ping/dashboard.tsx
@@ -4,30 +4,28 @@ import React from 'react';
 import { useSimpleDashboardData } from '../common/simple-dashboard-core';
 import {
   DashboardShell,
-  DetailPanelCard,
   FlexiblePanelSection,
   KpiSection,
   useFilteredChartPanels,
-  useFilteredDetailPanels,
-  useFilteredRingPanels
+  useFilteredRingPanels,
+  useFilteredSummaryCards
 } from '../common/dashboard-components';
 import { RingChartPanel, TrendChartPanel } from '../../shared/widgets';
 import { PING_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 
-const CHART_TITLES = ['延迟趋势', '丢包率趋势', 'TTL 趋势'];
-const DETAIL_TITLES = ['网络探测详情'];
-const RING_TITLES = ['连通质量分布'];
+const SUMMARY_TITLES = ['平均丢包率', '平均延迟'];
+const CHART_TITLES = ['丢包率趋势', '延迟趋势'];
+const RING_TITLES = ['结果码分布'];
 
 export default function PingDashboardPage() {
   const dashboard = useSimpleDashboardData(PING_DASHBOARD_CONFIG);
+  const summaryCards = useFilteredSummaryCards(dashboard.summaryCards, SUMMARY_TITLES);
   const charts = useFilteredChartPanels(dashboard.chartPanels, CHART_TITLES);
-  const detailPanels = useFilteredDetailPanels(dashboard.detailPanels, DETAIL_TITLES);
   const rings = useFilteredRingPanels(dashboard.ringPanels, RING_TITLES);
 
-  const [latencyChart, lossChart, ttlChart] = charts;
-  const [qualityRing] = rings;
-  const [detailPanel] = detailPanels;
+  const [lossChart, latencyChart] = charts;
+  const [resultRing] = rings;
 
   return (
     <DashboardShell
@@ -36,23 +34,9 @@ export default function PingDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={6} styles={styles} />
-          <div className={styles.sectionLabel}>分布与趋势</div>
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={3} styles={styles} />
+          <div className={styles.sectionLabel}>趋势与归因</div>
           <FlexiblePanelSection styles={styles}>
-            {qualityRing ? (
-              <RingChartPanel
-                key={qualityRing.panel.title}
-                title={qualityRing.panel.title}
-                subtitle={qualityRing.panel.subtitle}
-                guide={qualityRing.panel.guide}
-                data={qualityRing.data}
-                centerValue={qualityRing.centerValue}
-                centerCaption={qualityRing.panel.centerCaption}
-                isEmpty={qualityRing.isEmpty}
-                className={styles.span4}
-                styles={styles}
-              />
-            ) : null}
             {lossChart ? (
               <TrendChartPanel
                 key={lossChart.chart.title}
@@ -87,21 +71,18 @@ export default function PingDashboardPage() {
                 styles={styles}
               />
             ) : null}
-            {detailPanel ? <DetailPanelCard detailPanel={detailPanel} className={styles.span6} styles={styles} /> : null}
-            {ttlChart ? (
-              <TrendChartPanel
-                key={ttlChart.chart.title}
-                title={ttlChart.chart.title}
-                subtitle={ttlChart.chart.subtitle}
-                guide={ttlChart.chart.guide}
-                legends={ttlChart.legends}
-                data={ttlChart.data}
-                metric={ttlChart.metric}
-                unit={ttlChart.unit}
-                loading={dashboard.loading}
-                seriesStyles={ttlChart.seriesStyles}
-                onXRangeChange={dashboard.onXRangeChange}
-                className={`${styles.span6} ${styles.compactTrend}`}
+            {resultRing ? (
+              <RingChartPanel
+                key={resultRing.panel.title}
+                title={resultRing.panel.title}
+                subtitle={resultRing.panel.subtitle}
+                guide={resultRing.panel.guide}
+                data={resultRing.data}
+                centerValue={resultRing.centerValue}
+                centerCaption={resultRing.panel.centerCaption}
+                isEmpty={resultRing.isEmpty}
+                emptyDescription={resultRing.emptyDescription}
+                className={styles.span4}
                 styles={styles}
               />
             ) : null}

--- a/web/src/app/monitor/dashboards/objects/tcp/config.ts
+++ b/web/src/app/monitor/dashboards/objects/tcp/config.ts
@@ -1,13 +1,4 @@
 import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
-import type { MetricEnumMap } from '../../shared/types';
-
-const TCP_RESULT_CODE_ENUM: MetricEnumMap = {
-  0: { label: '成功', color: '#27c274' },
-  1: { label: '超时', color: '#ff4d4f' },
-  2: { label: '连接失败', color: '#ff4d4f' },
-  3: { label: '读取失败', color: '#ff4d4f' },
-  4: { label: '返回不匹配', color: '#faad14' }
-};
 
 export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'tcp',
@@ -52,28 +43,53 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       name: 'tcp_failure_rate',
       display_name: '探测失败率',
-      description: '结果码非 0（超时/连接失败/读取失败/返回不匹配）的探测占比。',
+      description: '结果码非 0 的探测占比。',
       unit: 'percent',
       query: 'avg(net_response_result_code{__$labels__} != bool 0) * 100',
       color: '#ff4d4f'
     },
     {
-      name: 'tcp_result_code_max',
-      display_name: '最差结果码',
-      description: '当前最差的 TCP 探测结果码。',
-      unit: 'none',
-      query: 'max(net_response_result_code{__$labels__})',
-      color: '#8a5cff'
+      name: 'tcp_result_success_rate',
+      display_name: '成功占比',
+      description: '结果码为成功的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} == bool 0) * 100',
+      color: '#27c274'
     },
     {
-      name: 'tcp_string_found_rate',
-      display_name: '返回匹配率',
-      description: '配置了期望返回串时，命中期望串的探测占比。',
+      name: 'tcp_result_timeout_rate',
+      display_name: '超时占比',
+      description: '结果码为超时的探测占比。',
       unit: 'percent',
-      query: 'avg(net_response_string_found{__$labels__}) * 100',
-      color: '#597ef7'
+      query: 'avg(net_response_result_code{__$labels__} == bool 1) * 100',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'tcp_result_conn_fail_rate',
+      display_name: '连接失败占比',
+      description: '结果码为连接失败的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} == bool 2) * 100',
+      color: '#ff7875'
+    },
+    {
+      name: 'tcp_result_read_fail_rate',
+      display_name: '读取失败占比',
+      description: '结果码为读取失败的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} == bool 3) * 100',
+      color: '#ffa940'
+    },
+    {
+      name: 'tcp_result_mismatch_rate',
+      display_name: '返回不匹配占比',
+      description: '结果码为返回不匹配的探测占比。',
+      unit: 'percent',
+      query: 'avg(net_response_result_code{__$labels__} == bool 4) * 100',
+      color: '#faad14'
     }
   ],
+  // Layer0 + A 连通成功率 + B 平均响应；最大响应/结果码进副文案与环图，不另占主卡
   summaryCards: [
     {
       title: '连通成功率',
@@ -83,8 +99,15 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       icon: 'health',
       compare: true,
       compareFavorableDirection: 'up',
-      guide: [{ label: '连通成功率', detail: '结果码为 0 的探测占比，反映 TCP 端口整体可达性。' }],
-      footer: [{ label: '最差结果码', metric: 'tcp_result_code_max', formatter: 'enumHealth', enumMap: TCP_RESULT_CODE_ENUM }]
+      guide: [
+        {
+          label: '连通成功率',
+          detail: '结果码为 0 的探测占比，反映 TCP 端口整体可达性。失败形态看「结果码分布」。'
+        }
+      ],
+      footer: [
+        { label: '失败占比', metric: 'tcp_failure_rate', unit: 'percent' }
+      ]
     },
     {
       title: '平均响应时间',
@@ -94,63 +117,58 @@ export const TCP_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       icon: 'clock',
       compare: true,
       compareFavorableDirection: 'down',
-      guide: [{ label: '平均响应时间', detail: 'TCP 建连平均耗时；持续升高时对照最大响应与失败率，区分链路变慢与间歇故障。' }],
-      footer: [{ label: '最大响应时间', metric: 'tcp_response_time_max', unit: 'ms' }]
-    },
-    {
-      title: '探测失败率',
-      metric: 'tcp_failure_rate',
-      unit: 'percent',
-      color: '#ff4d4f',
-      icon: 'api',
-      compare: true,
-      compareFavorableDirection: 'down',
-      guide: [{ label: '探测失败率', detail: '结果码非 0 的探测占比，升高表示端口不可达或响应异常。' }],
-      footer: [{ label: '返回匹配率', metric: 'tcp_string_found_rate', unit: 'percent' }]
-    },
-    {
-      title: '返回匹配率',
-      metric: 'tcp_string_found_rate',
-      unit: 'percent',
-      color: '#597ef7',
-      icon: 'api',
-      compare: true,
-      compareFavorableDirection: 'up',
-      guide: [{ label: '返回匹配率', detail: '仅在配置了期望返回串时统计，命中期望串的探测占比。' }],
-      footer: [{ label: '最小响应时间', metric: 'tcp_response_time_min', unit: 'ms' }]
+      guide: [
+        {
+          label: '平均响应时间',
+          detail: 'TCP 建连平均耗时；峰值见副文案与趋势图，不再单独占主卡。'
+        }
+      ],
+      footer: [
+        { label: '最大响应时间', metric: 'tcp_response_time_max', unit: 'ms' },
+        { label: '最小响应时间', metric: 'tcp_response_time_min', unit: 'ms' }
+      ]
     }
   ],
   charts: [
     {
-      title: '响应时间趋势',
-      subtitle: '平均、最小与最大',
-      metric: 'tcp_response_time_avg',
-      guide: [{ label: '响应时间趋势', detail: '观察 TCP 建连耗时的平均、最小和最大变化。' }],
-      series: [
-        { metric: 'tcp_response_time_avg', label: '平均响应时间', color: '#2f6bff', unit: 'ms' },
-        { metric: 'tcp_response_time_min', label: '最小响应时间', color: '#13c2c2', unit: 'ms' },
-        { metric: 'tcp_response_time_max', label: '最大响应时间', color: '#ff8a1f', unit: 'ms' }
-      ]
+      title: '连通成功率趋势',
+      subtitle: '端口可达性',
+      metric: 'tcp_success_rate',
+      guide: [{ label: '连通成功率趋势', detail: '下跌时优先查端口监听、防火墙与对端进程；对照结果码分布。' }],
+      series: [{ metric: 'tcp_success_rate', label: '连通成功率', color: '#27c274', unit: 'percent' }]
     },
     {
-      title: '连通成功率趋势',
-      subtitle: '成功率变化',
-      metric: 'tcp_success_rate',
-      guide: [{ label: '连通成功率趋势', detail: '成功率下跌时优先查端口监听、防火墙与对端进程；对照失败率与结果码。' }],
-      series: [{ metric: 'tcp_success_rate', label: '连通成功率', color: '#27c274', unit: 'percent' }]
+      title: '响应时间趋势',
+      subtitle: '平均与最大',
+      metric: 'tcp_response_time_avg',
+      guide: [{ label: '响应时间趋势', detail: '对比平均与最大建连耗时，判断整体变慢还是尖刺。' }],
+      series: [
+        { metric: 'tcp_response_time_avg', label: '平均响应时间', color: '#2f6bff', unit: 'ms' },
+        { metric: 'tcp_response_time_max', label: '最大响应时间', color: '#ff8a1f', unit: 'ms' }
+      ]
     }
   ],
   ringPanels: [
     {
-      title: '探测结果分布',
-      subtitle: '成功与失败占比',
+      title: '结果码分布',
+      subtitle: '失败形态归因',
+      guide: [
+        {
+          label: '结果码分布',
+          detail: '按 Telegraf net_response result_code：成功、超时、连接失败、读取失败、返回不匹配。用于定位失败形态。'
+        }
+      ],
       centerMetric: 'tcp_success_rate',
       centerCaption: '连通成功率',
       centerUnit: 'percent',
-      guide: [{ label: '探测结果分布', detail: '展示 TCP 探测成功与失败的当前结构。' }],
+      emptyWhenAllZero: true,
+      emptyDescription: '当前窗口无 TCP 探测结果码样本',
       segments: [
-        { label: '成功占比', metric: 'tcp_success_rate', color: '#27c274', unit: 'percent' },
-        { label: '失败占比', metric: 'tcp_failure_rate', color: '#ffccc7', unit: 'percent' }
+        { label: '成功', metric: 'tcp_result_success_rate', color: '#27c274', unit: 'percent' },
+        { label: '超时', metric: 'tcp_result_timeout_rate', color: '#ff4d4f', unit: 'percent' },
+        { label: '连接失败', metric: 'tcp_result_conn_fail_rate', color: '#ff7875', unit: 'percent' },
+        { label: '读取失败', metric: 'tcp_result_read_fail_rate', color: '#ffa940', unit: 'percent' },
+        { label: '返回不匹配', metric: 'tcp_result_mismatch_rate', color: '#faad14', unit: 'percent' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/tcp/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/tcp/dashboard.tsx
@@ -7,21 +7,24 @@ import {
   FlexiblePanelSection,
   KpiSection,
   useFilteredChartPanels,
-  useFilteredRingPanels
+  useFilteredRingPanels,
+  useFilteredSummaryCards
 } from '../common/dashboard-components';
 import { RingChartPanel, TrendChartPanel } from '../../shared/widgets';
 import { TCP_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 
-const CHART_TITLES = ['响应时间趋势', '连通成功率趋势'];
-const RING_TITLES = ['探测结果分布'];
+const SUMMARY_TITLES = ['连通成功率', '平均响应时间'];
+const CHART_TITLES = ['连通成功率趋势', '响应时间趋势'];
+const RING_TITLES = ['结果码分布'];
 
 export default function TcpDashboardPage() {
   const dashboard = useSimpleDashboardData(TCP_DASHBOARD_CONFIG);
+  const summaryCards = useFilteredSummaryCards(dashboard.summaryCards, SUMMARY_TITLES);
   const charts = useFilteredChartPanels(dashboard.chartPanels, CHART_TITLES);
   const rings = useFilteredRingPanels(dashboard.ringPanels, RING_TITLES);
 
-  const [responseChart, successChart] = charts;
+  const [successChart, responseChart] = charts;
   const [resultRing] = rings;
 
   return (
@@ -31,23 +34,9 @@ export default function TcpDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} kpiCols={6} styles={styles} />
-          <div className={styles.sectionLabel}>分布与趋势</div>
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={3} styles={styles} />
+          <div className={styles.sectionLabel}>趋势与归因</div>
           <FlexiblePanelSection styles={styles}>
-            {resultRing ? (
-              <RingChartPanel
-                key={resultRing.panel.title}
-                title={resultRing.panel.title}
-                subtitle={resultRing.panel.subtitle}
-                guide={resultRing.panel.guide}
-                data={resultRing.data}
-                centerValue={resultRing.centerValue}
-                centerCaption={resultRing.panel.centerCaption}
-                isEmpty={resultRing.isEmpty}
-                className={styles.span4}
-                styles={styles}
-              />
-            ) : null}
             {successChart ? (
               <TrendChartPanel
                 key={successChart.chart.title}
@@ -79,6 +68,21 @@ export default function TcpDashboardPage() {
                 seriesStyles={responseChart.seriesStyles}
                 onXRangeChange={dashboard.onXRangeChange}
                 className={`${styles.span4} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null}
+            {resultRing ? (
+              <RingChartPanel
+                key={resultRing.panel.title}
+                title={resultRing.panel.title}
+                subtitle={resultRing.panel.subtitle}
+                guide={resultRing.panel.guide}
+                data={resultRing.data}
+                centerValue={resultRing.centerValue}
+                centerCaption={resultRing.panel.centerCaption}
+                isEmpty={resultRing.isEmpty}
+                emptyDescription={resultRing.emptyDescription}
+                className={styles.span4}
                 styles={styles}
               />
             ) : null}

--- a/web/src/app/monitor/dashboards/objects/website/config.ts
+++ b/web/src/app/monitor/dashboards/objects/website/config.ts
@@ -11,13 +11,14 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   pageTitle: '网站监控仪表盘',
   objectFallbackName: '网站',
   instanceType: 'web',
-  collectionStatusQuery: "count(http_response_result_type{instance_type='web', collect_type='web', result='success', __$labels__}) by (instance_id)",
+  // Layer 0：任意 result_type 样本即表示采集在跑；不要求 success，避免失败时误报「无采集」。
+  collectionStatusQuery: "count(http_response_result_type{instance_type='web', collect_type='web', __$labels__}) by (instance_id)",
   metaItems: ['Telegraf', 'web'],
   metrics: [
     {
       name: 'website_success_rate_avg',
       display_name: '探测成功率',
-      description: '网站探测节点平均成功率。',
+      description: '网站探测节点平均成功率（Telegraf result_type=success，不等于 HTTP 2xx）。',
       unit: 'percent',
       query: SUCCESS_RATE_EXPR,
       color: '#27c274'
@@ -47,12 +48,60 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#8a5cff'
     },
     {
-      name: 'website_content_length_avg',
-      display_name: '平均内容长度',
-      description: '网站返回内容平均大小。',
-      unit: 'bytes',
-      query: 'avg by (instance_id) (http_response_content_length{__$labels__})',
-      color: '#597ef7'
+      name: 'website_result_success_rate',
+      display_name: '成功占比',
+      description: 'result_code=0 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 0) * 100',
+      color: '#27c274'
+    },
+    {
+      name: 'website_result_body_mismatch_rate',
+      display_name: '响应内容不匹配占比',
+      description: 'result_code=1 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 1) * 100',
+      color: '#faad14'
+    },
+    {
+      name: 'website_result_body_read_fail_rate',
+      display_name: '响应体读取失败占比',
+      description: 'result_code=2 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 2) * 100',
+      color: '#d48806'
+    },
+    {
+      name: 'website_result_conn_fail_rate',
+      display_name: '连接失败占比',
+      description: 'result_code=3 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 3) * 100',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'website_result_timeout_rate',
+      display_name: '超时占比',
+      description: 'result_code=4 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 4) * 100',
+      color: '#ff7875'
+    },
+    {
+      name: 'website_result_dns_fail_rate',
+      display_name: 'DNS错误占比',
+      description: 'result_code=5 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 5) * 100',
+      color: '#cf1322'
+    },
+    {
+      name: 'website_result_status_mismatch_rate',
+      display_name: '响应状态码不匹配占比',
+      description: 'result_code=6 的探测占比。',
+      unit: 'percent',
+      query: 'avg(http_response_result_code{__$labels__} == bool 6) * 100',
+      color: '#ffa940'
     },
     {
       name: 'website_status_code_2xx_count',
@@ -85,12 +134,22 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       unit: 'counts',
       query: 'count(http_response_http_response_code{__$labels__} >= 500) or on() vector(0)',
       color: '#ff4d4f'
-    },
+    }
   ],
+  // Layer0 + A 成功率 + B 响应时间；失败归因交给下方「探测结果分布 / 状态码分布」
   summaryCards: [
     {
       title: '探测成功率',
-      guide: [{ label: '探测成功率', detail: '优先确认当前可用性是否已下降，并结合失败占比判断影响面。' }],
+      guide: [
+        {
+          label: '探测成功率',
+          detail: '基于 Telegraf http_response 的 result_type=success。成功 ≠ HTTP 2xx；未配置期望状态码时非 2xx 仍可能计为成功。'
+        },
+        {
+          label: '失败占比',
+          detail: '与成功率互补。下跌时先看「探测结果分布」区分建连/超时/DNS 与内容/状态码校验失败。'
+        }
+      ],
       metric: 'website_success_rate_avg',
       color: '#27c274',
       icon: 'api',
@@ -99,43 +158,26 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       footer: [{ label: '失败占比', metric: 'website_failure_rate_avg', unit: 'percent' }]
     },
     {
-      title: '异常状态码',
-      guide: [{ label: '异常状态码', detail: '当前返回 5xx 的探测节点数，非零表示服务端错误，需立即排查。' }],
-      metric: 'website_status_code_5xx_count',
-      unit: 'counts',
-      color: '#ff4d4f',
-      icon: 'api',
-      compare: true,
-      compareFavorableDirection: 'down',
-      footer: [{ label: '4xx 节点', metric: 'website_status_code_4xx_count', unit: 'counts' }]
-    },
-    {
       title: '平均响应时间',
-      guide: [{ label: '平均响应时间', detail: '优先观察平均响应是否持续升高，再对比峰值判断是否存在抖动。' }],
+      guide: [{ label: '平均响应时间', detail: '优先观察平均响应是否持续升高，再对比峰值判断是整体变慢还是尖刺。' }],
       metric: 'website_response_time_avg',
       color: '#2f6bff',
       icon: 'clock',
       compare: true,
       footer: [{ label: '峰值响应', metric: 'website_response_time_max', unit: 's' }]
-    },
-    {
-      title: '可用节点(2xx)',
-      guide: [{ label: '可用节点(2xx)', detail: '当前返回 2xx 状态码的探测节点数,反映正常服务的探测覆盖面。' }],
-      metric: 'website_status_code_2xx_count',
-      unit: 'counts',
-      color: '#27c274',
-      icon: 'api',
-      compare: true,
-      compareFavorableDirection: 'up',
-      footer: [{ label: '3xx 节点', metric: 'website_status_code_3xx_count', unit: 'counts' }]
-    },
+    }
   ],
   charts: [
     {
       title: '探测成功率趋势',
-      subtitle: '多节点成功率',
+      subtitle: '可用性变化',
       metric: 'website_success_rate_avg',
-      guide: [{ label: '成功率趋势', detail: '成功率下跌时优先查 5xx/4xx 分布与响应时间；对照状态码条判断错误类型。' }],
+      guide: [
+        {
+          label: '成功率趋势',
+          detail: '下跌时先看探测结果分布与响应时间；连接失败/超时/DNS 不会产生 HTTP 状态码。'
+        }
+      ],
       series: [{ metric: 'website_success_rate_avg', label: '探测成功率', color: '#27c274', unit: 'percent' }]
     },
     {
@@ -147,22 +189,48 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { metric: 'website_response_time_avg', label: '平均响应', color: '#2f6bff', unit: 's' },
         { metric: 'website_response_time_max', label: '峰值响应', color: '#8a5cff', unit: 's' }
       ]
-    },
-    {
-      title: '内容长度趋势',
-      subtitle: '返回内容大小',
-      metric: 'website_content_length_avg',
-      guide: [{ label: '内容长度', detail: '单次响应正文字节数(bytes);骤增减常意味页面改版、错误页或被劫持,需核对页面内容。' }],
-      series: [{ metric: 'website_content_length_avg', label: '平均内容长度', color: '#597ef7', unit: 'bytes' }]
     }
   ],
-  ringPanels: [],
-  barPanels: [
+  ringPanels: [
+    {
+      title: '探测结果分布',
+      subtitle: '按 result_code 失败归因',
+      guide: [
+        {
+          label: '探测结果分布',
+          detail: 'Telegraf http_response result_code 占比：成功、内容不匹配、读体失败、连接失败、超时、DNS错误、状态码不匹配。'
+        }
+      ],
+      centerMetric: 'website_result_success_rate',
+      centerCaption: '成功占比',
+      centerUnit: 'percent',
+      emptyWhenAllZero: true,
+      emptyDescription: '当前窗口无探测结果码样本',
+      segments: [
+        { label: '成功', metric: 'website_result_success_rate', color: '#27c274', unit: 'percent' },
+        { label: '内容不匹配', metric: 'website_result_body_mismatch_rate', color: '#faad14', unit: 'percent' },
+        { label: '读体失败', metric: 'website_result_body_read_fail_rate', color: '#d48806', unit: 'percent' },
+        { label: '连接失败', metric: 'website_result_conn_fail_rate', color: '#ff4d4f', unit: 'percent' },
+        { label: '超时', metric: 'website_result_timeout_rate', color: '#ff7875', unit: 'percent' },
+        { label: 'DNS错误', metric: 'website_result_dns_fail_rate', color: '#cf1322', unit: 'percent' },
+        { label: '状态码不匹配', metric: 'website_result_status_mismatch_rate', color: '#ffa940', unit: 'percent' }
+      ]
+    },
     {
       title: '状态码分布',
-      subtitle: '2xx~5xx节点',
-      guide: [{ label: '状态码结构', detail: '优先判断当前异常请求主要集中在 4xx 还是 5xx。' }],
-      items: [
+      subtitle: '有 HTTP 响应时的码段结构',
+      guide: [
+        {
+          label: '状态码结构',
+          detail: '仅在拿到 HTTP 状态码时有意义。优先看 4xx vs 5xx；全空表示失败发生在建连/TLS/超时阶段，或尚未采集到状态码。'
+        }
+      ],
+      centerMetric: 'website_status_code_2xx_count',
+      centerCaption: '2xx 节点',
+      centerUnit: 'counts',
+      emptyWhenAllZero: true,
+      emptyDescription: '当前窗口无 HTTP 状态码（失败可能发生在建连/TLS/超时阶段，或尚未采集到状态码）',
+      segments: [
         { label: '2xx', metric: 'website_status_code_2xx_count', color: '#27c274', unit: 'counts' },
         { label: '3xx', metric: 'website_status_code_3xx_count', color: '#2f6bff', unit: 'counts' },
         { label: '4xx', metric: 'website_status_code_4xx_count', color: '#ff8a1f', unit: 'counts' },
@@ -170,5 +238,6 @@ export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     }
   ],
+  barPanels: [],
   details: []
 };

--- a/web/src/app/monitor/dashboards/objects/website/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/website/dashboard.tsx
@@ -6,29 +6,26 @@ import {
   DashboardShell,
   FlexiblePanelSection,
   KpiSection,
-  useFilteredBarPanels,
   useFilteredChartPanels,
+  useFilteredRingPanels,
   useFilteredSummaryCards
 } from '../common/dashboard-components';
-import {
-  HorizontalBarPanel,
-  TrendChartPanel
-} from '../../shared/widgets';
+import { RingChartPanel, TrendChartPanel } from '../../shared/widgets';
 import { WEBSITE_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 
-const SUMMARY_TITLES = ['探测成功率', '异常状态码', '平均响应时间', '可用节点(2xx)'];
-const PRIMARY_CHART_TITLES = ['探测成功率趋势', '响应时间趋势', '内容长度趋势'];
-const BAR_TITLES = ['状态码分布'];
+const SUMMARY_TITLES = ['探测成功率', '平均响应时间'];
+const PRIMARY_CHART_TITLES = ['探测成功率趋势', '响应时间趋势'];
+const RING_TITLES = ['探测结果分布', '状态码分布'];
 
 export default function WebsiteDashboardPage() {
   const dashboard = useSimpleDashboardData(WEBSITE_DASHBOARD_CONFIG);
   const summaryCards = useFilteredSummaryCards(dashboard.summaryCards, SUMMARY_TITLES);
   const charts = useFilteredChartPanels(dashboard.chartPanels, PRIMARY_CHART_TITLES);
-  const bars = useFilteredBarPanels(dashboard.barPanels, BAR_TITLES);
+  const rings = useFilteredRingPanels(dashboard.ringPanels, RING_TITLES);
 
-  const [successChart, responseChart, contentChart] = charts;
-  const [statusCodeBar] = bars;
+  const [successChart, responseChart] = charts;
+  const [resultCodeRing, statusCodeRing] = rings;
 
   return (
     <DashboardShell
@@ -37,9 +34,9 @@ export default function WebsiteDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={3} styles={styles} />
 
-          <div className={styles.sectionLabel}>性能趋势与分布</div>
+          <div className={styles.sectionLabel}>趋势</div>
           <FlexiblePanelSection styles={styles}>
             {successChart ? (
               <TrendChartPanel
@@ -75,31 +72,37 @@ export default function WebsiteDashboardPage() {
                 styles={styles}
               />
             ) : null}
-            {statusCodeBar ? (
-              <HorizontalBarPanel
-                key={statusCodeBar.panel.title}
-                title={statusCodeBar.panel.title}
-                subtitle={statusCodeBar.panel.subtitle}
-                guide={statusCodeBar.panel.guide}
-                items={statusCodeBar.items}
+          </FlexiblePanelSection>
+
+          <div className={styles.sectionLabel}>失败归因</div>
+          <FlexiblePanelSection styles={styles}>
+            {resultCodeRing ? (
+              <RingChartPanel
+                key={resultCodeRing.panel.title}
+                title={resultCodeRing.panel.title}
+                subtitle={resultCodeRing.panel.subtitle}
+                guide={resultCodeRing.panel.guide}
+                data={resultCodeRing.data}
+                centerValue={resultCodeRing.centerValue}
+                centerCaption={resultCodeRing.panel.centerCaption}
+                isEmpty={resultCodeRing.isEmpty}
+                emptyDescription={resultCodeRing.emptyDescription}
                 className={styles.span6}
                 styles={styles}
               />
             ) : null}
-            {contentChart ? (
-              <TrendChartPanel
-                key={contentChart.chart.title}
-                title={contentChart.chart.title}
-                subtitle={contentChart.chart.subtitle}
-                guide={contentChart.chart.guide}
-                legends={contentChart.legends}
-                data={contentChart.data}
-                metric={contentChart.metric}
-                unit={contentChart.unit}
-                loading={dashboard.loading}
-                seriesStyles={contentChart.seriesStyles}
-                onXRangeChange={dashboard.onXRangeChange}
-                className={`${styles.span6} ${styles.compactTrend}`}
+            {statusCodeRing ? (
+              <RingChartPanel
+                key={statusCodeRing.panel.title}
+                title={statusCodeRing.panel.title}
+                subtitle={statusCodeRing.panel.subtitle}
+                guide={statusCodeRing.panel.guide}
+                data={statusCodeRing.data}
+                centerValue={statusCodeRing.centerValue}
+                centerCaption={statusCodeRing.panel.centerCaption}
+                isEmpty={statusCodeRing.isEmpty}
+                emptyDescription={statusCodeRing.emptyDescription}
+                className={styles.span6}
                 styles={styles}
               />
             ) : null}

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -380,6 +380,26 @@ export const getProfessionalDashboardKey = (objectName?: string | null, objectDi
   return matched?.key || '';
 };
 
+/** 侧栏/列表展示名：优先 API display_name；TCPPort 等技术名回退到注册表 objectDisplayName（→ TCP）。 */
+export const getProfessionalObjectDisplayName = (objectName?: string | null, objectDisplayName?: string | null) => {
+  const matched = PROFESSIONAL_DASHBOARDS.find((item) => {
+    const candidates = getDashboardCandidates(item);
+    const objectCandidates = [objectName, objectDisplayName].map((value) => normalizeDashboardKey(value));
+    return objectCandidates.some((candidate) => candidate && candidates.includes(candidate));
+  });
+  const apiName = String(objectDisplayName || '').trim();
+  const technicalName = String(objectName || '').trim();
+  const apiKey = normalizeDashboardKey(apiName);
+  const techKey = normalizeDashboardKey(technicalName);
+
+  // 技术名 TCPPort（或 API 仍返回 TCPPort）时，强制用注册表展示名 TCP
+  if (techKey === 'tcpport' || apiKey === 'tcpport') {
+    return matched?.objectDisplayName || 'TCP';
+  }
+  if (apiName && apiName !== technicalName) return apiName;
+  return matched?.objectDisplayName || apiName || technicalName || '';
+};
+
 export const getProfessionalDashboardUrl = (
   objectName?: string | null,
   objectDisplayName?: string | null,

--- a/web/src/app/monitor/dashboards/shared/widgets/horizontal-bar-panel.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/horizontal-bar-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Tooltip } from 'antd';
+import { Empty, Tooltip } from 'antd';
 import { GuideItem } from '../types';
 import { ChartData } from '@/app/monitor/types';
 import { TitleWithGuide, GuideTooltipStyles } from './guide-tooltip';
@@ -54,6 +54,9 @@ export interface HorizontalBarPanelProps {
   emphasizeTop?: number;
   /** 分档模式:第 1 名醒目大行、2-3 名强调、≥4 名弱化。开启后忽略 emphasizeTop。需 item.rank。 */
   tiered?: boolean;
+  /** 空态：不渲染条形，展示 emptyDescription（与 RingChartPanel 对齐）。 */
+  isEmpty?: boolean;
+  emptyDescription?: React.ReactNode;
   styles: HorizontalBarPanelStyles;
 }
 
@@ -149,6 +152,8 @@ export const HorizontalBarPanel = ({
   className,
   emphasizeTop = 0,
   tiered = false,
+  isEmpty = false,
+  emptyDescription = '暂无数据',
   styles
 }: HorizontalBarPanelProps) => {
   return (
@@ -165,7 +170,13 @@ export const HorizontalBarPanel = ({
           {subtitle ? <div className={styles.panelSubTitle}>{subtitle}</div> : null}
         </div>
       </div>
-      <BarList items={items} emphasizeTop={emphasizeTop} tiered={tiered} styles={styles} />
+      {isEmpty ? (
+        <div style={{ minHeight: 176, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <Empty description={emptyDescription} image={Empty.PRESENTED_IMAGE_SIMPLE} />
+        </div>
+      ) : (
+        <BarList items={items} emphasizeTop={emphasizeTop} tiered={tiered} styles={styles} />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- 按「采集状态 → 通不通 → 好不好 → 为何/何处」瘦身网站 / Ping / TCP 拨测仪表盘：去掉冗余 KPI、镜像副指标与无意义的「最差结果码/最差探测结果」展示。
- 趋势图只保留平均与峰值；网站补探测结果/状态码分布环，Ping/TCP 补结果码分布环作失败归因；共享壳支持环图全零空态与 enumMap 优先展示。
- TCP 技术名 `TCPPort` 在侧栏、视图列表与语言兜底统一展示为 TCP。

## Test plan
- [ ] 打开网站拨测仪表盘：健康概览为采集状态 + 成功率 + 响应时间；趋势为成功率/响应；失败归因为探测结果分布 + 状态码分布
- [ ] 打开 Ping 仪表盘：概览为丢包 + 延迟；趋势为丢包/延迟（无最小线）；结果码分布环有数据时展示成功/错误/无法解析
- [ ] 打开 TCP 仪表盘：概览为连通成功率 + 平均响应；趋势无最小线；结果码分布环正常；侧栏/列表展示名为「TCP」而非 TCPPort
- [ ] 确认成功率文案说明成功 ≠ HTTP 2xx；状态码环在无 HTTP 响应时为空态而非误报健康
- [ ] 确认本次 PR 未包含本地 icon / `__enterprise-brands.js` 等无关改动