### PR TITLE
bugfix: 收敛采集任务详情结果负载

### DIFF
--- a/server/apps/cmdb/serializers/collect_serializer.py
+++ b/server/apps/cmdb/serializers/collect_serializer.py
@@ -2,29 +2,34 @@
 # @File: collect_serializer.py
 # @Time: 2025/3/3 13:58
 # @Author: windyzhao
-from rest_framework import serializers
 import copy
 
-from apps.cmdb.constants.constants import CollectDriverTypes, CollectPluginTypes, PERMISSION_TASK
+from rest_framework import serializers
+
+from apps.cmdb.constants.constants import PERMISSION_TASK, CollectDriverTypes, CollectPluginTypes
 from apps.cmdb.models.collect_model import (
     ALLOWED_TOPOLOGY_FALLBACK_STRATEGIES,
     ALLOWED_TOPOLOGY_PROTOCOLS,
-    CollectModels,
     DEFAULT_TOPOLOGY_FALLBACK_STRATEGY,
     DEFAULT_TOPOLOGY_MIN_CONFIDENCE,
     DEFAULT_TOPOLOGY_PROTOCOLS,
+    CollectModels,
     OidMapping,
     normalize_topology_contract,
 )
 from apps.cmdb.services.collect_credential_pool_service import CollectCredentialPoolService
 from apps.cmdb.services.encrypt_collect_password import get_collect_model_passwords
-from apps.cmdb.services.network_config_file_policy import (
-    normalize_network_config_instance,
-    validate_commands,
-    validate_network_config_instance,
-)
+from apps.cmdb.services.network_config_file_policy import normalize_network_config_instance, validate_commands, validate_network_config_instance
 from apps.cmdb.utils.config_file_path import validate_absolute_path
-from apps.core.utils.serializers import UsernameSerializer, AuthSerializer
+from apps.core.utils.serializers import AuthSerializer, UsernameSerializer
+
+COLLECT_RESULT_PAYLOAD_FIELDS = (
+    "collect_data",
+    "collect_digest",
+    "format_data",
+    "topology_snapshot",
+)
+
 
 class CollectModelSerializer(AuthSerializer):
     permission_key = PERMISSION_TASK
@@ -82,13 +87,9 @@ class CollectModelSerializer(AuthSerializer):
             if invalid_protocols:
                 errors["topology_protocols"] = f"仅支持以下拓扑协议: {', '.join(ALLOWED_TOPOLOGY_PROTOCOLS)}"
 
-        topology_fallback_strategy = params.get(
-            "topology_fallback_strategy", DEFAULT_TOPOLOGY_FALLBACK_STRATEGY
-        )
+        topology_fallback_strategy = params.get("topology_fallback_strategy", DEFAULT_TOPOLOGY_FALLBACK_STRATEGY)
         if topology_fallback_strategy not in ALLOWED_TOPOLOGY_FALLBACK_STRATEGIES:
-            errors["topology_fallback_strategy"] = (
-                "拓扑回退策略不合法"
-            )
+            errors["topology_fallback_strategy"] = "拓扑回退策略不合法"
 
         raw_min_confidence = params.get("min_confidence", DEFAULT_TOPOLOGY_MIN_CONFIDENCE)
         try:
@@ -162,11 +163,7 @@ class CollectModelSerializer(AuthSerializer):
             if credential_items is None and self.instance is not None:
                 credential_items = self.instance.credential
             credential_pool = CollectCredentialPoolService.normalize_pool(copy.deepcopy(credential_items))
-            need_enable = any(
-                bool(item.get("enable_password"))
-                for item in credential_pool
-                if isinstance(item, dict)
-            )
+            need_enable = any(bool(item.get("enable_password")) for item in credential_pool if isinstance(item, dict))
 
             attrs["instances"] = validated_instances
             attrs["ip_range"] = ""
@@ -227,6 +224,13 @@ class CollectModelSerializer(AuthSerializer):
             representation["params"] = self._normalize_topology_params(raw_params)
 
         return representation
+
+
+class CollectModelDetailSerializer(CollectModelSerializer):
+    """采集任务配置详情，不内联可通过 ``info`` 接口读取的结果数据。"""
+
+    class Meta(CollectModelSerializer.Meta):
+        exclude = ("execution_claim_token", *COLLECT_RESULT_PAYLOAD_FIELDS)
 
 
 class CollectModelIdStatusSerializer(AuthSerializer):

--- a/server/apps/cmdb/serializers/collect_serializer.py
+++ b/server/apps/cmdb/serializers/collect_serializer.py
@@ -30,6 +30,42 @@ COLLECT_RESULT_PAYLOAD_FIELDS = (
     "topology_snapshot",
 )
 
+COLLECT_MODEL_DETAIL_FIELDS = (
+    "id",
+    "name",
+    "task_type",
+    "driver_type",
+    "model_id",
+    "is_interval",
+    "cycle_value_type",
+    "cycle_value",
+    "scan_cycle",
+    "ip_range",
+    "instances",
+    "access_point",
+    "credential",
+    "timeout",
+    "exec_status",
+    "exec_time",
+    "task_id",
+    "params",
+    "plugin_id",
+    "input_method",
+    "data_cleanup_strategy",
+    "expire_days",
+    "team",
+    "is_system",
+    "is_visible",
+    "system_code",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+    "domain",
+    "updated_by_domain",
+    "permissions",
+)
+
 
 class CollectModelSerializer(AuthSerializer):
     permission_key = PERMISSION_TASK
@@ -229,8 +265,9 @@ class CollectModelSerializer(AuthSerializer):
 class CollectModelDetailSerializer(CollectModelSerializer):
     """采集任务配置详情，不内联可通过 ``info`` 接口读取的结果数据。"""
 
-    class Meta(CollectModelSerializer.Meta):
-        exclude = ("execution_claim_token", *COLLECT_RESULT_PAYLOAD_FIELDS)
+    class Meta:
+        model = CollectModels
+        fields = COLLECT_MODEL_DETAIL_FIELDS
 
 
 class CollectModelIdStatusSerializer(AuthSerializer):

--- a/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
+++ b/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
@@ -1,0 +1,155 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.cmdb.models.collect_model import CollectModels
+from apps.cmdb.serializers.collect_serializer import CollectModelDetailSerializer, CollectModelSerializer
+from apps.cmdb.views.collect import CollectModelViewSet
+
+RESULT_PAYLOAD_FIELDS = {
+    "collect_data",
+    "collect_digest",
+    "format_data",
+    "topology_snapshot",
+}
+
+
+def _request(*, query_params=None):
+    return SimpleNamespace(
+        user=SimpleNamespace(group_list=[]),
+        COOKIES={},
+        query_params=query_params or {},
+    )
+
+
+def _retrieve(task, user, monkeypatch, *, include_result_data=None):
+    monkeypatch.setattr(
+        CollectModelViewSet,
+        "get_queryset_by_permission",
+        lambda self, request, queryset, permission_key=None: queryset,
+    )
+    path = f"/cmdb/api/collect/{task.id}/"
+    if include_result_data is not None:
+        path = f"{path}?include_result_data={include_result_data}"
+    request = APIRequestFactory().get(path)
+    force_authenticate(request, user=user)
+    return CollectModelViewSet.as_view({"get": "retrieve"})(request, pk=task.id)
+
+
+@pytest.mark.django_db
+def test_collect_model_detail_serializer_bounds_default_payload_and_keeps_masked_credential(monkeypatch):
+    large_value = "x" * 256_000
+    instance = CollectModels(
+        model_id="host",
+        driver_type="job",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "encrypted"}],
+        collect_data={"items": large_value},
+        collect_digest={"items": large_value},
+        format_data={"items": large_value},
+        topology_snapshot={"items": large_value},
+    )
+    monkeypatch.setattr(
+        "apps.cmdb.serializers.collect_serializer.get_collect_model_passwords",
+        lambda collect_model_id, driver_type=None: ["password"],
+    )
+    monkeypatch.setattr(
+        "apps.core.utils.serializers.get_permission_rules",
+        lambda user, current_team, app_name, permission_key, include_children: {},
+    )
+
+    request = _request()
+    legacy_data = CollectModelSerializer(instance=instance, context={"request": request}).data
+    detail_data = CollectModelDetailSerializer(instance=instance, context={"request": request}).data
+
+    assert RESULT_PAYLOAD_FIELDS.isdisjoint(detail_data)
+    assert detail_data["credential"] == [{"credential_id": "cred-1", "username": "admin", "password": "******"}]
+    assert len(json.dumps(legacy_data)) > len(json.dumps(detail_data)) + 1_000_000
+
+
+@pytest.mark.django_db
+def test_collect_model_retrieve_defaults_to_bounded_payload(authenticated_user, monkeypatch):
+    authenticated_user.is_superuser = True
+    authenticated_user.save(update_fields=["is_superuser"])
+    task = CollectModels.objects.create(
+        name="bounded-detail",
+        task_type="host",
+        model_id="host",
+        cycle_value_type="cycle",
+        team=[1],
+        collect_data={"items": "x" * 4096},
+        collect_digest={"items": "x" * 4096},
+        format_data={"items": "x" * 4096},
+        topology_snapshot={"items": "x" * 4096},
+    )
+
+    response = _retrieve(task, authenticated_user, monkeypatch)
+
+    assert response.status_code == 200
+    assert RESULT_PAYLOAD_FIELDS.isdisjoint(response.data)
+
+
+@pytest.mark.django_db
+def test_collect_model_retrieve_keeps_legacy_result_payload_behind_explicit_switch(
+    authenticated_user,
+    monkeypatch,
+):
+    authenticated_user.is_superuser = True
+    authenticated_user.save(update_fields=["is_superuser"])
+    task = CollectModels.objects.create(
+        name="legacy-detail",
+        task_type="host",
+        model_id="host",
+        cycle_value_type="cycle",
+        team=[1],
+        collect_data={"items": [1]},
+        collect_digest={"items": [2]},
+        format_data={"items": [3]},
+        topology_snapshot={"items": [4]},
+    )
+
+    response = _retrieve(task, authenticated_user, monkeypatch, include_result_data="true")
+
+    assert response.status_code == 200
+    assert RESULT_PAYLOAD_FIELDS.issubset(response.data)
+
+
+@pytest.mark.parametrize(
+    ("query_params", "expected_serializer"),
+    [
+        ({}, CollectModelDetailSerializer),
+        ({"include_result_data": "false"}, CollectModelDetailSerializer),
+        ({"include_result_data": "1"}, CollectModelSerializer),
+        ({"include_result_data": "true"}, CollectModelSerializer),
+    ],
+)
+def test_collect_model_retrieve_routes_legacy_result_fields_only_when_explicitly_requested(
+    query_params,
+    expected_serializer,
+):
+    view = CollectModelViewSet()
+    view.action = "retrieve"
+    view.request = _request(query_params=query_params)
+
+    assert view.get_serializer_class() is expected_serializer
+
+
+def test_collect_model_retrieve_defers_result_columns_unless_legacy_payload_is_requested(monkeypatch):
+    monkeypatch.setattr(
+        CollectModelViewSet,
+        "get_queryset_by_permission",
+        lambda self, request, queryset, permission_key=None: queryset,
+    )
+    view = CollectModelViewSet()
+    view.action = "retrieve"
+    view.request = _request()
+
+    deferred_fields, is_deferred = view.get_queryset().query.deferred_loading
+
+    assert is_deferred is True
+    assert RESULT_PAYLOAD_FIELDS.issubset(deferred_fields)
+
+    view.request = _request(query_params={"include_result_data": "true"})
+    legacy_deferred_fields, _ = view.get_queryset().query.deferred_loading
+    assert RESULT_PAYLOAD_FIELDS.isdisjoint(legacy_deferred_fields)

--- a/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
+++ b/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
@@ -64,6 +64,7 @@ def test_collect_model_detail_serializer_bounds_default_payload_and_keeps_masked
     detail_data = CollectModelDetailSerializer(instance=instance, context={"request": request}).data
 
     assert RESULT_PAYLOAD_FIELDS.isdisjoint(detail_data)
+    assert set(detail_data) == set(legacy_data) - RESULT_PAYLOAD_FIELDS
     assert detail_data["credential"] == [{"credential_id": "cred-1", "username": "admin", "password": "******"}]
     assert len(json.dumps(legacy_data)) > len(json.dumps(detail_data)) + 1_000_000
 

--- a/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
+++ b/server/apps/cmdb/tests/test_collect_model_detail_serializer.py
@@ -120,6 +120,7 @@ def test_collect_model_retrieve_keeps_legacy_result_payload_behind_explicit_swit
     [
         ({}, CollectModelDetailSerializer),
         ({"include_result_data": "false"}, CollectModelDetailSerializer),
+        ({"include_result_data": "invalid"}, CollectModelDetailSerializer),
         ({"include_result_data": "1"}, CollectModelSerializer),
         ({"include_result_data": "true"}, CollectModelSerializer),
     ],
@@ -135,6 +136,7 @@ def test_collect_model_retrieve_routes_legacy_result_fields_only_when_explicitly
     assert view.get_serializer_class() is expected_serializer
 
 
+@pytest.mark.django_db
 def test_collect_model_retrieve_defers_result_columns_unless_legacy_payload_is_requested(monkeypatch):
     monkeypatch.setattr(
         CollectModelViewSet,
@@ -144,12 +146,18 @@ def test_collect_model_retrieve_defers_result_columns_unless_legacy_payload_is_r
     view = CollectModelViewSet()
     view.action = "retrieve"
     view.request = _request()
+    task = CollectModels.objects.create(
+        name="deferred-detail",
+        task_type="host",
+        model_id="host",
+        cycle_value_type="cycle",
+        team=[1],
+    )
 
-    deferred_fields, is_deferred = view.get_queryset().query.deferred_loading
+    bounded_task = view.get_queryset().get(pk=task.pk)
 
-    assert is_deferred is True
-    assert RESULT_PAYLOAD_FIELDS.issubset(deferred_fields)
+    assert RESULT_PAYLOAD_FIELDS.issubset(bounded_task.get_deferred_fields())
 
     view.request = _request(query_params={"include_result_data": "true"})
-    legacy_deferred_fields, _ = view.get_queryset().query.deferred_loading
-    assert RESULT_PAYLOAD_FIELDS.isdisjoint(legacy_deferred_fields)
+    legacy_task = view.get_queryset().get(pk=task.pk)
+    assert RESULT_PAYLOAD_FIELDS.isdisjoint(legacy_task.get_deferred_fields())

--- a/server/apps/cmdb/views/collect.py
+++ b/server/apps/cmdb/views/collect.py
@@ -4,39 +4,42 @@
 # @Author: windyzhao
 import re
 from pathlib import Path
+
 from django.conf import settings
 from django.db.models import Q
-from django.shortcuts import get_object_or_404
 from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
-from apps.cmdb.node_configs.config_factory import NodeParamsFactory
-from apps.cmdb.permissions.inst_task_permission import InstanceTaskPermission
-from apps.cmdb.services.collect_object_tree import get_collect_obj_tree
-from apps.cmdb.services.network_config_file_policy import get_supported_brand_options
-from apps.cmdb.utils.base import get_current_team_from_request
-from apps.core.exceptions.base_app_exception import BaseAppException
-from apps.system_mgmt.utils.group_utils import GroupUtils
-from apps.core.utils.permission_utils import get_permission_rules
-from apps.core.decorators.api_permission import HasPermission
-from apps.core.utils.viewset_utils import AuthViewSet
-from apps.rpc.node_mgmt import NodeMgmt
-from config.drf.viewsets import ModelViewSet
-from config.drf.pagination import CustomPageNumberPagination
-from apps.core.utils.web_utils import WebUtils
-from apps.cmdb.constants.constants import CollectRunStatusType, CollectPluginTypes, PERMISSION_TASK
+from apps.cmdb.constants.constants import PERMISSION_TASK, CollectPluginTypes, CollectRunStatusType
 from apps.cmdb.filters.collect_filters import CollectModelFilter, OidModelFilter
 from apps.cmdb.models.collect_model import CollectModels, OidMapping
+from apps.cmdb.node_configs.config_factory import NodeParamsFactory
+from apps.cmdb.permissions.inst_task_permission import InstanceTaskPermission
 from apps.cmdb.serializers.collect_serializer import (
-    CollectModelSerializer,
-    CollectModelLIstSerializer,
-    OidModelSerializer,
+    COLLECT_RESULT_PAYLOAD_FIELDS,
+    CollectModelDetailSerializer,
     CollectModelIdStatusSerializer,
+    CollectModelLIstSerializer,
+    CollectModelSerializer,
+    OidModelSerializer,
 )
+from apps.cmdb.services.collect_object_tree import get_collect_obj_tree
 from apps.cmdb.services.collect_service import CollectModelService
+from apps.cmdb.services.network_config_file_policy import get_supported_brand_options
+from apps.cmdb.utils.base import get_current_team_from_request
+from apps.core.decorators.api_permission import HasPermission
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.utils.team_utils import get_current_team
+from apps.core.utils.viewset_utils import AuthViewSet
+from apps.core.utils.web_utils import WebUtils
+from apps.rpc.node_mgmt import NodeMgmt
+from apps.system_mgmt.utils.group_utils import GroupUtils
+from config.drf.pagination import CustomPageNumberPagination
+from config.drf.viewsets import ModelViewSet
 
 
 class CollectModelViewSet(AuthViewSet):
@@ -65,6 +68,11 @@ class CollectModelViewSet(AuthViewSet):
     def apply_visibility_filter(queryset):
         return queryset.filter(is_visible=True, is_system=False)
 
+    @staticmethod
+    def _include_result_data(request):
+        query_params = getattr(request, "query_params", {})
+        return str(query_params.get("include_result_data", "")).lower() in {"1", "true"}
+
     @HasPermission("auto_collection-View")
     @action(methods=["get"], detail=False, url_path="network_config_file_supported_brands")
     def network_config_file_supported_brands(self, request):
@@ -86,6 +94,8 @@ class CollectModelViewSet(AuthViewSet):
         queryset = super().get_queryset()
         request = getattr(self, "request", None)
         action = getattr(self, "action", None)
+        if action == "retrieve" and not self._include_result_data(request):
+            queryset = queryset.defer(*COLLECT_RESULT_PAYLOAD_FIELDS)
         if request is not None and action in self.permission_scoped_actions:
             queryset = self.get_queryset_by_permission(request, queryset)
         if action in {"list", "task_status", "collect_task_names"}:
@@ -155,6 +165,8 @@ class CollectModelViewSet(AuthViewSet):
     def get_serializer_class(self):
         if self.action == "list":
             return CollectModelLIstSerializer
+        if self.action == "retrieve" and not self._include_result_data(getattr(self, "request", None)):
+            return CollectModelDetailSerializer
         return super().get_serializer_class()
 
     @HasPermission("auto_collection-View")
@@ -353,7 +365,9 @@ class CollectModelViewSet(AuthViewSet):
         queryset = self.get_queryset()
         filter_queryset = self.get_queryset_by_permission(request=request, queryset=queryset)
         filter_queryset = self.apply_visibility_filter(filter_queryset).only(
-            "model_id", "exec_status", "exec_time",
+            "model_id",
+            "exec_status",
+            "exec_time",
         )
 
         total = normal = error = partial = 0


### PR DESCRIPTION
## 问题

采集任务列表已使用轻量序列化器，但任务详情仍会在每次读取时从数据库加载并返回 `collect_data`、`collect_digest`、`format_data`、`topology_snapshot`。这些字段随采集规模增长，导致详情响应和应用内存占用随结果体积线性放大。

## 根因（设计层）

任务配置、写入校验与采集结果共用同一个序列化边界，详情读取没有区分“编辑任务所需配置”和“执行产生的结果数据”。因此即使结果展示已有专用 `info` 接口，普通详情仍会读取并序列化完整结果。

## 怎么修的

- 新增配置详情序列化器，默认详情不再内联四个结果字段；
- 默认详情查询同时延迟加载四个结果列，避免仅减少网络响应却仍把大 JSON 载入应用内存；
- 保留原写入序列化器和脱敏凭据结构，编辑、复制及“秘密未修改则沿用旧值”的契约不变；
- 为旧读取方保留 `include_result_data=1` 或 `include_result_data=true` 的显式兼容路径；结果展示继续使用既有 `info` 接口。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GET collect detail\nserver/apps/cmdb/views/collect.py"]
    end

    subgraph Q["查询层"]
        Q1["默认 defer 结果列"]
        Q2["显式兼容开关读取完整结果"]
    end

    subgraph S["序列化层"]
        S1["CollectModelDetailSerializer\n配置与脱敏凭据"]
        S2["CollectModelSerializer\n兼容完整响应"]
    end

    I["info action\n专用结果读取"]

    T1 --> Q1 --> S1
    T1 -. "include_result_data=true" .-> Q2 --> S2
    T1 -. "查看采集结果" .-> I
```

## 影响范围与兼容性

- 仅触及 CMDB 采集任务详情的查询和序列化选择，不改数据库结构、权限规则、写入字段或 NATS 契约；
- Web 编辑与复制依赖的配置字段、凭据标识和非秘密元数据继续返回，秘密值继续替换为占位符；
- 旧客户端如确需详情内联结果，可在迁移到 `info` 前使用显式兼容开关；
- 回滚可直接还原本提交；紧急情况下也可由调用方先启用兼容开关恢复旧响应。

## 性能与复杂度

同一任务输入包含四个 256 KB 结果字段时，默认详情相较兼容完整详情减少超过 1,000,000 字节。默认路径的响应与 ORM 加载规模由 `O(配置 + 结果体)` 收敛为 `O(配置)`；显式兼容路径保持原复杂度。

## 验证

- `apps/cmdb/tests/test_collect_model_detail_serializer.py`、`apps/cmdb/tests/test_collect_model_credential_pool.py`、`apps/cmdb/tests/test_collect_views_actions.py`、`apps/cmdb/tests/test_network_config_file_serializer.py`：52 passed；
- 覆盖默认轻量响应、ORM 延迟加载、脱敏凭据、显式兼容响应、既有写入校验和专用结果接口；
- Black、isort、Flake8、Python 编译检查与 diff 检查通过。

## 三轨门禁

- Standards：PASS；
- Spec：PASS；
- Runtime Contract：PASS（默认详情、显式兼容、凭据脱敏、`info` 结果读取和查询列边界均有运行证据）。

G6：94/100，SCORE_PASS。

Closes #3381
