### PR TITLE
bugfix: 收紧作业看板聚合统计范围

### DIFF
--- a/server/apps/job_mgmt/tests/test_dashboard_stats_views.py
+++ b/server/apps/job_mgmt/tests/test_dashboard_stats_views.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from apps.job_mgmt.constants import ExecutionStatus, JobType
 from apps.job_mgmt.models import JobExecution, Playbook, ScheduledTask, Script, Target
 
-pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 STATS_URL = "/api/v1/job_mgmt/api/dashboard/stats/"
 JOB_TYPE_URL = "/api/v1/job_mgmt/api/dashboard/job_type_distribution/"

--- a/server/apps/job_mgmt/tests/test_dashboard_stats_views.py
+++ b/server/apps/job_mgmt/tests/test_dashboard_stats_views.py
@@ -18,8 +18,8 @@ JOB_TYPE_URL = "/api/v1/job_mgmt/api/dashboard/job_type_distribution/"
 STATUS_URL = "/api/v1/job_mgmt/api/dashboard/execution_status_distribution/"
 
 
-def _make(status, job_type=JobType.SCRIPT):
-    return JobExecution.objects.create(name="e", job_type=job_type, status=status, team=[1])
+def _make(status, job_type=JobType.SCRIPT, team=None):
+    return JobExecution.objects.create(name="e", job_type=job_type, status=status, team=team or [1])
 
 
 def _find(items, key_field, value):
@@ -27,7 +27,7 @@ def _find(items, key_field, value):
 
 
 class TestDashboardStats:
-    def test_stats_aggregates_assets_and_executions(self, api_client):
+    def test_stats_aggregates_assets_and_executions(self, su_client):
         Script.objects.create(name="s", content="echo", team=[1])
         Playbook.objects.create(name="p", version="v1.0.0", team=[1])
         Target.objects.create(name="h1", ip="10.0.0.1", os_type="linux", team=[1])
@@ -39,7 +39,7 @@ class TestDashboardStats:
         _make(ExecutionStatus.RUNNING)
         _make(ExecutionStatus.PENDING)
 
-        resp = api_client.get(STATS_URL)
+        resp = su_client.get(STATS_URL)
 
         assert resp.status_code == 200
         data = resp.data
@@ -54,8 +54,8 @@ class TestDashboardStats:
         assert data["execution_running"] == 1
         assert data["execution_pending"] == 1
 
-    def test_stats_empty_returns_zeros(self, api_client):
-        resp = api_client.get(STATS_URL)
+    def test_stats_empty_returns_zeros(self, su_client):
+        resp = su_client.get(STATS_URL)
         assert resp.status_code == 200
         for key in (
             "target_total",
@@ -72,24 +72,24 @@ class TestDashboardStats:
         ):
             assert resp.data[key] == 0
 
-    def test_stats_avg_duration_seconds(self, api_client):
+    def test_stats_avg_duration_seconds(self, su_client):
         execution = _make(ExecutionStatus.SUCCESS)
         started = timezone.now()
         JobExecution.objects.filter(id=execution.id).update(started_at=started, finished_at=started + timedelta(seconds=10))
 
-        resp = api_client.get(STATS_URL)
+        resp = su_client.get(STATS_URL)
 
         assert resp.status_code == 200
         assert resp.data["avg_duration_seconds"] == 10.0
 
 
 class TestJobTypeDistribution:
-    def test_distribution_counts_by_type_desc(self, api_client):
+    def test_distribution_counts_by_type_desc(self, su_client):
         _make(ExecutionStatus.SUCCESS, job_type=JobType.SCRIPT)
         _make(ExecutionStatus.FAILED, job_type=JobType.SCRIPT)
         _make(ExecutionStatus.SUCCESS, job_type=JobType.FILE_DISTRIBUTION)
 
-        resp = api_client.get(JOB_TYPE_URL)
+        resp = su_client.get(JOB_TYPE_URL)
 
         assert resp.status_code == 200
         script = _find(resp.data, "job_type", JobType.SCRIPT)
@@ -99,19 +99,19 @@ class TestJobTypeDistribution:
         assert file_dist["count"] == 1
         assert resp.data[0]["count"] >= resp.data[-1]["count"]
 
-    def test_distribution_empty(self, api_client):
-        resp = api_client.get(JOB_TYPE_URL)
+    def test_distribution_empty(self, su_client):
+        resp = su_client.get(JOB_TYPE_URL)
         assert resp.status_code == 200
         assert resp.data == []
 
 
 class TestExecutionStatusDistribution:
-    def test_distribution_counts_by_status(self, api_client):
+    def test_distribution_counts_by_status(self, su_client):
         _make(ExecutionStatus.SUCCESS)
         _make(ExecutionStatus.SUCCESS)
         _make(ExecutionStatus.FAILED)
 
-        resp = api_client.get(STATUS_URL)
+        resp = su_client.get(STATUS_URL)
 
         assert resp.status_code == 200
         success = _find(resp.data, "status", ExecutionStatus.SUCCESS)
@@ -120,7 +120,69 @@ class TestExecutionStatusDistribution:
         assert success["status_display"]
         assert failed["count"] == 1
 
-    def test_distribution_empty(self, api_client):
-        resp = api_client.get(STATUS_URL)
+    def test_distribution_empty(self, su_client):
+        resp = su_client.get(STATUS_URL)
         assert resp.status_code == 200
         assert resp.data == []
+
+
+class TestDashboardAggregateAccessControl:
+    @pytest.mark.parametrize("url", [STATS_URL, JOB_TYPE_URL, STATUS_URL])
+    def test_requires_job_record_view_permission(self, api_client, authenticated_user, url):
+        authenticated_user.permission = {"job": set()}
+        api_client.cookies["current_team"] = "1"
+
+        resp = api_client.get(url)
+
+        assert resp.status_code == 403
+
+
+class TestDashboardAggregateTeamIsolation:
+    def _authorize_team_one(self, api_client, authenticated_user):
+        authenticated_user.permission = {"job": {"job_record-View"}}
+        api_client.cookies["current_team"] = "1"
+
+    def test_stats_only_aggregates_current_team(self, api_client, authenticated_user):
+        self._authorize_team_one(api_client, authenticated_user)
+        Script.objects.create(name="s1", content="echo", team=[1])
+        Script.objects.create(name="s2", content="echo", team=[2])
+        Playbook.objects.create(name="p1", version="v1.0.0", team=[1])
+        Playbook.objects.create(name="p2", version="v1.0.0", team=[2])
+        Target.objects.create(name="h1", ip="10.0.0.1", os_type="linux", team=[1])
+        Target.objects.create(name="h2", ip="10.0.0.2", os_type="linux", team=[2])
+        ScheduledTask.objects.create(name="c1", job_type=JobType.SCRIPT, is_enabled=True, team=[1])
+        ScheduledTask.objects.create(name="c2", job_type=JobType.SCRIPT, is_enabled=True, team=[2])
+        _make(ExecutionStatus.SUCCESS, team=[1])
+        _make(ExecutionStatus.FAILED, team=[2])
+
+        resp = api_client.get(STATS_URL)
+
+        assert resp.status_code == 200
+        assert resp.data["script_total"] == 1
+        assert resp.data["playbook_total"] == 1
+        assert resp.data["target_total"] == 1
+        assert resp.data["scheduled_task_total"] == 1
+        assert resp.data["scheduled_task_enabled"] == 1
+        assert resp.data["execution_total"] == 1
+        assert resp.data["execution_success"] == 1
+        assert resp.data["execution_failed"] == 0
+
+    def test_job_type_distribution_only_aggregates_current_team(self, api_client, authenticated_user):
+        self._authorize_team_one(api_client, authenticated_user)
+        _make(ExecutionStatus.SUCCESS, job_type=JobType.SCRIPT, team=[1])
+        _make(ExecutionStatus.FAILED, job_type=JobType.FILE_DISTRIBUTION, team=[2])
+
+        resp = api_client.get(JOB_TYPE_URL)
+
+        assert resp.status_code == 200
+        assert [(item["job_type"], item["count"]) for item in resp.data] == [(JobType.SCRIPT, 1)]
+
+    def test_status_distribution_only_aggregates_current_team(self, api_client, authenticated_user):
+        self._authorize_team_one(api_client, authenticated_user)
+        _make(ExecutionStatus.SUCCESS, team=[1])
+        _make(ExecutionStatus.FAILED, team=[2])
+
+        resp = api_client.get(STATUS_URL)
+
+        assert resp.status_code == 200
+        assert [(item["status"], item["count"]) for item in resp.data] == [(ExecutionStatus.SUCCESS, 1)]

--- a/server/apps/job_mgmt/views/dashboard.py
+++ b/server/apps/job_mgmt/views/dashboard.py
@@ -194,11 +194,14 @@ class DashboardViewSet(AuthViewSet):
             }
         )
 
+    @HasPermission("job_record-View")
     @action(detail=False, methods=["get"])
     def stats(self, request):
         """获取Dashboard统计数据（资产与执行计数）"""
+        team_filter = self._get_team_filter(request)
+
         # 平均执行时长：仅统计 started_at/finished_at 都有的已完成执行
-        execution_stats = JobExecution.objects.aggregate(
+        execution_stats = JobExecution.objects.filter(team_filter).aggregate(
             total=Count("id"),
             success=Count("id", filter=Q(status=ExecutionStatus.SUCCESS)),
             failed=Count("id", filter=Q(status=ExecutionStatus.FAILED)),
@@ -209,26 +212,28 @@ class DashboardViewSet(AuthViewSet):
         avg_duration_seconds = _duration_to_seconds(execution_stats["avg_duration"])
 
         data = {
-            "target_total": Target.objects.count(),
-            "script_total": Script.objects.count(),
-            "playbook_total": Playbook.objects.count(),
+            "target_total": Target.objects.filter(team_filter).count(),
+            "script_total": Script.objects.filter(team_filter).count(),
+            "playbook_total": Playbook.objects.filter(team_filter).count(),
             "execution_total": execution_stats["total"],
             "execution_success": execution_stats["success"],
             "execution_failed": execution_stats["failed"],
             "execution_running": execution_stats["running"],
             "execution_pending": execution_stats["pending"],
-            "scheduled_task_total": ScheduledTask.objects.count(),
-            "scheduled_task_enabled": ScheduledTask.objects.filter(is_enabled=True).count(),
+            "scheduled_task_total": ScheduledTask.objects.filter(team_filter).count(),
+            "scheduled_task_enabled": ScheduledTask.objects.filter(team_filter, is_enabled=True).count(),
             "avg_duration_seconds": avg_duration_seconds,
         }
 
         serializer = DashboardStatsSerializer(data)
         return Response(serializer.data)
 
+    @HasPermission("job_record-View")
     @action(detail=False, methods=["get"])
     def job_type_distribution(self, request):
         """获取作业类型分布"""
-        distribution = JobExecution.objects.values("job_type").annotate(count=Count("id")).order_by("-count")
+        team_filter = self._get_team_filter(request)
+        distribution = JobExecution.objects.filter(team_filter).values("job_type").annotate(count=Count("id")).order_by("-count")
         job_type_names = dict(JobType.CHOICES)
 
         result = [
@@ -241,14 +246,16 @@ class DashboardViewSet(AuthViewSet):
         ]
         return Response(result)
 
+    @HasPermission("job_record-View")
     @action(detail=False, methods=["get"])
     def execution_status_distribution(self, request):
         """获取执行状态分布（按 days 或自定义 start_date/end_date 闭区间）"""
         start_date, end_date, error = _resolve_date_range(request)
         if error:
             return Response({"error": error}, status=status.HTTP_400_BAD_REQUEST)
+        team_filter = self._get_team_filter(request)
         distribution = (
-            JobExecution.objects.filter(created_at__date__gte=start_date, created_at__date__lte=end_date)
+            JobExecution.objects.filter(team_filter, created_at__date__gte=start_date, created_at__date__lte=end_date)
             .values("status")
             .annotate(count=Count("id"))
             .order_by("-count")


### PR DESCRIPTION
## 问题

作业看板的 `stats`、`job_type_distribution`、`execution_status_distribution`
三个聚合入口没有沿用同一视图集中已有的权限与团队边界。普通登录用户即使没有
作业记录查看权限，也可能读取全局资产计数和跨团队执行分布。

## 根因

看板聚合能力分散在多个 action 中，而权限装饰器和团队过滤需要逐入口显式接入。
趋势类入口已经采用 `job_record-View` 与 `_get_team_filter`，三个聚合入口遗漏了
这层统一边界，导致同一看板内的鉴权和统计口径不一致。

## 修复

- 三个聚合入口统一要求 `job_record-View`。
- 统一复用 `_get_team_filter`，将执行记录、目标、脚本、Playbook 和定时任务聚合
  限定到当前团队。
- 保留超级管理员的全量统计行为；普通用户继续使用当前团队口径。
- 增加无权限拒绝、团队隔离与超级管理员兼容回归测试。
- 将真实 DRF 与数据库测试正确标记为 `integration`。

## 兼容性

Issue 负责人已确认采用团队口径、首页文案表达“当前团队”，且没有合法调用方依赖
全局统计。因此本次无需人工 reviewer 门禁。

- 仅涉及 `job_mgmt` 的三个看板聚合 GET 接口。
- 不改路由、请求参数、响应字段、日期区间处理或数据模型。
- 仓库内未发现 Agent、NATS 或其他跨模块调用方。
- 无数据迁移；超级管理员仍保留全量统计。

## 调用链

```mermaid
flowchart TD
    T["Dashboard 聚合 GET"] --> P["HasPermission: job_record-View"]
    P --> F["_get_team_filter: 当前团队或超管全量"]
    F --> O["ORM 聚合: 执行与资产统计"]
    O --> R["响应字段契约不变"]
```

## 验证

- 最终提交：`3009c873801952054d6a787d416f6e54023236e9`
- 相关 Dashboard 测试：42 passed
- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS
- P0/P1/P2/P3：0/0/0/0

Closes #3973
