### PR TITLE
bugfix: 补偿首次告警中心通知失败（#3341）

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -255,11 +255,16 @@ class AlertSourceAdapter(ABC):
             )
         bulk_events = self.bulk_save_events(events)
         accepted = sum(len(batch or []) for batch in (bulk_events or []))
+        rejected = skipped_missing
+        duplicates = max(0, len(add_events) - accepted - rejected - errored)
         self.last_ingestion_result = {
             "received": len(add_events),
             "accepted": accepted,
-            "skipped": max(0, len(add_events) - accepted - errored),
+            # 保留既有 skipped 汇总语义；细分字段供显式 opt-in 的逐事件 ACK 使用。
+            "skipped": rejected + duplicates,
             "errored": errored,
+            "duplicates": duplicates,
+            "rejected": rejected,
         }
         return bulk_events
 

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -385,12 +385,20 @@ class AlertSourceAdapter(ABC):
         # 可选 lifecycle_action 由可信内部生产者提供，用来区分 created/upgraded
         # 等映射到同一业务 action 的独立生命周期代次。
         lifecycle_action = alert.get("lifecycle_action")
+        if lifecycle_action not in {"created", "upgraded", "recovered", "closed"}:
+            lifecycle_action = None
         if self.trusted_internal and lifecycle_action:
+            lifecycle_generation = str(alert.get("lifecycle_generation") or "").strip()
+            lifecycle_identity = (
+                f"{lifecycle_action}:{lifecycle_generation}"
+                if lifecycle_generation
+                else lifecycle_action
+            )
             event.ingest_key = Event.build_ingest_key(
                 getattr(event.source, "id", None),
                 event.push_source_id,
                 event.external_id,
-                lifecycle_action,
+                lifecycle_identity,
                 event.start_time,
             )
 

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -381,6 +381,15 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
         event.team = self._resolve_event_team(alert)
 
+        # receiver-first 兼容扩展：可信内部生产者可提供逐次投递身份。
+        # 业务 external_id 仍用于 created/recovery 关联，ingest_key 单独用于幂等，
+        # 因而同一告警的升级代次不会再被首次 created 误判为重复。
+        delivery_id = alert.get("delivery_id")
+        if self.trusted_internal and delivery_id:
+            event.ingest_key = hashlib.sha256(
+                f"{self.alert_source.id}:{event.push_source_id}:{delivery_id}".encode("utf-8")
+            ).hexdigest()
+
         if not event.external_id or not str(event.external_id).strip():
             event.external_id = self.resolve_recovery_external_id(event) or self.generate_external_id(
                 event.item,

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -381,6 +381,19 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
         event.team = self._resolve_event_team(alert)
 
+        # 逐事件 ACK 的 delivery_id 只用于响应关联，不参与接收幂等身份。
+        # 可选 lifecycle_action 由可信内部生产者提供，用来区分 created/upgraded
+        # 等映射到同一业务 action 的独立生命周期代次。
+        lifecycle_action = alert.get("lifecycle_action")
+        if self.trusted_internal and lifecycle_action:
+            event.ingest_key = Event.build_ingest_key(
+                getattr(event.source, "id", None),
+                event.push_source_id,
+                event.external_id,
+                lifecycle_action,
+                event.start_time,
+            )
+
         if not event.external_id or not str(event.external_id).strip():
             event.external_id = self.resolve_recovery_external_id(event) or self.generate_external_id(
                 event.item,

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -381,15 +381,6 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
         event.team = self._resolve_event_team(alert)
 
-        # receiver-first 兼容扩展：可信内部生产者可提供逐次投递身份。
-        # 业务 external_id 仍用于 created/recovery 关联，ingest_key 单独用于幂等，
-        # 因而同一告警的升级代次不会再被首次 created 误判为重复。
-        delivery_id = alert.get("delivery_id")
-        if self.trusted_internal and delivery_id:
-            event.ingest_key = hashlib.sha256(
-                f"{self.alert_source.id}:{event.push_source_id}:{delivery_id}".encode("utf-8")
-            ).hexdigest()
-
         if not event.external_id or not str(event.external_id).strip():
             event.external_id = self.resolve_recovery_external_id(event) or self.generate_external_id(
                 event.item,

--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -381,9 +381,19 @@ class AlertSourceAdapter(ABC):
         event.event_id = f"EVENT-{uuid.uuid4().hex}"
         event.team = self._resolve_event_team(alert)
 
+        if not event.external_id or not str(event.external_id).strip():
+            event.external_id = self.resolve_recovery_external_id(event) or self.generate_external_id(
+                event.item,
+                event.resource_id,
+                event.resource_name,
+                event.resource_type,
+                self.alert_source.source_id,
+            )
+            logger.debug("[AlertSource] 已生成 external_id for event: %s", event.event_id)
+
         # 逐事件 ACK 的 delivery_id 只用于响应关联，不参与接收幂等身份。
-        # 可选 lifecycle_action 由可信内部生产者提供，用来区分 created/upgraded
-        # 等映射到同一业务 action 的独立生命周期代次。
+        # 必须在 external_id 回填后计算，否则缺少上游 ID 的 created/upgraded
+        # 会回退到相同业务 action，丢失生命周期代次隔离。
         lifecycle_action = alert.get("lifecycle_action")
         if lifecycle_action not in {"created", "upgraded", "recovered", "closed"}:
             lifecycle_action = None
@@ -401,16 +411,6 @@ class AlertSourceAdapter(ABC):
                 lifecycle_identity,
                 event.start_time,
             )
-
-        if not event.external_id or not str(event.external_id).strip():
-            event.external_id = self.resolve_recovery_external_id(event) or self.generate_external_id(
-                event.item,
-                event.resource_id,
-                event.resource_name,
-                event.resource_type,
-                self.alert_source.source_id,
-            )
-            logger.debug("[AlertSource] 已生成 external_id for event: %s", event.event_id)
 
     @staticmethod
     def build_ingress_dedup_key(event: Event) -> Optional[str]:

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -798,6 +798,9 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
             }
 
         if ack_mode == PER_EVENT_ACK_MODE:
+            if pusher not in TRUSTED_INTERNAL_PUSHERS:
+                logger.warning("[AlertEvent] 非可信 pusher 不允许逐事件 ACK: pusher=%s", pusher)
+                return {"result": False, "data": {}, "message": "Per-event acknowledgement is restricted."}
             if len(events) > PER_EVENT_ACK_MAX_EVENTS:
                 logger.warning("[AlertEvent] 逐事件 ACK 批次超限: pusher=%s event_count=%s", pusher, len(events))
                 return {
@@ -829,12 +832,6 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         # 内部约定：NATS 生效源（event_source 已校验）+ 明确允许的内部推送方，双重判断为可信内部推送。
         # 此时采信每个 event 自带的 organizations 作为归属组织，无需走组织级 secret。
         trusted_internal = pusher in TRUSTED_INTERNAL_PUSHERS
-        if ack_mode == PER_EVENT_ACK_MODE and not trusted_internal:
-            # Per-event ACK changes only response granularity. It must not be
-            # used as an authorization signal; untrusted producers retain the
-            # same organization resolution and payload trust boundary.
-            logger.info("[AlertEvent] 非内置 pusher 使用逐事件 ACK（保持非可信数据边界）: pusher=%s", pusher)
-
         # 创建适配器（内部调用无需密钥验证）
         adapter_class = AlertSourceAdapterFactory.get_adapter(event_source)
         # 传递空密钥，因为不需要认证

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -8,6 +8,7 @@
 
 import datetime
 import os
+import secrets
 from types import SimpleNamespace
 from typing import Any, Dict
 from zoneinfo import ZoneInfo
@@ -33,6 +34,7 @@ ALERT_LEVEL_DISPLAY_MAP = dict(EventLevel.CHOICES)
 TRUSTED_INTERNAL_PUSHERS = {"lite-monitor", "lite-log", "lite-apm"}
 PER_EVENT_ACK_MODE = "per_event_v1"
 PER_EVENT_ACK_MAX_EVENTS = 200
+PER_EVENT_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
 
 
 def _event_ack(delivery_id, ingestion):
@@ -779,6 +781,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         events = kwargs.pop("events", [])
         pusher = kwargs.pop("pusher", None)
         ack_mode = kwargs.pop("ack_mode", "")
+        ack_token = kwargs.pop("ack_token", "")
 
         # 参数校验
         if not source_id:
@@ -798,7 +801,11 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
             }
 
         if ack_mode == PER_EVENT_ACK_MODE:
-            if pusher not in TRUSTED_INTERNAL_PUSHERS:
+            if (
+                pusher not in TRUSTED_INTERNAL_PUSHERS
+                or not PER_EVENT_ACK_TOKEN
+                or not secrets.compare_digest(str(ack_token), PER_EVENT_ACK_TOKEN)
+            ):
                 logger.warning("[AlertEvent] 非可信 pusher 不允许逐事件 ACK: pusher=%s", pusher)
                 return {"result": False, "data": {}, "message": "Per-event acknowledgement is restricted."}
             if len(events) > PER_EVENT_ACK_MAX_EVENTS:

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -802,6 +802,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 "message": "Missing pusher identifier.",
             }
 
+        per_event_ack_authorized = False
         if ack_mode == PER_EVENT_ACK_MODE:
             if (
                 pusher not in TRUSTED_INTERNAL_PUSHERS
@@ -817,6 +818,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                     "data": {"max_events": PER_EVENT_ACK_MAX_EVENTS},
                     "message": "Too many events for per-event acknowledgement.",
                 }
+            per_event_ack_authorized = True
 
         event_source = AlertSource.objects.filter(
             source_id=source_id,
@@ -836,6 +838,12 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         for event in events:
             normalized_event = dict(event or {})
             normalized_event.setdefault("push_source_id", pusher)
+            if not per_event_ack_authorized:
+                # lifecycle_* 会改变接收幂等身份，只允许带共享凭据的逐事件
+                # ACK 协议使用。旧批量协议继续兼容组织与普通事件字段，但
+                # 不能仅凭消息体中的 pusher 提升新的可信身份字段。
+                normalized_event.pop("lifecycle_action", None)
+                normalized_event.pop("lifecycle_generation", None)
             normalized_events.append(normalized_event)
 
         # 内部约定：NATS 生效源（event_source 已校验）+ 明确允许的内部推送方，双重判断为可信内部推送。

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -848,6 +848,9 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
             ingestions = []
             event_results = []
             for index, normalized_event in enumerate(normalized_events):
+                delivery_id = normalized_event.get("delivery_id", str(index))
+                normalized_event = dict(normalized_event)
+                normalized_event.pop("delivery_id", None)
                 single_adapter = adapter_class(
                     alert_source=event_source,
                     secret="",
@@ -863,9 +866,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                     "rejected": 0,
                 }
                 ingestions.append(single_ingestion)
-                event_results.append(
-                    _event_ack(normalized_event.get("delivery_id", str(index)), single_ingestion)
-                )
+                event_results.append(_event_ack(delivery_id, single_ingestion))
             ingestion = {
                 key: sum(item.get(key, 0) for item in ingestions)
                 for key in ("received", "accepted", "skipped", "errored", "duplicates", "rejected")

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -798,9 +798,6 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
             }
 
         if ack_mode == PER_EVENT_ACK_MODE:
-            if pusher not in TRUSTED_INTERNAL_PUSHERS:
-                logger.warning("[AlertEvent] 非可信 pusher 不允许逐事件 ACK: pusher=%s", pusher)
-                return {"result": False, "data": {}, "message": "Per-event acknowledgement is restricted."}
             if len(events) > PER_EVENT_ACK_MAX_EVENTS:
                 logger.warning("[AlertEvent] 逐事件 ACK 批次超限: pusher=%s event_count=%s", pusher, len(events))
                 return {
@@ -832,6 +829,11 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         # 内部约定：NATS 生效源（event_source 已校验）+ 明确允许的内部推送方，双重判断为可信内部推送。
         # 此时采信每个 event 自带的 organizations 作为归属组织，无需走组织级 secret。
         trusted_internal = pusher in TRUSTED_INTERNAL_PUSHERS
+        if ack_mode == PER_EVENT_ACK_MODE and not trusted_internal:
+            # Per-event ACK changes only response granularity. It must not be
+            # used as an authorization signal; untrusted producers retain the
+            # same organization resolution and payload trust boundary.
+            logger.info("[AlertEvent] 非内置 pusher 使用逐事件 ACK（保持非可信数据边界）: pusher=%s", pusher)
 
         # 创建适配器（内部调用无需密钥验证）
         adapter_class = AlertSourceAdapterFactory.get_adapter(event_source)

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -32,6 +32,7 @@ from apps.core.utils.viewset_utils import GenericViewSetFun
 ALERT_LEVEL_DISPLAY_MAP = dict(EventLevel.CHOICES)
 TRUSTED_INTERNAL_PUSHERS = {"lite-monitor", "lite-log", "lite-apm"}
 PER_EVENT_ACK_MODE = "per_event_v1"
+PER_EVENT_ACK_MAX_EVENTS = 200
 
 
 def _event_ack(delivery_id, ingestion):
@@ -795,6 +796,18 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 "data": {},
                 "message": "Missing pusher identifier.",
             }
+
+        if ack_mode == PER_EVENT_ACK_MODE:
+            if pusher not in TRUSTED_INTERNAL_PUSHERS:
+                logger.warning("[AlertEvent] 非可信 pusher 不允许逐事件 ACK: pusher=%s", pusher)
+                return {"result": False, "data": {}, "message": "Per-event acknowledgement is restricted."}
+            if len(events) > PER_EVENT_ACK_MAX_EVENTS:
+                logger.warning("[AlertEvent] 逐事件 ACK 批次超限: pusher=%s event_count=%s", pusher, len(events))
+                return {
+                    "result": False,
+                    "data": {"max_events": PER_EVENT_ACK_MAX_EVENTS},
+                    "message": "Too many events for per-event acknowledgement.",
+                }
 
         event_source = AlertSource.objects.filter(
             source_id=source_id,

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -31,6 +31,23 @@ from apps.core.utils.viewset_utils import GenericViewSetFun
 
 ALERT_LEVEL_DISPLAY_MAP = dict(EventLevel.CHOICES)
 TRUSTED_INTERNAL_PUSHERS = {"lite-monitor", "lite-log", "lite-apm"}
+PER_EVENT_ACK_MODE = "per_event_v1"
+
+
+def _event_ack(delivery_id, ingestion):
+    if ingestion.get("accepted", 0):
+        status = "accepted"
+    elif ingestion.get("duplicates", 0):
+        status = "duplicate"
+    elif ingestion.get("rejected", 0):
+        status = "rejected"
+    else:
+        status = "errored"
+    return {
+        "delivery_id": delivery_id,
+        "status": status,
+        "retryable": status == "errored",
+    }
 
 
 def _positive_int_env(name, default):
@@ -760,6 +777,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         source_id = kwargs.pop("source_id", "")
         events = kwargs.pop("events", [])
         pusher = kwargs.pop("pusher", None)
+        ack_mode = kwargs.pop("ack_mode", "")
 
         # 参数校验
         if not source_id:
@@ -811,25 +829,61 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
         logger.info("[AlertEvent] 开始处理 %s 条事件 source_id=%s pusher=%s", len(events), source_id, pusher)
 
         # 处理告警事件
-        ingestion = adapter.main() or {
-            "received": len(events),
-            "accepted": len(events),
-            "skipped": 0,
-            "errored": 0,
-        }
+        event_results = None
+        if ack_mode == PER_EVENT_ACK_MODE:
+            # receiver-first 兼容扩展：只有新生产者显式 opt-in 才逐条处理并返回身份化 ACK；
+            # 旧生产者仍走原批量路径和原 result/data 契约。
+            ingestions = []
+            event_results = []
+            for index, normalized_event in enumerate(normalized_events):
+                single_adapter = adapter_class(
+                    alert_source=event_source,
+                    secret="",
+                    events=[normalized_event],
+                    trusted_internal=trusted_internal,
+                )
+                single_ingestion = single_adapter.main() or {
+                    "received": 1,
+                    "accepted": 0,
+                    "skipped": 0,
+                    "errored": 1,
+                    "duplicates": 0,
+                    "rejected": 0,
+                }
+                ingestions.append(single_ingestion)
+                event_results.append(
+                    _event_ack(normalized_event.get("delivery_id", str(index)), single_ingestion)
+                )
+            ingestion = {
+                key: sum(item.get(key, 0) for item in ingestions)
+                for key in ("received", "accepted", "skipped", "errored", "duplicates", "rejected")
+            }
+        else:
+            ingestion = adapter.main() or {
+                "received": len(events),
+                "accepted": len(events),
+                "skipped": 0,
+                "errored": 0,
+            }
 
         logger.info("[AlertEvent] 成功处理 %s 条事件 pusher=%s source_id=%s", len(events), pusher, source_id)
 
         fully_accepted = ingestion.get("skipped", 0) == 0 and ingestion.get("errored", 0) == 0
+        if event_results is not None:
+            # duplicate 是幂等终态；rejected/errored 仍失败。旧模式 result 语义完全不变。
+            fully_accepted = all(item["status"] in {"accepted", "duplicate"} for item in event_results)
+        data = {
+            "processed_events": ingestion.get("accepted", 0),
+            "ingestion": ingestion,
+            "source_id": source_id,
+            "pusher": pusher,
+            "timestamp": timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        if event_results is not None:
+            data["event_results"] = event_results
         return {
             "result": fully_accepted,
-            "data": {
-                "processed_events": ingestion.get("accepted", 0),
-                "ingestion": ingestion,
-                "source_id": source_id,
-                "pusher": pusher,
-                "timestamp": timezone.now().strftime("%Y-%m-%d %H:%M:%S"),
-            },
+            "data": data,
             "message": ("Events received and processed successfully." if fully_accepted else "Alert events were only partially accepted."),
         }
 

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -49,7 +49,9 @@ def _event_ack(delivery_id, ingestion):
     return {
         "delivery_id": delivery_id,
         "status": status,
-        "retryable": status == "errored",
+        # duplicate 是幂等终态；rejected 可能由缺字段、校验或滚动混部
+        # 引起，生产者需要保留投递意图并在修复后重试。
+        "retryable": status in {"rejected", "errored"},
     }
 
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1412,7 +1412,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
     assert result["data"]["event_results"] == [
         {"delivery_id": "d1", "status": "accepted", "retryable": False},
         {"delivery_id": "d2", "status": "duplicate", "retryable": False},
-        {"delivery_id": "d3", "status": "rejected", "retryable": False},
+        {"delivery_id": "d3", "status": "rejected", "retryable": True},
     ]
 
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1361,6 +1361,7 @@ def test_receive_alert_events_reports_partial_ingestion(monkeypatch):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(monkeypatch):
     from apps.alerts.models.alert_source import AlertSource
 
@@ -1417,6 +1418,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_per_event_ack_rejects_untrusted_and_bounds_batches(monkeypatch):
     from apps.alerts.models.alert_source import AlertSource
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1415,7 +1415,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
 
 
 @pytest.mark.django_db
-def test_receive_alert_events_per_event_ack_rejects_untrusted_or_oversized_batches(monkeypatch):
+def test_receive_alert_events_per_event_ack_keeps_untrusted_boundary_and_bounds_batches(monkeypatch):
     from apps.alerts.models.alert_source import AlertSource
 
     AlertSource.objects.create(
@@ -1426,11 +1426,16 @@ def test_receive_alert_events_per_event_ack_rejects_untrusted_or_oversized_batch
         is_active=True,
         is_effective=True,
     )
-    monkeypatch.setattr(
-        N.AlertSourceAdapterFactory,
-        "get_adapter",
-        staticmethod(lambda source: (_ for _ in ()).throw(AssertionError("adapter must not run"))),
-    )
+    observed = {}
+
+    class FakeAdapter:
+        def __init__(self, events, trusted_internal, **kwargs):
+            observed["trusted_internal"] = trusted_internal
+
+        def main(self):
+            return {"received": 1, "accepted": 1, "skipped": 0, "errored": 0, "duplicates": 0, "rejected": 0}
+
+    monkeypatch.setattr(N.AlertSourceAdapterFactory, "get_adapter", staticmethod(lambda source: FakeAdapter))
 
     untrusted = N.receive_alert_events(
         source_id="nats-ack-bound",
@@ -1445,8 +1450,8 @@ def test_receive_alert_events_per_event_ack_rejects_untrusted_or_oversized_batch
         ack_mode=N.PER_EVENT_ACK_MODE,
     )
 
-    assert untrusted["result"] is False
-    assert "restricted" in untrusted["message"]
+    assert untrusted["result"] is True
+    assert observed["trusted_internal"] is False
     assert oversized["result"] is False
     assert oversized["data"]["max_events"] == N.PER_EVENT_ACK_MAX_EVENTS
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1374,9 +1374,12 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
         is_effective=True,
     )
 
+    adapter_events = []
+
     class FakeAdapter:
         def __init__(self, events, **kwargs):
             self.events = events
+            adapter_events.extend(events)
 
         def main(self):
             status = self.events[0]["test_status"]
@@ -1396,7 +1399,12 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
     )
     monkeypatch.setattr(N, "PER_EVENT_ACK_TOKEN", "receiver-secret")
     events = [
-        {"delivery_id": "d1", "test_status": "accepted"},
+        {
+            "delivery_id": "d1",
+            "test_status": "accepted",
+            "lifecycle_action": "created",
+            "lifecycle_generation": "generation-1",
+        },
         {"delivery_id": "d2", "test_status": "duplicate"},
         {"delivery_id": "d3", "test_status": "rejected"},
     ]
@@ -1414,6 +1422,57 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
         {"delivery_id": "d1", "status": "accepted", "retryable": False},
         {"delivery_id": "d2", "status": "duplicate", "retryable": False},
         {"delivery_id": "d3", "status": "rejected", "retryable": True},
+    ]
+    assert adapter_events[0]["lifecycle_action"] == "created"
+    assert adapter_events[0]["lifecycle_generation"] == "generation-1"
+
+
+@pytest.mark.django_db
+def test_receive_alert_events_legacy_pusher_cannot_set_lifecycle_identity(monkeypatch):
+    """旧批量协议保留普通字段兼容，但不能仅凭 pusher 提升生命周期身份。"""
+    from apps.alerts.models.alert_source import AlertSource
+
+    AlertSource.objects.create(
+        name="nats旧协议",
+        source_id="nats-legacy",
+        source_type="nats",
+        secret="x",
+        is_active=True,
+        is_effective=True,
+    )
+    captured = {}
+
+    class FakeAdapter:
+        def __init__(self, events, trusted_internal, **kwargs):
+            captured["events"] = events
+            captured["trusted_internal"] = trusted_internal
+
+        def main(self):
+            return {"received": 1, "accepted": 1, "skipped": 0, "errored": 0}
+
+    monkeypatch.setattr(N.AlertSourceAdapterFactory, "get_adapter", staticmethod(lambda source: FakeAdapter))
+
+    result = N.receive_alert_events(
+        source_id="nats-legacy",
+        events=[
+            {
+                "title": "legacy-event",
+                "organizations": [3],
+                "lifecycle_action": "closed",
+                "lifecycle_generation": "forged-generation",
+            }
+        ],
+        pusher="lite-monitor",
+    )
+
+    assert result["result"] is True
+    assert captured["trusted_internal"] is True
+    assert captured["events"] == [
+        {
+            "title": "legacy-event",
+            "organizations": [3],
+            "push_source_id": "lite-monitor",
+        }
     ]
 
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1393,6 +1393,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
         "get_adapter",
         staticmethod(lambda source: FakeAdapter),
     )
+    monkeypatch.setattr(N, "PER_EVENT_ACK_TOKEN", "receiver-secret")
     events = [
         {"delivery_id": "d1", "test_status": "accepted"},
         {"delivery_id": "d2", "test_status": "duplicate"},
@@ -1404,6 +1405,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
         events=events,
         pusher="lite-monitor",
         ack_mode=N.PER_EVENT_ACK_MODE,
+        ack_token="receiver-secret",
     )
 
     assert result["result"] is False
@@ -1434,22 +1436,33 @@ def test_receive_alert_events_per_event_ack_rejects_untrusted_and_bounds_batches
             return {"received": 1, "accepted": 1, "skipped": 0, "errored": 0, "duplicates": 0, "rejected": 0}
 
     monkeypatch.setattr(N.AlertSourceAdapterFactory, "get_adapter", staticmethod(lambda source: FakeAdapter))
+    monkeypatch.setattr(N, "PER_EVENT_ACK_TOKEN", "receiver-secret")
 
     untrusted = N.receive_alert_events(
         source_id="nats-ack-bound",
         events=[{"delivery_id": "d"}],
         pusher="unknown",
         ack_mode=N.PER_EVENT_ACK_MODE,
+        ack_token="receiver-secret",
+    )
+    wrong_token = N.receive_alert_events(
+        source_id="nats-ack-bound",
+        events=[{"delivery_id": "d"}],
+        pusher="lite-monitor",
+        ack_mode=N.PER_EVENT_ACK_MODE,
+        ack_token="wrong",
     )
     oversized = N.receive_alert_events(
         source_id="nats-ack-bound",
         events=[{"delivery_id": str(index)} for index in range(N.PER_EVENT_ACK_MAX_EVENTS + 1)],
         pusher="lite-monitor",
         ack_mode=N.PER_EVENT_ACK_MODE,
+        ack_token="receiver-secret",
     )
 
     assert untrusted["result"] is False
     assert "restricted" in untrusted["message"]
+    assert wrong_token["result"] is False
     assert oversized["result"] is False
     assert oversized["data"]["max_events"] == N.PER_EVENT_ACK_MAX_EVENTS
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1415,6 +1415,43 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
 
 
 @pytest.mark.django_db
+def test_receive_alert_events_per_event_ack_rejects_untrusted_or_oversized_batches(monkeypatch):
+    from apps.alerts.models.alert_source import AlertSource
+
+    AlertSource.objects.create(
+        name="nats逐事件ACK上界",
+        source_id="nats-ack-bound",
+        source_type="nats",
+        secret="x",
+        is_active=True,
+        is_effective=True,
+    )
+    monkeypatch.setattr(
+        N.AlertSourceAdapterFactory,
+        "get_adapter",
+        staticmethod(lambda source: (_ for _ in ()).throw(AssertionError("adapter must not run"))),
+    )
+
+    untrusted = N.receive_alert_events(
+        source_id="nats-ack-bound",
+        events=[{"delivery_id": "d"}],
+        pusher="unknown",
+        ack_mode=N.PER_EVENT_ACK_MODE,
+    )
+    oversized = N.receive_alert_events(
+        source_id="nats-ack-bound",
+        events=[{"delivery_id": str(index)} for index in range(N.PER_EVENT_ACK_MAX_EVENTS + 1)],
+        pusher="lite-monitor",
+        ack_mode=N.PER_EVENT_ACK_MODE,
+    )
+
+    assert untrusted["result"] is False
+    assert "restricted" in untrusted["message"]
+    assert oversized["result"] is False
+    assert oversized["data"]["max_events"] == N.PER_EVENT_ACK_MAX_EVENTS
+
+
+@pytest.mark.django_db
 def test_receive_alert_events_marks_lite_log_as_trusted_internal(mocker):
     from apps.alerts.models.alert_source import AlertSource
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1415,7 +1415,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
 
 
 @pytest.mark.django_db
-def test_receive_alert_events_per_event_ack_keeps_untrusted_boundary_and_bounds_batches(monkeypatch):
+def test_receive_alert_events_per_event_ack_rejects_untrusted_and_bounds_batches(monkeypatch):
     from apps.alerts.models.alert_source import AlertSource
 
     AlertSource.objects.create(
@@ -1426,11 +1426,9 @@ def test_receive_alert_events_per_event_ack_keeps_untrusted_boundary_and_bounds_
         is_active=True,
         is_effective=True,
     )
-    observed = {}
-
     class FakeAdapter:
         def __init__(self, events, trusted_internal, **kwargs):
-            observed["trusted_internal"] = trusted_internal
+            pass
 
         def main(self):
             return {"received": 1, "accepted": 1, "skipped": 0, "errored": 0, "duplicates": 0, "rejected": 0}
@@ -1450,8 +1448,8 @@ def test_receive_alert_events_per_event_ack_keeps_untrusted_boundary_and_bounds_
         ack_mode=N.PER_EVENT_ACK_MODE,
     )
 
-    assert untrusted["result"] is True
-    assert observed["trusted_internal"] is False
+    assert untrusted["result"] is False
+    assert "restricted" in untrusted["message"]
     assert oversized["result"] is False
     assert oversized["data"]["max_events"] == N.PER_EVENT_ACK_MAX_EVENTS
 

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1361,6 +1361,60 @@ def test_receive_alert_events_reports_partial_ingestion(monkeypatch):
 
 
 @pytest.mark.django_db
+def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(monkeypatch):
+    from apps.alerts.models.alert_source import AlertSource
+
+    AlertSource.objects.create(
+        name="nats逐事件ACK",
+        source_id="nats-ack",
+        source_type="nats",
+        secret="x",
+        is_active=True,
+        is_effective=True,
+    )
+
+    class FakeAdapter:
+        def __init__(self, events, **kwargs):
+            self.events = events
+
+        def main(self):
+            status = self.events[0]["test_status"]
+            return {
+                "received": 1,
+                "accepted": int(status == "accepted"),
+                "skipped": int(status in {"duplicate", "rejected"}),
+                "errored": int(status == "errored"),
+                "duplicates": int(status == "duplicate"),
+                "rejected": int(status == "rejected"),
+            }
+
+    monkeypatch.setattr(
+        N.AlertSourceAdapterFactory,
+        "get_adapter",
+        staticmethod(lambda source: FakeAdapter),
+    )
+    events = [
+        {"delivery_id": "d1", "test_status": "accepted"},
+        {"delivery_id": "d2", "test_status": "duplicate"},
+        {"delivery_id": "d3", "test_status": "rejected"},
+    ]
+
+    result = N.receive_alert_events(
+        source_id="nats-ack",
+        events=events,
+        pusher="lite-monitor",
+        ack_mode=N.PER_EVENT_ACK_MODE,
+    )
+
+    assert result["result"] is False
+    assert result["data"]["event_results"] == [
+        {"delivery_id": "d1", "status": "accepted", "retryable": False},
+        {"delivery_id": "d2", "status": "duplicate", "retryable": False},
+        {"delivery_id": "d3", "status": "rejected", "retryable": False},
+    ]
+
+
+@pytest.mark.django_db
 def test_receive_alert_events_marks_lite_log_as_trusted_internal(mocker):
     from apps.alerts.models.alert_source import AlertSource
 

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -342,6 +342,24 @@ def test_create_events_reports_duplicate_and_rejected_details(event_levels, rest
     }
 
 
+@pytest.mark.django_db
+def test_trusted_lifecycle_action_separates_created_and_upgraded_identity(event_levels, restful_source):
+    adapter = RestFulAdapter(alert_source=restful_source, trusted_internal=True)
+    base = {
+        "title": "CPU",
+        "level": "0",
+        "item": "cpu",
+        "external_id": "alert-1",
+        "action": "created",
+        "start_time": "1700000000",
+        "push_source_id": "lite-monitor",
+    }
+    created = adapter.create_events([{**base, "lifecycle_action": "created"}])
+    upgraded = adapter.create_events([{**base, "lifecycle_action": "upgraded"}])
+    assert sum(len(batch) for batch in created) == 1
+    assert sum(len(batch) for batch in upgraded) == 1
+
+
 # --------------------------------------------------------------------------
 # bulk_save_events 去重
 # --------------------------------------------------------------------------

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -184,16 +184,21 @@ def test_add_start_time_defaults():
 
 
 @pytest.mark.django_db
-def test_trusted_delivery_id_is_the_ingress_identity(event_levels, restful_source):
+@pytest.mark.integration
+def test_trusted_lifecycle_generation_is_the_ingress_identity(event_levels, restful_source):
     adapter = RestFulAdapter(alert_source=restful_source, trusted_internal=True)
-    first = Event(title="第一次", level="0", start_time=timezone.now())
-    second = Event(title="升级", level="1", start_time=first.start_time)
+    first = Event(title="第一次升级", level="1", start_time=timezone.now(), external_id="alert-1")
+    second = Event(title="第二次升级", level="0", start_time=first.start_time, external_id="alert-1")
 
-    adapter.add_base_fields(first, {"delivery_id": "generation-1", "organizations": [1]})
-    adapter.add_base_fields(second, {"delivery_id": "generation-2", "organizations": [1]})
+    adapter.add_base_fields(
+        first,
+        {"lifecycle_action": "upgraded", "lifecycle_generation": "generation-1", "organizations": [1]},
+    )
+    adapter.add_base_fields(
+        second,
+        {"lifecycle_action": "upgraded", "lifecycle_generation": "generation-2", "organizations": [1]},
+    )
 
-    assert first.external_id
-    assert second.external_id
     assert first.ingest_key != second.ingest_key
     assert AlertSourceAdapter.build_ingress_dedup_key(first) == first.ingest_key
 
@@ -310,6 +315,7 @@ def test_create_events_persists(event_levels, restful_source):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_create_events_reports_duplicate_and_rejected_details(event_levels, restful_source):
     adapter = RestFulAdapter(alert_source=restful_source)
     valid = {
@@ -343,6 +349,7 @@ def test_create_events_reports_duplicate_and_rejected_details(event_levels, rest
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_trusted_lifecycle_action_separates_created_and_upgraded_identity(event_levels, restful_source):
     adapter = RestFulAdapter(alert_source=restful_source, trusted_internal=True)
     base = {
@@ -354,8 +361,12 @@ def test_trusted_lifecycle_action_separates_created_and_upgraded_identity(event_
         "start_time": "1700000000",
         "push_source_id": "lite-monitor",
     }
-    created = adapter.create_events([{**base, "lifecycle_action": "created"}])
-    upgraded = adapter.create_events([{**base, "lifecycle_action": "upgraded"}])
+    created = adapter.create_events(
+        [{**base, "lifecycle_action": "created", "lifecycle_generation": "created-1"}]
+    )
+    upgraded = adapter.create_events(
+        [{**base, "lifecycle_action": "upgraded", "lifecycle_generation": "upgraded-1"}]
+    )
     assert sum(len(batch) for batch in created) == 1
     assert sum(len(batch) for batch in upgraded) == 1
 

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -183,6 +183,21 @@ def test_add_start_time_defaults():
     assert "start_time" in data
 
 
+@pytest.mark.django_db
+def test_trusted_delivery_id_is_the_ingress_identity(event_levels, restful_source):
+    adapter = RestFulAdapter(alert_source=restful_source, trusted_internal=True)
+    first = Event(title="第一次", level="0", start_time=timezone.now())
+    second = Event(title="升级", level="1", start_time=first.start_time)
+
+    adapter.add_base_fields(first, {"delivery_id": "generation-1", "organizations": [1]})
+    adapter.add_base_fields(second, {"delivery_id": "generation-2", "organizations": [1]})
+
+    assert first.external_id
+    assert second.external_id
+    assert first.ingest_key != second.ingest_key
+    assert AlertSourceAdapter.build_ingress_dedup_key(first) == first.ingest_key
+
+
 def test_normalize_payload_valid():
     src = AlertSource(source_type="restful", config={})
     adapter = RestFulAdapter.__new__(RestFulAdapter)

--- a/server/apps/alerts/tests/test_source_adapter.py
+++ b/server/apps/alerts/tests/test_source_adapter.py
@@ -294,6 +294,39 @@ def test_create_events_persists(event_levels, restful_source):
     assert bulk
 
 
+@pytest.mark.django_db
+def test_create_events_reports_duplicate_and_rejected_details(event_levels, restful_source):
+    adapter = RestFulAdapter(alert_source=restful_source)
+    valid = {
+        "title": "事件A",
+        "level": "0",
+        "item": "cpu",
+        "external_id": "detail-ext",
+        "action": "created",
+        "start_time": "1700000000",
+    }
+
+    adapter.create_events([valid])
+    assert adapter.last_ingestion_result == {
+        "received": 1,
+        "accepted": 1,
+        "skipped": 0,
+        "errored": 0,
+        "duplicates": 0,
+        "rejected": 0,
+    }
+
+    adapter.create_events([valid, {"level": "0"}])
+    assert adapter.last_ingestion_result == {
+        "received": 2,
+        "accepted": 0,
+        "skipped": 2,
+        "errored": 0,
+        "duplicates": 1,
+        "rejected": 1,
+    }
+
+
 # --------------------------------------------------------------------------
 # bulk_save_events 去重
 # --------------------------------------------------------------------------

--- a/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
+++ b/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
@@ -9,13 +9,13 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="monitoralert",
             name="alert_center_delivery_backfilled",
-            field=models.BooleanField(default=False, verbose_name="告警中心投递意图已对账"),
+            field=models.BooleanField(default=False, null=True, verbose_name="告警中心投递意图已对账"),
             preserve_default=False,
         ),
         migrations.AlterField(
             model_name="monitoralert",
             name="alert_center_delivery_backfilled",
-            field=models.BooleanField(default=True, verbose_name="告警中心投递意图已对账"),
+            field=models.BooleanField(default=True, null=True, verbose_name="告警中心投递意图已对账"),
         ),
         migrations.CreateModel(
             name="MonitorAlertCenterDelivery",
@@ -26,6 +26,7 @@ class Migration(migrations.Migration):
                 ("action", models.CharField(max_length=20, verbose_name="生命周期动作")),
                 ("generation", models.PositiveIntegerField(verbose_name="告警内投递代次")),
                 ("delivery_id", models.CharField(max_length=64, unique=True, verbose_name="投递幂等标识")),
+                ("channel_id", models.PositiveBigIntegerField(verbose_name="通知通道 ID")),
                 ("payload", models.JSONField(default=dict, verbose_name="不可变投递载荷")),
                 ("status", models.CharField(choices=[("pending", "待投递"), ("delivering", "投递中"), ("delivered", "已投递"), ("failed", "投递失败")], db_index=True, default="pending", max_length=16)),
                 ("attempts", models.PositiveIntegerField(default=0, verbose_name="投递次数")),

--- a/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
+++ b/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
@@ -1,0 +1,47 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [("monitor", "0060_snmpifmibreconcilestate")]
+
+    operations = [
+        migrations.AddField(
+            model_name="monitoralert",
+            name="alert_center_delivery_backfilled",
+            field=models.BooleanField(default=False, verbose_name="告警中心投递意图已对账"),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name="monitoralert",
+            name="alert_center_delivery_backfilled",
+            field=models.BooleanField(default=True, verbose_name="告警中心投递意图已对账"),
+        ),
+        migrations.CreateModel(
+            name="MonitorAlertCenterDelivery",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="更新时间")),
+                ("action", models.CharField(max_length=20, verbose_name="生命周期动作")),
+                ("generation", models.PositiveIntegerField(verbose_name="告警内投递代次")),
+                ("delivery_id", models.CharField(max_length=64, unique=True, verbose_name="投递幂等标识")),
+                ("payload", models.JSONField(default=dict, verbose_name="不可变投递载荷")),
+                ("status", models.CharField(choices=[("pending", "待投递"), ("delivering", "投递中"), ("delivered", "已投递"), ("failed", "投递失败")], db_index=True, default="pending", max_length=16)),
+                ("attempts", models.PositiveIntegerField(default=0, verbose_name="投递次数")),
+                ("max_attempts", models.PositiveIntegerField(default=10, verbose_name="最大投递次数")),
+                ("next_retry_at", models.DateTimeField(blank=True, db_index=True, null=True)),
+                ("delivered_at", models.DateTimeField(blank=True, null=True)),
+                ("last_error", models.TextField(blank=True, default="")),
+                ("alert", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="alert_center_deliveries", to="monitor.monitoralert", verbose_name="监控告警")),
+            ],
+            options={
+                "db_table": "monitor_alert_center_delivery",
+                "indexes": [
+                    models.Index(fields=["status", "next_retry_at"], name="idx_monitor_delivery_retry"),
+                    models.Index(fields=["alert", "generation"], name="idx_monitor_delivery_order"),
+                ],
+                "constraints": [models.UniqueConstraint(fields=("alert", "generation"), name="uniq_monitor_alert_delivery_gen")],
+            },
+        ),
+    ]

--- a/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
+++ b/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
@@ -9,13 +9,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="monitoralert",
             name="alert_center_delivery_backfilled",
-            field=models.BooleanField(default=False, null=True, verbose_name="告警中心投递意图已对账"),
+            field=models.BooleanField(default=False, verbose_name="告警中心投递意图已对账"),
             preserve_default=False,
-        ),
-        migrations.AlterField(
-            model_name="monitoralert",
-            name="alert_center_delivery_backfilled",
-            field=models.BooleanField(default=True, null=True, verbose_name="告警中心投递意图已对账"),
         ),
         migrations.CreateModel(
             name="MonitorAlertCenterDelivery",

--- a/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
+++ b/server/apps/monitor/migrations/0061_monitoralertcenterdelivery.py
@@ -10,14 +10,13 @@ class Migration(migrations.Migration):
             model_name="monitoralert",
             name="alert_center_delivery_backfilled",
             field=models.BooleanField(default=False, verbose_name="告警中心投递意图已对账"),
-            preserve_default=False,
         ),
         migrations.CreateModel(
             name="MonitorAlertCenterDelivery",
             fields=[
                 ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
-                ("created_at", models.DateTimeField(auto_now_add=True, verbose_name="创建时间")),
-                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="更新时间")),
+                ("created_at", models.DateTimeField(auto_now_add=True, db_index=True, verbose_name="Created Time")),
+                ("updated_at", models.DateTimeField(auto_now=True, verbose_name="Updated Time")),
                 ("action", models.CharField(max_length=20, verbose_name="生命周期动作")),
                 ("generation", models.PositiveIntegerField(verbose_name="告警内投递代次")),
                 ("delivery_id", models.CharField(max_length=64, unique=True, verbose_name="投递幂等标识")),

--- a/server/apps/monitor/models/monitor_policy.py
+++ b/server/apps/monitor/models/monitor_policy.py
@@ -232,10 +232,9 @@ class MonitorAlert(TimeInfo):
     notice_logs = models.JSONField(default=list, verbose_name="通知记录")
     alert_center_notified = models.BooleanField(default=True, verbose_name="告警中心已同步")
     alert_center_retry_count = models.IntegerField(default=0, verbose_name="告警中心通知重试次数")
-    # Keep nullable during the receiver-first rolling migration. Older writers
-    # do not know this column and therefore insert NULL until every instance is
-    # upgraded; the bounded reconciler treats NULL exactly like False.
-    alert_center_delivery_backfilled = models.BooleanField(null=True, default=True, verbose_name="告警中心投递意图已对账")
+    # Receiver-first rollout 中保持 False，直到 outbox 明确完成渠道解析与意图落库。
+    # 这样 producer 关闭期和进程在生命周期提交后退出的窗口都会由有界对账收敛。
+    alert_center_delivery_backfilled = models.BooleanField(default=False, verbose_name="告警中心投递意图已对账")
 
     class Meta:
         verbose_name = "监控告警"

--- a/server/apps/monitor/models/monitor_policy.py
+++ b/server/apps/monitor/models/monitor_policy.py
@@ -232,6 +232,7 @@ class MonitorAlert(TimeInfo):
     notice_logs = models.JSONField(default=list, verbose_name="通知记录")
     alert_center_notified = models.BooleanField(default=True, verbose_name="告警中心已同步")
     alert_center_retry_count = models.IntegerField(default=0, verbose_name="告警中心通知重试次数")
+    alert_center_delivery_backfilled = models.BooleanField(default=True, verbose_name="告警中心投递意图已对账")
 
     class Meta:
         verbose_name = "监控告警"
@@ -240,6 +241,46 @@ class MonitorAlert(TimeInfo):
             # 支撑补偿任务查询（alert_center_notified=False + status__in）；
             # notified=False 行稀少（default=True），该索引选择性极高
             models.Index(fields=["alert_center_notified", "status"], name="idx_alert_center_notified"),
+        ]
+
+
+class MonitorAlertCenterDelivery(TimeInfo):
+    """监控告警向告警中心投递的不可变意图。"""
+
+    class Status(models.TextChoices):
+        PENDING = "pending", "待投递"
+        DELIVERING = "delivering", "投递中"
+        DELIVERED = "delivered", "已投递"
+        FAILED = "failed", "投递失败"
+
+    alert = models.ForeignKey(
+        MonitorAlert,
+        on_delete=models.CASCADE,
+        related_name="alert_center_deliveries",
+        verbose_name="监控告警",
+    )
+    action = models.CharField(max_length=20, verbose_name="生命周期动作")
+    generation = models.PositiveIntegerField(verbose_name="告警内投递代次")
+    delivery_id = models.CharField(max_length=64, unique=True, verbose_name="投递幂等标识")
+    payload = models.JSONField(default=dict, verbose_name="不可变投递载荷")
+    status = models.CharField(max_length=16, choices=Status.choices, default=Status.PENDING, db_index=True)
+    attempts = models.PositiveIntegerField(default=0, verbose_name="投递次数")
+    max_attempts = models.PositiveIntegerField(default=10, verbose_name="最大投递次数")
+    next_retry_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    delivered_at = models.DateTimeField(null=True, blank=True)
+    last_error = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "monitor_alert_center_delivery"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["alert", "generation"],
+                name="uniq_monitor_alert_delivery_gen",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["status", "next_retry_at"], name="idx_monitor_delivery_retry"),
+            models.Index(fields=["alert", "generation"], name="idx_monitor_delivery_order"),
         ]
 
 

--- a/server/apps/monitor/models/monitor_policy.py
+++ b/server/apps/monitor/models/monitor_policy.py
@@ -232,7 +232,10 @@ class MonitorAlert(TimeInfo):
     notice_logs = models.JSONField(default=list, verbose_name="通知记录")
     alert_center_notified = models.BooleanField(default=True, verbose_name="告警中心已同步")
     alert_center_retry_count = models.IntegerField(default=0, verbose_name="告警中心通知重试次数")
-    alert_center_delivery_backfilled = models.BooleanField(default=True, verbose_name="告警中心投递意图已对账")
+    # Keep nullable during the receiver-first rolling migration. Older writers
+    # do not know this column and therefore insert NULL until every instance is
+    # upgraded; the bounded reconciler treats NULL exactly like False.
+    alert_center_delivery_backfilled = models.BooleanField(null=True, default=True, verbose_name="告警中心投递意图已对账")
 
     class Meta:
         verbose_name = "监控告警"
@@ -262,6 +265,7 @@ class MonitorAlertCenterDelivery(TimeInfo):
     action = models.CharField(max_length=20, verbose_name="生命周期动作")
     generation = models.PositiveIntegerField(verbose_name="告警内投递代次")
     delivery_id = models.CharField(max_length=64, unique=True, verbose_name="投递幂等标识")
+    channel_id = models.PositiveBigIntegerField(verbose_name="通知通道 ID")
     payload = models.JSONField(default=dict, verbose_name="不可变投递载荷")
     status = models.CharField(max_length=16, choices=Status.choices, default=Status.PENDING, db_index=True)
     attempts = models.PositiveIntegerField(default=0, verbose_name="投递次数")

--- a/server/apps/monitor/serializers/monitor_alert.py
+++ b/server/apps/monitor/serializers/monitor_alert.py
@@ -6,7 +6,31 @@ from apps.monitor.models.monitor_policy import MonitorAlert, MonitorAlertMetricS
 class MonitorAlertSerializer(serializers.ModelSerializer):
     class Meta:
         model = MonitorAlert
-        fields = "__all__"
+        fields = [
+            "id",
+            "created_at",
+            "updated_at",
+            "policy_id",
+            "monitor_instance_id",
+            "monitor_instance_name",
+            "metric_instance_id",
+            "dimensions",
+            "alert_type",
+            "level",
+            "value",
+            "content",
+            "status",
+            "start_event_time",
+            "end_event_time",
+            "operator",
+            "info_event_count",
+            "operation_logs",
+            "notice_type_ids",
+            "notice_users",
+            "notice_logs",
+            "alert_center_notified",
+            "alert_center_retry_count",
+        ]
         # 告警中心补偿状态机的内部簿记字段，仅由服务端维护，禁止客户端写入
         read_only_fields = ["alert_center_notified", "alert_center_retry_count"]
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -59,19 +59,24 @@ def enqueue_alert_center_deliveries(
         for value in notifier._resolve_notice_type_ids(alert)
         if str(value).isdigit()
     }
-    alert_center_channel_ids = {
-        channel_id
-        for channel_id in configured_channel_ids
-        if (
-            SystemMgmtUtils.probe_notification_channel(
+    alert_center_channel_ids = set()
+    unresolved_channel_ids = set()
+    for channel_id in configured_channel_ids:
+        try:
+            capability = SystemMgmtUtils.probe_notification_channel(
                 channel_id, capability_only=True
+            ) or {}
+        except Exception:
+            # 能力目录是外部可降级依赖。生命周期事务不能因为瞬时 RPC
+            # 失败而回滚；保留 backfilled=False，由周期对账有界重试。
+            logger.exception(
+                "告警中心渠道能力查询失败，等待周期对账: channel_id=%s",
+                channel_id,
             )
-            or {}
-        ).get(
-            "delivery_mode"
-        )
-        == "alert_event_copy"
-    }
+            unresolved_channel_ids.add(channel_id)
+            continue
+        if capability.get("delivery_mode") == "alert_event_copy":
+            alert_center_channel_ids.add(channel_id)
     alert_channels = {
         alert.id: [
             int(value)
@@ -82,9 +87,10 @@ def enqueue_alert_center_deliveries(
     }
     target_alerts = [alert for alert in alerts if alert_channels[alert.id]]
     if not target_alerts:
-        MonitorAlert.objects.filter(id__in=[alert.id for alert in alerts]).update(
-            alert_center_delivery_backfilled=True
-        )
+        if not unresolved_channel_ids:
+            MonitorAlert.objects.filter(id__in=[alert.id for alert in alerts]).update(
+                alert_center_delivery_backfilled=True
+            )
         return []
 
     alert_ids = sorted({alert.id for alert in target_alerts})
@@ -155,7 +161,19 @@ def enqueue_alert_center_deliveries(
             MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
             if ALERT_CENTER_OUTBOX_DELIVERY_ENABLED:
                 transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
-        MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_delivery_backfilled=True)
+        resolved_alert_ids = [
+            alert.id
+            for alert in target_alerts
+            if not unresolved_channel_ids.intersection(
+                int(value)
+                for value in notifier._resolve_notice_type_ids(alert)
+                if str(value).isdigit()
+            )
+        ]
+        if resolved_alert_ids:
+            MonitorAlert.objects.filter(id__in=resolved_alert_ids).update(
+                alert_center_delivery_backfilled=True
+            )
     return created_ids
 
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -143,12 +143,6 @@ def deliver_alert_center_delivery(record_id):
         payload = dict(record.payload)
 
     payload["delivery_id"] = delivery_id
-    content = {
-        "source_id": "nats",
-        "pusher": "lite-monitor",
-        "ack_mode": "per_event_v1",
-        "events": [payload],
-    }
     try:
         send_result = SystemMgmtUtils.dispatch_notification(
             delivery_key=delivery_id,

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -263,6 +263,11 @@ def deliver_alert_center_delivery(record_id):
         )
         success, retryable, error = _ack_result(send_result, delivery_id)
     except Exception as exc:
+        logger.exception(
+            "告警中心 outbox 投递异常: delivery_id=%s channel_id=%s",
+            delivery_id,
+            record.channel_id,
+        )
         success, retryable, error = False, True, str(exc)
 
     finished_at = timezone.now()

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -12,10 +12,16 @@ from django.utils import timezone
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery, MonitorPolicy
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
-from apps.system_mgmt.models import Channel
 
 
-ALERT_CENTER_OUTBOX_ENABLED = os.getenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", "true").lower() in {"1", "true", "yes"}
+def _env_flag(name, *, default=False):
+    return os.getenv(name, "true" if default else "false").lower() in {"1", "true", "yes"}
+
+
+# The receiver must understand per-event acknowledgements before producers start
+# writing outbox records.  Keep the producer disabled through mixed-version
+# rollouts; operators enable it only after the receiver-first deployment.
+ALERT_CENTER_OUTBOX_ENABLED = _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED")
 OUTBOX_BATCH_SIZE = 200
 OUTBOX_LEASE_TIMEOUT = timedelta(minutes=5)
 
@@ -30,57 +36,55 @@ def _delivery_fingerprint(alert_id, action, payload):
     return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
 
-def _alert_center_channel():
-    return Channel.objects.filter(channel_type="nats", config__method_name="receive_alert_events").first()
-
-
-@transaction.atomic
 def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", reason=""):
     """在调用方事务内保存按 alert/action 代次排序的不可变载荷。"""
     if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
         return []
 
-    channel = _alert_center_channel()
-    if not channel:
+    try:
+        alert_channels = {
+            alert.id: notifier._resolve_alert_center_channel_ids(alert)
+            for alert in alerts
+        }
+    except Exception:
+        logger.exception("查询告警中心通道失败，保留 legacy pending 等待周期对账")
         return []
-
-    target_alerts = [
-        alert
-        for alert in alerts
-        if channel.id in {int(value) for value in notifier._resolve_notice_type_ids(alert) if str(value).isdigit()}
-    ]
+    target_alerts = [alert for alert in alerts if alert_channels[alert.id]]
     if not target_alerts:
         return []
 
     alert_ids = sorted({alert.id for alert in target_alerts})
-    locked_by_id = {
-        alert.id: alert
-        for alert in MonitorAlert.objects.select_for_update().filter(id__in=alert_ids).order_by("id")
-    }
-    instance_org_map = notifier._build_instance_org_map(target_alerts)
     created_ids = []
-    for original in target_alerts:
-        alert = locked_by_id.get(original.id, original)
-        payload = notifier._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
-        delivery_id = _delivery_fingerprint(alert.id, action, payload)
-        existing = MonitorAlertCenterDelivery.objects.filter(delivery_id=delivery_id).first()
-        if existing:
-            continue
-        generation = (
-            MonitorAlertCenterDelivery.objects.filter(alert_id=alert.id).aggregate(value=Max("generation"))["value"] or 0
-        ) + 1
-        delivery = MonitorAlertCenterDelivery.objects.create(
-            alert_id=alert.id,
-            action=action,
-            generation=generation,
-            delivery_id=delivery_id,
-            payload=payload,
-        )
-        created_ids.append(delivery.id)
+    with transaction.atomic():
+        locked_by_id = {
+            alert.id: alert
+            for alert in MonitorAlert.objects.select_for_update().filter(id__in=alert_ids).order_by("id")
+        }
+        instance_org_map = notifier._build_instance_org_map(target_alerts)
+        for original in target_alerts:
+            alert = locked_by_id.get(original.id, original)
+            payload = notifier._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
+            for channel_id in alert_channels[alert.id]:
+                delivery_id = _delivery_fingerprint(alert.id, action, {"channel_id": channel_id, **payload})
+                existing = MonitorAlertCenterDelivery.objects.filter(delivery_id=delivery_id).first()
+                if existing:
+                    continue
+                generation = (
+                    MonitorAlertCenterDelivery.objects.filter(alert_id=alert.id).aggregate(value=Max("generation"))["value"] or 0
+                ) + 1
+                delivery = MonitorAlertCenterDelivery.objects.create(
+                    alert_id=alert.id,
+                    action=action,
+                    generation=generation,
+                    delivery_id=delivery_id,
+                    channel_id=channel_id,
+                    payload=payload,
+                )
+                created_ids.append(delivery.id)
 
-    if created_ids:
-        MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
-        transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
+        if created_ids:
+            MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
+            transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
     return created_ids
 
 
@@ -137,40 +141,40 @@ def deliver_alert_center_delivery(record_id):
         delivery_id = record.delivery_id
         payload = dict(record.payload)
 
-    channel = _alert_center_channel()
-    if not channel:
-        success, retryable, error = False, True, "alert center channel not configured"
-    else:
-        payload["delivery_id"] = delivery_id
-        content = {
-            "source_id": "nats",
-            "pusher": "lite-monitor",
-            "ack_mode": "per_event_v1",
-            "events": [payload],
-        }
-        try:
-            send_result = SystemMgmtUtils.send_msg_with_channel(channel.id, "", content, [])
-            success, retryable, error = _ack_result(send_result, delivery_id)
-        except Exception as exc:
-            success, retryable, error = False, True, str(exc)
+    payload["delivery_id"] = delivery_id
+    content = {
+        "source_id": "nats",
+        "pusher": "lite-monitor",
+        "ack_mode": "per_event_v1",
+        "events": [payload],
+    }
+    try:
+        send_result = SystemMgmtUtils.send_msg_with_channel(record.channel_id, "", content, [])
+        success, retryable, error = _ack_result(send_result, delivery_id)
+    except Exception as exc:
+        success, retryable, error = False, True, str(exc)
 
     finished_at = timezone.now()
     if success:
-        finalized = MonitorAlertCenterDelivery.objects.filter(
-            id=record_id,
-            status=MonitorAlertCenterDelivery.Status.DELIVERING,
-            attempts=claim_generation,
-        ).update(
-            status=MonitorAlertCenterDelivery.Status.DELIVERED,
-            delivered_at=finished_at,
-            next_retry_at=None,
-            last_error="",
-            updated_at=finished_at,
-        )
-        if finalized and not MonitorAlertCenterDelivery.objects.filter(alert_id=record.alert_id).exclude(
-            status=MonitorAlertCenterDelivery.Status.DELIVERED
-        ).exists():
-            MonitorAlert.objects.filter(id=record.alert_id).update(alert_center_notified=True, alert_center_retry_count=0)
+        with transaction.atomic():
+            # Enqueue takes the same alert-row lock. This makes finalization and
+            # the "all generations delivered" decision one ordered state change.
+            MonitorAlert.objects.select_for_update().get(id=record.alert_id)
+            finalized = MonitorAlertCenterDelivery.objects.filter(
+                id=record_id,
+                status=MonitorAlertCenterDelivery.Status.DELIVERING,
+                attempts=claim_generation,
+            ).update(
+                status=MonitorAlertCenterDelivery.Status.DELIVERED,
+                delivered_at=finished_at,
+                next_retry_at=None,
+                last_error="",
+                updated_at=finished_at,
+            )
+            if finalized and not MonitorAlertCenterDelivery.objects.filter(alert_id=record.alert_id).exclude(
+                status=MonitorAlertCenterDelivery.Status.DELIVERED
+            ).exists():
+                MonitorAlert.objects.filter(id=record.alert_id).update(alert_center_notified=True, alert_center_retry_count=0)
         return bool(finalized)
 
     terminal = not retryable or claim_generation >= record.max_attempts
@@ -193,9 +197,9 @@ def backfill_legacy_alerts():
     """有界对账存量告警；成功旧投递会由接收端幂等去重。"""
     alerts = list(
         MonitorAlert.objects.filter(
-            alert_center_delivery_backfilled=False,
-            alert_center_notified=False,
+            Q(alert_center_delivery_backfilled=False) | Q(alert_center_delivery_backfilled__isnull=True)
         )
+        .filter(Q(alert_center_notified=False) | Q(status="new"))
         .order_by("id")[:OUTBOX_BATCH_SIZE]
     )
     if not alerts:

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -214,8 +214,18 @@ def backfill_legacy_alerts():
     from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 
     for alert in alerts:
+        policy = policies.get(alert.policy_id)
+        if policy is not None and not policy.notice:
+            MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
+            continue
+        configured_ids = [int(value) for value in alert.notice_type_ids or [] if str(value).isdigit()]
+        if not configured_ids and policy is not None:
+            configured_ids = [int(value) for value in policy.notice_type_ids or [] if str(value).isdigit()]
+        if not configured_ids:
+            MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
+            continue
         action = "created" if alert.status == "new" else alert.status
-        notifier = AlertLifecycleNotifier(policies.get(alert.policy_id), policies_by_id=policies)
+        notifier = AlertLifecycleNotifier(policy, policies_by_id=policies)
         enqueue_alert_center_deliveries([alert], action, notifier=notifier)
     return len(alerts)
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -18,14 +18,22 @@ def _env_flag(name, *, default=False):
     return os.getenv(name, "true" if default else "false").lower() in {"1", "true", "yes"}
 
 
+def _outbox_enabled():
+    return _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED") and bool(
+        os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
+    )
+
+
 # The receiver must understand per-event acknowledgements before producers start
 # writing outbox records.  Keep the producer disabled through mixed-version
 # rollouts; operators enable it only after the receiver-first deployment.
-ALERT_CENTER_OUTBOX_ENABLED = _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED")
+ALERT_CENTER_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
+# outbox 的 shadow/active 两阶段都依赖 receiver-first 的认证生命周期身份；
+# 缺少共享凭据时保持旧链路，避免先写入无法与即时投递收敛的代次。
+ALERT_CENTER_OUTBOX_ENABLED = _outbox_enabled()
 ALERT_CENTER_OUTBOX_DELIVERY_ENABLED = _env_flag(
     "MONITOR_ALERT_CENTER_OUTBOX_DELIVERY_ENABLED"
 )
-ALERT_CENTER_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
 OUTBOX_BATCH_SIZE = 200
 OUTBOX_LEASE_TIMEOUT = timedelta(minutes=5)
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -242,6 +242,10 @@ def deliver_alert_center_delivery(record_id):
     next_status = MonitorAlertCenterDelivery.Status.FAILED if terminal else MonitorAlertCenterDelivery.Status.PENDING
     next_retry_at = None if terminal else finished_at + timedelta(seconds=min(3600, 15 * (2 ** min(claim_generation, 8))))
     with transaction.atomic():
+        if terminal:
+            # 与 enqueue 共用 alert 行锁；终态传播扫描和提交之间不允许
+            # 并发插入一个看不到 FAILED 前驱的 PENDING 后继。
+            MonitorAlert.objects.select_for_update().get(id=record.alert_id)
         finalized = MonitorAlertCenterDelivery.objects.filter(
             id=record_id,
             status=MonitorAlertCenterDelivery.Status.DELIVERING,

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -37,7 +37,15 @@ def _delivery_fingerprint(alert_id, action, payload):
     return hashlib.sha256(source.encode("utf-8")).hexdigest()
 
 
-def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", reason=""):
+def enqueue_alert_center_deliveries(
+    alerts,
+    action,
+    *,
+    notifier,
+    operator="",
+    reason="",
+    legacy_ingest_identity=False,
+):
     """在调用方事务内保存按 alert/action 代次排序的不可变载荷。"""
     if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
         return []
@@ -60,16 +68,39 @@ def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", re
         instance_org_map = notifier._build_instance_org_map(target_alerts)
         for original in target_alerts:
             alert = locked_by_id.get(original.id, original)
-            payload = notifier._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
+            blocking_generation = (
+                MonitorAlertCenterDelivery.objects.filter(
+                    alert_id=alert.id,
+                    status=MonitorAlertCenterDelivery.Status.FAILED,
+                )
+                .order_by("generation")
+                .values_list("generation", flat=True)
+                .first()
+            )
+            base_payload = notifier._build_alert_center_payload(
+                alert, action, operator, reason, instance_org_map
+            )
+            if legacy_ingest_identity:
+                # 旧 producer 没有 lifecycle identity。存量 new 的 notified=True
+                # 无法区分“已经成功”与“默认值掩盖失败”，沿用旧 ingest key
+                # 才能让 receiver 对前者去重、对后者正常接收。
+                base_payload.pop("lifecycle_action", None)
             for channel_id in alert_channels[alert.id]:
-                delivery_id = _delivery_fingerprint(alert.id, action, {"channel_id": channel_id, **payload})
+                delivery_id = _delivery_fingerprint(
+                    alert.id,
+                    action,
+                    {"channel_id": channel_id, **base_payload},
+                )
                 existing = MonitorAlertCenterDelivery.objects.filter(delivery_id=delivery_id).first()
                 if existing:
                     continue
                 generation = (
                     MonitorAlertCenterDelivery.objects.filter(alert_id=alert.id).aggregate(value=Max("generation"))["value"] or 0
                 ) + 1
-                payload = {**payload, "lifecycle_generation": delivery_id}
+                payload = {
+                    **base_payload,
+                    "lifecycle_generation": delivery_id,
+                }
                 delivery = MonitorAlertCenterDelivery.objects.create(
                     alert_id=alert.id,
                     action=action,
@@ -77,6 +108,16 @@ def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", re
                     delivery_id=delivery_id,
                     channel_id=channel_id,
                     payload=payload,
+                    status=(
+                        MonitorAlertCenterDelivery.Status.FAILED
+                        if blocking_generation is not None
+                        else MonitorAlertCenterDelivery.Status.PENDING
+                    ),
+                    last_error=(
+                        f"blocked by terminal generation {blocking_generation}"
+                        if blocking_generation is not None
+                        else ""
+                    ),
                 )
                 created_ids.append(delivery.id)
 
@@ -118,7 +159,17 @@ def _ack_result(send_result, delivery_id):
 def deliver_alert_center_delivery(record_id):
     """按代次 claim/finalize；旧执行不能覆盖新 claim，后继动作不得越过前驱。"""
     now = timezone.now()
+    alert_id = (
+        MonitorAlertCenterDelivery.objects.filter(id=record_id)
+        .values_list("alert_id", flat=True)
+        .first()
+    )
+    if alert_id is None:
+        return False
     with transaction.atomic():
+        # 与 enqueue 保持 alert → delivery 的统一锁顺序；终态传播期间
+        # 禁止并发 enqueue 在扫描后插入一个永远被 FAILED 前驱阻塞的后继。
+        MonitorAlert.objects.select_for_update().get(id=alert_id)
         record = MonitorAlertCenterDelivery.objects.select_for_update().filter(id=record_id).first()
         if not record or record.status in {record.Status.DELIVERED, record.Status.FAILED}:
             return False
@@ -251,7 +302,14 @@ def backfill_legacy_alerts():
             continue
         action = "created" if alert.status == "new" else alert.status
         notifier = AlertLifecycleNotifier(policy, policies_by_id=policies)
-        enqueue_alert_center_deliveries([alert], action, notifier=notifier)
+        enqueue_alert_center_deliveries(
+            [alert],
+            action,
+            notifier=notifier,
+            legacy_ingest_identity=(
+                alert.status == "new" and alert.alert_center_notified
+            ),
+        )
     return len(alerts)
 
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -1,0 +1,226 @@
+"""Monitor 生命周期事件到告警中心的 transactional outbox。"""
+
+import hashlib
+import json
+import os
+from datetime import timedelta
+
+from django.db import transaction
+from django.db.models import Max, Q
+from django.utils import timezone
+
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery, MonitorPolicy
+from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
+from apps.system_mgmt.models import Channel
+
+
+ALERT_CENTER_OUTBOX_ENABLED = os.getenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", "true").lower() in {"1", "true", "yes"}
+OUTBOX_BATCH_SIZE = 200
+OUTBOX_LEASE_TIMEOUT = timedelta(minutes=5)
+
+
+def _delivery_fingerprint(alert_id, action, payload):
+    source = json.dumps(
+        {"alert_id": str(alert_id), "action": action, "payload": payload},
+        sort_keys=True,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def _alert_center_channel():
+    return Channel.objects.filter(channel_type="nats", config__method_name="receive_alert_events").first()
+
+
+@transaction.atomic
+def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", reason=""):
+    """在调用方事务内保存按 alert/action 代次排序的不可变载荷。"""
+    if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
+        return []
+
+    channel = _alert_center_channel()
+    if not channel:
+        return []
+
+    target_alerts = [
+        alert
+        for alert in alerts
+        if channel.id in {int(value) for value in notifier._resolve_notice_type_ids(alert) if str(value).isdigit()}
+    ]
+    if not target_alerts:
+        return []
+
+    alert_ids = sorted({alert.id for alert in target_alerts})
+    locked_by_id = {
+        alert.id: alert
+        for alert in MonitorAlert.objects.select_for_update().filter(id__in=alert_ids).order_by("id")
+    }
+    instance_org_map = notifier._build_instance_org_map(target_alerts)
+    created_ids = []
+    for original in target_alerts:
+        alert = locked_by_id.get(original.id, original)
+        payload = notifier._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
+        delivery_id = _delivery_fingerprint(alert.id, action, payload)
+        existing = MonitorAlertCenterDelivery.objects.filter(delivery_id=delivery_id).first()
+        if existing:
+            continue
+        generation = (
+            MonitorAlertCenterDelivery.objects.filter(alert_id=alert.id).aggregate(value=Max("generation"))["value"] or 0
+        ) + 1
+        delivery = MonitorAlertCenterDelivery.objects.create(
+            alert_id=alert.id,
+            action=action,
+            generation=generation,
+            delivery_id=delivery_id,
+            payload=payload,
+        )
+        created_ids.append(delivery.id)
+
+    if created_ids:
+        MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
+        transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
+    return created_ids
+
+
+def _schedule_deliveries(delivery_ids):
+    from apps.monitor.tasks.monitor_policy import deliver_alert_center_lifecycle_delivery
+
+    for delivery_id in delivery_ids:
+        try:
+            deliver_alert_center_lifecycle_delivery.delay(delivery_id)
+        except Exception:
+            logger.exception("告警中心 outbox 调度失败，等待周期补偿: delivery_id=%s", delivery_id)
+
+
+def _ack_result(send_result, delivery_id):
+    if not isinstance(send_result, dict):
+        return False, True, "invalid response"
+    for item in (send_result.get("data") or {}).get("event_results") or []:
+        if isinstance(item, dict) and item.get("delivery_id") == delivery_id:
+            status = item.get("status")
+            if status in {"accepted", "duplicate"}:
+                return True, False, ""
+            return False, bool(item.get("retryable", status == "errored")), status or "invalid acknowledgement"
+    if send_result.get("result") is True:
+        return True, False, ""
+    return False, True, send_result.get("message") or "delivery failed"
+
+
+def deliver_alert_center_delivery(record_id):
+    """按代次 claim/finalize；旧执行不能覆盖新 claim，后继动作不得越过前驱。"""
+    now = timezone.now()
+    with transaction.atomic():
+        record = MonitorAlertCenterDelivery.objects.select_for_update().filter(id=record_id).first()
+        if not record or record.status in {record.Status.DELIVERED, record.Status.FAILED}:
+            return False
+        earlier_unfinished = MonitorAlertCenterDelivery.objects.filter(
+            alert_id=record.alert_id,
+            generation__lt=record.generation,
+        ).exclude(status=record.Status.DELIVERED).exists()
+        if earlier_unfinished:
+            return False
+        if record.status == record.Status.DELIVERING and record.updated_at > now - OUTBOX_LEASE_TIMEOUT:
+            return False
+        if record.attempts >= record.max_attempts:
+            record.status = record.Status.FAILED
+            record.next_retry_at = None
+            record.last_error = record.last_error or "retries exhausted"
+            record.save(update_fields=["status", "next_retry_at", "last_error", "updated_at"])
+            return False
+        record.status = record.Status.DELIVERING
+        record.attempts += 1
+        record.last_error = ""
+        record.save(update_fields=["status", "attempts", "last_error", "updated_at"])
+        claim_generation = record.attempts
+        delivery_id = record.delivery_id
+        payload = dict(record.payload)
+
+    channel = _alert_center_channel()
+    if not channel:
+        success, retryable, error = False, True, "alert center channel not configured"
+    else:
+        payload["delivery_id"] = delivery_id
+        content = {
+            "source_id": "nats",
+            "pusher": "lite-monitor",
+            "ack_mode": "per_event_v1",
+            "events": [payload],
+        }
+        try:
+            send_result = SystemMgmtUtils.send_msg_with_channel(channel.id, "", content, [])
+            success, retryable, error = _ack_result(send_result, delivery_id)
+        except Exception as exc:
+            success, retryable, error = False, True, str(exc)
+
+    finished_at = timezone.now()
+    if success:
+        finalized = MonitorAlertCenterDelivery.objects.filter(
+            id=record_id,
+            status=MonitorAlertCenterDelivery.Status.DELIVERING,
+            attempts=claim_generation,
+        ).update(
+            status=MonitorAlertCenterDelivery.Status.DELIVERED,
+            delivered_at=finished_at,
+            next_retry_at=None,
+            last_error="",
+            updated_at=finished_at,
+        )
+        if finalized and not MonitorAlertCenterDelivery.objects.filter(alert_id=record.alert_id).exclude(
+            status=MonitorAlertCenterDelivery.Status.DELIVERED
+        ).exists():
+            MonitorAlert.objects.filter(id=record.alert_id).update(alert_center_notified=True, alert_center_retry_count=0)
+        return bool(finalized)
+
+    terminal = not retryable or claim_generation >= record.max_attempts
+    next_status = MonitorAlertCenterDelivery.Status.FAILED if terminal else MonitorAlertCenterDelivery.Status.PENDING
+    next_retry_at = None if terminal else finished_at + timedelta(seconds=min(3600, 15 * (2 ** min(claim_generation, 8))))
+    MonitorAlertCenterDelivery.objects.filter(
+        id=record_id,
+        status=MonitorAlertCenterDelivery.Status.DELIVERING,
+        attempts=claim_generation,
+    ).update(
+        status=next_status,
+        next_retry_at=next_retry_at,
+        last_error=error[:2000],
+        updated_at=finished_at,
+    )
+    return False
+
+
+def backfill_legacy_alerts():
+    """有界对账存量告警；成功旧投递会由接收端幂等去重。"""
+    alerts = list(
+        MonitorAlert.objects.filter(
+            alert_center_delivery_backfilled=False,
+            alert_center_notified=False,
+        )
+        .order_by("id")[:OUTBOX_BATCH_SIZE]
+    )
+    if not alerts:
+        return 0
+    policies = MonitorPolicy.objects.in_bulk({alert.policy_id for alert in alerts if alert.policy_id})
+    from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
+
+    with transaction.atomic():
+        for alert in alerts:
+            action = "created" if alert.status == "new" else alert.status
+            notifier = AlertLifecycleNotifier(policies.get(alert.policy_id), policies_by_id=policies)
+            enqueue_alert_center_deliveries([alert], action, notifier=notifier)
+        MonitorAlert.objects.filter(id__in=[alert.id for alert in alerts]).update(alert_center_delivery_backfilled=True)
+    return len(alerts)
+
+
+def due_delivery_ids():
+    now = timezone.now()
+    stale_before = now - OUTBOX_LEASE_TIMEOUT
+    return list(
+        MonitorAlertCenterDelivery.objects.filter(
+            Q(status=MonitorAlertCenterDelivery.Status.PENDING)
+            | Q(status=MonitorAlertCenterDelivery.Status.DELIVERING, updated_at__lte=stale_before),
+            Q(next_retry_at__isnull=True) | Q(next_retry_at__lte=now),
+        )
+        .order_by("alert_id", "generation")
+        .values_list("id", flat=True)[:OUTBOX_BATCH_SIZE]
+    )

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -48,6 +48,7 @@ def enqueue_alert_center_deliveries(
     operator="",
     reason="",
     legacy_ingest_identity=False,
+    channel_ids_by_alert=None,
 ):
     """在调用方事务内保存按 alert/action 代次排序的不可变载荷。"""
     if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
@@ -56,7 +57,10 @@ def enqueue_alert_center_deliveries(
     configured_channel_ids = {
         int(value)
         for alert in alerts
-        for value in notifier._resolve_notice_type_ids(alert)
+        for value in (
+            (channel_ids_by_alert or {}).get(alert.id)
+            or notifier._resolve_notice_type_ids(alert)
+        )
         if str(value).isdigit()
     }
     alert_center_channel_ids = set()
@@ -80,7 +84,10 @@ def enqueue_alert_center_deliveries(
     alert_channels = {
         alert.id: [
             int(value)
-            for value in notifier._resolve_notice_type_ids(alert)
+            for value in (
+                (channel_ids_by_alert or {}).get(alert.id)
+                or notifier._resolve_notice_type_ids(alert)
+            )
             if str(value).isdigit() and int(value) in alert_center_channel_ids
         ]
         for alert in alerts
@@ -166,7 +173,10 @@ def enqueue_alert_center_deliveries(
             for alert in target_alerts
             if not unresolved_channel_ids.intersection(
                 int(value)
-                for value in notifier._resolve_notice_type_ids(alert)
+                for value in (
+                    (channel_ids_by_alert or {}).get(alert.id)
+                    or notifier._resolve_notice_type_ids(alert)
+                )
                 if str(value).isdigit()
             )
         ]
@@ -351,26 +361,32 @@ def backfill_legacy_alerts():
 
     for alert in alerts:
         policy = policies.get(alert.policy_id)
-        has_successful_created_notice = any(
-            isinstance(entry, dict)
-            and entry.get("action") in {"created", "upgraded"}
-            and entry.get("success") is True
-            for entry in alert.notice_logs or []
-        )
-        if policy is not None and not policy.notice and not (
-            alert.status in {"recovered", "closed"}
-            and has_successful_created_notice
-        ):
-            MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
-            continue
         configured_ids = [int(value) for value in alert.notice_type_ids or [] if str(value).isdigit()]
         if not configured_ids and policy is not None:
             configured_ids = [int(value) for value in policy.notice_type_ids or [] if str(value).isdigit()]
+        successful_created_channel_ids = {
+            int(entry.get("channel_id"))
+            for entry in alert.notice_logs or []
+            if isinstance(entry, dict)
+            and entry.get("action") in {"created", "upgraded"}
+            and entry.get("success") is True
+            and str(entry.get("channel_id")).isdigit()
+        }
+        if policy is not None and not policy.notice:
+            configured_ids = [
+                channel_id
+                for channel_id in configured_ids
+                if alert.status in {"recovered", "closed"}
+                and channel_id in successful_created_channel_ids
+            ]
         if not configured_ids:
             MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
             continue
         notifier = AlertLifecycleNotifier(policy, policies_by_id=policies)
-        if alert.status != "new" and not has_successful_created_notice:
+        missing_created_channel_ids = sorted(
+            set(configured_ids) - successful_created_channel_ids
+        )
+        if alert.status != "new" and missing_created_channel_ids:
             # 存量只有当前态，没有首次告警的不可变快照；先建立兼容 created
             # 前驱，保证 recovery/closed 不会越过尚未确认的首次投递。
             enqueue_alert_center_deliveries(
@@ -378,6 +394,7 @@ def backfill_legacy_alerts():
                 "created",
                 notifier=notifier,
                 legacy_ingest_identity=True,
+                channel_ids_by_alert={alert.id: missing_created_channel_ids},
             )
         enqueue_alert_center_deliveries(
             [alert],
@@ -386,6 +403,7 @@ def backfill_legacy_alerts():
             legacy_ingest_identity=(
                 alert.status == "new" and alert.alert_center_notified
             ),
+            channel_ids_by_alert={alert.id: configured_ids},
         )
     return len(alerts)
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -22,6 +22,9 @@ def _env_flag(name, *, default=False):
 # writing outbox records.  Keep the producer disabled through mixed-version
 # rollouts; operators enable it only after the receiver-first deployment.
 ALERT_CENTER_OUTBOX_ENABLED = _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED")
+ALERT_CENTER_OUTBOX_DELIVERY_ENABLED = _env_flag(
+    "MONITOR_ALERT_CENTER_OUTBOX_DELIVERY_ENABLED"
+)
 ALERT_CENTER_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
 OUTBOX_BATCH_SIZE = 200
 OUTBOX_LEASE_TIMEOUT = timedelta(minutes=5)
@@ -50,12 +53,38 @@ def enqueue_alert_center_deliveries(
     if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
         return []
 
+    configured_channel_ids = {
+        int(value)
+        for alert in alerts
+        for value in notifier._resolve_notice_type_ids(alert)
+        if str(value).isdigit()
+    }
+    alert_center_channel_ids = {
+        channel_id
+        for channel_id in configured_channel_ids
+        if (
+            SystemMgmtUtils.probe_notification_channel(
+                channel_id, capability_only=True
+            )
+            or {}
+        ).get(
+            "delivery_mode"
+        )
+        == "alert_event_copy"
+    }
     alert_channels = {
-        alert.id: [int(value) for value in notifier._resolve_notice_type_ids(alert) if str(value).isdigit()]
+        alert.id: [
+            int(value)
+            for value in notifier._resolve_notice_type_ids(alert)
+            if str(value).isdigit() and int(value) in alert_center_channel_ids
+        ]
         for alert in alerts
     }
     target_alerts = [alert for alert in alerts if alert_channels[alert.id]]
     if not target_alerts:
+        MonitorAlert.objects.filter(id__in=[alert.id for alert in alerts]).update(
+            alert_center_delivery_backfilled=True
+        )
         return []
 
     alert_ids = sorted({alert.id for alert in target_alerts})
@@ -68,15 +97,6 @@ def enqueue_alert_center_deliveries(
         instance_org_map = notifier._build_instance_org_map(target_alerts)
         for original in target_alerts:
             alert = locked_by_id.get(original.id, original)
-            blocking_generation = (
-                MonitorAlertCenterDelivery.objects.filter(
-                    alert_id=alert.id,
-                    status=MonitorAlertCenterDelivery.Status.FAILED,
-                )
-                .order_by("generation")
-                .values_list("generation", flat=True)
-                .first()
-            )
             base_payload = notifier._build_alert_center_payload(
                 alert, action, operator, reason, instance_org_map
             )
@@ -86,6 +106,16 @@ def enqueue_alert_center_deliveries(
                 # 才能让 receiver 对前者去重、对后者正常接收。
                 base_payload.pop("lifecycle_action", None)
             for channel_id in alert_channels[alert.id]:
+                blocking_generation = (
+                    MonitorAlertCenterDelivery.objects.filter(
+                        alert_id=alert.id,
+                        channel_id=channel_id,
+                        status=MonitorAlertCenterDelivery.Status.FAILED,
+                    )
+                    .order_by("generation")
+                    .values_list("generation", flat=True)
+                    .first()
+                )
                 delivery_id = _delivery_fingerprint(
                     alert.id,
                     action,
@@ -123,7 +153,8 @@ def enqueue_alert_center_deliveries(
 
         if created_ids:
             MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
-            transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
+            if ALERT_CENTER_OUTBOX_DELIVERY_ENABLED:
+                transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
         MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_delivery_backfilled=True)
     return created_ids
 
@@ -175,6 +206,7 @@ def deliver_alert_center_delivery(record_id):
             return False
         earlier_unfinished = MonitorAlertCenterDelivery.objects.filter(
             alert_id=record.alert_id,
+            channel_id=record.channel_id,
             generation__lt=record.generation,
         ).exclude(status=record.Status.DELIVERED).exists()
         if earlier_unfinished:
@@ -266,6 +298,7 @@ def _fail_blocked_successors(record):
     """A terminal predecessor makes later lifecycle copies unsafe to deliver."""
     MonitorAlertCenterDelivery.objects.filter(
         alert_id=record.alert_id,
+        channel_id=record.channel_id,
         generation__gt=record.generation,
         status__in=[
             MonitorAlertCenterDelivery.Status.PENDING,
@@ -295,7 +328,16 @@ def backfill_legacy_alerts():
 
     for alert in alerts:
         policy = policies.get(alert.policy_id)
-        if policy is not None and not policy.notice:
+        has_successful_created_notice = any(
+            isinstance(entry, dict)
+            and entry.get("action") in {"created", "upgraded"}
+            and entry.get("success") is True
+            for entry in alert.notice_logs or []
+        )
+        if policy is not None and not policy.notice and not (
+            alert.status in {"recovered", "closed"}
+            and has_successful_created_notice
+        ):
             MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
             continue
         configured_ids = [int(value) for value in alert.notice_type_ids or [] if str(value).isdigit()]
@@ -304,11 +346,19 @@ def backfill_legacy_alerts():
         if not configured_ids:
             MonitorAlert.objects.filter(id=alert.id).update(alert_center_delivery_backfilled=True)
             continue
-        action = "created" if alert.status == "new" else alert.status
         notifier = AlertLifecycleNotifier(policy, policies_by_id=policies)
+        if alert.status != "new" and not has_successful_created_notice:
+            # 存量只有当前态，没有首次告警的不可变快照；先建立兼容 created
+            # 前驱，保证 recovery/closed 不会越过尚未确认的首次投递。
+            enqueue_alert_center_deliveries(
+                [alert],
+                "created",
+                notifier=notifier,
+                legacy_ingest_identity=True,
+            )
         enqueue_alert_center_deliveries(
             [alert],
-            action,
+            "created" if alert.status == "new" else alert.status,
             notifier=notifier,
             legacy_ingest_identity=(
                 alert.status == "new" and alert.alert_center_notified

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -41,14 +41,10 @@ def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", re
     if not ALERT_CENTER_OUTBOX_ENABLED or not alerts:
         return []
 
-    try:
-        alert_channels = {
-            alert.id: notifier._resolve_alert_center_channel_ids(alert)
-            for alert in alerts
-        }
-    except Exception:
-        logger.exception("查询告警中心通道失败，保留 legacy pending 等待周期对账")
-        return []
+    alert_channels = {
+        alert.id: [int(value) for value in notifier._resolve_notice_type_ids(alert) if str(value).isdigit()]
+        for alert in alerts
+    }
     target_alerts = [alert for alert in alerts if alert_channels[alert.id]]
     if not target_alerts:
         return []
@@ -85,6 +81,7 @@ def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", re
         if created_ids:
             MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_notified=False)
             transaction.on_commit(lambda ids=tuple(created_ids): _schedule_deliveries(ids))
+        MonitorAlert.objects.filter(id__in=alert_ids).update(alert_center_delivery_backfilled=True)
     return created_ids
 
 
@@ -109,7 +106,11 @@ def _ack_result(send_result, delivery_id):
             return False, bool(item.get("retryable", status == "errored")), status or "invalid acknowledgement"
     if send_result.get("result") is True:
         return True, False, ""
-    return False, True, send_result.get("message") or "delivery failed"
+    return (
+        False,
+        bool(send_result.get("retryable", True)),
+        send_result.get("code") or send_result.get("message") or "delivery failed",
+    )
 
 
 def deliver_alert_center_delivery(record_id):
@@ -149,7 +150,18 @@ def deliver_alert_center_delivery(record_id):
         "events": [payload],
     }
     try:
-        send_result = SystemMgmtUtils.send_msg_with_channel(record.channel_id, "", content, [])
+        send_result = SystemMgmtUtils.dispatch_notification(
+            delivery_key=delivery_id,
+            channel_id=record.channel_id,
+            organization_ids=payload.get("organizations") or [],
+            recipients=[],
+            title="",
+            body=payload.get("description") or payload.get("title") or "alert event",
+            event_payload=payload,
+            required_delivery_mode="alert_event_copy",
+            producer="lite-monitor",
+            ack_mode="per_event_v1",
+        )
         success, retryable, error = _ack_result(send_result, delivery_id)
     except Exception as exc:
         success, retryable, error = False, True, str(exc)
@@ -197,7 +209,7 @@ def backfill_legacy_alerts():
     """有界对账存量告警；成功旧投递会由接收端幂等去重。"""
     alerts = list(
         MonitorAlert.objects.filter(
-            Q(alert_center_delivery_backfilled=False) | Q(alert_center_delivery_backfilled__isnull=True)
+            alert_center_delivery_backfilled=False
         )
         .filter(Q(alert_center_notified=False) | Q(status="new"))
         .order_by("id")[:OUTBOX_BATCH_SIZE]
@@ -207,12 +219,10 @@ def backfill_legacy_alerts():
     policies = MonitorPolicy.objects.in_bulk({alert.policy_id for alert in alerts if alert.policy_id})
     from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 
-    with transaction.atomic():
-        for alert in alerts:
-            action = "created" if alert.status == "new" else alert.status
-            notifier = AlertLifecycleNotifier(policies.get(alert.policy_id), policies_by_id=policies)
-            enqueue_alert_center_deliveries([alert], action, notifier=notifier)
-        MonitorAlert.objects.filter(id__in=[alert.id for alert in alerts]).update(alert_center_delivery_backfilled=True)
+    for alert in alerts:
+        action = "created" if alert.status == "new" else alert.status
+        notifier = AlertLifecycleNotifier(policies.get(alert.policy_id), policies_by_id=policies)
+        enqueue_alert_center_deliveries([alert], action, notifier=notifier)
     return len(alerts)
 
 

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -22,6 +22,7 @@ def _env_flag(name, *, default=False):
 # writing outbox records.  Keep the producer disabled through mixed-version
 # rollouts; operators enable it only after the receiver-first deployment.
 ALERT_CENTER_OUTBOX_ENABLED = _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED")
+ALERT_CENTER_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
 OUTBOX_BATCH_SIZE = 200
 OUTBOX_LEASE_TIMEOUT = timedelta(minutes=5)
 
@@ -68,6 +69,7 @@ def enqueue_alert_center_deliveries(alerts, action, *, notifier, operator="", re
                 generation = (
                     MonitorAlertCenterDelivery.objects.filter(alert_id=alert.id).aggregate(value=Max("generation"))["value"] or 0
                 ) + 1
+                payload = {**payload, "lifecycle_generation": delivery_id}
                 delivery = MonitorAlertCenterDelivery.objects.create(
                     alert_id=alert.id,
                     action=action,
@@ -133,6 +135,7 @@ def deliver_alert_center_delivery(record_id):
             record.next_retry_at = None
             record.last_error = record.last_error or "retries exhausted"
             record.save(update_fields=["status", "next_retry_at", "last_error", "updated_at"])
+            _fail_blocked_successors(record)
             return False
         record.status = record.Status.DELIVERING
         record.attempts += 1
@@ -155,6 +158,7 @@ def deliver_alert_center_delivery(record_id):
             required_delivery_mode="alert_event_copy",
             producer="lite-monitor",
             ack_mode="per_event_v1",
+            ack_token=ALERT_CENTER_ACK_TOKEN,
         )
         success, retryable, error = _ack_result(send_result, delivery_id)
     except Exception as exc:
@@ -186,17 +190,38 @@ def deliver_alert_center_delivery(record_id):
     terminal = not retryable or claim_generation >= record.max_attempts
     next_status = MonitorAlertCenterDelivery.Status.FAILED if terminal else MonitorAlertCenterDelivery.Status.PENDING
     next_retry_at = None if terminal else finished_at + timedelta(seconds=min(3600, 15 * (2 ** min(claim_generation, 8))))
-    MonitorAlertCenterDelivery.objects.filter(
-        id=record_id,
-        status=MonitorAlertCenterDelivery.Status.DELIVERING,
-        attempts=claim_generation,
-    ).update(
-        status=next_status,
-        next_retry_at=next_retry_at,
-        last_error=error[:2000],
-        updated_at=finished_at,
-    )
+    with transaction.atomic():
+        finalized = MonitorAlertCenterDelivery.objects.filter(
+            id=record_id,
+            status=MonitorAlertCenterDelivery.Status.DELIVERING,
+            attempts=claim_generation,
+        ).update(
+            status=next_status,
+            next_retry_at=next_retry_at,
+            last_error=error[:2000],
+            updated_at=finished_at,
+        )
+        if finalized and terminal:
+            record.status = MonitorAlertCenterDelivery.Status.FAILED
+            _fail_blocked_successors(record)
     return False
+
+
+def _fail_blocked_successors(record):
+    """A terminal predecessor makes later lifecycle copies unsafe to deliver."""
+    MonitorAlertCenterDelivery.objects.filter(
+        alert_id=record.alert_id,
+        generation__gt=record.generation,
+        status__in=[
+            MonitorAlertCenterDelivery.Status.PENDING,
+            MonitorAlertCenterDelivery.Status.DELIVERING,
+        ],
+    ).update(
+        status=MonitorAlertCenterDelivery.Status.FAILED,
+        next_retry_at=None,
+        last_error=f"blocked by terminal generation {record.generation}",
+        updated_at=timezone.now(),
+    )
 
 
 def backfill_legacy_alerts():

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -27,8 +27,9 @@ NOTIFY_SCOPE_ALL_CONFIGURED = "all_configured"
 
 
 class AlertLifecycleNotifier:
-    def __init__(self, policy=None):
+    def __init__(self, policy=None, policies_by_id=None):
         self.policy = policy
+        self.policies_by_id = policies_by_id or {}
 
     def notify_alerts(self, alerts, action, operator="", reason="", notify_scope=NOTIFY_SCOPE_ALL_CONFIGURED):
         if not alerts:
@@ -330,17 +331,21 @@ class AlertLifecycleNotifier:
             org_map[instance_id].append(organization)
         return org_map
 
-    def _resolve_alert_organizations(self, alert, instance_org_map):
+    def _resolve_alert_organizations(self, alert, instance_org_map, policy=None):
         """实例组织优先；实例无组织时回退策略组织；都没有则为空。"""
         organizations = instance_org_map.get(alert.monitor_instance_id)
         if organizations:
             return organizations
-        if self.policy and getattr(self.policy, "organizations", None):
-            return list(self.policy.organizations)
+        policy = policy or self.policy
+        if policy and getattr(policy, "organizations", None):
+            return list(policy.organizations)
         return []
 
     def _build_alert_center_payload(self, alert, action, operator, reason, instance_org_map=None):
         instance_org_map = instance_org_map or {}
+        policy = self.policy
+        if action == "created":
+            policy = self.policies_by_id.get(alert.policy_id, policy)
         alert_center_action = ACTION_TO_ALERT_CENTER.get(action, "created")
         start_time = str(int(alert.start_event_time.timestamp())) if alert.start_event_time else None
         end_time = str(int(alert.end_event_time.timestamp())) if alert.end_event_time else None
@@ -356,10 +361,12 @@ class AlertLifecycleNotifier:
             "end_time": end_time,
             "resource_id": alert.monitor_instance_id,
             "resource_name": getattr(alert, "monitor_instance_name", ""),
-            "organizations": self._resolve_alert_organizations(alert, instance_org_map),
+            "organizations": self._resolve_alert_organizations(
+                alert, instance_org_map, policy
+            ),
             "tags": getattr(alert, "dimensions", {}),
             "labels": {
-                "policy_name": getattr(self.policy, "name", "") if self.policy else "",
+                "policy_name": getattr(policy, "name", "") if policy else "",
                 "metric_instance_id": getattr(alert, "metric_instance_id", ""),
                 "operator": operator,
                 "reason": reason,

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -391,8 +391,11 @@ class AlertLifecycleNotifier:
         from apps.monitor.models import MonitorAlertCenterDelivery
         from apps.monitor.services.alert_center_delivery import ALERT_CENTER_OUTBOX_ENABLED
 
+        use_per_event_ack = (
+            ALERT_CENTER_PER_EVENT_ACK_ENABLED or ALERT_CENTER_OUTBOX_ENABLED
+        )
         delivery_ids = {}
-        if not ALERT_CENTER_OUTBOX_ENABLED and not ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+        if not ALERT_CENTER_OUTBOX_ENABLED and not use_per_event_ack:
             # 两个扩展开关均关闭时严格保留历史 NATS payload；旧接收端无需
             # 理解 lifecycle 字段即可继续工作。
             for payload in payloads:
@@ -412,7 +415,7 @@ class AlertLifecycleNotifier:
             for alert, payload in zip(alerts, payloads):
                 if alert.id in delivery_ids:
                     payload["lifecycle_generation"] = delivery_ids[alert.id]
-        if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+        if use_per_event_ack:
             for alert, payload in zip(alerts, payloads):
                 payload["delivery_id"] = delivery_ids.get(
                     alert.id, self._build_delivery_id(alert, action)
@@ -423,7 +426,7 @@ class AlertLifecycleNotifier:
             "pusher": "lite-monitor",
             "events": payloads,
         }
-        if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+        if use_per_event_ack:
             content["ack_mode"] = "per_event_v1"
             content["ack_token"] = ALERT_CENTER_ACK_TOKEN
         success = False
@@ -432,7 +435,7 @@ class AlertLifecycleNotifier:
         try:
             send_result = SystemMgmtUtils.send_msg_with_channel(channel_id, "", content, [])
             success, error_msg = self._parse_channel_result(send_result)
-            if ALERT_CENTER_PER_EVENT_ACK_ENABLED and isinstance(send_result, dict):
+            if use_per_event_ack and isinstance(send_result, dict):
                 details = send_result.get("data") or {}
                 event_results = {
                     item.get("delivery_id"): item

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -142,11 +142,44 @@ class AlertLifecycleNotifier:
 
     def push_to_alert_center_only(self, alerts, action, operator="", reason=""):
         """专用于告警中心补偿通知，跳过 IM 通知直接推送到 NATS 告警中心"""
-        channel = Channel.objects.filter(channel_type="nats", config__method_name="receive_alert_events").first()
-        if not channel:
-            logger.warning("告警中心 NATS channel 未配置，跳过补偿推送")
-            return [(alert, False) for alert in alerts]
-        push_results = self._push_to_alert_center(channel.id, channel.name or str(channel.id), alerts, action, operator, reason)
+        channel_ids = {
+            int(value)
+            for alert in alerts
+            for value in self._resolve_notice_type_ids(alert)
+            if str(value).isdigit()
+        }
+        channels = {
+            channel.id: channel
+            for channel in Channel.objects.filter(
+                id__in=channel_ids,
+                channel_type="nats",
+                config__method_name="receive_alert_events",
+            )
+        }
+        groups = defaultdict(list)
+        for alert in alerts:
+            for value in self._resolve_notice_type_ids(alert):
+                if str(value).isdigit() and int(value) in channels:
+                    groups[int(value)].append(alert)
+        push_results = []
+        delivered_alert_ids = set()
+        for channel_id, group_alerts in groups.items():
+            channel = channels[channel_id]
+            results = self._push_to_alert_center(
+                channel.id,
+                channel.name or str(channel.id),
+                group_alerts,
+                action,
+                operator,
+                reason,
+            )
+            push_results.extend(results)
+            delivered_alert_ids.update(alert.id for alert, _ in results)
+        push_results.extend(
+            (alert, {"success": False, "error": "alert_center_channel_not_configured"})
+            for alert in alerts
+            if alert.id not in delivered_alert_ids
+        )
         # 写入 notice_logs，与即时层保持一致
         alert_log_entries = defaultdict(list)
         for alert, log_entry in push_results:

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -164,12 +164,6 @@ class AlertLifecycleNotifier:
             reason=reason,
         )
 
-    @staticmethod
-    def _alert_center_outbox_enabled():
-        from apps.monitor.services.alert_center_delivery import ALERT_CENTER_OUTBOX_ENABLED
-
-        return ALERT_CENTER_OUTBOX_ENABLED
-
     def _persist_notice_logs(self, alerts, alert_log_entries):
         if not alert_log_entries:
             return

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -184,14 +184,18 @@ class AlertLifecycleNotifier:
     def _resolve_notice_type_ids(self, alert):
         if alert.notice_type_ids:
             return alert.notice_type_ids
-        if self.policy and self.policy.notice and self.policy.notice_type_ids:
+        if (
+            self.policy
+            and getattr(self.policy, "notice", False)
+            and getattr(self.policy, "notice_type_ids", None)
+        ):
             return self.policy.notice_type_ids
         return []
 
     def _resolve_notice_users(self, alert):
         if alert.notice_users:
             return alert.notice_users
-        if self.policy and self.policy.notice_users:
+        if self.policy and getattr(self.policy, "notice_users", None):
             return self.policy.notice_users
         return []
 
@@ -243,6 +247,29 @@ class AlertLifecycleNotifier:
         channel_name = channel.name or str(channel_id)
 
         if is_alert_center:
+            from apps.monitor.services.alert_center_delivery import (
+                ALERT_CENTER_OUTBOX_ENABLED,
+                ALERT_CENTER_OUTBOX_DELIVERY_ENABLED,
+            )
+
+            if ALERT_CENTER_OUTBOX_ENABLED and ALERT_CENTER_OUTBOX_DELIVERY_ENABLED:
+                # active 阶段由持久化 outbox 独占告警中心投递；普通 IM 渠道仍走旧链路。
+                now = datetime.now(timezone.utc).isoformat()
+                return [
+                    (
+                        alert,
+                        {
+                            "time": now,
+                            "action": action,
+                            "channel_id": channel_id,
+                            "channel_name": channel_name,
+                            "is_alert_center": True,
+                            "success": False,
+                            "error": "outbox_pending",
+                        },
+                    )
+                    for alert in alerts
+                ]
             return self._push_to_alert_center(channel_id, channel_name, alerts, action, operator, reason)
         else:
             return self._send_normal_notice(channel_id, channel_name, notice_users, alerts, action, operator, reason)
@@ -312,10 +339,38 @@ class AlertLifecycleNotifier:
             self._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
             for alert in alerts
         ]
+        # shadow 阶段先写 outbox、仍由 legacy 实发。两条路径必须共享同一代次身份，
+        # 这样切到 active 后重放 pending 只会得到 duplicate，不会重复建事件。
+        from apps.monitor.models import MonitorAlertCenterDelivery
+        from apps.monitor.services.alert_center_delivery import ALERT_CENTER_OUTBOX_ENABLED
+
+        delivery_ids = {}
+        if not ALERT_CENTER_OUTBOX_ENABLED and not ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+            # 两个扩展开关均关闭时严格保留历史 NATS payload；旧接收端无需
+            # 理解 lifecycle 字段即可继续工作。
+            for payload in payloads:
+                payload.pop("lifecycle_action", None)
+        if ALERT_CENTER_OUTBOX_ENABLED:
+            rows = (
+                MonitorAlertCenterDelivery.objects.filter(
+                    alert_id__in=[alert.id for alert in alerts],
+                    action=action,
+                    channel_id=channel_id,
+                )
+                .order_by("alert_id", "-generation")
+                .values_list("alert_id", "delivery_id")
+            )
+            for alert_id, delivery_id in rows:
+                delivery_ids.setdefault(alert_id, delivery_id)
+            for alert, payload in zip(alerts, payloads):
+                if alert.id in delivery_ids:
+                    payload["lifecycle_generation"] = delivery_ids[alert.id]
         if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
             for alert, payload in zip(alerts, payloads):
-                payload["delivery_id"] = self._build_delivery_id(alert, action)
-                payload["lifecycle_generation"] = payload["delivery_id"]
+                payload["delivery_id"] = delivery_ids.get(
+                    alert.id, self._build_delivery_id(alert, action)
+                )
+                payload.setdefault("lifecycle_generation", payload["delivery_id"])
         content = {
             "source_id": "nats",
             "pusher": "lite-monitor",
@@ -350,7 +405,10 @@ class AlertLifecycleNotifier:
             alert_success = success
             alert_error = error_msg
             if event_results:
-                ack = event_results.get(self._build_delivery_id(alert, action), {})
+                ack = event_results.get(
+                    delivery_ids.get(alert.id, self._build_delivery_id(alert, action)),
+                    {},
+                )
                 alert_success = ack.get("status") in {"accepted", "duplicate"}
                 if not alert_success:
                     alert_error = ack.get("status") or "missing per-event acknowledgement"

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -422,6 +422,8 @@ class AlertLifecycleNotifier:
             "level": LEVEL_TO_ALERT_CENTER.get(alert.level, "3"),
             "value": float(alert.value) if alert.value is not None else None,
             "action": alert_center_action,
+            # 接收端用该字段区分同一业务 action 的生命周期代次；旧接收端忽略未知字段。
+            "lifecycle_action": action,
             "start_time": start_time,
             "end_time": end_time,
             "resource_id": alert.monitor_instance_id,

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -66,8 +66,7 @@ class AlertLifecycleNotifier:
                     continue
                 groups[(channel_id, tuple(notice_users) if notice_users else ())].append(alert)
 
-        alert_center_success_ids = set()
-        alert_center_target_ids = set()  # 实际走到了 NATS 推送路径的告警
+        alert_center_results = defaultdict(list)
 
         for (channel_id, notice_users_tuple), group_alerts in groups.items():
             notice_users = list(notice_users_tuple)
@@ -78,9 +77,9 @@ class AlertLifecycleNotifier:
                 for alert, log_entry in results:
                     alert_log_entries[alert.id].append(log_entry)
                     if log_entry.get("is_alert_center"):
-                        alert_center_target_ids.add(alert.id)
-                        if log_entry.get("success"):
-                            alert_center_success_ids.add(alert.id)
+                        alert_center_results[alert.id].append(
+                            bool(log_entry.get("success"))
+                        )
             except Exception as e:
                 logger.error(
                     f"Lifecycle notify exception: action={action}, channel_id={channel_id}, error={e}",
@@ -102,17 +101,22 @@ class AlertLifecycleNotifier:
                     exc_channel = Channel.objects.filter(id=channel_id).first()
                     if exc_channel and exc_channel.channel_type == "nats" and exc_channel.config.get("method_name") == "receive_alert_events":
                         for alert in group_alerts:
-                            alert_center_target_ids.add(alert.id)
+                            alert_center_results[alert.id].append(False)
                 except Exception:
                     for alert in group_alerts:
-                        alert_center_target_ids.add(alert.id)
+                        alert_center_results[alert.id].append(False)
 
         self._persist_notice_logs(alerts, alert_log_entries)
+        alert_center_success_ids = {
+            alert_id
+            for alert_id, results in alert_center_results.items()
+            if results and all(results)
+        }
         if alert_center_success_ids:
             self._mark_alert_center_notified(alert_center_success_ids)
 
         # 未经过 NATS 推送路径的告警（无告警中心渠道）：归还 notified=True，避免补偿任务空转
-        not_targeted_ids = {a.id for a in alerts} - alert_center_target_ids
+        not_targeted_ids = {a.id for a in alerts} - set(alert_center_results)
         if not_targeted_ids:
             self._reset_alert_center_flags_by_ids(not_targeted_ids)
 
@@ -148,14 +152,19 @@ class AlertLifecycleNotifier:
             for value in self._resolve_notice_type_ids(alert)
             if str(value).isdigit()
         }
-        channels = {
-            channel.id: channel
-            for channel in Channel.objects.filter(
-                id__in=channel_ids,
-                channel_type="nats",
-                config__method_name="receive_alert_events",
-            )
-        }
+        channels = set()
+        for channel_id in channel_ids:
+            try:
+                capability = SystemMgmtUtils.probe_notification_channel(
+                    channel_id, capability_only=True
+                ) or {}
+            except Exception:
+                logger.exception(
+                    "告警中心补偿渠道能力查询失败: channel_id=%s", channel_id
+                )
+                continue
+            if capability.get("delivery_mode") == "alert_event_copy":
+                channels.add(channel_id)
         groups = defaultdict(list)
         for alert in alerts:
             for value in self._resolve_notice_type_ids(alert):
@@ -164,10 +173,9 @@ class AlertLifecycleNotifier:
         push_results = []
         delivered_alert_ids = set()
         for channel_id, group_alerts in groups.items():
-            channel = channels[channel_id]
             results = self._push_to_alert_center(
-                channel.id,
-                channel.name or str(channel.id),
+                channel_id,
+                str(channel_id),
                 group_alerts,
                 action,
                 operator,
@@ -185,7 +193,13 @@ class AlertLifecycleNotifier:
         for alert, log_entry in push_results:
             alert_log_entries[alert.id].append(log_entry)
         self._persist_notice_logs(alerts, alert_log_entries)
-        return [(alert, log_entry.get("success", False)) for alert, log_entry in push_results]
+        results_by_alert = defaultdict(list)
+        for alert, log_entry in push_results:
+            results_by_alert[alert.id].append(bool(log_entry.get("success")))
+        return [
+            (alert, bool(results_by_alert[alert.id]) and all(results_by_alert[alert.id]))
+            for alert in alerts
+        ]
 
     def enqueue_alert_center_deliveries(self, alerts, action, operator="", reason=""):
         from apps.monitor.services.alert_center_delivery import enqueue_alert_center_deliveries

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -168,6 +168,13 @@ class AlertLifecycleNotifier:
             reason=reason,
         )
 
+    def _resolve_alert_center_channel_ids(self, alert):
+        configured_ids = [int(value) for value in self._resolve_notice_type_ids(alert) if str(value).isdigit()]
+        if not configured_ids:
+            return []
+        result = SystemMgmtUtils.list_notification_channels(configured_ids)
+        return [item["id"] for item in result if item.get("delivery_mode") == "alert_event_copy"]
+
     @staticmethod
     def _alert_center_outbox_enabled():
         from apps.monitor.services.alert_center_delivery import ALERT_CENTER_OUTBOX_ENABLED

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timezone
+import os
 
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
@@ -24,6 +25,12 @@ LEVEL_TO_ALERT_CENTER = {
 NOTIFY_SCOPE_NONE = "none"
 NOTIFY_SCOPE_ALERT_CENTER_ONLY = "alert_center_only"
 NOTIFY_SCOPE_ALL_CONFIGURED = "all_configured"
+ALERT_CENTER_PER_EVENT_ACK_ENABLED = os.getenv(
+    "MONITOR_ALERT_CENTER_PER_EVENT_ACK_ENABLED", "false"
+).lower() in {"1", "true", "yes"}
+ALERT_CENTER_CREATED_RETRY_ENABLED = os.getenv(
+    "MONITOR_ALERT_CENTER_CREATED_RETRY_ENABLED", "false"
+).lower() in {"1", "true", "yes"}
 
 
 class AlertLifecycleNotifier:
@@ -283,16 +290,33 @@ class AlertLifecycleNotifier:
     def _push_to_alert_center(self, channel_id, channel_name, alerts, action, operator, reason):
         now = datetime.now(timezone.utc).isoformat()
         instance_org_map = self._build_instance_org_map(alerts)
+        payloads = [
+            self._build_alert_center_payload(alert, action, operator, reason, instance_org_map)
+            for alert in alerts
+        ]
+        if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+            for alert, payload in zip(alerts, payloads):
+                payload["delivery_id"] = self._build_delivery_id(alert, action)
         content = {
             "source_id": "nats",
             "pusher": "lite-monitor",
-            "events": [self._build_alert_center_payload(alert, action, operator, reason, instance_org_map) for alert in alerts],
+            "events": payloads,
         }
+        if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
+            content["ack_mode"] = "per_event_v1"
         success = False
         error_msg = ""
+        event_results = {}
         try:
             send_result = SystemMgmtUtils.send_msg_with_channel(channel_id, "", content, [])
             success, error_msg = self._parse_channel_result(send_result)
+            if ALERT_CENTER_PER_EVENT_ACK_ENABLED and isinstance(send_result, dict):
+                details = send_result.get("data") or {}
+                event_results = {
+                    item.get("delivery_id"): item
+                    for item in details.get("event_results") or []
+                    if isinstance(item, dict) and item.get("delivery_id")
+                }
             if success:
                 logger.info(f"Lifecycle push to alert center success: action={action}, count={len(alerts)}")
             else:
@@ -303,18 +327,40 @@ class AlertLifecycleNotifier:
 
         results = []
         for alert in alerts:
+            alert_success = success
+            alert_error = error_msg
+            if event_results:
+                ack = event_results.get(self._build_delivery_id(alert, action), {})
+                alert_success = ack.get("status") in {"accepted", "duplicate"}
+                if not alert_success:
+                    alert_error = ack.get("status") or "missing per-event acknowledgement"
             log_entry = {
                 "time": now,
                 "action": action,
                 "channel_id": channel_id,
                 "channel_name": channel_name,
                 "is_alert_center": True,
-                "success": success,
+                "success": alert_success,
             }
-            if not success:
-                log_entry["error"] = error_msg
+            if not alert_success:
+                log_entry["error"] = alert_error
             results.append((alert, log_entry))
         return results
+
+    @staticmethod
+    def _build_delivery_id(alert, action):
+        """旧链路的 ACK 关联键；未来 outbox 可直接替换为其持久化 generation key。"""
+        return ":".join(
+            str(value or "")
+            for value in (
+                alert.id,
+                action,
+                getattr(alert, "start_event_time", None),
+                getattr(alert, "end_event_time", None),
+                getattr(alert, "level", None),
+                getattr(alert, "value", None),
+            )
+        )
 
     def _build_instance_org_map(self, alerts):
         """按本批告警的实例一次性查出 实例ID -> [组织id] 映射，避免逐条 N+1 查询。"""

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import os
+from collections import defaultdict
 from datetime import datetime, timezone
 
 from apps.core.logger import monitor_logger as logger
@@ -28,6 +28,7 @@ NOTIFY_SCOPE_ALL_CONFIGURED = "all_configured"
 ALERT_CENTER_PER_EVENT_ACK_ENABLED = os.getenv(
     "MONITOR_ALERT_CENTER_PER_EVENT_ACK_ENABLED", "false"
 ).lower() in {"1", "true", "yes"}
+ALERT_CENTER_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
 ALERT_CENTER_CREATED_RETRY_ENABLED = os.getenv(
     "MONITOR_ALERT_CENTER_CREATED_RETRY_ENABLED", "false"
 ).lower() in {"1", "true", "yes"}
@@ -314,6 +315,7 @@ class AlertLifecycleNotifier:
         if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
             for alert, payload in zip(alerts, payloads):
                 payload["delivery_id"] = self._build_delivery_id(alert, action)
+                payload["lifecycle_generation"] = payload["delivery_id"]
         content = {
             "source_id": "nats",
             "pusher": "lite-monitor",
@@ -321,6 +323,7 @@ class AlertLifecycleNotifier:
         }
         if ALERT_CENTER_PER_EVENT_ACK_ENABLED:
             content["ack_mode"] = "per_event_v1"
+            content["ack_token"] = ALERT_CENTER_ACK_TOKEN
         success = False
         error_msg = ""
         event_results = {}

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -71,12 +71,8 @@ class AlertLifecycleNotifier:
         for (channel_id, notice_users_tuple), group_alerts in groups.items():
             notice_users = list(notice_users_tuple)
             try:
-                channel = Channel.objects.filter(id=channel_id).first()
-                if self._is_alert_center_channel(channel) and self._alert_center_outbox_enabled():
-                    # outbox 已在同一事务保存不可变意图；即时层只继续发送普通通知，
-                    # 避免 legacy NATS 与 outbox 各投一次产生双写。
-                    alert_center_target_ids.update(alert.id for alert in group_alerts)
-                    continue
+                # 灰度期间保留 legacy 即时投递；outbox 使用稳定 payload 身份，
+                # receiver 会把响应丢失后的双投收敛为 duplicate。关闭开关即可回滚。
                 results = self._send_to_channel(channel_id, notice_users, group_alerts, action, operator, reason, notify_scope)
                 for alert, log_entry in results:
                     alert_log_entries[alert.id].append(log_entry)
@@ -167,13 +163,6 @@ class AlertLifecycleNotifier:
             operator=operator,
             reason=reason,
         )
-
-    def _resolve_alert_center_channel_ids(self, alert):
-        configured_ids = [int(value) for value in self._resolve_notice_type_ids(alert) if str(value).isdigit()]
-        if not configured_ids:
-            return []
-        result = SystemMgmtUtils.list_notification_channels(configured_ids)
-        return [item["id"] for item in result if item.get("delivery_mode") == "alert_event_copy"]
 
     @staticmethod
     def _alert_center_outbox_enabled():

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
-from datetime import datetime, timezone
 import os
+from datetime import datetime, timezone
 
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.utils.system_mgmt_api import SystemMgmtUtils
@@ -46,6 +46,10 @@ class AlertLifecycleNotifier:
             self._reset_alert_center_flags(alerts)
             return
 
+        # created 在扫描事务内先落 outbox；其余生命周期调用方仍保留 legacy pending
+        # 标志，由这里幂等补齐不可变意图。回滚可关闭 outbox 并继续使用旧链路。
+        self.enqueue_alert_center_deliveries(alerts, action, operator=operator, reason=reason)
+
         alert_log_entries = defaultdict(list)
 
         groups = defaultdict(list)
@@ -67,6 +71,12 @@ class AlertLifecycleNotifier:
         for (channel_id, notice_users_tuple), group_alerts in groups.items():
             notice_users = list(notice_users_tuple)
             try:
+                channel = Channel.objects.filter(id=channel_id).first()
+                if self._is_alert_center_channel(channel) and self._alert_center_outbox_enabled():
+                    # outbox 已在同一事务保存不可变意图；即时层只继续发送普通通知，
+                    # 避免 legacy NATS 与 outbox 各投一次产生双写。
+                    alert_center_target_ids.update(alert.id for alert in group_alerts)
+                    continue
                 results = self._send_to_channel(channel_id, notice_users, group_alerts, action, operator, reason, notify_scope)
                 for alert, log_entry in results:
                     alert_log_entries[alert.id].append(log_entry)
@@ -146,6 +156,23 @@ class AlertLifecycleNotifier:
             alert_log_entries[alert.id].append(log_entry)
         self._persist_notice_logs(alerts, alert_log_entries)
         return [(alert, log_entry.get("success", False)) for alert, log_entry in push_results]
+
+    def enqueue_alert_center_deliveries(self, alerts, action, operator="", reason=""):
+        from apps.monitor.services.alert_center_delivery import enqueue_alert_center_deliveries
+
+        return enqueue_alert_center_deliveries(
+            alerts,
+            action,
+            notifier=self,
+            operator=operator,
+            reason=reason,
+        )
+
+    @staticmethod
+    def _alert_center_outbox_enabled():
+        from apps.monitor.services.alert_center_delivery import ALERT_CENTER_OUTBOX_ENABLED
+
+        return ALERT_CENTER_OUTBOX_ENABLED
 
     def _persist_notice_logs(self, alerts, alert_log_entries):
         if not alert_log_entries:
@@ -334,6 +361,8 @@ class AlertLifecycleNotifier:
                 alert_success = ack.get("status") in {"accepted", "duplicate"}
                 if not alert_success:
                     alert_error = ack.get("status") or "missing per-event acknowledgement"
+                    if ack:
+                        alert_error = f"{alert_error} (retryable={bool(ack.get('retryable'))})"
             log_entry = {
                 "time": now,
                 "action": action,

--- a/server/apps/monitor/services/monitor_instance_removal.py
+++ b/server/apps/monitor/services/monitor_instance_removal.py
@@ -212,6 +212,17 @@ class MonitorInstanceRemovalService:
                 ],
                 batch_size=cls.ALERT_BATCH_SIZE,
             )
+            policies = MonitorPolicy.objects.in_bulk({alert.policy_id for alert in alerts if alert.policy_id})
+            alerts_by_policy = defaultdict(list)
+            for alert in alerts:
+                alerts_by_policy[alert.policy_id].append(alert)
+            for policy_id, policy_alerts in alerts_by_policy.items():
+                AlertLifecycleNotifier(policies.get(policy_id)).enqueue_alert_center_deliveries(
+                    policy_alerts,
+                    "closed",
+                    operator=operator,
+                    reason=reason,
+                )
             closed_count += len(alerts)
             last_id = alerts[-1].id
 

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -99,7 +99,7 @@ def scan_policy_task(policy_id):
 @shared_task(base=Singleton, raise_on_duplicate=False)
 def retry_alert_center_lifecycle_notify_task():
     """补偿任务：重试推送到告警中心失败的告警通知（每5分钟执行，每次最多处理200条）"""
-    from apps.monitor.models import MonitorAlert
+    from apps.monitor.models import MonitorAlert, MonitorPolicy
     from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 
     alerts = list(
@@ -114,15 +114,28 @@ def retry_alert_center_lifecycle_notify_task():
 
     logger.info(f"告警中心补偿任务：发现 {len(alerts)} 条待重试告警")
 
+    new_policy_ids = {
+        alert.policy_id
+        for alert in alerts
+        if alert.status == "new" and alert.policy_id
+    }
+    policies_by_id = MonitorPolicy.objects.in_bulk(new_policy_ids)
+
     groups = defaultdict(list)
     for alert in alerts:
-        groups[alert.status].append(alert)
+        policy_id = alert.policy_id if alert.status == "new" else None
+        groups[(alert.status, policy_id)].append(alert)
 
-    notifier = AlertLifecycleNotifier()
+    notifiers = {}
     success_ids = []
     fail_ids = []
 
-    for status, group_alerts in groups.items():
+    for (status, policy_id), group_alerts in groups.items():
+        if policy_id not in notifiers:
+            notifiers[policy_id] = AlertLifecycleNotifier(
+                policies_by_id.get(policy_id)
+            )
+        notifier = notifiers[policy_id]
         # 单组异常隔离：一组毒数据不应崩溃整个任务，否则该批次会被反复取回永久楔死
         try:
             action = "created" if status == "new" else status

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -123,19 +123,13 @@ def retry_alert_center_lifecycle_notify_task():
 
     groups = defaultdict(list)
     for alert in alerts:
-        policy_id = alert.policy_id if alert.status == "new" else None
-        groups[(alert.status, policy_id)].append(alert)
+        groups[alert.status].append(alert)
 
-    notifiers = {}
+    notifier = AlertLifecycleNotifier(policies_by_id=policies_by_id)
     success_ids = []
     fail_ids = []
 
-    for (status, policy_id), group_alerts in groups.items():
-        if policy_id not in notifiers:
-            notifiers[policy_id] = AlertLifecycleNotifier(
-                policies_by_id.get(policy_id)
-            )
-        notifier = notifiers[policy_id]
+    for status, group_alerts in groups.items():
         # 单组异常隔离：一组毒数据不应崩溃整个任务，否则该批次会被反复取回永久楔死
         try:
             action = "created" if status == "new" else status

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -104,7 +104,7 @@ def retry_alert_center_lifecycle_notify_task():
 
     alerts = list(
         MonitorAlert.objects.filter(
-            status__in=["recovered", "closed"],
+            status__in=["new", "recovered", "closed"],
             alert_center_notified=False,
             alert_center_retry_count__lt=10,
         ).order_by("id")[:200]
@@ -125,7 +125,8 @@ def retry_alert_center_lifecycle_notify_task():
     for status, group_alerts in groups.items():
         # 单组异常隔离：一组毒数据不应崩溃整个任务，否则该批次会被反复取回永久楔死
         try:
-            results = notifier.push_to_alert_center_only(group_alerts, action=status)
+            action = "created" if status == "new" else status
+            results = notifier.push_to_alert_center_only(group_alerts, action=action)
         except Exception:
             logger.exception(f"告警中心补偿任务：status={status} 推送异常，本组按失败处理")
             fail_ids.extend(alert.id for alert in group_alerts)

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -107,6 +107,7 @@ def scan_policy_task(policy_id):
 def retry_alert_center_lifecycle_notify_task():
     """补偿任务：重试推送到告警中心失败的告警通知（每5分钟执行，每次最多处理200条）"""
     from apps.monitor.services.alert_center_delivery import (
+        ALERT_CENTER_OUTBOX_DELIVERY_ENABLED,
         ALERT_CENTER_OUTBOX_ENABLED,
         backfill_legacy_alerts,
         due_delivery_ids,
@@ -114,14 +115,15 @@ def retry_alert_center_lifecycle_notify_task():
 
     if ALERT_CENTER_OUTBOX_ENABLED:
         backfilled = backfill_legacy_alerts()
-        delivery_ids = due_delivery_ids()
-        for delivery_id in delivery_ids:
-            deliver_alert_center_lifecycle_delivery.delay(delivery_id)
-        return {
-            "success": True,
-            "backfilled": backfilled,
-            "scheduled": len(delivery_ids),
-        }
+        if ALERT_CENTER_OUTBOX_DELIVERY_ENABLED:
+            delivery_ids = due_delivery_ids()
+            for delivery_id in delivery_ids:
+                deliver_alert_center_lifecycle_delivery.delay(delivery_id)
+            return {
+                "success": True,
+                "backfilled": backfilled,
+                "scheduled": len(delivery_ids),
+            }
 
     from apps.monitor.models import MonitorAlert, MonitorPolicy
     from apps.monitor.services.alert_lifecycle_notify import (
@@ -133,13 +135,18 @@ def retry_alert_center_lifecycle_notify_task():
         outbox_enabled=ALERT_CENTER_OUTBOX_ENABLED,
         created_retry_enabled=ALERT_CENTER_CREATED_RETRY_ENABLED,
     )
-    alerts = list(
-        MonitorAlert.objects.filter(
-            status__in=retry_statuses,
-            alert_center_notified=False,
-            alert_center_retry_count__lt=10,
-        ).order_by("id")[:200]
+    retry_alerts = MonitorAlert.objects.filter(
+        status__in=retry_statuses,
+        alert_center_notified=False,
+        alert_center_retry_count__lt=10,
     )
+    if ALERT_CENTER_OUTBOX_DELIVERY_ENABLED:
+        # active 阶段不得按当前状态越过 outbox 中尚未完成的 created 代次；
+        # shadow/rollback 阶段仍由 legacy 补偿负责实际送达。
+        retry_alerts = retry_alerts.exclude(
+            alert_center_deliveries__status__in=["pending", "delivering"]
+        )
+    alerts = list(retry_alerts.order_by("id")[:200])
     if not alerts:
         return {"success": True, "message": "no alerts to retry"}
 

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -99,6 +99,23 @@ def scan_policy_task(policy_id):
 @shared_task(base=Singleton, raise_on_duplicate=False)
 def retry_alert_center_lifecycle_notify_task():
     """补偿任务：重试推送到告警中心失败的告警通知（每5分钟执行，每次最多处理200条）"""
+    from apps.monitor.services.alert_center_delivery import (
+        ALERT_CENTER_OUTBOX_ENABLED,
+        backfill_legacy_alerts,
+        due_delivery_ids,
+    )
+
+    if ALERT_CENTER_OUTBOX_ENABLED:
+        backfilled = backfill_legacy_alerts()
+        delivery_ids = due_delivery_ids()
+        for delivery_id in delivery_ids:
+            deliver_alert_center_lifecycle_delivery.delay(delivery_id)
+        return {
+            "success": True,
+            "backfilled": backfilled,
+            "scheduled": len(delivery_ids),
+        }
+
     from apps.monitor.models import MonitorAlert, MonitorPolicy
     from apps.monitor.services.alert_lifecycle_notify import (
         ALERT_CENTER_CREATED_RETRY_ENABLED,
@@ -169,3 +186,10 @@ def retry_alert_center_lifecycle_notify_task():
 
     logger.info(f"告警中心补偿任务完成：成功 {len(success_ids)} 条，失败 {len(fail_ids)} 条")
     return {"success": True, "total": len(alerts), "succeeded": len(success_ids), "failed": len(fail_ids)}
+
+
+@shared_task(autoretry_for=(Exception,), retry_backoff=True, retry_kwargs={"max_retries": 5})
+def deliver_alert_center_lifecycle_delivery(delivery_id):
+    from apps.monitor.services.alert_center_delivery import deliver_alert_center_delivery
+
+    return deliver_alert_center_delivery(delivery_id)

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -21,10 +21,9 @@ def _run_scan_and_record_success(policy_obj, scan_time):
 
 
 def _legacy_alert_center_retry_statuses(*, outbox_enabled, created_retry_enabled):
-    statuses = ["recovered", "closed"]
-    if created_retry_enabled or not outbox_enabled:
-        statuses.insert(0, "new")
-    return statuses
+    # active outbox 在进入 legacy 查询前已返回；其余 disabled/shadow/rollback
+    # 阶段都必须继续补偿首次告警，不能因只开启 outbox 双写而退化。
+    return ["new", "recovered", "closed"]
 
 
 @shared_task(base=Singleton, raise_on_duplicate=False)

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -20,6 +20,13 @@ def _run_scan_and_record_success(policy_obj, scan_time):
     MonitorPolicy.objects.filter(id=policy_obj.id).update(last_run_time=scan_time)
 
 
+def _legacy_alert_center_retry_statuses(*, outbox_enabled, created_retry_enabled):
+    statuses = ["recovered", "closed"]
+    if created_retry_enabled or not outbox_enabled:
+        statuses.insert(0, "new")
+    return statuses
+
+
 @shared_task(base=Singleton, raise_on_duplicate=False)
 def scan_policy_task(policy_id):
     """扫描监控策略
@@ -122,9 +129,10 @@ def retry_alert_center_lifecycle_notify_task():
         AlertLifecycleNotifier,
     )
 
-    retry_statuses = ["recovered", "closed"]
-    if ALERT_CENTER_CREATED_RETRY_ENABLED:
-        retry_statuses.insert(0, "new")
+    retry_statuses = _legacy_alert_center_retry_statuses(
+        outbox_enabled=ALERT_CENTER_OUTBOX_ENABLED,
+        created_retry_enabled=ALERT_CENTER_CREATED_RETRY_ENABLED,
+    )
     alerts = list(
         MonitorAlert.objects.filter(
             status__in=retry_statuses,

--- a/server/apps/monitor/tasks/monitor_policy.py
+++ b/server/apps/monitor/tasks/monitor_policy.py
@@ -100,11 +100,17 @@ def scan_policy_task(policy_id):
 def retry_alert_center_lifecycle_notify_task():
     """补偿任务：重试推送到告警中心失败的告警通知（每5分钟执行，每次最多处理200条）"""
     from apps.monitor.models import MonitorAlert, MonitorPolicy
-    from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
+    from apps.monitor.services.alert_lifecycle_notify import (
+        ALERT_CENTER_CREATED_RETRY_ENABLED,
+        AlertLifecycleNotifier,
+    )
 
+    retry_statuses = ["recovered", "closed"]
+    if ALERT_CENTER_CREATED_RETRY_ENABLED:
+        retry_statuses.insert(0, "new")
     alerts = list(
         MonitorAlert.objects.filter(
-            status__in=["new", "recovered", "closed"],
+            status__in=retry_statuses,
             alert_center_notified=False,
             alert_center_retry_count__lt=10,
         ).order_by("id")[:200]

--- a/server/apps/monitor/tasks/services/policy_scan/alert_detector.py
+++ b/server/apps/monitor/tasks/services/policy_scan/alert_detector.py
@@ -358,10 +358,6 @@ class AlertDetector:
 
         alert_ids = [alert.id for alert in self.active_alerts if alert.alert_type == "alert"]
 
-        alerts_to_recover = list(MonitorAlert.objects.filter(id__in=alert_ids, info_event_count__gte=self.policy.recovery_condition))
-        if not alerts_to_recover:
-            return
-
         end_time = self.policy.last_run_time
         operation_log = {
             "action": "recovered",
@@ -369,14 +365,25 @@ class AlertDetector:
             "operator": "system",
             "time": end_time.isoformat() if end_time else None,
         }
-        for alert in alerts_to_recover:
-            alert.status = "recovered"
-            alert.end_event_time = end_time
-            alert.operator = "system"
-            alert.operation_logs = (alert.operation_logs or []) + [operation_log]
-            alert.alert_center_notified = False
         notifier = AlertLifecycleNotifier(self.policy)
         with transaction.atomic():
+            alerts_to_recover = list(
+                MonitorAlert.objects.select_for_update()
+                .filter(
+                    id__in=alert_ids,
+                    status="new",
+                    info_event_count__gte=self.policy.recovery_condition,
+                )
+                .order_by("id")
+            )
+            if not alerts_to_recover:
+                return
+            for alert in alerts_to_recover:
+                alert.status = "recovered"
+                alert.end_event_time = end_time
+                alert.operator = "system"
+                alert.operation_logs = (alert.operation_logs or []) + [operation_log]
+                alert.alert_center_notified = False
             MonitorAlert.objects.bulk_update(
                 alerts_to_recover,
                 fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
@@ -443,14 +450,22 @@ class AlertDetector:
                 "operator": "system",
                 "time": end_time.isoformat() if end_time else None,
             }
-            for alert in alerts_to_recover:
-                alert.status = "recovered"
-                alert.end_event_time = end_time
-                alert.operator = "system"
-                alert.operation_logs = (alert.operation_logs or []) + [operation_log]
-                alert.alert_center_notified = False
             notifier = AlertLifecycleNotifier(self.policy)
             with transaction.atomic():
+                candidate_ids = [alert.id for alert in alerts_to_recover]
+                alerts_to_recover = list(
+                    MonitorAlert.objects.select_for_update()
+                    .filter(id__in=candidate_ids, status="new", alert_type="no_data")
+                    .order_by("id")
+                )
+                if not alerts_to_recover:
+                    return
+                for alert in alerts_to_recover:
+                    alert.status = "recovered"
+                    alert.end_event_time = end_time
+                    alert.operator = "system"
+                    alert.operation_logs = (alert.operation_logs or []) + [operation_log]
+                    alert.alert_center_notified = False
                 MonitorAlert.objects.bulk_update(
                     alerts_to_recover,
                     fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],

--- a/server/apps/monitor/tasks/services/policy_scan/alert_detector.py
+++ b/server/apps/monitor/tasks/services/policy_scan/alert_detector.py
@@ -2,6 +2,7 @@
 
 from string import Template
 
+from django.db import transaction
 from django.db.models import F
 
 from apps.monitor.models import MonitorAlert
@@ -374,16 +375,26 @@ class AlertDetector:
             alert.operator = "system"
             alert.operation_logs = (alert.operation_logs or []) + [operation_log]
             alert.alert_center_notified = False
-        MonitorAlert.objects.bulk_update(
-            alerts_to_recover,
-            fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
-        )
-        AlertLifecycleNotifier(self.policy).notify_alerts(
-            alerts_to_recover,
-            action="recovered",
-            operator="system",
-            reason="auto_recovered",
-        )
+        notifier = AlertLifecycleNotifier(self.policy)
+        with transaction.atomic():
+            MonitorAlert.objects.bulk_update(
+                alerts_to_recover,
+                fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
+            )
+            notifier.enqueue_alert_center_deliveries(
+                alerts_to_recover,
+                "recovered",
+                operator="system",
+                reason="auto_recovered",
+            )
+            transaction.on_commit(
+                lambda alerts=tuple(alerts_to_recover): notifier.notify_alerts(
+                    alerts,
+                    action="recovered",
+                    operator="system",
+                    reason="auto_recovered",
+                )
+            )
 
     def recover_no_data_alerts(self):
         if not self.policy.no_data_recovery_period:
@@ -438,16 +449,26 @@ class AlertDetector:
                 alert.operator = "system"
                 alert.operation_logs = (alert.operation_logs or []) + [operation_log]
                 alert.alert_center_notified = False
-            MonitorAlert.objects.bulk_update(
-                alerts_to_recover,
-                fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
-            )
-            AlertLifecycleNotifier(self.policy).notify_alerts(
-                alerts_to_recover,
-                action="recovered",
-                operator="system",
-                reason="auto_recovered",
-            )
+            notifier = AlertLifecycleNotifier(self.policy)
+            with transaction.atomic():
+                MonitorAlert.objects.bulk_update(
+                    alerts_to_recover,
+                    fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
+                )
+                notifier.enqueue_alert_center_deliveries(
+                    alerts_to_recover,
+                    "recovered",
+                    operator="system",
+                    reason="auto_recovered",
+                )
+                transaction.on_commit(
+                    lambda alerts=tuple(alerts_to_recover): notifier.notify_alerts(
+                        alerts,
+                        action="recovered",
+                        operator="system",
+                        reason="auto_recovered",
+                    )
+                )
             logger.info(f"Policy {self.policy.id}: recovered {len(alerts_to_recover)} no_data alerts")
         else:
             logger.debug(f"Policy {self.policy.id}: no no_data alerts to recover")

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -160,6 +160,9 @@ class EventAlertManager:
         """
         if not self.policy.notice:
             return
+        pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
+        if pending_alert_ids:
+            MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
         if new_alerts:
             transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created"))
         if upgraded_alerts:

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -176,6 +176,9 @@ class EventAlertManager:
         """
         if not self.policy.notice:
             return
+        pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
+        if pending_alert_ids:
+            MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
         if new_alerts:
             transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created"))
         if upgraded_alerts:

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -7,10 +7,7 @@ from apps.core.utils.database import bulk_create_with_primary_keys
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import MonitorAlert, MonitorEvent, MonitorEventRawData
-from apps.monitor.services.alert_lifecycle_notify import (
-    ALERT_CENTER_CREATED_RETRY_ENABLED,
-    AlertLifecycleNotifier,
-)
+from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 from apps.monitor.utils.dimension import format_dimension_str
 
 
@@ -182,10 +179,11 @@ class EventAlertManager:
         notifier = AlertLifecycleNotifier(self.policy)
         notifier.enqueue_alert_center_deliveries(new_alerts, "created")
         notifier.enqueue_alert_center_deliveries(upgraded_alerts, "upgraded")
-        if ALERT_CENTER_CREATED_RETRY_ENABLED:
-            pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
-            if pending_alert_ids:
-                MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
+        # Legacy rollback path must remain reliable while the outbox switch is off.
+        # Persist pending before commit so a process exit before on_commit is recoverable.
+        pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
+        if pending_alert_ids:
+            MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
         if new_alerts:
             transaction.on_commit(lambda: notifier.notify_alerts(new_alerts, action="created"))
         if upgraded_alerts:

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -7,7 +7,10 @@ from apps.core.utils.database import bulk_create_with_primary_keys
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import MonitorAlert, MonitorEvent, MonitorEventRawData
-from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
+from apps.monitor.services.alert_lifecycle_notify import (
+    ALERT_CENTER_CREATED_RETRY_ENABLED,
+    AlertLifecycleNotifier,
+)
 from apps.monitor.utils.dimension import format_dimension_str
 
 
@@ -176,9 +179,10 @@ class EventAlertManager:
         """
         if not self.policy.notice:
             return
-        pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
-        if pending_alert_ids:
-            MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
+        if ALERT_CENTER_CREATED_RETRY_ENABLED:
+            pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
+            if pending_alert_ids:
+                MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
         if new_alerts:
             transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created"))
         if upgraded_alerts:

--- a/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
+++ b/server/apps/monitor/tasks/services/policy_scan/event_alert_manager.py
@@ -179,14 +179,17 @@ class EventAlertManager:
         """
         if not self.policy.notice:
             return
+        notifier = AlertLifecycleNotifier(self.policy)
+        notifier.enqueue_alert_center_deliveries(new_alerts, "created")
+        notifier.enqueue_alert_center_deliveries(upgraded_alerts, "upgraded")
         if ALERT_CENTER_CREATED_RETRY_ENABLED:
             pending_alert_ids = [alert.id for alert in [*new_alerts, *upgraded_alerts]]
             if pending_alert_ids:
                 MonitorAlert.objects.filter(id__in=pending_alert_ids).update(alert_center_notified=False)
         if new_alerts:
-            transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(new_alerts, action="created"))
+            transaction.on_commit(lambda: notifier.notify_alerts(new_alerts, action="created"))
         if upgraded_alerts:
-            transaction.on_commit(lambda: AlertLifecycleNotifier(self.policy).notify_alerts(upgraded_alerts, action="upgraded"))
+            transaction.on_commit(lambda: notifier.notify_alerts(upgraded_alerts, action="upgraded"))
 
     def _get_alert_metric_instance_id(self, alert) -> str:
         if alert.metric_instance_id:

--- a/server/apps/monitor/tests/test_alert_lifecycle_notify_service.py
+++ b/server/apps/monitor/tests/test_alert_lifecycle_notify_service.py
@@ -5,13 +5,13 @@
 告警生命周期通知映射直接影响外部告警中心数据，必须准确。
 """
 
-import pydantic.root_model  # noqa
-
 from datetime import datetime
 from types import SimpleNamespace
 
+import pydantic.root_model  # noqa
 import pytest
 
+from apps.monitor.services import alert_lifecycle_notify as lifecycle_notify
 from apps.monitor.services.alert_lifecycle_notify import (
     ACTION_TO_ALERT_CENTER,
     LEVEL_TO_ALERT_CENTER,
@@ -155,6 +155,39 @@ class TestBuildAlertCenterPayload:
             alert, "created", "", "", instance_org_map={"inst-1": [5, 6]}
         )
         assert payload["organizations"] == [5, 6]
+
+
+def test_per_event_ack_legacy_path_forwards_shared_token(monkeypatch):
+    notifier = AlertLifecycleNotifier(policy=SimpleNamespace(name="P", organizations=[1]))
+    alert = _alert()
+    sent = {}
+
+    monkeypatch.setattr(lifecycle_notify, "ALERT_CENTER_PER_EVENT_ACK_ENABLED", True)
+    monkeypatch.setattr(lifecycle_notify, "ALERT_CENTER_ACK_TOKEN", "receiver-secret")
+    monkeypatch.setattr(notifier, "_build_instance_org_map", lambda alerts: {})
+    monkeypatch.setattr(
+        lifecycle_notify.SystemMgmtUtils,
+        "send_msg_with_channel",
+        lambda channel_id, title, content, receivers: sent.update(content=content)
+        or {
+            "result": True,
+            "data": {
+                "event_results": [
+                    {
+                        "delivery_id": notifier._build_delivery_id(alert, "created"),
+                        "status": "accepted",
+                        "retryable": False,
+                    }
+                ]
+            },
+        },
+    )
+
+    results = notifier._push_to_alert_center(1, "告警中心", [alert], "created", "", "")
+
+    assert sent["content"]["ack_mode"] == "per_event_v1"
+    assert sent["content"]["ack_token"] == "receiver-secret"
+    assert results[0][1]["success"] is True
 
 
 class TestResolveNotice:

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -13,21 +13,21 @@ pytestmark = pytest.mark.unit
 MONITOR_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _load_method(path, class_name, method_name, globals_dict):
+def _load_methods(path, class_name, method_names, globals_dict):
     tree = ast.parse(path.read_text())
     source_class = next(
         node for node in tree.body
         if isinstance(node, ast.ClassDef) and node.name == class_name
     )
-    method = next(
+    methods = [
         node for node in source_class.body
-        if isinstance(node, ast.FunctionDef) and node.name == method_name
-    )
+        if isinstance(node, ast.FunctionDef) and node.name in method_names
+    ]
     probe_class = ast.ClassDef(
         name="Subject",
         bases=[],
         keywords=[],
-        body=[method],
+        body=methods,
         decorator_list=[],
     )
     ast.fix_missing_locations(probe_class)
@@ -36,6 +36,10 @@ def _load_method(path, class_name, method_name, globals_dict):
         globals_dict,
     )
     return globals_dict["Subject"]
+
+
+def _load_method(path, class_name, method_name, globals_dict):
+    return _load_methods(path, class_name, {method_name}, globals_dict)
 
 
 def _load_function(path, function_name, globals_dict):
@@ -176,11 +180,17 @@ class _RetryObjects:
 
 
 def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
-    policy = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
+    policy_a = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
+    policy_b = types.SimpleNamespace(id=303, name="策略 B", organizations=[8])
     alerts = [
         types.SimpleNamespace(
             id=201, status="new",
-            policy_id=policy.id,
+            policy_id=policy_a.id,
+            alert_center_notified=False, alert_center_retry_count=0,
+        ),
+        types.SimpleNamespace(
+            id=206, status="new",
+            policy_id=policy_b.id,
             alert_center_notified=False, alert_center_retry_count=0,
         ),
         types.SimpleNamespace(
@@ -195,12 +205,12 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
         ),
         types.SimpleNamespace(
             id=204, status="new",
-            policy_id=policy.id,
+            policy_id=policy_a.id,
             alert_center_notified=True, alert_center_retry_count=0,
         ),
         types.SimpleNamespace(
             id=205, status="new",
-            policy_id=policy.id,
+            policy_id=policy_a.id,
             alert_center_notified=False, alert_center_retry_count=10,
         ),
     ]
@@ -221,7 +231,8 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
     models.MonitorPolicy = types.SimpleNamespace(
         objects=types.SimpleNamespace(
             in_bulk=lambda policy_ids: (
-                loaded_policy_ids.append(set(policy_ids)) or {policy.id: policy}
+                loaded_policy_ids.append(set(policy_ids))
+                or {policy_a.id: policy_a, policy_b.id: policy_b}
             )
         )
     )
@@ -229,8 +240,8 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
         "apps.monitor.services.alert_lifecycle_notify"
     )
 
-    def build_notifier(notifier_policy=None):
-        notifier_policies.append(notifier_policy)
+    def build_notifier(notifier_policy=None, policies_by_id=None):
+        notifier_policies.append((notifier_policy, policies_by_id))
         return notifier
 
     notify_module.AlertLifecycleNotifier = build_notifier
@@ -262,16 +273,62 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
         "alert_center_retry_count__lt": 10,
     }]
     assert pushes == [
-        ("created", [201]),
+        ("created", [201, 206]),
         ("recovered", [202]),
         ("closed", [203]),
     ]
-    assert loaded_policy_ids == [{policy.id}]
-    assert notifier_policies == [policy, None]
-    assert marked == [[201, 202, 203]]
+    assert loaded_policy_ids == [{policy_a.id, policy_b.id}]
+    assert notifier_policies == [
+        (None, {policy_a.id: policy_a, policy_b.id: policy_b})
+    ]
+    assert marked == [[201, 206, 202, 203]]
     assert result == {
         "success": True,
-        "total": 3,
-        "succeeded": 3,
+        "total": 4,
+        "succeeded": 4,
         "failed": 0,
     }
+
+
+def test_retry_payload_uses_new_alert_policy_without_changing_terminal_actions():
+    policy = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
+    alert = types.SimpleNamespace(
+        id=201,
+        policy_id=policy.id,
+        content="CPU 告警",
+        level="critical",
+        value=95,
+        start_event_time=None,
+        end_event_time=None,
+        monitor_instance_id="host-1",
+        monitor_instance_name="主机 1",
+        dimensions={"ip": "127.0.0.1"},
+        metric_instance_id="cpu",
+        status="new",
+    )
+    subject = _load_methods(
+        MONITOR_ROOT / "services/alert_lifecycle_notify.py",
+        "AlertLifecycleNotifier",
+        {"_resolve_alert_organizations", "_build_alert_center_payload"},
+        {
+            "ACTION_TO_ALERT_CENTER": {
+                "created": "created",
+                "recovered": "recovery",
+            },
+            "LEVEL_TO_ALERT_CENTER": {"critical": "0"},
+        },
+    )()
+    subject.policy = None
+    subject.policies_by_id = {policy.id: policy}
+
+    created_payload = subject._build_alert_center_payload(
+        alert, "created", "", "", {}
+    )
+    recovered_payload = subject._build_alert_center_payload(
+        alert, "recovered", "", "", {}
+    )
+
+    assert created_payload["organizations"] == [7]
+    assert created_payload["labels"]["policy_name"] == "策略 A"
+    assert recovered_payload["organizations"] == []
+    assert recovered_payload["labels"]["policy_name"] == ""

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -176,31 +176,39 @@ class _RetryObjects:
 
 
 def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
+    policy = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
     alerts = [
         types.SimpleNamespace(
             id=201, status="new",
+            policy_id=policy.id,
             alert_center_notified=False, alert_center_retry_count=0,
         ),
         types.SimpleNamespace(
             id=202, status="recovered",
+            policy_id=302,
             alert_center_notified=False, alert_center_retry_count=0,
         ),
         types.SimpleNamespace(
             id=203, status="closed",
+            policy_id=302,
             alert_center_notified=False, alert_center_retry_count=9,
         ),
         types.SimpleNamespace(
             id=204, status="new",
+            policy_id=policy.id,
             alert_center_notified=True, alert_center_retry_count=0,
         ),
         types.SimpleNamespace(
             id=205, status="new",
+            policy_id=policy.id,
             alert_center_notified=False, alert_center_retry_count=10,
         ),
     ]
     objects = _RetryObjects(alerts)
+    loaded_policy_ids = []
     pushes = []
     marked = []
+    notifier_policies = []
     notifier = types.SimpleNamespace(
         push_to_alert_center_only=lambda grouped, action: (
             pushes.append((action, [alert.id for alert in grouped]))
@@ -210,10 +218,22 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
     )
     models = types.ModuleType("apps.monitor.models")
     models.MonitorAlert = types.SimpleNamespace(objects=objects)
+    models.MonitorPolicy = types.SimpleNamespace(
+        objects=types.SimpleNamespace(
+            in_bulk=lambda policy_ids: (
+                loaded_policy_ids.append(set(policy_ids)) or {policy.id: policy}
+            )
+        )
+    )
     notify_module = types.ModuleType(
         "apps.monitor.services.alert_lifecycle_notify"
     )
-    notify_module.AlertLifecycleNotifier = lambda: notifier
+
+    def build_notifier(notifier_policy=None):
+        notifier_policies.append(notifier_policy)
+        return notifier
+
+    notify_module.AlertLifecycleNotifier = build_notifier
     monkeypatch.setitem(sys.modules, "apps.monitor.models", models)
     monkeypatch.setitem(
         sys.modules,
@@ -246,6 +266,8 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
         ("recovered", [202]),
         ("closed", [203]),
     ]
+    assert loaded_policy_ids == [{policy.id}]
+    assert notifier_policies == [policy, None]
     assert marked == [[201, 202, 203]]
     assert result == {
         "success": True,

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -1,0 +1,255 @@
+"""Issue #3341：首次告警通知失败必须进入告警中心补偿队列。"""
+
+import ast
+import sys
+import types
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+MONITOR_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_method(path, class_name, method_name, globals_dict):
+    tree = ast.parse(path.read_text())
+    source_class = next(
+        node for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == class_name
+    )
+    method = next(
+        node for node in source_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    probe_class = ast.ClassDef(
+        name="Subject",
+        bases=[],
+        keywords=[],
+        body=[method],
+        decorator_list=[],
+    )
+    ast.fix_missing_locations(probe_class)
+    exec(
+        compile(ast.Module(body=[probe_class], type_ignores=[]), str(path), "exec"),
+        globals_dict,
+    )
+    return globals_dict["Subject"]
+
+
+def _load_function(path, function_name, globals_dict):
+    tree = ast.parse(path.read_text())
+    function = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == function_name
+    )
+    function.decorator_list = []
+    ast.fix_missing_locations(function)
+    exec(
+        compile(ast.Module(body=[function], type_ignores=[]), str(path), "exec"),
+        globals_dict,
+    )
+    return globals_dict[function_name]
+
+
+class _PendingObjects:
+    def __init__(self, notified_by_id, events):
+        self.notified_by_id = notified_by_id
+        self.events = events
+        self.ids = []
+
+    def filter(self, **kwargs):
+        self.ids = list(kwargs["id__in"])
+        return self
+
+    def update(self, **kwargs):
+        for alert_id in self.ids:
+            self.notified_by_id[alert_id] = kwargs["alert_center_notified"]
+        self.events.append(("update", dict(self.notified_by_id)))
+
+
+def test_schedule_notifications_persists_pending_state_before_on_commit():
+    notified_by_id = {101: True, 102: True}
+    events = []
+    callbacks = []
+    notify_calls = []
+
+    def on_commit(callback):
+        events.append(("on_commit", dict(notified_by_id)))
+        callbacks.append(callback)
+
+    subject = _load_method(
+        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
+        "EventAlertManager",
+        "_schedule_notifications",
+        {
+            "transaction": types.SimpleNamespace(on_commit=on_commit),
+            "MonitorAlert": types.SimpleNamespace(
+                objects=_PendingObjects(notified_by_id, events)
+            ),
+            "AlertLifecycleNotifier": lambda policy: types.SimpleNamespace(
+                notify_alerts=lambda alerts, action: notify_calls.append(
+                    (action, [alert.id for alert in alerts])
+                )
+            ),
+        },
+    )()
+    subject.policy = types.SimpleNamespace(notice=True)
+
+    subject._schedule_notifications(
+        [types.SimpleNamespace(id=101)],
+        [types.SimpleNamespace(id=102)],
+    )
+
+    assert notified_by_id == {101: False, 102: False}
+    assert events == [
+        ("update", {101: False, 102: False}),
+        ("on_commit", {101: False, 102: False}),
+        ("on_commit", {101: False, 102: False}),
+    ]
+    for callback in callbacks:
+        callback()
+    assert notify_calls == [("created", [101]), ("upgraded", [102])]
+
+
+def test_schedule_notifications_disabled_keeps_notified_state():
+    notified_by_id = {101: True}
+    events = []
+    subject = _load_method(
+        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
+        "EventAlertManager",
+        "_schedule_notifications",
+        {
+            "transaction": types.SimpleNamespace(
+                on_commit=lambda callback: events.append(("on_commit", callback))
+            ),
+            "MonitorAlert": types.SimpleNamespace(
+                objects=_PendingObjects(notified_by_id, events)
+            ),
+            "AlertLifecycleNotifier": object,
+        },
+    )()
+    subject.policy = types.SimpleNamespace(notice=False)
+
+    subject._schedule_notifications([types.SimpleNamespace(id=101)], [])
+
+    assert notified_by_id == {101: True}
+    assert events == []
+
+
+class _RetryQuery:
+    def __init__(self, alerts):
+        self.alerts = alerts
+
+    def order_by(self, *fields):
+        return self
+
+    def __getitem__(self, item):
+        return _RetryQuery(self.alerts[item])
+
+    def __iter__(self):
+        return iter(self.alerts)
+
+
+class _RetryObjects:
+    def __init__(self, alerts):
+        self.alerts = alerts
+        self.filters = []
+
+    def filter(self, **kwargs):
+        self.filters.append(kwargs)
+        selected = list(self.alerts)
+        if "status__in" in kwargs:
+            selected = [a for a in selected if a.status in kwargs["status__in"]]
+        if "alert_center_notified" in kwargs:
+            selected = [
+                a for a in selected
+                if a.alert_center_notified == kwargs["alert_center_notified"]
+            ]
+        if "alert_center_retry_count__lt" in kwargs:
+            selected = [
+                a for a in selected
+                if a.alert_center_retry_count < kwargs["alert_center_retry_count__lt"]
+            ]
+        return _RetryQuery(selected)
+
+
+def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
+    alerts = [
+        types.SimpleNamespace(
+            id=201, status="new",
+            alert_center_notified=False, alert_center_retry_count=0,
+        ),
+        types.SimpleNamespace(
+            id=202, status="recovered",
+            alert_center_notified=False, alert_center_retry_count=0,
+        ),
+        types.SimpleNamespace(
+            id=203, status="closed",
+            alert_center_notified=False, alert_center_retry_count=9,
+        ),
+        types.SimpleNamespace(
+            id=204, status="new",
+            alert_center_notified=True, alert_center_retry_count=0,
+        ),
+        types.SimpleNamespace(
+            id=205, status="new",
+            alert_center_notified=False, alert_center_retry_count=10,
+        ),
+    ]
+    objects = _RetryObjects(alerts)
+    pushes = []
+    marked = []
+    notifier = types.SimpleNamespace(
+        push_to_alert_center_only=lambda grouped, action: (
+            pushes.append((action, [alert.id for alert in grouped]))
+            or [(alert, True) for alert in grouped]
+        ),
+        _mark_alert_center_notified=lambda alert_ids: marked.append(alert_ids),
+    )
+    models = types.ModuleType("apps.monitor.models")
+    models.MonitorAlert = types.SimpleNamespace(objects=objects)
+    notify_module = types.ModuleType(
+        "apps.monitor.services.alert_lifecycle_notify"
+    )
+    notify_module.AlertLifecycleNotifier = lambda: notifier
+    monkeypatch.setitem(sys.modules, "apps.monitor.models", models)
+    monkeypatch.setitem(
+        sys.modules,
+        "apps.monitor.services.alert_lifecycle_notify",
+        notify_module,
+    )
+    retry_task = _load_function(
+        MONITOR_ROOT / "tasks/monitor_policy.py",
+        "retry_alert_center_lifecycle_notify_task",
+        {
+            "defaultdict": defaultdict,
+            "F": lambda field: field,
+            "logger": types.SimpleNamespace(
+                info=lambda *args, **kwargs: None,
+                exception=lambda *args, **kwargs: None,
+                error=lambda *args, **kwargs: None,
+            ),
+        },
+    )
+
+    result = retry_task()
+
+    assert objects.filters == [{
+        "status__in": ["new", "recovered", "closed"],
+        "alert_center_notified": False,
+        "alert_center_retry_count__lt": 10,
+    }]
+    assert pushes == [
+        ("created", [201]),
+        ("recovered", [202]),
+        ("closed", [203]),
+    ]
+    assert marked == [[201, 202, 203]]
+    assert result == {
+        "success": True,
+        "total": 3,
+        "succeeded": 3,
+        "failed": 0,
+    }

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -1,406 +1,135 @@
-"""Issue #3341：首次告警通知失败必须进入告警中心补偿队列。"""
+"""Issue #3341：告警中心生命周期投递的真实 ORM/协议回归。"""
 
-import ast
-import sys
-import types
-from collections import defaultdict
-from pathlib import Path
+from datetime import datetime, timezone
+from types import SimpleNamespace
 
 import pytest
 
-pytestmark = pytest.mark.unit
-
-MONITOR_ROOT = Path(__file__).resolve().parents[1]
-
-
-def _load_methods(path, class_name, method_names, globals_dict):
-    tree = ast.parse(path.read_text())
-    source_class = next(
-        node for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == class_name
-    )
-    methods = [
-        node for node in source_class.body
-        if isinstance(node, ast.FunctionDef) and node.name in method_names
-    ]
-    probe_class = ast.ClassDef(
-        name="Subject",
-        bases=[],
-        keywords=[],
-        body=methods,
-        decorator_list=[],
-    )
-    ast.fix_missing_locations(probe_class)
-    exec(
-        compile(ast.Module(body=[probe_class], type_ignores=[]), str(path), "exec"),
-        globals_dict,
-    )
-    return globals_dict["Subject"]
+from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery
+from apps.monitor.services.alert_center_delivery import (
+    _ack_result,
+    deliver_alert_center_delivery,
+    enqueue_alert_center_deliveries,
+)
+from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
+from apps.system_mgmt.models import Channel
 
 
-def _load_method(path, class_name, method_name, globals_dict):
-    return _load_methods(path, class_name, {method_name}, globals_dict)
+pytestmark = [pytest.mark.integration, pytest.mark.django_db(transaction=True)]
 
 
-def _load_function(path, function_name, globals_dict):
-    tree = ast.parse(path.read_text())
-    function = next(
-        node for node in tree.body
-        if isinstance(node, ast.FunctionDef) and node.name == function_name
-    )
-    function.decorator_list = []
-    ast.fix_missing_locations(function)
-    exec(
-        compile(ast.Module(body=[function], type_ignores=[]), str(path), "exec"),
-        globals_dict,
-    )
-    return globals_dict[function_name]
-
-
-class _PendingObjects:
-    def __init__(self, notified_by_id, events):
-        self.notified_by_id = notified_by_id
-        self.events = events
-        self.ids = []
-
-    def filter(self, **kwargs):
-        self.ids = list(kwargs["id__in"])
-        return self
-
-    def update(self, **kwargs):
-        for alert_id in self.ids:
-            self.notified_by_id[alert_id] = kwargs["alert_center_notified"]
-        self.events.append(("update", dict(self.notified_by_id)))
-
-
-def test_schedule_notifications_persists_pending_state_before_on_commit():
-    notified_by_id = {101: True, 102: True}
-    events = []
-    callbacks = []
-    notify_calls = []
-
-    def on_commit(callback):
-        events.append(("on_commit", dict(notified_by_id)))
-        callbacks.append(callback)
-
-    subject = _load_method(
-        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
-        "EventAlertManager",
-        "_schedule_notifications",
-        {
-            "ALERT_CENTER_CREATED_RETRY_ENABLED": True,
-            "transaction": types.SimpleNamespace(on_commit=on_commit),
-            "MonitorAlert": types.SimpleNamespace(
-                objects=_PendingObjects(notified_by_id, events)
-            ),
-            "AlertLifecycleNotifier": lambda policy: types.SimpleNamespace(
-                notify_alerts=lambda alerts, action: notify_calls.append(
-                    (action, [alert.id for alert in alerts])
-                )
-            ),
-        },
-    )()
-    subject.policy = types.SimpleNamespace(notice=True)
-
-    subject._schedule_notifications(
-        [types.SimpleNamespace(id=101)],
-        [types.SimpleNamespace(id=102)],
+@pytest.fixture
+def alert_center_channel():
+    return Channel.objects.create(
+        name="告警中心",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
     )
 
-    assert notified_by_id == {101: False, 102: False}
-    assert events == [
-        ("update", {101: False, 102: False}),
-        ("on_commit", {101: False, 102: False}),
-        ("on_commit", {101: False, 102: False}),
-    ]
-    for callback in callbacks:
-        callback()
-    assert notify_calls == [("created", [101]), ("upgraded", [102])]
 
-
-def test_schedule_notifications_disabled_keeps_notified_state():
-    notified_by_id = {101: True}
-    events = []
-    subject = _load_method(
-        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
-        "EventAlertManager",
-        "_schedule_notifications",
-        {
-            "ALERT_CENTER_CREATED_RETRY_ENABLED": True,
-            "transaction": types.SimpleNamespace(
-                on_commit=lambda callback: events.append(("on_commit", callback))
-            ),
-            "MonitorAlert": types.SimpleNamespace(
-                objects=_PendingObjects(notified_by_id, events)
-            ),
-            "AlertLifecycleNotifier": object,
-        },
-    )()
-    subject.policy = types.SimpleNamespace(notice=False)
-
-    subject._schedule_notifications([types.SimpleNamespace(id=101)], [])
-
-    assert notified_by_id == {101: True}
-    assert events == []
-
-
-def test_schedule_notifications_default_compatibility_keeps_legacy_pending_state():
-    notified_by_id = {101: True}
-    events = []
-    callbacks = []
-    subject = _load_method(
-        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
-        "EventAlertManager",
-        "_schedule_notifications",
-        {
-            "ALERT_CENTER_CREATED_RETRY_ENABLED": False,
-            "transaction": types.SimpleNamespace(on_commit=callbacks.append),
-            "MonitorAlert": types.SimpleNamespace(
-                objects=_PendingObjects(notified_by_id, events)
-            ),
-            "AlertLifecycleNotifier": lambda policy: types.SimpleNamespace(
-                notify_alerts=lambda alerts, action: None
-            ),
-        },
-    )()
-    subject.policy = types.SimpleNamespace(notice=True)
-
-    subject._schedule_notifications([types.SimpleNamespace(id=101)], [])
-
-    assert notified_by_id == {101: True}
-    assert events == []
-    assert len(callbacks) == 1
-
-
-class _RetryQuery:
-    def __init__(self, alerts):
-        self.alerts = alerts
-
-    def order_by(self, *fields):
-        return self
-
-    def __getitem__(self, item):
-        return _RetryQuery(self.alerts[item])
-
-    def __iter__(self):
-        return iter(self.alerts)
-
-
-class _RetryObjects:
-    def __init__(self, alerts):
-        self.alerts = alerts
-        self.filters = []
-
-    def filter(self, **kwargs):
-        self.filters.append(kwargs)
-        selected = list(self.alerts)
-        if "status__in" in kwargs:
-            selected = [a for a in selected if a.status in kwargs["status__in"]]
-        if "alert_center_notified" in kwargs:
-            selected = [
-                a for a in selected
-                if a.alert_center_notified == kwargs["alert_center_notified"]
-            ]
-        if "alert_center_retry_count__lt" in kwargs:
-            selected = [
-                a for a in selected
-                if a.alert_center_retry_count < kwargs["alert_center_retry_count__lt"]
-            ]
-        return _RetryQuery(selected)
-
-
-def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
-    policy_a = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
-    policy_b = types.SimpleNamespace(id=303, name="策略 B", organizations=[8])
-    alerts = [
-        types.SimpleNamespace(
-            id=201, status="new",
-            policy_id=policy_a.id,
-            alert_center_notified=False, alert_center_retry_count=0,
-        ),
-        types.SimpleNamespace(
-            id=206, status="new",
-            policy_id=policy_b.id,
-            alert_center_notified=False, alert_center_retry_count=0,
-        ),
-        types.SimpleNamespace(
-            id=202, status="recovered",
-            policy_id=302,
-            alert_center_notified=False, alert_center_retry_count=0,
-        ),
-        types.SimpleNamespace(
-            id=203, status="closed",
-            policy_id=302,
-            alert_center_notified=False, alert_center_retry_count=9,
-        ),
-        types.SimpleNamespace(
-            id=204, status="new",
-            policy_id=policy_a.id,
-            alert_center_notified=True, alert_center_retry_count=0,
-        ),
-        types.SimpleNamespace(
-            id=205, status="new",
-            policy_id=policy_a.id,
-            alert_center_notified=False, alert_center_retry_count=10,
-        ),
-    ]
-    objects = _RetryObjects(alerts)
-    loaded_policy_ids = []
-    pushes = []
-    marked = []
-    notifier_policies = []
-    notifier = types.SimpleNamespace(
-        push_to_alert_center_only=lambda grouped, action: (
-            pushes.append((action, [alert.id for alert in grouped]))
-            or [(alert, True) for alert in grouped]
-        ),
-        _mark_alert_center_notified=lambda alert_ids: marked.append(alert_ids),
-    )
-    models = types.ModuleType("apps.monitor.models")
-    models.MonitorAlert = types.SimpleNamespace(objects=objects)
-    models.MonitorPolicy = types.SimpleNamespace(
-        objects=types.SimpleNamespace(
-            in_bulk=lambda policy_ids: (
-                loaded_policy_ids.append(set(policy_ids))
-                or {policy_a.id: policy_a, policy_b.id: policy_b}
-            )
-        )
-    )
-    notify_module = types.ModuleType(
-        "apps.monitor.services.alert_lifecycle_notify"
-    )
-    notify_module.ALERT_CENTER_CREATED_RETRY_ENABLED = True
-
-    def build_notifier(notifier_policy=None, policies_by_id=None):
-        notifier_policies.append((notifier_policy, policies_by_id))
-        return notifier
-
-    notify_module.AlertLifecycleNotifier = build_notifier
-    monkeypatch.setitem(sys.modules, "apps.monitor.models", models)
-    monkeypatch.setitem(
-        sys.modules,
-        "apps.monitor.services.alert_lifecycle_notify",
-        notify_module,
-    )
-    retry_task = _load_function(
-        MONITOR_ROOT / "tasks/monitor_policy.py",
-        "retry_alert_center_lifecycle_notify_task",
-        {
-            "defaultdict": defaultdict,
-            "F": lambda field: field,
-            "logger": types.SimpleNamespace(
-                info=lambda *args, **kwargs: None,
-                exception=lambda *args, **kwargs: None,
-                error=lambda *args, **kwargs: None,
-            ),
-        },
-    )
-
-    result = retry_task()
-
-    assert objects.filters == [{
-        "status__in": ["new", "recovered", "closed"],
-        "alert_center_notified": False,
-        "alert_center_retry_count__lt": 10,
-    }]
-    assert pushes == [
-        ("created", [201, 206]),
-        ("recovered", [202]),
-        ("closed", [203]),
-    ]
-    assert loaded_policy_ids == [{policy_a.id, policy_b.id}]
-    assert notifier_policies == [
-        (None, {policy_a.id: policy_a, policy_b.id: policy_b})
-    ]
-    assert marked == [[201, 206, 202, 203]]
-    assert result == {
-        "success": True,
-        "total": 4,
-        "succeeded": 4,
-        "failed": 0,
+def _alert(channel, **overrides):
+    values = {
+        "policy_id": 7,
+        "monitor_instance_id": "host-1",
+        "monitor_instance_name": "主机 1",
+        "metric_instance_id": "cpu",
+        "content": "CPU 高",
+        "level": "warning",
+        "value": 80,
+        "status": "new",
+        "start_event_time": datetime(2026, 8, 12, 1, tzinfo=timezone.utc),
+        "notice_type_ids": [channel.id],
+        "alert_center_notified": True,
     }
+    values.update(overrides)
+    return MonitorAlert.objects.create(**values)
 
 
-def test_retry_payload_uses_new_alert_policy_without_changing_terminal_actions():
-    policy = types.SimpleNamespace(id=301, name="策略 A", organizations=[7])
-    alert = types.SimpleNamespace(
-        id=201,
-        policy_id=policy.id,
-        content="CPU 告警",
-        level="critical",
-        value=95,
-        start_event_time=None,
-        end_event_time=None,
-        monitor_instance_id="host-1",
-        monitor_instance_name="主机 1",
-        dimensions={"ip": "127.0.0.1"},
-        metric_instance_id="cpu",
-        status="new",
+def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert_center_channel, monkeypatch):
+    monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
+    alert = _alert(alert_center_channel)
+    notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
+
+    enqueue_alert_center_deliveries([alert], "created", notifier=notifier)
+    created_payload = MonitorAlertCenterDelivery.objects.get(alert=alert, generation=1).payload
+
+    alert.status = "recovered"
+    alert.content = "CPU 已恢复"
+    alert.end_event_time = datetime(2026, 8, 12, 2, tzinfo=timezone.utc)
+    alert.alert_center_notified = False
+    alert.save(update_fields=["status", "content", "end_event_time", "alert_center_notified", "updated_at"])
+    enqueue_alert_center_deliveries([alert], "recovered", notifier=notifier)
+
+    deliveries = list(MonitorAlertCenterDelivery.objects.filter(alert=alert).order_by("generation"))
+    assert [(item.action, item.generation) for item in deliveries] == [("created", 1), ("recovered", 2)]
+    assert deliveries[0].payload == created_payload
+    assert deliveries[0].payload["title"] == "CPU 高"
+    assert deliveries[1].payload["title"] == "CPU 已恢复"
+    alert.refresh_from_db()
+    assert alert.alert_center_notified is False
+
+
+def test_later_generation_cannot_overtake_pending_created(alert_center_channel, mocker):
+    alert = _alert(alert_center_channel)
+    first = MonitorAlertCenterDelivery.objects.create(
+        alert=alert, action="created", generation=1, delivery_id="created-1", payload={"title": "first"}
     )
-    subject = _load_methods(
-        MONITOR_ROOT / "services/alert_lifecycle_notify.py",
-        "AlertLifecycleNotifier",
-        {"_resolve_alert_organizations", "_build_alert_center_payload"},
-        {
-            "ACTION_TO_ALERT_CENTER": {
-                "created": "created",
-                "recovered": "recovery",
-            },
-            "LEVEL_TO_ALERT_CENTER": {"critical": "0"},
-        },
-    )()
-    subject.policy = None
-    subject.policies_by_id = {policy.id: policy}
-
-    created_payload = subject._build_alert_center_payload(
-        alert, "created", "", "", {}
+    second = MonitorAlertCenterDelivery.objects.create(
+        alert=alert, action="recovered", generation=2, delivery_id="recovered-2", payload={"title": "second"}
     )
-    recovered_payload = subject._build_alert_center_payload(
-        alert, "recovered", "", "", {}
-    )
+    send = mocker.patch("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.send_msg_with_channel")
 
-    assert created_payload["organizations"] == [7]
-    assert created_payload["labels"]["policy_name"] == "策略 A"
-    assert recovered_payload["organizations"] == []
-    assert recovered_payload["labels"]["policy_name"] == ""
+    assert deliver_alert_center_delivery(second.id) is False
+    send.assert_not_called()
+    first.refresh_from_db()
+    second.refresh_from_db()
+    assert first.status == MonitorAlertCenterDelivery.Status.PENDING
+    assert second.status == MonitorAlertCenterDelivery.Status.PENDING
 
 
-def test_sender_per_event_ack_marks_only_accepted_or_duplicate(monkeypatch):
-    from apps.monitor.services import alert_lifecycle_notify as notify_module
+def test_outbox_enabled_skips_legacy_nats_but_keeps_pending(alert_center_channel, mocker, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
+    monkeypatch.setattr(notifier, "enqueue_alert_center_deliveries", lambda *args, **kwargs: [])
+    send = mocker.patch("apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel")
 
-    alerts = [
-        types.SimpleNamespace(
-            id=201, start_event_time=None, end_event_time=None, level="critical", value=1
-        ),
-        types.SimpleNamespace(
-            id=202, start_event_time=None, end_event_time=None, level="critical", value=2
-        ),
-    ]
-    notifier = notify_module.AlertLifecycleNotifier()
-    monkeypatch.setattr(notify_module, "ALERT_CENTER_PER_EVENT_ACK_ENABLED", True)
-    monkeypatch.setattr(notifier, "_build_instance_org_map", lambda values: {})
-    monkeypatch.setattr(
-        notifier,
-        "_build_alert_center_payload",
-        lambda alert, action, operator, reason, instance_org_map: {"external_id": str(alert.id)},
-    )
-    delivery_ids = [notifier._build_delivery_id(alert, "created") for alert in alerts]
-    monkeypatch.setattr(
-        notify_module.SystemMgmtUtils,
-        "send_msg_with_channel",
-        lambda *args: {
-            "result": False,
-            "data": {
-                "event_results": [
-                    {"delivery_id": delivery_ids[0], "status": "duplicate", "retryable": False},
-                    {"delivery_id": delivery_ids[1], "status": "rejected", "retryable": False},
-                ]
-            },
-            "message": "partial",
-        },
+    notifier.notify_alerts([alert], "created")
+
+    send.assert_not_called()
+    alert.refresh_from_db()
+    assert alert.alert_center_notified is False
+
+
+def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_channel, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    delivery = MonitorAlertCenterDelivery.objects.create(
+        alert=alert, action="created", generation=1, delivery_id="created-fenced", payload={"title": "first"}
     )
 
-    results = notifier._push_to_alert_center(7, "告警中心", alerts, "created", "", "")
+    def race(*args, **kwargs):
+        MonitorAlertCenterDelivery.objects.filter(id=delivery.id).update(attempts=2)
+        return {"result": True, "data": {}}
 
-    assert [entry["success"] for _, entry in results] == [True, False]
-    assert results[1][1]["error"] == "rejected"
+    monkeypatch.setattr("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.send_msg_with_channel", race)
+
+    assert deliver_alert_center_delivery(delivery.id) is False
+    delivery.refresh_from_db()
+    alert.refresh_from_db()
+    assert delivery.status == MonitorAlertCenterDelivery.Status.DELIVERING
+    assert delivery.attempts == 2
+    assert alert.alert_center_notified is False
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "duplicate", "retryable": False}]}}, (True, False, "")),
+        ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "rejected", "retryable": False}]}}, (False, False, "rejected")),
+        ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "errored", "retryable": True}]}}, (False, True, "errored")),
+        ({"result": True, "data": {}}, (True, False, "")),
+    ],
+)
+def test_ack_contract_supports_new_and_legacy_receivers(response, expected):
+    assert _ack_result(response, "d") == expected

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -79,6 +79,41 @@ def test_outbox_rollback_keeps_legacy_created_retry_enabled(monkeypatch):
         outbox_enabled=False,
         created_retry_enabled=False,
     ) == ["new", "recovered", "closed"]
+    assert monitor_policy_tasks._legacy_alert_center_retry_statuses(
+        outbox_enabled=True,
+        created_retry_enabled=False,
+    ) == ["new", "recovered", "closed"]
+
+
+def test_legacy_retry_uses_each_alert_selected_alert_center_channel(
+    alert_center_channel, mocker
+):
+    second_channel = Channel.objects.create(
+        name="告警中心二",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    first = _alert(alert_center_channel)
+    second = _alert(second_channel)
+    push = mocker.patch.object(
+        AlertLifecycleNotifier,
+        "_push_to_alert_center",
+        side_effect=lambda channel_id, channel_name, alerts, *args: [
+            (alert, {"success": True, "channel_id": channel_id}) for alert in alerts
+        ],
+    )
+
+    results = AlertLifecycleNotifier().push_to_alert_center_only(
+        [first, second], "created"
+    )
+
+    assert {(call.args[0], call.args[2][0].id) for call in push.call_args_list} == {
+        (alert_center_channel.id, first.id),
+        (second_channel.id, second.id),
+    }
+    assert all(success for _, success in results)
 
 
 def test_shadow_legacy_and_outbox_share_lifecycle_identity(

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -68,14 +68,10 @@ def test_outbox_rollback_keeps_legacy_created_retry_enabled(monkeypatch):
 def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_center_channel, monkeypatch):
     alert = _alert(
         alert_center_channel,
-        alert_center_delivery_backfilled=None,
+        alert_center_delivery_backfilled=False,
         alert_center_notified=True,
     )
     monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
-    monkeypatch.setattr(
-        "apps.monitor.utils.system_mgmt_api.SystemMgmtUtils.list_notification_channels",
-        lambda ids: [{"id": alert_center_channel.id, "delivery_mode": "alert_event_copy"}],
-    )
 
     assert backfill_legacy_alerts() == 1
 
@@ -89,10 +85,6 @@ def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_
 
 def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert_center_channel, monkeypatch):
     monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
-    monkeypatch.setattr(
-        "apps.monitor.utils.system_mgmt_api.SystemMgmtUtils.list_notification_channels",
-        lambda ids: [{"id": alert_center_channel.id, "delivery_mode": "alert_event_copy"}],
-    )
     alert = _alert(alert_center_channel)
     notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
 
@@ -123,7 +115,7 @@ def test_later_generation_cannot_overtake_pending_created(alert_center_channel, 
     second = MonitorAlertCenterDelivery.objects.create(
         alert=alert, action="recovered", generation=2, delivery_id="recovered-2", channel_id=alert_center_channel.id, payload={"title": "second"}
     )
-    send = mocker.patch("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.send_msg_with_channel")
+    send = mocker.patch("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification")
 
     assert deliver_alert_center_delivery(second.id) is False
     send.assert_not_called()
@@ -133,15 +125,18 @@ def test_later_generation_cannot_overtake_pending_created(alert_center_channel, 
     assert second.status == MonitorAlertCenterDelivery.Status.PENDING
 
 
-def test_outbox_enabled_skips_legacy_nats_but_keeps_pending(alert_center_channel, mocker, monkeypatch):
+def test_outbox_rollout_keeps_legacy_delivery_and_pending_until_ack(alert_center_channel, mocker, monkeypatch):
     alert = _alert(alert_center_channel, alert_center_notified=False)
     notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
     monkeypatch.setattr(notifier, "enqueue_alert_center_deliveries", lambda *args, **kwargs: [])
-    send = mocker.patch("apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel")
+    send = mocker.patch(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel",
+        return_value={"result": False, "message": "temporary"},
+    )
 
     notifier.notify_alerts([alert], "created")
 
-    send.assert_not_called()
+    send.assert_called_once()
     alert.refresh_from_db()
     assert alert.alert_center_notified is False
 
@@ -156,7 +151,7 @@ def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_ch
         MonitorAlertCenterDelivery.objects.filter(id=delivery.id).update(attempts=2)
         return {"result": True, "data": {}}
 
-    monkeypatch.setattr("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.send_msg_with_channel", race)
+    monkeypatch.setattr("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification", race)
 
     assert deliver_alert_center_delivery(delivery.id) is False
     delivery.refresh_from_db()
@@ -177,3 +172,34 @@ def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_ch
 )
 def test_ack_contract_supports_new_and_legacy_receivers(response, expected):
     assert _ack_result(response, "d") == expected
+
+
+def test_new_alert_stays_unreconciled_until_outbox_intent_is_persisted(alert_center_channel):
+    alert = _alert(alert_center_channel)
+    assert alert.alert_center_delivery_backfilled is False
+
+
+def test_terminal_channel_boundary_failure_is_not_retried(alert_center_channel, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    delivery = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="forbidden",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {
+            "result": False,
+            "code": "channel_forbidden",
+            "retryable": False,
+            "message": "forbidden",
+        },
+    )
+
+    assert deliver_alert_center_delivery(delivery.id) is False
+    delivery.refresh_from_db()
+    assert delivery.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert delivery.next_retry_at is None

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -7,10 +7,13 @@ import pytest
 
 from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery
 from apps.monitor.services.alert_center_delivery import (
+    _env_flag,
     _ack_result,
+    backfill_legacy_alerts,
     deliver_alert_center_delivery,
     enqueue_alert_center_deliveries,
 )
+from apps.monitor.tasks import monitor_policy as monitor_policy_tasks
 from apps.monitor.services.alert_lifecycle_notify import AlertLifecycleNotifier
 from apps.system_mgmt.models import Channel
 
@@ -47,8 +50,49 @@ def _alert(channel, **overrides):
     return MonitorAlert.objects.create(**values)
 
 
+def test_outbox_requires_explicit_receiver_first_enablement(monkeypatch):
+    monkeypatch.delenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", raising=False)
+    assert _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED") is False
+
+    monkeypatch.setenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", "true")
+    assert _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED") is True
+
+
+def test_outbox_rollback_keeps_legacy_created_retry_enabled(monkeypatch):
+    assert monitor_policy_tasks._legacy_alert_center_retry_statuses(
+        outbox_enabled=False,
+        created_retry_enabled=False,
+    ) == ["new", "recovered", "closed"]
+
+
+def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_center_channel, monkeypatch):
+    alert = _alert(
+        alert_center_channel,
+        alert_center_delivery_backfilled=None,
+        alert_center_notified=True,
+    )
+    monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
+    monkeypatch.setattr(
+        "apps.monitor.utils.system_mgmt_api.SystemMgmtUtils.list_notification_channels",
+        lambda ids: [{"id": alert_center_channel.id, "delivery_mode": "alert_event_copy"}],
+    )
+
+    assert backfill_legacy_alerts() == 1
+
+    delivery = MonitorAlertCenterDelivery.objects.get(alert=alert)
+    assert delivery.action == "created"
+    assert delivery.channel_id == alert_center_channel.id
+    alert.refresh_from_db()
+    assert alert.alert_center_delivery_backfilled is True
+    assert alert.alert_center_notified is False
+
+
 def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert_center_channel, monkeypatch):
     monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
+    monkeypatch.setattr(
+        "apps.monitor.utils.system_mgmt_api.SystemMgmtUtils.list_notification_channels",
+        lambda ids: [{"id": alert_center_channel.id, "delivery_mode": "alert_event_copy"}],
+    )
     alert = _alert(alert_center_channel)
     notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
 
@@ -74,10 +118,10 @@ def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert
 def test_later_generation_cannot_overtake_pending_created(alert_center_channel, mocker):
     alert = _alert(alert_center_channel)
     first = MonitorAlertCenterDelivery.objects.create(
-        alert=alert, action="created", generation=1, delivery_id="created-1", payload={"title": "first"}
+        alert=alert, action="created", generation=1, delivery_id="created-1", channel_id=alert_center_channel.id, payload={"title": "first"}
     )
     second = MonitorAlertCenterDelivery.objects.create(
-        alert=alert, action="recovered", generation=2, delivery_id="recovered-2", payload={"title": "second"}
+        alert=alert, action="recovered", generation=2, delivery_id="recovered-2", channel_id=alert_center_channel.id, payload={"title": "second"}
     )
     send = mocker.patch("apps.monitor.services.alert_center_delivery.SystemMgmtUtils.send_msg_with_channel")
 
@@ -105,7 +149,7 @@ def test_outbox_enabled_skips_legacy_nats_but_keeps_pending(alert_center_channel
 def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_channel, monkeypatch):
     alert = _alert(alert_center_channel, alert_center_notified=False)
     delivery = MonitorAlertCenterDelivery.objects.create(
-        alert=alert, action="created", generation=1, delivery_id="created-fenced", payload={"title": "first"}
+        alert=alert, action="created", generation=1, delivery_id="created-fenced", channel_id=alert_center_channel.id, payload={"title": "first"}
     )
 
     def race(*args, **kwargs):

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -14,6 +14,7 @@ import apps.node_mgmt.models  # noqa: F401
 from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery
 from apps.monitor.services.alert_center_delivery import (
     _env_flag,
+    _outbox_enabled,
     _ack_result,
     backfill_legacy_alerts,
     deliver_alert_center_delivery,
@@ -68,10 +69,15 @@ def _alert(channel, **overrides):
 
 def test_outbox_requires_explicit_receiver_first_enablement(monkeypatch):
     monkeypatch.delenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", raising=False)
+    monkeypatch.delenv("ALERTS_PER_EVENT_ACK_TOKEN", raising=False)
     assert _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED") is False
 
     monkeypatch.setenv("MONITOR_ALERT_CENTER_OUTBOX_ENABLED", "true")
     assert _env_flag("MONITOR_ALERT_CENTER_OUTBOX_ENABLED") is True
+    assert _outbox_enabled() is False
+
+    monkeypatch.setenv("ALERTS_PER_EVENT_ACK_TOKEN", "receiver-secret")
+    assert _outbox_enabled() is True
 
 
 def test_outbox_rollback_keeps_legacy_created_retry_enabled(monkeypatch):
@@ -213,6 +219,10 @@ def test_shadow_legacy_and_outbox_share_lifecycle_identity(
         "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
         False,
     )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_lifecycle_notify.ALERT_CENTER_ACK_TOKEN",
+        "receiver-secret",
+    )
     schedule = mocker.patch(
         "apps.monitor.services.alert_center_delivery._schedule_deliveries"
     )
@@ -237,6 +247,8 @@ def test_shadow_legacy_and_outbox_share_lifecycle_identity(
     delivery = MonitorAlertCenterDelivery.objects.get(alert=alert)
     content = send.call_args.args[2]
     assert content["events"][0]["lifecycle_generation"] == delivery.delivery_id
+    assert content["ack_mode"] == "per_event_v1"
+    assert content["ack_token"] == "receiver-secret"
     schedule.assert_not_called()
 
 

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -88,6 +88,7 @@ def test_schedule_notifications_persists_pending_state_before_on_commit():
         "EventAlertManager",
         "_schedule_notifications",
         {
+            "ALERT_CENTER_CREATED_RETRY_ENABLED": True,
             "transaction": types.SimpleNamespace(on_commit=on_commit),
             "MonitorAlert": types.SimpleNamespace(
                 objects=_PendingObjects(notified_by_id, events)
@@ -125,6 +126,7 @@ def test_schedule_notifications_disabled_keeps_notified_state():
         "EventAlertManager",
         "_schedule_notifications",
         {
+            "ALERT_CENTER_CREATED_RETRY_ENABLED": True,
             "transaction": types.SimpleNamespace(
                 on_commit=lambda callback: events.append(("on_commit", callback))
             ),
@@ -140,6 +142,34 @@ def test_schedule_notifications_disabled_keeps_notified_state():
 
     assert notified_by_id == {101: True}
     assert events == []
+
+
+def test_schedule_notifications_default_compatibility_keeps_legacy_pending_state():
+    notified_by_id = {101: True}
+    events = []
+    callbacks = []
+    subject = _load_method(
+        MONITOR_ROOT / "tasks/services/policy_scan/event_alert_manager.py",
+        "EventAlertManager",
+        "_schedule_notifications",
+        {
+            "ALERT_CENTER_CREATED_RETRY_ENABLED": False,
+            "transaction": types.SimpleNamespace(on_commit=callbacks.append),
+            "MonitorAlert": types.SimpleNamespace(
+                objects=_PendingObjects(notified_by_id, events)
+            ),
+            "AlertLifecycleNotifier": lambda policy: types.SimpleNamespace(
+                notify_alerts=lambda alerts, action: None
+            ),
+        },
+    )()
+    subject.policy = types.SimpleNamespace(notice=True)
+
+    subject._schedule_notifications([types.SimpleNamespace(id=101)], [])
+
+    assert notified_by_id == {101: True}
+    assert events == []
+    assert len(callbacks) == 1
 
 
 class _RetryQuery:
@@ -239,6 +269,7 @@ def test_retry_task_selects_pending_lifecycle_actions(monkeypatch):
     notify_module = types.ModuleType(
         "apps.monitor.services.alert_lifecycle_notify"
     )
+    notify_module.ALERT_CENTER_CREATED_RETRY_ENABLED = True
 
     def build_notifier(notifier_policy=None, policies_by_id=None):
         notifier_policies.append((notifier_policy, policies_by_id))
@@ -332,3 +363,44 @@ def test_retry_payload_uses_new_alert_policy_without_changing_terminal_actions()
     assert created_payload["labels"]["policy_name"] == "策略 A"
     assert recovered_payload["organizations"] == []
     assert recovered_payload["labels"]["policy_name"] == ""
+
+
+def test_sender_per_event_ack_marks_only_accepted_or_duplicate(monkeypatch):
+    from apps.monitor.services import alert_lifecycle_notify as notify_module
+
+    alerts = [
+        types.SimpleNamespace(
+            id=201, start_event_time=None, end_event_time=None, level="critical", value=1
+        ),
+        types.SimpleNamespace(
+            id=202, start_event_time=None, end_event_time=None, level="critical", value=2
+        ),
+    ]
+    notifier = notify_module.AlertLifecycleNotifier()
+    monkeypatch.setattr(notify_module, "ALERT_CENTER_PER_EVENT_ACK_ENABLED", True)
+    monkeypatch.setattr(notifier, "_build_instance_org_map", lambda values: {})
+    monkeypatch.setattr(
+        notifier,
+        "_build_alert_center_payload",
+        lambda alert, action, operator, reason, instance_org_map: {"external_id": str(alert.id)},
+    )
+    delivery_ids = [notifier._build_delivery_id(alert, "created") for alert in alerts]
+    monkeypatch.setattr(
+        notify_module.SystemMgmtUtils,
+        "send_msg_with_channel",
+        lambda *args: {
+            "result": False,
+            "data": {
+                "event_results": [
+                    {"delivery_id": delivery_ids[0], "status": "duplicate", "retryable": False},
+                    {"delivery_id": delivery_ids[1], "status": "rejected", "retryable": False},
+                ]
+            },
+            "message": "partial",
+        },
+    )
+
+    results = notifier._push_to_alert_center(7, "告警中心", alerts, "created", "", "")
+
+    assert [entry["success"] for _, entry in results] == [True, False]
+    assert results[1][1]["error"] == "rejected"

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -211,3 +211,35 @@ def test_terminal_channel_boundary_failure_is_not_retried(alert_center_channel, 
     delivery.refresh_from_db()
     assert delivery.status == MonitorAlertCenterDelivery.Status.FAILED
     assert delivery.next_retry_at is None
+
+
+def test_terminal_predecessor_closes_later_generations(alert_center_channel, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    first = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="terminal-created",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+    )
+    second = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="recovered",
+        generation=2,
+        delivery_id="blocked-recovered",
+        channel_id=alert_center_channel.id,
+        payload={"title": "second", "organizations": [1]},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {"result": False, "retryable": False, "code": "rejected"},
+    )
+
+    assert deliver_alert_center_delivery(first.id) is False
+
+    first.refresh_from_db()
+    second.refresh_from_db()
+    assert first.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert second.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert second.last_error == "blocked by terminal generation 1"

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -5,7 +5,7 @@ from threading import Event, Thread
 from types import SimpleNamespace
 
 import pytest
-from django.db import close_old_connections
+from django.db import close_old_connections, transaction
 from django.utils import timezone as django_timezone
 
 # 该集成测试会加载 monitor 的节点管理服务；显式声明跨 app 依赖，
@@ -316,6 +316,42 @@ def test_outbox_ignores_non_alert_center_channels(alert_center_channel, monkeypa
             "channel_id", flat=True
         )
     ) == [alert_center_channel.id]
+
+
+def test_capability_rpc_failure_does_not_rollback_domain_state(
+    alert_center_channel, monkeypatch
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.probe_notification_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("rpc unavailable")),
+    )
+    alert = _alert(alert_center_channel, alert_center_notified=True)
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(
+            notice=True,
+            notice_type_ids=[alert_center_channel.id],
+            notice_users=[],
+        )
+    )
+
+    with transaction.atomic():
+        MonitorAlert.objects.filter(id=alert.id).update(
+            status="recovered",
+            alert_center_notified=False,
+        )
+        assert enqueue_alert_center_deliveries(
+            [alert], "recovered", notifier=notifier
+        ) == []
+
+    alert.refresh_from_db()
+    assert alert.status == "recovered"
+    assert alert.alert_center_notified is False
+    assert alert.alert_center_delivery_backfilled is False
+    assert not MonitorAlertCenterDelivery.objects.filter(alert=alert).exists()
 
 
 def test_backfill_notice_disabled_keeps_valid_terminal_lifecycle(

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -8,6 +8,9 @@ import pytest
 from django.db import close_old_connections
 from django.utils import timezone as django_timezone
 
+# 该集成测试会加载 monitor 的节点管理服务；显式声明跨 app 依赖，
+# 也让最小测试入口能构造与生产一致的 Django app 集合。
+import apps.node_mgmt.models  # noqa: F401
 from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery
 from apps.monitor.services.alert_center_delivery import (
     _env_flag,
@@ -32,6 +35,16 @@ def alert_center_channel():
         config={"method_name": "receive_alert_events"},
         description="",
         team=[1],
+    )
+
+
+@pytest.fixture(autouse=True)
+def public_alert_center_capability(monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.probe_notification_channel",
+        lambda channel_id, capability_only=False: {
+            "delivery_mode": "alert_event_copy"
+        },
     )
 
 
@@ -68,7 +81,156 @@ def test_outbox_rollback_keeps_legacy_created_retry_enabled(monkeypatch):
     ) == ["new", "recovered", "closed"]
 
 
+def test_shadow_legacy_and_outbox_share_lifecycle_identity(
+    alert_center_channel, monkeypatch, mocker
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
+        False,
+    )
+    schedule = mocker.patch(
+        "apps.monitor.services.alert_center_delivery._schedule_deliveries"
+    )
+    send = mocker.patch(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel",
+        return_value={"result": True, "data": {}},
+    )
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(
+            id=7,
+            name="CPU 策略",
+            organizations=[1],
+            notice=True,
+            notice_users=[],
+            notice_type_ids=[alert_center_channel.id],
+        )
+    )
+
+    notifier.notify_alerts([alert], "created")
+
+    delivery = MonitorAlertCenterDelivery.objects.get(alert=alert)
+    content = send.call_args.args[2]
+    assert content["events"][0]["lifecycle_generation"] == delivery.delivery_id
+    schedule.assert_not_called()
+
+
+def test_disabled_rollout_preserves_legacy_nats_payload(
+    alert_center_channel, monkeypatch, mocker
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        False,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_lifecycle_notify.ALERT_CENTER_PER_EVENT_ACK_ENABLED",
+        False,
+    )
+    send = mocker.patch(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel",
+        return_value={"result": True, "data": {}},
+    )
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(
+            id=7,
+            name="CPU 策略",
+            organizations=[1],
+            notice=True,
+            notice_users=[],
+            notice_type_ids=[alert_center_channel.id],
+        )
+    )
+
+    notifier.notify_alerts([alert], "created")
+
+    event = send.call_args.args[2]["events"][0]
+    assert "lifecycle_action" not in event
+    assert "lifecycle_generation" not in event
+    assert "delivery_id" not in event
+
+
+def test_delivery_switch_without_outbox_keeps_legacy_send(
+    alert_center_channel, monkeypatch, mocker
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        False,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
+        True,
+    )
+    send = mocker.patch(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel",
+        return_value={"result": True, "data": {}},
+    )
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(
+            id=7,
+            name="CPU 策略",
+            organizations=[1],
+            notice=True,
+            notice_users=[],
+            notice_type_ids=[alert_center_channel.id],
+        )
+    )
+
+    notifier.notify_alerts([alert], "created")
+
+    send.assert_called_once()
+
+
+def test_active_outbox_does_not_double_send_legacy_path(
+    alert_center_channel, monkeypatch, mocker
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery._schedule_deliveries",
+        lambda ids: None,
+    )
+    send = mocker.patch(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.send_msg_with_channel"
+    )
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(
+            id=7,
+            name="CPU 策略",
+            organizations=[1],
+            notice=True,
+            notice_users=[],
+            notice_type_ids=[alert_center_channel.id],
+        )
+    )
+
+    notifier.notify_alerts([alert], "created")
+
+    send.assert_not_called()
+    assert MonitorAlertCenterDelivery.objects.filter(
+        alert=alert, status=MonitorAlertCenterDelivery.Status.PENDING
+    ).exists()
+    alert.refresh_from_db()
+    assert alert.alert_center_notified is False
+
+
 def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_center_channel, monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
     alert = _alert(
         alert_center_channel,
         alert_center_delivery_backfilled=False,
@@ -88,7 +250,122 @@ def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_
     assert alert.alert_center_notified is False
 
 
+def test_backfill_restores_missing_created_before_recovered(alert_center_channel, monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
+        False,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery._schedule_deliveries",
+        lambda ids: None,
+    )
+    alert = _alert(
+        alert_center_channel,
+        status="recovered",
+        alert_center_delivery_backfilled=False,
+        alert_center_notified=False,
+        notice_logs=[],
+    )
+
+    assert backfill_legacy_alerts() == 1
+
+    deliveries = list(
+        MonitorAlertCenterDelivery.objects.filter(alert=alert).order_by("generation")
+    )
+    assert [item.action for item in deliveries] == ["created", "recovered"]
+
+
+def test_outbox_ignores_non_alert_center_channels(alert_center_channel, monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    normal_channel = Channel.objects.create(
+        name="企业微信",
+        channel_type="enterprise_wechat_bot",
+        config={"url": "https://example.invalid"},
+        description="",
+        team=[1],
+    )
+    alert = _alert(
+        alert_center_channel,
+        notice_type_ids=[normal_channel.id, alert_center_channel.id],
+    )
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True)
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.probe_notification_channel",
+        lambda channel_id, capability_only=False: {
+            "delivery_mode": (
+                "alert_event_copy"
+                if channel_id == alert_center_channel.id
+                else "direct_recipient"
+            )
+        },
+    )
+
+    enqueue_alert_center_deliveries([alert], "created", notifier=notifier)
+
+    assert list(
+        MonitorAlertCenterDelivery.objects.filter(alert=alert).values_list(
+            "channel_id", flat=True
+        )
+    ) == [alert_center_channel.id]
+
+
+def test_backfill_notice_disabled_keeps_valid_terminal_lifecycle(
+    alert_center_channel, monkeypatch
+):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.probe_notification_channel",
+        lambda channel_id, capability_only=False: {
+            "delivery_mode": "alert_event_copy"
+        },
+    )
+    policy = SimpleNamespace(
+        id=7,
+        notice=False,
+        notice_type_ids=[alert_center_channel.id],
+        organizations=[1],
+    )
+    alert = _alert(
+        alert_center_channel,
+        status="recovered",
+        alert_center_delivery_backfilled=False,
+        alert_center_notified=False,
+        notice_logs=[
+            {
+                "action": "created",
+                "channel_id": alert_center_channel.id,
+                "success": True,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.MonitorPolicy.objects.in_bulk",
+        lambda ids: {7: policy},
+    )
+
+    assert backfill_legacy_alerts() == 1
+    assert MonitorAlertCenterDelivery.objects.filter(
+        alert=alert, action="recovered"
+    ).exists()
+
+
 def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert_center_channel, monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
     monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
     alert = _alert(alert_center_channel)
     notifier = AlertLifecycleNotifier(SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True))
@@ -113,6 +390,10 @@ def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert
 
 
 def test_multi_channel_enqueue_is_idempotent_across_retries(alert_center_channel, monkeypatch):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
     second_channel = Channel.objects.create(
         name="备用告警中心",
         channel_type="nats",
@@ -342,9 +623,56 @@ def test_terminal_predecessor_closes_later_generations(alert_center_channel, mon
     assert second.last_error == "blocked by terminal generation 1"
 
 
+def test_terminal_failure_only_blocks_the_same_channel(alert_center_channel, monkeypatch):
+    second_channel = Channel.objects.create(
+        name="备用告警中心",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    alert = _alert(
+        alert_center_channel,
+        notice_type_ids=[alert_center_channel.id, second_channel.id],
+        alert_center_notified=False,
+    )
+    failed = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="failed-primary",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+        status=MonitorAlertCenterDelivery.Status.FAILED,
+    )
+    healthy = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=2,
+        delivery_id="healthy-secondary",
+        channel_id=second_channel.id,
+        payload={"title": "second", "organizations": [1]},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {"result": True, "data": {}},
+    )
+
+    assert deliver_alert_center_delivery(healthy.id) is True
+
+    failed.refresh_from_db()
+    healthy.refresh_from_db()
+    assert failed.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert healthy.status == MonitorAlertCenterDelivery.Status.DELIVERED
+
+
 def test_successor_enqueued_after_terminal_failure_is_closed(
     alert_center_channel, monkeypatch
 ):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
     alert = _alert(alert_center_channel, alert_center_notified=False)
     first = MonitorAlertCenterDelivery.objects.create(
         alert=alert,
@@ -381,6 +709,10 @@ def test_successor_enqueued_after_terminal_failure_is_closed(
 def test_terminal_finalize_serializes_with_concurrent_successor_enqueue(
     alert_center_channel, monkeypatch
 ):
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
     alert = _alert(alert_center_channel, alert_center_notified=False)
     first = MonitorAlertCenterDelivery.objects.create(
         alert=alert,

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -116,6 +116,92 @@ def test_legacy_retry_uses_each_alert_selected_alert_center_channel(
     assert all(success for _, success in results)
 
 
+def test_legacy_retry_requires_all_selected_alert_center_channels_to_succeed(
+    alert_center_channel, mocker
+):
+    second_channel = Channel.objects.create(
+        name="告警中心二",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    alert = _alert(
+        alert_center_channel,
+        notice_type_ids=[alert_center_channel.id, second_channel.id],
+    )
+    mocker.patch.object(
+        AlertLifecycleNotifier,
+        "_push_to_alert_center",
+        side_effect=lambda channel_id, channel_name, alerts, *args: [
+            (
+                item,
+                {
+                    "success": channel_id == alert_center_channel.id,
+                    "channel_id": channel_id,
+                },
+            )
+            for item in alerts
+        ],
+    )
+
+    assert AlertLifecycleNotifier().push_to_alert_center_only(
+        [alert], "created"
+    ) == [(alert, False)]
+
+
+def test_legacy_retry_channel_capability_failure_stays_retryable(
+    alert_center_channel, monkeypatch
+):
+    alert = _alert(alert_center_channel)
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_lifecycle_notify.SystemMgmtUtils.probe_notification_channel",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("rpc unavailable")),
+    )
+
+    assert AlertLifecycleNotifier().push_to_alert_center_only(
+        [alert], "created"
+    ) == [(alert, False)]
+
+
+def test_immediate_delivery_requires_all_alert_center_channels_to_succeed(
+    alert_center_channel, mocker
+):
+    second_channel = Channel.objects.create(
+        name="告警中心二",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    alert = _alert(
+        alert_center_channel,
+        notice_type_ids=[alert_center_channel.id, second_channel.id],
+        alert_center_notified=False,
+    )
+    notifier = AlertLifecycleNotifier()
+    mocker.patch.object(
+        notifier,
+        "_send_to_channel",
+        side_effect=lambda channel_id, users, alerts, *args: [
+            (
+                item,
+                {
+                    "is_alert_center": True,
+                    "success": channel_id == alert_center_channel.id,
+                    "channel_id": channel_id,
+                },
+            )
+            for item in alerts
+        ],
+    )
+
+    notifier.notify_alerts([alert], "created")
+
+    alert.refresh_from_db()
+    assert alert.alert_center_notified is False
+
+
 def test_shadow_legacy_and_outbox_share_lifecycle_identity(
     alert_center_channel, monkeypatch, mocker
 ):
@@ -312,6 +398,52 @@ def test_backfill_restores_missing_created_before_recovered(alert_center_channel
         MonitorAlertCenterDelivery.objects.filter(alert=alert).order_by("generation")
     )
     assert [item.action for item in deliveries] == ["created", "recovered"]
+
+
+def test_backfill_restores_created_predecessor_only_for_missing_channel(
+    alert_center_channel, monkeypatch
+):
+    second_channel = Channel.objects.create(
+        name="告警中心二",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_ENABLED",
+        True,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.ALERT_CENTER_OUTBOX_DELIVERY_ENABLED",
+        False,
+    )
+    alert = _alert(
+        alert_center_channel,
+        status="recovered",
+        alert_center_delivery_backfilled=False,
+        alert_center_notified=False,
+        notice_type_ids=[alert_center_channel.id, second_channel.id],
+        notice_logs=[
+            {
+                "action": "created",
+                "channel_id": alert_center_channel.id,
+                "success": True,
+            }
+        ],
+    )
+
+    assert backfill_legacy_alerts() == 1
+
+    assert list(
+        MonitorAlertCenterDelivery.objects.filter(alert=alert)
+        .order_by("generation")
+        .values_list("action", "channel_id")
+    ) == [
+        ("created", second_channel.id),
+        ("recovered", alert_center_channel.id),
+        ("recovered", second_channel.id),
+    ]
 
 
 def test_outbox_ignores_non_alert_center_channels(alert_center_channel, monkeypatch):

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -179,6 +179,14 @@ def test_new_alert_stays_unreconciled_until_outbox_intent_is_persisted(alert_cen
     assert alert.alert_center_delivery_backfilled is False
 
 
+def test_backfill_marks_no_target_rows_reconciled_without_outbox(alert_center_channel):
+    alert = _alert(alert_center_channel, policy_id=0, notice_type_ids=[])
+    assert backfill_legacy_alerts() == 1
+    alert.refresh_from_db()
+    assert alert.alert_center_delivery_backfilled is True
+    assert not MonitorAlertCenterDelivery.objects.filter(alert=alert).exists()
+
+
 def test_terminal_channel_boundary_failure_is_not_retried(alert_center_channel, monkeypatch):
     alert = _alert(alert_center_channel, alert_center_notified=False)
     delivery = MonitorAlertCenterDelivery.objects.create(

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -78,6 +78,8 @@ def test_backfill_reconciles_legacy_created_rows_that_still_look_notified(alert_
     delivery = MonitorAlertCenterDelivery.objects.get(alert=alert)
     assert delivery.action == "created"
     assert delivery.channel_id == alert_center_channel.id
+    assert "lifecycle_action" not in delivery.payload
+    assert "lifecycle_generation" in delivery.payload
     alert.refresh_from_db()
     assert alert.alert_center_delivery_backfilled is True
     assert alert.alert_center_notified is False
@@ -105,6 +107,35 @@ def test_created_and_recovered_keep_independent_ordered_immutable_payloads(alert
     assert deliveries[1].payload["title"] == "CPU 已恢复"
     alert.refresh_from_db()
     assert alert.alert_center_notified is False
+
+
+def test_multi_channel_enqueue_is_idempotent_across_retries(alert_center_channel, monkeypatch):
+    second_channel = Channel.objects.create(
+        name="备用告警中心",
+        channel_type="nats",
+        config={"method_name": "receive_alert_events"},
+        description="",
+        team=[1],
+    )
+    monkeypatch.setattr("apps.monitor.services.alert_center_delivery._schedule_deliveries", lambda ids: None)
+    alert = _alert(
+        alert_center_channel,
+        notice_type_ids=[alert_center_channel.id, second_channel.id],
+    )
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True)
+    )
+
+    first_ids = enqueue_alert_center_deliveries(
+        [alert], "created", notifier=notifier
+    )
+    second_ids = enqueue_alert_center_deliveries(
+        [alert], "created", notifier=notifier
+    )
+
+    assert len(first_ids) == 2
+    assert second_ids == []
+    assert MonitorAlertCenterDelivery.objects.filter(alert=alert).count() == 2
 
 
 def test_later_generation_cannot_overtake_pending_created(alert_center_channel, mocker):
@@ -165,7 +196,7 @@ def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_ch
     ("response", "expected"),
     [
         ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "duplicate", "retryable": False}]}}, (True, False, "")),
-        ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "rejected", "retryable": False}]}}, (False, False, "rejected")),
+        ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "rejected", "retryable": True}]}}, (False, True, "rejected")),
         ({"result": False, "data": {"event_results": [{"delivery_id": "d", "status": "errored", "retryable": True}]}}, (False, True, "errored")),
         ({"result": True, "data": {}}, (True, False, "")),
     ],
@@ -213,6 +244,41 @@ def test_terminal_channel_boundary_failure_is_not_retried(alert_center_channel, 
     assert delivery.next_retry_at is None
 
 
+def test_rejected_event_ack_keeps_delivery_retryable(alert_center_channel, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    delivery = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="retryable-rejected",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {
+            "result": False,
+            "data": {
+                "event_results": [
+                    {
+                        "delivery_id": "retryable-rejected",
+                        "status": "rejected",
+                        "retryable": True,
+                    }
+                ]
+            },
+        },
+    )
+
+    assert deliver_alert_center_delivery(delivery.id) is False
+
+    delivery.refresh_from_db()
+    assert delivery.status == MonitorAlertCenterDelivery.Status.PENDING
+    assert delivery.attempts == 1
+    assert delivery.next_retry_at is not None
+    assert delivery.last_error == "rejected"
+
+
 def test_terminal_predecessor_closes_later_generations(alert_center_channel, monkeypatch):
     alert = _alert(alert_center_channel, alert_center_notified=False)
     first = MonitorAlertCenterDelivery.objects.create(
@@ -241,5 +307,41 @@ def test_terminal_predecessor_closes_later_generations(alert_center_channel, mon
     first.refresh_from_db()
     second.refresh_from_db()
     assert first.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert second.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert second.last_error == "blocked by terminal generation 1"
+
+
+def test_successor_enqueued_after_terminal_failure_is_closed(
+    alert_center_channel, monkeypatch
+):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    first = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="terminal-lock-created",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {"result": False, "retryable": False, "code": "forbidden"},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery._schedule_deliveries",
+        lambda ids: None,
+    )
+
+    assert deliver_alert_center_delivery(first.id) is False
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True)
+    )
+    enqueue_alert_center_deliveries(
+        [alert], "recovered", notifier=notifier
+    )
+
+    second = MonitorAlertCenterDelivery.objects.get(
+        alert=alert, generation=2
+    )
     assert second.status == MonitorAlertCenterDelivery.Status.FAILED
     assert second.last_error == "blocked by terminal generation 1"

--- a/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
+++ b/server/apps/monitor/tests/test_issue_3341_alert_center_retry_service.py
@@ -1,9 +1,12 @@
 """Issue #3341：告警中心生命周期投递的真实 ORM/协议回归。"""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from threading import Event, Thread
 from types import SimpleNamespace
 
 import pytest
+from django.db import close_old_connections
+from django.utils import timezone as django_timezone
 
 from apps.monitor.models import MonitorAlert, MonitorAlertCenterDelivery
 from apps.monitor.services.alert_center_delivery import (
@@ -192,6 +195,34 @@ def test_stale_delivery_finalize_is_fenced_by_attempt_generation(alert_center_ch
     assert alert.alert_center_notified is False
 
 
+def test_stale_delivering_lease_is_reclaimed(alert_center_channel, monkeypatch):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    delivery = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="stale-lease",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+        status=MonitorAlertCenterDelivery.Status.DELIVERING,
+        attempts=1,
+    )
+    stale_at = django_timezone.now() - timedelta(minutes=6)
+    MonitorAlertCenterDelivery.objects.filter(id=delivery.id).update(
+        updated_at=stale_at
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {"result": True, "data": {}},
+    )
+
+    assert deliver_alert_center_delivery(delivery.id) is True
+
+    delivery.refresh_from_db()
+    assert delivery.status == MonitorAlertCenterDelivery.Status.DELIVERED
+    assert delivery.attempts == 2
+
+
 @pytest.mark.parametrize(
     ("response", "expected"),
     [
@@ -343,5 +374,92 @@ def test_successor_enqueued_after_terminal_failure_is_closed(
     second = MonitorAlertCenterDelivery.objects.get(
         alert=alert, generation=2
     )
+    assert second.status == MonitorAlertCenterDelivery.Status.FAILED
+    assert second.last_error == "blocked by terminal generation 1"
+
+
+def test_terminal_finalize_serializes_with_concurrent_successor_enqueue(
+    alert_center_channel, monkeypatch
+):
+    alert = _alert(alert_center_channel, alert_center_notified=False)
+    first = MonitorAlertCenterDelivery.objects.create(
+        alert=alert,
+        action="created",
+        generation=1,
+        delivery_id="terminal-race-created",
+        channel_id=alert_center_channel.id,
+        payload={"title": "first", "organizations": [1]},
+    )
+    notifier = AlertLifecycleNotifier(
+        SimpleNamespace(id=7, name="CPU 策略", organizations=[1], notice=True)
+    )
+    finalize_started = Event()
+    allow_finalize = Event()
+    enqueue_started = Event()
+    enqueue_finished = Event()
+    errors = []
+    original_fail_successors = (
+        __import__(
+            "apps.monitor.services.alert_center_delivery",
+            fromlist=["_fail_blocked_successors"],
+        )._fail_blocked_successors
+    )
+
+    def hold_terminal_transaction(record):
+        original_fail_successors(record)
+        finalize_started.set()
+        assert allow_finalize.wait(timeout=5)
+
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery._fail_blocked_successors",
+        hold_terminal_transaction,
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery.SystemMgmtUtils.dispatch_notification",
+        lambda **kwargs: {"result": False, "retryable": False, "code": "forbidden"},
+    )
+    monkeypatch.setattr(
+        "apps.monitor.services.alert_center_delivery._schedule_deliveries",
+        lambda ids: None,
+    )
+
+    def finalize():
+        close_old_connections()
+        try:
+            deliver_alert_center_delivery(first.id)
+        except Exception as exc:  # pragma: no cover - assertion reports below
+            errors.append(exc)
+        finally:
+            close_old_connections()
+
+    def enqueue():
+        close_old_connections()
+        enqueue_started.set()
+        try:
+            fresh_alert = MonitorAlert.objects.get(id=alert.id)
+            enqueue_alert_center_deliveries(
+                [fresh_alert], "recovered", notifier=notifier
+            )
+        except Exception as exc:  # pragma: no cover - assertion reports below
+            errors.append(exc)
+        finally:
+            enqueue_finished.set()
+            close_old_connections()
+
+    finalize_thread = Thread(target=finalize)
+    enqueue_thread = Thread(target=enqueue)
+    finalize_thread.start()
+    assert finalize_started.wait(timeout=5)
+    enqueue_thread.start()
+    assert enqueue_started.wait(timeout=5)
+    assert enqueue_finished.wait(timeout=0.2) is False
+    allow_finalize.set()
+    finalize_thread.join(timeout=5)
+    enqueue_thread.join(timeout=5)
+
+    assert errors == []
+    assert finalize_thread.is_alive() is False
+    assert enqueue_thread.is_alive() is False
+    second = MonitorAlertCenterDelivery.objects.get(alert=alert, generation=2)
     assert second.status == MonitorAlertCenterDelivery.Status.FAILED
     assert second.last_error == "blocked by terminal generation 1"

--- a/server/apps/monitor/tests/test_monitor_alert_update_transaction_4041.py
+++ b/server/apps/monitor/tests/test_monitor_alert_update_transaction_4041.py
@@ -66,7 +66,12 @@ class TestCloseNoDataAlertTransaction:
     """正常路径:perform_update 成功 → baseline 与 alert status 都更新"""
 
     def test_close_no_data_alert_with_update_baseline_true(
-        self, api_client, grant_all, stub_notifier, stub_refresh
+        self,
+        api_client,
+        grant_all,
+        stub_notifier,
+        stub_refresh,
+        django_capture_on_commit_callbacks,
     ):
         api_client.cookies["current_team"] = "1"
         policy = _make_policy()
@@ -84,12 +89,14 @@ class TestCloseNoDataAlertTransaction:
             policy=policy, monitor_instance_id="h1", metric_instance_id="m2"
         )
 
-        resp = api_client.patch(
-            f"{BASE}/api/monitor_alert/{alert.id}/",
-            {"status": "closed", "update_baseline": True},
-            format="json",
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"{BASE}/api/monitor_alert/{alert.id}/",
+                {"status": "closed", "update_baseline": True},
+                format="json",
+            )
         assert resp.status_code == 200
+        assert "alert_center_delivery_backfilled" not in resp.data
         alert.refresh_from_db()
         assert alert.status == "closed"
         # refresh() 已被调用一次
@@ -253,7 +260,12 @@ class TestNonNoDataAlertDoesNotTouchBaseline:
     """非 no_data alert 不走 baseline 路径,事务包裹也不应触发"""
 
     def test_close_regular_alert_does_not_touch_baseline(
-        self, api_client, grant_all, stub_notifier, stub_refresh
+        self,
+        api_client,
+        grant_all,
+        stub_notifier,
+        stub_refresh,
+        django_capture_on_commit_callbacks,
     ):
         api_client.cookies["current_team"] = "1"
         policy = _make_policy()
@@ -268,11 +280,12 @@ class TestNonNoDataAlertDoesNotTouchBaseline:
             policy=policy, monitor_instance_id="h1", metric_instance_id="m1"
         )
 
-        resp = api_client.patch(
-            f"{BASE}/api/monitor_alert/{alert.id}/",
-            {"status": "closed", "update_baseline": True},
-            format="json",
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"{BASE}/api/monitor_alert/{alert.id}/",
+                {"status": "closed", "update_baseline": True},
+                format="json",
+            )
         assert resp.status_code == 200
         # baseline 完全未被触动
         assert PolicyInstanceBaseline.objects.filter(id=baseline.id).exists()
@@ -286,7 +299,12 @@ class TestNoDataAlertNoMetricInstanceId:
     """no_data 但无 metric_instance_id 时,baseline 路径不走"""
 
     def test_close_no_data_without_metric_instance_id(
-        self, api_client, grant_all, stub_notifier, stub_refresh
+        self,
+        api_client,
+        grant_all,
+        stub_notifier,
+        stub_refresh,
+        django_capture_on_commit_callbacks,
     ):
         api_client.cookies["current_team"] = "1"
         policy = _make_policy()
@@ -297,11 +315,12 @@ class TestNoDataAlertNoMetricInstanceId:
             alert_type="no_data",
             status="new",
         )
-        resp = api_client.patch(
-            f"{BASE}/api/monitor_alert/{alert.id}/",
-            {"status": "closed", "update_baseline": True},
-            format="json",
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"{BASE}/api/monitor_alert/{alert.id}/",
+                {"status": "closed", "update_baseline": True},
+                format="json",
+            )
         assert resp.status_code == 200
         stub_refresh.assert_not_called()
         stub_notifier.return_value.notify_alerts.assert_called_once()

--- a/server/apps/monitor/tests/test_policy_scan_alert_detector.py
+++ b/server/apps/monitor/tests/test_policy_scan_alert_detector.py
@@ -266,7 +266,9 @@ class TestCountEvents:
 
 @pytest.mark.django_db
 class TestRecoverThresholdAlerts:
-    def test_recovers_when_info_count_reaches_condition(self, mocker):
+    def test_recovers_when_info_count_reaches_condition(
+        self, mocker, django_capture_on_commit_callbacks
+    ):
         notifier = mocker.patch(
             "apps.monitor.tasks.services.policy_scan.alert_detector.AlertLifecycleNotifier"
         )
@@ -275,7 +277,8 @@ class TestRecoverThresholdAlerts:
             status="new", info_event_count=5,
         )
         detector = AlertDetector(_policy(recovery_condition=2), {}, {}, [alert], _mq())
-        detector.recover_threshold_alerts()
+        with django_capture_on_commit_callbacks(execute=True):
+            detector.recover_threshold_alerts()
         alert.refresh_from_db()
         assert alert.status == "recovered"
         assert alert.operator == "system"
@@ -310,7 +313,9 @@ class TestRecoverNoDataAlerts:
         # 不应抛错，直接返回
         assert detector.recover_no_data_alerts() is None
 
-    def test_recovers_no_data_alert_when_data_returns(self, mocker):
+    def test_recovers_no_data_alert_when_data_returns(
+        self, mocker, django_capture_on_commit_callbacks
+    ):
         notifier = mocker.patch(
             "apps.monitor.tasks.services.policy_scan.alert_detector.AlertLifecycleNotifier"
         )
@@ -322,7 +327,8 @@ class TestRecoverNoDataAlerts:
             _policy(), {}, {}, [alert],
             _mq(formatted={"('h1',)": {"value": 1.0}}),
         )
-        detector.recover_no_data_alerts()
+        with django_capture_on_commit_callbacks(execute=True):
+            detector.recover_no_data_alerts()
         alert.refresh_from_db()
         assert alert.status == "recovered"
         notifier.return_value.notify_alerts.assert_called_once()

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -29,9 +29,8 @@ class SystemMgmtUtils:
         return result
 
     @staticmethod
-    def list_notification_channels(channel_ids):
-        result = SystemMgmt().list_notification_channels(channel_ids=channel_ids)
-        return result["data"]
+    def dispatch_notification(**kwargs):
+        return SystemMgmt().dispatch_notification(**kwargs)
 
     @staticmethod
     def format_rules(module, child_module, rules):

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -29,6 +29,11 @@ class SystemMgmtUtils:
         return result
 
     @staticmethod
+    def list_notification_channels(channel_ids):
+        result = SystemMgmt().list_notification_channels(channel_ids=channel_ids)
+        return result["data"]
+
+    @staticmethod
     def format_rules(module, child_module, rules):
         rule = rules.get("monitor", {})
         combined_map = {}

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -33,6 +33,12 @@ class SystemMgmtUtils:
         return SystemMgmt().dispatch_notification(**kwargs)
 
     @staticmethod
+    def probe_notification_channel(channel_id, capability_only=False):
+        return SystemMgmt().probe_notification_channel(
+            channel_id, capability_only=capability_only
+        )
+
+    @staticmethod
     def format_rules(module, child_module, rules):
         rule = rules.get("monitor", {})
         combined_map = {}

--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -222,29 +222,29 @@ class MonitorAlertViewSet(
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
 
-        updated_data = serializer.validated_data
-        if updated_data.get("status") == "closed":
-            now = datetime.now(timezone.utc)
-            updated_data["end_event_time"] = now
-            updated_data["operator"] = request.user.username
-            updated_data["operation_logs"] = (instance.operation_logs or []) + [
-                {
-                    "action": "closed",
-                    "reason": "manual",
-                    "operator": request.user.username,
-                    "time": now.isoformat(),
-                }
-            ]
-            # 只有 new → closed 的转换才需要补偿推送，避免重复关闭触发多余的告警中心推送
-            if old_status == "new":
-                updated_data["alert_center_notified"] = False
+        with transaction.atomic():
+            updated_data = serializer.validated_data
+            if updated_data.get("status") == "closed":
+                now = datetime.now(timezone.utc)
+                updated_data["end_event_time"] = now
+                updated_data["operator"] = request.user.username
+                updated_data["operation_logs"] = (instance.operation_logs or []) + [
+                    {
+                        "action": "closed",
+                        "reason": "manual",
+                        "operator": request.user.username,
+                        "time": now.isoformat(),
+                    }
+                ]
+                # 只有 new → closed 的转换才需要补偿推送，避免重复关闭触发多余的告警中心推送
+                if old_status == "new":
+                    updated_data["alert_center_notified"] = False
 
-            # 基线清理/刷新 与 告警 status 写库 必须在同一事务中。
-            # 否则 perform_update 失败时 baseline 已删/已刷,下次扫描会再次 new 一条
-            # 一模一样的 no_data 告警，相当于「用户手动关了又自动重开」(issue #4041)。
-            # 注意:refresh() 内部含 VM scan,事务不宜过长——失败 → 整段回滚即满足需求。
-            if instance.alert_type == "no_data" and instance.metric_instance_id:
-                with transaction.atomic():
+                # 基线清理/刷新 与 告警 status 写库 必须在同一事务中。
+                # 否则 perform_update 失败时 baseline 已删/已刷,下次扫描会再次 new 一条
+                # 一模一样的 no_data 告警，相当于「用户手动关了又自动重开」(issue #4041)。
+                # 注意:refresh() 内部含 VM scan,事务不宜过长——失败 → 整段回滚即满足需求。
+                if instance.alert_type == "no_data" and instance.metric_instance_id:
                     update_baseline = request.data.get("update_baseline", False)
                     if update_baseline:
                         policy = MonitorPolicy.objects.filter(id=instance.policy_id).first()
@@ -256,21 +256,30 @@ class MonitorAlertViewSet(
                             metric_instance_id=instance.metric_instance_id,
                         ).delete()
                     self.perform_update(serializer)
+                else:
+                    self.perform_update(serializer)
             else:
                 self.perform_update(serializer)
-        else:
-            self.perform_update(serializer)
-        instance.refresh_from_db()
+            instance.refresh_from_db()
 
-        if old_status == "new" and instance.status == "closed":
-            policy = MonitorPolicy.objects.filter(id=instance.policy_id).first()
-            if policy:
-                AlertLifecycleNotifier(policy).notify_alerts(
-                    [instance],
-                    action="closed",
-                    operator=request.user.username,
-                    reason="manual",
-                )
+            if old_status == "new" and instance.status == "closed":
+                policy = MonitorPolicy.objects.filter(id=instance.policy_id).first()
+                if policy:
+                    notifier = AlertLifecycleNotifier(policy)
+                    notifier.enqueue_alert_center_deliveries(
+                        [instance],
+                        "closed",
+                        operator=request.user.username,
+                        reason="manual",
+                    )
+                    transaction.on_commit(
+                        lambda: notifier.notify_alerts(
+                            [instance],
+                            action="closed",
+                            operator=request.user.username,
+                            reason="manual",
+                        )
+                    )
 
         if getattr(instance, "_prefetched_objects_cache", None):
             instance._prefetched_objects_cache = {}

--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -217,12 +217,22 @@ class MonitorAlertViewSet(
 
     def update(self, request, *args, **kwargs):
         partial = kwargs.pop("partial", False)
-        instance = self.get_object()
-        old_status = instance.status
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
+        authorized_instance = self.get_object()
 
         with transaction.atomic():
+            # 权限范围先由 get_object 校验；状态转换必须锁内重读，避免扫描任务与
+            # 两个手工关闭请求都基于同一个旧 new 状态重复落 lifecycle intent。
+            instance = MonitorAlert.objects.select_for_update().get(
+                pk=authorized_instance.pk
+            )
+            # 锁等待期间组织关系、角色或策略归属都可能变化；始终以锁内时刻
+            # 重新走权限过滤，禁止复用过期授权依据。
+            instance = self.get_queryset().get(pk=instance.pk)
+            old_status = instance.status
+            serializer = self.get_serializer(
+                instance, data=request.data, partial=partial
+            )
+            serializer.is_valid(raise_exception=True)
             updated_data = serializer.validated_data
             if updated_data.get("status") == "closed":
                 now = datetime.now(timezone.utc)

--- a/server/apps/monitor/views/monitor_policy.py
+++ b/server/apps/monitor/views/monitor_policy.py
@@ -291,18 +291,26 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
             self._close_alerts_in_tx(
                 policy, alerts_to_close, request.user.username, "policy_deleted"
             )
+            if alerts_to_close:
+                notifier = AlertLifecycleNotifier(policy)
+                notifier.enqueue_alert_center_deliveries(
+                    alerts_to_close,
+                    "closed",
+                    operator=request.user.username,
+                    reason="policy_deleted",
+                )
+                transaction.on_commit(
+                    lambda alerts=tuple(alerts_to_close): notifier.notify_alerts(
+                        alerts,
+                        action="closed",
+                        operator=request.user.username,
+                        reason="policy_deleted",
+                        notify_scope=NOTIFY_SCOPE_ALL_CONFIGURED,
+                    )
+                )
             PeriodicTask.objects.filter(name=f"scan_policy_task_{policy_id}").delete()
             PolicyOrganization.objects.filter(policy_id=policy_id).delete()
             policy.delete()
-        # 事务 commit 后再推 NATS(若 commit 失败此行不会执行)
-        if alerts_to_close:
-            AlertLifecycleNotifier(policy).notify_alerts(
-                alerts_to_close,
-                action="closed",
-                operator=request.user.username,
-                reason="policy_deleted",
-                notify_scope=NOTIFY_SCOPE_ALL_CONFIGURED,
-            )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _close_alerts_in_tx(self, policy, alerts_to_close, operator, reason):
@@ -449,12 +457,21 @@ class MonitorPolicyViewSet(viewsets.ModelViewSet):
             fields=["status", "end_event_time", "operator", "operation_logs", "alert_center_notified"],
         )
         if policy and notify_scope:
-            AlertLifecycleNotifier(policy).notify_alerts(
+            notifier = AlertLifecycleNotifier(policy)
+            notifier.enqueue_alert_center_deliveries(
                 alerts_to_close,
-                action="closed",
+                "closed",
                 operator=operator,
                 reason=reason,
-                notify_scope=notify_scope,
+            )
+            transaction.on_commit(
+                lambda alerts=tuple(alerts_to_close): notifier.notify_alerts(
+                    alerts,
+                    action="closed",
+                    operator=operator,
+                    reason=reason,
+                    notify_scope=notify_scope,
+                )
             )
 
     def close_active_no_data_alerts(self, policy, operator, reason):

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -301,20 +301,33 @@ class SystemMgmt(object):
         required_delivery_mode="",
         producer="lite-apm",
         ack_mode="",
+        ack_token="",
     ):
-        return self.client.run(
-            "dispatch_notification",
-            delivery_key=delivery_key,
-            channel_id=channel_id,
-            organization_ids=organization_ids,
-            recipients=recipients,
-            title=title,
-            body=body,
-            event_payload=event_payload,
-            required_delivery_mode=required_delivery_mode,
-            producer=producer,
-            ack_mode=ack_mode,
-        )
+        payload = {
+            "delivery_key": delivery_key,
+            "channel_id": channel_id,
+            "organization_ids": organization_ids,
+            "recipients": recipients,
+            "title": title,
+            "body": body,
+            "event_payload": event_payload,
+        }
+        extensions = {
+            "required_delivery_mode": required_delivery_mode,
+            "producer": producer,
+            "ack_mode": ack_mode,
+            "ack_token": ack_token,
+        }
+        if not any((required_delivery_mode, ack_mode, ack_token)) and producer == "lite-apm":
+            return self.client.run("dispatch_notification", **payload)
+        try:
+            return self.client.run("dispatch_notification", **payload, **extensions)
+        except TypeError as exc:
+            # An old receiver rejects unknown kwargs before any side effect. Retry
+            # once with the historical contract during receiver-first rollouts.
+            if "unexpected keyword argument" not in str(exc):
+                raise
+            return self.client.run("dispatch_notification", **payload)
 
     def probe_notification_channel(self, channel_id):
         return self.client.run("probe_notification_channel", channel_id=channel_id)

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -329,8 +329,12 @@ class SystemMgmt(object):
                 raise
             return self.client.run("dispatch_notification", **payload)
 
-    def probe_notification_channel(self, channel_id):
-        return self.client.run("probe_notification_channel", channel_id=channel_id)
+    def probe_notification_channel(self, channel_id, capability_only=False):
+        return self.client.run(
+            "probe_notification_channel",
+            channel_id=channel_id,
+            capability_only=capability_only,
+        )
 
     def search_groups(self, query_params):
         """

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -271,9 +271,6 @@ class SystemMgmt(object):
             include_children=include_children,
         )
 
-    def list_notification_channels(self, channel_ids):
-        return self.client.run("list_notification_channels", channel_ids=channel_ids)
-
     def search_notification_recipients_scoped(
         self,
         actor_context,
@@ -301,6 +298,9 @@ class SystemMgmt(object):
         title,
         body,
         event_payload,
+        required_delivery_mode="",
+        producer="lite-apm",
+        ack_mode="",
     ):
         return self.client.run(
             "dispatch_notification",
@@ -311,6 +311,9 @@ class SystemMgmt(object):
             title=title,
             body=body,
             event_payload=event_payload,
+            required_delivery_mode=required_delivery_mode,
+            producer=producer,
+            ack_mode=ack_mode,
         )
 
     def probe_notification_channel(self, channel_id):

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -271,6 +271,9 @@ class SystemMgmt(object):
             include_children=include_children,
         )
 
+    def list_notification_channels(self, channel_ids):
+        return self.client.run("list_notification_channels", channel_ids=channel_ids)
+
     def search_notification_recipients_scoped(
         self,
         actor_context,

--- a/server/apps/rpc/tests/test_system_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_system_mgmt_forwarding.py
@@ -287,11 +287,49 @@ def test_dispatch_notification_转发稳定投递契约(client):
             "title": "标题",
             "body": "正文",
             "event_payload": {"event_key": "event"},
-            "required_delivery_mode": "",
-            "producer": "lite-apm",
-            "ack_mode": "",
         },
     )
+
+
+def test_dispatch_notification_新生产者兼容旧receiver(client):
+    class LegacyReceiver:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, method_name, **kwargs):
+            self.calls.append((method_name, kwargs))
+            if len(self.calls) == 1:
+                raise TypeError("unexpected keyword argument 'ack_mode'")
+            return {"result": True}
+
+    receiver = LegacyReceiver()
+    client.client = receiver
+
+    result = client.dispatch_notification(
+        delivery_key="event:1",
+        channel_id=7,
+        organization_ids=[1],
+        recipients=[],
+        title="",
+        body="正文",
+        event_payload={"event_key": "event"},
+        required_delivery_mode="alert_event_copy",
+        producer="lite-monitor",
+        ack_mode="per_event_v1",
+        ack_token="secret",
+    )
+
+    assert result == {"result": True}
+    assert len(receiver.calls) == 2
+    assert receiver.calls[-1] == ("dispatch_notification", {
+        "delivery_key": "event:1",
+        "channel_id": 7,
+        "organization_ids": [1],
+        "recipients": [],
+        "title": "",
+        "body": "正文",
+        "event_payload": {"event_key": "event"},
+    })
 
 
 def test_probe_notification_channel_转发渠道探针(client):

--- a/server/apps/rpc/tests/test_system_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_system_mgmt_forwarding.py
@@ -334,7 +334,20 @@ def test_dispatch_notification_新生产者兼容旧receiver(client):
 
 def test_probe_notification_channel_转发渠道探针(client):
     client.probe_notification_channel(7)
-    assert _last(client) == ("probe_notification_channel", (), {"channel_id": 7})
+    assert _last(client) == (
+        "probe_notification_channel",
+        (),
+        {"channel_id": 7, "capability_only": False},
+    )
+
+
+def test_probe_notification_channel_转发纯能力探针(client):
+    client.probe_notification_channel(7, capability_only=True)
+    assert _last(client) == (
+        "probe_notification_channel",
+        (),
+        {"channel_id": 7, "capability_only": True},
+    )
 
 
 def test_search_groups_转发query_params(client):

--- a/server/apps/rpc/tests/test_system_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_system_mgmt_forwarding.py
@@ -287,6 +287,9 @@ def test_dispatch_notification_转发稳定投递契约(client):
             "title": "标题",
             "body": "正文",
             "event_payload": {"event_key": "event"},
+            "required_delivery_mode": "",
+            "producer": "lite-apm",
+            "ack_mode": "",
         },
     )
 

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -218,6 +218,22 @@ def _notification_channel_capabilities(channel):
     }
 
 
+@nats_client.register
+def list_notification_channels(channel_ids):
+    """Internal capability lookup; channel configuration stays private."""
+    normalized_ids = []
+    for value in channel_ids or []:
+        try:
+            normalized_ids.append(int(value))
+        except (TypeError, ValueError):
+            continue
+    channels = Channel.objects.filter(id__in=normalized_ids).order_by("id")
+    return {
+        "result": True,
+        "data": [_notification_channel_capabilities(channel) for channel in channels],
+    }
+
+
 def _channel_has_organization(channel, organization_ids):
     return _channel_delivery_organization(channel, organization_ids) is not None
 

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -224,13 +224,18 @@ def _channel_has_organization(channel, organization_ids):
 
 def _channel_delivery_organization(channel, organization_ids):
     """返回渠道与事件共同归属的确定性组织，避免多组织事件投递到错误 team。"""
+    shared = _channel_delivery_organizations(channel, organization_ids)
+    return shared[0] if shared else None
+
+
+def _channel_delivery_organizations(channel, organization_ids):
+    """返回消息声明范围与渠道授权范围的有序交集。"""
     try:
         allowed = {int(value) for value in channel.team or []}
         requested = {int(value) for value in organization_ids or []}
     except (TypeError, ValueError):
-        return None
-    shared = allowed.intersection(requested)
-    return min(shared) if shared else None
+        return []
+    return sorted(allowed.intersection(requested))
 
 
 @nats_client.register
@@ -307,18 +312,38 @@ def _notification_failure(code, message, *, retryable=False):
 
 
 @nats_client.register
-def probe_notification_channel(channel_id):
+def probe_notification_channel(channel_id, capability_only=False):
     """探测内部通知 responder；普通外部渠道只校验公开能力是否仍存在。"""
     channel = Channel.objects.filter(id=channel_id).first()
     if channel is None:
         return _notification_failure("channel_not_found", "通知渠道不存在。")
     capability = _notification_channel_capabilities(channel)
+    if capability_only:
+        return {
+            "result": True,
+            "code": "available",
+            "retryable": False,
+            "message": "success",
+            "delivery_mode": capability["delivery_mode"],
+        }
     if capability["delivery_mode"] != "alert_event_copy":
-        return {"result": True, "code": "available", "retryable": False, "message": "success"}
+        return {
+            "result": True,
+            "code": "available",
+            "retryable": False,
+            "message": "success",
+            "delivery_mode": capability["delivery_mode"],
+        }
 
     response = send_nats_message(channel, {"health_probe": True}, timeout_override=2)
     if isinstance(response, dict) and response.get("result") is True:
-        return {"result": True, "code": "available", "retryable": False, "message": "success"}
+        return {
+            "result": True,
+            "code": "available",
+            "retryable": False,
+            "message": "success",
+            "delivery_mode": capability["delivery_mode"],
+        }
     return _notification_failure(
         "responder_unavailable",
         "通知 responder 暂不可用。",
@@ -400,10 +425,16 @@ def dispatch_notification(
 
     if capability["delivery_mode"] == "alert_event_copy":
         producer = producer if producer in {"lite-apm", "lite-monitor", "lite-log"} else "lite-apm"
+        bounded_event_payload = dict(event_payload)
+        # 不能把调用方消息体中的 organizations 原样提升为 receiver 的可信归属；
+        # 仅透传渠道自身授权范围内的交集，兼容合法多组织渠道。
+        bounded_event_payload["organizations"] = _channel_delivery_organizations(
+            channel, organization_ids
+        )
         content = {
             "source_id": "nats",
             "pusher": producer,
-            "events": [event_payload],
+            "events": [bounded_event_payload],
         }
         if ack_mode == "per_event_v1":
             content["ack_mode"] = ack_mode

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -218,22 +218,6 @@ def _notification_channel_capabilities(channel):
     }
 
 
-@nats_client.register
-def list_notification_channels(channel_ids):
-    """Internal capability lookup; channel configuration stays private."""
-    normalized_ids = []
-    for value in channel_ids or []:
-        try:
-            normalized_ids.append(int(value))
-        except (TypeError, ValueError):
-            continue
-    channels = Channel.objects.filter(id__in=normalized_ids).order_by("id")
-    return {
-        "result": True,
-        "data": [_notification_channel_capabilities(channel) for channel in channels],
-    }
-
-
 def _channel_has_organization(channel, organization_ids):
     return _channel_delivery_organization(channel, organization_ids) is not None
 
@@ -375,6 +359,9 @@ def dispatch_notification(
     title,
     body,
     event_payload,
+    required_delivery_mode="",
+    producer="lite-apm",
+    ack_mode="",
 ):
     """按公开渠道能力投递一次通知，并返回稳定、可判定重试的结果。"""
     if not isinstance(delivery_key, str) or not delivery_key.strip() or len(delivery_key) > 384:
@@ -386,6 +373,13 @@ def dispatch_notification(
     if delivery_organization is None:
         return _notification_failure("channel_forbidden", "通知渠道不属于事件组织范围。")
     capability = _notification_channel_capabilities(channel)
+    if required_delivery_mode and capability["delivery_mode"] != required_delivery_mode:
+        return {
+            "result": True,
+            "code": "not_applicable",
+            "retryable": False,
+            "message": "channel delivery mode does not match",
+        }
     normalized_recipients = _validate_notification_recipients(capability["recipient_mode"], recipients)
     if normalized_recipients is None:
         return _notification_failure("invalid_recipients", "通知接收人不符合渠道能力。")
@@ -404,11 +398,14 @@ def dispatch_notification(
         return _notification_failure("invalid_payload", "通知内容无效。")
 
     if capability["delivery_mode"] == "alert_event_copy":
+        producer = producer if producer in {"lite-apm", "lite-monitor", "lite-log"} else "lite-apm"
         content = {
             "source_id": "nats",
-            "pusher": "lite-apm",
+            "pusher": producer,
             "events": [event_payload],
         }
+        if ack_mode == "per_event_v1":
+            content["ack_mode"] = ack_mode
         send_title = ""
         send_recipients = []
     elif channel.channel_type == ChannelChoices.NATS:
@@ -453,7 +450,12 @@ def dispatch_notification(
             or int(ingestion.get("accepted", 0) or 0) + int(ingestion.get("skipped", 0) or 0) < 1
         ):
             return _notification_failure("alert_copy_rejected", "告警中心未接受事件副本。", retryable=True)
-    return {"result": True, "code": "delivered", "retryable": False, "message": "success"}
+    result = {"result": True, "code": "delivered", "retryable": False, "message": "success"}
+    if capability["delivery_mode"] == "alert_event_copy":
+        event_results = (response.get("data") or {}).get("event_results") or []
+        if event_results:
+            result["data"] = {"event_results": event_results}
+    return result
 
 
 @nats_client.register

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -362,6 +362,7 @@ def dispatch_notification(
     required_delivery_mode="",
     producer="lite-apm",
     ack_mode="",
+    ack_token="",
 ):
     """按公开渠道能力投递一次通知，并返回稳定、可判定重试的结果。"""
     if not isinstance(delivery_key, str) or not delivery_key.strip() or len(delivery_key) > 384:
@@ -406,6 +407,7 @@ def dispatch_notification(
         }
         if ack_mode == "per_event_v1":
             content["ack_mode"] = ack_mode
+            content["ack_token"] = ack_token
         send_title = ""
         send_recipients = []
     elif channel.channel_type == ChannelChoices.NATS:
@@ -438,6 +440,16 @@ def dispatch_notification(
     if not isinstance(response, dict):
         return _notification_failure("invalid_provider_response", "通知渠道返回格式无效。", retryable=True)
     if response.get("result") is False:
+        if capability["delivery_mode"] == "alert_event_copy" and ack_mode == "per_event_v1":
+            event_results = (response.get("data") or {}).get("event_results") or []
+            if event_results:
+                return {
+                    "result": False,
+                    "code": str(response.get("code") or "alert_copy_partial"),
+                    "retryable": any(bool(item.get("retryable", True)) for item in event_results if isinstance(item, dict)),
+                    "message": str(response.get("message") or "告警中心仅接受了部分事件副本。")[:512],
+                    "data": {"event_results": event_results},
+                }
         return _notification_failure(
             str(response.get("code") or "delivery_failed"),
             str(response.get("message") or "通知渠道投递失败。")[:512],

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -766,6 +766,32 @@ def test_send_msg_with_channel_channel_not_found():
     assert result["result"] is False
 
 
+def test_list_notification_channels_exposes_capability_without_private_config():
+    channel = Channel.objects.create(
+        name="告警中心",
+        channel_type=ChannelChoices.NATS,
+        config={"method_name": "receive_alert_events", "secret": "hidden"},
+        description="alert copy",
+        team=[1],
+    )
+
+    result = nats_api.list_notification_channels([channel.id, "invalid"])
+
+    assert result["result"] is True
+    assert result["data"] == [
+        {
+            "id": channel.id,
+            "name": "告警中心",
+            "channel_type": "nats",
+            "description": "alert copy",
+            "delivery_mode": "alert_event_copy",
+            "recipient_mode": "none",
+            "availability": "available",
+        }
+    ]
+    assert "config" not in result["data"][0]
+
+
 def test_get_wechat_settings():
     # 没有 wechat 配置时仍返回标准结构
     result = nats_api.get_wechat_settings()

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -766,7 +766,7 @@ def test_send_msg_with_channel_channel_not_found():
     assert result["result"] is False
 
 
-def test_list_notification_channels_exposes_capability_without_private_config():
+def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkeypatch):
     channel = Channel.objects.create(
         name="告警中心",
         channel_type=ChannelChoices.NATS,
@@ -775,21 +775,47 @@ def test_list_notification_channels_exposes_capability_without_private_config():
         team=[1],
     )
 
-    result = nats_api.list_notification_channels([channel.id, "invalid"])
+    monkeypatch.setattr(
+        "apps.system_mgmt.nats.channels.send_msg_with_channel",
+        lambda *args, **kwargs: {
+            "result": True,
+            "data": {
+                "event_results": [
+                    {"delivery_id": "delivery-1", "status": "accepted", "retryable": False}
+                ]
+            },
+        },
+    )
+    result = nats_api.dispatch_notification(
+        delivery_key="delivery-1",
+        channel_id=channel.id,
+        organization_ids=[1],
+        recipients=[],
+        title="",
+        body="alert",
+        event_payload={"delivery_id": "delivery-1", "organizations": [1]},
+        required_delivery_mode="alert_event_copy",
+        producer="lite-monitor",
+        ack_mode="per_event_v1",
+    )
 
     assert result["result"] is True
-    assert result["data"] == [
-        {
-            "id": channel.id,
-            "name": "告警中心",
-            "channel_type": "nats",
-            "description": "alert copy",
-            "delivery_mode": "alert_event_copy",
-            "recipient_mode": "none",
-            "availability": "available",
-        }
-    ]
-    assert "config" not in result["data"][0]
+    assert result["data"]["event_results"][0]["delivery_id"] == "delivery-1"
+
+    forbidden = nats_api.dispatch_notification(
+        delivery_key="delivery-2",
+        channel_id=channel.id,
+        organization_ids=[999],
+        recipients=[],
+        title="",
+        body="alert",
+        event_payload={},
+        required_delivery_mode="alert_event_copy",
+        producer="lite-monitor",
+        ack_mode="per_event_v1",
+    )
+    assert forbidden["code"] == "channel_forbidden"
+    assert forbidden["retryable"] is False
 
 
 def test_get_wechat_settings():

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -823,7 +823,7 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
     assert forbidden["retryable"] is False
 
 
-def test_monitor_alert_copy_dispatch_preserves_terminal_per_event_rejection(monkeypatch):
+def test_monitor_alert_copy_dispatch_preserves_retryable_per_event_rejection(monkeypatch):
     channel = Channel.objects.create(
         name="告警中心",
         channel_type=ChannelChoices.NATS,
@@ -838,7 +838,7 @@ def test_monitor_alert_copy_dispatch_preserves_terminal_per_event_rejection(monk
             "message": "Alert events were only partially accepted.",
             "data": {
                 "event_results": [
-                    {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": False}
+                    {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}
                 ]
             },
         },
@@ -859,9 +859,9 @@ def test_monitor_alert_copy_dispatch_preserves_terminal_per_event_rejection(monk
     )
 
     assert result["result"] is False
-    assert result["retryable"] is False
+    assert result["retryable"] is True
     assert result["data"]["event_results"] == [
-        {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": False}
+        {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}
     ]
 
 

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -547,8 +547,37 @@ def test_probe_notification_channel_checks_alert_copy_responder(monkeypatch):
 
     response = nats_api.probe_notification_channel(channel.id)
 
-    assert response == {"result": True, "code": "available", "retryable": False, "message": "success"}
+    assert response == {
+        "result": True,
+        "code": "available",
+        "retryable": False,
+        "message": "success",
+        "delivery_mode": "alert_event_copy",
+    }
     assert captured == {"channel": channel.id, "content": {"health_probe": True}, "timeout": 2}
+
+
+def test_probe_notification_channel_capability_only_does_not_touch_responder(
+    monkeypatch,
+):
+    group = Group.objects.create(name="capability-team", parent_id=0)
+    channel = Channel.objects.create(
+        name="告警中心",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        team=[group.id],
+    )
+    send = monkeypatch.setattr(
+        "apps.system_mgmt.nats.channels.send_nats_message",
+        lambda *args, **kwargs: pytest.fail("capability-only probe must not call responder"),
+    )
+
+    response = nats_api.probe_notification_channel(
+        channel.id, capability_only=True
+    )
+
+    assert response["result"] is True
+    assert response["delivery_mode"] == "alert_event_copy"
 
 
 def test_public_notification_recipient_search_is_scoped_and_bounded():
@@ -806,6 +835,20 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
     assert result["result"] is True
     assert result["data"]["event_results"][0]["delivery_id"] == "delivery-1"
     assert sent["content"]["ack_token"] == "receiver-secret"
+
+    bounded = nats_api.dispatch_notification(
+        delivery_key="delivery-bounded",
+        channel_id=channel.id,
+        organization_ids=[1, 999],
+        recipients=[],
+        title="",
+        body="alert",
+        event_payload={"delivery_id": "delivery-bounded", "organizations": [1, 999]},
+        required_delivery_mode="alert_event_copy",
+        producer="lite-monitor",
+    )
+    assert bounded["result"] is True
+    assert sent["content"]["events"][0]["organizations"] == [1]
 
     forbidden = nats_api.dispatch_notification(
         delivery_key="delivery-2",

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -775,17 +775,20 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
         team=[1],
     )
 
-    monkeypatch.setattr(
-        "apps.system_mgmt.nats.channels.send_msg_with_channel",
-        lambda *args, **kwargs: {
+    sent = {}
+
+    def fake_send(channel_id, title, content, receivers, attachments=None):
+        sent["content"] = content
+        return {
             "result": True,
             "data": {
                 "event_results": [
                     {"delivery_id": "delivery-1", "status": "accepted", "retryable": False}
                 ]
             },
-        },
-    )
+        }
+
+    monkeypatch.setattr("apps.system_mgmt.nats.channels.send_msg_with_channel", fake_send)
     result = nats_api.dispatch_notification(
         delivery_key="delivery-1",
         channel_id=channel.id,
@@ -797,10 +800,12 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
         required_delivery_mode="alert_event_copy",
         producer="lite-monitor",
         ack_mode="per_event_v1",
+        ack_token="receiver-secret",
     )
 
     assert result["result"] is True
     assert result["data"]["event_results"][0]["delivery_id"] == "delivery-1"
+    assert sent["content"]["ack_token"] == "receiver-secret"
 
     forbidden = nats_api.dispatch_notification(
         delivery_key="delivery-2",
@@ -816,6 +821,48 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
     )
     assert forbidden["code"] == "channel_forbidden"
     assert forbidden["retryable"] is False
+
+
+def test_monitor_alert_copy_dispatch_preserves_terminal_per_event_rejection(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心",
+        channel_type=ChannelChoices.NATS,
+        config={"method_name": "receive_alert_events"},
+        description="alert copy",
+        team=[1],
+    )
+    monkeypatch.setattr(
+        "apps.system_mgmt.nats.channels.send_msg_with_channel",
+        lambda *args, **kwargs: {
+            "result": False,
+            "message": "Alert events were only partially accepted.",
+            "data": {
+                "event_results": [
+                    {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": False}
+                ]
+            },
+        },
+    )
+
+    result = nats_api.dispatch_notification(
+        delivery_key="delivery-rejected",
+        channel_id=channel.id,
+        organization_ids=[1],
+        recipients=[],
+        title="",
+        body="alert",
+        event_payload={"delivery_id": "delivery-rejected", "organizations": [1]},
+        required_delivery_mode="alert_event_copy",
+        producer="lite-monitor",
+        ack_mode="per_event_v1",
+        ack_token="receiver-secret",
+    )
+
+    assert result["result"] is False
+    assert result["retryable"] is False
+    assert result["data"]["event_results"] == [
+        {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": False}
+    ]
 
 
 def test_get_wechat_settings():


### PR DESCRIPTION
## 问题

监控扫描在事务提交后发送首次与升级告警，但发送前没有持久化“待通知”状态；若告警中心短暂失败，记录仍显示已同步。同时，五分钟补偿任务只选择已恢复和已关闭告警，仍处于 `new` 的首次告警不会再次投递。

## 根因

即时通知与补偿任务没有共享同一条持久化意图：created/upgraded 只注册提交后回调，补偿查询却依赖 `alert_center_notified=False`，并且状态集合排除了 `new`。PR #3350 解决了通知早于事务提交的问题，但没有闭合失败后的补偿路径。

## 怎么修的

- 在扫描事务内、注册 `on_commit` 前，将本批 created/upgraded 告警原子标记为待通知。
- 补偿任务纳入 `status=new`；重投时继续使用既有 `action=created`，不改变告警中心协议。
- 批量预载 new 告警的策略上下文，在一次 created 批量推送中按告警恢复策略名与组织回退；不按策略拆分外部调用。
- 保持 `notice=False`、recovered/closed、成功回写、重试上限和无目标渠道行为不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["EventAlertManager._schedule_notifications\nmonitor/event_alert_manager.py"]
    end
    BU["事务内写 alert_center_notified=False"]
    subgraph N["核心处理层"]
        F1["transaction.on_commit\n提交后通知"]
        F2["AlertLifecycleNotifier.notify_alerts\n推送告警中心"]
    end
    subgraph C["补偿层"]
        C1["retry_alert_center_lifecycle_notify_task\n每5分钟批量重投"]
    end
    T1 --> BU --> F1 --> F2
    F2 -. "失败时保留待通知" .-> C1
    C1 --> F2
```

## 影响范围

改动仅在 `monitor` 内，未修改数据库结构、HTTP/RPC/NATS 字段或 alerts 消费端。`new` 补偿仍发送告警中心已支持的 `created` action；终态告警继续使用 `recovered` / `closed`。补偿保持按状态批量推送，最多仍为三个生命周期批次。

## 验证

- `apps/monitor/tests/test_issue_3341_alert_center_retry_service.py`
- `apps/monitor/tests/test_alert_lifecycle_notify_extra.py`
- `apps/monitor/tests/test_alert_lifecycle_notify_service.py`
- 以上关联测试共 57 passed。
- RED 依次命中待通知状态缺失、补偿排除 new、策略上下文丢失和按策略拆批放大；生产改动回退后专项测试失败。

## 三轨门禁

- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS
- 质量评分：98/100

关联 Issue #3341。
