### PR TITLE
fix: generate random UUIDs for network probe instances

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/ping/ping/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/ping/ping/UI.json
@@ -6,7 +6,7 @@
     "ping"
   ],
   "collector": "Telegraf",
-  "instance_id": "{{instance_type}}_{{url}}",
+  "instance_id": "{{uuid}}",
   "form_fields": [
     {
       "name": "monitor_url",

--- a/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/tcp/tcp/UI.json
@@ -6,7 +6,7 @@
     "net_response"
   ],
   "collector": "Telegraf",
-  "instance_id": "{{instance_type}}_{{host}}_{{port}}",
+  "instance_id": "{{uuid}}",
   "form_fields": [
     {
       "name": "host",

--- a/server/apps/monitor/support-files/plugins/Telegraf/web/web/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/web/web/UI.json
@@ -6,7 +6,7 @@
     "http_response"
   ],
   "collector": "Telegraf",
-  "instance_id": "{{instance_type}}_{{url}}",
+  "instance_id": "{{uuid}}",
   "form_fields": [
     {
       "name": "monitor_url",

--- a/web/src/app/monitor/hooks/integration/Readme.md
+++ b/web/src/app/monitor/hooks/integration/Readme.md
@@ -685,6 +685,15 @@ auto 模式下可选择，edit 模式下仅显示（不可编辑）：
 "instance_id": "{{cloud_region}}_{{instance_type}}_snmp_{{ip}}"
 ```
 
+若每一行代表独立任务、不应按业务字段去重，可声明 UUID 策略：
+
+```json
+"instance_id": "{{uuid}}"
+```
+
+auto 模式会复用当前行稳定的 UUID v4 `key`，输出去掉连字符后的 32 位小写
+`instance_id`。同一行提交失败后重试时 ID 不变；新增、复制或导入的每一行使用不同 ID。
+
 #### 变量来源（按优先级）
 
 1. **当前行字段**（来自 table_columns）

--- a/web/src/app/monitor/hooks/integration/useDataMapper.ts
+++ b/web/src/app/monitor/hooks/integration/useDataMapper.ts
@@ -358,12 +358,16 @@ export class DataMapper {
           (n: any) => n?.value === firstNodeId || n?.id === firstNodeId
         )
         : undefined;
-      // 生成 instance_id（如果有模板）,使用 SHA256 哈希编码
+      // 生成 instance_id：UUID 策略复用当前行稳定的 UUID key；
+      // 普通模板继续使用既有哈希编码。
       let instance_id = row.instance_id;
       if (!instance_id && context.instance_id) {
-        instance_id = this.hashInstanceId(
-          this.applyTemplate(context.instance_id, row, context)
-        );
+        instance_id =
+          context.instance_id === '{{uuid}}'
+            ? String(row.key).replaceAll('-', '').toLowerCase()
+            : this.hashInstanceId(
+              this.applyTemplate(context.instance_id, row, context)
+            );
       }
       // 过滤掉 key 字段和所有 _error 字段，并处理加密字段
       const cleanedInstanceData = Object.keys(row)


### PR DESCRIPTION
## Summary

- add an explicit `{{uuid}}` instance ID strategy for automatic monitoring access
- switch the built-in Website, TCP, and Ping plugins to UUID-based instance IDs
- preserve the existing template hashing behavior for all other plugins
- document the UUID strategy and retry semantics

## Why

Website, TCP, and Ping instance IDs were deterministically derived from their targets. When different organizations configured the same target, they produced the same global monitor instance identity and could not maintain independent probe intervals, nodes, or organization ownership.

Each new probe row now reuses its stable UI row UUID, normalized to a UUID v4 represented by 32 lowercase hexadecimal characters without hyphens. Retrying the same row keeps its identity, while new, copied, and imported rows receive independent identities. Existing instances and edit flows are unchanged.

## Validation

### Code

- focused random probe instance ID regression script passed
- existing ordinary DataMapper behavior remains on the template hashing path
- targeted ESLint passed
- Website, TCP, and Ping `UI.json` parsing passed
- monitor-scoped TypeScript type check passed
- `git diff --check` passed

### Local runtime

Validated through the real page at `127.0.0.1:3000` against the local backend and collector stack:

- Website, Ping, and TCP configuration requests returned HTTP 200
- Ping and TCP page submissions returned to their integration lists; TCP displayed `添加成功`
- Django ORM confirmed three distinct IDs, all valid UUID v4 values encoded as 32 lowercase hexadecimal characters
- Node child configurations contained the matching instance IDs and the expected targets; Ping and TCP both used the configured 30-second interval
- the selected local node reported `1 running / 0 stopped / 0 failing`
- VictoriaMetrics returned current successful Website, Ping, and TCP samples for the exact generated instance IDs

Targeted Django tests could not enter collection because the current local test environment does not register `django_celery_beat` in `INSTALLED_APPS`; no server test result is claimed.

## Scope

The commit contains exactly five implementation and contract-documentation files. The local TDD validation script remains untracked and is intentionally excluded from the PR according to the repository test-commit policy.