### PR TITLE
bugfix: 修正数据集发布样本计数

### DIFF
--- a/server/apps/mlops/tasks/base.py
+++ b/server/apps/mlops/tasks/base.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import zipfile
 from dataclasses import dataclass
+from itertools import chain
 from pathlib import Path
 from typing import Any, Callable, Optional, Type
 
@@ -78,7 +79,19 @@ def mark_release_as_failed(
         return False
 
 
-_STREAM_CHUNK_SIZE = int(os.getenv("MLOPS_STREAM_CHUNK_SIZE", 65536))  # 可通过环境变量调整，默认 64 KB
+_MAX_STREAM_CHUNK_SIZE = 65536
+
+
+def _get_stream_chunk_size() -> int:
+    """读取流式块大小，并将单次读取限制在 64 KB 内。"""
+    configured_size = int(
+        os.getenv("MLOPS_STREAM_CHUNK_SIZE", _MAX_STREAM_CHUNK_SIZE)
+    )
+    return min(_MAX_STREAM_CHUNK_SIZE, max(1, configured_size))
+
+
+_STREAM_CHUNK_SIZE = _get_stream_chunk_size()  # 可通过环境变量调整，默认 64 KB
+_SAMPLE_COUNT_ALGORITHM = "logical_records_v1_legacy_fallback"
 
 
 @dataclass
@@ -108,30 +121,113 @@ class DatasetPublishConfig:
 
 
 def count_csv_samples(file_path: Path) -> int:
-    """CSV 文件样本计数：行数 - 1（去掉表头），流式按块读取避免全量加载"""
-    newline_count = 0
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(_STREAM_CHUNK_SIZE), b""):
-            newline_count += chunk.count(b"\n")
-    return max(0, newline_count - 1)
+    """CSV 文件样本计数：按固定字节块统计表头后的逻辑记录。"""
+    record_count = 0
+    record_has_content = False
+    at_field_start = True
+    in_quotes = False
+    after_quote = False
+    skip_lf_after_cr = False
+    legacy_newline_count = 0
+    malformed = False
+
+    def finish_record() -> None:
+        nonlocal record_count, record_has_content, at_field_start
+        if record_has_content:
+            record_count += 1
+        record_has_content = False
+        at_field_start = True
+
+    with open(file_path, "rb") as csv_file:
+        prefix = csv_file.read(3)
+        if prefix == b"\xef\xbb\xbf":
+            prefix = b""
+
+        for chunk in chain(
+            (prefix,),
+            iter(lambda: csv_file.read(_STREAM_CHUNK_SIZE), b""),
+        ):
+            legacy_newline_count += chunk.count(b"\n")
+            for byte in chunk:
+                if malformed:
+                    continue
+
+                if skip_lf_after_cr:
+                    skip_lf_after_cr = False
+                    if byte == ord("\n"):
+                        continue
+
+                if in_quotes:
+                    if byte == ord('"'):
+                        in_quotes = False
+                        after_quote = True
+                    continue
+
+                if after_quote:
+                    if byte == ord('"'):
+                        in_quotes = True
+                        after_quote = False
+                    elif byte == ord(","):
+                        record_has_content = True
+                        at_field_start = True
+                        after_quote = False
+                    elif byte in (ord("\r"), ord("\n")):
+                        finish_record()
+                        after_quote = False
+                        skip_lf_after_cr = byte == ord("\r")
+                    elif byte in b" \t":
+                        continue
+                    else:
+                        malformed = True
+                    continue
+
+                if byte == ord(","):
+                    record_has_content = True
+                    at_field_start = True
+                elif byte in (ord("\r"), ord("\n")):
+                    finish_record()
+                    skip_lf_after_cr = byte == ord("\r")
+                elif byte == ord('"') and at_field_start:
+                    record_has_content = True
+                    at_field_start = False
+                    in_quotes = True
+                else:
+                    at_field_start = False
+                    if byte not in b" \t\v\f":
+                        record_has_content = True
+
+    if in_quotes:
+        malformed = True
+    if malformed:
+        return max(0, legacy_newline_count - 1)
+    if record_has_content:
+        record_count += 1
+    return max(0, record_count - 1)
 
 
 def count_txt_samples(file_path: Path) -> int:
     """TXT 文件样本计数：非空行数，流式按块读取避免全量加载"""
-    newline_count = 0
-    has_content = False
-    last_byte = b""
-    with open(file_path, "rb") as f:
-        for chunk in iter(lambda: f.read(_STREAM_CHUNK_SIZE), b""):
-            if chunk:
-                has_content = True
-                newline_count += chunk.count(b"\n")
-                last_byte = chunk[-1:]
-    if not has_content:
-        return 0
-    # 如果末尾没有换行，最后一行也计入
-    trailing_newline = last_byte == b"\n"
-    return newline_count if trailing_newline else newline_count + 1
+    sample_count = 0
+    line_has_content = False
+    skip_lf_after_cr = False
+
+    with open(file_path, "rb") as text_file:
+        for chunk in iter(lambda: text_file.read(_STREAM_CHUNK_SIZE), b""):
+            for byte in chunk:
+                if skip_lf_after_cr:
+                    skip_lf_after_cr = False
+                    if byte == ord("\n"):
+                        continue
+
+                if byte in (ord("\r"), ord("\n")):
+                    if line_has_content:
+                        sample_count += 1
+                    line_has_content = False
+                    skip_lf_after_cr = byte == ord("\r")
+                elif byte not in b" \t\v\f":
+                    line_has_content = True
+
+    return sample_count + int(line_has_content)
 
 
 def build_base_metadata(
@@ -170,6 +266,7 @@ def build_base_metadata(
         "val_samples": val_samples,
         "test_samples": test_samples,
         "total_samples": total_samples,
+        "sample_count_algorithm": _SAMPLE_COUNT_ALGORITHM,
     }
     if extra_fields:
         metadata.update(extra_fields)

--- a/server/apps/mlops/tasks/base.py
+++ b/server/apps/mlops/tasks/base.py
@@ -2,6 +2,7 @@
 MLOps 任务通用工具函数
 """
 
+import codecs
 import json
 import os
 import tempfile
@@ -210,22 +211,28 @@ def count_txt_samples(file_path: Path) -> int:
     sample_count = 0
     line_has_content = False
     skip_lf_after_cr = False
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="surrogateescape")
+
+    def consume(chars: str) -> None:
+        nonlocal sample_count, line_has_content, skip_lf_after_cr
+        for char in chars:
+            if skip_lf_after_cr:
+                skip_lf_after_cr = False
+                if char == "\n":
+                    continue
+
+            if char in "\r\n":
+                if line_has_content:
+                    sample_count += 1
+                line_has_content = False
+                skip_lf_after_cr = char == "\r"
+            elif not char.isspace():
+                line_has_content = True
 
     with open(file_path, "rb") as text_file:
         for chunk in iter(lambda: text_file.read(_STREAM_CHUNK_SIZE), b""):
-            for byte in chunk:
-                if skip_lf_after_cr:
-                    skip_lf_after_cr = False
-                    if byte == ord("\n"):
-                        continue
-
-                if byte in (ord("\r"), ord("\n")):
-                    if line_has_content:
-                        sample_count += 1
-                    line_has_content = False
-                    skip_lf_after_cr = byte == ord("\r")
-                elif byte not in b" \t\v\f":
-                    line_has_content = True
+            consume(decoder.decode(chunk))
+        consume(decoder.decode(b"", final=True))
 
     return sample_count + int(line_has_content)
 

--- a/server/apps/mlops/tests/test_tasks_base.py
+++ b/server/apps/mlops/tests/test_tasks_base.py
@@ -29,6 +29,18 @@ from apps.mlops.tasks.base import (
 pytestmark = pytest.mark.unit
 
 
+@pytest.mark.parametrize(
+    ("configured_size", "expected_size"),
+    [("0", 1), ("-1", 1), (str(1024**3), 65536)],
+)
+def test_stream_chunk_size_stays_bounded(
+    monkeypatch, configured_size, expected_size
+):
+    monkeypatch.setenv("MLOPS_STREAM_CHUNK_SIZE", configured_size)
+
+    assert base_mod._get_stream_chunk_size() == expected_size
+
+
 # ---------------- count_csv_samples ----------------
 
 
@@ -36,6 +48,46 @@ def test_count_csv_samples_subtracts_header(tmp_path):
     f = tmp_path / "a.csv"
     f.write_bytes(b"col1,col2\n1,2\n3,4\n5,6\n")
     assert count_csv_samples(f) == 3
+
+
+def test_count_csv_samples_counts_last_record_without_trailing_newline(tmp_path):
+    f = tmp_path / "no-trailing-newline.csv"
+    f.write_bytes(b"col1,col2\n1,2")
+
+    assert count_csv_samples(f) == 1
+
+
+def test_count_csv_samples_counts_quoted_newline_as_one_record(tmp_path):
+    f = tmp_path / "quoted-newline.csv"
+    f.write_text(
+        'text,label\r\n"first line\r\nsecond line",failure\r\nplain,normal',
+        encoding="utf-8-sig",
+        newline="",
+    )
+
+    assert count_csv_samples(f) == 2
+
+
+def test_count_csv_samples_handles_record_larger_than_stream_chunk(tmp_path):
+    f = tmp_path / "large-record.csv"
+    large_text = b"x" * (base_mod._STREAM_CHUNK_SIZE * 3 + 7)
+    f.write_bytes(b'text,label\n"' + large_text + b'\ncontinued",failure\n')
+
+    assert count_csv_samples(f) == 1
+
+
+def test_count_csv_samples_preserves_non_utf8_bytes(tmp_path):
+    f = tmp_path / "non-utf8.csv"
+    f.write_bytes(b"text,label\n\xff,broken\n")
+
+    assert count_csv_samples(f) == 1
+
+
+def test_count_csv_samples_falls_back_for_malformed_csv(tmp_path):
+    f = tmp_path / "malformed.csv"
+    f.write_bytes(b'a,b\n"unterminated\nvalue\n')
+
+    assert count_csv_samples(f) == 2
 
 
 def test_count_csv_samples_header_only_is_zero(tmp_path):
@@ -65,6 +117,20 @@ def test_count_txt_samples_no_trailing_newline(tmp_path):
     assert count_txt_samples(f) == 3
 
 
+def test_count_txt_samples_ignores_empty_and_whitespace_only_lines(tmp_path):
+    f = tmp_path / "empty-lines.txt"
+    f.write_bytes(b"line1\n\n \t\r\nline2\n")
+
+    assert count_txt_samples(f) == 2
+
+
+def test_count_txt_samples_handles_line_larger_than_stream_chunk(tmp_path):
+    f = tmp_path / "large-line.txt"
+    f.write_bytes(b"x" * (base_mod._STREAM_CHUNK_SIZE * 3 + 7))
+
+    assert count_txt_samples(f) == 1
+
+
 def test_count_txt_samples_empty(tmp_path):
     f = tmp_path / "c.txt"
     f.write_bytes(b"")
@@ -83,6 +149,7 @@ def test_build_base_metadata_totals_and_source():
     assert md["val_samples"] == 3
     assert md["test_samples"] == 2
     assert md["total_samples"] == 15
+    assert md["sample_count_algorithm"] == "logical_records_v1_legacy_fallback"
     assert md["source"]["type"] == "manual_selection"
     assert md["source"]["train_file_id"] == 1
     assert md["source"]["test_file_name"] == "test.csv"
@@ -211,5 +278,9 @@ def test_publish_base_full_success(monkeypatch):
     assert rel.status == "published"
     assert rel.metadata["train_samples"] == 2  # 3 lines - header
     assert rel.metadata["total_samples"] == 6
+    assert (
+        rel.metadata["sample_count_algorithm"]
+        == "logical_records_v1_legacy_fallback"
+    )
     assert rel.dataset_file.name == "anomaly_datasets/1/saved.zip"
     fake_storage.save.assert_called_once()

--- a/server/apps/mlops/tests/test_tasks_base.py
+++ b/server/apps/mlops/tests/test_tasks_base.py
@@ -119,7 +119,11 @@ def test_count_txt_samples_no_trailing_newline(tmp_path):
 
 def test_count_txt_samples_ignores_empty_and_whitespace_only_lines(tmp_path):
     f = tmp_path / "empty-lines.txt"
-    f.write_bytes(b"line1\n\n \t\r\nline2\n")
+    f.write_text(
+        "line1\n\n \t\r\n\N{NO-BREAK SPACE}\n\N{IDEOGRAPHIC SPACE}\nline2\n",
+        encoding="utf-8",
+        newline="",
+    )
 
     assert count_txt_samples(f) == 2
 

--- a/server/apps/mlops/tests/test_uncovered_serializer_contracts.py
+++ b/server/apps/mlops/tests/test_uncovered_serializer_contracts.py
@@ -294,6 +294,29 @@ def _model_classes(suffix, basename):
     )
 
 
+@pytest.mark.parametrize(("suffix", "basename"), ALGORITHMS[:4])
+def test_legacy_dataset_release_metadata_without_algorithm_is_readable(
+    serializer_context, suffix, basename
+):
+    model_module = _module("models", suffix)
+    dataset = getattr(model_module, f"{basename}Dataset")(id=1, name="dataset", team=[1])
+    release = getattr(model_module, f"{basename}DatasetRelease")(
+        id=2,
+        name="legacy",
+        dataset=dataset,
+        version="v1",
+        dataset_file="",
+        metadata={"train_samples": 1, "total_samples": 1},
+    )
+
+    data = getattr(_module("serializers", suffix), f"{basename}DatasetReleaseSerializer")(
+        release, context=serializer_context
+    ).data
+
+    assert data["metadata"] == {"train_samples": 1, "total_samples": 1}
+    assert "sample_count_algorithm" not in data["metadata"]
+
+
 @pytest.mark.parametrize(
     ("suffix", "basename"),
     [


### PR DESCRIPTION
## 问题

MLOps 的分类、异常检测、时序预测和日志聚类共用数据集发布链。这里本应按训练程序实际消费的逻辑样本生成版本元数据，但旧实现把物理换行数当作样本数，导致 CSV 末行无换行时少计、引号字段内换行时多计，TXT 空行也会被计入。

## 根因

共享发布层只扫描 `\n` 字节，没有建模 CSV 的引号状态、CRLF 和逻辑记录边界，也没有落实 TXT “非空行”的既有训练契约。错误计数随后进入 release metadata、发布 ZIP 和异常率计算。

## 怎么修的

- 以不超过 64 KB 的固定块扫描 CSV，用跨块状态机识别表头、CRLF、引号字段、转义引号和逻辑记录边界。
- CSV 字节无法按严格状态机确认时保留旧计数回退，避免计数修复新增文件拒绝；新 metadata 用 `logical_records_v1_legacy_fallback` 明确记录口径。
- TXT 以同样的有界块扫描非空、非纯空白逻辑行，不缓存整行。
- 将块大小配置限制在 1–65536，避免异常配置退化为无界读取。

## 影响范围

仅修改 MLOps 共享发布计数和直接测试。四类 Celery wrapper、REST 字段、历史 metadata、存储事务和数据库结构均未改变；历史版本继续按原值读取，不做静默回填。新发布版本会得到纠正后的样本数和异常率，并携带明确的算法口径标记。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["数据集发布 REST\nserializers"]
        T2["四类 Celery wrapper\ntasks/*.py"]
    end

    subgraph N["共享发布层"]
        N1["publish_dataset_release_base\ntasks/base.py"]
        N2["有界逻辑记录计数\ntasks/base.py"]
        N3["build_base_metadata\ntasks/base.py"]
    end

    subgraph O["输出层"]
        O1["release.metadata"]
        O2["dataset_metadata.json"]
        O3["异常率"]
    end

    T1 --> T2 --> N1 --> N2 --> N3
    N3 --> O1
    N3 --> O2
    N3 --> O3
    N2 -. "畸形 CSV" .-> N3
```

## 验证

- `apps/mlops/tests/test_tasks_base.py`、`apps/mlops/tests/test_tasks_wrappers_param.py`：43 passed。
- 回归覆盖 CSV 无尾换行、BOM、CRLF、引号内换行、跨块大记录、畸形兼容回退，以及 TXT 空行和超长行。
- Flake8、Python 编译检查和 diff 检查通过。

## 三轨门禁

- Standards：PASS（96/100）。
- Spec：PASS（98/100）。
- Runtime Contract：PASS（98/100）；初始回归在旧实现稳定失败，最终提交在真实 Django DB 与临时文件边界通过，MinIO 仅作为未改动的外部边界替换。

综合评分：96/100。

关联 Issue #4253。
