### PR TITLE
bugfix: 收紧管理员引导凭据边界

### DIFF
--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -4,6 +4,7 @@
 """
 
 import os
+import secrets
 
 from django.apps import apps as django_apps
 from django.core.management import call_command
@@ -104,7 +105,7 @@ class Command(BaseCommand):
     @staticmethod
     def _get_admin_password() -> str:
         admin_password = os.getenv("BK_INIT_ADMIN_PASSWORD", "").strip()
-        return admin_password or "password"
+        return admin_password or secrets.token_urlsafe(32)
 
     def _init_cmdb(self):
         """CMDB资源初始化"""

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import secrets
 
 from django.apps import apps as django_apps
 from django.core.management import call_command
@@ -120,7 +121,7 @@ class Command(BaseCommand):
     @staticmethod
     def _get_admin_password() -> str:
         admin_password = os.getenv("BK_INIT_ADMIN_PASSWORD", "").strip()
-        return admin_password or "password"
+        return admin_password or secrets.token_urlsafe(32)
 
     def _init_cmdb(self):
         """CMDB资源初始化"""

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -5,7 +5,7 @@
 
 import logging
 import os
-import secrets
+from pathlib import Path
 
 from django.apps import apps as django_apps
 from django.core.management import call_command
@@ -109,19 +109,66 @@ class Command(BaseCommand):
     def _init_system_mgmt(self):
         """系统管理资源初始化"""
         self.stdout.write("系统管理资源初始化...")
-        admin_password = self._get_admin_password()
+        migrate_existing_password = self._should_migrate_admin_password()
+        managed_password_configured = self._has_managed_admin_password()
+        if self._admin_exists() and not migrate_existing_password:
+            # create_user 对存量用户是 no-op；不读取可选 Secret，避免坏挂载扩大启动失败面。
+            admin_password = "password"
+        else:
+            admin_password = self._get_admin_password()
         call_command("cleanup_opspilot_legacy_knowledge_menus")
         call_command("init_realm_resource")
         call_command("init_login_settings")
-        call_command("create_user", "admin", admin_password, email="admin@bklite.net", is_superuser=True)
+        call_command(
+            "create_user",
+            "admin",
+            admin_password,
+            email="admin@bklite.net",
+            is_superuser=True,
+            temporary_password=managed_password_configured,
+            update_existing_password=migrate_existing_password,
+        )
         call_command("init_custom_menu")
         call_command("init_bk_login_settings")
         call_command("clean_group_data")
 
     @staticmethod
+    def _admin_exists() -> bool:
+        user_model = django_apps.get_model("system_mgmt", "User")
+        return user_model.objects.filter(username="admin", domain="domain.com").exists()
+
+    @staticmethod
+    def _has_managed_admin_password() -> bool:
+        return bool(os.getenv("BK_INIT_ADMIN_PASSWORD", "").strip() or os.getenv("BK_INIT_ADMIN_PASSWORD_FILE", "").strip())
+
+    @staticmethod
     def _get_admin_password() -> str:
         admin_password = os.getenv("BK_INIT_ADMIN_PASSWORD", "").strip()
-        return admin_password or secrets.token_urlsafe(32)
+        if admin_password:
+            return admin_password
+
+        password_file = os.getenv("BK_INIT_ADMIN_PASSWORD_FILE", "").strip()
+        if not password_file:
+            # 保留未迁移部署的既有行为；生产部署应先挂载 Secret 文件，再显式启用迁移。
+            return "password"
+        try:
+            password = Path(password_file).read_text(encoding="utf-8").strip()
+        except OSError as error:
+            raise CommandError(f"无法读取管理员密码 Secret 文件: {type(error).__name__}") from error
+        if not password:
+            raise CommandError("管理员密码 Secret 文件不能为空")
+        return password
+
+    @staticmethod
+    def _should_migrate_admin_password() -> bool:
+        value = os.getenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", "").strip().lower()
+        if value in {"", "false", "0", "no"}:
+            return False
+        if value in {"true", "1", "yes"}:
+            if not Command._has_managed_admin_password():
+                raise CommandError("迁移既有管理员密码必须配置 BK_INIT_ADMIN_PASSWORD 或 BK_INIT_ADMIN_PASSWORD_FILE")
+            return True
+        raise CommandError("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING 仅支持 true/false")
 
     def _init_cmdb(self):
         """CMDB资源初始化"""

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -14,6 +14,7 @@ from django.core.management.base import BaseCommand, CommandError
 from apps.core.utils.loader import preload_language_cache
 
 logger = logging.getLogger("app")
+_ADMIN_PASSWORD_FILE_MAX_CHARS = 4096
 
 
 class Command(BaseCommand):
@@ -110,24 +111,21 @@ class Command(BaseCommand):
         """系统管理资源初始化"""
         self.stdout.write("系统管理资源初始化...")
         migrate_existing_password = self._should_migrate_admin_password()
-        managed_password_configured = self._has_managed_admin_password()
-        if self._admin_exists() and not migrate_existing_password:
-            # create_user 对存量用户是 no-op；不读取可选 Secret，避免坏挂载扩大启动失败面。
-            admin_password = "password"
-        else:
+        should_bootstrap_password = not self._admin_exists() or migrate_existing_password
+        if should_bootstrap_password:
             admin_password = self._get_admin_password()
         call_command("cleanup_opspilot_legacy_knowledge_menus")
         call_command("init_realm_resource")
         call_command("init_login_settings")
-        call_command(
-            "create_user",
-            "admin",
-            admin_password,
-            email="admin@bklite.net",
-            is_superuser=True,
-            temporary_password=managed_password_configured,
-            update_existing_password=migrate_existing_password,
-        )
+        if should_bootstrap_password:
+            call_command(
+                "create_user",
+                "admin",
+                admin_password,
+                email="admin@bklite.net",
+                is_superuser=True,
+                update_existing_password=migrate_existing_password,
+            )
         call_command("init_custom_menu")
         call_command("init_bk_login_settings")
         call_command("clean_group_data")
@@ -149,12 +147,15 @@ class Command(BaseCommand):
 
         password_file = os.getenv("BK_INIT_ADMIN_PASSWORD_FILE", "").strip()
         if not password_file:
-            # 保留未迁移部署的既有行为；生产部署应先挂载 Secret 文件，再显式启用迁移。
-            return "password"
+            raise CommandError("初始化管理员必须配置 BK_INIT_ADMIN_PASSWORD 或 BK_INIT_ADMIN_PASSWORD_FILE")
         try:
-            password = Path(password_file).read_text(encoding="utf-8").strip()
-        except OSError as error:
+            with Path(password_file).open(encoding="utf-8") as file:
+                password = file.read(_ADMIN_PASSWORD_FILE_MAX_CHARS + 1)
+        except (OSError, UnicodeError) as error:
             raise CommandError(f"无法读取管理员密码 Secret 文件: {type(error).__name__}") from error
+        if len(password) > _ADMIN_PASSWORD_FILE_MAX_CHARS:
+            raise CommandError("管理员密码 Secret 文件内容过大")
+        password = password.strip()
         if not password:
             raise CommandError("管理员密码 Secret 文件不能为空")
         return password

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from django.apps import apps as django_apps
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
 
 from apps.core.utils.loader import preload_language_cache
 
@@ -110,14 +111,20 @@ class Command(BaseCommand):
     def _init_system_mgmt(self):
         """系统管理资源初始化"""
         self.stdout.write("系统管理资源初始化...")
-        migrate_existing_password = self._should_migrate_admin_password()
-        should_bootstrap_password = not self._admin_exists() or migrate_existing_password
-        if should_bootstrap_password:
-            admin_password = self._get_admin_password()
         call_command("cleanup_opspilot_legacy_knowledge_menus")
         call_command("init_realm_resource")
         call_command("init_login_settings")
-        if should_bootstrap_password:
+        self._bootstrap_admin()
+        call_command("init_custom_menu")
+        call_command("init_bk_login_settings")
+        call_command("clean_group_data")
+
+    def _bootstrap_admin(self) -> None:
+        migrate_existing_password = self._should_migrate_admin_password()
+        with transaction.atomic():
+            if self._any_admin_username_exists() and not migrate_existing_password:
+                return
+            admin_password = self._get_admin_password()
             call_command(
                 "create_user",
                 "admin",
@@ -126,14 +133,13 @@ class Command(BaseCommand):
                 is_superuser=True,
                 update_existing_password=migrate_existing_password,
             )
-        call_command("init_custom_menu")
-        call_command("init_bk_login_settings")
-        call_command("clean_group_data")
 
     @staticmethod
-    def _admin_exists() -> bool:
+    def _any_admin_username_exists() -> bool:
         user_model = django_apps.get_model("system_mgmt", "User")
-        return user_model.objects.filter(username="admin", domain="domain.com").exists()
+        # create_user 历史上对任意域的同名用户均 no-op；这里保持同一存量判定，
+        # 避免仅有外域 admin 的合法升级环境被新 Secret 门禁意外阻断。
+        return user_model.objects.select_for_update().filter(username="admin").exists()
 
     @staticmethod
     def _has_managed_admin_password() -> bool:

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -146,12 +146,19 @@ class TestHandleDispatch:
 
     def test_system_mgmt_creates_admin_with_resolved_password(self, calls, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        entropy_sizes = []
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
+        )
         cmd = _make_command()
         cmd.handle(apps="system_mgmt", continue_on_error=False)
         create_user = [c for c in calls if c[0] == "create_user"]
         assert len(create_user) == 1
         _, args, kwargs = create_user[0]
-        assert args == ("admin", "password")
+        assert args == ("admin", "s" * 43)
+        assert entropy_sizes == [32]
         assert kwargs.get("is_superuser") is True
 
     def test_system_mgmt_runs_opspilot_legacy_menu_cleanup_before_realm_resource(self, calls):
@@ -236,15 +243,39 @@ class TestErrorHandlingPolicy:
 class TestGetAdminPassword:
     def test_env_password_used_when_set(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "  s3cret  ")
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda _byte_count: pytest.fail("显式密码不应调用随机源"),
+        )
         assert bi.Command._get_admin_password() == "s3cret"
 
-    def test_blank_env_falls_back_to_default(self, monkeypatch):
+    def test_blank_env_generates_secure_password(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "   ")
-        assert bi.Command._get_admin_password() == "password"
+        entropy_sizes = []
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
+        )
+        generated_password = bi.Command._get_admin_password()
+        assert generated_password == "s" * 43
+        assert entropy_sizes == [32]
 
-    def test_missing_env_falls_back_to_default(self, monkeypatch):
+    def test_missing_env_generates_unique_secure_passwords(self, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
-        assert bi.Command._get_admin_password() == "password"
+        entropy_sizes = []
+        generated_passwords = iter(("a" * 43, "b" * 43))
+
+        def generate_password(byte_count):
+            entropy_sizes.append(byte_count)
+            return next(generated_passwords)
+
+        monkeypatch.setattr(bi.secrets, "token_urlsafe", generate_password)
+        first_password = bi.Command._get_admin_password()
+        second_password = bi.Command._get_admin_password()
+        assert (first_password, second_password) == ("a" * 43, "b" * 43)
+        assert entropy_sizes == [32, 32]
 
 
 class TestPreloadLanguageCache:

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -51,6 +51,9 @@ def calls(monkeypatch):
 def _stub_critical_schema_gate(monkeypatch):
     monkeypatch.setattr(bi.Command, "_verify_critical_schema", lambda self: None)
     monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: False)
+    monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "Managed-Secret-1!")
+    monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
+    monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
 
 
 class TestHandleDispatch:
@@ -154,21 +157,26 @@ class TestHandleDispatch:
 
         assert [call[0] for call in calls][-1] == "reconcile_node_mgmt_sync"
 
-    def test_system_mgmt_legacy_config_keeps_existing_default(self, calls, monkeypatch):
+    def test_fresh_system_mgmt_without_managed_secret_fails_closed(self, calls, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
-        cmd = _make_command()
-        cmd.handle(apps="system_mgmt", continue_on_error=False)
-        create_user = [c for c in calls if c[0] == "create_user"]
-        assert len(create_user) == 1
-        _, args, kwargs = create_user[0]
-        assert args == ("admin", "password")
-        assert kwargs.get("is_superuser") is True
-        assert kwargs.get("temporary_password") is False
-        assert kwargs.get("update_existing_password") is False
+
+        with pytest.raises(CommandError, match="必须配置"):
+            _make_command().handle(apps="system_mgmt", continue_on_error=False)
+
+        assert not [call for call in calls if call[0] == "create_user"]
+
+    def test_fresh_system_mgmt_uses_explicit_managed_secret(self, calls):
+        _make_command().handle(apps="system_mgmt", continue_on_error=False)
+
+        create_user = [call for call in calls if call[0] == "create_user"]
+        assert create_user[0][1] == ("admin", "Managed-Secret-1!")
+        assert create_user[0][2]["update_existing_password"] is False
+        assert "temporary_password" not in create_user[0][2]
 
     def test_system_mgmt_secret_file_can_migrate_existing_admin(self, calls, monkeypatch, tmp_path):
+        monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: True)
         password_file = tmp_path / "admin-password"
         password_file.write_text("Generated-Secret-1!\n", encoding="utf-8")
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
@@ -179,10 +187,10 @@ class TestHandleDispatch:
 
         create_user = [c for c in calls if c[0] == "create_user"]
         assert create_user[0][1] == ("admin", "Generated-Secret-1!")
-        assert create_user[0][2]["temporary_password"] is True
+        assert "temporary_password" not in create_user[0][2]
         assert create_user[0][2]["update_existing_password"] is True
 
-    def test_existing_admin_without_migration_does_not_read_broken_secret_file(self, calls, monkeypatch, tmp_path):
+    def test_existing_admin_without_migration_skips_password_bootstrap(self, calls, monkeypatch, tmp_path):
         monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: True)
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(tmp_path / "missing-secret"))
@@ -190,9 +198,7 @@ class TestHandleDispatch:
 
         _make_command().handle(apps="system_mgmt", continue_on_error=False)
 
-        create_user = [c for c in calls if c[0] == "create_user"]
-        assert create_user[0][1] == ("admin", "password")
-        assert create_user[0][2]["update_existing_password"] is False
+        assert not [call for call in calls if call[0] == "create_user"]
 
     def test_system_mgmt_runs_opspilot_legacy_menu_cleanup_before_realm_resource(self, calls):
         cmd = _make_command()
@@ -356,10 +362,11 @@ class TestGetAdminPassword:
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "  s3cret  ")
         assert bi.Command._get_admin_password() == "s3cret"
 
-    def test_blank_env_without_file_keeps_legacy_fallback(self, monkeypatch):
+    def test_blank_env_without_file_fails_closed(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "   ")
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
-        assert bi.Command._get_admin_password() == "password"
+        with pytest.raises(CommandError, match="必须配置"):
+            bi.Command._get_admin_password()
 
     def test_missing_env_reads_secret_file(self, monkeypatch, tmp_path):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
@@ -374,6 +381,22 @@ class TestGetAdminPassword:
         password_file.write_text("\n", encoding="utf-8")
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
         with pytest.raises(CommandError, match="不能为空"):
+            bi.Command._get_admin_password()
+
+    def test_oversized_secret_file_fails_closed(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        password_file = tmp_path / "admin-password"
+        password_file.write_text("x" * 4097, encoding="utf-8")
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
+        with pytest.raises(CommandError, match="内容过大"):
+            bi.Command._get_admin_password()
+
+    def test_non_utf8_secret_file_fails_with_sanitized_error(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        password_file = tmp_path / "admin-password"
+        password_file.write_bytes(b"\xff")
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
+        with pytest.raises(CommandError, match="无法读取.*UnicodeDecodeError"):
             bi.Command._get_admin_password()
 
     def test_missing_secret_file_fails_closed_when_password_is_needed(self, monkeypatch, tmp_path):

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -7,6 +7,8 @@ call_command 序列 + 错误处理策略（默认失败即中断，启用 contin
 后继续执行并汇总失败）”。
 """
 
+from contextlib import nullcontext
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -16,6 +18,7 @@ import apps.core.management.commands.batch_init as bi
 
 pytestmark = pytest.mark.unit
 _verify_critical_schema = bi.Command._verify_critical_schema
+_any_admin_username_exists = bi.Command._any_admin_username_exists
 
 
 class _Style:
@@ -50,7 +53,8 @@ def calls(monkeypatch):
 @pytest.fixture(autouse=True)
 def _stub_critical_schema_gate(monkeypatch):
     monkeypatch.setattr(bi.Command, "_verify_critical_schema", lambda self: None)
-    monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: False)
+    monkeypatch.setattr(bi.Command, "_any_admin_username_exists", lambda _self: False)
+    monkeypatch.setattr(bi.transaction, "atomic", nullcontext)
     monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "Managed-Secret-1!")
     monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
     monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
@@ -176,7 +180,7 @@ class TestHandleDispatch:
         assert "temporary_password" not in create_user[0][2]
 
     def test_system_mgmt_secret_file_can_migrate_existing_admin(self, calls, monkeypatch, tmp_path):
-        monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: True)
+        monkeypatch.setattr(bi.Command, "_any_admin_username_exists", lambda _self: True)
         password_file = tmp_path / "admin-password"
         password_file.write_text("Generated-Secret-1!\n", encoding="utf-8")
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
@@ -191,7 +195,7 @@ class TestHandleDispatch:
         assert create_user[0][2]["update_existing_password"] is True
 
     def test_existing_admin_without_migration_skips_password_bootstrap(self, calls, monkeypatch, tmp_path):
-        monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: True)
+        monkeypatch.setattr(bi.Command, "_any_admin_username_exists", lambda _self: True)
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(tmp_path / "missing-secret"))
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
@@ -199,6 +203,31 @@ class TestHandleDispatch:
         _make_command().handle(apps="system_mgmt", continue_on_error=False)
 
         assert not [call for call in calls if call[0] == "create_user"]
+
+    def test_any_domain_admin_preserves_legacy_noop_without_secret(self, calls, monkeypatch, tmp_path):
+        monkeypatch.setattr(bi.Command, "_any_admin_username_exists", lambda _self: True)
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(tmp_path / "missing-secret"))
+
+        _make_command().handle(apps="system_mgmt", continue_on_error=False)
+
+        assert not [call for call in calls if call[0] == "create_user"]
+
+    def test_admin_existence_check_matches_legacy_cross_domain_scope(self, monkeypatch):
+        calls = []
+        queryset = SimpleNamespace(exists=lambda: calls.append("exists") or True)
+        manager = SimpleNamespace(filter=lambda **kwargs: calls.append(("filter", kwargs)) or queryset)
+        manager.select_for_update = lambda: calls.append("select_for_update") or manager
+        model = SimpleNamespace(objects=manager)
+        monkeypatch.setattr(bi.django_apps, "get_model", lambda *args: calls.append(("get_model", args)) or model)
+
+        assert _any_admin_username_exists() is True
+        assert calls == [
+            ("get_model", ("system_mgmt", "User")),
+            "select_for_update",
+            ("filter", {"username": "admin"}),
+            "exists",
+        ]
 
     def test_system_mgmt_runs_opspilot_legacy_menu_cleanup_before_realm_resource(self, calls):
         cmd = _make_command()
@@ -416,6 +445,14 @@ class TestGetAdminPassword:
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", "true")
         with pytest.raises(CommandError, match="必须配置"):
             bi.Command._should_migrate_admin_password()
+
+    def test_dev_password_remains_scoped_to_explicit_make_target(self):
+        makefile = (Path(__file__).resolve().parents[3] / "Makefile").read_text(encoding="utf-8")
+        setup_dev_user = makefile.split("setup-dev-user:", 1)[1].split("\n\n", 1)[0]
+
+        assert "DJANGO_SUPERUSER_PASSWORD=password" in setup_dev_user
+        assert "manage.py createsuperuser --noinput" in setup_dev_user
+        assert "batch_init" not in setup_dev_user
 
 
 class TestPreloadLanguageCache:

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -50,6 +50,7 @@ def calls(monkeypatch):
 @pytest.fixture(autouse=True)
 def _stub_critical_schema_gate(monkeypatch):
     monkeypatch.setattr(bi.Command, "_verify_critical_schema", lambda self: None)
+    monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: False)
 
 
 class TestHandleDispatch:
@@ -153,22 +154,45 @@ class TestHandleDispatch:
 
         assert [call[0] for call in calls][-1] == "reconcile_node_mgmt_sync"
 
-    def test_system_mgmt_creates_admin_with_resolved_password(self, calls, monkeypatch):
+    def test_system_mgmt_legacy_config_keeps_existing_default(self, calls, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
-        entropy_sizes = []
-        monkeypatch.setattr(
-            bi.secrets,
-            "token_urlsafe",
-            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
-        )
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
         cmd = _make_command()
         cmd.handle(apps="system_mgmt", continue_on_error=False)
         create_user = [c for c in calls if c[0] == "create_user"]
         assert len(create_user) == 1
         _, args, kwargs = create_user[0]
-        assert args == ("admin", "s" * 43)
-        assert entropy_sizes == [32]
+        assert args == ("admin", "password")
         assert kwargs.get("is_superuser") is True
+        assert kwargs.get("temporary_password") is False
+        assert kwargs.get("update_existing_password") is False
+
+    def test_system_mgmt_secret_file_can_migrate_existing_admin(self, calls, monkeypatch, tmp_path):
+        password_file = tmp_path / "admin-password"
+        password_file.write_text("Generated-Secret-1!\n", encoding="utf-8")
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", "true")
+
+        _make_command().handle(apps="system_mgmt", continue_on_error=False)
+
+        create_user = [c for c in calls if c[0] == "create_user"]
+        assert create_user[0][1] == ("admin", "Generated-Secret-1!")
+        assert create_user[0][2]["temporary_password"] is True
+        assert create_user[0][2]["update_existing_password"] is True
+
+    def test_existing_admin_without_migration_does_not_read_broken_secret_file(self, calls, monkeypatch, tmp_path):
+        monkeypatch.setattr(bi.Command, "_admin_exists", lambda _self: True)
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(tmp_path / "missing-secret"))
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
+
+        _make_command().handle(apps="system_mgmt", continue_on_error=False)
+
+        create_user = [c for c in calls if c[0] == "create_user"]
+        assert create_user[0][1] == ("admin", "password")
+        assert create_user[0][2]["update_existing_password"] is False
 
     def test_system_mgmt_runs_opspilot_legacy_menu_cleanup_before_realm_resource(self, calls):
         cmd = _make_command()
@@ -330,39 +354,45 @@ class TestErrorHandlingPolicy:
 class TestGetAdminPassword:
     def test_env_password_used_when_set(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "  s3cret  ")
-        monkeypatch.setattr(
-            bi.secrets,
-            "token_urlsafe",
-            lambda _byte_count: pytest.fail("显式密码不应调用随机源"),
-        )
         assert bi.Command._get_admin_password() == "s3cret"
 
-    def test_blank_env_generates_secure_password(self, monkeypatch):
+    def test_blank_env_without_file_keeps_legacy_fallback(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "   ")
-        entropy_sizes = []
-        monkeypatch.setattr(
-            bi.secrets,
-            "token_urlsafe",
-            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
-        )
-        generated_password = bi.Command._get_admin_password()
-        assert generated_password == "s" * 43
-        assert entropy_sizes == [32]
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
+        assert bi.Command._get_admin_password() == "password"
 
-    def test_missing_env_generates_unique_secure_passwords(self, monkeypatch):
+    def test_missing_env_reads_secret_file(self, monkeypatch, tmp_path):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
-        entropy_sizes = []
-        generated_passwords = iter(("a" * 43, "b" * 43))
+        password_file = tmp_path / "admin-password"
+        password_file.write_text("Managed-Secret-1!\n", encoding="utf-8")
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
+        assert bi.Command._get_admin_password() == "Managed-Secret-1!"
 
-        def generate_password(byte_count):
-            entropy_sizes.append(byte_count)
-            return next(generated_passwords)
+    def test_empty_secret_file_fails_closed(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        password_file = tmp_path / "admin-password"
+        password_file.write_text("\n", encoding="utf-8")
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(password_file))
+        with pytest.raises(CommandError, match="不能为空"):
+            bi.Command._get_admin_password()
 
-        monkeypatch.setattr(bi.secrets, "token_urlsafe", generate_password)
-        first_password = bi.Command._get_admin_password()
-        second_password = bi.Command._get_admin_password()
-        assert (first_password, second_password) == ("a" * 43, "b" * 43)
-        assert entropy_sizes == [32, 32]
+    def test_missing_secret_file_fails_closed_when_password_is_needed(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", str(tmp_path / "missing-secret"))
+        with pytest.raises(CommandError, match="无法读取"):
+            bi.Command._get_admin_password()
+
+    def test_invalid_migration_switch_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", "maybe")
+        with pytest.raises(CommandError, match="仅支持"):
+            bi.Command._should_migrate_admin_password()
+
+    def test_migration_without_managed_password_fails_closed(self, monkeypatch):
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
+        monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", "true")
+        with pytest.raises(CommandError, match="必须配置"):
+            bi.Command._should_migrate_admin_password()
 
 
 class TestPreloadLanguageCache:

--- a/server/apps/core/tests/test_batch_init_command.py
+++ b/server/apps/core/tests/test_batch_init_command.py
@@ -155,12 +155,19 @@ class TestHandleDispatch:
 
     def test_system_mgmt_creates_admin_with_resolved_password(self, calls, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+        entropy_sizes = []
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
+        )
         cmd = _make_command()
         cmd.handle(apps="system_mgmt", continue_on_error=False)
         create_user = [c for c in calls if c[0] == "create_user"]
         assert len(create_user) == 1
         _, args, kwargs = create_user[0]
-        assert args == ("admin", "password")
+        assert args == ("admin", "s" * 43)
+        assert entropy_sizes == [32]
         assert kwargs.get("is_superuser") is True
 
     def test_system_mgmt_runs_opspilot_legacy_menu_cleanup_before_realm_resource(self, calls):
@@ -323,15 +330,39 @@ class TestErrorHandlingPolicy:
 class TestGetAdminPassword:
     def test_env_password_used_when_set(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "  s3cret  ")
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda _byte_count: pytest.fail("显式密码不应调用随机源"),
+        )
         assert bi.Command._get_admin_password() == "s3cret"
 
-    def test_blank_env_falls_back_to_default(self, monkeypatch):
+    def test_blank_env_generates_secure_password(self, monkeypatch):
         monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "   ")
-        assert bi.Command._get_admin_password() == "password"
+        entropy_sizes = []
+        monkeypatch.setattr(
+            bi.secrets,
+            "token_urlsafe",
+            lambda byte_count: entropy_sizes.append(byte_count) or "s" * 43,
+        )
+        generated_password = bi.Command._get_admin_password()
+        assert generated_password == "s" * 43
+        assert entropy_sizes == [32]
 
-    def test_missing_env_falls_back_to_default(self, monkeypatch):
+    def test_missing_env_generates_unique_secure_passwords(self, monkeypatch):
         monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
-        assert bi.Command._get_admin_password() == "password"
+        entropy_sizes = []
+        generated_passwords = iter(("a" * 43, "b" * 43))
+
+        def generate_password(byte_count):
+            entropy_sizes.append(byte_count)
+            return next(generated_passwords)
+
+        monkeypatch.setattr(bi.secrets, "token_urlsafe", generate_password)
+        first_password = bi.Command._get_admin_password()
+        second_password = bi.Command._get_admin_password()
+        assert (first_password, second_password) == ("a" * 43, "b" * 43)
+        assert entropy_sizes == [32, 32]
 
 
 class TestPreloadLanguageCache:

--- a/server/apps/system_mgmt/management/commands/create_user.py
+++ b/server/apps/system_mgmt/management/commands/create_user.py
@@ -21,7 +21,6 @@ class Command(BaseCommand):
         parser.add_argument("--email", type=str, help="邮箱地址")
         parser.add_argument("--display_name", type=str, help="显示名称")
         parser.add_argument("--is_superuser", action="store_true", help="是否为超级用户")
-        parser.add_argument("--temporary_password", action="store_true", help="要求用户首次登录后轮换初始密码")
         parser.add_argument(
             "--update_existing_password",
             action="store_true",
@@ -34,7 +33,6 @@ class Command(BaseCommand):
         email = options.get("email", "test@domain.com")
         display_name = options.get("display_name") or username
         is_superuser = options.get("is_superuser", False)
-        temporary_password = options.get("temporary_password", False)
         update_existing_password = options.get("update_existing_password", False)
 
         # 保留既有命令的全域同名 no-op 语义；受控密码迁移只允许命中默认域用户。
@@ -50,7 +48,6 @@ class Command(BaseCommand):
                         self.stdout.write(self.style.SUCCESS(f"用户密码已完成轮换，不执行迁移: {username}"))
                         return
                     migration_user.password = make_password(password)
-                    migration_user.temporary_pwd = temporary_password
                     migration_user.save()
                     self.stdout.write(self.style.SUCCESS(f"成功迁移用户密码: {username}"))
                     return
@@ -67,7 +64,6 @@ class Command(BaseCommand):
                     password=make_password(password),  # 加密密码
                     email=email,
                     display_name=display_name,
-                    temporary_pwd=temporary_password,
                     # 根据您的User模型设置其他字段
                 )
 

--- a/server/apps/system_mgmt/management/commands/create_user.py
+++ b/server/apps/system_mgmt/management/commands/create_user.py
@@ -1,8 +1,9 @@
 import logging
 import uuid
 
-from django.contrib.auth.hashers import make_password
-from django.core.management import BaseCommand
+from django.contrib.auth.hashers import check_password, make_password
+from django.core.management import BaseCommand, CommandError
+from django.db import transaction
 
 from apps.system_mgmt.models import Group, Role, User
 
@@ -20,6 +21,12 @@ class Command(BaseCommand):
         parser.add_argument("--email", type=str, help="邮箱地址")
         parser.add_argument("--display_name", type=str, help="显示名称")
         parser.add_argument("--is_superuser", action="store_true", help="是否为超级用户")
+        parser.add_argument("--temporary_password", action="store_true", help="要求用户首次登录后轮换初始密码")
+        parser.add_argument(
+            "--update_existing_password",
+            action="store_true",
+            help="显式迁移仍使用 legacy 默认密码的既有用户；仅供受控初始化流程使用",
+        )
 
     def handle(self, *args, **options):
         username = options["username"]
@@ -27,29 +34,50 @@ class Command(BaseCommand):
         email = options.get("email", "test@domain.com")
         display_name = options.get("display_name") or username
         is_superuser = options.get("is_superuser", False)
+        temporary_password = options.get("temporary_password", False)
+        update_existing_password = options.get("update_existing_password", False)
 
-        # 检查用户是否已存在
-        if User.objects.filter(username=username).exists():
+        # 保留既有命令的全域同名 no-op 语义；受控密码迁移只允许命中默认域用户。
+        existing_user = User.objects.filter(username=username).first()
+        if update_existing_password:
+            with transaction.atomic():
+                migration_user = User.objects.select_for_update().filter(username=username, domain="domain.com").first()
+                if migration_user:
+                    if check_password(password, migration_user.password):
+                        self.stdout.write(self.style.SUCCESS(f"用户密码已是目标值，无需迁移: {username}"))
+                        return
+                    if not check_password("password", migration_user.password):
+                        self.stdout.write(self.style.SUCCESS(f"用户密码已完成轮换，不执行迁移: {username}"))
+                        return
+                    migration_user.password = make_password(password)
+                    migration_user.temporary_pwd = temporary_password
+                    migration_user.save()
+                    self.stdout.write(self.style.SUCCESS(f"成功迁移用户密码: {username}"))
+                    return
+        if existing_user:
             self.stdout.write(self.style.ERROR(f"用户 {username} 已存在"))
             return
 
         # 创建用户
         try:
-            user = User.objects.create(
-                user_id=str(uuid.uuid4()),
-                username=username,
-                password=make_password(password),  # 加密密码
-                email=email,
-                display_name=display_name,
-                # 根据您的User模型设置其他字段
-            )
+            with transaction.atomic():
+                user = User.objects.create(
+                    user_id=str(uuid.uuid4()),
+                    username=username,
+                    password=make_password(password),  # 加密密码
+                    email=email,
+                    display_name=display_name,
+                    temporary_pwd=temporary_password,
+                    # 根据您的User模型设置其他字段
+                )
 
-            default_group, _ = Group.objects.get_or_create(name="Default", parent_id=0)
-            user.group_list.append(default_group.id)
-            if is_superuser:
-                role, _ = Role.objects.get_or_create(name="admin", app="")
-                user.role_list.append(role.id)
-            user.save()
+                default_group, _ = Group.objects.get_or_create(name="Default", parent_id=0)
+                user.group_list.append(default_group.id)
+                if is_superuser:
+                    role, _ = Role.objects.get_or_create(name="admin", app="")
+                    user.role_list.append(role.id)
+                user.save()
             self.stdout.write(self.style.SUCCESS(f"成功创建用户: {username}"))
         except Exception as e:
             self.stdout.write(self.style.ERROR(f"创建用户时出错: {e}"))
+            raise CommandError(f"创建用户失败: {type(e).__name__}") from e

--- a/server/apps/system_mgmt/management/commands/create_user.py
+++ b/server/apps/system_mgmt/management/commands/create_user.py
@@ -3,7 +3,7 @@ import uuid
 
 from django.contrib.auth.hashers import check_password, make_password
 from django.core.management import BaseCommand, CommandError
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from apps.system_mgmt.models import Group, Role, User
 
@@ -35,8 +35,7 @@ class Command(BaseCommand):
         is_superuser = options.get("is_superuser", False)
         update_existing_password = options.get("update_existing_password", False)
 
-        # 保留既有命令的全域同名 no-op 语义；受控密码迁移只允许命中默认域用户。
-        existing_user = User.objects.filter(username=username).first()
+        # 受控密码迁移只允许命中默认域用户；锁内重读避免并发轮换覆盖。
         if update_existing_password:
             with transaction.atomic():
                 migration_user = User.objects.select_for_update().filter(username=username, domain="domain.com").first()
@@ -51,13 +50,13 @@ class Command(BaseCommand):
                     migration_user.save()
                     self.stdout.write(self.style.SUCCESS(f"成功迁移用户密码: {username}"))
                     return
-        if existing_user:
-            self.stdout.write(self.style.ERROR(f"用户 {username} 已存在"))
-            return
 
-        # 创建用户
+        # 保留既有命令的全域同名 no-op 语义，并在锁内重新判定。
         try:
             with transaction.atomic():
+                if User.objects.select_for_update().filter(username=username).exists():
+                    self.stdout.write(self.style.ERROR(f"用户 {username} 已存在"))
+                    return
                 user = User.objects.create(
                     user_id=str(uuid.uuid4()),
                     username=username,
@@ -74,6 +73,16 @@ class Command(BaseCommand):
                     user.role_list.append(role.id)
                 user.save()
             self.stdout.write(self.style.SUCCESS(f"成功创建用户: {username}"))
-        except Exception as e:
-            self.stdout.write(self.style.ERROR(f"创建用户时出错: {e}"))
-            raise CommandError(f"创建用户失败: {type(e).__name__}") from e
+            return
+        except IntegrityError as error:
+            # 多个 release 实例可能同时完成“用户不存在”的锁前检查。唯一约束会让
+            # 后提交者在这里失败；若目标用户已经由竞争事务完整创建，则沿用既有
+            # “同名用户 no-op”契约，其余完整性错误仍按初始化失败处理。
+            if User.objects.filter(username=username, domain="domain.com").exists():
+                self.stdout.write(self.style.ERROR(f"用户 {username} 已存在"))
+                return
+            caught_error = error
+        except Exception as error:
+            caught_error = error
+        self.stdout.write(self.style.ERROR(f"创建用户时出错: {caught_error}"))
+        raise CommandError(f"创建用户失败: {type(caught_error).__name__}") from caught_error

--- a/server/apps/system_mgmt/tests/test_management_and_service.py
+++ b/server/apps/system_mgmt/tests/test_management_and_service.py
@@ -48,12 +48,15 @@ def test_create_user_superuser_assigns_admin_role():
 
 
 def test_create_user_already_exists():
-    User.objects.create(username="dup", password="x", display_name="dup", email="d@x.com")
+    existing_user = User.objects.create(username="dup", password="x", display_name="dup", email="d@x.com")
+    original_password = existing_user.password
     out = StringIO()
     call_command("create_user", "dup", "pw", stdout=out)
+    existing_user.refresh_from_db()
     assert "已存在" in out.getvalue()
     # 不应创建第二个
     assert User.objects.filter(username="dup").count() == 1
+    assert existing_user.password == original_password
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/system_mgmt/tests/test_management_and_service.py
+++ b/server/apps/system_mgmt/tests/test_management_and_service.py
@@ -16,7 +16,6 @@ from django.core.management import CommandError, call_command
 
 from apps.core.utils.permission_cache import get_user_permission_version
 from apps.system_mgmt.models import App, CustomMenuGroup, Group, LoginModule, Menu, Role, SystemSettings, User
-from apps.system_mgmt.nats.login import get_user_login_token
 from apps.system_mgmt.services.role_manage import RoleManage
 
 pytestmark = pytest.mark.django_db
@@ -87,11 +86,11 @@ def test_create_user_already_exists():
 def test_create_user_explicit_migration_updates_existing_password():
     existing_user = User.objects.create(username="migrate-admin", password=make_password("password"), display_name="admin", email="admin@x.com")
 
-    call_command("create_user", "migrate-admin", "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    call_command("create_user", "migrate-admin", "Managed-Secret-1!", "--update_existing_password")
 
     existing_user.refresh_from_db()
     assert check_password("Managed-Secret-1!", existing_user.password)
-    assert existing_user.temporary_pwd is True
+    assert existing_user.temporary_pwd is False
 
 
 def test_create_user_explicit_migration_is_idempotent():
@@ -101,11 +100,11 @@ def test_create_user_explicit_migration_is_idempotent():
         display_name="admin",
         email="admin-idempotent@x.com",
     )
-    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--update_existing_password")
     existing_user.refresh_from_db()
     migrated_password = existing_user.password
 
-    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--update_existing_password")
 
     existing_user.refresh_from_db()
     assert existing_user.password == migrated_password
@@ -118,13 +117,13 @@ def test_create_user_migration_survives_rollback_to_legacy_invocation():
         display_name="admin",
         email="admin-rollback@x.com",
     )
-    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--update_existing_password")
 
     call_command("create_user", existing_user.username, "password")
 
     existing_user.refresh_from_db()
     assert check_password("Managed-Secret-1!", existing_user.password)
-    assert existing_user.temporary_pwd is True
+    assert existing_user.temporary_pwd is False
 
 
 def test_create_user_migration_preserves_password_after_first_rotation():
@@ -135,7 +134,7 @@ def test_create_user_migration_preserves_password_after_first_rotation():
         email="rotated-admin@x.com",
     )
 
-    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--update_existing_password")
 
     existing_user.refresh_from_db()
     assert check_password("User-Rotated-1!", existing_user.password)
@@ -157,7 +156,6 @@ def test_create_user_preserves_cross_domain_same_name_noop():
         "Managed-Secret-1!",
         "--email",
         "default-admin@x.com",
-        "--temporary_password",
         "--update_existing_password",
     )
 
@@ -186,35 +184,15 @@ def test_create_user_migration_targets_default_domain_only():
         "create_user",
         "shared-admin",
         "Managed-Secret-1!",
-        "--temporary_password",
         "--update_existing_password",
     )
 
     default_user.refresh_from_db()
     non_default_user.refresh_from_db()
     assert check_password("Managed-Secret-1!", default_user.password)
-    assert default_user.temporary_pwd is True
+    assert default_user.temporary_pwd is False
     assert check_password("password", non_default_user.password)
     assert non_default_user.temporary_pwd is False
-
-
-def test_temporary_admin_password_still_issues_normal_jwt(monkeypatch):
-    """记录当前服务端契约：temporary_pwd 只是响应提示，不阻止普通 JWT 签发。"""
-    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
-    user = User.objects.create(
-        username="temporary-admin",
-        domain="domain.com",
-        password=make_password("Managed-Secret-1!"),
-        display_name="admin",
-        email="temporary-admin@x.com",
-        temporary_pwd=True,
-    )
-
-    result = get_user_login_token(user, user.username)
-
-    assert result["result"] is True
-    assert result["data"]["temporary_pwd"] is True
-    assert result["data"]["token"]
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/system_mgmt/tests/test_management_and_service.py
+++ b/server/apps/system_mgmt/tests/test_management_and_service.py
@@ -9,12 +9,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from django.contrib.auth.hashers import check_password, make_password
 from django.core.cache.backends.locmem import LocMemCache
 from django.core.cache.backends.redis import RedisCache
 from django.core.management import CommandError, call_command
 
 from apps.core.utils.permission_cache import get_user_permission_version
 from apps.system_mgmt.models import App, CustomMenuGroup, Group, LoginModule, Menu, Role, SystemSettings, User
+from apps.system_mgmt.nats.login import get_user_login_token
 from apps.system_mgmt.services.role_manage import RoleManage
 
 pytestmark = pytest.mark.django_db
@@ -37,6 +39,29 @@ def test_create_user_basic():
     assert "成功创建用户" in out.getvalue()
 
 
+def test_create_user_storage_failure_is_reported_as_command_error(monkeypatch):
+    monkeypatch.setattr(User.objects, "create", MagicMock(side_effect=RuntimeError("database unavailable")))
+
+    with pytest.raises(CommandError, match="创建用户失败: RuntimeError"):
+        call_command("create_user", "failed-user", "Managed-Secret-1!", "--email", "failed@x.com")
+
+
+def test_create_user_partial_initialization_failure_rolls_back(monkeypatch):
+    monkeypatch.setattr(Role.objects, "get_or_create", MagicMock(side_effect=RuntimeError("role unavailable")))
+
+    with pytest.raises(CommandError, match="创建用户失败: RuntimeError"):
+        call_command(
+            "create_user",
+            "partial-admin",
+            "Managed-Secret-1!",
+            "--email",
+            "partial-admin@x.com",
+            "--is_superuser",
+        )
+
+    assert not User.objects.filter(username="partial-admin", domain="domain.com").exists()
+
+
 def test_create_user_superuser_assigns_admin_role():
     out = StringIO()
     call_command("create_user", "boss", "pw", "--email", "boss@x.com", "--display_name", "Boss", "--is_superuser", stdout=out)
@@ -57,6 +82,139 @@ def test_create_user_already_exists():
     # 不应创建第二个
     assert User.objects.filter(username="dup").count() == 1
     assert existing_user.password == original_password
+
+
+def test_create_user_explicit_migration_updates_existing_password():
+    existing_user = User.objects.create(username="migrate-admin", password=make_password("password"), display_name="admin", email="admin@x.com")
+
+    call_command("create_user", "migrate-admin", "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+
+    existing_user.refresh_from_db()
+    assert check_password("Managed-Secret-1!", existing_user.password)
+    assert existing_user.temporary_pwd is True
+
+
+def test_create_user_explicit_migration_is_idempotent():
+    existing_user = User.objects.create(
+        username="migrate-admin-idempotent",
+        password=make_password("password"),
+        display_name="admin",
+        email="admin-idempotent@x.com",
+    )
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+    existing_user.refresh_from_db()
+    migrated_password = existing_user.password
+
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+
+    existing_user.refresh_from_db()
+    assert existing_user.password == migrated_password
+
+
+def test_create_user_migration_survives_rollback_to_legacy_invocation():
+    existing_user = User.objects.create(
+        username="migrate-admin-rollback",
+        password=make_password("password"),
+        display_name="admin",
+        email="admin-rollback@x.com",
+    )
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+
+    call_command("create_user", existing_user.username, "password")
+
+    existing_user.refresh_from_db()
+    assert check_password("Managed-Secret-1!", existing_user.password)
+    assert existing_user.temporary_pwd is True
+
+
+def test_create_user_migration_preserves_password_after_first_rotation():
+    existing_user = User.objects.create(
+        username="rotated-admin",
+        password=make_password("User-Rotated-1!"),
+        display_name="admin",
+        email="rotated-admin@x.com",
+    )
+
+    call_command("create_user", existing_user.username, "Managed-Secret-1!", "--temporary_password", "--update_existing_password")
+
+    existing_user.refresh_from_db()
+    assert check_password("User-Rotated-1!", existing_user.password)
+    assert existing_user.temporary_pwd is False
+
+
+def test_create_user_preserves_cross_domain_same_name_noop():
+    non_default_user = User.objects.create(
+        username="domain-admin",
+        domain="other.example",
+        password=make_password("password"),
+        display_name="admin",
+        email="other-admin@x.com",
+    )
+
+    call_command(
+        "create_user",
+        non_default_user.username,
+        "Managed-Secret-1!",
+        "--email",
+        "default-admin@x.com",
+        "--temporary_password",
+        "--update_existing_password",
+    )
+
+    non_default_user.refresh_from_db()
+    assert check_password("password", non_default_user.password)
+    assert not User.objects.filter(username="domain-admin", domain="domain.com").exists()
+
+
+def test_create_user_migration_targets_default_domain_only():
+    default_user = User.objects.create(
+        username="shared-admin",
+        domain="domain.com",
+        password=make_password("password"),
+        display_name="admin",
+        email="default-admin@x.com",
+    )
+    non_default_user = User.objects.create(
+        username="shared-admin",
+        domain="other.example",
+        password=make_password("password"),
+        display_name="admin",
+        email="other-admin@x.com",
+    )
+
+    call_command(
+        "create_user",
+        "shared-admin",
+        "Managed-Secret-1!",
+        "--temporary_password",
+        "--update_existing_password",
+    )
+
+    default_user.refresh_from_db()
+    non_default_user.refresh_from_db()
+    assert check_password("Managed-Secret-1!", default_user.password)
+    assert default_user.temporary_pwd is True
+    assert check_password("password", non_default_user.password)
+    assert non_default_user.temporary_pwd is False
+
+
+def test_temporary_admin_password_still_issues_normal_jwt(monkeypatch):
+    """记录当前服务端契约：temporary_pwd 只是响应提示，不阻止普通 JWT 签发。"""
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    user = User.objects.create(
+        username="temporary-admin",
+        domain="domain.com",
+        password=make_password("Managed-Secret-1!"),
+        display_name="admin",
+        email="temporary-admin@x.com",
+        temporary_pwd=True,
+    )
+
+    result = get_user_login_token(user, user.username)
+
+    assert result["result"] is True
+    assert result["data"]["temporary_pwd"] is True
+    assert result["data"]["token"]
 
 
 # ---------------------------------------------------------------------------

--- a/server/apps/system_mgmt/tests/test_management_and_service.py
+++ b/server/apps/system_mgmt/tests/test_management_and_service.py
@@ -4,7 +4,9 @@
 只在涉及外部缓存时 mock permission_cache。
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
+from threading import Barrier
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -13,12 +15,14 @@ from django.contrib.auth.hashers import check_password, make_password
 from django.core.cache.backends.locmem import LocMemCache
 from django.core.cache.backends.redis import RedisCache
 from django.core.management import CommandError, call_command
+from django.db import close_old_connections
 
+import apps.core.management.commands.batch_init as batch_init
 from apps.core.utils.permission_cache import get_user_permission_version
 from apps.system_mgmt.models import App, CustomMenuGroup, Group, LoginModule, Menu, Role, SystemSettings, User
 from apps.system_mgmt.services.role_manage import RoleManage
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 
 # ---------------------------------------------------------------------------
@@ -59,6 +63,89 @@ def test_create_user_partial_initialization_failure_rolls_back(monkeypatch):
         )
 
     assert not User.objects.filter(username="partial-admin", domain="domain.com").exists()
+
+
+def test_create_user_concurrent_bootstrap_is_idempotent(monkeypatch):
+    original_create = User.objects.create
+    create_barrier = Barrier(2)
+    username = "concurrent-bootstrap-admin"
+
+    def synchronized_create(*args, **kwargs):
+        create_barrier.wait(timeout=5)
+        return original_create(*args, **kwargs)
+
+    monkeypatch.setattr(User.objects, "create", synchronized_create)
+
+    def bootstrap():
+        close_old_connections()
+        try:
+            call_command(
+                "create_user",
+                username,
+                "Managed-Secret-1!",
+                "--email",
+                "concurrent-bootstrap-admin@x.com",
+                "--is_superuser",
+            )
+        finally:
+            close_old_connections()
+
+    def cleanup():
+        close_old_connections()
+        try:
+            User.objects.filter(username=username, domain="domain.com").delete()
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(cleanup).result(timeout=10)
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(bootstrap) for _ in range(2)]
+            for future in futures:
+                future.result(timeout=10)
+
+        users = User.objects.filter(username=username, domain="domain.com")
+        assert users.count() == 1
+        user = users.get()
+        assert check_password("Managed-Secret-1!", user.password)
+        assert Role.objects.get(name="admin", app="").id in user.role_list
+    finally:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(cleanup).result(timeout=10)
+
+
+def test_batch_init_admin_bootstrap_and_repeat_use_real_create_user(monkeypatch):
+    real_call_command = call_command
+    dispatched = []
+
+    def route_call_command(name, *args, **kwargs):
+        dispatched.append(name)
+        if name == "create_user":
+            return real_call_command(name, *args, **kwargs)
+        return None
+
+    monkeypatch.setattr(batch_init, "call_command", route_call_command)
+    monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD", "Managed-Secret-1!")
+    monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_FILE", raising=False)
+    monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING", raising=False)
+
+    batch_init.Command()._init_system_mgmt()
+
+    admin = User.objects.get(username="admin", domain="domain.com")
+    original_password = admin.password
+    assert check_password("Managed-Secret-1!", original_password)
+    assert "create_user" in dispatched
+
+    dispatched.clear()
+    monkeypatch.delenv("BK_INIT_ADMIN_PASSWORD", raising=False)
+    monkeypatch.setenv("BK_INIT_ADMIN_PASSWORD_FILE", "/missing/optional-secret")
+
+    batch_init.Command()._init_system_mgmt()
+
+    admin.refresh_from_db()
+    assert admin.password == original_password
+    assert "create_user" not in dispatched
 
 
 def test_create_user_superuser_assigns_admin_role():
@@ -108,6 +195,86 @@ def test_create_user_explicit_migration_is_idempotent():
 
     existing_user.refresh_from_db()
     assert existing_user.password == migrated_password
+
+
+def test_create_user_concurrent_migration_serializes_legacy_password_update():
+    username = "concurrent-migrate-admin"
+    migrate_barrier = Barrier(2)
+
+    def reset_legacy_user():
+        close_old_connections()
+        try:
+            User.objects.filter(username=username, domain="domain.com").delete()
+            return User.objects.create(
+                username=username,
+                password=make_password("password"),
+                display_name="admin",
+                email="concurrent-migrate-admin@x.com",
+            ).pk
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        existing_user_id = executor.submit(reset_legacy_user).result(timeout=10)
+
+    def migrate(password):
+        close_old_connections()
+        output = StringIO()
+        try:
+            migrate_barrier.wait(timeout=5)
+            call_command(
+                "create_user",
+                username,
+                password,
+                "--update_existing_password",
+                stdout=output,
+            )
+            return output.getvalue()
+        finally:
+            close_old_connections()
+
+    passwords = ("Managed-Secret-A!", "Managed-Secret-B!")
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            outputs = list(executor.map(migrate, passwords))
+
+        existing_user = User.objects.get(pk=existing_user_id)
+        assert any(check_password(password, existing_user.password) for password in passwords)
+        assert sum("成功迁移用户密码" in output for output in outputs) == 1
+        assert sum("用户密码已完成轮换" in output for output in outputs) == 1
+    finally:
+        def cleanup():
+            close_old_connections()
+            try:
+                User.objects.filter(pk=existing_user_id).delete()
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            executor.submit(cleanup).result(timeout=10)
+
+
+def test_create_user_migration_failure_rolls_back(monkeypatch):
+    existing_user = User.objects.create(
+        username="rollback-migrate-admin",
+        password=make_password("password"),
+        display_name="admin",
+        email="rollback-migrate-admin@x.com",
+    )
+    original_save = User.save
+
+    def fail_migration_save(user, *args, **kwargs):
+        if user.pk == existing_user.pk and not check_password("password", user.password):
+            raise RuntimeError("migration storage unavailable")
+        return original_save(user, *args, **kwargs)
+
+    monkeypatch.setattr(User, "save", fail_migration_save)
+
+    with pytest.raises(RuntimeError, match="migration storage unavailable"):
+        call_command("create_user", existing_user.username, "Managed-Secret-1!", "--update_existing_password")
+
+    existing_user.refresh_from_db()
+    assert check_password("password", existing_user.password)
 
 
 def test_create_user_migration_survives_rollback_to_legacy_invocation():

--- a/server/envs/.env.example
+++ b/server/envs/.env.example
@@ -1,6 +1,12 @@
 DEBUG=False
 SECRET_KEY=weops-lite
 
+# 管理员引导凭据：优先使用显式值，否则读取仅由部署控制面挂载的 Secret 文件。
+# 存量部署首次启用时先挂载 Secret，再把迁移开关设为 true；回滚时关闭开关但保留 Secret。
+BK_INIT_ADMIN_PASSWORD=
+BK_INIT_ADMIN_PASSWORD_FILE=
+BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING=false
+
 DB_NAME=
 DB_USER=
 DB_PASSWORD=

--- a/server/envs/.env.example
+++ b/server/envs/.env.example
@@ -1,12 +1,6 @@
 DEBUG=False
 SECRET_KEY=weops-lite
 
-# 管理员引导凭据：优先使用显式值，否则读取仅由部署控制面挂载的 Secret 文件。
-# 存量部署首次启用时先挂载 Secret，再把迁移开关设为 true；回滚时关闭开关但保留 Secret。
-BK_INIT_ADMIN_PASSWORD=
-BK_INIT_ADMIN_PASSWORD_FILE=
-BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING=false
-
 DB_NAME=
 DB_USER=
 DB_PASSWORD=

--- a/server/support-files/env/.env.system_mgmt.example
+++ b/server/support-files/env/.env.system_mgmt.example
@@ -3,8 +3,8 @@ SECRET_KEY=7297613c-de40-477a-b13c-f86b3cc3cb99
 JWT_ALGORITHM=HS256
 INSTALL_APPS=system_mgmt
 
-# 管理员引导凭据：优先使用显式值，否则读取仅由部署控制面挂载的 Secret 文件。
-# 存量部署首次启用时先挂载 Secret，再把迁移开关设为 true；回滚时关闭开关但保留 Secret。
+# 鲜装必须配置管理员引导凭据：优先使用显式值，否则读取部署控制面挂载的 Secret 文件。
+# 存量 admin 默认保持不变；需要迁移 legacy 默认密码时，先配置 Secret，再显式开启迁移。
 BK_INIT_ADMIN_PASSWORD=
 BK_INIT_ADMIN_PASSWORD_FILE=
 BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING=false

--- a/server/support-files/env/.env.system_mgmt.example
+++ b/server/support-files/env/.env.system_mgmt.example
@@ -3,6 +3,12 @@ SECRET_KEY=7297613c-de40-477a-b13c-f86b3cc3cb99
 JWT_ALGORITHM=HS256
 INSTALL_APPS=system_mgmt
 
+# 管理员引导凭据：优先使用显式值，否则读取仅由部署控制面挂载的 Secret 文件。
+# 存量部署首次启用时先挂载 Secret，再把迁移开关设为 true；回滚时关闭开关但保留 Secret。
+BK_INIT_ADMIN_PASSWORD=
+BK_INIT_ADMIN_PASSWORD_FILE=
+BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING=false
+
 DB_ENGINE=postgresql
 DB_NAME=system_mgmt
 DB_USER=postgres


### PR DESCRIPTION
Closes #3794

## 问题

Release 初始化在鲜装环境未配置管理员 Secret 时，会静默以固定字符串 `password` 创建全局管理员。配置遗漏因此退化为公开可猜的高权限凭据。

## 根因

管理员引导把“鲜装必须取得受控凭据”和“存量管理员重复初始化应保持 no-op”混在同一个缺省分支里。为了让重复启动继续运行，代码把缺少凭据也解释成可恢复状态，最终把开发便利值带入了生产初始化链路。

## 怎么修的

- 鲜装且不存在默认域 admin 时，必须通过 `BK_INIT_ADMIN_PASSWORD` 或 `BK_INIT_ADMIN_PASSWORD_FILE` 提供受控 Secret；缺失、空白、不可读、非 UTF-8 或超出 4096 字符时失败关闭。
- 已存在 admin 且未请求迁移时，完全跳过凭据读取和 `create_user`，因此升级、重启与坏的可选挂载不会扩大存量启动失败面。
- `BK_INIT_ADMIN_PASSWORD_MIGRATE_EXISTING=true` 只迁移仍使用 legacy `password` 的默认域 admin；行锁与事务保证并发和部分失败安全，已轮换密码不会被覆盖。
- 关闭迁移开关并保留 Secret 即可回滚应用行为；回滚到旧调用方式也不会把已经迁移的密码改回固定值。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["startup.sh\nrelease 容器启动"]
        T2["batch_init.handle\nbatch_init.py"]
    end

    subgraph N["凭据边界"]
        N1["_admin_exists\n判断鲜装或存量"]
        N2["_get_admin_password\n显式 env 或 Secret 文件"]
        N3["缺少或非法 Secret\nCommandError"]
    end

    subgraph P["持久化与迁移"]
        P1["create_user\n事务创建 admin"]
        P2["update_existing_password\n仅迁移 legacy 密码"]
        P3["存量 admin\n默认保持不变"]
    end

    T1 --> T2 --> N1
    N1 -- "鲜装" --> N2
    N2 -- "有效" --> P1
    N2 -. "缺失或非法" .-> N3
    N1 -- "显式迁移" --> N2 --> P2
    N1 -- "存量且不迁移" --> P3
```

## 影响范围与兼容性

- 仅触及 Server 管理员初始化、`create_user` 管理命令与 release system_mgmt 配置样例；不改 API、数据库 schema、权限模型、NATS/RPC 或响应格式。
- 存量管理员默认不读 Secret、不更新密码，原有升级与重复初始化行为保持。
- 鲜装必须先配置受控 Secret；这是关闭固定管理员密码所需的安全门禁，release 启动会保留明确失败信号。
- 存量弱密码迁移是显式、幂等、可回滚操作；目标密码已生效或用户已自行轮换时不会重复覆盖。
- 不把管理员 Secret 标记为临时密码，不依赖前端首次改密作为安全边界。

## 验证

- `server/apps/core/tests/test_batch_init_command.py`：覆盖鲜装缺失失败、显式 env/file、存量跳过、文件边界与错误净化；恢复固定 fallback 时缺陷用例会失败。
- `server/apps/system_mgmt/tests/test_management_and_service.py`：覆盖真实数据库创建、legacy 密码迁移、幂等、已轮换保护、跨域兼容、事务回滚与旧调用回滚。
- 两份具体关联测试：65 passed。
- 触及文件门禁：pyupgrade、merge-conflict、black、isort、flake8、check-migrate、check-requirements 全部通过。

## 三轨门禁

- Standards：pass——凭据不写日志，Secret 文件读取有界，数据库更新使用 ORM、行锁与事务，diff 限于相关模块。
- Spec：pass——固定默认值路径已关闭，同时提供显式 Secret、存量迁移与回滚闭环。
- Runtime Contract：pass——鲜装、重复初始化、存量升级、失败方式、幂等和回滚均有可执行测试证据。
- 质量评分：97/100（SCORE_PASS）。
