### PR TITLE
bugfix: 补齐日志资源组织范围校验

### DIFF
--- a/server/apps/system_mgmt/tests/test_group_data_rule_log_scope.py
+++ b/server/apps/system_mgmt/tests/test_group_data_rule_log_scope.py
@@ -1,0 +1,96 @@
+import json
+import types
+
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.system_mgmt.viewset.group_data_rule_viewset import GroupDataRuleViewSet
+
+
+def _request_user(group_ids, *, is_superuser=False):
+    return types.SimpleNamespace(
+        username="log-scope-operator",
+        domain="domain.com",
+        locale="en",
+        is_authenticated=True,
+        is_superuser=is_superuser,
+        permission={"system-manager": {"data_permission-View"}},
+        group_list=[{"id": group_id} for group_id in group_ids],
+    )
+
+
+def _get_log_app_data(monkeypatch, *, group_ids, group_id, is_superuser=False):
+    captured = {}
+
+    class FakeClient:
+        def get_module_data(self, **kwargs):
+            captured.update(kwargs)
+            return {"count": 0, "items": []}
+
+    def fake_get_client(params):
+        params.pop("app")
+        return FakeClient()
+
+    monkeypatch.setattr(GroupDataRuleViewSet, "get_client", staticmethod(fake_get_client))
+
+    request = APIRequestFactory().get(
+        "/system_mgmt/api/group_data_rule/get_app_data/",
+        {
+            "app": "log",
+            "module": "log_group",
+            "child_module": "",
+            "page": "1",
+            "page_size": "10",
+            "group_id": group_id,
+        },
+    )
+    force_authenticate(request, user=_request_user(group_ids, is_superuser=is_superuser))
+
+    response = GroupDataRuleViewSet.as_view({"get": "get_app_data"})(request)
+    return response, json.loads(response.content), captured
+
+
+def test_log_get_app_data_rejects_unauthorized_group(monkeypatch):
+    response, payload, captured = _get_log_app_data(monkeypatch, group_ids=[7], group_id="8")
+
+    assert response.status_code == 403
+    assert payload == {
+        "result": False,
+        "message": "You do not have permission to access this group.",
+    }
+    assert captured == {}
+
+
+def test_log_get_app_data_allows_authorized_group(monkeypatch):
+    response, payload, captured = _get_log_app_data(monkeypatch, group_ids=[7], group_id="7")
+
+    assert response.status_code == 200
+    assert payload == {"result": True, "data": {"count": 0, "items": []}}
+    assert captured == {
+        "module": "log_group",
+        "child_module": "",
+        "page": 1,
+        "page_size": 10,
+        "group_id": "7",
+    }
+
+
+def test_log_get_app_data_allows_superuser(monkeypatch):
+    response, payload, captured = _get_log_app_data(monkeypatch, group_ids=[], group_id="8", is_superuser=True)
+
+    assert response.status_code == 200
+    assert payload == {"result": True, "data": {"count": 0, "items": []}}
+    assert captured == {
+        "module": "log_group",
+        "child_module": "",
+        "page": 1,
+        "page_size": 10,
+        "group_id": "8",
+    }
+
+
+def test_log_get_app_data_rejects_invalid_group_id(monkeypatch):
+    response, payload, captured = _get_log_app_data(monkeypatch, group_ids=[7], group_id="invalid")
+
+    assert response.status_code == 400
+    assert payload == {"result": False, "message": "group_id 参数非法"}
+    assert captured == {}

--- a/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
+++ b/server/apps/system_mgmt/viewset/group_data_rule_viewset.py
@@ -212,7 +212,7 @@ class GroupDataRuleViewSet(LanguageViewSet):
         params = request.GET.dict()
         # 记录 app 值（get_client 会从 params 中弹出），用于后续判断是否注入上下文
         app = params.get("app", "")
-        if app in {"job", "mlops"}:
+        if app in {"job", "log", "mlops"}:
             try:
                 group_id = int(params.get("group_id"))
             except (TypeError, ValueError):
@@ -227,7 +227,7 @@ class GroupDataRuleViewSet(LanguageViewSet):
                 if error_response:
                     return error_response
                 params["actor_context"] = actor_context
-            else:
+            elif app == "job":
                 user_group_ids = self._get_user_group_ids(request.user)
                 params["team"] = [group_id] if user_group_ids is None else sorted(user_group_ids)
 


### PR DESCRIPTION
## 问题

系统管理的应用数据入口本应在访问目标组织资源前校验调用用户的组织范围，但 `app=log` 分支绕过了这层校验。普通授权用户因此可以把 `group_id` 换成其他组织并读取日志资源元数据。

## 根因

组织授权边界只覆盖了 `job` 和 `mlops` 分支，日志分支直接进入 Log RPC。边界校验放置不完整，导致同一个 HTTP action 的不同应用分支具备不一致的授权语义。

## 怎么修的

- 让 `app=log` 复用入口已有的 `group_id` 整数校验和组织成员校验。
- 保持只有 `job` 分支注入 `team`，不改变 Log RPC/NATS 的参数、响应或 handler。
- 越权请求在 RPC 前返回既有 403；非法 `group_id` 返回既有 400。

## 影响范围

- 仅影响 system_mgmt 的 `get_app_data` HTTP 入口。
- 目标组织成员与超级管理员继续按原参数访问，成功响应不变。
- Web 请求形态、Log RPC/NATS 契约、数据模型和持久化数据均不变。
- 无数据迁移；回滚可直接还原本提交。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["get_app_data\nsystem_mgmt viewset"]
    end

    subgraph A["授权层"]
        A1["解析 group_id"]
        A2["校验目标组织成员"]
        A3["返回 400 / 403"]
    end

    subgraph R["日志调用层"]
        R1["Log.get_module_data"]
        R2["get_log_module_data"]
    end

    T1 --> A1 --> A2
    A2 -->|合法成员或超管| R1 --> R2
    A1 -. "非法参数" .-> A3
    A2 -. "越权" .-> A3
```

## 验证

- RED：`apps/system_mgmt/tests/test_group_data_rule_log_scope.py` 在修复前命中越权请求实际 200、预期 403。
- GREEN：`apps/system_mgmt/tests/test_group_data_rule_log_scope.py`：4 passed。
- 合法成员与超管用例断言完整 Log RPC 参数；越权与非法参数用例断言 RPC 未调用。
- `git diff --check` 通过，最终提交工作树洁净。

## 三轨门禁

- Standards：PASS，无 Critical / Important。
- Spec：PASS，修复范围与负责人确认的 HTTP 最小方案一致。
- Runtime Contract：PASS，覆盖越权、合法成员、超级管理员、非法参数、成功响应及 Log RPC 参数兼容。
- G6：98 / 100。

Fixes #3950
