### PR TITLE
build(fusion-collector): 镜像内置 prestage 双架构控制器包材料

### DIFF
--- a/agents/fusion-collector/agent/Dockerfile
+++ b/agents/fusion-collector/agent/Dockerfile
@@ -42,6 +42,8 @@ ADD ./linux/bklite-controller-installer /opt/release/linux/fusion-collectors/bkl
 
 # exporters
 ADD ./linux/exporters /opt/release/linux/exporters
+# prestage: 双架构控制器包材料（bootstrap 据此生成异构架构控制器 zip）
+ADD ./linux/prestage /opt/release/linux/prestage
 # ansible executor
 ADD ./linux/ansible-executor/ ./bin/
 # Suporvisor


### PR DESCRIPTION
## 变更内容

fusion-collector 镜像 Dockerfile 新增 2 行：`ADD ./linux/prestage /opt/release/linux/prestage`，将 amd64/arm64 双架构控制器包材料（collector-sidecar / telegraf / vector / nats-executor / bklite-controller-installer）内置进镜像。

## 背景与语义

社区版保持 **amd64 单架构镜像 + 双架构包分发**：镜像本身仍只构建 amd64，但部署 bootstrap 可从镜像内 prestage 材料生成 x86 与 ARM 两套控制器分发 zip，使 x86 部署的 server 也能纳管 ARM 主机。

## 配套状态

- 构建 context 的 `linux/prestage/{amd64,arm64}` 材料由 fusion-collectors 流水线组装段提供（已上线，无条件组装）
- bootstrap 侧 `generate_alt_arch_packages` 从镜像抽取 prestage 组包的逻辑已实现；旧镜像无 prestage 目录时优雅跳过，前后兼容
- 对镜像体积影响约 +420MB（五件双架构二进制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)