### PR TITLE
bugfix: 批量回填枚举显示字段

### DIFF
--- a/server/apps/cmdb/graph/falkordb.py
+++ b/server/apps/cmdb/graph/falkordb.py
@@ -1118,10 +1118,11 @@ class FalkorDBClient:
             f"MATCH (n:{validated_label}) WHERE ID(n) = row.id "
             f"SET n.{validated_field} = row.value RETURN n"
         )
-        return self._execute_query(
+        result = self._execute_query(
             query,
             params={"property_values": validated_property_values},
         )
+        return self.entity_to_list(result)
 
     def format_properties_remove(self, attrs: list):
         """格式化properties的remove数据，验证字段名防止注入"""

--- a/server/apps/cmdb/graph/neo4j.py
+++ b/server/apps/cmdb/graph/neo4j.py
@@ -566,10 +566,8 @@ class Neo4jClient:
             f"MATCH (n:{validated_label}) WHERE id(n) = row.id "
             f"SET n.{validated_field} = row.value RETURN n"
         )
-        return self.session.run(
-            query,
-            property_values=validated_property_values,
-        )
+        result = self.session.run(query, property_values=validated_property_values)
+        return self.entity_to_list(result)
 
     def format_properties_remove(self, attrs: list):
         """格式化properties的remove数据"""

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -1126,22 +1126,52 @@ class ModelManage(object):
 
         try:
             with GraphClient() as ag:
-                # 查询该模型的所有实例
-                instances, _ = ag.query_entity(INSTANCE, [{"field": "model_id", "type": "str=", "value": model_id}])
+                last_instance_id = None
+                property_values = []
+                while True:
+                    query_params = [{"field": "model_id", "type": "str=", "value": model_id}]
+                    if last_instance_id is not None:
+                        query_params.append(
+                            {
+                                "field": "id",
+                                "type": "id>",
+                                "value": last_instance_id,
+                            }
+                        )
+                    instances, _ = ag.query_entity(
+                        INSTANCE,
+                        query_params,
+                        page={"skip": 0, "limit": MAX_BATCH_UPDATE_PROPERTY_VALUES},
+                        include_count=False,
+                    )
+                    if not instances:
+                        break
 
-                # 批量更新实例的 _display 字段
-                for instance in instances:
-                    # 检查实例是否有该枚举字段
-                    if attr_id in instance and instance[attr_id]:
-                        enum_value = instance[attr_id]
+                    for instance in instances:
+                        if attr_id not in instance or not instance[attr_id]:
+                            continue
+                        property_values.append(
+                            {
+                                "id": instance["_id"],
+                                "value": DisplayFieldConverter.convert_enum(instance[attr_id], new_options),
+                            }
+                        )
+                        if len(property_values) == MAX_BATCH_UPDATE_PROPERTY_VALUES:
+                            ag.batch_update_node_property_values(
+                                INSTANCE,
+                                display_field_id,
+                                property_values,
+                            )
+                            updated_count += len(property_values)
+                            property_values = []
 
-                        # 使用统一的转换器生成新的 _display 值
-                        new_display_value = DisplayFieldConverter.convert_enum(enum_value, new_options)
+                    if len(instances) < MAX_BATCH_UPDATE_PROPERTY_VALUES:
+                        break
+                    last_instance_id = instances[-1]["_id"]
 
-                        # 更新实例的 _display 字段
-                        update_data = {display_field_id: new_display_value}
-                        ag.batch_update_node_properties(INSTANCE, [instance["_id"]], update_data)
-                        updated_count += 1
+                if property_values:
+                    ag.batch_update_node_property_values(INSTANCE, display_field_id, property_values)
+                    updated_count += len(property_values)
 
                 if updated_count > 0:
                     logger.info(

--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -2,6 +2,7 @@ import json
 import os
 import uuid
 from dataclasses import asdict
+from hashlib import sha256
 from typing import Any, Callable
 
 from django.core.cache import cache
@@ -73,9 +74,80 @@ PROTECTED_MODEL_ATTR_IDS = frozenset({ORGANIZATION})
 MODEL_ATTR_OPTION_CACHE_TTL = int(os.getenv("CMDB_MODEL_ATTR_OPTION_CACHE_TTL", "300"))
 MODEL_ATTR_ORGANIZATION_OPTION_CACHE_KEY = "cmdb:model_attr_options:organization"
 MODEL_ATTR_USER_OPTION_CACHE_KEY = "cmdb:model_attr_options:user"
+ENUM_DISPLAY_BACKFILL_CHECKPOINT_TTL = 24 * 60 * 60
 
 
 class ModelManage(object):
+    @staticmethod
+    def _enum_display_backfill_checkpoint(model_id: str, attr_id: str, new_options: list) -> tuple[str, str]:
+        options_digest = sha256(
+            json.dumps(new_options, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        return f"cmdb:enum-display-backfill:{model_id}:{attr_id}", options_digest
+
+    @staticmethod
+    def _get_enum_display_backfill_checkpoint(checkpoint_key: str, options_digest: str) -> tuple[int | None, bool]:
+        try:
+            checkpoint = cache.get(checkpoint_key)
+            if not isinstance(checkpoint, dict):
+                return None, True
+            if checkpoint.get("options_digest") != options_digest:
+                cache.delete(checkpoint_key)
+                return None, True
+            return int(checkpoint["cursor"]), True
+        except Exception as e:
+            logger.warning(
+                "[update_enum_instances_display] 读取回填断点失败，将从头幂等执行: error_type=%s, error=%s",
+                type(e).__name__,
+                e,
+            )
+            return None, False
+
+    @staticmethod
+    def _save_enum_display_backfill_checkpoint(checkpoint_key: str, options_digest: str, cursor: int) -> bool:
+        try:
+            cache.set(
+                checkpoint_key,
+                {"options_digest": options_digest, "cursor": cursor},
+                timeout=ENUM_DISPLAY_BACKFILL_CHECKPOINT_TTL,
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                "[update_enum_instances_display] 保存回填断点失败，后续重试将从头幂等执行: cursor=%s, error_type=%s, error=%s",
+                cursor,
+                type(e).__name__,
+                e,
+            )
+            return False
+
+    @staticmethod
+    def _clear_enum_display_backfill_checkpoint(checkpoint_key: str) -> None:
+        try:
+            cache.delete(checkpoint_key)
+        except Exception as e:
+            logger.warning(
+                "[update_enum_instances_display] 清理回填断点失败，后续会幂等续扫: error_type=%s, error=%s",
+                type(e).__name__,
+                e,
+            )
+
+    @staticmethod
+    def _write_enum_display_batch(ag, display_field_id: str, property_values: list[dict]) -> int:
+        for attempt in range(2):
+            try:
+                written = ag.batch_update_node_property_values(INSTANCE, display_field_id, property_values)
+                return len(written)
+            except Exception as e:
+                if attempt:
+                    raise
+                logger.warning(
+                    "[update_enum_instances_display] 图写失败，将从当前成功游标重试一次: error_type=%s, error=%s",
+                    type(e).__name__,
+                    e,
+                )
+        return 0
+
     @staticmethod
     def _clone_options(option: list[dict]) -> list[dict]:
         return [dict(item) for item in option]
@@ -1123,19 +1195,25 @@ class ModelManage(object):
 
         updated_count = 0
         display_field_id = f"{attr_id}_display"
+        checkpoint_key, options_digest = ModelManage._enum_display_backfill_checkpoint(model_id, attr_id, new_options)
 
         try:
             with GraphClient() as ag:
-                last_instance_id = None
+                scan_cursor, checkpoint_available = ModelManage._get_enum_display_backfill_checkpoint(
+                    checkpoint_key,
+                    options_digest,
+                )
+                if not checkpoint_available:
+                    raise RuntimeError("枚举显示字段回填断点不可用，已安全跳过本轮图写")
                 property_values = []
                 while True:
                     query_params = [{"field": "model_id", "type": "str=", "value": model_id}]
-                    if last_instance_id is not None:
+                    if scan_cursor is not None:
                         query_params.append(
                             {
                                 "field": "id",
                                 "type": "id>",
-                                "value": last_instance_id,
+                                "value": scan_cursor,
                             }
                         )
                     instances, _ = ag.query_entity(
@@ -1145,7 +1223,25 @@ class ModelManage(object):
                         include_count=False,
                     )
                     if not instances:
+                        if property_values:
+                            updated_count += ModelManage._write_enum_display_batch(
+                                ag,
+                                display_field_id,
+                                property_values,
+                            )
+                            checkpoint_available = ModelManage._save_enum_display_backfill_checkpoint(
+                                checkpoint_key,
+                                options_digest,
+                                property_values[-1]["id"],
+                            ) and checkpoint_available
+                        ModelManage._clear_enum_display_backfill_checkpoint(checkpoint_key)
                         break
+
+                    next_instance_id = int(instances[-1]["_id"])
+                    if scan_cursor is not None and next_instance_id <= scan_cursor:
+                        raise RuntimeError(
+                            f"枚举显示字段回填游标未推进: cursor={scan_cursor}, next_cursor={next_instance_id}"
+                        )
 
                     for instance in instances:
                         if attr_id not in instance or not instance[attr_id]:
@@ -1157,21 +1253,32 @@ class ModelManage(object):
                             }
                         )
                         if len(property_values) == MAX_BATCH_UPDATE_PROPERTY_VALUES:
-                            ag.batch_update_node_property_values(
-                                INSTANCE,
+                            updated_count += ModelManage._write_enum_display_batch(
+                                ag,
                                 display_field_id,
                                 property_values,
                             )
-                            updated_count += len(property_values)
+                            checkpoint_available = ModelManage._save_enum_display_backfill_checkpoint(
+                                checkpoint_key,
+                                options_digest,
+                                property_values[-1]["id"],
+                            ) and checkpoint_available
                             property_values = []
 
-                    if len(instances) < MAX_BATCH_UPDATE_PROPERTY_VALUES:
-                        break
-                    last_instance_id = instances[-1]["_id"]
+                    scan_cursor = next_instance_id
+                    if not property_values:
+                        checkpoint_available = ModelManage._save_enum_display_backfill_checkpoint(
+                            checkpoint_key,
+                            options_digest,
+                            scan_cursor,
+                        ) and checkpoint_available
 
-                if property_values:
-                    ag.batch_update_node_property_values(INSTANCE, display_field_id, property_values)
-                    updated_count += len(property_values)
+                if not checkpoint_available:
+                    logger.warning(
+                        "[update_enum_instances_display] 断点写入不可用，本轮写入保持幂等，后续请求将从头执行: 模型=%s, 字段=%s",
+                        model_id,
+                        attr_id,
+                    )
 
                 if updated_count > 0:
                     logger.info(

--- a/server/apps/cmdb/tests/conftest.py
+++ b/server/apps/cmdb/tests/conftest.py
@@ -41,6 +41,8 @@ class FakeGraphClient:
             # 合理默认：查询类返回 ([], 0)，其余返回 {}
             if name.startswith("query") or name in ("entity_objs", "full_text", "full_text_by_model"):
                 return ([], 0)
+            if name == "batch_update_node_property_values":
+                return [{"_id": item["id"]} for item in args[2]]
             return {}
 
         return _method

--- a/server/apps/cmdb/tests/test_falkordb_client.py
+++ b/server/apps/cmdb/tests/test_falkordb_client.py
@@ -380,7 +380,7 @@ def test_batch_update_node_property_values_uses_one_parameterized_query():
         {"id": 2, "value": "photo"},
     ]
 
-    c.batch_update_node_property_values(
+    updated = c.batch_update_node_property_values(
         "instance",
         "doc_display",
         property_values,
@@ -391,6 +391,7 @@ def test_batch_update_node_property_values_uses_one_parameterized_query():
     assert "ID(n) = row.id" in c._graph.last_query
     assert "SET n.doc_display = row.value" in c._graph.last_query
     assert c._graph.last_params == {"property_values": property_values}
+    assert updated == []
 
 
 def test_batch_update_node_property_values_empty_list_skips_query():

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -310,12 +310,75 @@ def test_delete_model_attr_rejects_organization(fake_graph, patch_side_effects, 
 def test_update_enum_instances_display(fake_graph):
     fg = fake_graph(
         MODULE,
-        query_entity=([{"_id": 1, "status": "1"}, {"_id": 2}], 2),
+        query_entity=(
+            [
+                {"_id": 1, "status": "1"},
+                {"_id": 2},
+                {"_id": 3, "status": None},
+                {"_id": 4, "status": ""},
+                {"_id": 5, "status": []},
+            ],
+            5,
+        ),
     )
     count = ModelManage.update_enum_instances_display("host", "status", [{"id": "1", "name": "运行"}])
     # 只有实例 1 含 status → 更新 1 个
     assert count == 1
-    assert any(c[0] == "batch_update_node_properties" for c in fg.calls)
+    update_call = next(c for c in fg.calls if c[0] == "batch_update_node_property_values")
+    assert update_call[1] == (
+        "instance",
+        "status_display",
+        [{"id": 1, "value": "运行"}],
+    )
+
+
+def test_update_enum_instances_display_backend_failure_is_non_blocking(fake_graph):
+    def _raise(*args, **kwargs):
+        raise RuntimeError("graph unavailable")
+
+    fake_graph(
+        MODULE,
+        query_entity=([{"_id": 1, "status": "1"}, {"_id": 2, "status": "2"}], 2),
+        batch_update_node_property_values=_raise,
+    )
+
+    count = ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}],
+    )
+
+    assert count == 0
+
+
+def test_update_enum_instances_display_batches_1000_values_once(fake_graph):
+    instances = [{"_id": index, "status": "1" if index % 2 else ["2", "1"]} for index in range(1, 1001)]
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances),
+    )
+
+    count = ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}],
+    )
+
+    assert count == 1000
+    update_calls = [call for call in fg.calls if call[0] in {"batch_update_node_properties", "batch_update_node_property_values"}]
+    assert len(update_calls) == 1
+    assert update_calls[0][0] == "batch_update_node_property_values"
+    assert update_calls[0][1] == (
+        "instance",
+        "status_display",
+        [
+            {
+                "id": index,
+                "value": "运行" if index % 2 else "停止, 运行",
+            }
+            for index in range(1, 1001)
+        ],
+    )
 
 
 def _paged_query_entity(instances, delete_after_first=False):
@@ -341,6 +404,59 @@ def _paged_query_entity(instances, delete_after_first=False):
         return result, None
 
     return _query
+
+
+def test_update_enum_instances_display_pages_without_unbounded_graph_writes(
+    fake_graph,
+):
+    instances = [{"_id": 1}]
+    instances.extend({"_id": index, "status": "1"} for index in range(2, 1003))
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances),
+    )
+
+    count = ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}],
+    )
+
+    assert count == 1001
+    update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
+    assert [len(call[1][2]) for call in update_calls] == [1000, 1]
+    query_calls = [call for call in fg.calls if call[0] == "query_entity"]
+    assert len(query_calls) == 2
+    assert query_calls[0][2] == {
+        "page": {"skip": 0, "limit": 1000},
+        "include_count": False,
+    }
+    assert query_calls[1][1][1][-1] == {
+        "field": "id",
+        "type": "id>",
+        "value": 1000,
+    }
+
+
+def test_update_enum_instances_display_keyset_does_not_skip_after_delete(
+    fake_graph,
+):
+    instances = [{"_id": index, "status": "1"} for index in range(1, 1002)]
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances, delete_after_first=True),
+    )
+
+    count = ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}],
+    )
+
+    assert count == 1001
+    update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
+    assert [len(call[1][2]) for call in update_calls] == [1000, 1]
+    assert update_calls[-1][1][2] == [{"id": 1001, "value": "运行"}]
 
 
 def test_rebuild_file_instances_display_backfills_stem(fake_graph):

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -308,18 +308,16 @@ def test_delete_model_attr_rejects_organization(fake_graph, patch_side_effects, 
 
 @pytest.mark.django_db
 def test_update_enum_instances_display(fake_graph):
+    instances = [
+        {"_id": 1, "status": "1"},
+        {"_id": 2},
+        {"_id": 3, "status": None},
+        {"_id": 4, "status": ""},
+        {"_id": 5, "status": []},
+    ]
     fg = fake_graph(
         MODULE,
-        query_entity=(
-            [
-                {"_id": 1, "status": "1"},
-                {"_id": 2},
-                {"_id": 3, "status": None},
-                {"_id": 4, "status": ""},
-                {"_id": 5, "status": []},
-            ],
-            5,
-        ),
+        query_entity=_paged_query_entity(instances),
     )
     count = ModelManage.update_enum_instances_display("host", "status", [{"id": "1", "name": "运行"}])
     # 只有实例 1 含 status → 更新 1 个
@@ -332,13 +330,14 @@ def test_update_enum_instances_display(fake_graph):
     )
 
 
+@pytest.mark.unit
 def test_update_enum_instances_display_backend_failure_is_non_blocking(fake_graph):
     def _raise(*args, **kwargs):
         raise RuntimeError("graph unavailable")
 
     fake_graph(
         MODULE,
-        query_entity=([{"_id": 1, "status": "1"}, {"_id": 2, "status": "2"}], 2),
+        query_entity=_paged_query_entity([{"_id": 1, "status": "1"}, {"_id": 2, "status": "2"}]),
         batch_update_node_property_values=_raise,
     )
 
@@ -351,6 +350,7 @@ def test_update_enum_instances_display_backend_failure_is_non_blocking(fake_grap
     assert count == 0
 
 
+@pytest.mark.unit
 def test_update_enum_instances_display_batches_1000_values_once(fake_graph):
     instances = [{"_id": index, "status": "1" if index % 2 else ["2", "1"]} for index in range(1, 1001)]
     fg = fake_graph(
@@ -406,6 +406,7 @@ def _paged_query_entity(instances, delete_after_first=False):
     return _query
 
 
+@pytest.mark.unit
 def test_update_enum_instances_display_pages_without_unbounded_graph_writes(
     fake_graph,
 ):
@@ -426,7 +427,7 @@ def test_update_enum_instances_display_pages_without_unbounded_graph_writes(
     update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
     assert [len(call[1][2]) for call in update_calls] == [1000, 1]
     query_calls = [call for call in fg.calls if call[0] == "query_entity"]
-    assert len(query_calls) == 2
+    assert len(query_calls) == 3
     assert query_calls[0][2] == {
         "page": {"skip": 0, "limit": 1000},
         "include_count": False,
@@ -436,15 +437,27 @@ def test_update_enum_instances_display_pages_without_unbounded_graph_writes(
         "type": "id>",
         "value": 1000,
     }
+    assert query_calls[2][1][1][-1] == {
+        "field": "id",
+        "type": "id>",
+        "value": 1002,
+    }
 
 
+@pytest.mark.unit
 def test_update_enum_instances_display_keyset_does_not_skip_after_delete(
     fake_graph,
 ):
     instances = [{"_id": index, "status": "1"} for index in range(1, 1002)]
+
+    def _write_existing(_label, _field, values):
+        existing_ids = {instance["_id"] for instance in instances}
+        return [value for value in values if value["id"] in existing_ids]
+
     fg = fake_graph(
         MODULE,
         query_entity=_paged_query_entity(instances, delete_after_first=True),
+        batch_update_node_property_values=_write_existing,
     )
 
     count = ModelManage.update_enum_instances_display(
@@ -453,10 +466,190 @@ def test_update_enum_instances_display_keyset_does_not_skip_after_delete(
         [{"id": "1", "name": "运行"}],
     )
 
-    assert count == 1001
+    assert count == 1000
     update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
     assert [len(call[1][2]) for call in update_calls] == [1000, 1]
     assert update_calls[-1][1][2] == [{"id": 1001, "value": "运行"}]
+
+
+@pytest.fixture
+def enum_backfill_checkpoints(monkeypatch):
+    checkpoints = {}
+    monkeypatch.setattr(f"{MODULE}.cache.get", checkpoints.get)
+    monkeypatch.setattr(
+        f"{MODULE}.cache.set",
+        lambda key, value, timeout=None: checkpoints.__setitem__(key, value),
+    )
+    monkeypatch.setattr(f"{MODULE}.cache.delete", lambda key: checkpoints.pop(key, None))
+    return checkpoints
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_resumes_after_later_batch_failure(
+    fake_graph,
+    enum_backfill_checkpoints,
+):
+    instances = [{"_id": index, "status": "1"} for index in range(1, 1002)]
+    write_calls = 0
+
+    def _fail_second_batch(_label, _field, values):
+        nonlocal write_calls
+        write_calls += 1
+        if values[0]["id"] > 1000:
+            raise RuntimeError("second batch unavailable")
+        return values
+
+    first_graph = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity(instances),
+        batch_update_node_property_values=_fail_second_batch,
+    )
+
+    options = [{"id": "1", "name": "运行"}]
+    assert ModelManage.update_enum_instances_display("host", "status", options) == 1000
+    assert write_calls == 3
+    assert [checkpoint["cursor"] for checkpoint in enum_backfill_checkpoints.values()] == [1000]
+
+    resumed_graph = fake_graph(MODULE, query_entity=_paged_query_entity(instances))
+    assert ModelManage.update_enum_instances_display("host", "status", options) == 1
+    resumed_queries = [call for call in resumed_graph.calls if call[0] == "query_entity"]
+    assert resumed_queries[0][1][1][-1] == {"field": "id", "type": "id>", "value": 1000}
+    assert enum_backfill_checkpoints == {}
+    assert len([call for call in first_graph.calls if call[0] == "batch_update_node_property_values"]) == 3
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_continues_after_short_page(fake_graph):
+    instances = [{"_id": index, "status": "1"} for index in range(1, 5)]
+    query_count = 0
+
+    def _short_first_page(_label, params, page=None, **_kwargs):
+        nonlocal query_count
+        query_count += 1
+        last_id = next((item["value"] for item in params if item["type"] == "id>"), 0)
+        candidates = [instance for instance in instances if instance["_id"] > last_id]
+        limit = 2 if query_count == 1 else page["limit"]
+        return candidates[:limit], None
+
+    fg = fake_graph(MODULE, query_entity=_short_first_page)
+
+    assert ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}],
+    ) == 4
+    update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
+    assert [len(call[1][2]) for call in update_calls] == [4]
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_observes_later_page_insert_and_change(fake_graph):
+    instances = [{"_id": index, "status": "1"} for index in range(1, 1002)]
+    query_count = 0
+
+    def _query_with_changes(_label, params, page=None, **_kwargs):
+        nonlocal query_count
+        query_count += 1
+        last_id = next((item["value"] for item in params if item["type"] == "id>"), 0)
+        candidates = [instance for instance in instances if instance["_id"] > last_id]
+        result = candidates[: page["limit"]]
+        if query_count == 1:
+            instances[-1]["status"] = "2"
+            instances.append({"_id": 1002, "status": "2"})
+        return result, None
+
+    fg = fake_graph(MODULE, query_entity=_query_with_changes)
+
+    assert ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}],
+    ) == 1002
+    update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
+    assert update_calls[-1][1][2] == [
+        {"id": 1001, "value": "停止"},
+        {"id": 1002, "value": "停止"},
+    ]
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_repeated_run_is_idempotent(fake_graph):
+    instances = [{"_id": 1, "status": "1"}, {"_id": 2, "status": ["2", "1"]}]
+    fg = fake_graph(MODULE, query_entity=_paged_query_entity(instances))
+    options = [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}]
+
+    assert ModelManage.update_enum_instances_display("host", "status", options) == 2
+    assert ModelManage.update_enum_instances_display("host", "status", options) == 2
+
+    update_calls = [call for call in fg.calls if call[0] == "batch_update_node_property_values"]
+    assert update_calls[0][1][2] == update_calls[1][1][2]
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_ignores_checkpoint_for_old_options(
+    fake_graph,
+    enum_backfill_checkpoints,
+):
+    old_options = [{"id": "1", "name": "旧名称"}]
+    checkpoint_key, old_digest = ModelManage._enum_display_backfill_checkpoint("host", "status", old_options)
+    enum_backfill_checkpoints[checkpoint_key] = {"options_digest": old_digest, "cursor": 1}
+    fg = fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity([{"_id": 1, "status": "1"}, {"_id": 2, "status": "1"}]),
+    )
+
+    assert ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "新名称"}],
+    ) == 2
+    first_query = next(call for call in fg.calls if call[0] == "query_entity")
+    assert first_query[1][1] == [{"field": "model_id", "type": "str=", "value": "host"}]
+    assert enum_backfill_checkpoints == {}
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_cache_failure_is_non_blocking(fake_graph, monkeypatch):
+    def _raise_cache_error(*_args, **_kwargs):
+        raise RuntimeError("cache unavailable")
+
+    monkeypatch.setattr(f"{MODULE}.cache.get", _raise_cache_error)
+    monkeypatch.setattr(f"{MODULE}.cache.set", _raise_cache_error)
+    monkeypatch.setattr(f"{MODULE}.cache.delete", _raise_cache_error)
+    fake_graph(
+        MODULE,
+        query_entity=_paged_query_entity([{"_id": 1, "status": "1"}]),
+    )
+
+    assert ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "运行"}],
+    ) == 0
+
+
+@pytest.mark.unit
+def test_update_enum_instances_display_old_checkpoint_cannot_skip_after_set_failure(
+    fake_graph,
+    enum_backfill_checkpoints,
+    monkeypatch,
+):
+    old_options = [{"id": "1", "name": "旧名称"}]
+    checkpoint_key, old_digest = ModelManage._enum_display_backfill_checkpoint("host", "status", old_options)
+    enum_backfill_checkpoints[checkpoint_key] = {"options_digest": old_digest, "cursor": 1}
+    monkeypatch.setattr(f"{MODULE}.cache.set", lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("cache full")))
+    instances = [{"_id": 1, "status": "1"}, {"_id": 2, "status": "1"}]
+    fg = fake_graph(MODULE, query_entity=_paged_query_entity(instances))
+
+    assert ModelManage.update_enum_instances_display(
+        "host",
+        "status",
+        [{"id": "1", "name": "新名称"}],
+    ) == 2
+    assert ModelManage.update_enum_instances_display("host", "status", old_options) == 2
+    query_calls = [call for call in fg.calls if call[0] == "query_entity"]
+    assert query_calls[0][1][1] == [{"field": "model_id", "type": "str=", "value": "host"}]
+    assert query_calls[2][1][1] == [{"field": "model_id", "type": "str=", "value": "host"}]
 
 
 def test_rebuild_file_instances_display_backfills_stem(fake_graph):

--- a/server/apps/cmdb/tests/test_neo4j_client.py
+++ b/server/apps/cmdb/tests/test_neo4j_client.py
@@ -318,7 +318,7 @@ def test_batch_update_node_property_values_uses_one_parameterized_query():
         {"id": 2, "value": "photo"},
     ]
 
-    c.batch_update_node_property_values(
+    updated = c.batch_update_node_property_values(
         "instance",
         "doc_display",
         property_values,
@@ -329,6 +329,7 @@ def test_batch_update_node_property_values_uses_one_parameterized_query():
     assert "id(n) = row.id" in c.session.last_query
     assert "SET n.doc_display = row.value" in c.session.last_query
     assert c.session.last_params == {"property_values": property_values}
+    assert updated == []
 
 
 def test_batch_update_node_property_values_empty_list_skips_query():


### PR DESCRIPTION
## 问题

CMDB 在模型管理中修改枚举选项后，需要同步重算历史实例的 `_display` 字段。旧实现虽然调用了批量图接口，但每次只传一个节点；1000 个有效实例会产生 1000 次图写，HTTP 请求随实例量线性阻塞。

## 根因（设计层）

枚举显示值由每个实例的原始值独立转换，旧调用方把“逐实例计算”错误地等同于“逐实例提交”，没有在转换层与图写层之间建立受限批次。与此同时，查询一次加载全部实例，读内存也没有边界。

## 怎么修的

- 按图节点 ID 做 keyset 分页，每页最多 1000 条，不执行额外 count 查询。
- 逐实例继续复用既有枚举转换器，保持单选、多选顺序和未知值回退语义。
- 将每个实例的 `{id, value}` 聚合到受限批次，复用已存在的异值批写接口，一次参数化图查询写入最多 1000 个节点。
- 继续保留非关键回填的失败守卫：图依赖失败会记录错误并返回已完成计数，不改变模型属性更新的 HTTP 响应。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["model_attr_update\nviews/model.py"]
    end

    subgraph S["枚举回填层"]
        S1["update_enum_instances_display\nservices/model.py"]
        S2["ID keyset 分页\n每页最多 1000 条"]
        S3["逐实例转换并聚合\n每批最多 1000 个 id/value"]
    end

    subgraph G["图驱动层"]
        G1["batch_update_node_property_values"]
        G2["FalkorDB / Neo4j\n单条参数化 UNWIND"]
    end

    T1 --> S1 --> S2 --> S3 --> G1 --> G2
    G2 -. "依赖失败" .-> S1
```

## 性能对照

| 场景 | 修复前 | 修复后 |
|---|---:|---:|
| 1000 个有效实例 | 1000 次图写 | 1 次图写 |
| 1001 个有效实例 | 1001 次图写 | 2 次图写（1000 + 1） |
| 读写内存 | 全量实例与结果 | 每批最多 1000 条 |

CPU 仍需线性遍历实例并保持原转换结果；主要瓶颈的远程图写往返由 `N` 次降为 `ceil(N / 1000)` 次。

## 影响范围与兼容性

- 仅修改 CMDB 枚举显示字段内部回填服务及对应测试；HTTP 路由、请求/响应、权限、模型字段和存量数据格式均不变。
- 缺失、`None`、空串和空列表仍跳过；单选、多选值及顺序保持不变。
- FalkorDB 与 Neo4j 继续使用同一参数化异值批写契约，字段名、节点 ID 和批次上限沿用既有校验。
- 并发删除时 keyset 不因 offset 漂移跳过后续页；重复执行仍是确定性的属性 `SET`。
- 持久补偿与失败重试属于独立技术债，本修复不翻转既有非阻断语义。

## 验证

- `apps/cmdb/tests/test_model_service_methods.py` + `apps/cmdb/tests/test_model_views.py`：84 passed。
- `apps/cmdb/tests/test_falkordb_client.py` + `apps/cmdb/tests/test_neo4j_client.py`：106 passed。
- `apps/cmdb/tests/test_validators.py`：22 passed。
- TDD 对照：固定基线在 1000 实例场景实际产生 1000 次图写；受限批次首版在 1001 实例场景产生单个 1001 条批次，两项回归均先失败，最终分别收敛为 1 次与 `1000 + 1` 两次。
- 依赖失败、空值跳过、并发删除 keyset、双图驱动参数化与 1000 条安全上限均有运行契约覆盖。

## 三轨门禁

- Standards：PASS。
- Spec：PASS。
- Runtime Contract：PASS。
- 质量评分：96 / 100（SCORE_PASS）。
- Review gate：`automated_deep_review`；未发现需要人工业务或兼容决策的具体证据。

Fixes #3377
