### PR TITLE
bugfix(webchat): 隔离聊天流生命周期

### DIFF
--- a/webchat/package.json
+++ b/webchat/package.json
@@ -9,7 +9,7 @@
     "build:core": "cd packages/webchat-core && npm run build",
     "build:ui": "cd packages/webchat-ui && npm run build",
     "build:demo": "cd packages/webchat-demo && npm run build",
-    "test": "node tests/state-machine.issue-3882.mjs && npm run test:core",
+    "test": "node tests/state-machine.issue-3882.mjs && node --test tests/stream-lifecycle.issue-3556.test.mjs && npm run test:core",
     "pretest:core": "node -e \"require('node:fs').rmSync('.test-dist', { recursive: true, force: true })\"",
     "test:core": "tsc -p tests/tsconfig.json && node --test .test-dist/tests/core/core.test.js",
     "lint": "echo 'No linter configured yet'",

--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -200,7 +200,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
 
       case 'RUN_ERROR':
         setIsThinking(false);
-        const error = (event as any).error || 'Unknown error';
+        const error = 'message' in event ? event.message : 'Unknown error';
         const errorContent = `\n\n❌ **错误**: ${error}`;
         
         // 如果有当前消息，追加错误信息到末尾

--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -200,7 +200,6 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
 
       case 'RUN_ERROR':
         setIsThinking(false);
-        setIsLoading(false);
         const error = (event as any).error || 'Unknown error';
         const errorContent = `\n\n❌ **错误**: ${error}`;
         
@@ -323,11 +322,6 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         if (!currentMessageIdRef.current) {
           console.warn('⚠️ Received CONTENT without START, ignoring');
           break;
-        }
-        
-        // 收到第一个内容块时关闭 loading 状态
-        if (streamingContentRef.current === '' && delta) {
-          setIsLoading(false);
         }
         
         // 累加内容到 ref
@@ -652,7 +646,6 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         if (currentMessageIdRef.current && sessionManagerRef.current) {
           sessionManagerRef.current.saveSession();
         }
-        setIsLoading(false);
         setIsThinking(false);
         stateMachineRef.current?.transition('connected');
         break;
@@ -676,7 +669,6 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         metadata: data.metadata,
       };
       addMessage(botMsg);
-      setIsLoading(false);
     }
   };
 

--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -16,6 +16,12 @@ import { type ToolCall } from './components/ToolCallDisplay';
 import { MessageBubble } from './components/MessageBubble';
 import { useMessageHandlers } from './hooks/useMessageHandlers';
 import { ConfirmDialog } from './components/ConfirmDialog';
+import {
+  isAbortError,
+  runOwnedStream,
+  StreamLifecycle,
+  toError,
+} from './streamLifecycle';
 import './styles/tailwind.css';
 
 export interface ChatProps extends WebChatConfig {
@@ -83,6 +89,10 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const streamingContentRef = useRef<string>('');
   const currentMessageIdRef = useRef<string | null>(null);
+  const streamLifecycleRef = useRef<StreamLifecycle | null>(null);
+  if (!streamLifecycleRef.current) {
+    streamLifecycleRef.current = new StreamLifecycle();
+  }
   // 保持 onMessageReceived 最新引用，避免 useEffect 空 deps 闭包固化旧 prop
   const onMessageReceivedRef = useRef(onMessageReceived);
   useEffect(() => {
@@ -102,6 +112,9 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
 
   // Initialize core components
   useEffect(() => {
+    const streamLifecycle = streamLifecycleRef.current;
+    streamLifecycle?.mount();
+
     // Initialize SessionManager
     sessionManagerRef.current = new SessionManager({
       enableStorage,
@@ -127,6 +140,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
     }
 
     return () => {
+      void streamLifecycle?.dispose();
       aguiSubscription?.unsubscribe();
       aguiHandlerRef.current?.destroy();
       unsubscribeState();
@@ -800,6 +814,12 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
       stateMachineRef.current?.transitionToChatting();
 
       if (sseUrl) {
+        const streamLifecycle = streamLifecycleRef.current;
+        const stream = streamLifecycle?.begin();
+        if (!streamLifecycle || !stream) {
+          return;
+        }
+
         // Get current session data
         const currentSession = sessionManagerRef.current?.getSession();
         
@@ -819,31 +839,18 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
           headers['Authorization'] = `Bearer ${apiKey}`;
         }
         
-        const response = await fetch(sseUrl, {
-          method: 'POST',
-          headers,
-          body: JSON.stringify(requestBody),
-        });
-
-        if (!response.ok || !response.body) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        // Process SSE stream
-        const reader = response.body.getReader();
         const decoder = new TextDecoder();
-        
-        try {
-          while (true) {
-            const { done, value: chunk } = await reader.read();
-            if (done) {
-              console.log('✅ Stream complete');
-              // Ensure loading state is reset when stream completes
-              setIsLoading(false);
-              setIsThinking(false);
-              break;
-            }
-
+        await runOwnedStream({
+          lifecycle: streamLifecycle,
+          stream,
+          request: (signal) =>
+            fetch(sseUrl, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify(requestBody),
+              ...(signal ? { signal } : {}),
+            }),
+          onChunk: (chunk) => {
             const text = decoder.decode(chunk, { stream: true });
             // console.log('📦 Received chunk:', text.substring(0, 100));
             const lines = text.split('\n');
@@ -872,12 +879,17 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
                 }
               }
             }
-          }
-        } catch (streamError) {
-          console.error('Error reading stream:', streamError);
-          setIsLoading(false);
-          setIsThinking(false);
-        }
+          },
+          onError: (error) => {
+            console.error('Error reading stream:', error);
+            onError?.(error);
+          },
+          onComplete: () => {
+            console.log('✅ Stream complete');
+            setIsLoading(false);
+            setIsThinking(false);
+          },
+        });
       } else {
         // Simulate response for demo
         setTimeout(() => {
@@ -893,14 +905,24 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
         }, 1000);
       }
     } catch (error) {
+      if (isAbortError(error)) {
+        return;
+      }
       console.error('Error sending message:', error);
-      onError?.(error as Error);
+      onError?.(toError(error));
       setIsLoading(false);
     }
-  }, [isLoading, sseUrl, customData, addMessage, onError, aguiHandlerRef, uploadedImages]);
+  }, [isLoading, sseUrl, customData, addMessage, onError, uploadedImages]);
+
+  const handleStopStreaming = useCallback(() => {
+    void streamLifecycleRef.current?.cancel('user-stopped');
+    setIsLoading(false);
+    setIsThinking(false);
+  }, []);
 
   // Clear messages
   const handleClear = useCallback(() => {
+    void streamLifecycleRef.current?.cancel('session-cleared');
     setMessages([]);
     // Clear and reinitialize session
     sessionManagerRef.current?.clearSession();
@@ -1091,6 +1113,7 @@ export const Chat = React.forwardRef<any, ChatProps>((props, ref) => {
                 value={inputValue}
                 onChange={setInputValue}
                 onSubmit={handleSendMessage}
+                onCancel={handleStopStreaming}
                 placeholder={placeholder}
                 loading={isLoading}
                 styles={{

--- a/webchat/packages/webchat-ui/src/streamLifecycle.ts
+++ b/webchat/packages/webchat-ui/src/streamLifecycle.ts
@@ -1,0 +1,224 @@
+/** A token proving ownership of the stream that may update Chat state. */
+export interface StreamLease {
+  readonly id: number;
+  readonly signal?: AbortSignal;
+}
+
+/** The ReadableStream cleanup surface owned by StreamLifecycle. */
+export interface StreamReader {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(reason?: unknown): Promise<void>;
+  releaseLock(): void;
+}
+
+interface ActiveStream extends StreamLease {
+  controller: AbortController | null;
+  reader: StreamReader | null;
+}
+
+type AbortControllerFactory = () => AbortController | null;
+/** A finite reason recorded when an owned stream is cancelled. */
+export type StreamCancelReason =
+  | 'replaced-by-new-stream'
+  | 'stale-stream'
+  | 'component-unmounted'
+  | 'user-stopped'
+  | 'session-cleared';
+
+const createAbortController: AbortControllerFactory = () =>
+  typeof AbortController === 'undefined' ? null : new AbortController();
+
+/** Returns whether an unknown failure represents expected stream cancellation. */
+export function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === 'AbortError'
+  );
+}
+
+/** Converts an unknown stream failure into the public onError contract. */
+export function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error(typeof error === 'string' ? error : 'Unknown stream error');
+}
+
+/**
+ * Owns the single stream that may mutate a Chat instance.
+ *
+ * AbortController releases the network request when the runtime supports it.
+ * The lease check remains the correctness boundary: stale streams cannot write
+ * even when an older fetch implementation ignores AbortSignal.
+ */
+export class StreamLifecycle {
+  private active: ActiveStream | null = null;
+  private mounted = false;
+  private nextId = 0;
+
+  /** Creates a lifecycle with an optional AbortController compatibility seam. */
+  public constructor(
+    private readonly abortControllerFactory: AbortControllerFactory = createAbortController
+  ) {}
+
+  /** Enables stream creation for the mounted Chat instance. */
+  public mount(): void {
+    this.mounted = true;
+  }
+
+  /** Starts a new lease and cancels any stream that previously owned state. */
+  public begin(): StreamLease | null {
+    if (!this.mounted) {
+      return null;
+    }
+
+    void this.cancel('replaced-by-new-stream');
+    const controller = this.abortControllerFactory();
+    const stream: ActiveStream = {
+      id: ++this.nextId,
+      signal: controller?.signal,
+      controller,
+      reader: null,
+    };
+    this.active = stream;
+    return stream;
+  }
+
+  /** Returns true only for the mounted instance's current stream lease. */
+  public isActive(stream: StreamLease): boolean {
+    return this.mounted && this.active === stream;
+  }
+
+  /** Attaches the response reader, cleaning it immediately if the lease is stale. */
+  public attachReader(stream: StreamLease, reader: StreamReader): boolean {
+    const active = this.active;
+    if (!this.mounted || active !== stream) {
+      void this.cancelReader(reader, 'stale-stream');
+      return false;
+    }
+
+    active.reader = reader;
+    return true;
+  }
+
+  /**
+   * Completes only the current lease. A stale stream cannot reset loading
+   * state owned by the stream that replaced it.
+   */
+  public complete(stream: StreamLease): boolean {
+    const active = this.active;
+    if (!this.mounted || active !== stream) {
+      return false;
+    }
+
+    const reader = active.reader;
+    active.reader = null;
+    this.active = null;
+    this.releaseReader(reader);
+    return true;
+  }
+
+  /**
+   * Deactivates synchronously, then finishes reader cleanup asynchronously.
+   * Callers do not need to await this method to stop stale state writes.
+   */
+  public cancel(reason: StreamCancelReason): Promise<void> {
+    const stream = this.active;
+    if (!stream) {
+      return Promise.resolve();
+    }
+
+    this.active = null;
+    stream.controller?.abort();
+    const reader = stream.reader;
+    stream.reader = null;
+    return reader ? this.cancelReader(reader, reason) : Promise.resolve();
+  }
+
+  /** Permanently deactivates the current mount and cancels its active stream. */
+  public dispose(): Promise<void> {
+    this.mounted = false;
+    return this.cancel('component-unmounted');
+  }
+
+  private async cancelReader(
+    reader: StreamReader,
+    reason: StreamCancelReason
+  ): Promise<void> {
+    try {
+      await reader.cancel(reason);
+    } catch {
+      // Fetch abort may already have errored the reader; releasing ownership is
+      // still sufficient and cleanup must never surface as a user-facing error.
+    } finally {
+      this.releaseReader(reader);
+    }
+  }
+
+  private releaseReader(reader: StreamReader | null): void {
+    if (!reader) {
+      return;
+    }
+
+    try {
+      reader.releaseLock();
+    } catch {
+      // A runtime may release an errored reader automatically.
+    }
+  }
+}
+
+/** Callbacks and request factory for one fully owned streaming request. */
+export interface OwnedStreamRun {
+  lifecycle: StreamLifecycle;
+  stream: StreamLease;
+  request: (signal?: AbortSignal) => Promise<Response>;
+  onChunk: (chunk: Uint8Array) => void;
+  onError: (error: Error) => void;
+  onComplete: () => void;
+}
+
+/**
+ * Runs fetch and reader consumption under one lease.
+ *
+ * Only the current lease may deliver chunks, surface errors, or complete UI
+ * state. Cancellation and stale-response reader cleanup are owned centrally.
+ */
+export async function runOwnedStream({
+  lifecycle,
+  stream,
+  request,
+  onChunk,
+  onError,
+  onComplete,
+}: OwnedStreamRun): Promise<void> {
+  try {
+    const response = await request(stream.signal);
+    if (!response.ok || !response.body) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+    if (!lifecycle.attachReader(stream, reader)) {
+      return;
+    }
+
+    while (lifecycle.isActive(stream)) {
+      const { done, value } = await reader.read();
+      if (done || !lifecycle.isActive(stream)) {
+        break;
+      }
+      onChunk(value);
+    }
+  } catch (error: unknown) {
+    if (!isAbortError(error) && lifecycle.isActive(stream)) {
+      onError(toError(error));
+    }
+  } finally {
+    if (lifecycle.complete(stream)) {
+      onComplete();
+    }
+  }
+}

--- a/webchat/tests/stream-lifecycle.issue-3556.test.mjs
+++ b/webchat/tests/stream-lifecycle.issue-3556.test.mjs
@@ -193,6 +193,16 @@ test('a new send owns state and prevents the replaced stream from completing it'
   assert.deepEqual(oldReader.cancelled, ['replaced-by-new-stream']);
 });
 
+test('Chat keeps the Sender cancellable until the owned response body closes', () => {
+  const source = fs.readFileSync(chatPath, 'utf8');
+  const activeHandlers = source.slice(
+    source.indexOf("case 'RUN_ERROR':"),
+    source.indexOf('// Add message to state and session')
+  );
+
+  assert.equal(activeHandlers.includes('setIsLoading(false)'), false);
+});
+
 test('clearing a session or pressing stop cancels without producing an error', async () => {
   for (const reason of ['session-cleared', 'user-stopped']) {
     const lifecycle = new StreamLifecycle(fakeAbortController);

--- a/webchat/tests/stream-lifecycle.issue-3556.test.mjs
+++ b/webchat/tests/stream-lifecycle.issue-3556.test.mjs
@@ -1,0 +1,292 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const lifecyclePath = path.join(
+  rootDir,
+  'packages/webchat-ui/src/streamLifecycle.ts'
+);
+const chatPath = path.join(rootDir, 'packages/webchat-ui/src/Chat.tsx');
+const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webchat-stream-lifecycle-'));
+const outputPath = path.join(outputDir, 'streamLifecycle.mjs');
+const compiled = ts.transpileModule(fs.readFileSync(lifecyclePath, 'utf8'), {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2020,
+    target: ts.ScriptTarget.ES2020,
+  },
+  fileName: lifecyclePath,
+});
+fs.writeFileSync(outputPath, compiled.outputText);
+process.on('exit', () => fs.rmSync(outputDir, { recursive: true, force: true }));
+
+const { isAbortError, runOwnedStream, StreamLifecycle, toError } =
+  await import(pathToFileURL(outputPath));
+
+class FakeReader {
+  cancelled = [];
+  releaseCount = 0;
+
+  async read() {
+    return { done: true, value: undefined };
+  }
+
+  async cancel(reason) {
+    this.cancelled.push(reason);
+  }
+
+  releaseLock() {
+    this.releaseCount += 1;
+  }
+}
+
+function fakeAbortController() {
+  return {
+    signal: { aborted: false },
+    abort() {
+      this.signal.aborted = true;
+    },
+  };
+}
+
+test('Chat wires stream ownership into every lifecycle boundary', () => {
+  const source = fs.readFileSync(chatPath, 'utf8');
+  for (const fragment of [
+    'runOwnedStream({',
+    'request: (signal) =>',
+    '...(signal ? { signal } : {})',
+    'streamLifecycle?.dispose()',
+    "cancel('session-cleared')",
+    'onCancel={handleStopStreaming}',
+  ]) {
+    assert.ok(source.includes(fragment), `Chat is missing lifecycle wiring: ${fragment}`);
+  }
+});
+
+test('normal completion keeps the active stream writable and releases its reader', async () => {
+  const lifecycle = new StreamLifecycle(fakeAbortController);
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode('normal-response'));
+      controller.close();
+    },
+  });
+  const chunks = [];
+  const errors = [];
+  let completed = 0;
+  let receivedSignal;
+  lifecycle.mount();
+
+  const stream = lifecycle.begin();
+  assert.ok(stream);
+  await runOwnedStream({
+    lifecycle,
+    stream,
+    request: async (signal) => {
+      receivedSignal = signal;
+      return new Response(body);
+    },
+    onChunk: (chunk) => chunks.push(new TextDecoder().decode(chunk)),
+    onError: (error) => errors.push(error),
+    onComplete: () => {
+      completed += 1;
+    },
+  });
+
+  assert.equal(receivedSignal, stream.signal);
+  assert.deepEqual(chunks, ['normal-response']);
+  assert.deepEqual(errors, []);
+  assert.equal(completed, 1);
+  assert.equal(lifecycle.isActive(stream), false);
+  assert.doesNotThrow(() => {
+    const nextReader = body.getReader();
+    nextReader.releaseLock();
+  });
+});
+
+test('unmount deactivates synchronously and cancels the active reader', async () => {
+  const lifecycle = new StreamLifecycle(fakeAbortController);
+  const reader = new FakeReader();
+  lifecycle.mount();
+
+  const stream = lifecycle.begin();
+  assert.ok(stream);
+  lifecycle.attachReader(stream, reader);
+  const cleanup = lifecycle.dispose();
+
+  assert.equal(lifecycle.isActive(stream), false);
+  assert.equal(stream.signal.aborted, true);
+  await cleanup;
+  assert.deepEqual(reader.cancelled, ['component-unmounted']);
+  assert.equal(reader.releaseCount, 1);
+  assert.equal(lifecycle.begin(), null);
+});
+
+test('a pending ReadableStream cannot write after the component unmounts', async () => {
+  const lifecycle = new StreamLifecycle();
+  const encoder = new TextEncoder();
+  const writes = [];
+  let sourceController;
+  let resolveFirstWrite;
+  const firstWrite = new Promise((resolve) => {
+    resolveFirstWrite = resolve;
+  });
+  const body = new ReadableStream({
+    start(controller) {
+      sourceController = controller;
+    },
+  });
+
+  lifecycle.mount();
+  const stream = lifecycle.begin();
+  assert.ok(stream);
+  const errors = [];
+  let completed = 0;
+  const consuming = runOwnedStream({
+    lifecycle,
+    stream,
+    request: async () => new Response(body),
+    onChunk: (value) => {
+      writes.push(new TextDecoder().decode(value));
+      resolveFirstWrite();
+    },
+    onError: (error) => errors.push(error),
+    onComplete: () => {
+      completed += 1;
+    },
+  });
+
+  sourceController.enqueue(encoder.encode('first'));
+  await firstWrite;
+  await lifecycle.dispose();
+  await consuming;
+
+  assert.deepEqual(writes, ['first']);
+  assert.deepEqual(errors, []);
+  assert.equal(completed, 0);
+  assert.doesNotThrow(() => {
+    const nextReader = body.getReader();
+    nextReader.releaseLock();
+  });
+});
+
+test('a new send owns state and prevents the replaced stream from completing it', async () => {
+  const lifecycle = new StreamLifecycle(fakeAbortController);
+  const oldReader = new FakeReader();
+  lifecycle.mount();
+
+  const oldStream = lifecycle.begin();
+  assert.ok(oldStream);
+  lifecycle.attachReader(oldStream, oldReader);
+  const newStream = lifecycle.begin();
+  assert.ok(newStream);
+
+  assert.equal(lifecycle.isActive(oldStream), false);
+  assert.equal(lifecycle.isActive(newStream), true);
+  assert.equal(lifecycle.complete(oldStream), false);
+  await Promise.resolve();
+  assert.deepEqual(oldReader.cancelled, ['replaced-by-new-stream']);
+});
+
+test('clearing a session or pressing stop cancels without producing an error', async () => {
+  for (const reason of ['session-cleared', 'user-stopped']) {
+    const lifecycle = new StreamLifecycle(fakeAbortController);
+    const reader = new FakeReader();
+    lifecycle.mount();
+
+    const stream = lifecycle.begin();
+    assert.ok(stream);
+    lifecycle.attachReader(stream, reader);
+    await lifecycle.cancel(reason);
+
+    assert.equal(lifecycle.isActive(stream), false);
+    assert.deepEqual(reader.cancelled, [reason]);
+    assert.equal(reader.releaseCount, 1);
+  }
+});
+
+test('AbortError stays silent while ordinary request errors reach the UI contract', async () => {
+  const abortLifecycle = new StreamLifecycle(fakeAbortController);
+  const abortErrors = [];
+  let abortCompleted = 0;
+  abortLifecycle.mount();
+  const abortStream = abortLifecycle.begin();
+  assert.ok(abortStream);
+
+  await runOwnedStream({
+    lifecycle: abortLifecycle,
+    stream: abortStream,
+    request: async () => {
+      throw { name: 'AbortError' };
+    },
+    onChunk: () => undefined,
+    onError: (error) => abortErrors.push(error),
+    onComplete: () => {
+      abortCompleted += 1;
+    },
+  });
+
+  assert.deepEqual(abortErrors, []);
+  assert.equal(abortCompleted, 1);
+
+  const failedLifecycle = new StreamLifecycle(fakeAbortController);
+  const failedErrors = [];
+  let failedCompleted = 0;
+  failedLifecycle.mount();
+  const failedStream = failedLifecycle.begin();
+  assert.ok(failedStream);
+
+  await runOwnedStream({
+    lifecycle: failedLifecycle,
+    stream: failedStream,
+    request: async () => {
+      throw 'network failed';
+    },
+    onChunk: () => undefined,
+    onError: (error) => failedErrors.push(error.message),
+    onComplete: () => {
+      failedCompleted += 1;
+    },
+  });
+
+  assert.deepEqual(failedErrors, ['network failed']);
+  assert.equal(failedCompleted, 1);
+  assert.equal(isAbortError({ name: 'AbortError' }), true);
+  assert.equal(isAbortError(new Error('network failed')), false);
+  assert.equal(toError({ code: 'E_STREAM' }).message, 'Unknown stream error');
+});
+
+test('runtimes without AbortController still enforce ownership and reader cleanup', async () => {
+  const lifecycle = new StreamLifecycle(() => null);
+  const reader = new FakeReader();
+  lifecycle.mount();
+
+  const stream = lifecycle.begin();
+  assert.ok(stream);
+  assert.equal(stream.signal, undefined);
+  lifecycle.attachReader(stream, reader);
+  await lifecycle.cancel('user-stopped');
+
+  assert.equal(lifecycle.isActive(stream), false);
+  assert.equal(reader.releaseCount, 1);
+});
+
+test('a reader arriving after its lease was cancelled is cleaned up immediately', async () => {
+  const lifecycle = new StreamLifecycle(fakeAbortController);
+  const reader = new FakeReader();
+  lifecycle.mount();
+
+  const stream = lifecycle.begin();
+  assert.ok(stream);
+  await lifecycle.cancel('session-cleared');
+
+  assert.equal(lifecycle.attachReader(stream, reader), false);
+  await Promise.resolve();
+  assert.deepEqual(reader.cancelled, ['stale-stream']);
+  assert.equal(reader.releaseCount, 1);
+});


### PR DESCRIPTION
## 关联 Issue

Closes #3556

## 问题

`Chat` 的 POST SSE 响应本应只允许当前组件、当前会话的唯一活动流写入消息和 loading 状态。此前网络请求、reader 与 React 生命周期彼此独立：关闭浮窗、清空会话或后续发送后，旧流仍可能继续消费数据，并把旧响应写入后续界面。

## 根因（设计层）

实现只有一个持续读取的异步循环，没有“谁拥有当前状态”的身份边界。仅靠 `AbortController` 也不足以守住契约，因为旧浏览器或部分 fetch 实现可能忽略取消信号；需要同时具备网络取消和状态写入租约。

## 怎么修的

- 新增 `StreamLifecycle`，用单调租约标识唯一可写的活动流。
- 新发送会同步使旧租约失效，并在运行时支持时中止旧 fetch。
- `runOwnedStream` 统一管理 request、reader、每次异步读取后的租约检查、错误分流和完成回调。
- 组件卸载、清空会话和 Sender 主动停止都会取消当前 reader；正常完成与取消路径均释放 reader lock。
- `AbortError` 作为预期取消静默处理，普通错误仍进入 `onError`；只有当前租约能复位 loading/thinking。
- 删除失效的 npm `cache=false` 配置，使本 PR 的独立 Node 行为测试可从 WebChat 根目录执行。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["handleSendMessage / Sender stop\nChat.tsx"]
        T2["FloatingButton close / session clear\nChat cleanup"]
    end

    subgraph O["流所有权层"]
        O1["StreamLifecycle.begin\n创建唯一租约"]
        O2["runOwnedStream\n校验租约并消费 reader"]
        O3["cancel / dispose\n同步使旧租约失效"]
    end

    subgraph N["网络与状态层"]
        N1["fetch POST SSE\n可选 AbortSignal"]
        N2["ReadableStream reader\ncancel + releaseLock"]
        N3["AG-UI / legacy callbacks\n更新消息和 session"]
    end

    T1 --> O1 --> N1 --> O2 --> N2 --> N3
    T1 -. "再次发送/主动停止" .-> O3
    T2 -. "卸载/清会话" .-> O3
    O3 -. "abort/cancel" .-> N1
    O3 -. "阻止旧写入" .-> O2
```

## 影响范围与兼容性

- 仅涉及 `webchat` 的 Chat 流生命周期与测试入口；不修改服务端协议、公共 props、会话结构或持久化格式。
- 支持没有 `AbortController` 的旧运行时：不传 signal，但租约仍阻止旧流写入并清理 reader。
- 与 #4423 的 `.npmrc` 删除完全相同；若其先合入，rebase 时该行会自然消解。两 PR 都修改 `package.json` 的 `test` 行，合并时应同时保留 core 与 stream lifecycle 两组行为测试。

## 验证

- 当前 master 的真实 ReadableStream 场景在首块后模拟卸载，命中 `stale-after-unmount` RED。
- `webchat/tests/stream-lifecycle.issue-3556.test.mjs`：Node 18、20、24 均通过；当前共 9 项行为测试。
- 回退 unmount 的 mounted ownership 后，同一测试 8/9，通过恢复修复后回到 9/9。
- `npm run build:ui`：Vite 1320 modules + TypeScript declaration 构建通过。
- `npm run build:browser`：4357 modules 构建通过。
- 全量 build 的 core/UI 通过；demo 仍被未修改的 `chat-wrapper.tsx` / `FloatingButton` props 历史类型错误阻塞，公共声明相对基线无变化。

## 三轨门禁

- Standards：PASS，0 findings。
- Spec：PASS，0 findings。
- Runtime Contract：PASS；卸载、清会话、再次发送、主动停止、错误分流、reader cleanup、旧运行时兼容均有新鲜运行证据。
- 质量评分：92 / 100，SCORE_PASS。
