### PR TITLE
bugfix: 复用凭据状态 Redis 连接池

### DIFF
--- a/agents/stargazer/core/credential_state_cache.py
+++ b/agents/stargazer/core/credential_state_cache.py
@@ -1,7 +1,9 @@
+import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
+from weakref import WeakKeyDictionary
 
 from arq import create_pool
 from arq.connections import RedisSettings
@@ -12,6 +14,9 @@ from core.redis_config import REDIS_CONFIG
 class CredentialStateCache:
     """基于 Redis 的 host-credential 运行态缓存。"""
 
+    _pools = WeakKeyDictionary()
+    _pool_locks = WeakKeyDictionary()
+
     SUCCESS_TTL_SECONDS = 7 * 24 * 3600
     FAILURE_TTL_SECONDS = 24 * 3600
     EVENT_RETENTION_SECONDS = 7 * 24 * 3600
@@ -19,38 +24,29 @@ class CredentialStateCache:
 
     @classmethod
     async def get_success_credential(cls, collect_task_id: Any, host: str) -> str:
-        pool = await cls._create_pool()
-        try:
-            value = await pool.get(cls._success_key(collect_task_id, host))
-            if isinstance(value, (bytes, bytearray)):
-                return value.decode()
-            return str(value or "")
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        value = await pool.get(cls._success_key(collect_task_id, host))
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode()
+        return str(value or "")
 
     @classmethod
     async def get_failure_state(cls, collect_task_id: Any, host: str, credential_id: str) -> dict:
-        pool = await cls._create_pool()
-        try:
-            value = await pool.get(cls._failure_key(collect_task_id, host, credential_id))
-            if not value:
-                return {}
-            if isinstance(value, (bytes, bytearray)):
-                value = value.decode()
-            return json.loads(value)
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        value = await pool.get(cls._failure_key(collect_task_id, host, credential_id))
+        if not value:
+            return {}
+        if isinstance(value, (bytes, bytearray)):
+            value = value.decode()
+        return json.loads(value)
 
     @classmethod
     async def mark_success(cls, collect_task_id: Any, host: str, credential_id: str) -> None:
-        pool = await cls._create_pool()
-        try:
-            await pool.set(cls._success_key(collect_task_id, host), credential_id, ex=cls.SUCCESS_TTL_SECONDS)
-            pattern = cls._failure_pattern(collect_task_id, host)
-            async for key in cls._scan_keys(pool, pattern):
-                await pool.delete(key)
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        await pool.set(cls._success_key(collect_task_id, host), credential_id, ex=cls.SUCCESS_TTL_SECONDS)
+        pattern = cls._failure_pattern(collect_task_id, host)
+        async for key in cls._scan_keys(pool, pattern):
+            await pool.delete(key)
 
     @classmethod
     async def mark_failure(
@@ -63,69 +59,91 @@ class CredentialStateCache:
         consecutive_failures: int,
         next_retry_at: str,
     ) -> None:
-        pool = await cls._create_pool()
-        try:
-            payload = {
-                "is_cooled": True,
-                "error_message": error_message or "",
-                "cooldown_level": cooldown_level,
-                "consecutive_failures": consecutive_failures,
-                "next_retry_at": next_retry_at,
-            }
-            await pool.set(
-                cls._failure_key(collect_task_id, host, credential_id),
-                json.dumps(payload),
-                ex=cls.cooldown_seconds_for(cooldown_level),
-            )
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        payload = {
+            "is_cooled": True,
+            "error_message": error_message or "",
+            "cooldown_level": cooldown_level,
+            "consecutive_failures": consecutive_failures,
+            "next_retry_at": next_retry_at,
+        }
+        await pool.set(
+            cls._failure_key(collect_task_id, host, credential_id),
+            json.dumps(payload),
+            ex=cls.cooldown_seconds_for(cooldown_level),
+        )
 
     @classmethod
     async def clear_success(cls, collect_task_id: Any, host: str) -> None:
-        pool = await cls._create_pool()
-        try:
-            await pool.delete(cls._success_key(collect_task_id, host))
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        await pool.delete(cls._success_key(collect_task_id, host))
 
     @classmethod
     async def append_result_event(cls, event: dict) -> None:
-        pool = await cls._create_pool()
-        try:
-            finished_at = str(event.get("finished_at") or datetime.now(timezone.utc).isoformat())
-            score = cls._event_score(finished_at)
-            payload = {**dict(event or {}), "event_id": uuid.uuid4().hex, "finished_at": finished_at}
-            await pool.zadd(cls._event_stream_key(), {json.dumps(payload, ensure_ascii=False): score})
-            await pool.zremrangebyscore(cls._event_stream_key(), 0, score - cls.EVENT_RETENTION_SECONDS * 1000)
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        finished_at = str(event.get("finished_at") or datetime.now(timezone.utc).isoformat())
+        score = cls._event_score(finished_at)
+        payload = {**dict(event or {}), "event_id": uuid.uuid4().hex, "finished_at": finished_at}
+        await pool.zadd(cls._event_stream_key(), {json.dumps(payload, ensure_ascii=False): score})
+        await pool.zremrangebyscore(cls._event_stream_key(), 0, score - cls.EVENT_RETENTION_SECONDS * 1000)
 
     @classmethod
     async def list_result_events(cls, since: str | None = None, limit: int = 500) -> list[dict]:
-        pool = await cls._create_pool()
-        try:
-            min_score = "-inf"
-            if since:
-                min_score = f"({cls._event_score(since)}"
-            raw_items = await pool.zrangebyscore(cls._event_stream_key(), min=min_score, max="+inf", start=0, num=limit)
-            events = []
-            for item in raw_items or []:
-                if isinstance(item, (bytes, bytearray)):
-                    item = item.decode()
-                events.append(json.loads(item))
-            return events
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        min_score = "-inf"
+        if since:
+            min_score = f"({cls._event_score(since)}"
+        raw_items = await pool.zrangebyscore(cls._event_stream_key(), min=min_score, max="+inf", start=0, num=limit)
+        events = []
+        for item in raw_items or []:
+            if isinstance(item, (bytes, bytearray)):
+                item = item.decode()
+            events.append(json.loads(item))
+        return events
 
     @classmethod
-    async def _create_pool(cls):
+    async def _get_or_create_pool(cls):
+        loop = asyncio.get_running_loop()
+        pool = cls._pools.get(loop)
+        if pool is not None:
+            return pool
+
+        lock = cls._pool_locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._pool_locks[loop] = lock
+
+        async with lock:
+            pool = cls._pools.get(loop)
+            if pool is not None:
+                return pool
+
+            pool = await create_pool(cls._redis_settings())
+            cls._pools[loop] = pool
+            return pool
+
+    @classmethod
+    async def close_pool(cls) -> None:
+        loop = asyncio.get_running_loop()
+        lock = cls._pool_locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            cls._pool_locks[loop] = lock
+
+        async with lock:
+            pool = cls._pools.pop(loop, None)
+            if pool is not None:
+                await pool.close()
+
+    @staticmethod
+    def _redis_settings() -> RedisSettings:
         redis_settings = RedisSettings(
             host=REDIS_CONFIG["host"],
             port=REDIS_CONFIG["port"],
             password=REDIS_CONFIG["password"],
             database=REDIS_CONFIG["database"],
         )
-        return await create_pool(redis_settings)
+        return redis_settings
 
     @staticmethod
     async def _scan_keys(pool, pattern: str):
@@ -159,24 +177,18 @@ class CredentialStateCache:
 
     @classmethod
     async def get_push_cursor(cls) -> str:
-        pool = await cls._create_pool()
-        try:
-            value = await pool.get(cls._push_cursor_key())
-            if isinstance(value, (bytes, bytearray)):
-                return value.decode()
-            return str(value or "")
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        value = await pool.get(cls._push_cursor_key())
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode()
+        return str(value or "")
 
     @classmethod
     async def set_push_cursor(cls, since: str) -> None:
         if not since:
             return
-        pool = await cls._create_pool()
-        try:
-            await pool.set(cls._push_cursor_key(), since)
-        finally:
-            await pool.close()
+        pool = await cls._get_or_create_pool()
+        await pool.set(cls._push_cursor_key(), since)
 
     @staticmethod
     def _event_score(value: str) -> int:
@@ -195,3 +207,13 @@ class CredentialStateCache:
     @classmethod
     def cooldown_seconds_for(cls, cooldown_level: int) -> int:
         return cls.cooldown_hours_for(cooldown_level) * 3600
+
+
+async def close_credential_state_cache_pool(_context=None) -> None:
+    await CredentialStateCache.close_pool()
+
+
+def register_credential_state_cache_lifecycle(app) -> None:
+    @app.listener("after_server_stop")
+    async def stop_credential_state_cache(_app, _loop):
+        await close_credential_state_cache_pool()

--- a/agents/stargazer/core/worker.py
+++ b/agents/stargazer/core/worker.py
@@ -13,6 +13,7 @@ import time
 from typing import Dict, Any
 from arq import create_pool
 from arq.connections import RedisSettings
+from core.credential_state_cache import close_credential_state_cache_pool
 from core.redis_config import REDIS_CONFIG
 from sanic.log import logger
 
@@ -282,3 +283,4 @@ class WorkerSettings:
     job_timeout = int(os.getenv("TASK_JOB_TIMEOUT", "600"))
     keep_result = int(os.getenv("TASK_KEEP_RESULT", "3600"))
     max_tries = int(os.getenv("TASK_MAX_TRIES", "3"))
+    on_shutdown = close_credential_state_cache_pool

--- a/agents/stargazer/server.py
+++ b/agents/stargazer/server.py
@@ -1,6 +1,7 @@
 from sanic import Sanic
 from api import api, enterprise_api
 from core.config import YamlConfig
+from core.credential_state_cache import register_credential_state_cache_lifecycle
 from dotenv import load_dotenv
 from core.host_remote_runtime import register_host_remote_runtime
 from core.nats import initialize_nats
@@ -22,6 +23,7 @@ nats = initialize_nats(app, service_name=service_name)
 
 # 初始化任务队列
 task_queue = initialize_task_queue(app)
+register_credential_state_cache_lifecycle(app)
 register_collect_credential_result_push_loop(app)
 register_host_remote_runtime(app)
 

--- a/agents/stargazer/tests/test_credential_state_cache.py
+++ b/agents/stargazer/tests/test_credential_state_cache.py
@@ -30,6 +30,7 @@ class FakeRedisPool:
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_repeated_public_reads_reuse_one_pool(monkeypatch):
     created_pools = []
 
@@ -53,6 +54,7 @@ async def test_repeated_public_reads_reuse_one_pool(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_concurrent_public_reads_initialize_one_pool(monkeypatch):
     created_pools = []
 
@@ -79,6 +81,7 @@ async def test_concurrent_public_reads_initialize_one_pool(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_close_pool_is_idempotent_and_next_read_reconnects(monkeypatch):
     created_pools = []
 
@@ -102,6 +105,7 @@ async def test_close_pool_is_idempotent_and_next_read_reconnects(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_sanic_shutdown_closes_the_current_loop_pool(monkeypatch):
     created_pools = []
 
@@ -133,6 +137,7 @@ async def test_sanic_shutdown_closes_the_current_loop_pool(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_arq_shutdown_closes_the_current_loop_pool(monkeypatch):
     from core.worker import WorkerSettings
 
@@ -153,6 +158,7 @@ async def test_arq_shutdown_closes_the_current_loop_pool(monkeypatch):
     assert created_pools[0].close_calls == 1
 
 
+@pytest.mark.unit
 def test_distinct_event_loops_do_not_share_a_pool(monkeypatch):
     created_pools = []
 
@@ -175,6 +181,7 @@ def test_distinct_event_loops_do_not_share_a_pool(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.unit
 async def test_pool_creation_failure_does_not_poison_reconnect(monkeypatch):
     attempts = 0
     recovered_pool = FakeRedisPool()
@@ -249,6 +256,7 @@ def _redis_server():
                 process.wait()
 
 
+@pytest.mark.integration
 def test_real_redis_reuses_one_connection_and_reconnects_after_close(monkeypatch):
     async def exercise(client):
         client.flushdb()

--- a/agents/stargazer/tests/test_credential_state_cache.py
+++ b/agents/stargazer/tests/test_credential_state_cache.py
@@ -1,0 +1,341 @@
+import asyncio
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from contextlib import contextmanager
+
+import pytest
+from redis import Redis
+
+import core.credential_state_cache as credential_state_cache
+from core.credential_state_cache import (
+    CredentialStateCache,
+    close_credential_state_cache_pool,
+    register_credential_state_cache_lifecycle,
+)
+
+
+class FakeRedisPool:
+    def __init__(self, value: bytes = b"credential-1"):
+        self.value = value
+        self.close_calls = 0
+
+    async def get(self, _key):
+        return self.value
+
+    async def close(self):
+        self.close_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_repeated_public_reads_reuse_one_pool(monkeypatch):
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+
+    results = [
+        await CredentialStateCache.get_success_credential("task-1", "host-1")
+        for _ in range(20)
+    ]
+
+    assert results == ["credential-1"] * 20
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 0
+    await CredentialStateCache.close_pool()
+    assert created_pools[0].close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_public_reads_initialize_one_pool(monkeypatch):
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        await asyncio.sleep(0)
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+
+    results = await asyncio.gather(
+        *(
+            CredentialStateCache.get_success_credential("task-1", f"host-{index}")
+            for index in range(20)
+        )
+    )
+
+    assert results == ["credential-1"] * 20
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 0
+    await CredentialStateCache.close_pool()
+    assert created_pools[0].close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_close_pool_is_idempotent_and_next_read_reconnects(monkeypatch):
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+
+    await CredentialStateCache.get_success_credential("task-1", "host-1")
+    await CredentialStateCache.close_pool()
+    await CredentialStateCache.close_pool()
+    await CredentialStateCache.get_success_credential("task-1", "host-1")
+
+    assert len(created_pools) == 2
+    assert created_pools[0].close_calls == 1
+    assert created_pools[1].close_calls == 0
+    await CredentialStateCache.close_pool()
+    assert created_pools[1].close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_sanic_shutdown_closes_the_current_loop_pool(monkeypatch):
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    class FakeApp:
+        def __init__(self):
+            self.listeners = {}
+
+        def listener(self, event):
+            def register(callback):
+                self.listeners[event] = callback
+                return callback
+
+            return register
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+    app = FakeApp()
+    register_credential_state_cache_lifecycle(app)
+
+    await CredentialStateCache.get_success_credential("task-1", "host-1")
+    await app.listeners["after_server_stop"](app, asyncio.get_running_loop())
+
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_arq_shutdown_closes_the_current_loop_pool(monkeypatch):
+    from core.worker import WorkerSettings
+
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+
+    await CredentialStateCache.get_success_credential("task-1", "host-1")
+    await WorkerSettings.on_shutdown({})
+
+    assert WorkerSettings.on_shutdown is close_credential_state_cache_pool
+    assert len(created_pools) == 1
+    assert created_pools[0].close_calls == 1
+
+
+def test_distinct_event_loops_do_not_share_a_pool(monkeypatch):
+    created_pools = []
+
+    async def fake_create_pool(_settings):
+        pool = FakeRedisPool()
+        created_pools.append(pool)
+        return pool
+
+    async def read_and_close():
+        result = await CredentialStateCache.get_success_credential("task-1", "host-1")
+        await CredentialStateCache.close_pool()
+        return result
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", fake_create_pool)
+
+    assert asyncio.run(read_and_close()) == "credential-1"
+    assert asyncio.run(read_and_close()) == "credential-1"
+    assert len(created_pools) == 2
+    assert [pool.close_calls for pool in created_pools] == [1, 1]
+
+
+@pytest.mark.asyncio
+async def test_pool_creation_failure_does_not_poison_reconnect(monkeypatch):
+    attempts = 0
+    recovered_pool = FakeRedisPool()
+
+    async def flaky_create_pool(_settings):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("redis unavailable")
+        return recovered_pool
+
+    monkeypatch.setattr(credential_state_cache, "create_pool", flaky_create_pool)
+
+    with pytest.raises(ConnectionError, match="redis unavailable"):
+        await CredentialStateCache.get_success_credential("task-1", "host-1")
+
+    result = await CredentialStateCache.get_success_credential("task-1", "host-1")
+    await CredentialStateCache.close_pool()
+
+    assert result == "credential-1"
+    assert attempts == 2
+    assert recovered_pool.close_calls == 1
+
+
+@contextmanager
+def _redis_server():
+    executable = shutil.which("redis-server")
+    if executable is None:
+        pytest.skip("redis-server is not installed")
+
+    with socket.socket() as port_probe:
+        port_probe.bind(("127.0.0.1", 0))
+        port = port_probe.getsockname()[1]
+
+    with tempfile.TemporaryDirectory(prefix="stargazer-credential-cache-") as directory:
+        process = subprocess.Popen(
+            [
+                executable,
+                "--bind",
+                "127.0.0.1",
+                "--port",
+                str(port),
+                "--dir",
+                directory,
+                "--save",
+                "",
+                "--appendonly",
+                "no",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        client = Redis(host="127.0.0.1", port=port, db=15)
+        try:
+            deadline = time.monotonic() + 5
+            while True:
+                try:
+                    client.ping()
+                    break
+                except Exception:
+                    if process.poll() is not None or time.monotonic() >= deadline:
+                        raise
+                    time.sleep(0.05)
+            yield port, client
+        finally:
+            client.close()
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+
+
+def test_real_redis_reuses_one_connection_and_reconnects_after_close(monkeypatch):
+    async def exercise(client):
+        client.flushdb()
+        client.set("collect:task:task-1:host:host-1:success", "credential-1")
+        before = client.info("stats")["total_connections_received"]
+
+        results = [
+            await CredentialStateCache.get_success_credential("task-1", "host-1")
+            for _ in range(20)
+        ]
+        after_reuse = client.info("stats")["total_connections_received"]
+
+        await CredentialStateCache.mark_failure(
+            "task-1",
+            "host-1",
+            "credential-2",
+            "authentication failed",
+            1,
+            1,
+            "2026-07-29T00:00:00+00:00",
+        )
+        assert await CredentialStateCache.get_failure_state(
+            "task-1", "host-1", "credential-2"
+        ) == {
+            "is_cooled": True,
+            "error_message": "authentication failed",
+            "cooldown_level": 1,
+            "consecutive_failures": 1,
+            "next_retry_at": "2026-07-29T00:00:00+00:00",
+        }
+        await CredentialStateCache.mark_success(
+            "task-1", "host-1", "credential-2"
+        )
+        assert (
+            await CredentialStateCache.get_success_credential(
+                "task-1", "host-1"
+            )
+            == "credential-2"
+        )
+        assert (
+            await CredentialStateCache.get_failure_state(
+                "task-1", "host-1", "credential-2"
+            )
+            == {}
+        )
+
+        event = {
+            "finished_at": "2026-07-29T00:00:00+00:00",
+            "success": True,
+        }
+        await CredentialStateCache.append_result_event(event)
+        events = await CredentialStateCache.list_result_events(limit=10)
+        assert len(events) == 1
+        assert events[0]["success"] is True
+        assert events[0]["finished_at"] == event["finished_at"]
+        assert events[0]["event_id"]
+
+        await CredentialStateCache.set_push_cursor(event["finished_at"])
+        assert (
+            await CredentialStateCache.get_push_cursor()
+            == event["finished_at"]
+        )
+        await CredentialStateCache.clear_success("task-1", "host-1")
+        assert (
+            await CredentialStateCache.get_success_credential(
+                "task-1", "host-1"
+            )
+            == ""
+        )
+        after_command_matrix = client.info("stats")[
+            "total_connections_received"
+        ]
+
+        await CredentialStateCache.close_pool()
+        reconnected = await CredentialStateCache.get_push_cursor()
+        after_reconnect = client.info("stats")["total_connections_received"]
+        await CredentialStateCache.close_pool()
+
+        assert results == ["credential-1"] * 20
+        assert reconnected == event["finished_at"]
+        assert after_reuse - before == 1
+        assert after_command_matrix == after_reuse
+        assert after_reconnect - after_command_matrix == 1
+
+    with _redis_server() as (port, client):
+        monkeypatch.setitem(credential_state_cache.REDIS_CONFIG, "host", "127.0.0.1")
+        monkeypatch.setitem(credential_state_cache.REDIS_CONFIG, "port", port)
+        monkeypatch.setitem(credential_state_cache.REDIS_CONFIG, "password", "")
+        monkeypatch.setitem(credential_state_cache.REDIS_CONFIG, "database", 15)
+        asyncio.run(exercise(client))


### PR DESCRIPTION
## 问题

Stargazer 的凭据状态缓存需要在高频采集选择、任务结果回写和定时推送中访问 Redis。原实现的九个公开路径每次调用都新建并立即关闭连接池，使正常热路径产生不必要的连接握手和连接数抖动。

## 根因

缓存只复用了统一 Redis 配置，没有把连接生命周期纳入 Sanic Server 与独立 ARQ Worker 的进程生命周期。调用方法因此同时承担业务命令和连接回收，无法在同一运行时复用已建立的连接。

## 怎么修的

- 按当前进程的 asyncio 事件循环惰性创建并复用连接池，并用异步锁保证并发首调只初始化一次。
- 不同事件循环各自持有连接池，避免跨事件循环复用异步连接。
- Sanic 在 `after_server_stop`、ARQ Worker 在 `on_shutdown` 幂等关闭各自连接池；关闭或首次创建失败后，下次调用可重新连接。
- 保持缓存公开方法、Redis key、命令、TTL、返回值和异常传播语义不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["采集 API / 结果推送<br/>api/collect.py · service"]
        T2["ARQ 采集任务<br/>tasks/handlers/plugin_handler.py"]
    end

    subgraph C["缓存层"]
        C1["CredentialStateCache<br/>core/credential_state_cache.py"]
        C2["_get_or_create_pool<br/>按事件循环惰性复用"]
    end

    R["Redis<br/>既有 key 与命令"]
    S1["Sanic after_server_stop"]
    S2["ARQ on_shutdown"]

    T1 --> C1
    T2 --> C1
    C1 --> C2 --> R
    S1 -. "停机关闭" .-> C2
    S2 -. "停机关闭" .-> C2
```

## 影响范围

改动仅限 Stargazer。生产仍由两个 Sanic 进程和四个 ARQ Worker 进程分别管理自己的连接；不修改 Server、Web、Agent 间协议、NATS subject、Redis 配置或持久化数据，无迁移要求。回滚可直接恢复旧版本代码。

## 验证

`agents/stargazer/tests/test_credential_state_cache.py` 覆盖 8 个场景：

- 20 次顺序读取及 20 次并发读取均只创建一个连接池；
- 不同事件循环不共享连接，关闭幂等且下次访问可重连；
- 首次连接失败不污染后续重试；
- Sanic 与 ARQ 的真实生命周期接线均执行关闭；
- 最小真实 Redis 验证九个公开路径的命令、返回值、清理和游标契约不变，20 次读取只增加一个连接，关闭后重连只增加一个连接。

Revert-fail：在修复前提交上，同一 20 次公开读取会创建并关闭 20 个连接池。

## 三轨门禁

- Standards：PASS。仓库约束、并发模型、资源回收、最小范围与代码质量复核通过。
- Spec：PASS。Issue 要求的连接复用、跨事件循环隔离、双运行时关闭、重连和兼容边界均已覆盖。
- Runtime Contract：PASS。顺序、并发、失败恢复、跨事件循环、双停机入口和真实 Redis 命令矩阵均取得新鲜可红证据。

Closes #4003
