### PR TITLE
优化主机与 Redis 监控仪表盘版面

### DIFF
--- a/web/src/app/monitor/dashboards/objects/host/config.ts
+++ b/web/src/app/monitor/dashboards/objects/host/config.ts
@@ -92,61 +92,12 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#faad14'
     },
     {
-      name: 'host_cpu_core_count',
-      display_name: 'CPU 核数',
-      description: '主机逻辑 CPU 核数，用作负载对照基线。',
-      unit: 'counts',
-      // ①HTTP Remote 直采；②Telegraf system.n_cpus；③按非汇总 CPU 序列计数兜底。
-      query: 'host_cpu_core_count_gauge{instance_type="os", __$labels__} or system_n_cpus{instance_type="os", __$labels__} or count by (instance_id) (cpu_usage_idle{cpu!="cpu-total", instance_type="os", __$labels__})',
-      color: '#597ef7'
-    },
-    {
-      name: 'mem_total',
-      display_name: '总内存',
-      description: '主机总内存容量。',
-      unit: 'bytes',
-      query: 'mem_total{instance_type="os", __$labels__} or host_mem_total_bytes_gauge{instance_type="os", __$labels__} or mem_total_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#2f6bff'
-    },
-    {
       name: 'mem_available',
       display_name: '可用内存',
       description: '主机当前可用内存。',
       unit: 'bytes',
       query: 'mem_available{instance_type="os", __$labels__} or host_mem_available_bytes_gauge{instance_type="os", __$labels__} or mem_available_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
       color: '#13c2c2'
-    },
-    {
-      name: 'mem_cached',
-      display_name: '缓存内存',
-      description: '主机页缓存占用的内存。',
-      unit: 'bytes',
-      query: 'mem_cached{instance_type="os", __$labels__} or mem_cached_gauge{instance_type="os", __$labels__}',
-      color: '#597ef7'
-    },
-    {
-      name: 'mem_buffered',
-      display_name: '缓冲内存',
-      description: '主机缓冲区占用的内存。',
-      unit: 'bytes',
-      query: 'mem_buffered{instance_type="os", __$labels__} or mem_buffered_gauge{instance_type="os", __$labels__}',
-      color: '#ff8a1f'
-    },
-    {
-      name: 'mem_used_bytes',
-      display_name: '已用内存',
-      description: '主机当前已使用的内存。',
-      unit: 'bytes',
-      query: 'host_mem_used_bytes_gauge{instance_type="os", __$labels__} or clamp_min(mem_total{instance_type="os", __$labels__} - mem_available{instance_type="os", __$labels__}, 0) or clamp_min(host_mem_total_bytes_gauge{instance_type="os", __$labels__} - host_mem_available_bytes_gauge{instance_type="os", __$labels__}, 0) or clamp_min(mem_total_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} - mem_available_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}, 0)',
-      color: '#27c274'
-    },
-    {
-      name: 'processes_running',
-      display_name: '运行进程数',
-      description: '当前正在运行的进程数量。',
-      unit: 'counts',
-      query: 'processes_running{instance_type="os", __$labels__} or processes_running_gauge{instance_type="os", __$labels__} or processes_running_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#2f6bff'
     },
     {
       name: 'processes_blocked',
@@ -157,28 +108,12 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#ff8a1f'
     },
     {
-      name: 'processes_sleeping',
-      display_name: '休眠进程数',
-      description: '当前处于休眠状态的进程数量。',
-      unit: 'counts',
-      query: 'processes_sleeping{instance_type="os", __$labels__} or processes_sleeping_gauge{instance_type="os", __$labels__} or processes_sleeping_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
-      color: '#13c2c2'
-    },
-    {
       name: 'processes_zombies',
       display_name: '僵尸进程数',
       description: '当前处于僵尸状态的进程数量。',
       unit: 'counts',
       query: 'processes_zombies{instance_type="os", __$labels__} or processes_zombies_gauge{instance_type="os", __$labels__} or processes_zombies_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
       color: '#8a5cff'
-    },
-    {
-      name: 'processes_total',
-      display_name: '总进程数',
-      description: '当前主机进程总量。',
-      unit: 'counts',
-      query: '(processes_running{instance_type="os", __$labels__} + processes_sleeping{instance_type="os", __$labels__} + processes_blocked{instance_type="os", __$labels__} + processes_zombies{instance_type="os", __$labels__}) or (processes_running_gauge{instance_type="os", __$labels__} + processes_sleeping_gauge{instance_type="os", __$labels__} + processes_blocked_gauge{instance_type="os", __$labels__} + processes_zombies_gauge{instance_type="os", __$labels__}) or (processes_running_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} + processes_sleeping_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} + processes_blocked_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__} + processes_zombies_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__})',
-      color: '#13c2c2'
     },
     {
       name: 'net_bytes_recv_rate',
@@ -353,7 +288,7 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'processes_blocked',
       guide: [{
         label: '进程异常',
-        detail: '阻塞进程持续非零多与慢 I/O / 不可中断等待相关；僵尸进程非零查父进程未回收。I/O Wait 见上方 KPI 与资源趋势（Linux）；运行/休眠等结构见「进程状态分布」。'
+        detail: '阻塞进程持续非零多与慢 I/O / 不可中断等待相关；僵尸进程非零查父进程未回收。I/O Wait 见上方 KPI 与资源趋势（Linux）。'
       }],
       series: [
         { metric: 'processes_blocked', label: '阻塞进程', color: '#ff8a1f', unit: 'counts' },
@@ -361,6 +296,8 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     }
   ],
+  // 内存占用环与进程状态环已砍：前者与内存 KPI 镜像，后者常态被休眠进程淹没；
+  // 进程异常看「进程异常趋势」，内存看 KPI 与资源使用趋势。
   ringPanels: [
     {
       title: 'CPU 时间分布',
@@ -374,32 +311,6 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: '内核态', metric: 'cpu_usage_system_total', color: '#597ef7', unit: 'percent' },
         { label: 'I/O Wait 占比', metric: 'cpu_usage_iowait_total', color: '#ff8a1f', unit: 'percent' },
         { label: '其他', metric: 'cpu_usage_other_total', color: '#e8f0fe', unit: 'percent' }
-      ]
-    },
-    {
-      title: '内存占用分布',
-      subtitle: '已用与可用内存',
-      centerMetric: 'mem_used_percent',
-      centerCaption: '内存使用率',
-      centerUnit: 'percent',
-      guide: [{ label: '内存结构', detail: '对比当前已用内存与可用内存容量。' }],
-      segments: [
-        { label: '已用内存', metric: 'mem_used_bytes', color: '#27c274', unit: 'bytes' },
-        { label: '可用内存', metric: 'mem_available', color: '#e8f0fe', unit: 'bytes' }
-      ]
-    },
-    {
-      title: '进程状态分布',
-      subtitle: '运行、休眠、阻塞、僵尸',
-      centerMetric: 'processes_total',
-      centerCaption: '总进程数',
-      centerUnit: 'counts',
-      guide: [{ label: '进程结构', detail: '对比主机当前运行、休眠、阻塞和僵尸进程的数量分布。' }],
-      segments: [
-        { label: '运行中', metric: 'processes_running', color: '#2f6bff', unit: 'counts' },
-        { label: '休眠中', metric: 'processes_sleeping', color: '#27c274', unit: 'counts' },
-        { label: '阻塞中', metric: 'processes_blocked', color: '#ff8a1f', unit: 'counts' },
-        { label: '僵尸', metric: 'processes_zombies', color: '#8a5cff', unit: 'counts' }
       ]
     }
   ],

--- a/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/host/dashboard.tsx
@@ -19,7 +19,7 @@ import styles from './index.module.scss';
 const TOP_CHART_TITLES = ['资源使用趋势', '系统负载趋势'];
 const NETWORK_CHART_TITLES = ['网络吞吐趋势', '网络错误速率'];
 const DISK_PROCESS_CHART_TITLES = ['磁盘吞吐趋势', '进程异常趋势'];
-const RING_TITLES = ['CPU 时间分布', '内存占用分布', '进程状态分布'];
+const RING_TITLES = ['CPU 时间分布'];
 
 export default function HostDashboardPage() {
   const dashboard = useSimpleDashboardData(HOST_DASHBOARD_CONFIG);
@@ -31,7 +31,7 @@ export default function HostDashboardPage() {
   const [resourceChart, loadChart] = topCharts;
   const [networkChart, networkErrorChart] = networkCharts;
   const [diskChart, processAnomalyChart] = diskProcessCharts;
-  const [cpuRing, memoryRing, processRing] = rings;
+  const [cpuRing] = rings;
 
   return (
     <DashboardShell
@@ -57,7 +57,7 @@ export default function HostDashboardPage() {
                 loading={dashboard.loading}
                 seriesStyles={chart.seriesStyles}
                 onXRangeChange={dashboard.onXRangeChange}
-                className={`${styles.span6} ${styles.compactTrend}`}
+                className={`${styles.span4} ${styles.compactTrend}`}
                 styles={styles}
               />
             ) : null)}
@@ -71,34 +71,6 @@ export default function HostDashboardPage() {
                 centerValue={cpuRing.centerValue}
                 centerCaption={cpuRing.panel.centerCaption}
                 isEmpty={cpuRing.isEmpty}
-                className={styles.span4}
-                styles={styles}
-              />
-            ) : null}
-            {memoryRing ? (
-              <RingChartPanel
-                key={memoryRing.panel.title}
-                title={memoryRing.panel.title}
-                subtitle={memoryRing.panel.subtitle}
-                guide={memoryRing.panel.guide}
-                data={memoryRing.data}
-                centerValue={memoryRing.centerValue}
-                centerCaption={memoryRing.panel.centerCaption}
-                isEmpty={memoryRing.isEmpty}
-                className={styles.span4}
-                styles={styles}
-              />
-            ) : null}
-            {processRing ? (
-              <RingChartPanel
-                key={processRing.panel.title}
-                title={processRing.panel.title}
-                subtitle={processRing.panel.subtitle}
-                guide={processRing.panel.guide}
-                data={processRing.data}
-                centerValue={processRing.centerValue}
-                centerCaption={processRing.panel.centerCaption}
-                isEmpty={processRing.isEmpty}
                 className={styles.span4}
                 styles={styles}
               />

--- a/web/src/app/monitor/dashboards/objects/redis/config.ts
+++ b/web/src/app/monitor/dashboards/objects/redis/config.ts
@@ -66,14 +66,6 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#faad14'
     },
     {
-      name: 'redis_instantaneous_ops_per_sec',
-      display_name: '实时 OPS',
-      description: 'Redis 实例当前每秒处理的命令数量。',
-      unit: 'cps',
-      query: 'redis_instantaneous_ops_per_sec{__$labels__}',
-      color: '#27c274'
-    },
-    {
       name: 'redis_total_commands_processed_rate',
       display_name: '命令处理速率',
       description: 'Redis 实例处理命令的平均速率。',
@@ -209,8 +201,11 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       metric: 'redis_clients',
       color: '#2f6bff',
       icon: 'node',
-      guide: [{ label: '客户端连接', detail: '当前活跃的客户端连接数量。' }],
-      footer: [{ label: '阻塞客户端', metric: 'redis_blocked_clients', unit: 'counts' }]
+      guide: [{ label: '客户端连接', detail: '当前活跃的客户端连接数量。阻塞非零常见于 BLPOP/BRPOP 等待；连接拒绝非零说明触及 maxclients。' }],
+      footer: [
+        { label: '阻塞客户端', metric: 'redis_blocked_clients', unit: 'counts' },
+        { label: '连接拒绝', metric: 'redis_rejected_connections_rate', unit: 'cps' }
+      ]
     }
   ],
   charts: [
@@ -228,8 +223,8 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       ]
     },
     {
-      title: '命中未命中趋势',
-      subtitle: '键命中与未命中',
+      title: '缓存命中趋势',
+      subtitle: '键命中与未命中频率',
       metric: 'redis_keyspace_hits_rate',
       guide: [
         { label: '键命中', detail: '键空间成功命中频率。' },
@@ -242,30 +237,26 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     },
     {
       title: '命令吞吐趋势',
-      subtitle: '实时 OPS 与命令速率',
-      metric: 'redis_instantaneous_ops_per_sec',
+      subtitle: '命令处理平均速率',
+      metric: 'redis_total_commands_processed_rate',
       guide: [
-        { label: '实时 OPS', detail: '当前每秒处理命令数(瞬时)。' },
-        { label: '命令速率', detail: '所选时间窗口内命令处理平均速率。' }
+        { label: '命令速率', detail: '所选时间窗口内命令处理平均速率；与其他 rate 指标口径一致。' }
       ],
       series: [
-        { metric: 'redis_instantaneous_ops_per_sec', label: '实时 OPS', color: '#27c274', unit: 'cps' },
         { metric: 'redis_total_commands_processed_rate', label: '命令速率', color: '#13c2c2', unit: 'cps' }
       ]
     },
     {
       title: '键生命周期',
-      subtitle: '过期、驱逐与连接拒绝',
+      subtitle: '过期与驱逐',
       metric: 'redis_expired_keys_rate',
       guide: [
         { label: '键过期频率', detail: '键到期被自动清除的速率。' },
-        { label: '键驱逐频率', detail: '内存压力下被驱逐键的速率,非零说明内存吃紧。' },
-        { label: '连接拒绝频率', detail: '因超出 maxclients 被拒绝的连接速率。' }
+        { label: '键驱逐频率', detail: '内存压力下被驱逐键的速率,非零说明内存吃紧。连接拒绝见连接数 KPI 副文案。' }
       ],
       series: [
         { metric: 'redis_expired_keys_rate', label: '键过期频率', color: '#2f6bff', unit: 'cps' },
-        { metric: 'redis_evicted_keys_rate', label: '键驱逐频率', color: '#ff4d4f', unit: 'cps' },
-        { metric: 'redis_rejected_connections_rate', label: '连接拒绝频率', color: '#faad14', unit: 'cps' }
+        { metric: 'redis_evicted_keys_rate', label: '键驱逐频率', color: '#ff4d4f', unit: 'cps' }
       ]
     },
     {
@@ -291,22 +282,23 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       series: [
         { metric: 'redis_mem_fragmentation_ratio', label: '内存碎片率', color: '#8a5cff', unit: 'none' }
       ]
-    }
-  ],
-  ringPanels: [],
-  barPanels: [
+    },
     {
-      title: '客户端状态',
-      subtitle: '连接、阻塞与拒绝',
-      showTrend: true,
-      guide: [{ label: '客户端状态', detail: '汇总客户端连接、阻塞等待与连接拒绝。阻塞或拒绝非零即需排查。' }],
-      items: [
-        { label: '客户端连接', metric: 'redis_clients', color: '#2f6bff', unit: 'counts' },
-        { label: '阻塞客户端', metric: 'redis_blocked_clients', color: '#ff8a1f', unit: 'counts' },
-        { label: '连接拒绝', metric: 'redis_rejected_connections_rate', color: '#ff4d4f', unit: 'cps' }
+      title: '客户端连接趋势',
+      subtitle: '活跃与阻塞',
+      metric: 'redis_clients',
+      guide: [
+        { label: '活跃连接', detail: '当前客户端连接数变化。' },
+        { label: '阻塞客户端', detail: '处于阻塞等待的客户端数；持续非零优先查阻塞命令（如 BLPOP）与慢消费。连接拒绝见连接数 KPI 副文案。' }
+      ],
+      series: [
+        { metric: 'redis_clients', label: '活跃连接', color: '#2f6bff', unit: 'counts' },
+        { metric: 'redis_blocked_clients', label: '阻塞客户端', color: '#ff8a1f', unit: 'counts' }
       ]
     }
   ],
-  // 键生命周期 / 网络流量 / 内存碎片 已改为 charts(折线图),不再用 detail 缩略图。
+  ringPanels: [],
+  barPanels: [],
+  // 键生命周期 / 网络流量 / 内存碎片 / 客户端连接 已改为 charts(折线图),不再用 detail 缩略图或条形卡。
   details: []
 };

--- a/web/src/app/monitor/dashboards/objects/redis/config.ts
+++ b/web/src/app/monitor/dashboards/objects/redis/config.ts
@@ -203,7 +203,6 @@ export const REDIS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       icon: 'node',
       guide: [{ label: '客户端连接', detail: '当前活跃的客户端连接数量。阻塞非零常见于 BLPOP/BRPOP 等待；连接拒绝非零说明触及 maxclients。' }],
       footer: [
-        { label: '阻塞客户端', metric: 'redis_blocked_clients', unit: 'counts' },
         { label: '连接拒绝', metric: 'redis_rejected_connections_rate', unit: 'cps' }
       ]
     }

--- a/web/src/app/monitor/dashboards/objects/redis/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/redis/dashboard.tsx
@@ -6,16 +6,15 @@ import {
   DashboardShell,
   KpiSection,
   TrendSection,
-  useFilteredBarPanels,
   useFilteredChartPanels,
   useFilteredSummaryCards
 } from '../common/dashboard-components';
-import { TrendChartPanel, HorizontalBarPanel } from '../../shared/widgets';
+import { TrendChartPanel } from '../../shared/widgets';
 import { REDIS_DASHBOARD_CONFIG } from './config';
 import styles from './index.module.scss';
 
 const SUMMARY_TITLES = ['运行时长', '内存使用率', '缓存命中率', '键驱逐频率', '客户端连接数'];
-const TREND_TITLES = ['内存压力趋势', '命中未命中趋势', '命令吞吐趋势'];
+const TREND_TITLES = ['内存压力趋势', '缓存命中趋势', '命令吞吐趋势'];
 // 键生命周期 + 网络流量 两张折线图占满一行(各 span6)。
 const LIFECYCLE_TITLES = ['键生命周期', '网络流量'];
 
@@ -26,7 +25,7 @@ export default function RedisDashboardPage() {
   const trendCharts = useFilteredChartPanels(dashboard.chartPanels, TREND_TITLES);
   const lifecycleCharts = useFilteredChartPanels(dashboard.chartPanels, LIFECYCLE_TITLES);
   const fragChart = useFilteredChartPanels(dashboard.chartPanels, ['内存碎片'])[0];
-  const clientBar = useFilteredBarPanels(dashboard.barPanels, ['客户端状态'])[0];
+  const clientChart = useFilteredChartPanels(dashboard.chartPanels, ['客户端连接趋势'])[0];
 
   return (
     <DashboardShell
@@ -59,12 +58,18 @@ export default function RedisDashboardPage() {
                   styles={styles}
                 />
               )}
-              {clientBar && (
-                <HorizontalBarPanel
-                  title={clientBar.panel.title}
-                  subtitle={clientBar.panel.subtitle}
-                  guide={clientBar.panel.guide}
-                  items={clientBar.items}
+              {clientChart && (
+                <TrendChartPanel
+                  title={clientChart.chart.title}
+                  subtitle={clientChart.chart.subtitle}
+                  guide={clientChart.chart.guide}
+                  legends={clientChart.legends}
+                  data={clientChart.data}
+                  metric={clientChart.metric}
+                  unit={clientChart.unit}
+                  loading={dashboard.loading}
+                  seriesStyles={clientChart.seriesStyles}
+                  onXRangeChange={dashboard.onXRangeChange}
                   className={`${styles.panel} ${styles.span6}`}
                   styles={styles}
                 />


### PR DESCRIPTION
## Summary
- 主机：去掉与 KPI 镜像的「内存占用分布」环、常态无信息量的「进程状态分布」环，只保留「CPU 时间分布」；趋势区布局调整为资源/负载/CPU 环一行三栏。
- Redis：删除混单位的「客户端状态」条形迷你趋势卡，改为「客户端连接趋势」（活跃+阻塞）；连接拒绝挂到连接数 KPI 副文案；「命中未命中趋势」更名为「缓存命中趋势」。
- MySQL：经 USE/RED 评审无需改动，本 PR 不包含。

## Test plan
- [ ] 主机仪表盘：健康概览 5 卡不变；性能区仅 1 枚 CPU 时间分布环；无内存/进程状态环
- [ ] Redis 仪表盘：无「客户端状态」条形卡；「内存与客户端」为碎片趋势 + 客户端连接趋势
- [ ] Redis KPI「客户端连接数」footer 含阻塞客户端与连接拒绝
- [ ] Redis「缓存命中趋势」标题正确；命令吞吐仍为独立单线图
- [ ] MySQL 仪表盘行为与合并前一致
- [ ] 确认 PR 未包含 icon / `__enterprise-brands.js` 等无关改动