### PR TITLE
bugfix: 修正 CMDB 采集任务分页总数

### DIFF
--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -312,8 +312,9 @@ def get_cmdb_module_data(module, child_module, page, page_size, group_id, user_i
         instances = CollectModels.objects.filter(
             task_type=child_module,
             is_system=False,
-        ).values("id", "name", "model_id")[start:end]
+        )
         count = instances.count()
+        instances = instances.values("id", "name", "model_id")[start:end]
         queryset = [{"id": str(i["id"]), "name": f"{i['model_id']}_{i['name']}"} for i in instances]
     elif module == PERMISSION_INSTANCES:
         # 构建真实权限 map：根据调用方传入的 user_info 查询用户在目标模型上的权限范围

--- a/server/apps/cmdb/tests/test_cmdb_module_data_service.py
+++ b/server/apps/cmdb/tests/test_cmdb_module_data_service.py
@@ -1,0 +1,23 @@
+import pytest
+
+from apps.cmdb.constants.constants import CollectPluginTypes, PERMISSION_TASK
+from apps.cmdb.models.collect_model import CollectModels
+from apps.cmdb.nats.nats import get_cmdb_module_data
+
+
+@pytest.mark.django_db
+def test_permission_task_enum_returns_total_count_across_pages():
+    for index in range(3):
+        CollectModels.objects.create(
+            name=f"普通采集-{index}",
+            task_type=CollectPluginTypes.HOST,
+            model_id="host",
+            driver_type="ordinary",
+            cycle_value_type="cycle",
+            team=[1],
+        )
+
+    result = get_cmdb_module_data(PERMISSION_TASK, CollectPluginTypes.HOST, 1, 2, 1)
+
+    assert result["count"] == 3
+    assert len(result["items"]) == 2

--- a/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
+++ b/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
@@ -146,6 +146,24 @@ def test_permission_task_enum_excludes_node_mgmt_system_tasks(system_task):
 
 
 @pytest.mark.django_db
+def test_permission_task_enum_returns_total_count_across_pages(system_task):
+    for index in range(3):
+        CollectModels.objects.create(
+            name=f"普通采集-{index}",
+            task_type=CollectPluginTypes.HOST,
+            model_id="host",
+            driver_type="ordinary",
+            cycle_value_type="cycle",
+            team=[1],
+        )
+
+    result = get_cmdb_module_data(PERMISSION_TASK, CollectPluginTypes.HOST, 1, 2, 1)
+
+    assert result["count"] == 3
+    assert len(result["items"]) == 2
+
+
+@pytest.mark.django_db
 def test_collect_statistics_queryset_excludes_node_mgmt_system_tasks(system_task):
     queryset = _get_collect_task_queryset({"team": 1})
 

--- a/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
+++ b/server/apps/cmdb/tests/test_collect_tool_system_task_isolation.py
@@ -146,24 +146,6 @@ def test_permission_task_enum_excludes_node_mgmt_system_tasks(system_task):
 
 
 @pytest.mark.django_db
-def test_permission_task_enum_returns_total_count_across_pages(system_task):
-    for index in range(3):
-        CollectModels.objects.create(
-            name=f"普通采集-{index}",
-            task_type=CollectPluginTypes.HOST,
-            model_id="host",
-            driver_type="ordinary",
-            cycle_value_type="cycle",
-            team=[1],
-        )
-
-    result = get_cmdb_module_data(PERMISSION_TASK, CollectPluginTypes.HOST, 1, 2, 1)
-
-    assert result["count"] == 3
-    assert len(result["items"]) == 2
-
-
-@pytest.mark.django_db
 def test_collect_statistics_queryset_excludes_node_mgmt_system_tasks(system_task):
     queryset = _get_collect_task_queryset({"team": 1})
 


### PR DESCRIPTION
## 问题

CMDB 的采集任务权限枚举接口应同时返回当前页条目和过滤后总数。原实现先分页切片、再执行 `count()`，任务数超过一页时会把页内数量误当总数，导致权限配置页面低估分页总量。

## 根因

`PERMISSION_TASK` 分支把“用于总量统计的集合”和“当前结果页”复用了同一个已切片 QuerySet，破坏了 `{count, items}` 分页契约。

## 怎么修的

- 复用同一组 `task_type` 与 `is_system=False` 过滤条件。
- 在分页切片前统计总量，再对 QuerySet 执行 `values(...)[start:end]`。
- 补充多页回归：3 条可见任务、页大小 2 时，`count` 保持为 3、`items` 为 2。

## 影响范围

- 仅修正 CMDB `get_cmdb_module_data` 的采集任务分支。
- 不改 NATS subject、请求参数、响应字段、任务过滤、页内条目格式和其他权限分支。
- SystemMgmt 与 Web 调用方继续使用既有 `{count, items}` 契约，无数据迁移；可按本 PR 整体回滚。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["usePermissionData\nweb/src/app/system-manager/hooks/usePermissionData.ts"]
    end

    subgraph R["路由与 RPC 层"]
        R1["GroupDataRuleViewSet.get_app_data\ngroup_data_rule_viewset.py"]
        R2["CMDB.get_module_data\nserver/apps/rpc/cmdb.py"]
    end

    subgraph N["CMDB 处理层"]
        N1["get_cmdb_module_data\nserver/apps/cmdb/nats/nats.py"]
        N2["过滤 QuerySet 先 count\n再执行分页切片"]
    end

    T1 --> R1 --> R2 --> N1 --> N2
    N2 --> T1
```

## 验证

- `apps/cmdb/tests/test_cmdb_module_data_service.py`
- `apps/cmdb/tests/test_collect_tool_system_task_isolation.py`
- `apps/cmdb/tests/test_get_cmdb_module_data_permission_3662.py`
- `apps/rpc/tests/test_misc_forwarding.py`
- 结果：65 passed。
- TDD RED：旧实现对 3 条总量、页大小 2 返回 `count=2`；修复后返回 `count=3`。

## 三轨门禁

- Standards：PASS，无 Critical、Important 或 Minor 问题。
- Spec：PASS，修复与 Issue 及 Spec 一致，范围无遗漏。
- Runtime Contract：PASS，正常分页、过滤、响应形状、其他分支和 RPC 转发均通过；DB 异常与并发分页语义未恶化。
- 质量评分：96/100，SCORE_PASS。

Closes #3374
