### PR TITLE
fix(monitor): preserve FalconStor brand icon

### DIFF
--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -784,7 +784,7 @@ const BRANDS: { match: RegExp; label: string; icon?: string }[] = [
   { match: /infinera|coriant|groove/i, label: 'Infinera', icon: 'mm-infinera_infinera' },
   { match: /bridgewave|flexport|fe80/i, label: 'BridgeWave', icon: 'mm-bridgewave_bridgewave' },
   { match: /huber\s*\+?\s*suhner|cubo\s*mini|cube\s*optics/i, label: 'Huber+Suhner Cubo', icon: 'mm-hubersuhner_hubersuhner' },
-  { match: /fibrolan|falcon/i, label: 'Fibrolan', icon: 'mm-fibrolan_fibrolan' },
+  { match: /fibrolan|falcon(?!stor)/i, label: 'Fibrolan', icon: 'mm-fibrolan_fibrolan' },
   { match: /smartoptics/i, label: 'Smartoptics', icon: 'mm-smartoptics_smartoptics' },
   { match: /racom|\bray\b/i, label: 'RACOM', icon: 'mm-racom_racom' },
   { match: /ifotec/i, label: 'Ifotec', icon: 'mm-ifotec_ifotec' },


### PR DESCRIPTION
## Summary

- Preserve the dedicated FalconStor monitor logo by preventing the generic FibroLAN Falcon rule from matching `FALCONSTOR`.
- Keep existing FibroLAN Falcon hardware matching intact.

## Validation

- TDD RED: with the old rule, `FALCONSTOR` resolved to `mm-fibrolan_fibrolan`.
- GREEN: `pnpm exec tsx -e ...` FalconStor collision validation passed.
- `git diff --check tencent-upstream/master...HEAD` passed.

## Scope checked

- PR diff contains only `web/src/app/monitor/utils/common.tsx`.
- Existing local generated/public asset changes are intentionally not included.