### PR TITLE
bugfix: 收敛身份敏感 NATS 查询入口

### DIFF
--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -68,7 +68,6 @@ def search_channel_list(channel_type="", teams=None, include_children=False):
     }
 
 
-@nats_client.register
 def search_channel_list_scoped(actor_context, channel_type="", teams=None, include_children=False):
     """
     在调用方授权范围内查询通知通道列表。

--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -114,7 +114,6 @@ def get_group_users_scoped(actor_context, group=None, include_children=False):
     return {"result": True, "data": list(users)}
 
 
-@nats_client.register
 def get_authorized_groups_scoped(actor_context, include_children=False):
     """返回调用方在当前组织上下文下可访问的组织范围。"""
     user_obj, authorized_groups = _get_actor_user_scope(actor_context, include_children=include_children)

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers.py
@@ -71,8 +71,10 @@ def test_nats_api_compat_exports_local_and_nats_entrypoints():
         "bk_lite_user_login",
         "get_group_users",
         "get_group_users_scoped",
+        "get_authorized_groups_scoped",
         "get_all_users",
         "search_users",
+        "search_channel_list_scoped",
     }
     registered_entrypoints = expected_entrypoints - local_only_entrypoints
 

--- a/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
+++ b/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
@@ -10,14 +10,20 @@ LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS = {
     "search_users",
 }
 
+LOCAL_ONLY_IDENTITY_SCOPED_ENTRYPOINTS = {
+    "get_authorized_groups_scoped",
+    "search_channel_list_scoped",
+}
 
-def test_user_directory_entrypoints_are_local_only():
+
+def test_identity_sensitive_entrypoints_are_local_only():
+    local_only_entrypoints = LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS | LOCAL_ONLY_IDENTITY_SCOPED_ENTRYPOINTS
     exported_entrypoints = {
-        name for name in LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS if callable(getattr(nats_api, name, None))
+        name for name in local_only_entrypoints if callable(getattr(nats_api, name, None))
     }
     registered_entrypoints = {
         item["name"] for item in nats_client.registry.default_registry.registry.values()
     }
 
-    assert exported_entrypoints == LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS
-    assert LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS.isdisjoint(registered_entrypoints)
+    assert exported_entrypoints == local_only_entrypoints
+    assert local_only_entrypoints.isdisjoint(registered_entrypoints)


### PR DESCRIPTION
## 当前状态

2026-08-05 重评结论：本 PR 保持草稿并阻塞合入。

- 状态：OPEN / draft
- Head：`75d014c7f16329023faf43661953c08e1a108da0`
- 与最新 `master`：CONFLICTING
- Checks：import-check 成功、开源扫描成功、CLA pending
- Review decision：暂无

历史的 33 项测试只覆盖旧基线上的两个直接注册点，不能证明最新 `master` 的身份可信边界已经闭环。

## 问题

当前实现已经不再信任调用方自报的 `is_superuser` 和 `group_list`，但 NATS 分发层仍无法证明消息中的 `username/domain` 属于发布者。调用方只要冒充一个真实高权限用户，服务端就会按该持久化用户计算组织范围。

## 本 PR 已完成的部分

- 保留 `SystemMgmt` / `AppClient` 本地函数与返回结构。
- 在旧基线上取消 `get_authorized_groups_scoped`、`search_channel_list_scoped` 两个直接 NATS 注册。
- 增加旧注册表边界断言。

这能收敛两个直达 subject，但不能封闭最新代码中的同类入口和间接调用链。

## 未闭环的边界

- `list_notification_channels_scoped`、`search_notification_recipients_scoped` 和 `get_assignable_groups` 仍是直接 NATS handler，并继续按消息中的 `username/domain` 定位持久化用户。
- log、monitor、node 的已注册 handler 仍可把消息中的身份字段传给本地 `SystemMgmt` 权限查询。
- NATS listener 只把消息体中的 `args/kwargs` 交给注册函数，没有可用于绑定发布者与业务用户的可信身份。
- 直接撤销公开 subject 或强制新证明都会改变现有失败语义，并可能拒绝尚未迁移的合法调用方；当前补丁没有双轨迁移、观测窗口或 ACL/凭据回滚方案。

## 调用链

```mermaid
flowchart TD
    P["NATS 发布者\n自报 username/domain"]
    D["直接 scoped handlers\nsystem_mgmt/nats"]
    I["间接 handlers\nlog / monitor / node"]
    A["本地 SystemMgmt\nrpc/system_mgmt.py"]
    S["_get_actor_user_scope\nusers.py"]
    U["按持久化用户权限\n返回组织/通道/接收人"]

    P --> D --> S --> U
    P --> I --> A --> S
```

## 三轨重评

- Standards：FAIL。PR 与最新 `master` 冲突，旧测试文件已迁移；原补丁无法直接适配现行签名和测试契约。
- Spec：FAIL。只注销两个旧入口，没有解决 `username/domain` 身份绑定，也遗漏新增直接入口与跨模块间接入口。
- Runtime Contract：FAIL。缺少真实身份冒充、间接 handler、稳定失败语义、合法旧调用和回滚的运行边界证据；最新 master 仍有明确可达的冒充路径。

质量评分：42 / 100（SCORE_LOW）。

## 建议后续

按技术债分阶段实施：定义短时效、绑定 audience/username/domain/current_team 的可验证 actor assertion；提供 v2 subject 并迁移合法调用方；按服务拆分 NATS ACL/凭据；观测旧入口清零后再退役，同时保留可回滚的混合版本窗口。
