### PR TITLE
feat(monitor): 为 SNMP 网络设备增加接口维度黑白名单过滤

### DIFF
--- a/server/apps/monitor/constants/snmp_interface.py
+++ b/server/apps/monitor/constants/snmp_interface.py
@@ -1,0 +1,31 @@
+"""SNMP 接口维度过滤常量（与 UI default_value / 创建渲染默认注入同源）。"""
+
+# 默认排除的 IANA ifType（页面「排除的接口类型」预填值；创建时由 plugin_controller 注入）
+DEFAULT_IFTYPE_EXCLUDE = ["24", "53", "131", "135", "136"]
+
+# 采集配置表单可选的常见 ifType（提交值为编号字符串）
+IFTYPE_OPTIONS = [
+    {"value": "6", "label": "6 - ethernetCsmacd", "label_en": "6 - ethernetCsmacd"},
+    {"value": "24", "label": "24 - Loopback", "label_en": "24 - Loopback"},
+    {"value": "53", "label": "53 - Virtual", "label_en": "53 - Virtual"},
+    {"value": "117", "label": "117 - gigabitEthernet", "label_en": "117 - gigabitEthernet"},
+    {"value": "131", "label": "131 - Tunnel", "label_en": "131 - Tunnel"},
+    {"value": "135", "label": "135 - L2 VLAN", "label_en": "135 - L2 VLAN"},
+    {"value": "136", "label": "136 - L3 VLAN", "label_en": "136 - L3 VLAN"},
+    {"value": "161", "label": "161 - ieee8023adLag", "label_en": "161 - ieee8023adLag"},
+]
+
+IFTYPE_OID = "1.3.6.1.2.1.2.2.1.3"
+
+# 模板 / 表单字段名
+FIELD_IFTYPE_INCLUDE = "iftype_include"
+FIELD_IFTYPE_EXCLUDE = "iftype_exclude"
+FIELD_IFDESCR_INCLUDE = "ifdescr_include"
+FIELD_IFDESCR_EXCLUDE = "ifdescr_exclude"
+
+FILTER_TEMPLATE_VARS = (
+    FIELD_IFTYPE_INCLUDE,
+    FIELD_IFTYPE_EXCLUDE,
+    FIELD_IFDESCR_INCLUDE,
+    FIELD_IFDESCR_EXCLUDE,
+)

--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -30,6 +30,13 @@ def _table_has_iftype(table: dict) -> bool:
     return False
 
 
+def _config_has_ifdescr(config: dict) -> bool:
+    tables = config.get("table")
+    return isinstance(tables, list) and any(
+        isinstance(table, dict) and _table_has_ifdescr(table) for table in tables
+    )
+
+
 def _ensure_iftype_fields(config: dict) -> bool:
     changed = False
     tables = config.get("table")
@@ -54,8 +61,12 @@ def _ensure_iftype_fields(config: dict) -> bool:
 
 def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
     changed = False
-    if config.get("tagexclude") != ["ifType"]:
+    tagexclude = config.get("tagexclude")
+    if tagexclude is None:
         config["tagexclude"] = ["ifType"]
+        changed = True
+    elif "ifType" not in tagexclude:
+        tagexclude.append("ifType")
         changed = True
     tagdrop = config.get("tagdrop")
     if not isinstance(tagdrop, dict):
@@ -70,43 +81,15 @@ def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
     return changed
 
 
-def _remove_filters(config: dict) -> bool:
-    changed = False
-    if "tagexclude" in config:
-        config.pop("tagexclude", None)
-        changed = True
-    for table_name in ("tagpass", "tagdrop"):
-        if table_name in config:
-            config.pop(table_name, None)
-            changed = True
-    tables = config.get("table")
-    if isinstance(tables, list):
-        for table in tables:
-            if not isinstance(table, dict):
-                continue
-            fields = table.get("field")
-            if not isinstance(fields, list):
-                continue
-            new_fields = [
-                field
-                for field in fields
-                if not (
-                    isinstance(field, dict)
-                    and (field.get("name") == "ifType" or field.get("oid") == IFTYPE_OID)
-                )
-            ]
-            if len(new_fields) != len(fields):
-                table["field"] = new_fields
-                changed = True
-    return changed
-
-
-def patch_child_content_dict(content: dict, revert: bool = False, overwrite_default: bool = False) -> bool:
+def patch_child_content_dict(content: dict, overwrite_default: bool = False) -> bool:
     if not isinstance(content, dict) or not isinstance(content.get("config"), dict):
         return False
     config = content["config"]
-    if revert:
-        return _remove_filters(config)
+    if not _config_has_ifdescr(config):
+        return False
+    tagexclude = config.get("tagexclude")
+    if tagexclude is not None and not isinstance(tagexclude, list):
+        return False
     changed = _ensure_iftype_fields(config)
     changed = _ensure_default_tagdrop(config, overwrite=overwrite_default) or changed
     return changed
@@ -115,9 +98,9 @@ def patch_child_content_dict(content: dict, revert: bool = False, overwrite_defa
 class Command(BaseCommand):
     help = (
         "Idempotently backfill ifType fields and default tagdrop.ifType for existing SNMP child configs; "
-        "supports --dry-run / --revert. Not hooked into startup init. "
+        "supports --dry-run and compensating rollback on update failure. Not hooked into startup init. "
         "为存量 SNMP 子配置幂等补齐 ifType 字段与默认 tagdrop.ifType；"
-        "支持 --dry-run / --revert。不挂入启动期初始化。"
+        "支持 --dry-run，更新失败时自动补偿回滚。不挂入启动期初始化。"
     )
 
     def add_arguments(self, parser):
@@ -125,11 +108,6 @@ class Command(BaseCommand):
             "--dry-run",
             action="store_true",
             help="Print config_ids that would change only / 只打印将变更的 config_id",
-        )
-        parser.add_argument(
-            "--revert",
-            action="store_true",
-            help="Remove injected ifType fields and filter blocks / 移除注入的 ifType 与过滤段",
         )
         parser.add_argument(
             "--overwrite-default",
@@ -142,7 +120,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
-        revert = options["revert"]
         overwrite_default = options["overwrite_default"]
 
         config_ids = list(
@@ -159,7 +136,7 @@ class Command(BaseCommand):
             logger.error("Failed to fetch SNMP child configs / 获取 SNMP 子配置失败: %s", exc)
             raise
 
-        updated = 0
+        pending_updates: list[tuple[str, str, str]] = []
         for child in child_configs:
             config_id = child.get("id")
             raw_content = child.get("content")
@@ -177,34 +154,51 @@ class Command(BaseCommand):
 
             changed = patch_child_content_dict(
                 content,
-                revert=revert,
                 overwrite_default=overwrite_default,
             )
             if not changed:
                 continue
 
-            summary = "revert" if revert else "patch"
-            self.stdout.write(f"{summary}: {config_id}")
-            if dry_run:
-                updated += 1
-                continue
-            try:
-                node_mgmt.update_child_config_content(
-                    config_id,
-                    ConfigFormat.json_to_toml(content),
-                )
-                updated += 1
-            except Exception as exc:
-                logger.error(
-                    "Failed to update child config / 更新子配置失败 config_id=%s: %s",
-                    config_id,
-                    exc,
-                )
+            pending_updates.append((config_id, raw_content, ConfigFormat.json_to_toml(content)))
+            self.stdout.write(f"patch: {config_id}")
 
-        mode = "dry-run" if dry_run else "applied"
+        if dry_run:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Done (dry-run), changed {len(pending_updates)}/{len(child_configs)} / "
+                    f"完成 (dry-run)，变更 {len(pending_updates)}/{len(child_configs)}"
+                )
+            )
+            return
+
+        attempted: list[tuple[str, str]] = []
+        try:
+            for config_id, original_content, updated_content in pending_updates:
+                attempted.append((config_id, original_content))
+                node_mgmt.update_child_config_content(config_id, updated_content)
+        except Exception as exc:
+            logger.error(
+                "Failed to update child config; rolling back attempted configs / "
+                "更新 SNMP 子配置失败，开始回滚已尝试配置 config_id=%s: %s",
+                config_id,
+                exc,
+            )
+            rollback_errors: list[str] = []
+            for attempted_id, original_content in reversed(attempted):
+                try:
+                    node_mgmt.update_child_config_content(attempted_id, original_content)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"{attempted_id}: {rollback_exc}")
+            if rollback_errors:
+                logger.error(
+                    "Failed to roll back SNMP child configs / 回滚 SNMP 子配置失败: %s",
+                    "; ".join(rollback_errors),
+                )
+            raise
+
         self.stdout.write(
             self.style.SUCCESS(
-                f"Done ({mode}), changed {updated}/{len(child_configs)} / "
-                f"完成 ({mode})，变更 {updated}/{len(child_configs)}"
+                f"Done (applied), changed {len(pending_updates)}/{len(child_configs)} / "
+                f"完成 (applied)，变更 {len(pending_updates)}/{len(child_configs)}"
             )
         )

--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -1,0 +1,210 @@
+from django.core.management.base import BaseCommand
+
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE, IFTYPE_OID
+from apps.monitor.models import CollectConfig
+from apps.monitor.utils.config_format import ConfigFormat
+from apps.rpc.node_mgmt import NodeMgmt
+
+
+IFTYPE_FIELD = {
+    "oid": IFTYPE_OID,
+    "name": "ifType",
+    "is_tag": True,
+}
+
+
+def _table_has_ifdescr(table: dict) -> bool:
+    for field in table.get("field") or []:
+        if isinstance(field, dict) and field.get("name") == "ifDescr":
+            return True
+    return False
+
+
+def _table_has_iftype(table: dict) -> bool:
+    for field in table.get("field") or []:
+        if isinstance(field, dict) and (
+            field.get("name") == "ifType" or field.get("oid") == IFTYPE_OID
+        ):
+            return True
+    return False
+
+
+def _ensure_iftype_fields(config: dict) -> bool:
+    changed = False
+    tables = config.get("table")
+    if not isinstance(tables, list):
+        return False
+    for table in tables:
+        if not isinstance(table, dict) or not _table_has_ifdescr(table):
+            continue
+        if _table_has_iftype(table):
+            continue
+        fields = table.setdefault("field", [])
+        # insert after ifDescr
+        insert_at = 0
+        for idx, field in enumerate(fields):
+            if isinstance(field, dict) and field.get("name") == "ifDescr":
+                insert_at = idx + 1
+                break
+        fields.insert(insert_at, dict(IFTYPE_FIELD))
+        changed = True
+    return changed
+
+
+def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
+    changed = False
+    if config.get("tagexclude") != ["ifType"]:
+        config["tagexclude"] = ["ifType"]
+        changed = True
+    tagdrop = config.get("tagdrop")
+    if not isinstance(tagdrop, dict):
+        tagdrop = {}
+        config["tagdrop"] = tagdrop
+        changed = True
+    existing = tagdrop.get("ifType")
+    if overwrite or existing in (None, [], ""):
+        if existing != DEFAULT_IFTYPE_EXCLUDE:
+            tagdrop["ifType"] = list(DEFAULT_IFTYPE_EXCLUDE)
+            changed = True
+    return changed
+
+
+def _remove_filters(config: dict) -> bool:
+    changed = False
+    if "tagexclude" in config:
+        config.pop("tagexclude", None)
+        changed = True
+    for table_name in ("tagpass", "tagdrop"):
+        if table_name in config:
+            config.pop(table_name, None)
+            changed = True
+    tables = config.get("table")
+    if isinstance(tables, list):
+        for table in tables:
+            if not isinstance(table, dict):
+                continue
+            fields = table.get("field")
+            if not isinstance(fields, list):
+                continue
+            new_fields = [
+                field
+                for field in fields
+                if not (
+                    isinstance(field, dict)
+                    and (field.get("name") == "ifType" or field.get("oid") == IFTYPE_OID)
+                )
+            ]
+            if len(new_fields) != len(fields):
+                table["field"] = new_fields
+                changed = True
+    return changed
+
+
+def patch_child_content_dict(content: dict, revert: bool = False, overwrite_default: bool = False) -> bool:
+    if not isinstance(content, dict) or not isinstance(content.get("config"), dict):
+        return False
+    config = content["config"]
+    if revert:
+        return _remove_filters(config)
+    changed = _ensure_iftype_fields(config)
+    changed = _ensure_default_tagdrop(config, overwrite=overwrite_default) or changed
+    return changed
+
+
+class Command(BaseCommand):
+    help = (
+        "Idempotently backfill ifType fields and default tagdrop.ifType for existing SNMP child configs; "
+        "supports --dry-run / --revert. Not hooked into startup init. "
+        "为存量 SNMP 子配置幂等补齐 ifType 字段与默认 tagdrop.ifType；"
+        "支持 --dry-run / --revert。不挂入启动期初始化。"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Print config_ids that would change only / 只打印将变更的 config_id",
+        )
+        parser.add_argument(
+            "--revert",
+            action="store_true",
+            help="Remove injected ifType fields and filter blocks / 移除注入的 ifType 与过滤段",
+        )
+        parser.add_argument(
+            "--overwrite-default",
+            action="store_true",
+            help=(
+                "Reset tagdrop.ifType to the default exclude set even if already set "
+                "(use with care) / 即使已有 tagdrop.ifType 也重置为默认排除集（慎用）"
+            ),
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        revert = options["revert"]
+        overwrite_default = options["overwrite_default"]
+
+        config_ids = list(
+            CollectConfig.objects.filter(collect_type="snmp", is_child=True).values_list("id", flat=True)
+        )
+        if not config_ids:
+            self.stdout.write("No SNMP child configs found / 未发现 SNMP 子配置")
+            return
+
+        node_mgmt = NodeMgmt()
+        try:
+            child_configs = node_mgmt.get_child_configs_by_ids(config_ids) or []
+        except Exception as exc:
+            logger.error("Failed to fetch SNMP child configs / 获取 SNMP 子配置失败: %s", exc)
+            raise
+
+        updated = 0
+        for child in child_configs:
+            config_id = child.get("id")
+            raw_content = child.get("content")
+            if not config_id or not raw_content:
+                continue
+            try:
+                content = ConfigFormat.toml_to_dict(raw_content)
+            except Exception as exc:
+                logger.error(
+                    "Failed to parse child config / 解析子配置失败 config_id=%s: %s",
+                    config_id,
+                    exc,
+                )
+                continue
+
+            changed = patch_child_content_dict(
+                content,
+                revert=revert,
+                overwrite_default=overwrite_default,
+            )
+            if not changed:
+                continue
+
+            summary = "revert" if revert else "patch"
+            self.stdout.write(f"{summary}: {config_id}")
+            if dry_run:
+                updated += 1
+                continue
+            try:
+                node_mgmt.update_child_config_content(
+                    config_id,
+                    ConfigFormat.json_to_toml(content),
+                )
+                updated += 1
+            except Exception as exc:
+                logger.error(
+                    "Failed to update child config / 更新子配置失败 config_id=%s: %s",
+                    config_id,
+                    exc,
+                )
+
+        mode = "dry-run" if dry_run else "applied"
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done ({mode}), changed {updated}/{len(child_configs)} / "
+                f"完成 ({mode})，变更 {updated}/{len(child_configs)}"
+            )
+        )

--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -68,6 +68,9 @@ def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
     elif "ifType" not in tagexclude:
         tagexclude.append("ifType")
         changed = True
+    tagpass = config.get("tagpass")
+    if isinstance(tagpass, dict) and tagpass.get("ifType") not in (None, [], ""):
+        return changed
     tagdrop = config.get("tagdrop")
     if not isinstance(tagdrop, dict):
         tagdrop = {}

--- a/server/apps/monitor/management/scripts/patch_snmp_interface_filters_assets.py
+++ b/server/apps/monitor/management/scripts/patch_snmp_interface_filters_assets.py
@@ -1,0 +1,111 @@
+"""精简 SNMP 资产：剥离各插件复制的过滤 UI / Jinja / ifType OID。
+
+上述契约由运行时单一真相源注入：
+  apps.monitor.utils.snmp_interface_template
+
+正常情况下 support-files/Telegraf/snmp 保持与上游一致，无需批量改插件文件。
+本脚本仅用于清理误写入磁盘的重复块。
+
+用法（仓库根目录）:
+  python3 server/apps/monitor/management/scripts/patch_snmp_interface_filters_assets.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[5]
+SNMP_DIR = ROOT / "server/apps/monitor/support-files/plugins/Telegraf/snmp"
+
+FILTER_MARKER_BEGIN = "# ---- BK-Lite SNMP interface dimension filters (begin) ----"
+FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
+
+FILTER_FIELD_NAMES = {
+    "iftype_exclude",
+    "iftype_include",
+    "ifdescr_exclude",
+    "ifdescr_include",
+}
+
+INTERFACE_HINT_RE = re.compile(
+    r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.2\.2"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.31\.1\.1"',
+    re.MULTILINE,
+)
+FILTER_BLOCK_RE = re.compile(
+    re.escape(FILTER_MARKER_BEGIN) + r".*?" + re.escape(FILTER_MARKER_END) + r"\n?",
+    re.DOTALL,
+)
+TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
+CANONICAL_IFTYPE_FIELD_RE = re.compile(
+    r"\n?[ \t]*\[\[inputs\.snmp\.table\.field\]\]\s*\n"
+    r"[ \t]*oid\s*=\s*\"1\.3\.6\.1\.2\.1\.2\.2\.1\.3\"\s*\n"
+    r"[ \t]*name\s*=\s*\"ifType\"\s*\n"
+    r"[ \t]*is_tag\s*=\s*true\s*\n?",
+    re.MULTILINE,
+)
+
+
+def _has_interface_collection(text: str) -> bool:
+    return bool(INTERFACE_HINT_RE.search(text))
+
+
+def _strip_runtime_injected_bits(text: str) -> str:
+    text = FILTER_BLOCK_RE.sub("", text)
+    text = TAGEXCLUDE_IFTYPE_RE.sub("", text)
+    text = CANONICAL_IFTYPE_FIELD_RE.sub("\n", text)
+    return re.sub(r"\n{3,}", "\n\n", text)
+
+
+def patch_template(path: Path) -> dict:
+    original = path.read_text(encoding="utf-8")
+    if not _has_interface_collection(original):
+        return {"path": str(path), "skipped": "no-interface"}
+    text = _strip_runtime_injected_bits(original)
+    if text != original:
+        path.write_text(text, encoding="utf-8")
+    return {
+        "path": str(path.relative_to(ROOT)),
+        "changed": text != original,
+    }
+
+
+def patch_ui(path: Path) -> dict:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    tmpl_candidates = list(path.parent.glob("*.child.toml.j2"))
+    if not tmpl_candidates:
+        return {"path": str(path), "skipped": "no-template"}
+    tmpl_text = tmpl_candidates[0].read_text(encoding="utf-8")
+    if not _has_interface_collection(tmpl_text):
+        return {"path": str(path), "skipped": "no-interface"}
+
+    form_fields = data.get("form_fields") or []
+    kept = [f for f in form_fields if not (isinstance(f, dict) and f.get("name") in FILTER_FIELD_NAMES)]
+    changed = len(kept) != len(form_fields)
+    if data.pop("advanced_panel", None) is not None:
+        changed = True
+    if changed:
+        data["form_fields"] = kept
+        path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {"path": str(path.relative_to(ROOT)), "changed": changed}
+
+
+def main() -> int:
+    if not SNMP_DIR.is_dir():
+        print(f"SNMP dir not found: {SNMP_DIR}", file=sys.stderr)
+        return 1
+
+    tmpl_results = [patch_template(path) for path in sorted(SNMP_DIR.glob("*/*.child.toml.j2"))]
+    ui_results = [patch_ui(path) for path in sorted(SNMP_DIR.glob("*/UI.json"))]
+
+    tmpl_changed = sum(1 for r in tmpl_results if r.get("changed"))
+    ui_changed = sum(1 for r in ui_results if r.get("changed"))
+    print(f"templates changed={tmpl_changed}/{len(tmpl_results)}")
+    print(f"ui changed={ui_changed}/{len(ui_results)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/apps/monitor/management/scripts/patch_snmp_interface_filters_assets.py
+++ b/server/apps/monitor/management/scripts/patch_snmp_interface_filters_assets.py
@@ -19,17 +19,18 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[5]
 SNMP_DIR = ROOT / "server/apps/monitor/support-files/plugins/Telegraf/snmp"
+SERVER_DIR = ROOT / "server"
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
 
-FILTER_MARKER_BEGIN = "# ---- BK-Lite SNMP interface dimension filters (begin) ----"
-FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
+from apps.monitor.constants.snmp_interface import FILTER_TEMPLATE_VARS, IFTYPE_OID  # noqa: E402
+from apps.monitor.utils.snmp_interface_template import (  # noqa: E402
+    FILTER_MARKER_BEGIN,
+    FILTER_MARKER_END,
+    UI_ADVANCED_PANEL,
+)
 
-FILTER_FIELD_NAMES = {
-    "iftype_exclude",
-    "iftype_include",
-    "ifdescr_exclude",
-    "ifdescr_include",
-}
-
+FILTER_FIELD_NAMES = set(FILTER_TEMPLATE_VARS)
 INTERFACE_HINT_RE = re.compile(
     r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.2\.2"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.31\.1\.1"',
     re.MULTILINE,
@@ -40,10 +41,10 @@ FILTER_BLOCK_RE = re.compile(
 )
 TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
 CANONICAL_IFTYPE_FIELD_RE = re.compile(
-    r"\n?[ \t]*\[\[inputs\.snmp\.table\.field\]\]\s*\n"
-    r"[ \t]*oid\s*=\s*\"1\.3\.6\.1\.2\.1\.2\.2\.1\.3\"\s*\n"
-    r"[ \t]*name\s*=\s*\"ifType\"\s*\n"
-    r"[ \t]*is_tag\s*=\s*true\s*\n?",
+    r"(?:\r?\n)?[ \t]*\[\[inputs\.snmp\.table\.field\]\]\r?\n"
+    rf"[ \t]*oid\s*=\s*\"{re.escape(IFTYPE_OID)}\"\r?\n"
+    r"[ \t]*name\s*=\s*\"ifType\"\r?\n"
+    r"[ \t]*is_tag\s*=\s*true",
     re.MULTILINE,
 )
 
@@ -84,7 +85,8 @@ def patch_ui(path: Path) -> dict:
     form_fields = data.get("form_fields") or []
     kept = [f for f in form_fields if not (isinstance(f, dict) and f.get("name") in FILTER_FIELD_NAMES)]
     changed = len(kept) != len(form_fields)
-    if data.pop("advanced_panel", None) is not None:
+    if data.get("advanced_panel") == UI_ADVANCED_PANEL:
+        data.pop("advanced_panel")
         changed = True
     if changed:
         data["form_fields"] = kept

--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -343,6 +343,14 @@ def _process_ui_templates(plugin_dir, plugin_obj, db_ui_template):
     if ui_file.exists() and ui_file.is_file():
         try:
             ui_data = json.loads(ui_file.read_text(encoding="utf-8"))
+            # SNMP：入库前合并接口过滤字段，避免仅依赖读时 enrich
+            if (
+                getattr(plugin_obj, "collect_type", None) == "snmp"
+                or plugin_dir.parent.name == "snmp"
+            ):
+                from apps.monitor.utils.snmp_interface_template import merge_snmp_interface_filter_ui
+
+                ui_data = merge_snmp_interface_filter_ui(ui_data) or ui_data
 
             if db_ui_template:
                 if db_ui_template.content != ui_data:

--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -967,5 +967,9 @@ class InstanceConfigService:
                     validate_rendered_website_config(child_info.get("content") or {}, env_config)
                 except ValueError as exc:
                     raise BaseAppException(str(exc)) from exc
+            if config_obj.collect_type == "snmp":
+                from apps.monitor.utils.snmp_interface_filters import normalize_snmp_interface_filter_config
+
+                child_info["content"] = normalize_snmp_interface_filter_config(child_info.get("content"))
             content = ConfigFormat.json_to_toml(child_info["content"]) if child_info else None
             NodeMgmt().update_child_config_content(child_info["id"], content, env_config)

--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -967,7 +967,7 @@ class InstanceConfigService:
                     validate_rendered_website_config(child_info.get("content") or {}, env_config)
                 except ValueError as exc:
                     raise BaseAppException(str(exc)) from exc
-            if config_obj.collect_type == "snmp":
+            if (config_obj.collect_type or "").startswith("snmp"):
                 from apps.monitor.utils.snmp_interface_filters import normalize_snmp_interface_filter_config
 
                 child_info["content"] = normalize_snmp_interface_filter_config(child_info.get("content"))

--- a/server/apps/monitor/services/ui_template_locale.py
+++ b/server/apps/monitor/services/ui_template_locale.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
 
 
 # 磁盘 UI.json 相对 DB 模板可热更新的展示字段（无需等 plugin_init）。
-_FILE_OVERLAY_FIELD_KEYS = ("guide_short", "section")
+_FILE_OVERLAY_FIELD_KEYS = ("guide_short", "section", "rules")
+_FILE_OVERLAY_TOP_KEYS = ("advanced_panel",)
 
 
 _EN_LOCALES = {"en", "en-us", "en-gb"}
@@ -232,51 +233,65 @@ def _localize_node(node: Any, locale: str) -> Any:
 def enrich_ui_template_from_plugin_files(content: dict | None, plugin: MonitorPlugin | None) -> dict | None:
     """用插件目录 UI.json 覆盖 DB 模板中的悬浮提示等展示字段。
 
-    内置插件以 support-files 下的 UI.json 为展示文案真相源；仅同步 guide_short /
+    内置插件以 support-files 下的 UI.json 为展示文案真相源；一般仅同步 guide_short /
     section 等不影响已下发配置语义的字段，避免每次改提示都强制跑 plugin_init。
+
+    SNMP 接口过滤四字段与 advanced_panel 由常量运行时注入（见 snmp_interface_template），
+    各插件 UI.json 不再复制该块。
     """
-    if not content or not plugin:
+    if content is None or not plugin:
+        return content
+    if not isinstance(content, dict):
         return content
 
     from apps.monitor.services.plugin_guide import PluginGuideService
-
-    plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
-    if plugin_dir is None:
-        return content
-
-    ui_file = Path(plugin_dir) / "UI.json"
-    if not ui_file.is_file():
-        return content
-
-    try:
-        file_ui = json.loads(ui_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, TypeError):
-        return content
-
-    file_fields = {
-        str(field.get("name")): field
-        for field in (file_ui.get("form_fields") or [])
-        if isinstance(field, dict) and field.get("name")
-    }
-    if not file_fields:
-        return content
+    from apps.monitor.utils.snmp_interface_template import (
+        merge_snmp_interface_filter_ui,
+        should_inject_snmp_interface_filters,
+    )
 
     enriched = deepcopy(content)
-    form_fields = enriched.get("form_fields")
-    if not isinstance(form_fields, list):
-        return enriched
 
-    for field in form_fields:
-        if not isinstance(field, dict):
-            continue
-        source = file_fields.get(str(field.get("name") or ""))
-        if not source:
-            continue
-        for key in _FILE_OVERLAY_FIELD_KEYS:
-            value = source.get(key)
-            if value in (None, ""):
-                continue
-            field[key] = value
+    plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
+    if plugin_dir is not None:
+        ui_file = Path(plugin_dir) / "UI.json"
+        if ui_file.is_file():
+            try:
+                file_ui = json.loads(ui_file.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError, TypeError):
+                file_ui = None
+
+            if isinstance(file_ui, dict):
+                file_fields = {
+                    str(field.get("name")): field
+                    for field in (file_ui.get("form_fields") or [])
+                    if isinstance(field, dict) and field.get("name")
+                }
+                for key in _FILE_OVERLAY_TOP_KEYS:
+                    value = file_ui.get(key)
+                    if value not in (None, ""):
+                        enriched[key] = value
+
+                form_fields = enriched.get("form_fields")
+                if isinstance(form_fields, list) and file_fields:
+                    for field in form_fields:
+                        if not isinstance(field, dict):
+                            continue
+                        name = str(field.get("name") or "")
+                        source = file_fields.get(name)
+                        if not source:
+                            continue
+                        for key in _FILE_OVERLAY_FIELD_KEYS:
+                            if key not in source:
+                                continue
+                            value = source.get(key)
+                            if value in (None, ""):
+                                continue
+                            field[key] = deepcopy(value)
+
+    if should_inject_snmp_interface_filters(plugin, enriched):
+        enriched = merge_snmp_interface_filter_ui(enriched)
+
     return enriched
 
 

--- a/server/apps/monitor/utils/config_format.py
+++ b/server/apps/monitor/utils/config_format.py
@@ -1,23 +1,55 @@
 import toml
 import yaml
+from copy import deepcopy
 from urllib.parse import urlencode, urlparse, parse_qs
 
 class ConfigFormat:
     @staticmethod
     def toml_to_dict(toml_config):
         config_dict = toml.loads(toml_config)
-        result = {}
-        for key1, value1 in config_dict.items():
+        plugin = None
+
+        # Telegraf 子配置可能同时包含 inputs、processors 等多个顶层段。
+        # 编辑表单对应的是采集输入，不能把遍历到的最后一个 processor 当成配置。
+        namespaces = [
+            ("inputs", config_dict.get("inputs", {})),
+            *[(key, value) for key, value in config_dict.items() if key != "inputs"],
+        ]
+        for key1, value1 in namespaces:
+            if not isinstance(value1, dict):
+                continue
             for key2, value2 in value1.items():
-                result["plugin"] = (key1, key2)
-                result["config"] = value2[0]
-        return result
+                if isinstance(value2, list) and value2:
+                    plugin = (key1, key2)
+                    break
+            if plugin:
+                break
+
+        if not plugin:
+            return {}
+
+        key1, key2 = plugin
+        return {
+            "plugin": plugin,
+            "config": config_dict[key1][key2][0],
+            # 更新时用于保留同一 TOML 中不属于编辑表单的 processors 等配置。
+            "_toml_document": config_dict,
+        }
 
     @staticmethod
     def json_to_toml(json_config):
-        data = {json_config["plugin"][0]: {json_config["plugin"][1]: [json_config["config"]]}}
+        key1, key2 = json_config["plugin"]
+        if json_config.get("_toml_document"):
+            data = deepcopy(json_config["_toml_document"])
+            data.setdefault(key1, {}).setdefault(key2, [{}])
+            data[key1][key2][0] = json_config["config"]
+        else:
+            data = {key1: {key2: [json_config["config"]]}}
         result = toml.dumps(data)
-        result = result.replace("[inputs]", '')  # 将单引号替换为双引号
+        # toml.dumps 会为数组表补一个空的顶层父表；Telegraf 配置只需要
+        # [[inputs.snmp]] / [[processors.enum]] 这样的实际插件段。
+        for namespace in data:
+            result = result.replace(f"[{namespace}]\n", "")
         return result
 
     @staticmethod

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -2,7 +2,7 @@ import uuid
 
 from jinja2 import BaseLoader, DebugUndefined, Environment
 
-from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
 from apps.core.utils.safe_template import (
     TemplateSecurityError,
     build_sandboxed_env,
@@ -23,6 +23,7 @@ _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "lower",
     "urlencode",
     "replace",
+    "to_toml_str_array",
 )
 _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "ENV_BEARER_TOKEN",
@@ -44,6 +45,10 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "endpoint",
     "expect",
     "host",
+    "ifdescr_exclude",
+    "ifdescr_include",
+    "iftype_exclude",
+    "iftype_include",
     "insecure_skip_verify",
     "instance_id",
     "instance_type",
@@ -112,6 +117,22 @@ def to_toml_dict(d):
     return "{ " + ", ".join(f'"{_escape_toml_string(k)}" = "{_escape_toml_string(v)}"' for k, v in d.items()) + " }"
 
 
+def to_toml_str_array(value):
+    """将列表或逗号分隔字符串转为 TOML 字符串数组字面量，如 ["24", "53"]。"""
+    from apps.monitor.utils.snmp_interface_filters import normalize_filter_list
+
+    items = normalize_filter_list(value)
+    return "[" + ", ".join(f'"{_escape_toml_string(item)}"' for item in items) + "]"
+
+
+def normalize_filter_list(value):
+    """兼容旧导入路径；实现见 snmp_interface_filters.normalize_filter_list。"""
+    from apps.monitor.utils.snmp_interface_filters import (
+        normalize_filter_list as _normalize_filter_list,
+    )
+
+    return _normalize_filter_list(value)
+
 def _escape_toml_context_strings(value):
     if isinstance(value, str):
         return _escape_toml_string(value)
@@ -146,14 +167,25 @@ class Controller:
             env = build_sandboxed_env(
                 loader=BaseLoader(),
                 undefined=DebugUndefined,
-                extra_filters={"to_toml": to_toml_dict},
+                extra_filters={
+                    "to_toml": to_toml_dict,
+                    "to_toml_str_array": to_toml_str_array,
+                },
             )
             missing_filters = [
-                name for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS if name not in _DEFAULT_JINJA_ENV.filters
+                name
+                for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
+                if name not in _DEFAULT_JINJA_ENV.filters and name not in env.filters
             ]
             if missing_filters:
                 raise BaseAppException(f"Missing default Jinja filters: {', '.join(missing_filters)}")
-            env.filters.update({name: _DEFAULT_JINJA_ENV.filters[name] for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS})
+            env.filters.update(
+                {
+                    name: _DEFAULT_JINJA_ENV.filters[name]
+                    for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
+                    if name in _DEFAULT_JINJA_ENV.filters
+                }
+            )
             self._jinja_env = env
         return self._jinja_env
 
@@ -220,6 +252,15 @@ class Controller:
                 except Exception as e:
                     logger.error(f"解析 instance_id 失败: {instance_id}, 错误: {e}")
                     raise ValueError(f"无效的 instance_id 格式: {instance_id}") from e
+
+        from apps.monitor.utils.snmp_interface_template import (
+            ensure_snmp_interface_filter_jinja,
+            needs_snmp_interface_filter_jinja,
+        )
+
+        # SNMP 接口过滤 Jinja 单一真相源：渲染前幂等注入，插件 child 模板无需复制
+        if needs_snmp_interface_filter_jinja(template_content):
+            template_content = ensure_snmp_interface_filter_jinja(template_content)
 
         safe_context = sanitize_template_context(_context)
         if escape_toml_strings:
@@ -343,16 +384,30 @@ class Controller:
                 config_id = str(uuid.uuid4().hex)
 
                 try:
+                    render_context = {
+                        **config_info,
+                        "config_id": config_id.upper(),
+                        "plugin_id": plugin_template_id or plugin_id,
+                        "monitor_plugin_id": plugin_id,
+                    }
+                    if collect_type == "snmp" and "iftype_exclude" not in render_context:
+                        from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
+
+                        render_context["iftype_exclude"] = list(DEFAULT_IFTYPE_EXCLUDE)
+                    if collect_type == "snmp" and is_child:
+                        from apps.monitor.utils.snmp_interface_filters import (
+                            assert_snmp_interface_filter_mutex_from_values,
+                        )
+
+                        # 互斥校验放在模板渲染前，避免被包装成「渲染采集模板失败」
+                        assert_snmp_interface_filter_mutex_from_values(render_context)
                     template_config = self.render_template(
                         template["content"],
-                        {
-                            **config_info,
-                            "config_id": config_id.upper(),
-                            "plugin_id": plugin_template_id or plugin_id,
-                            "monitor_plugin_id": plugin_id,
-                        },
+                        render_context,
                         escape_toml_strings=template["file_type"] == "toml",
                     )
+                except ValidationAppException:
+                    raise
                 except ValueError as e:
                     raw_id = config_info.get("instance_id")
                     logical_id = config_info.get("logical_instance_value")

--- a/server/apps/monitor/utils/snmp_interface_filters.py
+++ b/server/apps/monitor/utils/snmp_interface_filters.py
@@ -1,0 +1,158 @@
+"""SNMP 采集配置中的接口维度过滤规范化。"""
+
+from __future__ import annotations
+
+import re
+
+from apps.core.exceptions.base_app_exception import ValidationAppException
+from apps.monitor.constants.snmp_interface import (
+    FIELD_IFDESCR_EXCLUDE,
+    FIELD_IFDESCR_INCLUDE,
+    FIELD_IFTYPE_EXCLUDE,
+    FIELD_IFTYPE_INCLUDE,
+)
+
+_IFTYPE_LABELED_RE = re.compile(r"^(\d+)\s+-\s+.+$")
+
+_MSG_IFTYPE_MUTEX = {
+    "zh": "排除与仅采集的接口类型不能同时配置，请先清空其中一侧",
+    "en": "Excluded and included interface types cannot be set together. Clear one side first",
+}
+_MSG_IFDESCR_MUTEX = {
+    "zh": "排除与仅采集的接口名称不能同时配置，请先清空其中一侧",
+    "en": "Excluded and included interface names cannot be set together. Clear one side first",
+}
+
+
+def _is_english_locale() -> bool:
+    try:
+        from django.utils.translation import get_language
+
+        lang = (get_language() or "").lower().replace("_", "-")
+    except Exception:
+        return False
+    return lang.startswith("en")
+
+
+def _mutex_message(messages: dict[str, str]) -> str:
+    return messages["en"] if _is_english_locale() else messages["zh"]
+
+
+def normalize_filter_list(value) -> list[str]:
+    """规范化黑白名单字段为去空白字符串列表；空输入返回 []。"""
+    if value is None or value is False:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [part.strip() for part in str(value).split(",") if part.strip()]
+
+
+def normalize_iftype_list(value) -> list[str]:
+    """ifType 仅保留数字；兼容「24 - Loopback」展示格式，丢弃非法项。"""
+    values: list[str] = []
+    seen: set[str] = set()
+    for item in normalize_filter_list(value):
+        if item.isdigit():
+            parsed = item
+        else:
+            match = _IFTYPE_LABELED_RE.match(item)
+            if not match:
+                continue
+            parsed = match.group(1)
+        if parsed not in seen:
+            seen.add(parsed)
+            values.append(parsed)
+    return values
+
+
+def _prune_table_key(config: dict, table_name: str, key: str, values: list[str]) -> None:
+    table = config.get(table_name)
+    if values:
+        if not isinstance(table, dict):
+            table = {}
+            config[table_name] = table
+        table[key] = values
+        return
+    if not isinstance(table, dict):
+        return
+    table.pop(key, None)
+    if not table:
+        config.pop(table_name, None)
+
+
+def assert_snmp_interface_filter_mutex(
+    *,
+    iftype_include: list[str] | None = None,
+    iftype_exclude: list[str] | None = None,
+    ifdescr_include: list[str] | None = None,
+    ifdescr_exclude: list[str] | None = None,
+) -> None:
+    """黑白名单互斥：同一维度两侧不能同时有值。"""
+    iftype_include_values = normalize_iftype_list(iftype_include)
+    iftype_exclude_values = normalize_iftype_list(iftype_exclude)
+    if iftype_include_values and iftype_exclude_values:
+        raise ValidationAppException(_mutex_message(_MSG_IFTYPE_MUTEX))
+
+    ifdescr_include_values = normalize_filter_list(ifdescr_include)
+    ifdescr_exclude_values = normalize_filter_list(ifdescr_exclude)
+    if ifdescr_include_values and ifdescr_exclude_values:
+        raise ValidationAppException(_mutex_message(_MSG_IFDESCR_MUTEX))
+
+
+def assert_snmp_interface_filter_mutex_from_values(values: dict | None) -> None:
+    """从创建/编辑表单字段校验黑白名单互斥；顺带规范化 ifType 为数字。"""
+    values = values or {}
+    if FIELD_IFTYPE_INCLUDE in values:
+        values[FIELD_IFTYPE_INCLUDE] = normalize_iftype_list(values.get(FIELD_IFTYPE_INCLUDE))
+    if FIELD_IFTYPE_EXCLUDE in values:
+        values[FIELD_IFTYPE_EXCLUDE] = normalize_iftype_list(values.get(FIELD_IFTYPE_EXCLUDE))
+    assert_snmp_interface_filter_mutex(
+        iftype_include=values.get(FIELD_IFTYPE_INCLUDE),
+        iftype_exclude=values.get(FIELD_IFTYPE_EXCLUDE),
+        ifdescr_include=values.get(FIELD_IFDESCR_INCLUDE),
+        ifdescr_exclude=values.get(FIELD_IFDESCR_EXCLUDE),
+    )
+
+
+def normalize_snmp_interface_filter_config(content: dict | None, form_values: dict | None = None) -> dict | None:
+    """规范化 child content 中的 tagpass/tagdrop，空规则删除键。
+
+    form_values 可选：来自编辑表单的原始字段，优先于 content 内已有值。
+    """
+    if not isinstance(content, dict):
+        return content
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return content
+
+    form_values = form_values or {}
+
+    def resolve(field_name: str, table: str, key: str, *, iftype: bool = False) -> list[str]:
+        normalizer = normalize_iftype_list if iftype else normalize_filter_list
+        if field_name in form_values:
+            return normalizer(form_values.get(field_name))
+        table_obj = config.get(table)
+        if isinstance(table_obj, dict):
+            return normalizer(table_obj.get(key))
+        return []
+
+    iftype_include = resolve(FIELD_IFTYPE_INCLUDE, "tagpass", "ifType", iftype=True)
+    iftype_exclude = resolve(FIELD_IFTYPE_EXCLUDE, "tagdrop", "ifType", iftype=True)
+    ifdescr_include = resolve(FIELD_IFDESCR_INCLUDE, "tagpass", "ifDescr")
+    ifdescr_exclude = resolve(FIELD_IFDESCR_EXCLUDE, "tagdrop", "ifDescr")
+
+    assert_snmp_interface_filter_mutex(
+        iftype_include=iftype_include,
+        iftype_exclude=iftype_exclude,
+        ifdescr_include=ifdescr_include,
+        ifdescr_exclude=ifdescr_exclude,
+    )
+
+    _prune_table_key(config, "tagpass", "ifType", iftype_include)
+    _prune_table_key(config, "tagpass", "ifDescr", ifdescr_include)
+    _prune_table_key(config, "tagdrop", "ifType", iftype_exclude)
+    _prune_table_key(config, "tagdrop", "ifDescr", ifdescr_exclude)
+
+    if "tagexclude" not in config:
+        config["tagexclude"] = ["ifType"]
+    return content

--- a/server/apps/monitor/utils/snmp_interface_template.py
+++ b/server/apps/monitor/utils/snmp_interface_template.py
@@ -1,0 +1,313 @@
+"""SNMP 接口过滤的 UI / Jinja 单一真相源（运行时注入，避免各插件复制）。"""
+
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from apps.monitor.constants.snmp_interface import (
+    DEFAULT_IFTYPE_EXCLUDE,
+    FILTER_TEMPLATE_VARS,
+    IFTYPE_OPTIONS,
+)
+
+FILTER_MARKER_BEGIN = "# ---- BK-Lite SNMP interface dimension filters (begin) ----"
+FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
+
+FILTER_JINJA_BLOCK = f"""\
+    tagexclude = ["ifType"]
+{FILTER_MARKER_BEGIN}
+{{# ifType/ifDescr 黑白名单：空规则不输出对应键；默认排除由页面/创建注入，模板不做静默 fallback #}}
+{{# 使用 |default 而非 is defined：采集沙箱 Environment 清空了 Jinja tests #}}
+{{% set _iftype_include = iftype_include | default('', true) %}}
+{{% set _iftype_exclude = iftype_exclude | default('', true) %}}
+{{% set _ifdescr_include = ifdescr_include | default('', true) %}}
+{{% set _ifdescr_exclude = ifdescr_exclude | default('', true) %}}
+{{% if _iftype_include or _ifdescr_include %}}
+    [inputs.snmp.tagpass]
+{{% if _iftype_include %}}
+        ifType = {{{{ _iftype_include | to_toml_str_array }}}}
+{{% endif %}}
+{{% if _ifdescr_include %}}
+        ifDescr = {{{{ _ifdescr_include | to_toml_str_array }}}}
+{{% endif %}}
+{{% endif %}}
+{{% if _iftype_exclude or _ifdescr_exclude %}}
+    [inputs.snmp.tagdrop]
+{{% if _iftype_exclude %}}
+        ifType = {{{{ _iftype_exclude | to_toml_str_array }}}}
+{{% endif %}}
+{{% if _ifdescr_exclude %}}
+        ifDescr = {{{{ _ifdescr_exclude | to_toml_str_array }}}}
+{{% endif %}}
+{{% endif %}}
+{FILTER_MARKER_END}
+"""
+
+UI_ADVANCED_PANEL = {
+    "title": "接口过滤",
+    "title_en": "Interface Filters",
+    "hint": "按接口类型（ifType）和名称（ifDescr）配置排除或仅采集",
+    "hint_en": "Configure exclude or include filters by ifType and ifDescr",
+}
+
+_UI_FILTER_FIELDS: list[dict[str, Any]] = [
+    {
+        "name": "iftype_exclude",
+        "label": "排除的接口类型（ifType）",
+        "label_en": "Excluded Interface Types (ifType)",
+        "type": "select",
+        "required": False,
+        "advanced": True,
+        "section": "interface_filter",
+        "default_value": list(DEFAULT_IFTYPE_EXCLUDE),
+        "description": "默认排除 Loopback/Virtual/Tunnel/L2VLAN/L3VLAN；清空则不再按类型排除。与「仅采集」互斥，不可选择相同类型。",
+        "description_en": "Defaults exclude Loopback/Virtual/Tunnel/L2VLAN/L3VLAN. Clear to disable type exclusion. Mutually exclusive with include list.",
+        "options": IFTYPE_OPTIONS,
+        "widget_props": {
+            "mode": "tags",
+            "allowClear": True,
+            "tokenSeparators": [","],
+            "placeholder": "选择常用类型，或输入数字（如 22）后回车",
+            "placeholder_en": "Select a common type, or type a number (e.g. 22) and press Enter",
+        },
+        "rules": [
+            {
+                "type": "mutex_with",
+                "field": "iftype_include",
+                "message": "排除与仅采集的接口类型存在冲突，请勿同时选择：{{conflicts}}",
+                "message_en": "Excluded and included ifType values conflict: {{conflicts}}",
+            }
+        ],
+        "transform_on_edit": {
+            "origin_path": "child.content.config.tagdrop.ifType",
+            "to_api": {},
+        },
+    },
+    {
+        "name": "iftype_include",
+        "label": "仅采集的接口类型（ifType）",
+        "label_en": "Included Interface Types (ifType)",
+        "type": "select",
+        "required": False,
+        "advanced": True,
+        "section": "interface_filter",
+        "default_value": [],
+        "description": "留空表示不限制类型。非空时只保留所选 ifType；与排除列表互斥。填写后本配置中的非接口指标将不再采集，一般建议优先使用排除黑名单。",
+        "description_en": "Leave empty for no type restriction. Mutually exclusive with exclude list. Non-empty keeps only matching interface metrics; non-interface metrics from this config will not be collected.",
+        "options": IFTYPE_OPTIONS,
+        "widget_props": {
+            "mode": "tags",
+            "allowClear": True,
+            "tokenSeparators": [","],
+            "placeholder": "选择常用类型，或输入数字（如 22）后回车；留空不限制",
+            "placeholder_en": "Select a common type, or type a number (e.g. 22); empty = all types",
+        },
+        "rules": [
+            {
+                "type": "mutex_with",
+                "field": "iftype_exclude",
+                "message": "排除与仅采集的接口类型存在冲突，请勿同时选择：{{conflicts}}",
+                "message_en": "Excluded and included ifType values conflict: {{conflicts}}",
+            }
+        ],
+        "transform_on_edit": {
+            "origin_path": "child.content.config.tagpass.ifType",
+            "to_api": {},
+        },
+    },
+    {
+        "name": "ifdescr_exclude",
+        "label": "排除的接口名称（ifDescr）",
+        "label_en": "Excluded Interface Names (ifDescr)",
+        "type": "input",
+        "required": False,
+        "advanced": True,
+        "section": "interface_filter",
+        "default_value": "",
+        "description": "逗号分隔，支持通配符，例如 Loopback*,Vlan*,Null*。与「仅采集」名称列表互斥，不可填写相同条目。",
+        "description_en": "Comma-separated globs, e.g. Loopback*,Vlan*,Null*. Mutually exclusive with include name list.",
+        "widget_props": {
+            "placeholder": "例如 Loopback*,Vlan*,Null*",
+            "placeholder_en": "e.g. Loopback*,Vlan*,Null*",
+        },
+        "rules": [
+            {
+                "type": "mutex_with",
+                "field": "ifdescr_include",
+                "message": "排除与仅采集的接口名称存在冲突，请勿同时填写：{{conflicts}}",
+                "message_en": "Excluded and included ifDescr values conflict: {{conflicts}}",
+            }
+        ],
+        "transform_on_edit": {
+            "origin_path": "child.content.config.tagdrop.ifDescr",
+            "to_form": {"array_join": ","},
+            "to_api": {"split": ","},
+        },
+    },
+    {
+        "name": "ifdescr_include",
+        "label": "仅采集的接口名称（ifDescr）",
+        "label_en": "Included Interface Names (ifDescr)",
+        "type": "input",
+        "required": False,
+        "advanced": True,
+        "section": "interface_filter",
+        "default_value": "",
+        "description": "留空表示不限制名称。非空时只保留名称匹配的接口；与排除名称列表互斥。与 ifType 白名单同时填写时需同时命中（AND）。",
+        "description_en": "Leave empty for no name restriction. Mutually exclusive with exclude name list. Combined with ifType include uses AND.",
+        "widget_props": {
+            "placeholder": "不限制；例如 GigabitEthernet*,Eth-Trunk*",
+            "placeholder_en": "No restriction; e.g. GigabitEthernet*,Eth-Trunk*",
+        },
+        "rules": [
+            {
+                "type": "mutex_with",
+                "field": "ifdescr_exclude",
+                "message": "排除与仅采集的接口名称存在冲突，请勿同时填写：{{conflicts}}",
+                "message_en": "Excluded and included ifDescr values conflict: {{conflicts}}",
+            }
+        ],
+        "transform_on_edit": {
+            "origin_path": "child.content.config.tagpass.ifDescr",
+            "to_form": {"array_join": ","},
+            "to_api": {"split": ","},
+        },
+    },
+]
+
+IFTYPE_OID = "1.3.6.1.2.1.2.2.1.3"
+IFTYPE_FIELD_BLOCK = f"""\
+    [[inputs.snmp.table.field]]
+        oid = "{IFTYPE_OID}"
+        name = "ifType"
+        is_tag = true
+"""
+
+INTERFACE_HINT_RE = re.compile(
+    r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.2\.2"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.31\.1\.1"',
+    re.MULTILINE,
+)
+IFDESCR_FIELD_RE = re.compile(
+    r'(\[\[inputs\.snmp\.table\.field\]\]\s*\n\s*oid\s*=\s*"[^"]+"\s*\n\s*name\s*=\s*"ifDescr"\s*\n\s*is_tag\s*=\s*true\s*)',
+    re.MULTILINE,
+)
+CANONICAL_IFTYPE_FIELD_RE = re.compile(
+    r"\n?[ \t]*\[\[inputs\.snmp\.table\.field\]\]\s*\n"
+    r"[ \t]*oid\s*=\s*\"1\.3\.6\.1\.2\.1\.2\.2\.1\.3\"\s*\n"
+    r"[ \t]*name\s*=\s*\"ifType\"\s*\n"
+    r"[ \t]*is_tag\s*=\s*true\s*\n?",
+    re.MULTILINE,
+)
+PROCESSORS_RE = re.compile(r"^\[\[processors\.", re.MULTILINE)
+FILTER_BLOCK_RE = re.compile(
+    re.escape(FILTER_MARKER_BEGIN) + r".*?" + re.escape(FILTER_MARKER_END) + r"\n?",
+    re.DOTALL,
+)
+TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
+
+
+def get_ui_filter_fields() -> list[dict[str, Any]]:
+    return deepcopy(_UI_FILTER_FIELDS)
+
+
+def get_ui_advanced_panel() -> dict[str, Any]:
+    return deepcopy(UI_ADVANCED_PANEL)
+
+
+def has_interface_collection(template_content: str) -> bool:
+    return bool(INTERFACE_HINT_RE.search(template_content or ""))
+
+
+def should_inject_snmp_interface_filters(plugin: Any, content: dict | None = None) -> bool:
+    """判断是否应注入接口过滤 UI（collect_type / 表单指纹 / 插件目录）。"""
+    if plugin is not None and getattr(plugin, "collect_type", None) == "snmp":
+        return True
+
+    if isinstance(content, dict):
+        names = {
+            str(field.get("name") or "")
+            for field in (content.get("form_fields") or [])
+            if isinstance(field, dict)
+        }
+        if {"port", "version", "community"} <= names:
+            return True
+        if {"port", "version", "sec_name"} <= names:
+            return True
+
+    if plugin is not None:
+        try:
+            from apps.monitor.services.plugin_guide import PluginGuideService
+
+            plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
+        except Exception:
+            plugin_dir = None
+        if plugin_dir is not None and "snmp" in Path(plugin_dir).parts:
+            return True
+    return False
+
+
+def needs_snmp_interface_filter_jinja(template_content: str) -> bool:
+    text = template_content or ""
+    return has_interface_collection(text) or FILTER_MARKER_BEGIN in text
+
+
+def ensure_iftype_tag_fields(template_content: str) -> str:
+    """幂等：在每个 ifDescr 采集字段后注入 ifType tag，供 tagpass/tagdrop 使用。"""
+    if not has_interface_collection(template_content):
+        return template_content
+
+    text = CANONICAL_IFTYPE_FIELD_RE.sub("\n", template_content)
+    out: list[str] = []
+    last = 0
+    for match in IFDESCR_FIELD_RE.finditer(text):
+        out.append(text[last : match.end()])
+        out.append("\n" + IFTYPE_FIELD_BLOCK.rstrip() + "\n")
+        last = match.end()
+    if last == 0:
+        return template_content
+    out.append(text[last:])
+    return re.sub(r"\n{3,}", "\n\n", "".join(out))
+
+
+def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
+    """幂等：注入 ifType OID 字段 + 过滤 Jinja 片段（单一真相源）。"""
+    if not needs_snmp_interface_filter_jinja(template_content):
+        return template_content
+
+    text = ensure_iftype_tag_fields(template_content)
+    text = FILTER_BLOCK_RE.sub("", text)
+    text = TAGEXCLUDE_IFTYPE_RE.sub("", text)
+
+    processors = PROCESSORS_RE.search(text)
+    insert_at = processors.start() if processors else len(text)
+    before = text[:insert_at].rstrip() + "\n"
+    after = text[insert_at:]
+    if after and not after.startswith("\n"):
+        after = "\n" + after
+    return before + "\n" + FILTER_JINJA_BLOCK + after
+
+
+def merge_snmp_interface_filter_ui(content: dict | None) -> dict | None:
+    """用常量四字段 + advanced_panel 覆盖/补齐 UI 模板（SNMP 运行时注入）。"""
+    if not content:
+        return content
+
+    enriched = content
+    form_fields = enriched.get("form_fields")
+    if not isinstance(form_fields, list):
+        form_fields = []
+        enriched["form_fields"] = form_fields
+
+    filter_names = set(FILTER_TEMPLATE_VARS)
+    kept = [
+        field
+        for field in form_fields
+        if not (isinstance(field, dict) and field.get("name") in filter_names)
+    ]
+    kept.extend(get_ui_filter_fields())
+    enriched["form_fields"] = kept
+    enriched["advanced_panel"] = get_ui_advanced_panel()
+    return enriched

--- a/server/apps/monitor/utils/snmp_interface_template.py
+++ b/server/apps/monitor/utils/snmp_interface_template.py
@@ -10,6 +10,7 @@ from typing import Any
 from apps.monitor.constants.snmp_interface import (
     DEFAULT_IFTYPE_EXCLUDE,
     FILTER_TEMPLATE_VARS,
+    IFTYPE_OID,
     IFTYPE_OPTIONS,
 )
 
@@ -178,7 +179,6 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
     },
 ]
 
-IFTYPE_OID = "1.3.6.1.2.1.2.2.1.3"
 IFTYPE_FIELD_BLOCK = f"""\
     [[inputs.snmp.table.field]]
         oid = "{IFTYPE_OID}"
@@ -190,16 +190,14 @@ INTERFACE_HINT_RE = re.compile(
     r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.2\.2"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.31\.1\.1"',
     re.MULTILINE,
 )
-IFDESCR_FIELD_RE = re.compile(
-    r'(\[\[inputs\.snmp\.table\.field\]\]\s*\n\s*oid\s*=\s*"[^"]+"\s*\n\s*name\s*=\s*"ifDescr"\s*\n\s*is_tag\s*=\s*true\s*)',
-    re.MULTILINE,
+TABLE_BLOCK_RE = re.compile(
+    r"^[ \t]*\[\[inputs\.snmp\.table\]\][^\n]*\n.*?"
+    r"(?=^[ \t]*\[\[(?!inputs\.snmp\.table\.field\]\])|\Z)",
+    re.MULTILINE | re.DOTALL,
 )
-CANONICAL_IFTYPE_FIELD_RE = re.compile(
-    r"\n?[ \t]*\[\[inputs\.snmp\.table\.field\]\]\s*\n"
-    r"[ \t]*oid\s*=\s*\"1\.3\.6\.1\.2\.1\.2\.2\.1\.3\"\s*\n"
-    r"[ \t]*name\s*=\s*\"ifType\"\s*\n"
-    r"[ \t]*is_tag\s*=\s*true\s*\n?",
-    re.MULTILINE,
+FIELD_BLOCK_RE = re.compile(
+    r"^[ \t]*\[\[inputs\.snmp\.table\.field\]\][^\n]*\n.*?(?=^[ \t]*\[\[|\Z)",
+    re.MULTILINE | re.DOTALL,
 )
 PROCESSORS_RE = re.compile(r"^\[\[processors\.", re.MULTILINE)
 FILTER_BLOCK_RE = re.compile(
@@ -259,17 +257,32 @@ def ensure_iftype_tag_fields(template_content: str) -> str:
     if not has_interface_collection(template_content):
         return template_content
 
-    text = CANONICAL_IFTYPE_FIELD_RE.sub("\n", template_content)
-    out: list[str] = []
-    last = 0
-    for match in IFDESCR_FIELD_RE.finditer(text):
-        out.append(text[last : match.end()])
-        out.append("\n" + IFTYPE_FIELD_BLOCK.rstrip() + "\n")
-        last = match.end()
-    if last == 0:
-        return template_content
-    out.append(text[last:])
-    return re.sub(r"\n{3,}", "\n\n", "".join(out))
+    def ensure_table(table_match: re.Match[str]) -> str:
+        table_text = table_match.group(0)
+        fields = list(FIELD_BLOCK_RE.finditer(table_text))
+        ifdescr = next(
+            (field for field in fields if re.search(r'^\s*name\s*=\s*"ifDescr"\s*$', field.group(0), re.MULTILINE)),
+            None,
+        )
+        if ifdescr is None:
+            return table_text
+        if any(
+            re.search(r'^\s*name\s*=\s*"ifType"\s*$', field.group(0), re.MULTILINE)
+            or re.search(
+                rf'^\s*oid\s*=\s*"{re.escape(IFTYPE_OID)}"\s*$',
+                field.group(0),
+                re.MULTILINE,
+            )
+            for field in fields
+        ):
+            return table_text
+        insert_at = ifdescr.end()
+        before = table_text[:insert_at].rstrip("\n")
+        after = table_text[insert_at:].lstrip("\n")
+        injected = f"{before}\n{IFTYPE_FIELD_BLOCK.rstrip()}"
+        return f"{injected}\n{after}" if after else f"{injected}\n"
+
+    return TABLE_BLOCK_RE.sub(ensure_table, template_content)
 
 
 def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
@@ -280,14 +293,16 @@ def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
     text = ensure_iftype_tag_fields(template_content)
     text = FILTER_BLOCK_RE.sub("", text)
     text = TAGEXCLUDE_IFTYPE_RE.sub("", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
 
     processors = PROCESSORS_RE.search(text)
     insert_at = processors.start() if processors else len(text)
-    before = text[:insert_at].rstrip() + "\n"
-    after = text[insert_at:]
-    if after and not after.startswith("\n"):
-        after = "\n" + after
-    return before + "\n" + FILTER_JINJA_BLOCK + after
+    before = text[:insert_at].rstrip("\n")
+    after = text[insert_at:].lstrip("\n")
+    block = FILTER_JINJA_BLOCK.strip("\n")
+    if after:
+        return f"{before}\n\n{block}\n\n{after}"
+    return f"{before}\n\n{block}\n"
 
 
 def merge_snmp_interface_filter_ui(content: dict | None) -> dict | None:

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -13,7 +13,10 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
-import { trackSnmpFilterMutexLastChanged, normalizeMutexValues, formatSnmpFilterMutexConflict } from '@/app/monitor/hooks/integration/snmpFilterMutex';
+import {
+  getSnmpFilterMutexConflicts,
+  trackSnmpFilterMutexLastChanged
+} from '@/app/monitor/hooks/integration/snmpFilterMutex';
 
 const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const [form] = Form.useForm();
@@ -100,19 +103,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
 
   const handleSubmit = () => {
     form.validateFields().then((values) => {
-      const mutexErrors: string[] = [];
-      if (
-        normalizeMutexValues(values.iftype_exclude).length &&
-        normalizeMutexValues(values.iftype_include).length
-      ) {
-        mutexErrors.push(formatSnmpFilterMutexConflict(t, 'iftype'));
-      }
-      if (
-        normalizeMutexValues(values.ifdescr_exclude).length &&
-        normalizeMutexValues(values.ifdescr_include).length
-      ) {
-        mutexErrors.push(formatSnmpFilterMutexConflict(t, 'ifdescr'));
-      }
+      const mutexErrors = getSnmpFilterMutexConflicts(values, t);
       if (mutexErrors.length) {
         mutexErrors.forEach((msg) => message.error(msg));
         return;

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from '@/utils/i18n';
 import OperateModal from '@/components/operate-modal';
 import useApiClient from '@/utils/request';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
+import { trackSnmpFilterMutexLastChanged, normalizeMutexValues, formatSnmpFilterMutexConflict } from '@/app/monitor/hooks/integration/snmpFilterMutex';
 
 const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const [form] = Form.useForm();
@@ -86,6 +87,8 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const initData = (row: TableDataItem) => {
     const activeFormData = configsInfo.getDefaultForm?.(row) || {};
     form.setFieldsValue(activeFormData);
+    // 用当前值初始化互斥追踪基线，避免默认排除被误判为“后填写”
+    trackSnmpFilterMutexLastChanged({}, form.getFieldsValue(true), form);
   };
 
   const handleCancel = () => {
@@ -97,6 +100,23 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
 
   const handleSubmit = () => {
     form.validateFields().then((values) => {
+      const mutexErrors: string[] = [];
+      if (
+        normalizeMutexValues(values.iftype_exclude).length &&
+        normalizeMutexValues(values.iftype_include).length
+      ) {
+        mutexErrors.push(formatSnmpFilterMutexConflict(t, 'iftype'));
+      }
+      if (
+        normalizeMutexValues(values.ifdescr_exclude).length &&
+        normalizeMutexValues(values.ifdescr_include).length
+      ) {
+        mutexErrors.push(formatSnmpFilterMutexConflict(t, 'ifdescr'));
+      }
+      if (mutexErrors.length) {
+        mutexErrors.forEach((msg) => message.error(msg));
+        return;
+      }
       operateConfig(values);
     });
   };
@@ -150,7 +170,15 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
             {showEmpty ? (
               <Empty description={t('monitor.integrations.noConfigData')} />
             ) : (
-              <Form ref={formRef} form={form} name="basic" layout="vertical">
+              <Form
+                ref={formRef}
+                form={form}
+                name="basic"
+                layout="vertical"
+                onValuesChange={(changed, all) => {
+                  trackSnmpFilterMutexLastChanged(changed, all, form);
+                }}
+              >
                 {formItems}
               </Form>
             )}

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -24,7 +24,10 @@ import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
 import { useConfigRenderer } from '@/app/monitor/hooks/integration/useConfigRenderer';
-import { trackSnmpFilterMutexLastChanged, normalizeMutexValues, formatSnmpFilterMutexConflict } from '@/app/monitor/hooks/integration/snmpFilterMutex';
+import {
+  getSnmpFilterMutexConflicts,
+  trackSnmpFilterMutexLastChanged
+} from '@/app/monitor/hooks/integration/snmpFilterMutex';
 import { toMonitorNodeOption } from '@/app/monitor/hooks/integration/nodeOptions';
 import BatchEditModal from './batchEditModal';
 import ExcelImportModal from './excelImportModal';
@@ -806,19 +809,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     }
     form.validateFields().then((values) => {
       try {
-        const mutexErrors: string[] = [];
-        if (
-          normalizeMutexValues(values.iftype_exclude).length &&
-          normalizeMutexValues(values.iftype_include).length
-        ) {
-          mutexErrors.push(formatSnmpFilterMutexConflict(t, 'iftype'));
-        }
-        if (
-          normalizeMutexValues(values.ifdescr_exclude).length &&
-          normalizeMutexValues(values.ifdescr_include).length
-        ) {
-          mutexErrors.push(formatSnmpFilterMutexConflict(t, 'ifdescr'));
-        }
+        const mutexErrors = getSnmpFilterMutexConflicts(values, t);
         if (mutexErrors.length) {
           mutexErrors.forEach((msg) => message.error(msg));
           return;

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -24,6 +24,7 @@ import Permission from '@/components/permission';
 import { cloneDeep } from 'lodash';
 import { usePluginFromJson } from '@/app/monitor/hooks/integration/usePluginFromJson';
 import { useConfigRenderer } from '@/app/monitor/hooks/integration/useConfigRenderer';
+import { trackSnmpFilterMutexLastChanged, normalizeMutexValues, formatSnmpFilterMutexConflict } from '@/app/monitor/hooks/integration/snmpFilterMutex';
 import { toMonitorNodeOption } from '@/app/monitor/hooks/integration/nodeOptions';
 import BatchEditModal from './batchEditModal';
 import ExcelImportModal from './excelImportModal';
@@ -709,6 +710,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     form.setFieldsValue({
       ...(formConfig?.defaultForm || {})
     });
+    trackSnmpFilterMutexLastChanged({}, form.getFieldsValue(true), form);
   };
 
   const getNodeList = async () => {
@@ -804,6 +806,23 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     }
     form.validateFields().then((values) => {
       try {
+        const mutexErrors: string[] = [];
+        if (
+          normalizeMutexValues(values.iftype_exclude).length &&
+          normalizeMutexValues(values.iftype_include).length
+        ) {
+          mutexErrors.push(formatSnmpFilterMutexConflict(t, 'iftype'));
+        }
+        if (
+          normalizeMutexValues(values.ifdescr_exclude).length &&
+          normalizeMutexValues(values.ifdescr_include).length
+        ) {
+          mutexErrors.push(formatSnmpFilterMutexConflict(t, 'ifdescr'));
+        }
+        if (mutexErrors.length) {
+          mutexErrors.forEach((msg) => message.error(msg));
+          return;
+        }
         const row = cloneDeep(values);
         delete row.nodes;
         const params =
@@ -831,6 +850,12 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       });
       const targetUrl = `/monitor/integration/list?${searchParams.toString()}`;
       router.push(targetUrl);
+    } catch (error: any) {
+      message.error(
+        error?.response?.data?.message ||
+          error?.message ||
+          t('common.operationFailed')
+      );
     } finally {
       setConfirmLoading(false);
     }
@@ -852,7 +877,10 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       form={form}
       name="basic"
       layout="vertical"
-      onValuesChange={clearCollectDetectState}
+      onValuesChange={(changed, all) => {
+        clearCollectDetectState();
+        trackSnmpFilterMutexLastChanged(changed, all, form);
+      }}
     >
       <div className="flex items-center justify-between mb-[10px]">
         <b className="text-[14px] ml-[-10px]">

--- a/web/src/app/monitor/hooks/integration/snmpFilterMutex.ts
+++ b/web/src/app/monitor/hooks/integration/snmpFilterMutex.ts
@@ -1,0 +1,146 @@
+import type { FormInstance } from 'antd/es/form';
+
+export const FILTER_MUTEX_PEERS: Record<string, string> = {
+  iftype_exclude: 'iftype_include',
+  iftype_include: 'iftype_exclude',
+  ifdescr_exclude: 'ifdescr_include',
+  ifdescr_include: 'ifdescr_exclude',
+};
+
+/** 记录同一维度后填写的一侧，仅该侧展示冲突提示 */
+export const FILTER_MUTEX_LAST_KEYS: Record<string, string> = {
+  iftype_exclude: '_mutex_last_iftype',
+  iftype_include: '_mutex_last_iftype',
+  ifdescr_exclude: '_mutex_last_ifdescr',
+  ifdescr_include: '_mutex_last_ifdescr',
+};
+
+const previousValuesByForm = new WeakMap<FormInstance, Record<string, unknown>>();
+
+export const normalizeMutexValues = (value: unknown): string[] => {
+  if (value == null || value === '') return [];
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter(Boolean);
+  }
+  return String(value)
+    .split(/[,，]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+};
+
+/**
+ * 解析单条 ifType：仅接受纯数字，或「数字 - 名称」展示格式（取数字）。
+ * 「111-asdf」这类非法输入返回 null。
+ */
+export const parseIfTypeTag = (raw: unknown): string | null => {
+  const text = String(raw ?? '').trim();
+  if (!text) return null;
+  if (/^\d+$/.test(text)) return text;
+  const labeled = text.match(/^(\d+)\s+-\s+.+$/);
+  return labeled ? labeled[1] : null;
+};
+
+/** 规范化 ifType 多选/tags 值；rejected 为无法识别的原始输入 */
+export const normalizeIfTypeTags = (
+  value: unknown
+): { values: string[]; rejected: string[] } => {
+  const list = Array.isArray(value)
+    ? value
+    : value == null || value === ''
+      ? []
+      : [value];
+  const values: string[] = [];
+  const rejected: string[] = [];
+  const seen = new Set<string>();
+  for (const item of list) {
+    const raw = String(item ?? '').trim();
+    if (!raw) continue;
+    const parsed = parseIfTypeTag(raw);
+    if (!parsed) {
+      rejected.push(raw);
+      continue;
+    }
+    if (!seen.has(parsed)) {
+      seen.add(parsed);
+      values.push(parsed);
+    }
+  }
+  return { values, rejected };
+};
+
+/**
+ * 两侧都有值时，把“后变为非空”的一侧记为后填写侧；冲突解除时清空标记。
+ * 先填写的一侧不提示，仅后填写侧右侧红字提示。
+ */
+export const trackSnmpFilterMutexLastChanged = (
+  changedValues: Record<string, unknown>,
+  allValues: Record<string, unknown>,
+  form: FormInstance
+) => {
+  const touched = Object.keys(changedValues || {}).filter(
+    (field) => field in FILTER_MUTEX_PEERS
+  );
+  const prev = previousValuesByForm.get(form) || {};
+  const patch: Record<string, unknown> = {};
+
+  const pairKeys = new Set<string>();
+  touched.forEach((field) => {
+    const lastKey = FILTER_MUTEX_LAST_KEYS[field];
+    if (lastKey) pairKeys.add(lastKey);
+  });
+
+  pairKeys.forEach((lastKey) => {
+    const fields = Object.entries(FILTER_MUTEX_LAST_KEYS)
+      .filter(([, key]) => key === lastKey)
+      .map(([field]) => field);
+    if (fields.length !== 2) return;
+    const [fieldA, fieldB] = fields;
+
+    const aOcc = normalizeMutexValues(allValues?.[fieldA]).length > 0;
+    const bOcc = normalizeMutexValues(allValues?.[fieldB]).length > 0;
+    const prevAOcc = normalizeMutexValues(prev[fieldA]).length > 0;
+    const prevBOcc = normalizeMutexValues(prev[fieldB]).length > 0;
+
+    if (aOcc && bOcc) {
+      const wasConflict = prevAOcc && prevBOcc;
+      if (!wasConflict) {
+        const newlyA = aOcc && !prevAOcc;
+        const newlyB = bOcc && !prevBOcc;
+        if (fieldA in (changedValues || {}) && newlyA) {
+          patch[lastKey] = fieldA;
+        } else if (fieldB in (changedValues || {}) && newlyB) {
+          patch[lastKey] = fieldB;
+        } else if (fieldA in (changedValues || {}) && aOcc) {
+          patch[lastKey] = fieldA;
+        } else if (fieldB in (changedValues || {}) && bOcc) {
+          patch[lastKey] = fieldB;
+        }
+      }
+      return;
+    }
+
+    patch[lastKey] = undefined;
+  });
+
+  if (Object.keys(patch).length) {
+    form.setFieldsValue(patch);
+  }
+
+  previousValuesByForm.set(form, { ...(allValues || {}) });
+};
+
+export const getSnmpFilterMutexLastKey = (field: string) =>
+  FILTER_MUTEX_LAST_KEYS[field];
+
+/** 保存拦截用：点名互斥的两个字段 */
+export const formatSnmpFilterMutexConflict = (
+  t: (id: string, defaultMessage?: string, values?: Record<string, string>) => string,
+  dimension: 'iftype' | 'ifdescr'
+) => {
+  const left = dimension === 'iftype' ? 'iftype_exclude' : 'ifdescr_exclude';
+  const right = dimension === 'iftype' ? 'iftype_include' : 'ifdescr_include';
+  return t('monitor.integrations.filterMutexConflict', '', {
+    left: t(`monitor.integrations.filterMutexFields.${left}`),
+    right: t(`monitor.integrations.filterMutexFields.${right}`),
+  });
+};

--- a/web/src/app/monitor/hooks/integration/snmpFilterMutex.ts
+++ b/web/src/app/monitor/hooks/integration/snmpFilterMutex.ts
@@ -144,3 +144,24 @@ export const formatSnmpFilterMutexConflict = (
     right: t(`monitor.integrations.filterMutexFields.${right}`),
   });
 };
+
+/** 保存拦截用：返回所有同维黑白名单冲突 */
+export const getSnmpFilterMutexConflicts = (
+  values: Record<string, unknown>,
+  t: (id: string, defaultMessage?: string, values?: Record<string, string>) => string
+): string[] => {
+  const conflicts: string[] = [];
+  if (
+    normalizeMutexValues(values.iftype_exclude).length &&
+    normalizeMutexValues(values.iftype_include).length
+  ) {
+    conflicts.push(formatSnmpFilterMutexConflict(t, 'iftype'));
+  }
+  if (
+    normalizeMutexValues(values.ifdescr_exclude).length &&
+    normalizeMutexValues(values.ifdescr_include).length
+  ) {
+    conflicts.push(formatSnmpFilterMutexConflict(t, 'ifdescr'));
+  }
+  return conflicts;
+};

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -7,8 +7,7 @@ import {
   Checkbox,
   Button,
   Tooltip,
-  Switch,
-  message
+  Switch
 } from 'antd';
 import { ExclamationCircleFilled, MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import Password from '@/components/password';
@@ -172,9 +171,27 @@ export const useConfigRenderer = () => {
     const mutexPeerOccupiedTip = mutexPeerLabel
       ? t('monitor.integrations.filterMutexPeerOccupied', '', { peer: mutexPeerLabel })
       : '';
+    const isIfTypeFilterField =
+      name === 'iftype_exclude' || name === 'iftype_include';
 
     const formRules = [
       ...(required ? [{ required: true, message: t('common.required') }] : []),
+      ...(isIfTypeFilterField
+        ? [
+          {
+            validator: async (_: unknown, value: unknown) => {
+              const { rejected } = normalizeIfTypeTags(value);
+              if (rejected.length) {
+                throw new Error(
+                  t('monitor.integrations.filterIfTypeInvalid', '', {
+                    values: rejected.join(', ')
+                  })
+                );
+              }
+            }
+          }
+        ]
+        : []),
       ...rules.flatMap((rule: any) => {
         if (rule?.type === 'mutex_with') {
           return [];
@@ -409,9 +426,6 @@ export const useConfigRenderer = () => {
       }
     };
 
-    const isIfTypeFilterField =
-      name === 'iftype_exclude' || name === 'iftype_include';
-
     const renderNamedControl = () => (
       <Form.Item
         noStyle
@@ -420,22 +434,6 @@ export const useConfigRenderer = () => {
         dependencies={mutexPeerFields}
         initialValue={default_value}
         valuePropName={type === 'switch' ? 'checked' : 'value'}
-        getValueFromEvent={
-          isIfTypeFilterField
-            ? (value) => {
-              const { values, rejected } = normalizeIfTypeTags(value);
-              if (rejected.length) {
-                message.warning(
-                  t('monitor.integrations.filterIfTypeInvalid', '', {
-                    values: rejected.join(', ')
-                  })
-                );
-              }
-              return values;
-            }
-            : undefined
-        }
-        normalize={isIfTypeFilterField ? (value) => normalizeIfTypeTags(value).values : undefined}
       >
         {renderWidget()}
       </Form.Item>

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -7,7 +7,8 @@ import {
   Checkbox,
   Button,
   Tooltip,
-  Switch
+  Switch,
+  message
 } from 'antd';
 import { ExclamationCircleFilled, MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import Password from '@/components/password';
@@ -15,6 +16,27 @@ import GroupTreeSelector from '@/components/group-tree-select';
 import { useTranslation } from '@/utils/i18n';
 import FieldGuideTip from '@/app/monitor/(pages)/integration/list/detail/configure/fieldGuideTip';
 import { applyTableChangeHandler } from './tableChangeHandler';
+import {
+  FILTER_MUTEX_PEERS,
+  getSnmpFilterMutexLastKey,
+  normalizeIfTypeTags,
+  normalizeMutexValues
+} from './snmpFilterMutex';
+
+const mutexValuesEqual = (left: any, right: any) => {
+  if (left === right) return true;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    const leftList = Array.isArray(left) ? left : left == null || left === '' ? [] : [left];
+    const rightList = Array.isArray(right)
+      ? right
+      : right == null || right === ''
+        ? []
+        : [right];
+    if (leftList.length !== rightList.length) return false;
+    return leftList.every((item, index) => String(item) === String(rightList[index]));
+  }
+  return false;
+};
 
 export const useConfigRenderer = () => {
   const { t } = useTranslation();
@@ -137,25 +159,66 @@ export const useConfigRenderer = () => {
       );
     }
 
+    const mutexPeerField = (FILTER_MUTEX_PEERS[name] ||
+      (rules || []).find((rule: any) => rule?.type === 'mutex_with' && rule.field)?.field) as
+      | string
+      | undefined;
+    const mutexPeerFields = mutexPeerField ? [mutexPeerField] : [];
+    const mutexLastKey = mutexPeerField ? getSnmpFilterMutexLastKey(name) : undefined;
+    const mutexPeerLabel = mutexPeerField
+      ? t(`monitor.integrations.filterMutexFields.${mutexPeerField}`)
+      : '';
+    // react-intl 使用 ICU `{peer}`，不是 `{{peer}}`
+    const mutexPeerOccupiedTip = mutexPeerLabel
+      ? t('monitor.integrations.filterMutexPeerOccupied', '', { peer: mutexPeerLabel })
+      : '';
+
     const formRules = [
       ...(required ? [{ required: true, message: t('common.required') }] : []),
-      ...rules
+      ...rules.flatMap((rule: any) => {
+        if (rule?.type === 'mutex_with') {
+          return [];
+        }
+        if (rule?.type === 'pattern' && rule.pattern) {
+          return [
+            {
+              pattern: new RegExp(rule.pattern),
+              message: rule.message || t('common.required')
+            }
+          ];
+        }
+        return [rule];
+      })
+      // 冲突仅在后填写侧右侧红字提示；保存仍由后端校验
     ];
     const watchField = dependency?.field;
 
-    const shouldUpdate = watchField
-      ? (prevValues: any, currentValues: any) => {
-        if (typeof watchField === 'string') {
-          return prevValues[watchField] !== currentValues[watchField];
+    const shouldUpdate = (prevValues: any, currentValues: any) => {
+      if (mutexPeerField) {
+        if (!mutexValuesEqual(prevValues[mutexPeerField], currentValues[mutexPeerField])) {
+          return true;
         }
-        if (Array.isArray(watchField)) {
-          return watchField.some(
-            (field: string) => prevValues[field] !== currentValues[field]
-          );
+        if (!mutexValuesEqual(prevValues[name], currentValues[name])) {
+          return true;
         }
-        return false;
+        if (
+          mutexLastKey &&
+          prevValues[mutexLastKey] !== currentValues[mutexLastKey]
+        ) {
+          return true;
+        }
       }
-      : undefined;
+      if (!watchField) return false;
+      if (typeof watchField === 'string') {
+        return prevValues[watchField] !== currentValues[watchField];
+      }
+      if (Array.isArray(watchField)) {
+        return watchField.some(
+          (field: string) => prevValues[field] !== currentValues[field]
+        );
+      }
+      return false;
+    };
 
     const isFieldVisible = (getFieldValue: any) => {
       if (!watchField) return true;
@@ -183,12 +246,25 @@ export const useConfigRenderer = () => {
       return true;
     };
 
+    const locked = mode === 'edit' && editable === false;
+
+    const renderLabel = () =>
+      hasGuideTip ? (
+        <span className="inline-flex items-center">
+          {label}
+          <FieldGuideTip short={guideTip} />
+        </span>
+      ) : (
+        label
+      );
+
     const renderWidget = () => {
       switch (type) {
         case 'input':
           return (
             <Input
               {...widget_props}
+              disabled={Boolean(locked || widget_props.disabled)}
               placeholder={widget_props.placeholder || label}
               className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px]`}
             />
@@ -204,7 +280,7 @@ export const useConfigRenderer = () => {
             />
           );
 
-        case 'inputNumber':
+        case 'inputNumber': {
           const { addonAfter, ...restProps } = widget_props;
           return (
             <InputNumber
@@ -224,23 +300,40 @@ export const useConfigRenderer = () => {
               addonAfter={addonAfter ? addonAfter : undefined}
             />
           );
+        }
 
-        case 'select':
+        case 'select': {
+          const allowCustomTags =
+            name === 'iftype_exclude' || name === 'iftype_include';
           return (
             <Select
               {...widget_props}
-              placeholder={widget_props.placeholder || label}
+              mode={allowCustomTags ? 'tags' : widget_props.mode}
+              tokenSeparators={
+                allowCustomTags
+                  ? widget_props.tokenSeparators || [',']
+                  : widget_props.tokenSeparators
+              }
+              disabled={Boolean(locked || widget_props.disabled)}
+              placeholder={
+                allowCustomTags
+                  ? widget_props.placeholder ||
+                    t('monitor.integrations.filterIfTypeTagsPlaceholder')
+                  : widget_props.placeholder || label
+              }
               showSearch
+              optionFilterProp="label"
               className="mr-[10px]"
               style={{ width: `${FORM_WIDGET_WIDTH}px` }}
             >
               {options.map((option: any) => (
-                <Select.Option key={option.value} value={option.value}>
+                <Select.Option key={option.value} value={option.value} label={option.label}>
                   {option.label}
                 </Select.Option>
               ))}
             </Select>
           );
+        }
 
         case 'textarea':
           return (
@@ -277,7 +370,7 @@ export const useConfigRenderer = () => {
                         {option.label}
                       </span>
                       {option.description && (
-                        <span className="text-[var(--color-text-3)] text-[12px]">
+                        <span className="text-[12px] text-[var(--color-text-3)]">
                           {option.description}
                         </span>
                       )}
@@ -316,34 +409,71 @@ export const useConfigRenderer = () => {
       }
     };
 
-    if (dependency?.field) {
+    const isIfTypeFilterField =
+      name === 'iftype_exclude' || name === 'iftype_include';
+
+    const renderNamedControl = () => (
+      <Form.Item
+        noStyle
+        name={name}
+        rules={formRules}
+        dependencies={mutexPeerFields}
+        initialValue={default_value}
+        valuePropName={type === 'switch' ? 'checked' : 'value'}
+        getValueFromEvent={
+          isIfTypeFilterField
+            ? (value) => {
+                const { values, rejected } = normalizeIfTypeTags(value);
+                if (rejected.length) {
+                  message.warning(
+                    t('monitor.integrations.filterIfTypeInvalid', '', {
+                      values: rejected.join(', ')
+                    })
+                  );
+                }
+                return values;
+              }
+            : undefined
+        }
+        normalize={isIfTypeFilterField ? (value) => normalizeIfTypeTags(value).values : undefined}
+      >
+        {renderWidget()}
+      </Form.Item>
+    );
+
+    if (dependency?.field || mutexPeerField) {
       return (
         <Form.Item noStyle shouldUpdate={shouldUpdate} key={name}>
-          {({ getFieldValue }) =>
-            isFieldVisible(getFieldValue) ? (
-              <Form.Item
-                required={required}
-                label={
-                  hasGuideTip ? (
-                    <span className="inline-flex items-center">
-                      {label}
-                      <FieldGuideTip short={guideTip} />
-                    </span>
-                  ) : (
-                    label
-                  )
-                }
-              >
-                <Form.Item
-                  noStyle
-                  name={name}
-                  rules={formRules}
-                  initialValue={default_value}
-                  valuePropName={type === 'switch' ? 'checked' : 'value'}
-                >
-                  {renderWidget()}
-                </Form.Item>
-                {showInlineDescription && (
+          {({ getFieldValue }) => {
+            if (dependency?.field && !isFieldVisible(getFieldValue)) {
+              return null;
+            }
+            const selfOccupied = normalizeMutexValues(getFieldValue(name)).length > 0;
+            const peerOccupied = mutexPeerField
+              ? normalizeMutexValues(getFieldValue(mutexPeerField)).length > 0
+              : false;
+            const lastChanged = mutexLastKey
+              ? getFieldValue(mutexLastKey)
+              : undefined;
+            // 仅后填写的一侧展示提示
+            const showMutexConflict = Boolean(
+              mutexPeerField &&
+                selfOccupied &&
+                peerOccupied &&
+                lastChanged === name
+            );
+            return (
+              <Form.Item required={required} label={renderLabel()}>
+                {renderNamedControl()}
+                {showMutexConflict ? (
+                  <span
+                    className="text-[12px] leading-[18px] text-[var(--color-fail)]"
+                    style={{ verticalAlign: 'middle' }}
+                  >
+                    {mutexPeerOccupiedTip}
+                  </span>
+                ) : null}
+                {showInlineDescription && !showMutexConflict && (
                   <span
                     className="text-[12px] text-[var(--color-text-3)]"
                     style={{ verticalAlign: 'middle' }}
@@ -352,27 +482,14 @@ export const useConfigRenderer = () => {
                   </span>
                 )}
               </Form.Item>
-            ) : null
-          }
+            );
+          }}
         </Form.Item>
       );
     }
 
     return (
-      <Form.Item
-        key={name}
-        required={required}
-        label={
-          hasGuideTip ? (
-            <span className="inline-flex items-center">
-              {label}
-              <FieldGuideTip short={guideTip} />
-            </span>
-          ) : (
-            label
-          )
-        }
-      >
+      <Form.Item key={name} required={required} label={renderLabel()}>
         <Form.Item
           noStyle
           name={name}

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -423,16 +423,16 @@ export const useConfigRenderer = () => {
         getValueFromEvent={
           isIfTypeFilterField
             ? (value) => {
-                const { values, rejected } = normalizeIfTypeTags(value);
-                if (rejected.length) {
-                  message.warning(
-                    t('monitor.integrations.filterIfTypeInvalid', '', {
-                      values: rejected.join(', ')
-                    })
-                  );
-                }
-                return values;
+              const { values, rejected } = normalizeIfTypeTags(value);
+              if (rejected.length) {
+                message.warning(
+                  t('monitor.integrations.filterIfTypeInvalid', '', {
+                    values: rejected.join(', ')
+                  })
+                );
               }
+              return values;
+            }
             : undefined
         }
         normalize={isIfTypeFilterField ? (value) => normalizeIfTypeTags(value).values : undefined}

--- a/web/src/app/monitor/hooks/integration/useDataMapper.ts
+++ b/web/src/app/monitor/hooks/integration/useDataMapper.ts
@@ -77,6 +77,15 @@ export class DataMapper {
           const match = processedValue.match(new RegExp(to_form.regex));
           processedValue = match ? match[1] || match[0] : processedValue;
         }
+        // 数组用分隔符拼成字符串（SNMP ifDescr 黑白名单回显）
+        if (to_form.array_join) {
+          const sep = typeof to_form.array_join === 'string' ? to_form.array_join : ',';
+          if (Array.isArray(processedValue)) {
+            processedValue = processedValue.join(sep);
+          } else if (processedValue == null) {
+            processedValue = '';
+          }
+        }
         // 类型转换
         if (to_form.type) {
           switch (to_form.type) {
@@ -191,6 +200,18 @@ export class DataMapper {
         processedValue !== null
       ) {
         processedValue = String(processedValue) + to_api.suffix;
+      }
+      // 字符串按分隔符拆成数组（SNMP ifDescr 黑白名单提交）
+      if (to_api.split) {
+        const sep = typeof to_api.split === 'string' ? to_api.split : ',';
+        if (typeof processedValue === 'string') {
+          processedValue = processedValue
+            .split(sep)
+            .map((item: string) => item.trim())
+            .filter(Boolean);
+        } else if (processedValue == null || processedValue === '') {
+          processedValue = [];
+        }
       }
       // 模板拼接（支持从 formData 获取其他字段）
       if (to_api.template && formData) {

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -426,7 +426,10 @@ export const usePluginFromJson = () => {
               }
             });
             // SNMP 接口黑白名单：空数组/空串不得写成 []（会误杀全部接口），改为删除对应键
-            if (config.collect_type === 'snmp' && result?.child?.content?.config) {
+            if (
+              String(config.collect_type || '').startsWith('snmp') &&
+              result?.child?.content?.config
+            ) {
               const snmpFilterNames = new Set(
                 (formFields || [])
                   .map((field: any) => field?.name)

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -162,7 +162,27 @@ export const usePluginFromJson = () => {
       const formFields = getFieldsForMode(config.form_fields || [], extra.mode);
       const advancedFields = formFields?.filter((field: any) => field.advanced) || [];
       const basicFields = formFields?.filter((field: any) => !field.advanced) || [];
-      const ADVANCED_SECTION_ORDER = ['request', 'auth', 'response', 'tls'];
+      const ADVANCED_SECTION_ORDER = ['request', 'auth', 'response', 'tls', 'interface_filter'];
+      const advancedPanel = config.advanced_panel || {};
+      const isInterfaceFilterAdvanced =
+        Boolean(advancedPanel.title) ||
+        (advancedFields.length > 0 &&
+          advancedFields.every(
+            (field: any) =>
+              field.section === 'interface_filter' ||
+              ['iftype_exclude', 'iftype_include', 'ifdescr_exclude', 'ifdescr_include'].includes(
+                field.name
+              )
+          ));
+      const advancedTitle =
+        advancedPanel.title ||
+        (isInterfaceFilterAdvanced
+          ? t('monitor.integrations.advancedFilterConfiguration')
+          : t('monitor.integrations.advancedConfiguration'));
+      // 接口过滤只展示功能说明；互斥提示放在字段旁，避免顶部残留旧文案
+      const advancedHint = isInterfaceFilterAdvanced
+        ? t('monitor.integrations.advancedFilterConfigurationHint')
+        : (advancedPanel.hint || t('monitor.integrations.advancedConfigurationHint'));
 
       const renderAdvancedFieldGroups = (fields: any[]) => {
         const hasSections = fields.some((field) => field.section);
@@ -188,11 +208,14 @@ export const usePluginFromJson = () => {
           <div className="space-y-5">
             {orderedSections.map((section) => (
               <section key={section} className="space-y-3">
-                <div className="border-b border-[var(--color-border-1)] pb-2">
-                  <h4 className="m-0 text-[13px] font-medium leading-5 text-[var(--color-text-1)]">
-                    {t(`monitor.integrations.advancedSections.${section}`)}
-                  </h4>
-                </div>
+                {/* 仅网站等多分组高级区展示小节标题；单一接口过滤组不再重复标题 */}
+                {orderedSections.length > 1 && (
+                  <div className="border-b border-[var(--color-border-1)] pb-2">
+                    <h4 className="m-0 text-[13px] font-medium leading-5 text-[var(--color-text-1)]">
+                      {t(`monitor.integrations.advancedSections.${section}`)}
+                    </h4>
+                  </div>
+                )}
                 <div className="space-y-1">
                   {(sectionMap.get(section) || []).map((fieldConfig: any) =>
                     renderFormField(fieldConfig, extra.mode)
@@ -220,11 +243,13 @@ export const usePluginFromJson = () => {
                 label: (
                   <div>
                     <div className="text-[13px] font-medium leading-5 text-[var(--color-text-1)]">
-                      {t('monitor.integrations.advancedConfiguration')}
+                      {advancedTitle}
                     </div>
-                    <div className="mt-0.5 text-[12px] font-normal leading-[18px] text-[var(--color-text-3)]">
-                      {t('monitor.integrations.advancedConfigurationHint')}
-                    </div>
+                    {advancedHint ? (
+                      <div className="mt-0.5 text-[12px] font-normal leading-[18px] text-[var(--color-text-3)]">
+                        {advancedHint}
+                      </div>
+                    ) : null}
                   </div>
                 ),
                 forceRender: true,
@@ -400,6 +425,86 @@ export const usePluginFromJson = () => {
                 }
               }
             });
+            // SNMP 接口黑白名单：空数组/空串不得写成 []（会误杀全部接口），改为删除对应键
+            if (config.collect_type === 'snmp' && result?.child?.content?.config) {
+              const snmpFilterNames = new Set(
+                (formFields || [])
+                  .map((field: any) => field?.name)
+                  .filter((name: string) =>
+                    [
+                      'iftype_include',
+                      'iftype_exclude',
+                      'ifdescr_include',
+                      'ifdescr_exclude'
+                    ].includes(name)
+                  )
+              );
+              if (snmpFilterNames.size) {
+                const snmpConfig = result.child.content.config;
+                const pruneFilterKey = (
+                  tableName: 'tagpass' | 'tagdrop',
+                  key: string,
+                  value: any
+                ) => {
+                  const empty =
+                    value == null ||
+                    value === '' ||
+                    (Array.isArray(value) && value.length === 0);
+                  if (!snmpConfig[tableName]) {
+                    return;
+                  }
+                  if (empty) {
+                    delete snmpConfig[tableName][key];
+                    if (Object.keys(snmpConfig[tableName]).length === 0) {
+                      delete snmpConfig[tableName];
+                    }
+                  }
+                };
+                if (snmpFilterNames.has('iftype_include')) {
+                  pruneFilterKey(
+                    'tagpass',
+                    'ifType',
+                    filledFormData.iftype_include
+                  );
+                }
+                if (snmpFilterNames.has('iftype_exclude')) {
+                  pruneFilterKey(
+                    'tagdrop',
+                    'ifType',
+                    filledFormData.iftype_exclude
+                  );
+                }
+                if (snmpFilterNames.has('ifdescr_include')) {
+                  const descrInclude = DataMapper.transformValue(
+                    filledFormData.ifdescr_include,
+                    {
+                      origin_path: 'child.content.config.tagpass.ifDescr',
+                      to_api: { split: ',' }
+                    },
+                    'toApi',
+                    undefined,
+                    filledFormData
+                  );
+                  pruneFilterKey('tagpass', 'ifDescr', descrInclude);
+                }
+                if (snmpFilterNames.has('ifdescr_exclude')) {
+                  const descrExclude = DataMapper.transformValue(
+                    filledFormData.ifdescr_exclude,
+                    {
+                      origin_path: 'child.content.config.tagdrop.ifDescr',
+                      to_api: { split: ',' }
+                    },
+                    'toApi',
+                    undefined,
+                    filledFormData
+                  );
+                  pruneFilterKey('tagdrop', 'ifDescr', descrExclude);
+                }
+                if (!snmpConfig.tagexclude) {
+                  snmpConfig.tagexclude = ['ifType'];
+                }
+              }
+            }
             // 处理额外字段（extra_edit_fields）
             if (config.extra_edit_fields) {
               Object.entries(config.extra_edit_fields).forEach(

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -569,11 +569,25 @@
       "collectDetectNodeRequired": "Please select a collection node first",
       "advancedConfiguration": "Advanced Configuration",
       "advancedConfigurationHint": "Configure request payload, authentication, and expected response checks as needed",
+      "advancedFilterConfiguration": "Interface Filters",
+      "advancedFilterConfigurationHint": "Configure exclude or include filters by ifType and ifDescr",
+      "filterMutexConflict": "\"{left}\" and \"{right}\" cannot be set together. Clear one side first",
+      "filterMutexOptionDisabled": "Already selected in \"{peer}\"",
+      "filterMutexPeerOccupied": "\"{peer}\" is already set; cannot configure both",
+      "filterIfTypeTagsPlaceholder": "Select a common type, or type a number (e.g. 22) and press Enter",
+      "filterIfTypeInvalid": "ifType must be a number (e.g. 22); ignored: {values}",
+      "filterMutexFields": {
+        "iftype_exclude": "Excluded Interface Types",
+        "iftype_include": "Included Interface Types",
+        "ifdescr_exclude": "Excluded Interface Names",
+        "ifdescr_include": "Included Interface Names"
+      },
       "advancedSections": {
         "request": "Request",
         "auth": "Authentication",
         "response": "Expected Response",
         "tls": "TLS",
+        "interface_filter": "Interface Filters",
         "other": "Other"
       },
       "keyValueEmpty": "No entries yet. Add one below.",

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -575,7 +575,7 @@
       "filterMutexOptionDisabled": "Already selected in \"{peer}\"",
       "filterMutexPeerOccupied": "\"{peer}\" is already set; cannot configure both",
       "filterIfTypeTagsPlaceholder": "Select a common type, or type a number (e.g. 22) and press Enter",
-      "filterIfTypeInvalid": "ifType must be a number (e.g. 22); ignored: {values}",
+      "filterIfTypeInvalid": "ifType must be a number (e.g. 22); invalid: {values}",
       "filterMutexFields": {
         "iftype_exclude": "Excluded Interface Types",
         "iftype_include": "Included Interface Types",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -575,7 +575,7 @@
       "filterMutexOptionDisabled": "「{peer}」已选中该值",
       "filterMutexPeerOccupied": "「{peer}」已填写，不能同时配置",
       "filterIfTypeTagsPlaceholder": "选择常用类型，或输入数字（如 22）后回车",
-      "filterIfTypeInvalid": "ifType 请填数字（如 22）；已忽略：{values}",
+      "filterIfTypeInvalid": "ifType 请填数字（如 22）；无效值：{values}",
       "filterMutexFields": {
         "iftype_exclude": "排除的接口类型",
         "iftype_include": "仅采集的接口类型",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -569,11 +569,25 @@
       "collectDetectNodeRequired": "请先选择采集节点",
       "advancedConfiguration": "高级配置",
       "advancedConfigurationHint": "按需配置请求内容、认证方式与期望响应判断",
+      "advancedFilterConfiguration": "接口过滤",
+      "advancedFilterConfigurationHint": "按接口类型（ifType）和名称（ifDescr）配置排除或仅采集",
+      "filterMutexConflict": "「{left}」与「{right}」不能同时配置，请先清空其中一侧",
+      "filterMutexOptionDisabled": "「{peer}」已选中该值",
+      "filterMutexPeerOccupied": "「{peer}」已填写，不能同时配置",
+      "filterIfTypeTagsPlaceholder": "选择常用类型，或输入数字（如 22）后回车",
+      "filterIfTypeInvalid": "ifType 请填数字（如 22）；已忽略：{values}",
+      "filterMutexFields": {
+        "iftype_exclude": "排除的接口类型",
+        "iftype_include": "仅采集的接口类型",
+        "ifdescr_exclude": "排除的接口名称",
+        "ifdescr_include": "仅采集的接口名称"
+      },
       "advancedSections": {
         "request": "请求内容",
         "auth": "认证凭据",
         "response": "期望响应",
         "tls": "证书校验",
+        "interface_filter": "接口过滤",
         "other": "其他"
       },
       "keyValueEmpty": "暂无条目，点击下方添加",


### PR DESCRIPTION
## Summary
- 为 SNMP 网络设备采集增加 ifType / ifDescr 接口维度黑白名单（默认排除噪音 ifType），创建/编辑路径规范化并渲染到 Telegraf `tagpass` / `tagdrop` / `tagexclude`
- 同维互斥前后端校验与中英文提示；磁盘 UI 热合并过滤字段；存量配置提供手动 patch 命令（不进入启动）
- 纳入 Jinja / 互斥 / enrich 契约测试；模板去掉静默字面量 fallback，常量同源

## Test plan
- [ ] 新建 SNMP 实例：确认默认 `iftype_exclude` 下发为 tagdrop，且含 `tagexclude = ["ifType"]`
- [ ] 清空排除后保存：子配置不再输出 tagdrop
- [ ] 仅配置 include：输出 tagpass，无同维 tagdrop
- [ ] 同维同时填 include+exclude：前端拦截；后端返回中/英互斥错误
- [ ] 存量 DB UI 无四字段时：打开配置页能热合并出过滤字段
- [ ] 可选：对存量实例执行 `patch_snmp_interface_filters --dry-run` 后再正式 patch

## Scope note
已核对提交范围：仅包含本功能相关的 monitor 服务端/前端与 Telegraf SNMP UI.json + j2；工作区无关 icon / brands / scripts 未纳入本次 PR。