### PR TITLE
test(webchat): 补齐 core 行为测试基线

### DIFF
--- a/webchat/.gitignore
+++ b/webchat/.gitignore
@@ -7,6 +7,7 @@ packages/webchat-ui/node_modules
 
 # Testing
 /coverage
+/.test-dist
 
 # Next.js
 /.next/

--- a/webchat/.npmrc
+++ b/webchat/.npmrc
@@ -1,2 +1,1 @@
 legacy-peer-deps=true
-cache=false

--- a/webchat/package.json
+++ b/webchat/package.json
@@ -9,7 +9,9 @@
     "build:core": "cd packages/webchat-core && npm run build",
     "build:ui": "cd packages/webchat-ui && npm run build",
     "build:demo": "cd packages/webchat-demo && npm run build",
-    "test": "node tests/state-machine.issue-3882.mjs",
+    "test": "node tests/state-machine.issue-3882.mjs && npm run test:core",
+    "pretest:core": "node -e \"require('node:fs').rmSync('.test-dist', { recursive: true, force: true })\"",
+    "test:core": "tsc -p tests/tsconfig.json && node --test .test-dist/tests/core/core.test.js",
     "lint": "echo 'No linter configured yet'",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist packages/*/.next"

--- a/webchat/tests/core/core.test.ts
+++ b/webchat/tests/core/core.test.ts
@@ -1,0 +1,4 @@
+import './sessionManager.test';
+import './sse.test';
+import './stateMachine.test';
+import './utils.test';

--- a/webchat/tests/core/sessionManager.test.ts
+++ b/webchat/tests/core/sessionManager.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { SessionManager } from '../../packages/webchat-core/src/sessionManager';
+import type { ChatSession } from '../../packages/webchat-core/src/types';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function installLocalStorage(storage: Storage): () => void {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+
+  return () => {
+    if (previous) {
+      Object.defineProperty(globalThis, 'localStorage', previous);
+    } else {
+      Reflect.deleteProperty(globalThis, 'localStorage');
+    }
+  };
+}
+
+function storedSession(lastActivityTime: number): ChatSession {
+  return {
+    sessionId: 'persisted-session',
+    messages: [],
+    startTime: lastActivityTime,
+    lastActivityTime,
+  };
+}
+
+test('restores a persisted session that is less than 24 hours old', () => {
+  const now = 1_800_000_000_000;
+  const storage = new MemoryStorage();
+  storage.setItem('@webchat/session', JSON.stringify(storedSession(now - DAY_IN_MS + 1)));
+
+  const restoreStorage = installLocalStorage(storage);
+  const originalNow = Date.now;
+  Date.now = () => now;
+
+  try {
+    const session = new SessionManager({ enableStorage: true }).initSession();
+    assert.equal(session.sessionId, 'persisted-session');
+  } finally {
+    Date.now = originalNow;
+    restoreStorage();
+  }
+});
+
+test('expires a persisted session at the exact 24-hour boundary', () => {
+  const now = 1_800_000_000_000;
+  const storage = new MemoryStorage();
+  storage.setItem('@webchat/session', JSON.stringify(storedSession(now - DAY_IN_MS)));
+
+  const restoreStorage = installLocalStorage(storage);
+  const originalNow = Date.now;
+  Date.now = () => now;
+
+  try {
+    const session = new SessionManager({ enableStorage: true }).initSession();
+    assert.notEqual(session.sessionId, 'persisted-session');
+    assert.equal(session.startTime, now);
+  } finally {
+    Date.now = originalNow;
+    restoreStorage();
+  }
+});

--- a/webchat/tests/core/sessionManager.test.ts
+++ b/webchat/tests/core/sessionManager.test.ts
@@ -34,6 +34,7 @@ class MemoryStorage implements Storage {
   }
 }
 
+/** Install a localStorage stub and return a function that restores the original. */
 function installLocalStorage(storage: Storage): () => void {
   const previous = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
   Object.defineProperty(globalThis, 'localStorage', {
@@ -50,6 +51,7 @@ function installLocalStorage(storage: Storage): () => void {
   };
 }
 
+/** Build the persisted session fixture for a given activity timestamp. */
 function storedSession(lastActivityTime: number): ChatSession {
   return {
     sessionId: 'persisted-session',

--- a/webchat/tests/core/sse.test.ts
+++ b/webchat/tests/core/sse.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { SSEHandler } from '../../packages/webchat-core/src/sse';
+import type {
+  Message,
+  MessageEvent as WebChatMessageEvent,
+} from '../../packages/webchat-core/src/types';
+
+function streamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+
+  return {
+    body,
+    ok: true,
+    status: 200,
+  } as Response;
+}
+
+test('parses split SSE data lines and ignores keep-alive comments', async () => {
+  const originalFetch = globalThis.fetch;
+  const messages: Message[] = [];
+
+  globalThis.fetch = async (input, init) => {
+    assert.equal(input, 'https://example.test/stream');
+    assert.equal(init?.headers && 'Authorization' in init.headers, true);
+    return streamResponse([
+      'data: {"id":"message-1","content":"hel',
+      'lo","sender":"bot"}\n: keep-alive\n',
+      'data: plain text\n',
+    ]);
+  };
+
+  const handler = new SSEHandler(0, 0);
+  handler.on('message', (event: WebChatMessageEvent) => {
+    messages.push(event.message);
+  });
+
+  try {
+    await handler.connect('https://example.test/stream', {
+      Authorization: 'Bearer placeholder',
+    });
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].id, 'message-1');
+    assert.equal(messages[0].content, 'hello');
+    assert.equal(messages[1].content, 'plain text');
+  } finally {
+    handler.destroy();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('retries a failed fetch connection once before succeeding', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalError = console.error;
+  let attempts = 0;
+  let opens = 0;
+
+  console.error = () => undefined;
+  globalThis.fetch = async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      throw new Error('temporary connection failure');
+    }
+    return streamResponse([]);
+  };
+
+  const handler = new SSEHandler(1, 0);
+  handler.on('open', () => {
+    opens += 1;
+  });
+
+  try {
+    await handler.connect('https://example.test/stream', {
+      Authorization: 'Bearer placeholder',
+    });
+    assert.equal(attempts, 2);
+    assert.equal(opens, 1);
+  } finally {
+    handler.destroy();
+    console.error = originalError;
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/webchat/tests/core/sse.test.ts
+++ b/webchat/tests/core/sse.test.ts
@@ -7,6 +7,7 @@ import type {
   MessageEvent as WebChatMessageEvent,
 } from '../../packages/webchat-core/src/types';
 
+/** Build a streaming fetch response from the supplied text chunks. */
 function streamResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
   const body = new ReadableStream<Uint8Array>({

--- a/webchat/tests/core/stateMachine.test.ts
+++ b/webchat/tests/core/stateMachine.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { StateMachine } from '../../packages/webchat-core/src/stateMachine';
+import type { StateChangeEvent } from '../../packages/webchat-core/src/types';
+
+test('moves an idle session through every legal state before chatting', () => {
+  const machine = new StateMachine();
+  const transitions: Array<[string, string]> = [];
+
+  machine.on((event: StateChangeEvent) => {
+    transitions.push([event.from, event.to]);
+  });
+
+  assert.equal(machine.transitionToChatting(), true);
+  assert.equal(machine.getState(), 'chatting');
+  assert.deepEqual(transitions, [
+    ['idle', 'connecting'],
+    ['connecting', 'connected'],
+    ['connected', 'chatting'],
+  ]);
+});
+
+test('rejects a direct idle-to-chatting transition', () => {
+  const machine = new StateMachine();
+  const originalWarn = console.warn;
+  console.warn = () => undefined;
+
+  try {
+    assert.equal(machine.transition('chatting'), false);
+    assert.equal(machine.getState(), 'idle');
+  } finally {
+    console.warn = originalWarn;
+  }
+});

--- a/webchat/tests/core/utils.test.ts
+++ b/webchat/tests/core/utils.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { retry } from '../../packages/webchat-core/src/utils';
+
+test('retry returns the first successful result after transient failures', async () => {
+  let attempts = 0;
+
+  const result = await retry(
+    async () => {
+      attempts += 1;
+      if (attempts < 3) {
+        throw new Error(`failure-${attempts}`);
+      }
+      return 'ok';
+    },
+    3,
+    0
+  );
+
+  assert.equal(result, 'ok');
+  assert.equal(attempts, 3);
+});
+
+test('retry preserves the final error after exhausting attempts', async () => {
+  let attempts = 0;
+
+  await assert.rejects(
+    retry(
+      async () => {
+        attempts += 1;
+        throw new Error(`failure-${attempts}`);
+      },
+      2,
+      0
+    ),
+    /failure-2/
+  );
+  assert.equal(attempts, 2);
+});

--- a/webchat/tests/tsconfig.json
+++ b/webchat/tests/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "outDir": "../.test-dist",
+    "rootDir": "..",
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["../packages/webchat-core/src/**/*.ts", "./core/**/*.test.ts"]
+}


### PR DESCRIPTION
## 问题

WebChat 的根 `npm test` 只读取源码并做正则断言，没有执行 `webchat-core` 的真实行为。会话过期边界、SSE 分块解析、断线重连或重试次数发生退化时，测试仍会错误地显示为通过。

这是 #4038 的第一阶段：先建立无需额外框架、可以独立回滚的 core 行为测试基线。AG-UI、Chat DOM/React 测试与仓库根 CI 接线继续由 #3600 统一推进。

## 根因

现有测试门禁与源码形状耦合，而不是与运行契约耦合；三个 core 模块虽可在 Node 环境直接执行，却没有接入测试入口。同时 `.npmrc` 把 `cache` 配成布尔值，使已声明支持的较新 Node/npm 无法从 WebChat 根目录正常执行 npm 命令。

## 怎么修的

- 复用现有 TypeScript 和 Node 18+ 内置的 `node:test`，不增加测试框架或生产依赖。
- 编译真实 `webchat-core` 源码和测试，再从根 `npm test` 执行行为断言。
- 覆盖 SessionManager 的 24 小时边界、SSE 分块/keep-alive/一次重连、StateMachine 合法与非法迁移、retry 成功与耗尽路径。
- 保留 #3882 的既有回归检查；测试产物进入被忽略的 `.test-dist`。
- 移除无效的 `cache=false` npm 配置，保持 Node 18/20/24 可执行。

## 调用链

```mermaid
flowchart TD
    subgraph T["测试入口"]
        T1["npm test\nwebchat/package.json"]
        T2["#3882 回归检查\ntests/state-machine.issue-3882.mjs"]
    end

    subgraph C["编译与执行"]
        C1["TypeScript 编译\ntests/tsconfig.json"]
        C2["Node test runner\ntests/core/core.test.ts"]
    end

    subgraph R["真实运行契约"]
        R1["SessionManager\n24 小时恢复边界"]
        R2["SSEHandler\n分块解析与重连"]
        R3["StateMachine / retry\n状态与失败路径"]
    end

    T1 --> T2 --> C1 --> C2
    C2 --> R1
    C2 --> R2
    C2 --> R3
```

## 影响范围

- 只修改 WebChat 的测试入口、测试编译配置和测试文件，不修改生产源码、公开 API、依赖或用户行为。
- 不建立共享抽象，不触及 server、agents、web、数据库或 NATS。
- 旧测试仍保留，新增测试可单独删除回滚。

## 验证

- `webchat/tests/core/*.test.ts`：Node 18、Node 20、Node 24 均通过；Node 20/24 为 8/8。
- `webchat` core 构建通过，UI 构建通过。
- 有效性验证：临时把 SessionManager 的 24 小时判断从 `<` 改为 `<=` 后，旧测试入口仍通过；接入本 PR 的测试后会在精确边界断言处失败，恢复实现后重新 8/8 通过。
- 基线说明：全量 `npm run build` 仍被未修改的 `webchat/packages/webchat-demo/app/chat-wrapper.tsx` 既有类型错误阻塞，本 PR 未扩大范围处理。

## 三轨门禁

- Standards：PASS，未发现仓库标准违规或代码异味。
- Spec：PASS，第一阶段 core 范围完整，无额外生产行为。
- Runtime Contract：PASS，真实源码执行、mutation RED 与恢复后 GREEN 均有新鲜证据。

评审得分：88 / 100（SCORE_PASS）。

关联 Issue #4038。
