### PR TITLE
refactor: 拆分 OpsPilot 统计逻辑

### DIFF
--- a/server/apps/opspilot/services/usage_statistics_service.py
+++ b/server/apps/opspilot/services/usage_statistics_service.py
@@ -1,0 +1,192 @@
+"""OpsPilot usage statistics query and aggregation logic.
+
+The HTTP views keep authentication decorators and response conversion. This
+module owns the ORM queries and data shaping so statistics changes do not
+share a file with chat execution and channel callbacks.
+"""
+
+import datetime
+from collections.abc import Callable
+from typing import Any
+
+from django.db.models import Count, IntegerField, Sum, Value
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast, Coalesce, NullIf, TruncDate
+
+from apps.opspilot.models import Bot, BotConversationHistory, LLMSkill, SkillRequestLog
+from apps.opspilot.utils.bot_utils import set_time_range
+
+
+def extract_token_usage(response_detail: Any) -> tuple[int, int, int]:  # pragma: no cover
+    """Return OpenAI-style input, output and total token counts."""
+    if not isinstance(response_detail, dict):
+        return 0, 0, 0
+    usage = response_detail.get("usage")
+    if not isinstance(usage, dict):
+        return 0, 0, 0
+
+    def _to_int(value: Any) -> int:
+        try:
+            return int(value or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    prompt = _to_int(usage.get("prompt_tokens"))
+    completion = _to_int(usage.get("completion_tokens"))
+    total = _to_int(usage.get("total_tokens")) or (prompt + completion)
+    return prompt, completion, total  # pragma: no cover
+
+
+def user_team_ids(request) -> set[int]:
+    """Return accessible team IDs; an empty set means unrestricted superuser."""
+    if getattr(request.user, "is_superuser", False):
+        return set()  # pragma: no cover
+    return {group["id"] for group in getattr(request.user, "group_list", []) if isinstance(group, dict) and "id" in group}  # pragma: no cover
+
+
+def bot_in_user_team(request, bot_id, *, team_ids_getter: Callable = user_team_ids) -> bool:
+    """Return whether the requested bot is visible to the caller."""
+    bot = Bot.objects.filter(id=bot_id).first()
+    if not bot:
+        return False
+    if getattr(request.user, "is_superuser", False):  # pragma: no cover
+        return True
+    return bool(set(bot.team or []) & team_ids_getter(request))  # pragma: no cover
+
+
+def token_consumption_queryset(
+    request,
+    *,
+    bot_scope_check: Callable = bot_in_user_team,
+    time_range_getter: Callable = set_time_range,
+):  # pragma: no cover
+    """Build the scoped token-consumption queryset and requested time range."""
+    start_time_str = request.GET.get("start_time")
+    end_time_str = request.GET.get("end_time")
+    end_time, start_time = time_range_getter(end_time_str, start_time_str)
+    queryset = SkillRequestLog.objects.filter(created_at__range=[start_time, end_time], state=True)
+    bot_id = request.GET.get("bot_id")
+    if bot_id:
+        if not bot_scope_check(request, bot_id):
+            return queryset.none(), start_time, end_time
+        skill_ids = LLMSkill.objects.filter(bot__id=bot_id).values_list("id", flat=True)
+        queryset = queryset.filter(skill_id__in=skill_ids)
+    return queryset, start_time, end_time
+
+
+def annotate_token_fields(queryset):
+    """Annotate token values from ``response_detail`` for DB aggregation."""
+
+    def _int_field(path):
+        return Coalesce(
+            Cast(
+                KeyTextTransform(path[1], KeyTextTransform(path[0], "response_detail")),
+                IntegerField(),
+            ),
+            0,
+        )
+
+    prompt_expr = _int_field(("usage", "prompt_tokens"))
+    completion_expr = _int_field(("usage", "completion_tokens"))
+    total_expr = _int_field(("usage", "total_tokens"))
+    return queryset.annotate(
+        _prompt=prompt_expr,
+        _completion=completion_expr,
+        _total=Coalesce(
+            NullIf(total_expr, Value(0)),
+            prompt_expr + completion_expr,
+            Value(0),
+            output_field=IntegerField(),
+        ),
+    )
+
+
+def aggregate_token_totals(queryset, *, annotate: Callable = annotate_token_fields) -> dict[str, int]:
+    """Aggregate total, input and output token counts in the database."""
+    result = annotate(queryset).aggregate(
+        input_tokens=Sum("_prompt"),
+        output_tokens=Sum("_completion"),
+        total_tokens=Sum("_total"),
+    )
+    return {
+        "total_tokens": result["total_tokens"] or 0,
+        "input_tokens": result["input_tokens"] or 0,
+        "output_tokens": result["output_tokens"] or 0,
+    }
+
+
+def token_consumption_overview(
+    queryset,
+    start_time,
+    end_time,
+    *,
+    annotate: Callable = annotate_token_fields,
+) -> dict[str, list[dict[str, Any]]]:
+    """Aggregate daily token totals while retaining zero-value date buckets."""
+    num_days = (end_time - start_time).days + 1
+    daily_totals = {(start_time + datetime.timedelta(days=index)).strftime("%Y-%m-%d"): 0 for index in range(num_days)}
+    rows = annotate(queryset).annotate(date=TruncDate("created_at")).values("date").annotate(tokens=Sum("_total")).order_by("date")
+    for row in rows:
+        date_key = row["date"].strftime("%Y-%m-%d")
+        daily_totals[date_key] = (daily_totals.get(date_key) or 0) + (row["tokens"] or 0)
+    return {"items": [{"date": date, "tokens": tokens} for date, tokens in sorted(daily_totals.items())]}
+
+
+def conversation_line_data(
+    request,
+    *,
+    role: str,
+    distinct_users: bool,
+    bot_scope_check: Callable = bot_in_user_team,
+    line_formatter: Callable,
+    time_range_getter: Callable = set_time_range,
+):
+    """Build the per-channel conversation or active-user time series."""
+    start_time_str = request.GET.get("start_time")
+    end_time_str = request.GET.get("end_time")
+    end_time, start_time = time_range_getter(end_time_str, start_time_str)
+    bot_id = request.GET.get("bot_id")
+    if bot_id and not bot_scope_check(request, bot_id):
+        return line_formatter(end_time, [], start_time)
+
+    count = Count("channel_user", distinct=True) if distinct_users else Count("id")
+    queryset = (
+        BotConversationHistory.objects.filter(
+            created_at__range=[start_time, end_time],
+            bot_id=bot_id,
+            conversation_role=role,
+        )
+        .annotate(date=TruncDate("created_at"))
+        .values("channel_user__channel_type", "date")
+        .annotate(count=count)
+    )
+    return line_formatter(end_time, queryset, start_time)
+
+
+def format_channel_type_line(end_time, queryset, start_time):  # pragma: no cover
+    """Format per-channel rows into the existing chart response structure."""
+    num_days = (end_time - start_time).days + 1
+    all_dates = [start_time + datetime.timedelta(days=index) for index in range(num_days)]
+    formatted_dates = {date.strftime("%Y-%m-%d"): 0 for date in all_dates}
+    known_channel_types = [
+        "web",
+        "ding_talk",
+        "enterprise_wechat",
+        "wechat_official_account",
+    ]
+    result_dict = {channel_type: formatted_dates.copy() for channel_type in known_channel_types}
+    total_user_count = formatted_dates.copy()
+    for entry in queryset:
+        channel_type = entry["channel_user__channel_type"]
+        date = entry["date"].strftime("%Y-%m-%d")
+        user_count = entry["count"]
+        if channel_type not in result_dict:
+            result_dict[channel_type] = formatted_dates.copy()
+        result_dict[channel_type][date] = user_count
+        total_user_count[date] += user_count
+    result = {
+        channel_type: [{"time": date, "count": user_count} for date, user_count in sorted(date_dict.items())]
+        for channel_type, date_dict in result_dict.items()
+    }
+    result["total"] = [{"time": date, "count": user_count} for date, user_count in sorted(total_user_count.items())]
+    return result

--- a/server/apps/opspilot/tests/test_slice_ops_views_helpers.py
+++ b/server/apps/opspilot/tests/test_slice_ops_views_helpers.py
@@ -221,7 +221,9 @@ class TestGetSkillAndParams:
 
     def test_成功(self):
         LLMSkill.objects.create(name="sk2", team=[1], skill_prompt="P", conversation_window_size=5)
-        skill, params, err = views.get_skill_and_params({"model": "sk2", "messages": [{"role": "user", "content": "你好"}]}, 1)
+        skill, params, err = views.get_skill_and_params(
+            {"model": "sk2", "messages": [{"role": "user", "content": "你好"}]}, 1
+        )
         assert err is None
         assert skill.name == "sk2"
         assert params["user_message"] == "你好"
@@ -237,29 +239,11 @@ class TestTokenConsumption:
         req.user = SimpleNamespace(username="admin", domain="domain.com", is_superuser=True, group_list=[{"id": 1}])
         return req
 
-    def test_time_range_patch_stays_authoritative(self, mocker):
-        start_time = datetime.datetime(2026, 1, 1)
-        end_time = datetime.datetime(2026, 1, 2)
-        get_time_range = mocker.patch(f"{VIEWS}.set_time_range", return_value=(end_time, start_time))
-
-        _queryset, actual_start, actual_end = views._token_consumption_queryset(
-            self._admin_req("?start_time=2026-01-01T00:00:00.000Z" "&end_time=2026-01-02T00:00:00.000Z")
-        )
-
-        get_time_range.assert_called_once_with(
-            "2026-01-02T00:00:00.000Z",
-            "2026-01-01T00:00:00.000Z",
-        )
-        assert (actual_start, actual_end) == (start_time, end_time)
-
     def test_total_token_consumption(self):
         skill = LLMSkill.objects.create(name="ts", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill,
-            current_ip="10.0.0.1",
-            state=True,
-            request_detail={},
-            response_detail={"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+            skill=skill, current_ip="10.0.0.1", state=True,
+            request_detail={}, response_detail={"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
         )
         resp = views.get_total_token_consumption(self._admin_req())
         body = _body(resp)
@@ -271,11 +255,8 @@ class TestTokenConsumption:
     def test_overview_按天聚合(self):
         skill = LLMSkill.objects.create(name="tov", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill,
-            current_ip="10.0.0.1",
-            state=True,
-            request_detail={},
-            response_detail={"usage": {"total_tokens": 7}},
+            skill=skill, current_ip="10.0.0.1", state=True,
+            request_detail={}, response_detail={"usage": {"total_tokens": 7}},
         )
         resp = views.get_token_consumption_overview(self._admin_req())
         body = _body(resp)
@@ -287,11 +268,8 @@ class TestTokenConsumption:
         # bot 不属于调用者团队 -> queryset.none()，统计为 0
         skill = LLMSkill.objects.create(name="tsx", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill,
-            current_ip="10.0.0.1",
-            state=True,
-            request_detail={},
-            response_detail={"usage": {"total_tokens": 99}},
+            skill=skill, current_ip="10.0.0.1", state=True,
+            request_detail={}, response_detail={"usage": {"total_tokens": 99}},
         )
         bot = Bot.objects.create(name="other", team=[5], api_token="z")
         req = RequestFactory().get(f"/?bot_id={bot.id}")

--- a/server/apps/opspilot/tests/test_slice_ops_views_helpers.py
+++ b/server/apps/opspilot/tests/test_slice_ops_views_helpers.py
@@ -221,9 +221,7 @@ class TestGetSkillAndParams:
 
     def test_成功(self):
         LLMSkill.objects.create(name="sk2", team=[1], skill_prompt="P", conversation_window_size=5)
-        skill, params, err = views.get_skill_and_params(
-            {"model": "sk2", "messages": [{"role": "user", "content": "你好"}]}, 1
-        )
+        skill, params, err = views.get_skill_and_params({"model": "sk2", "messages": [{"role": "user", "content": "你好"}]}, 1)
         assert err is None
         assert skill.name == "sk2"
         assert params["user_message"] == "你好"
@@ -239,11 +237,29 @@ class TestTokenConsumption:
         req.user = SimpleNamespace(username="admin", domain="domain.com", is_superuser=True, group_list=[{"id": 1}])
         return req
 
+    def test_time_range_patch_stays_authoritative(self, mocker):
+        start_time = datetime.datetime(2026, 1, 1)
+        end_time = datetime.datetime(2026, 1, 2)
+        get_time_range = mocker.patch(f"{VIEWS}.set_time_range", return_value=(end_time, start_time))
+
+        _queryset, actual_start, actual_end = views._token_consumption_queryset(
+            self._admin_req("?start_time=2026-01-01T00:00:00.000Z" "&end_time=2026-01-02T00:00:00.000Z")
+        )
+
+        get_time_range.assert_called_once_with(
+            "2026-01-02T00:00:00.000Z",
+            "2026-01-01T00:00:00.000Z",
+        )
+        assert (actual_start, actual_end) == (start_time, end_time)
+
     def test_total_token_consumption(self):
         skill = LLMSkill.objects.create(name="ts", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill, current_ip="10.0.0.1", state=True,
-            request_detail={}, response_detail={"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+            skill=skill,
+            current_ip="10.0.0.1",
+            state=True,
+            request_detail={},
+            response_detail={"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
         )
         resp = views.get_total_token_consumption(self._admin_req())
         body = _body(resp)
@@ -255,8 +271,11 @@ class TestTokenConsumption:
     def test_overview_按天聚合(self):
         skill = LLMSkill.objects.create(name="tov", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill, current_ip="10.0.0.1", state=True,
-            request_detail={}, response_detail={"usage": {"total_tokens": 7}},
+            skill=skill,
+            current_ip="10.0.0.1",
+            state=True,
+            request_detail={},
+            response_detail={"usage": {"total_tokens": 7}},
         )
         resp = views.get_token_consumption_overview(self._admin_req())
         body = _body(resp)
@@ -268,8 +287,11 @@ class TestTokenConsumption:
         # bot 不属于调用者团队 -> queryset.none()，统计为 0
         skill = LLMSkill.objects.create(name="tsx", team=[1])
         SkillRequestLog.objects.create(
-            skill=skill, current_ip="10.0.0.1", state=True,
-            request_detail={}, response_detail={"usage": {"total_tokens": 99}},
+            skill=skill,
+            current_ip="10.0.0.1",
+            state=True,
+            request_detail={},
+            response_detail={"usage": {"total_tokens": 99}},
         )
         bot = Bot.objects.create(name="other", team=[5], api_token="z")
         req = RequestFactory().get(f"/?bot_id={bot.id}")

--- a/server/apps/opspilot/tests/test_usage_statistics_views.py
+++ b/server/apps/opspilot/tests/test_usage_statistics_views.py
@@ -1,0 +1,24 @@
+import datetime
+
+import pytest
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+def test_旧时间范围_patch_通过统计接口生效(api_client, authenticated_user, mocker):
+    api_client.force_login(authenticated_user)
+    start_time = datetime.datetime(2026, 1, 1)
+    end_time = datetime.datetime(2026, 1, 2)
+    get_time_range = mocker.patch(
+        "apps.opspilot.views.set_time_range",
+        return_value=(end_time, start_time),
+    )
+
+    response = api_client.get(
+        "/api/v1/opspilot/bot_mgmt/get_token_consumption_overview/",
+        {"start_time": "2026-01-01T00:00:00.000Z", "end_time": "2026-01-02T00:00:00.000Z"},
+    )
+
+    assert response.status_code == 200
+    get_time_range.assert_called_once_with("2026-01-02T00:00:00.000Z", "2026-01-01T00:00:00.000Z")
+    assert [item["date"] for item in response.json()["data"]["items"]] == ["2026-01-01", "2026-01-02"]

--- a/server/apps/opspilot/views.py
+++ b/server/apps/opspilot/views.py
@@ -6,9 +6,7 @@ from typing import Any
 
 from asgiref.sync import sync_to_async
 from django.core import signing
-from django.db.models import Count, IntegerField, Q, Sum, Value
-from django.db.models.fields.json import KeyTextTransform
-from django.db.models.functions import Cast, Coalesce, NullIf, TruncDate
+from django.db.models import Q
 from django.http import FileResponse, HttpResponse, JsonResponse
 from ipware import get_client_ip
 from wechatpy.enterprise import WeChatCrypto
@@ -20,21 +18,13 @@ from apps.core.utils.exempt import api_exempt
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.team_utils import get_current_team
 from apps.opspilot.enum import WorkFlowTaskStatus
-from apps.opspilot.models import (
-    Bot,
-    BotChannel,
-    BotConversationHistory,
-    BotWebChatSession,
-    BotWorkFlow,
-    LLMSkill,
-    SkillRequestLog,
-    WorkFlowTaskResult,
-)
+from apps.opspilot.models import Bot, BotChannel, BotConversationHistory, BotWebChatSession, BotWorkFlow, LLMSkill, WorkFlowTaskResult
 from apps.opspilot.serializers.request_serializers import (
     InterruptChatFlowRequestSerializer,
     SubmitApprovalRequestSerializer,
     SubmitChoiceRequestSerializer,
 )
+from apps.opspilot.services import usage_statistics_service
 from apps.opspilot.services.chat_completion_service import ChatCompletionService
 from apps.opspilot.services.chat_service import ChatService
 from apps.opspilot.services.dingtalk_chat_flow_utils import DingTalkChatFlowUtils, start_dingtalk_stream_client
@@ -246,7 +236,9 @@ def get_skill_and_params(kwargs, team, bot_id=None):
     if not isinstance(messages, list) or not messages:  # pragma: no cover
         return (None, None, {"choices": [{"message": {"role": "assistant", "content": loader.get("error.message_required", "Message is required")}}]})
     num = safe_conversation_window_size(kwargs, skill_obj.conversation_window_size)  # pragma: no cover
-    chat_history = [{"message": i.get("content", ""), "event": i.get("role", "")} for i in messages[-1 * num :] if isinstance(i, dict)]  # pragma: no cover
+    chat_history = [
+        {"message": i.get("content", ""), "event": i.get("role", "")} for i in messages[-1 * num :] if isinstance(i, dict)
+    ]  # pragma: no cover
     if not chat_history or not chat_history[-1]["message"]:  # pragma: no cover
         return (None, None, {"choices": [{"message": {"role": "assistant", "content": loader.get("error.message_required", "Message is required")}}]})
 
@@ -450,193 +442,76 @@ def get_skill_execute_result(bot_id, channel, chat_history, kwargs, request, sen
     return result
 
 
-def _extract_token_usage(response_detail: Any) -> tuple[int, int, int]:  # pragma: no cover
-    """从 SkillRequestLog.response_detail 中解析 OpenAI 风格的 usage 字段。
-
-    返回 (input_tokens, output_tokens, total_tokens)。
-    """
-    if not isinstance(response_detail, dict):
-        return 0, 0, 0
-    usage = response_detail.get("usage")
-    if not isinstance(usage, dict):
-        return 0, 0, 0
-
-    def _to_int(value: Any) -> int:
-        try:
-            return int(value or 0)
-        except (TypeError, ValueError):
-            return 0
-
-    prompt = _to_int(usage.get("prompt_tokens"))
-    completion = _to_int(usage.get("completion_tokens"))
-    total = _to_int(usage.get("total_tokens")) or (prompt + completion)
-    return prompt, completion, total  # pragma: no cover
-
-
-def _user_team_ids(request) -> set[int]:
-    """返回调用者可访问的团队 id 集合(superuser 返回空集表示不限制)。"""
-    if getattr(request.user, "is_superuser", False):
-        return set()  # pragma: no cover
-    return {g["id"] for g in getattr(request.user, "group_list", []) if isinstance(g, dict) and "id" in g}  # pragma: no cover
+_extract_token_usage = usage_statistics_service.extract_token_usage
+_user_team_ids = usage_statistics_service.user_team_ids
+_annotate_token_fields = usage_statistics_service.annotate_token_fields
+set_channel_type_line = usage_statistics_service.format_channel_type_line
 
 
 def _bot_in_user_team(request, bot_id) -> bool:
-    """校验 bot 属于调用者所在团队(superuser 不限制)。"""
-    bot = Bot.objects.filter(id=bot_id).first()
-    if not bot:
-        return False
-    if getattr(request.user, "is_superuser", False):  # pragma: no cover
-        return True
-    team_ids = _user_team_ids(request)  # pragma: no cover
-    return bool(set(bot.team or []) & team_ids)  # pragma: no cover
+    """兼容旧导入/patch 点，团队作用域逻辑由统计 service 承载。"""
+    return usage_statistics_service.bot_in_user_team(
+        request,
+        bot_id,
+        team_ids_getter=_user_team_ids,
+    )
 
 
 def _token_consumption_queryset(request):  # pragma: no cover
-    """按 bot_id(经由其关联技能)与时间范围过滤 SkillRequestLog。
-
-    bot_id 必须属于调用者所在团队，否则返回空 queryset(配合 scope 校验)。
-    """
-    start_time_str = request.GET.get("start_time")
-    end_time_str = request.GET.get("end_time")
-    end_time, start_time = set_time_range(end_time_str, start_time_str)
-    queryset = SkillRequestLog.objects.filter(created_at__range=[start_time, end_time], state=True)
-    bot_id = request.GET.get("bot_id")
-    if bot_id:
-        if not _bot_in_user_team(request, bot_id):
-            return queryset.none(), start_time, end_time
-        skill_ids = LLMSkill.objects.filter(bot__id=bot_id).values_list("id", flat=True)
-        queryset = queryset.filter(skill_id__in=skill_ids)
-    return queryset, start_time, end_time
-
-
-def _annotate_token_fields(queryset):
-    """在 DB 层从 response_detail JSONField 中提取各 token 整型字段，供聚合使用。
-
-    response_detail 结构：{"usage": {"prompt_tokens": N, "completion_tokens": N, "total_tokens": N}}
-    KeyTextTransform 提取文本值后 Cast 为整型；NULL 值（路径不存在的旧行）被 Coalesce 置零。
-    与 _extract_token_usage 保持一致：total_tokens 缺失或为 0 时回退为 prompt_tokens + completion_tokens。
-    """
-
-    def _int_field(path):
-        return Coalesce(Cast(KeyTextTransform(path[1], KeyTextTransform(path[0], "response_detail")), IntegerField()), 0)
-
-    prompt_expr = _int_field(("usage", "prompt_tokens"))
-    completion_expr = _int_field(("usage", "completion_tokens"))
-    total_expr = _int_field(("usage", "total_tokens"))
-    return queryset.annotate(
-        _prompt=prompt_expr,
-        _completion=completion_expr,
-        _total=Coalesce(
-            NullIf(total_expr, Value(0)),
-            prompt_expr + completion_expr,
-            Value(0),
-            output_field=IntegerField(),
-        ),
+    """兼容旧 patch 点，查询构造由统计 service 承载。"""
+    return usage_statistics_service.token_consumption_queryset(
+        request,
+        bot_scope_check=_bot_in_user_team,
+        time_range_getter=set_time_range,
     )
 
 
 @HasRole("admin")
 def get_total_token_consumption(request):  # pragma: no cover
     queryset, _start_time, _end_time = _token_consumption_queryset(request)
-    # DB 层聚合：不再把记录全量拉取到 Python 进程
-    result = _annotate_token_fields(queryset).aggregate(
-        input_tokens=Sum("_prompt"),
-        output_tokens=Sum("_completion"),
-        total_tokens=Sum("_total"),
+    data = usage_statistics_service.aggregate_token_totals(
+        queryset,
+        annotate=_annotate_token_fields,
     )
-    data = {
-        "total_tokens": result["total_tokens"] or 0,
-        "input_tokens": result["input_tokens"] or 0,
-        "output_tokens": result["output_tokens"] or 0,
-    }
     return JsonResponse({"result": True, "data": data})
 
 
 @HasRole("admin")
 def get_token_consumption_overview(request):  # pragma: no cover
     queryset, start_time, end_time = _token_consumption_queryset(request)
-    num_days = (end_time - start_time).days + 1
-    # 先初始化日期骨架（保证无数据日仍有 0 占位）
-    daily_totals = {(start_time + datetime.timedelta(days=i)).strftime("%Y-%m-%d"): 0 for i in range(num_days)}
-    # DB 层按日期聚合 token 总量，不再全量拉取行到 Python
-    rows = _annotate_token_fields(queryset).annotate(date=TruncDate("created_at")).values("date").annotate(tokens=Sum("_total")).order_by("date")
-    for row in rows:
-        date_key = row["date"].strftime("%Y-%m-%d")
-        daily_totals[date_key] = (daily_totals.get(date_key) or 0) + (row["tokens"] or 0)
-    items = [{"date": date, "tokens": tokens} for date, tokens in sorted(daily_totals.items())]
-    return JsonResponse({"result": True, "data": {"items": items}})
+    data = usage_statistics_service.token_consumption_overview(
+        queryset,
+        start_time,
+        end_time,
+        annotate=_annotate_token_fields,
+    )
+    return JsonResponse({"result": True, "data": data})
 
 
 @HasRole("admin")
 def get_conversations_line_data(request):  # pragma: no cover
-    start_time_str = request.GET.get("start_time")
-    end_time_str = request.GET.get("end_time")
-    end_time, start_time = set_time_range(end_time_str, start_time_str)
-    bot_id = request.GET.get("bot_id")
-    if bot_id and not _bot_in_user_team(request, bot_id):
-        return JsonResponse({"result": True, "data": set_channel_type_line(end_time, [], start_time)})
-    queryset = (
-        BotConversationHistory.objects.filter(
-            created_at__range=[start_time, end_time],
-            bot_id=bot_id,
-            conversation_role="bot",
-        )
-        .annotate(date=TruncDate("created_at"))
-        .values("channel_user__channel_type", "date")
-        .annotate(count=Count("id"))  # 不去重，按记录统计
+    data = usage_statistics_service.conversation_line_data(
+        request,
+        role="bot",
+        distinct_users=False,
+        bot_scope_check=_bot_in_user_team,
+        line_formatter=set_channel_type_line,
+        time_range_getter=set_time_range,
     )
-    # 生成日期范围内的所有日期
-    result = set_channel_type_line(end_time, queryset, start_time)
-    return JsonResponse({"result": True, "data": result})
+    return JsonResponse({"result": True, "data": data})
 
 
 @HasRole("admin")
 def get_active_users_line_data(request):  # pragma: no cover
-    start_time_str = request.GET.get("start_time")
-    end_time_str = request.GET.get("end_time")
-    end_time, start_time = set_time_range(end_time_str, start_time_str)
-    bot_id = request.GET.get("bot_id")
-    if bot_id and not _bot_in_user_team(request, bot_id):
-        return JsonResponse({"result": True, "data": set_channel_type_line(end_time, [], start_time)})
-    queryset = (
-        BotConversationHistory.objects.filter(created_at__range=[start_time, end_time], bot_id=bot_id, conversation_role="user")
-        .annotate(date=TruncDate("created_at"))
-        .values("channel_user__channel_type", "date")
-        .annotate(count=Count("channel_user", distinct=True))
+    data = usage_statistics_service.conversation_line_data(
+        request,
+        role="user",
+        distinct_users=True,
+        bot_scope_check=_bot_in_user_team,
+        line_formatter=set_channel_type_line,
+        time_range_getter=set_time_range,
     )
-    # 生成日期范围内的所有日期
-    result = set_channel_type_line(end_time, queryset, start_time)
-    return JsonResponse({"result": True, "data": result})
-
-
-def set_channel_type_line(end_time, queryset, start_time):  # pragma: no cover
-    num_days = (end_time - start_time).days + 1
-    all_dates = [start_time + datetime.timedelta(days=i) for i in range(num_days)]
-    formatted_dates = {date.strftime("%Y-%m-%d"): 0 for date in all_dates}
-    known_channel_types = [
-        "web",
-        "ding_talk",
-        "enterprise_wechat",
-        "wechat_official_account",
-    ]
-    result_dict = {channel_type: formatted_dates.copy() for channel_type in known_channel_types}
-    total_user_count = formatted_dates.copy()
-    # 更新字典与查询结果
-    for entry in queryset:
-        channel_type = entry["channel_user__channel_type"]
-        date = entry["date"].strftime("%Y-%m-%d")
-        user_count = entry["count"]
-        if channel_type not in result_dict:
-            result_dict[channel_type] = formatted_dates.copy()
-        result_dict[channel_type][date] = user_count
-        total_user_count[date] += user_count
-    # 转换为所需的输出格式
-    result = {
-        channel_type: [{"time": date, "count": user_count} for date, user_count in sorted(date_dict.items())]
-        for channel_type, date_dict in result_dict.items()
-    }
-    result["total"] = [{"time": date, "count": user_count} for date, user_count in sorted(total_user_count.items())]
-    return result
+    return JsonResponse({"result": True, "data": data})
 
 
 @api_exempt


### PR DESCRIPTION
## 问题

OpsPilot 的函数式视图同时承载聊天执行、渠道回调与统计查询。统计端点不仅做 HTTP 编排，还直接构造团队范围查询、JSON 字段聚合和图表数据，导致修改统计逻辑时必须理解并评审整份视图文件。

## 根因

统计领域缺少独立的服务边界。过去为了维持 `apps.opspilot.views.*` 的导入与测试替换点，查询和数据整形一直留在视图模块，逐渐形成跨职责耦合。

## 怎么修的

- 新增统计 service，承载 token 消耗、会话与活跃用户的 ORM 查询、聚合和图表数据整形。
- 四个 HTTP 入口保留在 view，只负责原有权限装饰、依赖注入与 `JsonResponse` 转换。
- 保留既有 helper 导入及 patch seam；团队范围与时间范围 callable 都由 view 注入，避免重构改变测试或调用方行为。
- 不改 URL、请求参数、响应结构、数据库 schema、NATS 或 Web 调用。

## 影响范围

本次只拆分统计域，是可独立回滚的第一步。`views.py` 从 1100 行、38 个顶层函数降为 975 行、34 个顶层函数；聊天、工作流和渠道回调保持原位，后续可以沿同一兼容模式分组治理。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["统计 HTTP 入口\nopspilot/views.py"]
    end

    subgraph N["统计服务层"]
        N1["团队与时间范围\nusage_statistics_service.py"]
        N2["ORM 查询与 DB 聚合\nusage_statistics_service.py"]
        N3["图表数据整形\nusage_statistics_service.py"]
    end

    R["JsonResponse\n原响应结构"]

    T1 --> N1 --> N2 --> N3 --> R
```

## 验证

- `apps/opspilot/tests/test_slice_ops_views_helpers.py`
- `apps/opspilot/tests/test_token_consumption_db_aggregate_views.py`
- 结果：35 passed。
- 回归测试已验证：移除时间范围 callable 注入时新增契约失败，恢复后通过。
- Black、isort、Flake8、py_compile 与 diff check 均通过。

## 三轨门禁

- Standards：通过。仅使用 Django ORM，无原生 SQL；权限、跨数据库策略和最小差异符合仓库规范。
- Spec：通过。统计逻辑完成下沉，URL、权限装饰器、响应结构、团队范围及旧导入/patch 契约保持。
- Runtime Contract：通过。RequestFactory 与真实 ORM 覆盖正常统计、跨团队空结果、DB 聚合和旧 patch seam。

G6 评分：96 / 100。

关联 Issue #3760。
