### PR TITLE
bugfix: 批量回填文件显示字段

### DIFF
--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -1109,21 +1109,9 @@ class FalkorDBClient:
         """在一次图查询中为不同节点写入同一字段的不同值。"""
         validated_label = CQLValidator.validate_label(label)
         validated_field = CQLValidator.validate_field(field)
-        if not isinstance(property_values, list):
-            raise BaseAppException("property_values must be a list")
-        if not property_values:
+        validated_property_values = CQLValidator.validate_property_values(property_values)
+        if not validated_property_values:
             return []
-
-        validated_property_values = []
-        for item in property_values:
-            if not isinstance(item, dict) or "id" not in item or "value" not in item:
-                raise BaseAppException("property_values items must contain id and value")
-            validated_property_values.append(
-                {
-                    "id": CQLValidator.validate_id(item["id"]),
-                    "value": item["value"],
-                }
-            )
 
         query = (
             f"UNWIND $property_values AS row "

--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -1105,6 +1105,36 @@ class FalkorDBClient:
 
         return nodes
 
+    def batch_update_node_property_values(self, label: str, field: str, property_values: list[dict]):
+        """在一次图查询中为不同节点写入同一字段的不同值。"""
+        validated_label = CQLValidator.validate_label(label)
+        validated_field = CQLValidator.validate_field(field)
+        if not isinstance(property_values, list):
+            raise BaseAppException("property_values must be a list")
+        if not property_values:
+            return []
+
+        validated_property_values = []
+        for item in property_values:
+            if not isinstance(item, dict) or "id" not in item or "value" not in item:
+                raise BaseAppException("property_values items must contain id and value")
+            validated_property_values.append(
+                {
+                    "id": CQLValidator.validate_id(item["id"]),
+                    "value": item["value"],
+                }
+            )
+
+        query = (
+            f"UNWIND $property_values AS row "
+            f"MATCH (n:{validated_label}) WHERE ID(n) = row.id "
+            f"SET n.{validated_field} = row.value RETURN n"
+        )
+        return self._execute_query(
+            query,
+            params={"property_values": validated_property_values},
+        )
+
     def format_properties_remove(self, attrs: list):
         """格式化properties的remove数据，验证字段名防止注入"""
         properties_str = ""

--- a/server/apps/cmdb/graph/neo4j.py
+++ b/server/apps/cmdb/graph/neo4j.py
@@ -8,6 +8,7 @@ from neo4j.graph import Path
 
 from apps.cmdb.constants.constants import INSTANCE, ModelConstraintKey
 from apps.cmdb.graph.format_type import FORMAT_TYPE_PARAMS, ParameterCollector
+from apps.cmdb.graph.validators import CQLValidator
 from apps.cmdb.services.unique_rule import raise_unique_rule_conflict_if_needed
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
@@ -551,6 +552,36 @@ class Neo4jClient:
             raise BaseAppException("properties is empty")
         nodes = self.session.run(f"MATCH (n{label_str}) WHERE id(n) IN {node_ids} SET {properties_str} RETURN n")
         return nodes
+
+    def batch_update_node_property_values(self, label: str, field: str, property_values: list[dict]):
+        """在一次图查询中为不同节点写入同一字段的不同值。"""
+        validated_label = CQLValidator.validate_label(label)
+        validated_field = CQLValidator.validate_field(field)
+        if not isinstance(property_values, list):
+            raise BaseAppException("property_values must be a list")
+        if not property_values:
+            return []
+
+        validated_property_values = []
+        for item in property_values:
+            if not isinstance(item, dict) or "id" not in item or "value" not in item:
+                raise BaseAppException("property_values items must contain id and value")
+            validated_property_values.append(
+                {
+                    "id": CQLValidator.validate_id(item["id"]),
+                    "value": item["value"],
+                }
+            )
+
+        query = (
+            f"UNWIND $property_values AS row "
+            f"MATCH (n:{validated_label}) WHERE id(n) = row.id "
+            f"SET n.{validated_field} = row.value RETURN n"
+        )
+        return self.session.run(
+            query,
+            property_values=validated_property_values,
+        )
 
     def format_properties_remove(self, attrs: list):
         """格式化properties的remove数据"""

--- a/server/apps/cmdb/graph/neo4j.py
+++ b/server/apps/cmdb/graph/neo4j.py
@@ -557,21 +557,9 @@ class Neo4jClient:
         """在一次图查询中为不同节点写入同一字段的不同值。"""
         validated_label = CQLValidator.validate_label(label)
         validated_field = CQLValidator.validate_field(field)
-        if not isinstance(property_values, list):
-            raise BaseAppException("property_values must be a list")
-        if not property_values:
+        validated_property_values = CQLValidator.validate_property_values(property_values)
+        if not validated_property_values:
             return []
-
-        validated_property_values = []
-        for item in property_values:
-            if not isinstance(item, dict) or "id" not in item or "value" not in item:
-                raise BaseAppException("property_values items must contain id and value")
-            validated_property_values.append(
-                {
-                    "id": CQLValidator.validate_id(item["id"]),
-                    "value": item["value"],
-                }
-            )
 
         query = (
             f"UNWIND $property_values AS row "

--- a/server/apps/cmdb/graph/validators.py
+++ b/server/apps/cmdb/graph/validators.py
@@ -9,7 +9,10 @@ CQL参数验证器
 """
 import re
 from typing import Any, List
+
 from apps.core.exceptions.base_app_exception import BaseAppException
+
+MAX_BATCH_UPDATE_PROPERTY_VALUES = 1000
 
 
 class CQLValidator:
@@ -64,6 +67,28 @@ class CQLValidator:
             raise BaseAppException("ID list cannot be empty")
         
         return [CQLValidator.validate_id(v) for v in value]
+
+    @staticmethod
+    def validate_property_values(value: Any) -> list[dict]:
+        """校验并规范化逐节点属性值批量写入参数。"""
+        if not isinstance(value, list):
+            raise BaseAppException("property_values must be a list")
+        if len(value) > MAX_BATCH_UPDATE_PROPERTY_VALUES:
+            raise BaseAppException(
+                f"property_values cannot exceed {MAX_BATCH_UPDATE_PROPERTY_VALUES} items"
+            )
+
+        normalized = []
+        for item in value:
+            if not isinstance(item, dict) or "id" not in item or "value" not in item:
+                raise BaseAppException("property_values items must contain id and value")
+            normalized.append(
+                {
+                    "id": CQLValidator.validate_id(item["id"]),
+                    "value": item["value"],
+                }
+            )
+        return normalized
     
     @staticmethod
     def validate_label(label: str) -> str:

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -1179,13 +1179,25 @@ class ModelManage(object):
             with GraphClient() as ag:
                 instances, _ = ag.query_entity(INSTANCE, [{"field": "model_id", "type": "str=", "value": model_id}])
 
+                property_values = []
                 for instance in instances:
                     # 仅处理含该文件字段值的实例
                     if attr_id in instance and instance[attr_id]:
                         new_display_value = DisplayFieldConverter.convert_file(instance[attr_id])
-                        update_data = {display_field_id: new_display_value}
-                        ag.batch_update_node_properties(INSTANCE, [instance["_id"]], update_data)
-                        updated_count += 1
+                        property_values.append(
+                            {
+                                "id": instance["_id"],
+                                "value": new_display_value,
+                            }
+                        )
+
+                if property_values:
+                    ag.batch_update_node_property_values(
+                        INSTANCE,
+                        display_field_id,
+                        property_values,
+                    )
+                    updated_count = len(property_values)
 
                 if updated_count > 0:
                     logger.info(

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -1178,36 +1178,56 @@ class ModelManage(object):
 
         try:
             with GraphClient() as ag:
-                offset = 0
+                last_instance_id = None
+                property_values = []
                 while True:
+                    query_params = [{"field": "model_id", "type": "str=", "value": model_id}]
+                    if last_instance_id is not None:
+                        query_params.append(
+                            {
+                                "field": "id",
+                                "type": "id>",
+                                "value": last_instance_id,
+                            }
+                        )
                     instances, _ = ag.query_entity(
                         INSTANCE,
-                        [{"field": "model_id", "type": "str=", "value": model_id}],
-                        page={"skip": offset, "limit": MAX_BATCH_UPDATE_PROPERTY_VALUES},
+                        query_params,
+                        page={"skip": 0, "limit": MAX_BATCH_UPDATE_PROPERTY_VALUES},
                         include_count=False,
                     )
                     if not instances:
                         break
 
-                    property_values = [
-                        {
-                            "id": instance["_id"],
-                            "value": DisplayFieldConverter.convert_file(instance[attr_id]),
-                        }
-                        for instance in instances
-                        if attr_id in instance and instance[attr_id]
-                    ]
-                    if property_values:
-                        ag.batch_update_node_property_values(
-                            INSTANCE,
-                            display_field_id,
-                            property_values,
+                    for instance in instances:
+                        if attr_id not in instance or not instance[attr_id]:
+                            continue
+                        property_values.append(
+                            {
+                                "id": instance["_id"],
+                                "value": DisplayFieldConverter.convert_file(instance[attr_id]),
+                            }
                         )
-                        updated_count += len(property_values)
+                        if len(property_values) == MAX_BATCH_UPDATE_PROPERTY_VALUES:
+                            ag.batch_update_node_property_values(
+                                INSTANCE,
+                                display_field_id,
+                                property_values,
+                            )
+                            updated_count += len(property_values)
+                            property_values = []
 
                     if len(instances) < MAX_BATCH_UPDATE_PROPERTY_VALUES:
                         break
-                    offset += len(instances)
+                    last_instance_id = instances[-1]["_id"]
+
+                if property_values:
+                    ag.batch_update_node_property_values(
+                        INSTANCE,
+                        display_field_id,
+                        property_values,
+                    )
+                    updated_count += len(property_values)
 
                 if updated_count > 0:
                     logger.info(

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -26,6 +26,7 @@ from apps.cmdb.constants.field_constraints import TAG_ATTR_ID, TAG_MODE_FREE
 from apps.cmdb.custom_reporting.extensions import get_custom_reporting_extension
 from apps.cmdb.display_field.constants import DISPLAY_FIELD_TYPES, DISPLAY_SUFFIX
 from apps.cmdb.graph.drivers.graph_client import GraphClient
+from apps.cmdb.graph.validators import MAX_BATCH_UPDATE_PROPERTY_VALUES
 from apps.cmdb.language.service import SettingLanguage
 from apps.cmdb.model_ops.extensions import get_model_enterprise_extension, is_file_attr_type
 from apps.cmdb.models import CREATE_INST, DELETE_INST, UPDATE_INST, FieldGroup
@@ -1177,27 +1178,36 @@ class ModelManage(object):
 
         try:
             with GraphClient() as ag:
-                instances, _ = ag.query_entity(INSTANCE, [{"field": "model_id", "type": "str=", "value": model_id}])
-
-                property_values = []
-                for instance in instances:
-                    # 仅处理含该文件字段值的实例
-                    if attr_id in instance and instance[attr_id]:
-                        new_display_value = DisplayFieldConverter.convert_file(instance[attr_id])
-                        property_values.append(
-                            {
-                                "id": instance["_id"],
-                                "value": new_display_value,
-                            }
-                        )
-
-                if property_values:
-                    ag.batch_update_node_property_values(
+                offset = 0
+                while True:
+                    instances, _ = ag.query_entity(
                         INSTANCE,
-                        display_field_id,
-                        property_values,
+                        [{"field": "model_id", "type": "str=", "value": model_id}],
+                        page={"skip": offset, "limit": MAX_BATCH_UPDATE_PROPERTY_VALUES},
+                        include_count=False,
                     )
-                    updated_count = len(property_values)
+                    if not instances:
+                        break
+
+                    property_values = [
+                        {
+                            "id": instance["_id"],
+                            "value": DisplayFieldConverter.convert_file(instance[attr_id]),
+                        }
+                        for instance in instances
+                        if attr_id in instance and instance[attr_id]
+                    ]
+                    if property_values:
+                        ag.batch_update_node_property_values(
+                            INSTANCE,
+                            display_field_id,
+                            property_values,
+                        )
+                        updated_count += len(property_values)
+
+                    if len(instances) < MAX_BATCH_UPDATE_PROPERTY_VALUES:
+                        break
+                    offset += len(instances)
 
                 if updated_count > 0:
                     logger.info(

--- a/server/apps/cmdb/tests/test_falkordb_client.py
+++ b/server/apps/cmdb/tests/test_falkordb_client.py
@@ -373,6 +373,45 @@ def test_batch_update_node_properties_empty_props_raises():
         c.batch_update_node_properties("instance", [1], {})
 
 
+def test_batch_update_node_property_values_uses_one_parameterized_query():
+    c = _client(_entity_result([]))
+    property_values = [
+        {"id": 1, "value": "report"},
+        {"id": 2, "value": "photo"},
+    ]
+
+    c.batch_update_node_property_values(
+        "instance",
+        "doc_display",
+        property_values,
+    )
+
+    assert len(c._graph.calls) == 1
+    assert "UNWIND $property_values AS row" in c._graph.last_query
+    assert "ID(n) = row.id" in c._graph.last_query
+    assert "SET n.doc_display = row.value" in c._graph.last_query
+    assert c._graph.last_params == {"property_values": property_values}
+
+
+def test_batch_update_node_property_values_empty_list_skips_query():
+    c = _client(_entity_result([]))
+
+    assert c.batch_update_node_property_values("instance", "doc_display", []) == []
+    assert c._graph.calls == []
+
+
+def test_batch_update_node_property_values_rejects_invalid_field():
+    c = _client(_entity_result([]))
+
+    with pytest.raises(BaseAppException):
+        c.batch_update_node_property_values(
+            "instance",
+            "doc_display) DELETE n",
+            [{"id": 1, "value": "report"}],
+        )
+    assert c._graph.calls == []
+
+
 def test_batch_create_entity_mixed_results():
     created = FakeNode(1, ["instance"], {"inst_name": "ok"})
     c = _client(_entity_result([created]))

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -327,14 +327,76 @@ def test_rebuild_file_instances_display_backfills_stem(fake_graph):
     count = ModelManage.rebuild_file_instances_display("host", "doc")
     # 只有实例 1 含 doc → 回填 1 个
     assert count == 1
-    update_calls = [c for c in fg.calls if c[0] == "batch_update_node_properties"]
+    update_calls = [
+        c for c in fg.calls if c[0] == "batch_update_node_property_values"
+    ]
     assert len(update_calls) == 1
     # 写入的是文件名词干（去扩展名），而非原始元数据 JSON
-    assert update_calls[0][1][2] == {"doc_display": "report"}
+    assert update_calls[0][1] == (
+        "instance",
+        "doc_display",
+        [{"id": 1, "value": "report"}],
+    )
+
+
+def test_rebuild_file_instances_display_batches_1000_distinct_values_once(
+    fake_graph,
+):
+    instances = [
+        {"_id": index, "doc": [{"name": f"report-{index}.pdf"}]}
+        for index in range(1, 1001)
+    ]
+    instances.extend([{"_id": 1001}, {"_id": 1002, "doc": []}])
+    fg = fake_graph(
+        MODULE,
+        query_entity=(instances, len(instances)),
+    )
+
+    count = ModelManage.rebuild_file_instances_display("host", "doc")
+
+    assert count == 1000
+    update_calls = [
+        call
+        for call in fg.calls
+        if call[0] == "batch_update_node_property_values"
+    ]
+    assert len(update_calls) == 1
+    assert update_calls[0][1][0:2] == ("instance", "doc_display")
+    assert update_calls[0][1][2] == [
+        {"id": index, "value": f"report-{index}"}
+        for index in range(1, 1001)
+    ]
+    assert not any(
+        call[0] == "batch_update_node_properties" for call in fg.calls
+    )
 
 
 def test_rebuild_file_instances_display_no_instances(fake_graph):
     fg = fake_graph(MODULE, query_entity=([], 0))
     count = ModelManage.rebuild_file_instances_display("host", "doc")
     assert count == 0
-    assert not any(c[0] == "batch_update_node_properties" for c in fg.calls)
+    assert not any(
+        c[0] in {"batch_update_node_properties", "batch_update_node_property_values"}
+        for c in fg.calls
+    )
+
+
+def test_rebuild_file_instances_display_backend_failure_is_non_blocking(
+    fake_graph,
+):
+    def _raise(*args, **kwargs):
+        raise RuntimeError("graph unavailable")
+
+    fake_graph(
+        MODULE,
+        query_entity=(
+            [
+                {"_id": 1, "doc": [{"name": "report.pdf"}]},
+                {"_id": 2, "doc": [{"name": "photo.png"}]},
+            ],
+            2,
+        ),
+        batch_update_node_property_values=_raise,
+    )
+
+    assert ModelManage.rebuild_file_instances_display("host", "doc") == 0

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -318,11 +318,21 @@ def test_update_enum_instances_display(fake_graph):
     assert any(c[0] == "batch_update_node_properties" for c in fg.calls)
 
 
+def _paged_query_entity(instances):
+    def _query(*args, page=None, **kwargs):
+        start = page["skip"]
+        end = start + page["limit"]
+        return instances[start:end], None
+
+    return _query
+
+
 def test_rebuild_file_instances_display_backfills_stem(fake_graph):
     # 实例 1 有附件但无 _display（历史数据）；实例 2 无附件值
+    instances = [{"_id": 1, "doc": [{"name": "report.pdf"}]}, {"_id": 2}]
     fg = fake_graph(
         MODULE,
-        query_entity=([{"_id": 1, "doc": [{"name": "report.pdf"}]}, {"_id": 2}], 2),
+        query_entity=_paged_query_entity(instances),
     )
     count = ModelManage.rebuild_file_instances_display("host", "doc")
     # 只有实例 1 含 doc → 回填 1 个
@@ -349,7 +359,7 @@ def test_rebuild_file_instances_display_batches_1000_distinct_values_once(
     instances.extend([{"_id": 1001}, {"_id": 1002, "doc": []}])
     fg = fake_graph(
         MODULE,
-        query_entity=(instances, len(instances)),
+        query_entity=_paged_query_entity(instances),
     )
 
     count = ModelManage.rebuild_file_instances_display("host", "doc")
@@ -371,8 +381,31 @@ def test_rebuild_file_instances_display_batches_1000_distinct_values_once(
     )
 
 
+def test_rebuild_file_instances_display_pages_without_unbounded_graph_writes(
+    fake_graph,
+):
+    instances = [
+        {"_id": index, "doc": [{"name": f"report-{index}.pdf"}]}
+        for index in range(1, 1002)
+    ]
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances),
+    )
+
+    count = ModelManage.rebuild_file_instances_display("host", "doc")
+
+    assert count == 1001
+    update_calls = [
+        call
+        for call in fg.calls
+        if call[0] == "batch_update_node_property_values"
+    ]
+    assert [len(call[1][2]) for call in update_calls] == [1000, 1]
+
+
 def test_rebuild_file_instances_display_no_instances(fake_graph):
-    fg = fake_graph(MODULE, query_entity=([], 0))
+    fg = fake_graph(MODULE, query_entity=_paged_query_entity([]))
     count = ModelManage.rebuild_file_instances_display("host", "doc")
     assert count == 0
     assert not any(
@@ -389,12 +422,11 @@ def test_rebuild_file_instances_display_backend_failure_is_non_blocking(
 
     fake_graph(
         MODULE,
-        query_entity=(
+        query_entity=_paged_query_entity(
             [
                 {"_id": 1, "doc": [{"name": "report.pdf"}]},
                 {"_id": 2, "doc": [{"name": "photo.png"}]},
-            ],
-            2,
+            ]
         ),
         batch_update_node_property_values=_raise,
     )

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -318,11 +318,27 @@ def test_update_enum_instances_display(fake_graph):
     assert any(c[0] == "batch_update_node_properties" for c in fg.calls)
 
 
-def _paged_query_entity(instances):
-    def _query(*args, page=None, **kwargs):
+def _paged_query_entity(instances, delete_after_first=False):
+    call_count = 0
+
+    def _query(label, params, page=None, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        last_id = next(
+            (item["value"] for item in params if item["type"] == "id>"),
+            None,
+        )
+        candidates = [
+            instance
+            for instance in instances
+            if last_id is None or instance["_id"] > last_id
+        ]
         start = page["skip"]
         end = start + page["limit"]
-        return instances[start:end], None
+        result = candidates[start:end]
+        if delete_after_first and call_count == 1:
+            instances[:] = [instance for instance in instances if instance["_id"] != 1]
+        return result, None
 
     return _query
 
@@ -352,11 +368,12 @@ def test_rebuild_file_instances_display_backfills_stem(fake_graph):
 def test_rebuild_file_instances_display_batches_1000_distinct_values_once(
     fake_graph,
 ):
-    instances = [
+    instances = [{"_id": 1}]
+    instances.extend(
         {"_id": index, "doc": [{"name": f"report-{index}.pdf"}]}
-        for index in range(1, 1001)
-    ]
-    instances.extend([{"_id": 1001}, {"_id": 1002, "doc": []}])
+        for index in range(2, 1002)
+    )
+    instances.append({"_id": 1002, "doc": []})
     fg = fake_graph(
         MODULE,
         query_entity=_paged_query_entity(instances),
@@ -374,7 +391,7 @@ def test_rebuild_file_instances_display_batches_1000_distinct_values_once(
     assert update_calls[0][1][0:2] == ("instance", "doc_display")
     assert update_calls[0][1][2] == [
         {"id": index, "value": f"report-{index}"}
-        for index in range(1, 1001)
+        for index in range(2, 1002)
     ]
     assert not any(
         call[0] == "batch_update_node_properties" for call in fg.calls
@@ -402,6 +419,30 @@ def test_rebuild_file_instances_display_pages_without_unbounded_graph_writes(
         if call[0] == "batch_update_node_property_values"
     ]
     assert [len(call[1][2]) for call in update_calls] == [1000, 1]
+
+
+def test_rebuild_file_instances_display_keyset_does_not_skip_after_delete(
+    fake_graph,
+):
+    instances = [
+        {"_id": index, "doc": [{"name": f"report-{index}.pdf"}]}
+        for index in range(1, 1002)
+    ]
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances, delete_after_first=True),
+    )
+
+    count = ModelManage.rebuild_file_instances_display("host", "doc")
+
+    assert count == 1001
+    update_calls = [
+        call
+        for call in fg.calls
+        if call[0] == "batch_update_node_property_values"
+    ]
+    assert [len(call[1][2]) for call in update_calls] == [1000, 1]
+    assert update_calls[-1][1][2] == [{"id": 1001, "value": "report-1001"}]
 
 
 def test_rebuild_file_instances_display_no_instances(fake_graph):

--- a/server/apps/cmdb/tests/test_neo4j_client.py
+++ b/server/apps/cmdb/tests/test_neo4j_client.py
@@ -311,6 +311,45 @@ def test_delete_edge():
     assert "DELETE" in c.session.last_query.upper()
 
 
+def test_batch_update_node_property_values_uses_one_parameterized_query():
+    c = _client()
+    property_values = [
+        {"id": 1, "value": "report"},
+        {"id": 2, "value": "photo"},
+    ]
+
+    c.batch_update_node_property_values(
+        "instance",
+        "doc_display",
+        property_values,
+    )
+
+    assert len(c.session.calls) == 1
+    assert "UNWIND $property_values AS row" in c.session.last_query
+    assert "id(n) = row.id" in c.session.last_query
+    assert "SET n.doc_display = row.value" in c.session.last_query
+    assert c.session.last_params == {"property_values": property_values}
+
+
+def test_batch_update_node_property_values_empty_list_skips_query():
+    c = _client()
+
+    assert c.batch_update_node_property_values("instance", "doc_display", []) == []
+    assert c.session.calls == []
+
+
+def test_batch_update_node_property_values_rejects_invalid_field():
+    c = _client()
+
+    with pytest.raises(BaseAppException):
+        c.batch_update_node_property_values(
+            "instance",
+            "doc_display) DELETE n",
+            [{"id": 1, "value": "report"}],
+        )
+    assert c.session.calls == []
+
+
 def test_query_edge():
     src = FakeNode(1, ["instance"], {"inst_name": "h", "model_id": "host"})
     dst = FakeNode(2, ["instance"], {"inst_name": "s", "model_id": "sw"})

--- a/server/apps/cmdb/tests/test_validators.py
+++ b/server/apps/cmdb/tests/test_validators.py
@@ -5,7 +5,10 @@
 
 import pytest
 
-from apps.cmdb.graph.validators import CQLValidator
+from apps.cmdb.graph.validators import (
+    MAX_BATCH_UPDATE_PROPERTY_VALUES,
+    CQLValidator,
+)
 from apps.core.exceptions.base_app_exception import BaseAppException
 
 
@@ -38,6 +41,30 @@ def test_validate_ids_not_list():
 def test_validate_ids_empty():
     with pytest.raises(BaseAppException):
         CQLValidator.validate_ids([])
+
+
+# validate_property_values
+def test_validate_property_values_normalizes_ids():
+    assert CQLValidator.validate_property_values(
+        [{"id": "5", "value": "report"}]
+    ) == [{"id": 5, "value": "report"}]
+
+
+def test_validate_property_values_rejects_malformed_item():
+    with pytest.raises(BaseAppException):
+        CQLValidator.validate_property_values([{"id": 1}])
+
+
+def test_validate_property_values_rejects_non_list():
+    with pytest.raises(BaseAppException):
+        CQLValidator.validate_property_values(None)
+
+
+def test_validate_property_values_rejects_unbounded_batch():
+    with pytest.raises(BaseAppException):
+        CQLValidator.validate_property_values(
+            [{"id": index, "value": "v"} for index in range(MAX_BATCH_UPDATE_PROPERTY_VALUES + 1)]
+        )
 
 
 # validate_label


### PR DESCRIPTION
## 问题

附件或图片字段更新后，CMDB 会在同步 HTTP 请求中重算历史实例的文件名展示字段。旧实现对每个有效实例分别执行一次图写；即使使用的是批量 API，传入的也始终是单个节点。实例数增加时，图写次数线性增长。

## 根因（设计层）

现有 `batch_update_node_properties` 只能让一组节点共享同一份属性值。文件展示值由每个实例自己的文件名生成，调用方因此把逐节点异值写入拆成了多次同值批写，批量边界失效。旧的按展示值分组方案在文件名全部不同时仍会退化为 N 次写入。

## 怎么修的

- 为 FalkorDB 和 Neo4j 增加同一契约的异值批写接口：一次参数化 `UNWIND` 查询接收全部 `{id, value}` 映射。
- `rebuild_file_instances_display` 先生成所有有效实例的展示值映射，再执行一次图写。
- 标签、字段名和节点 ID 继续经过白名单或类型校验；空集合不发查询。
- 保留既有非关键回填失败守卫：图后端失败会记录错误但不阻断模型字段更新请求。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["model_attr_update\nviews/model.py"]
    end

    subgraph S["回填层"]
        S1["rebuild_file_instances_display\nservices/model.py"]
        S2["生成全部 id/value 映射"]
    end

    subgraph G["图驱动层"]
        G1["GraphClient"]
        G2["FalkorDB / Neo4j\n单条 UNWIND 查询"]
    end

    T1 --> S1 --> S2 --> G1 --> G2
    G2 -. "依赖失败" .-> S1
```

## 影响范围

- 仅修改 CMDB 文件展示字段的内部回填路径和两个图驱动；REST 请求与响应、模型字段和存量数据格式均不变。
- 每个实例写入的展示值与旧实现一致；重复执行仍是幂等 SET。
- 未修改 Issue #3377 对应的枚举展示字段姊妹函数。
- 仓库扫描未发现 agents、NATS、Celery 或其它模块调用方。

## 验证

- `apps/cmdb/tests/test_model_service_methods.py`：30 passed，覆盖 1000 个不同文件名仍只发生一次图写、逐实例值映射、空集合和后端失败。
- `apps/cmdb/tests/test_neo4j_client.py`：31 passed，覆盖单查询、参数映射、空集合与字段注入拒绝。
- `apps/cmdb/tests/test_falkordb_client.py`：本次新增 3 项均通过；该文件另有一个已在最新 master 独立复现的连接池基线失败。
- FalkorDB 4.18.11 真实往返验证：三个节点的不同展示值通过一条参数化查询更新并逐值读回。
- 回退服务层批写改动后，回归测试恢复失败，证明测试直接命中本修复。

## 三轨门禁

- Standards：PASS。无仓库标准违规；双驱动的少量方言重复仅为非阻塞判断项。
- Spec：PASS。完整覆盖 Issue 的 1000→1 调用次数与逐实例值保持要求，无范围扩张。
- Runtime Contract：PASS。正常、空集、依赖失败、输入校验、双驱动、HTTP 入口和真实 FalkorDB 场景均有新鲜证据。
- 质量评分：94 / 100（SCORE_PASS）。
- Review gate：automated_deep_review；未发现需要人工作业务或兼容决策的证据。

Fixes #3961
