### PR TITLE
docs(monitor): add JVM and MinIO configuration guides

### DIFF
--- a/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/guide/en.md
@@ -1,0 +1,105 @@
+# JVM-JMX Monitoring Guide
+
+## Prerequisites
+
+- Remote JMX/RMI is enabled on the target Java application.
+- The JVM-JMX collector is installed on the collector node, and that node can reach the target JMX port.
+- The JMX Registry port and RMI Server port are fixed and allowed through firewalls or security groups.
+- `java.rmi.server.hostname` is set to a target address reachable from the collector node, not an address available only on the target host.
+- If JMX authentication is enabled, a read-only monitoring username and password are available.
+- An unused port is reserved on the collector node for the JVM-JMX collector to expose the local Prometheus `/metrics` endpoint.
+
+Example JVM options:
+
+```text
+-Dcom.sun.management.jmxremote
+-Dcom.sun.management.jmxremote.port=9010
+-Dcom.sun.management.jmxremote.rmi.port=9010
+-Djava.rmi.server.hostname=<reachable-target-address>
+-Dcom.sun.management.jmxremote.authenticate=false
+-Dcom.sun.management.jmxremote.ssl=false
+```
+
+This example disables authentication and SSL and is suitable only for a controlled test environment. In production, enable authentication according to the Java JMX security mechanism and restrict access to the JMX port.
+
+## Setup Steps
+
+1. From the collector node, confirm that the target JMX port is reachable and validate the connection URL with a JMX client.
+2. Select the `JVM` plugin on the monitoring integration page.
+3. If JMX authentication is enabled on the target Java application, enter the username and password; otherwise leave them empty.
+4. Set the collection interval. The default is `60` seconds.
+5. In the monitored objects table, select the collector node, enter the listen port and JMX URL, and set the instance name and optional group.
+6. Save the configuration, wait for at least one collection interval, and then check the instance or metrics page.
+
+## Pre-checks
+
+Check the target JMX port from the actual collector node:
+
+```bash
+nc -vz <target-host> 9010
+```
+
+Example standard JMX/RMI URL:
+
+```text
+service:jmx:rmi:///jndi/rmi://<target-host>:9010/jmxrmi
+```
+
+Also connect to the same URL with `jconsole`, `jmc`, or another JMX client. The address, RMI callback, authentication, and network configuration are basically valid only when the client can connect and read MBeans in the `java.lang` and `java.nio` domains.
+
+> This plugin connects through standard JMX/RMI. It does not accept a Jolokia HTTP URL such as `http://<host>:<port>/jolokia`.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Username | No | Enter when JMX authentication is enabled; otherwise leave it empty. |
+| Password | No | Password for the JMX monitoring account; used together with the username. |
+| JMX URL | Yes | Standard JMX Service URL, for example `service:jmx:rmi:///jndi/rmi://10.0.0.12:9010/jmxrmi`. |
+| Listen Port | Yes | Local port where the JVM-JMX collector exposes `/metrics` on the selected collector node. It is not the target application's JMX port. Different instances on the same node must use different ports. |
+| Interval | Yes | Collection interval in seconds. The default is `60`. |
+| Node | Yes | Node that runs the JVM-JMX collector. It must be able to reach the target JMX/RMI address. |
+| Instance Name | Yes | Display name of the instance in the platform. |
+| Group | No | Optional group for the instance. |
+
+For a new integration, enter the listen port and JMX URL in the monitored objects table. When editing an existing configuration, the page displays the corresponding collection fields.
+
+## Post-setup Verification
+
+After saving the configuration and waiting for at least one collection interval:
+
+1. Confirm that the JVM-JMX collector process is running on the selected node and that its listen port has no conflict.
+2. From the collector node, open `http://127.0.0.1:<listen-port>/metrics` and confirm that `jmx_` or `jvm_` metrics are present.
+3. Confirm that `jmx_scrape_error_gauge` is `0` in the platform.
+4. Confirm that at least the following JVM metrics are queryable:
+   - `jvm_memory_usage_used_value`
+   - `jvm_threads_count_value`
+   - `jvm_gc_collectiontime_seconds_value`
+
+The current rules cover standard MBeans for JVM memory, threads, operating system, buffer pools, garbage collection, and memory pools. Application-specific MBeans outside the whitelist are not collected automatically.
+
+## Troubleshooting
+
+### 1. The JMX port is reachable, but collection still fails
+
+- Check that `java.rmi.server.hostname` resolves to an IP address or hostname reachable from the collector node.
+- JMX/RMI can connect to the Registry port and then call back through a different random port. Set `com.sun.management.jmxremote.rmi.port` to a fixed port and allow it through the network boundary.
+- Retry the same URL with a JMX client from the collector node, not only from the target host.
+
+### 2. Authentication fails
+
+- Confirm whether `com.sun.management.jmxremote.authenticate` is enabled on the target JVM.
+- Check the username, password, and permissions of the JMX password and access files.
+- When authentication is disabled, leave both username and password empty.
+
+### 3. The JVM-JMX collector does not start or its local `/metrics` endpoint is unavailable
+
+- Check whether another process or JVM monitoring instance already uses the configured listen port.
+- Confirm that the selected node has the JVM-JMX collector and a Java runtime installed.
+- Inspect the collector process arguments and logs to confirm that the generated configuration was loaded.
+
+### 4. `jmx_scrape_error_gauge` is non-zero or only some metrics are available
+
+- Check whether the target JVM version provides the standard MBeans used by the current rules.
+- Confirm that the monitoring account can read the `java.lang` and `java.nio` domains.
+- Application-specific MBeans and Tomcat thread-pool metrics are outside the generic JVM scope and require the corresponding monitoring capability or additional collection rules.

--- a/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/JVM-JMX/jmx/jvm/guide/zh-Hans.md
@@ -1,0 +1,105 @@
+# JVM-JMX 监控接入指南
+
+## 前置要求
+
+- 目标 Java 应用已开启远程 JMX/RMI。
+- 采集节点已安装 JVM-JMX 采集器，并且能够访问目标 JMX 端口。
+- JMX Registry 端口和 RMI Server 端口应固定并在防火墙、安全组中放通。
+- `java.rmi.server.hostname` 必须设置为采集节点能够访问的目标地址，不能使用仅目标主机本地可达的地址。
+- 如启用了 JMX 认证，需准备只读监控账号及密码。
+- 采集节点上需预留一个未被占用的监听端口，用于 JVM-JMX 采集器在本地暴露 Prometheus `/metrics`。
+
+JVM 启动参数示例：
+
+```text
+-Dcom.sun.management.jmxremote
+-Dcom.sun.management.jmxremote.port=9010
+-Dcom.sun.management.jmxremote.rmi.port=9010
+-Djava.rmi.server.hostname=<目标主机可达地址>
+-Dcom.sun.management.jmxremote.authenticate=false
+-Dcom.sun.management.jmxremote.ssl=false
+```
+
+上述示例关闭了认证和 SSL，仅适合受控测试环境。生产环境应按 Java 官方 JMX 安全机制启用认证，并限制 JMX 端口的访问来源。
+
+## 接入步骤
+
+1. 在采集节点上确认目标 JMX 端口可达，并使用 JMX 客户端验证连接地址。
+2. 在监控接入页面选择 `JVM` 插件。
+3. 如目标 Java 应用开启了 JMX 认证，填写用户名和密码；否则留空。
+4. 设置采集间隔，默认 `60` 秒。
+5. 在监控对象表格中选择采集节点，填写监听端口和 JMX URL，并设置实例名称及可选分组。
+6. 保存配置后等待至少一个采集周期，再到实例或指标页面检查数据。
+
+## 接入前校验
+
+先从实际采集节点检查目标 JMX 端口：
+
+```bash
+nc -vz <target-host> 9010
+```
+
+标准 JMX/RMI URL 示例：
+
+```text
+service:jmx:rmi:///jndi/rmi://<target-host>:9010/jmxrmi
+```
+
+建议再使用 `jconsole`、`jmc` 或其他 JMX 客户端连接同一个 URL。能够成功连接并读取 `java.lang`、`java.nio` 域中的 MBean，才表示地址、RMI 回连、认证和网络配置基本可用。
+
+> 本插件连接标准 JMX/RMI，不使用 Jolokia HTTP 地址。请勿填写 `http://<host>:<port>/jolokia`。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| 用户名 | 否 | 开启 JMX 认证时填写；未开启认证时留空。 |
+| 密码 | 否 | JMX 监控账号的密码；与用户名配套使用。 |
+| JMX URL | 是 | 标准 JMX Service URL，例如 `service:jmx:rmi:///jndi/rmi://10.0.0.12:9010/jmxrmi`。 |
+| 监听端口 | 是 | JVM-JMX 采集器在所选采集节点上暴露 `/metrics` 的本地端口，不是目标 Java 应用的 JMX 端口；同一节点上的不同实例不能使用相同端口。 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60`。 |
+| 节点 | 是 | 运行 JVM-JMX 采集器的节点，必须能访问目标 JMX/RMI 地址。 |
+| 实例名称 | 是 | 平台内展示的实例名称。 |
+| 组 | 否 | 实例所属分组。 |
+
+首次接入时，监听端口和 JMX URL 在监控对象表格中填写；编辑已有配置时，页面会回显对应的采集配置字段。
+
+## 接入后验证
+
+保存配置并等待至少一个采集周期后，按以下顺序检查：
+
+1. 确认 JVM-JMX 采集器进程已在所选节点启动，且监听端口未发生冲突。
+2. 在采集节点本地访问 `http://127.0.0.1:<监听端口>/metrics`，确认能看到 `jmx_` 或 `jvm_` 指标。
+3. 在平台中确认 `jmx_scrape_error_gauge` 为 `0`。
+4. 确认至少能查询到以下 JVM 指标：
+   - `jvm_memory_usage_used_value`
+   - `jvm_threads_count_value`
+   - `jvm_gc_collectiontime_seconds_value`
+
+当前采集规则覆盖 JVM 内存、线程、操作系统、Buffer Pool、垃圾回收和 Memory Pool 等标准 MBean。未在采集白名单中的业务自定义 MBean 不会自动上报。
+
+## 常见问题
+
+### 1. JMX 端口可连接，但采集仍然失败
+
+- 检查 `java.rmi.server.hostname` 是否为采集节点可达的 IP 或域名。
+- JMX/RMI 可能先连接 Registry 端口，再回连另一个随机端口；应通过 `com.sun.management.jmxremote.rmi.port` 固定 RMI Server 端口并放通。
+- 使用 JMX 客户端从采集节点重试同一个 URL，不能只在目标主机本地验证。
+
+### 2. 返回认证失败
+
+- 确认目标 JVM 是否启用了 `com.sun.management.jmxremote.authenticate`。
+- 检查用户名、密码以及 JMX password/access 文件权限。
+- 未启用认证时，用户名和密码应同时留空。
+
+### 3. JVM-JMX 采集器无法启动或本地 `/metrics` 不可访问
+
+- 检查所填监听端口是否已被其他进程或其他 JVM 监控实例占用。
+- 确认所选节点已安装 JVM-JMX 采集器及 Java 运行环境。
+- 查看采集器进程参数和日志，确认配置文件已正确生成并加载。
+
+### 4. `jmx_scrape_error_gauge` 非 0 或只有部分指标
+
+- 检查目标 JVM 版本是否提供当前规则使用的标准 MBean。
+- 确认监控账号有权读取 `java.lang` 和 `java.nio` 域。
+- 自定义应用 MBean、Tomcat 线程池等不属于 JVM 通用采集范围，需要使用对应监控能力或扩展采集规则。

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
@@ -1,0 +1,93 @@
+# MinIO Monitoring Guide
+
+## Prerequisites
+
+- The target MinIO service exposes Prometheus v2 metrics endpoints.
+- The collector node can reach the MinIO API host and port over HTTP. The default port is commonly `9000`.
+- The following three endpoints allow anonymous access from the collector node:
+  - `/minio/v2/metrics/cluster`
+  - `/minio/v2/metrics/bucket`
+  - `/minio/v2/metrics/resource`
+- If the MinIO metrics endpoints require authentication by default, configure the Prometheus authentication type as `public` on the MinIO side and restrict access to the port within a controlled network.
+
+The current plugin always sends anonymous HTTP requests. It does not send a username, password, or Bearer Token, and it cannot be configured for HTTPS. An environment that permits only HTTPS or authenticated access cannot be integrated directly with the current configuration.
+
+## Setup Steps
+
+1. From the actual collector node, open each of the three MinIO metrics endpoints and confirm that it returns Prometheus text metrics.
+2. Select the `MinIO` plugin on the monitoring integration page.
+3. Set the collection interval. The default is `60` seconds.
+4. In the monitored objects table, select the collector node and enter the MinIO host and API port.
+5. Set the instance name and optional group, and then save the configuration.
+6. Wait for at least one collection interval before checking the instance or metrics page.
+
+## Pre-checks
+
+Run the following commands from the actual collector node:
+
+```bash
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/cluster | grep '^minio_'
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/bucket | grep '^minio_'
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/resource | grep '^minio_'
+```
+
+All three commands should succeed and print Prometheus metrics beginning with `minio_`. Run these checks from the collector node's network. Success from an administrator workstation alone does not prove that the collection path is reachable.
+
+## Field Reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Host | Yes | IP address or hostname of the MinIO API. Do not include `http://`, a port, or a path. |
+| Port | Yes | MinIO API port, commonly `9000`. |
+| Interval | Yes | Collection interval in seconds. The default is `60`. |
+| Node | Yes | Collector node that runs Telegraf. It must be able to reach all three metrics endpoints. |
+| Instance Name | Yes | Display name of the instance in the platform. It can be generated from `host:port` by default. |
+| Group | No | Optional group for the instance. |
+
+The plugin builds the following fixed URLs from the host and port. No metrics path is entered on the page:
+
+```text
+http://<host>:<port>/minio/v2/metrics/cluster
+http://<host>:<port>/minio/v2/metrics/bucket
+http://<host>:<port>/minio/v2/metrics/resource
+```
+
+## Post-setup Verification
+
+After saving the configuration and waiting for at least one collection interval:
+
+1. Confirm that the Telegraf collection task is running normally on the selected node.
+2. Confirm that none of the three metrics endpoints returns a connection error, `401`, `403`, or `404`.
+3. Confirm that at least the following metrics are queryable in the platform:
+   - `minio_cluster_health_status_gauge`
+   - `minio_cluster_capacity_usable_free_bytes_gauge`
+   - `minio_cluster_drive_online_total_gauge`
+4. To verify resource and S3 service data, also check:
+   - `minio_node_cpu_avg_idle_gauge`
+   - `minio_s3_traffic_received_bytes_counter_rate`
+
+## Troubleshooting
+
+### 1. The endpoint returns `401 Unauthorized` or `403 Forbidden`
+
+- The current plugin does not support a username, password, or Bearer Token.
+- Allow the collector node to read the Prometheus metrics endpoints anonymously on the MinIO side, for example by setting the Prometheus authentication type to `public`.
+- After making the endpoints public, restrict their source network with a firewall, security group, or another controlled network boundary.
+
+### 2. The endpoint returns `404 Not Found`
+
+- Confirm that the target MinIO version provides the `/minio/v2/metrics/cluster`, `bucket`, and `resource` endpoints.
+- Confirm that the configured port is the MinIO API port, not the Console administration port.
+- The current plugin cannot change the metrics paths and is not compatible with the legacy `/minio/prometheus/metrics` path.
+
+### 3. HTTP access fails or a TLS error occurs
+
+- The current template generates only `http://` URLs and does not support `https://`.
+- Check routing, firewalls, and security groups between the collector node and the MinIO API port.
+- If the target forces an HTTPS redirect, the current plugin cannot collect it directly because the protocol does not match.
+
+### 4. Only some MinIO metrics are available
+
+- Check the cluster, bucket, and resource endpoints separately. A failure on any endpoint removes the corresponding group of metrics.
+- When there are no buckets or related activities, some Bucket or S3 metric series may be absent.
+- Inspect the Telegraf logs for the exact failing URL and HTTP status code.

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
@@ -1,0 +1,93 @@
+# MinIO 监控接入指南
+
+## 前置要求
+
+- 目标 MinIO 服务已启用 Prometheus v2 指标端点。
+- 采集节点能够通过 HTTP 访问 MinIO API 地址和端口，默认端口通常为 `9000`。
+- 以下三个端点必须允许采集节点匿名访问：
+  - `/minio/v2/metrics/cluster`
+  - `/minio/v2/metrics/bucket`
+  - `/minio/v2/metrics/resource`
+- 如 MinIO 指标端点默认要求认证，需要在 MinIO 侧将 Prometheus 认证类型配置为 `public`，并在受控网络中限制端口访问来源。
+
+当前插件固定使用匿名 HTTP 请求，不会发送用户名、密码或 Bearer Token，也不能配置 HTTPS。若目标环境只允许 HTTPS 或鉴权访问，当前配置无法直接接入。
+
+## 接入步骤
+
+1. 从实际采集节点分别访问三个 MinIO 指标端点，确认均能返回 Prometheus 指标文本。
+2. 在监控接入页面选择 `MinIO` 插件。
+3. 设置采集间隔，默认 `60` 秒。
+4. 在监控对象表格中选择采集节点，填写 MinIO 主机和 API 端口。
+5. 设置实例名称及可选分组，保存配置。
+6. 等待至少一个采集周期，再到实例或指标页面检查数据。
+
+## 接入前校验
+
+在实际采集节点上执行：
+
+```bash
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/cluster | grep '^minio_'
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/bucket | grep '^minio_'
+curl -fsS http://<minio-host>:<port>/minio/v2/metrics/resource | grep '^minio_'
+```
+
+三个命令均应成功，并能看到以 `minio_` 开头的 Prometheus 指标。必须在采集节点所在网络执行校验，仅从运维终端访问成功不能证明采集链路可用。
+
+## 页面字段说明
+
+| 页面字段 | 是否必填 | 说明 |
+| --- | --- | --- |
+| 主机 | 是 | MinIO API 的 IP 地址或域名，不要包含 `http://`、端口或路径。 |
+| 端口 | 是 | MinIO API 端口，通常为 `9000`。 |
+| 间隔 | 是 | 采集周期，单位秒，默认 `60`。 |
+| 节点 | 是 | 运行 Telegraf 的采集节点，必须能访问三个指标端点。 |
+| 实例名称 | 是 | 平台内展示的实例名称，默认可按 `主机:端口` 生成。 |
+| 组 | 否 | 实例所属分组。 |
+
+插件会根据主机和端口固定生成以下 URL，无需在页面填写指标路径：
+
+```text
+http://<host>:<port>/minio/v2/metrics/cluster
+http://<host>:<port>/minio/v2/metrics/bucket
+http://<host>:<port>/minio/v2/metrics/resource
+```
+
+## 接入后验证
+
+保存配置并等待至少一个采集周期后，按以下顺序检查：
+
+1. 确认所选节点上的 Telegraf 采集任务正常运行。
+2. 确认三个指标端点没有返回连接错误、`401`、`403` 或 `404`。
+3. 在平台中确认至少能查询到以下指标：
+   - `minio_cluster_health_status_gauge`
+   - `minio_cluster_capacity_usable_free_bytes_gauge`
+   - `minio_cluster_drive_online_total_gauge`
+4. 如需验证资源和 S3 服务数据，再检查：
+   - `minio_node_cpu_avg_idle_gauge`
+   - `minio_s3_traffic_received_bytes_counter_rate`
+
+## 常见问题
+
+### 1. 返回 `401 Unauthorized` 或 `403 Forbidden`
+
+- 当前插件不支持用户名、密码或 Bearer Token。
+- 需要在 MinIO 侧允许采集节点匿名读取 Prometheus 指标端点，例如将 Prometheus 认证类型配置为 `public`。
+- 指标端点公开后，应通过防火墙、安全组或受控网络限制访问来源，避免暴露到非可信网络。
+
+### 2. 返回 `404 Not Found`
+
+- 确认目标 MinIO 版本提供 `/minio/v2/metrics/cluster`、`bucket` 和 `resource` 端点。
+- 确认填写的是 MinIO API 端口，而不是 Console 管理端口。
+- 当前插件不能修改指标路径，也不兼容旧的 `/minio/prometheus/metrics` 路径。
+
+### 3. HTTP 访问失败或发生 TLS 错误
+
+- 当前模板只生成 `http://` URL，不支持 `https://`。
+- 检查采集节点到 MinIO API 端口的路由、防火墙和安全组。
+- 如果目标强制跳转 HTTPS，当前插件会因协议不匹配而无法直接采集。
+
+### 4. 只有部分 MinIO 指标
+
+- 分别检查 cluster、bucket、resource 三个端点，任一端点失败都会造成对应指标组缺失。
+- 没有 Bucket 或相关活动时，部分 Bucket/S3 指标可能暂时没有序列。
+- 检查 Telegraf 日志，确认具体失败 URL 和 HTTP 状态码。


### PR DESCRIPTION
## Summary

- add Chinese and English configuration guides for JVM-JMX monitoring
- document the actual JMX/RMI connection, local exporter port, validation, and troubleshooting contract
- add Chinese and English configuration guides for MinIO monitoring
- document the current anonymous HTTP collection contract for the three Prometheus v2 endpoints

## Validation

- completed independent Standards and Spec reviews with zero remaining findings
- verified guide fields, endpoints, and sample metrics against the current UI, collector templates, and metrics definitions
- verified `PluginGuideService.get_guide` resolves both locales for JVM and MinIO
- passed Markdown structure and `git diff --check` validation
- existing `test_plugin_guide.py` was blocked before collection by the baseline `django_celery_beat.models.SolarSchedule` app registration error

## Scope

- reviewed the staged and base diffs before commit
- the PR contains only four guide Markdown files
- existing local brand script, icon, test, design, and environment files were not included
