### PR TITLE
bugfix: 监控策略创建多步写入事务化

### DIFF
--- a/server/apps/monitor/tests/integration/test_monitor_policy_create_transaction_4039.py
+++ b/server/apps/monitor/tests/integration/test_monitor_policy_create_transaction_4039.py
@@ -1,0 +1,101 @@
+"""Issue #4039: 新建监控策略的多步写入必须保持原子性。"""
+
+from uuid import uuid4
+
+import pytest
+from django.db import IntegrityError
+from django_celery_beat.models import PeriodicTask
+
+from apps.monitor.models.monitor_object import MonitorObject
+from apps.monitor.models.monitor_policy import MonitorPolicy, PolicyOrganization
+from apps.monitor.views.monitor_policy import MonitorPolicyViewSet
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+BASE = "/api/v1/monitor"
+
+
+@pytest.fixture(autouse=True)
+def disable_error_log_async(mocker):
+    return mocker.patch(
+        "apps.system_mgmt.middleware.error_log_middleware.write_error_log_async"
+    )
+
+
+def _patch_policy_permissions(mocker):
+    permission = {"team": [1], "instance": []}
+    mocker.patch(
+        "apps.core.utils.current_team_scope.SystemMgmt.get_authorized_groups_scoped",
+        return_value={"result": True, "data": [1]},
+    )
+    mocker.patch(
+        "apps.core.utils.current_team_scope.SystemMgmt.get_assignable_groups",
+        return_value={"result": True, "data": [1]},
+    )
+    mocker.patch(
+        "apps.monitor.views.monitor_policy.get_permission_rules",
+        return_value=permission,
+    )
+
+
+def _policy_payload(monitor_object, name):
+    return {
+        "name": name,
+        "monitor_object": monitor_object.id,
+        "organizations": [1],
+        "algorithm": "max_over_time",
+        "group_algorithm": "max",
+        "query_condition": {"type": "pmq", "query": "up"},
+        "source": {},
+        "schedule": {"type": "min", "value": 5},
+        "period": {"type": "min", "value": 5},
+        "group_by": [],
+        "threshold": [],
+        "trigger_count": 1,
+        "recovery_condition": 1,
+        "enable_alerts": ["threshold"],
+        "enable": True,
+    }
+
+
+class TestMonitorPolicyCreateTransaction:
+    @pytest.mark.parametrize(
+        ("failing_method", "enable_alerts"),
+        [
+            ("update_policy_organizations", ["threshold"]),
+            ("update_policy_baselines", ["no_data"]),
+        ],
+    )
+    def test_late_write_failure_rolls_back_all_create_side_effects(
+        self, api_client, mocker, failing_method, enable_alerts
+    ):
+        api_client.cookies["current_team"] = "1"
+        _patch_policy_permissions(mocker)
+        monitor_object = MonitorObject.objects.create(
+            name=f"PolicyCreateTx-{uuid4().hex[:8]}",
+            level="base",
+            instance_id_keys=["instance_id"],
+        )
+        policy_name = f"policy-create-tx-{uuid4().hex[:8]}"
+        before_task_ids = set(PeriodicTask.objects.values_list("id", flat=True))
+        failing_write = mocker.patch.object(
+            MonitorPolicyViewSet,
+            failing_method,
+            side_effect=IntegrityError("simulated create side-effect failure"),
+        )
+        payload = _policy_payload(monitor_object, policy_name)
+        payload["enable_alerts"] = enable_alerts
+
+        response = api_client.post(
+            f"{BASE}/api/monitor_policy/",
+            payload,
+            format="json",
+        )
+
+        assert response.status_code == 500
+        failing_write.assert_called_once()
+        assert not MonitorPolicy.objects.filter(name=policy_name).exists()
+        assert set(PeriodicTask.objects.values_list("id", flat=True)) == before_task_ids
+        assert not PolicyOrganization.objects.filter(
+            policy__name=policy_name
+        ).exists()

--- a/server/apps/monitor/tests/test_monitor_policy_create_transaction_4039_views.py
+++ b/server/apps/monitor/tests/test_monitor_policy_create_transaction_4039_views.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import pytest
 from django.db import IntegrityError
-from django_celery_beat.models import PeriodicTask
+from django_celery_beat.models import CrontabSchedule, PeriodicTask
 
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.models.monitor_policy import MonitorPolicy, PolicyOrganization
@@ -78,6 +78,7 @@ class TestMonitorPolicyCreateTransaction:
         )
         policy_name = f"policy-create-tx-{uuid4().hex[:8]}"
         before_task_ids = set(PeriodicTask.objects.values_list("id", flat=True))
+        before_schedule_ids = set(CrontabSchedule.objects.values_list("id", flat=True))
         failing_write = mocker.patch.object(
             MonitorPolicyViewSet,
             failing_method,
@@ -96,6 +97,7 @@ class TestMonitorPolicyCreateTransaction:
         failing_write.assert_called_once()
         assert not MonitorPolicy.objects.filter(name=policy_name).exists()
         assert set(PeriodicTask.objects.values_list("id", flat=True)) == before_task_ids
+        assert set(CrontabSchedule.objects.values_list("id", flat=True)) == before_schedule_ids
         assert not PolicyOrganization.objects.filter(
             policy__name=policy_name
         ).exists()

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -167,15 +167,16 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
     def create(self, request, *args, **kwargs):
         self._ensure_target_organizations(request.data.get("organizations", []))
         request.data["created_by"] = request.user.username
-        response = super().create(request, *args, **kwargs)
-        policy_id = response.data["id"]
-        policy = MonitorPolicy.objects.filter(id=policy_id).first()
-        schedule = request.data.get("schedule")
-        organizations = request.data.get("organizations", [])
-        self.update_or_create_task(policy_id, schedule)
-        self.update_policy_organizations(policy_id, organizations)
-        if self.is_no_data_alert_enabled(policy):
-            self.update_policy_baselines(policy_id, policy.enable_alerts)
+        with transaction.atomic():
+            response = super().create(request, *args, **kwargs)
+            policy_id = response.data["id"]
+            policy = MonitorPolicy.objects.filter(id=policy_id).first()
+            schedule = request.data.get("schedule")
+            organizations = request.data.get("organizations", [])
+            self.update_or_create_task(policy_id, schedule)
+            self.update_policy_organizations(policy_id, organizations)
+            if self.is_no_data_alert_enabled(policy):
+                self.update_policy_baselines(policy_id, policy.enable_alerts)
         return response
 
     def update(self, request, *args, **kwargs):


### PR DESCRIPTION
## 问题

HTTP 新建监控策略时，策略本体、周期扫描任务、组织关联和无数据基线属于一次业务操作。原实现分别提交这些数据库写入；后续步骤抛错会返回 5xx，但此前数据仍留在库中，形成不会正常工作的半截策略。

## 根因（设计层）

`update` 和 `partial_update` 已把同一组多步写放在事务边界内，`create` 却遗漏了这层一致性边界。因此创建流程把一个业务不变量拆成了多个可独立提交的数据库状态。

## 怎么修的

在 `MonitorPolicyViewSet.create()` 中用一个 `transaction.atomic()` 覆盖：

1. 策略本体保存；
2. `PeriodicTask` 创建；
3. `PolicyOrganization` 创建；
4. 无数据告警基线刷新。

任何后续数据库写失败都会回滚此前步骤，不改变请求、响应、权限或调度配置契约。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        POST["POST /api/monitor_policy/\nmonitor_policy.py"]
    end

    subgraph TX["事务边界"]
        CREATE["MonitorPolicyViewSet.create"]
        POLICY["保存 MonitorPolicy"]
        TASK["创建 PeriodicTask"]
        ORG["创建 PolicyOrganization"]
        BASELINE["刷新 PolicyInstanceBaseline"]
    end

    ROLLBACK["任一步失败\n整体回滚"]

    POST --> CREATE --> POLICY --> TASK --> ORG --> BASELINE
    POLICY -. "异常" .-> ROLLBACK
    TASK -. "异常" .-> ROLLBACK
    ORG -. "异常" .-> ROLLBACK
    BASELINE -. "异常" .-> ROLLBACK
```

## 影响范围

- 仅修改监控模块 HTTP 创建路径；NATS 创建入口没有经过该 ViewSet，不在本 Issue 范围内。
- 成功路径仍返回 201，并继续创建相同的策略、周期任务和组织关系。
- 无字段、权限、默认值、API/RPC/NATS 契约或数据迁移变化。
- 风险档为中：修复数据一致性，采用与现有 update/partial_update 一致的事务模式，不触发人工决策闸。

## 验证

- `apps/monitor/tests/integration/test_monitor_policy_create_transaction_4039.py`：2 passed。分别在组织关联和最后一步基线写入失败时验证策略、周期任务与组织关联整体回滚；移除事务包裹后测试会失败。
- `apps/monitor/tests/test_monitor_permission_business_flows.py`：10 passed。覆盖合法创建返回 201、任务和组织关系创建，以及后续查询、更新、删除和权限行为。

## 三轨门禁

- Standards：PASS。事务、测试分层、markers 与回滚测试符合仓库规范。
- Spec：PASS。完整覆盖 Issue 指定的 HTTP create 多步写原子性范围，无扩项。
- Runtime Contract：PASS。PostgreSQL 真实 HTTP 边界的 RED/GREEN、两个晚期失败点和既有成功/权限流程均通过。
- 质量评分：96 / 100（SCORE_PASS）。

## 残余风险

启用无数据告警时，基线刷新中的只读指标查询仍会延长事务持续时间；现有 update/partial_update 采用相同模式。若后续要异步化，应先补持久化状态、幂等重试和失败补偿，避免用 `on_commit` 直接削弱本次全有或全无语义。

