### PR TITLE
bugfix: 收口微信用户注册 NATS 入口

### DIFF
--- a/server/apps/system_mgmt/nats/wechat.py
+++ b/server/apps/system_mgmt/nats/wechat.py
@@ -6,7 +6,6 @@ from .common import _build_jwt_payload
 from .users import set_opspilot_guest_group_default_rule
 
 
-@nats_client.register
 def wechat_user_register(user_id, nick_name):
     with transaction.atomic():
         user, is_first_login = User.objects.select_for_update().get_or_create(

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers.py
@@ -15,7 +15,7 @@ from apps.system_mgmt import nats_api
 from apps.system_mgmt.models import App, Channel, Group, GroupDataRule, Menu, Role, User
 from apps.system_mgmt.models.channel import ChannelChoices
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 def test_nats_api_compat_exports_local_and_nats_entrypoints():
@@ -69,6 +69,7 @@ def test_nats_api_compat_exports_local_and_nats_entrypoints():
         "_list_opspilot_nats_channels",
         "create_default_rule",
         "bk_lite_user_login",
+        "wechat_user_register",
         "get_group_users",
         "get_group_users_scoped",
         "get_all_users",

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -1,4 +1,4 @@
-"""apps/system_mgmt/nats_api.py 处理函数单元测试。
+"""apps/system_mgmt/nats_api.py 处理函数服务层测试。
 
 nats handler 直接可调用（@nats_client.register 返回原函数）。
 只 mock 真实外部边界（cache、send_msg、jwt token 验证等），断言真实 DB 行为与返回结构。

--- a/server/apps/system_mgmt/tests/test_wechat_registration_boundary_service.py
+++ b/server/apps/system_mgmt/tests/test_wechat_registration_boundary_service.py
@@ -1,15 +1,19 @@
+import asyncio
+
 import pytest
 
 import nats_client
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt import nats_api
 from apps.system_mgmt.models import User
+from nats_client.handlers import nats_handler
+from nats_client.management.commands import nats_listener
 
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 def test_wechat_user_register_keeps_local_app_client_path(monkeypatch):
-    monkeypatch.setattr(nats_api._wechat, "_build_jwt_payload", lambda user_id: {"user_id": user_id})
+    monkeypatch.setattr(nats_api, "_build_jwt_payload", lambda user_id: {"user_id": user_id})
     monkeypatch.setattr(nats_api._wechat.jwt, "encode", lambda **kwargs: "local-wechat-token")
 
     result = SystemMgmt().wechat_user_register("wechat-local-user", "WeChat Local User")
@@ -18,3 +22,30 @@ def test_wechat_user_register_keeps_local_app_client_path(monkeypatch):
     assert result["data"]["token"] == "local-wechat-token"
     assert User.objects.filter(username="wechat-local-user").exists()
     assert "bklite.wechat_user_register" not in nats_client.registry.default_registry.registry
+
+
+def test_nats_listener_and_dispatch_reject_wechat_user_register(monkeypatch, settings):
+    subscribed = []
+
+    class FakeNats:
+        async def subscribe(self, subject, queue, cb):
+            subscribed.append(subject)
+
+    async def fake_get_nc_client(client):
+        return client
+
+    monkeypatch.setattr(nats_listener, "get_nc_client", fake_get_nc_client)
+    settings.NATS_JETSTREAM_ENABLED = False
+    command = nats_listener.Command()
+    command.nats = FakeNats()
+
+    asyncio.run(command.nats_coroutine())
+
+    assert "bklite.wechat_user_register" not in subscribed
+    with pytest.raises(ValueError, match="No function found"):
+        asyncio.run(
+            nats_handler(
+                "bklite.wechat_user_register",
+                {"args": ["remote-user", "Remote User"], "kwargs": {}},
+            )
+        )

--- a/server/apps/system_mgmt/tests/test_wechat_registration_boundary_service.py
+++ b/server/apps/system_mgmt/tests/test_wechat_registration_boundary_service.py
@@ -1,0 +1,20 @@
+import pytest
+
+import nats_client
+from apps.rpc.system_mgmt import SystemMgmt
+from apps.system_mgmt import nats_api
+from apps.system_mgmt.models import User
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+def test_wechat_user_register_keeps_local_app_client_path(monkeypatch):
+    monkeypatch.setattr(nats_api._wechat, "_build_jwt_payload", lambda user_id: {"user_id": user_id})
+    monkeypatch.setattr(nats_api._wechat.jwt, "encode", lambda **kwargs: "local-wechat-token")
+
+    result = SystemMgmt().wechat_user_register("wechat-local-user", "WeChat Local User")
+
+    assert result["result"] is True
+    assert result["data"]["token"] == "local-wechat-token"
+    assert User.objects.filter(username="wechat-local-user").exists()
+    assert "bklite.wechat_user_register" not in nats_client.registry.default_registry.registry

--- a/specs/capabilities/legacy-ard-modules-system-mgmt.md
+++ b/specs/capabilities/legacy-ard-modules-system-mgmt.md
@@ -26,6 +26,9 @@ DRF Router 注册 13 个路由组：`group`/`user`/`role`/`channel`/`group_data_
 
 ## 4. 认证与权限【已实现/已存在】
 - 真实 NATS handler 分布在 `nats/auth.py`、`nats/login.py`、`nats/otp.py`、`nats/settings.py`、`nats/wechat.py`、`nats/users.py` 等子模块；`nats_api.py` 现为旧导入路径兼容导出层，会同步 `_verify_token`、`_build_jwt_payload`、`create_challenge` 等 legacy helper，再转发到真实 handler。
+- `wechat_user_register` 只保留为同进程兼容导出：旧微信 HTTP 入口先校验微信 code，再由 `SystemMgmt` 的本地 `AppClient` 调用；它不注册为 NATS subject，远程请求按“无订阅者/无 handler”失败。
+- 仓库内 `server`、`web`、`agents`、`algorithms`、`mobile`、部署模板、配置样例和测试未发现该 subject 的合法远程生产者；部署若有仓外消费者，升级前须迁移到已校验 code 的 HTTP 登录链路。
+- 此边界调整不迁移数据库或角色数据，也不改变本地函数参数和响应。紧急回滚时可恢复 `nats/wechat.py` 的注册装饰器；回滚会重新暴露未校验调用方身份的入口，只可作为短期止血。
 - JWT（含 jti/exp）、OTP（二维码/挑战/限频）、token 黑名单。
 - 角色继承：`get_user_all_roles` 沿 `parent_id`+`allow_inherit_roles` 递归汇总；权限缓存 TTL 由 `PERMISSION_CACHE_TTL` 配置（默认 600s），token 信息缓存 TTL 由 `TOKEN_INFO_CACHE_TTL` 配置（默认 60s）。
 - 密码策略：`utils/password_validator.py`（失败锁定）。


### PR DESCRIPTION
## 问题

`wechat_user_register` 同时承担本进程用户注册能力和 NATS 远程入口。远程入口没有可信调用方身份，拥有对应 namespace 发布能力的客户端可以绕过微信 code 校验，直接创建访客用户并取得 JWT。

## 根因

本地函数与远程传输注册共用了同一个装饰器。合法微信登录需要的是同进程函数能力，但装饰器额外将其暴露为远程 subject；消息参数中也没有可验证的调用服务身份。

## 怎么修的

- 保留 `wechat_user_register` 的函数签名、事务、用户/角色初始化和 JWT 返回结构。
- 保留 `apps.system_mgmt.nats_api` 兼容导出，以及 `SystemMgmt` 固定使用 `AppClient` 的本地调用路径。
- 仅取消该函数的 NATS 注册，使未认证的远程请求不再有订阅者。

## 影响范围、迁移与回滚

- 已扫描 server、agents、web、部署模板和测试：仓库内没有远程 NATS 调用方；两个 Web 微信入口都调用同一个 core HTTP 接口，后端验证微信 code 后通过本地 `AppClient` 注册用户。
- 升级后 `bklite.wechat_user_register` 不再提供远程响应。若部署存在仓库外消费者，需要在升级前迁移到受验证的 HTTP 登录链路；PR 保留人工兼容性 Review 门禁。
- 不改数据库、持久数据、HTTP API、函数参数或响应结构。回滚时恢复该函数的 NATS 注册装饰器即可。
- 修复沿用已合并 PR #4384 的“保留本地能力、收口远程注册”架构。

## 调用链

```mermaid
flowchart TD
    subgraph W["合法 Web 登录（保留）"]
        WEB["Web 微信入口"]
        HTTP["wechat_login\ncore/views/index_view.py"]
        VERIFY["verify_wechat_code"]
        APP["SystemMgmt + AppClient"]
        LOCAL["wechat_user_register\nsystem_mgmt/nats/wechat.py"]
        DB["创建或读取用户并初始化角色"]
        JWT["签发 JWT"]
        WEB --> HTTP --> VERIFY --> APP --> LOCAL --> DB --> JWT
    end

    subgraph N["远程 NATS 路径（收口）"]
        CLIENT["NATS 客户端"]
        REGISTRY["NATS Registry"]
        CLIENT --> REGISTRY
        REGISTRY -. "不再注册该 subject" .-> LOCAL
    end
```

## 验证

- 修复前，新增注册边界测试命中 `wechat_user_register` 仍在 registry：1 failed。
- `apps/system_mgmt/tests/test_nats_api_handlers.py`、`apps/system_mgmt/tests/test_wechat_registration_boundary_service.py`、`apps/system_mgmt/tests/test_permission_version_invalidation.py`、`apps/rpc/tests/test_system_mgmt_forwarding.py`、`apps/core/tests/views/test_wechat_login.py`：90 passed。
- 测试覆盖 NATS subject 不可达、`SystemMgmt` 本地创建用户并返回 JWT、RPC 转发、注册事务以及旧微信 HTTP 成功/失败路径。
- `git diff --check`：通过。

## 三轨门禁

- Standards：PASS。安全边界的调用方盘点、迁移、回滚和测试分层已明确。
- Spec：PASS。消除未认证远程入口，同时保留合法旧微信登录。
- Runtime Contract：PASS。监听器只订阅 registry 项；专项 PostgreSQL 测试证明修后 subject 不在 registry，而本地用户/JWT 副作用仍成功。

关联 Issue #3984。
