### PR TITLE
bugfix: 登录模块响应隐藏应用密钥

### DIFF
--- a/server/apps/system_mgmt/serializers/login_module_serializer.py
+++ b/server/apps/system_mgmt/serializers/login_module_serializer.py
@@ -8,10 +8,27 @@ from apps.system_mgmt.tasks import sync_user_and_group_by_login_module
 class LoginModuleSerializer(serializers.ModelSerializer):
     # 自定义 name 字段，用于展示时可能的翻译
     display_name = serializers.SerializerMethodField()
+    # app_secret 仅接受写入，不在 API 响应中返回，避免密文暴露给前端
+    app_secret = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+    )
 
     class Meta:
         model = LoginModule
-        fields = "__all__"
+        fields = (
+            "id",
+            "name",
+            "source_type",
+            "app_id",
+            "app_secret",
+            "other_config",
+            "enabled",
+            "is_build_in",
+            "display_name",
+        )
 
     def get_display_name(self, obj):
         # 如果是内置模块，翻译name
@@ -45,6 +62,9 @@ class LoginModuleSerializer(serializers.ModelSerializer):
         return instance
 
     def update(self, instance, validated_data):
+        # 未输入新密钥时保留现值；前端编辑表单会将空值视为“不更换密钥”
+        if validated_data.get("app_secret") in (None, ""):
+            validated_data.pop("app_secret", None)
         instance = super().update(instance, validated_data)
         if instance.source_type == "bk_lite":
             try:

--- a/server/apps/system_mgmt/tests/test_login_module_serializer_pure.py
+++ b/server/apps/system_mgmt/tests/test_login_module_serializer_pure.py
@@ -1,0 +1,105 @@
+"""Issue #3465 的 LoginModuleSerializer 密钥边界回归测试。"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.system_mgmt.models import LoginModule
+from apps.system_mgmt.serializers.login_module_serializer import LoginModuleSerializer
+
+pytestmark = pytest.mark.unit
+
+
+class FakeLoginModule:
+    """满足 ModelSerializer 输出所需属性的最小对象。"""
+
+    def __init__(self, **kwargs):
+        self.id = kwargs.get("id", 1)
+        self.name = kwargs.get("name", "企业微信")
+        self.source_type = kwargs.get("source_type", "wechat")
+        self.app_id = kwargs.get("app_id", "wx_app_id_123")
+        self.app_secret = kwargs.get("app_secret", "ENCRYPTED_CIPHERTEXT_XYZ")
+        self.other_config = kwargs.get("other_config", {})
+        self.enabled = kwargs.get("enabled", True)
+        self.is_build_in = kwargs.get("is_build_in", False)
+        self.pk = self.id
+
+
+class TestLoginModuleSerializerAppSecretNotExposed:
+    @staticmethod
+    def _make_serializer(instance, method="GET"):
+        request = MagicMock()
+        request.method = method
+        return LoginModuleSerializer(instance, context={"request": request})
+
+    def test_app_secret_not_in_serializer_output(self):
+        instance = FakeLoginModule(app_secret="ENCRYPTED_CIPHER_SECRET")
+        serializer = self._make_serializer(instance)
+
+        data = serializer.to_representation(instance)
+
+        assert "app_secret" not in data
+
+    def test_non_secret_fields_still_present(self):
+        instance = FakeLoginModule(
+            name="企业微信登录",
+            source_type="wechat",
+            app_id="wx123",
+            enabled=True,
+        )
+        serializer = self._make_serializer(instance)
+
+        data = serializer.to_representation(instance)
+
+        assert {"name", "source_type", "app_id", "enabled"} <= data.keys()
+
+    def test_app_secret_field_is_write_only_and_optional(self):
+        field = LoginModuleSerializer().fields["app_secret"]
+
+        assert field.write_only is True
+        assert field.required is False
+
+
+class TestLoginModuleSerializerUpdatePreservesSecret:
+    @staticmethod
+    def _update(existing_cipher, validated_data):
+        instance = LoginModule(
+            name="企业微信",
+            source_type="wechat",
+            app_secret=existing_cipher,
+            other_config={},
+        )
+        serializer = LoginModuleSerializer()
+        with patch.object(instance, "save") as save:
+            updated = serializer.update(instance, validated_data)
+        save.assert_called_once_with()
+        return updated
+
+    def test_update_preserves_existing_app_secret_when_not_in_payload(self):
+        existing_cipher = "gAAAAAB_EXISTING_CIPHER"
+
+        updated = self._update(existing_cipher, {"name": "新名称"})
+
+        assert updated.app_secret == existing_cipher
+
+    def test_update_preserves_existing_app_secret_when_null(self):
+        existing_cipher = "gAAAAAB_EXISTING_CIPHER"
+
+        updated = self._update(existing_cipher, {"app_secret": None})
+
+        assert updated.app_secret == existing_cipher
+
+    def test_update_preserves_existing_app_secret_when_blank(self):
+        existing_cipher = "gAAAAAB_EXISTING_CIPHER"
+
+        updated = self._update(existing_cipher, {"app_secret": ""})
+
+        assert updated.app_secret == existing_cipher
+
+    def test_update_uses_provided_app_secret_when_in_payload(self):
+        updated = self._update(
+            "gAAAAAB_OLD_CIPHER",
+            {"name": "企业微信", "app_secret": "new_plain_secret"},
+        )
+
+        assert updated.app_secret == "new_plain_secret"

--- a/web/src/app/system-manager/components/security/authSourceFormConfig.tsx
+++ b/web/src/app/system-manager/components/security/authSourceFormConfig.tsx
@@ -13,6 +13,7 @@ interface FormConfigParams {
   dynamicForm: FormInstance;
   copyToClipboard: (text: string) => void;
   isBuiltIn?: boolean;
+  isEditing?: boolean;
 }
 
 export const getNewAuthSourceFormFields = ({
@@ -218,7 +219,8 @@ export const getBluekingFormFields = ({
 export const getWeChatFormFields = ({
   t,
   dynamicForm,
-  copyToClipboard
+  copyToClipboard,
+  isEditing = false
 }: FormConfigParams) => [
   {
     name: 'name',
@@ -239,7 +241,7 @@ export const getWeChatFormFields = ({
     type: 'editablePwd',
     label: t('system.security.appSecret'),
     placeholder: `${t('common.inputMsg')}${t('system.security.appSecret')}`,
-    rules: [{ required: true, message: `${t('common.inputMsg')}${t('system.security.appSecret')}` }]
+    rules: [{ required: !isEditing, message: `${t('common.inputMsg')}${t('system.security.appSecret')}` }]
   },
   {
     name: 'redirect_uri',

--- a/web/src/app/system-manager/components/security/sourcesList.tsx
+++ b/web/src/app/system-manager/components/security/sourcesList.tsx
@@ -115,7 +115,8 @@ const AuthSourcesList: React.FC<AuthSourcesListProps> = ({
     roleTreeData,
     selectedRoles,
     setSelectedRoles,
-  }), [t, dynamicForm, handleCopy, roleTreeData, selectedRoles, setSelectedRoles]);
+    isEditing: Boolean(editingSource),
+  }), [t, dynamicForm, handleCopy, roleTreeData, selectedRoles, setSelectedRoles, editingSource]);
 
   const renderWeChatModal = () => (
     <div className="w-full">

--- a/web/src/app/system-manager/hooks/useAuthSourceModal.ts
+++ b/web/src/app/system-manager/hooks/useAuthSourceModal.ts
@@ -9,6 +9,7 @@ import {
   SourceType,
   buildUpdatePayload,
   buildCreatePayload,
+  mergeAuthSourceUpdate,
   populateFormFromSource,
   getDefaultRolesFromSource,
   getFieldsToResetOnTypeChange,
@@ -79,7 +80,7 @@ export function useAuthSourceModal({
         );
         await updateAuthSource(editingSource.id, updateData);
 
-        const updatedSource = { ...editingSource, ...updateData };
+        const updatedSource = mergeAuthSourceUpdate(editingSource, updateData);
         const enhancedSource = enhanceAuthSourcesList([updatedSource])[0];
 
         onUpdate(authSources.map(item =>

--- a/web/src/app/system-manager/utils/__tests__/authSourceFormUtils.test.tsx
+++ b/web/src/app/system-manager/utils/__tests__/authSourceFormUtils.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import type { AuthSource } from '../../types/security';
+import {
+  buildUpdatePayload,
+  mergeAuthSourceUpdate,
+  populateFormFromSource,
+  type WeChatFormValues,
+} from '../authSourceFormUtils';
+
+const existingSource: AuthSource = {
+  id: 1,
+  name: '企业微信',
+  source_type: 'wechat',
+  app_id: 'wx-app-id',
+  app_secret: 'ENCRYPTED_CIPHER',
+  other_config: {
+    redirect_uri: 'https://example.com/callback',
+    callback_url: 'https://example.com/callback',
+  },
+  enabled: true,
+  is_build_in: false,
+};
+
+const formValues: WeChatFormValues = {
+  name: '企业微信',
+  app_id: 'wx-app-id',
+  app_secret: '',
+  enabled: true,
+  redirect_uri: 'https://example.com/callback',
+  callback_url: 'https://example.com/callback',
+};
+
+describe('认证源密钥编辑契约', () => {
+  it('编辑表单不回填响应中的历史密钥', () => {
+    const populated = populateFormFromSource(existingSource);
+
+    expect(populated).not.toHaveProperty('app_secret');
+  });
+
+  it('未输入新密钥时更新 payload 不发送 app_secret', () => {
+    const payload = buildUpdatePayload('wechat', formValues, []);
+
+    expect(payload).not.toHaveProperty('app_secret');
+  });
+
+  it('输入新密钥时更新 payload 显式发送 app_secret', () => {
+    const payload = buildUpdatePayload(
+      'wechat',
+      { ...formValues, app_secret: 'new-secret' },
+      []
+    );
+
+    expect(payload.app_secret).toBe('new-secret');
+  });
+
+  it('保存成功后不把新旧 app_secret 合并回前端列表状态', () => {
+    const merged = mergeAuthSourceUpdate(existingSource, {
+      name: '新名称',
+      app_secret: 'new-secret',
+    });
+
+    expect(merged.name).toBe('新名称');
+    expect(merged).not.toHaveProperty('app_secret');
+  });
+});

--- a/web/src/app/system-manager/utils/authSourceFormUtils.ts
+++ b/web/src/app/system-manager/utils/authSourceFormUtils.ts
@@ -63,16 +63,19 @@ export function buildUpdatePayload(
 ): Partial<AuthSource> {
   if (sourceType === 'wechat') {
     const v = values as WeChatFormValues;
-    return {
+    const payload: Partial<AuthSource> = {
       name: v.name,
       app_id: v.app_id,
-      app_secret: v.app_secret,
       enabled: v.enabled,
       other_config: {
         redirect_uri: v.redirect_uri,
         callback_url: v.callback_url,
       },
     };
+    if (v.app_secret) {
+      payload.app_secret = v.app_secret;
+    }
+    return payload;
   }
 
   if (sourceType === 'bk_login') {
@@ -149,12 +152,22 @@ export function buildCreatePayload(
   };
 }
 
+export function mergeAuthSourceUpdate(
+  source: AuthSource,
+  updateData: Partial<AuthSource>
+): AuthSource {
+  const safeSource = { ...source };
+  const safeUpdateData = { ...updateData };
+  delete safeSource.app_secret;
+  delete safeUpdateData.app_secret;
+  return { ...safeSource, ...safeUpdateData };
+}
+
 export function populateFormFromSource(source: AuthSource): Record<string, any> {
   if (source.source_type === 'wechat') {
     return {
       name: source.name,
       app_id: source.app_id,
-      app_secret: source.app_secret,
       enabled: source.enabled,
       redirect_uri: source.other_config.redirect_uri,
       callback_url: source.other_config.callback_url,


### PR DESCRIPTION
## 问题

登录模块列表与详情共用模型序列化器，原实现会把加密存储的 `app_secret` 一并写入 API 响应；编辑流程又依赖响应回填并重传该值，使密钥进入浏览器状态并延长驻留时间。

## 根因

序列化边界采用模型全字段自动展开，没有显式区分可读字段与只写凭据。前端也把认证源响应和更新载荷直接合并到列表状态，缺少凭据字段的单向流转约束。

## 怎么修的

- 将 `app_secret` 声明为可选只写字段，并改用显式序列化字段清单。
- 更新时把缺失、`null`、空字符串解释为“不更换密钥”，保留已有配置；非空值仍可显式换密钥。
- Web 编辑不回填或提交空密钥，保存成功后的列表状态同时剔除旧密文与新输入明文。
- 创建、显式换密钥、普通字段及模型既有加密逻辑保持不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["登录模块列表/详情与编辑\nsystem_mgmt + Web"]
    end

    subgraph N["序列化与更新层"]
        N1["LoginModuleSerializer\n只写 app_secret"]
        N2["buildUpdatePayload\n仅提交非空新密钥"]
    end

    subgraph C["前端状态层"]
        C1["mergeAuthSourceUpdate\n剔除新旧密钥"]
    end

    T1 --> N1
    T1 --> N2
    N2 --> C1
    N1 -. "响应不含密钥" .-> C1
```

## 影响范围

改动仅涉及 `system_mgmt` 登录模块序列化器和对应 Web 认证源编辑流程；不修改模型、加密实现、数据库结构、权限或 NATS 契约。回滚可按单提交还原，无存量数据迁移。

## 验证

- `apps/system_mgmt/tests/test_login_module_serializer_pure.py`：7 passed
- `src/app/system-manager/utils/__tests__/authSourceFormUtils.test.tsx`：4 passed
- 相关 Web 文件定向 ESLint：通过
- Web TypeScript 类型检查：通过

回归用例已验证修复前会暴露密文并保留前端密钥状态，修复后上述边界均通过。

## 三轨门禁

- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS

运行契约覆盖响应隐藏、普通字段保留、缺失/空值兼容、显式换密钥、编辑载荷和保存后状态净化。G6：97/100。

Closes #3465