### PR TITLE
fix: 修复接入配置页卡死并补齐 Postgres 监控关键配置

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/UI.json
@@ -24,7 +24,7 @@
       "transform_on_edit": {
         "origin_path": "child.content.config.address",
         "to_form": {
-          "regex": "user=([^ ]+)"
+          "regex": "://([^:]+):"
         }
       },
       "label_en": "Username",
@@ -66,7 +66,7 @@
       "transform_on_edit": {
         "origin_path": "child.content.config.address",
         "to_form": {
-          "regex": "host=([^ ]+)"
+          "regex": "@([^:]+):"
         }
       },
       "label_en": "Host"
@@ -90,10 +90,73 @@
       "transform_on_edit": {
         "origin_path": "child.content.config.address",
         "to_form": {
-          "regex": "port=(\\d+)"
+          "regex": ":(\\d+)/"
         }
       },
       "label_en": "Port"
+    },
+    {
+      "name": "dbname",
+      "label": "数据库名",
+      "type": "input",
+      "required": true,
+      "default_value": "postgres",
+      "editable": false,
+      "description": "用于建立监控连接的数据库名",
+      "guide_short": "填写监控账号可登录的数据库名，默认 postgres；Telegraf 会通过该连接采集各库统计，并忽略 template0/template1。",
+      "guide_short_en": "Enter a database the monitoring account can log into, commonly postgres. Telegraf uses this connection to collect per-database stats and ignores template0/template1.",
+      "widget_props": {
+        "placeholder": "数据库名",
+        "placeholder_en": "Database Name"
+      },
+      "transform_on_edit": {
+        "origin_path": "child.content.config.address",
+        "to_form": {
+          "regex": "/([^/?]+)(?:\\?|$)"
+        }
+      },
+      "label_en": "Database Name",
+      "description_en": "Database name used to establish the monitoring connection"
+    },
+    {
+      "name": "sslmode",
+      "label": "SSL 模式",
+      "type": "select",
+      "required": true,
+      "default_value": "disable",
+      "editable": false,
+      "description": "PostgreSQL 连接的 SSL 模式",
+      "guide_short": "按目标要求选择 disable、prefer 或 require。本模板不支持证书路径，verify-ca / verify-full 暂不可用。",
+      "guide_short_en": "Choose disable, prefer, or require according to the target. Certificate paths are not supported; verify-ca and verify-full are unavailable in this template.",
+      "widget_props": {
+        "placeholder": "SSL 模式",
+        "placeholder_en": "SSL Mode"
+      },
+      "options": [
+        {
+          "label": "disable",
+          "value": "disable",
+          "label_en": "disable"
+        },
+        {
+          "label": "prefer",
+          "value": "prefer",
+          "label_en": "prefer"
+        },
+        {
+          "label": "require",
+          "value": "require",
+          "label_en": "require"
+        }
+      ],
+      "transform_on_edit": {
+        "origin_path": "child.content.config.address",
+        "to_form": {
+          "regex": "sslmode=([^&]+)"
+        }
+      },
+      "label_en": "SSL Mode",
+      "description_en": "SSL mode for the PostgreSQL connection"
     },
     {
       "name": "interval",

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/guide/en.md
@@ -1,19 +1,19 @@
 # PostgreSQL Monitoring Guide
 
-This capability uses Telegraf `inputs.postgresql` to connect to a specified PostgreSQL host and port. The database is fixed to `postgres`.
+This capability uses Telegraf `inputs.postgresql` to connect to a specified PostgreSQL host, port, and database.
 
 ## Prerequisites
 
 - The collector node can reach the target PostgreSQL host and actual port.
-- Prepare an account that can log in to the `postgres` database and read the required statistics views. On PostgreSQL 10 and later, `pg_monitor` can be granted according to least privilege.
+- Prepare an account that can log in to the configured database and read the required statistics views. On PostgreSQL 10 and later, `pg_monitor` can be granted according to least privilege.
 - The target `pg_hba.conf` allows this account to connect from the collector node.
-- The current template always uses `sslmode=disable`. The page has no database-name, SSL, or certificate fields.
+- The page supports SSL modes `disable`, `prefer`, and `require`. Certificate paths are not supported; `verify-ca` and `verify-full` are unavailable in this template.
 - The template always ignores `template0` and `template1`.
 
 ## Setup Steps
 
-1. From the actual collector node, validate the target address, account, `postgres` database, and statistics-view permissions.
-2. Enter the username, password, host, actual port, and interval (default `60` seconds).
+1. From the actual collector node, validate the target address, account, database name, SSL mode, and statistics-view permissions.
+2. Enter the username, password, host, actual port, database name, SSL mode, and interval (default `60` seconds).
 3. In the monitored objects table, select the node and enter the host, port, instance name, and optional group.
 4. Save the configuration and wait for at least one collection interval.
 
@@ -25,7 +25,7 @@ This capability uses Telegraf `inputs.postgresql` to connect to a specified Post
 psql --host db.example.com --port 5432 --username monitor --dbname postgres --password --command "SELECT count(*) FROM pg_stat_database;"
 ```
 
-The command must return a result without authentication, network, or statistics-view permission errors.
+The command must return a result without authentication, network, or statistics-view permission errors. If the target requires SSL, add the corresponding SSL parameters to the validation command.
 
 ## Field Reference
 
@@ -35,6 +35,8 @@ The command must return a result without authentication, network, or statistics-
 | Password | Yes | Password for the account. |
 | Host | Yes | PostgreSQL hostname or IP address without a scheme. |
 | Port | Yes | Actual PostgreSQL listener port. |
+| Database Name | Yes | Database used to establish the monitoring connection; default `postgres`. |
+| SSL Mode | Yes | `disable` / `prefer` / `require`; default `disable`. |
 | Interval | Yes | Collection interval in seconds; default `60`. |
 | Node | Yes | Collector node that can reach PostgreSQL. |
 | Instance Name | Yes | Display name in the platform. |
@@ -47,13 +49,13 @@ After saving and waiting for one interval, confirm that these metrics are querya
 - `postgresql_numbackends`
 - `postgresql_xact_commit_rate`
 - `postgresql_deadlocks_rate`
-- `postgresql_blks_hit_rate`
+- `postgresql_cache_hit_ratio`
 
 ## Troubleshooting
 
 ### Authentication or the source address is rejected
 
-- Check whether `pg_hba.conf` allows the collector source address, account, and `postgres` database.
+- Check whether `pg_hba.conf` allows the collector source address, account, and target database.
 - Check that the server's password-authentication mode matches the account configuration.
 
 ### Login succeeds but data is incomplete
@@ -63,4 +65,4 @@ After saving and waiting for one interval, confirm that these metrics are querya
 
 ### The target enforces SSL
 
-- The template always uses `sslmode=disable` and the page has no SSL fields. An SSL-only target cannot be integrated directly.
+- Set SSL mode to `require` (or `prefer`). Certificate paths are not supported; targets that require `verify-ca` or `verify-full` cannot be integrated directly with this template.

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/guide/zh-Hans.md
@@ -1,19 +1,19 @@
 # PostgreSQL 监控接入指南
 
-本能力通过 Telegraf `inputs.postgresql` 连接指定 PostgreSQL 主机和端口，数据库固定使用 `postgres`。
+本能力通过 Telegraf `inputs.postgresql` 连接指定 PostgreSQL 主机、端口和数据库。
 
 ## 前置要求
 
 - 采集节点能够访问目标 PostgreSQL 主机和实际端口。
-- 准备可登录 `postgres` 数据库并读取所需统计视图的账号；PostgreSQL 10 及以上可按最小权限授予 `pg_monitor`。
+- 准备可登录指定数据库并读取所需统计视图的账号；PostgreSQL 10 及以上可按最小权限授予 `pg_monitor`。
 - 目标的 `pg_hba.conf` 允许来自采集节点的该账号连接。
-- 当前模板固定 `sslmode=disable`，页面没有数据库名、SSL 或证书字段。
+- 页面可选 SSL 模式 `disable`、`prefer`、`require`；本模板不支持证书路径，`verify-ca` / `verify-full` 暂不可用。
 - 模板固定忽略 `template0` 和 `template1`。
 
 ## 接入步骤
 
-1. 从实际采集节点验证目标地址、账号、`postgres` 数据库和统计视图权限。
-2. 填写用户名、密码、主机、实际端口和采集间隔（默认 `60` 秒）。
+1. 从实际采集节点验证目标地址、账号、数据库名、SSL 模式和统计视图权限。
+2. 填写用户名、密码、主机、实际端口、数据库名、SSL 模式和采集间隔（默认 `60` 秒）。
 3. 在监控对象表格中选择节点，填写主机、端口、实例名称和可选分组。
 4. 保存后等待至少一个采集周期。
 
@@ -25,7 +25,7 @@
 psql --host db.example.com --port 5432 --username monitor --dbname postgres --password --command "SELECT count(*) FROM pg_stat_database;"
 ```
 
-命令应成功返回结果，并且不能出现认证、网络或统计视图权限错误。
+命令应成功返回结果，并且不能出现认证、网络或统计视图权限错误。若目标要求 SSL，请在校验命令中增加相应 SSL 参数。
 
 ## 页面字段说明
 
@@ -35,6 +35,8 @@ psql --host db.example.com --port 5432 --username monitor --dbname postgres --pa
 | 密码 | 是 | 对应账号密码。 |
 | 主机 | 是 | PostgreSQL 主机名或 IP，不包含协议。 |
 | 端口 | 是 | PostgreSQL 实际监听端口。 |
+| 数据库名 | 是 | 建立监控连接的数据库，默认 `postgres`。 |
+| SSL 模式 | 是 | `disable` / `prefer` / `require`，默认 `disable`。 |
 | 间隔 | 是 | 采集周期，单位秒，默认 `60`。 |
 | 节点 | 是 | 能够访问 PostgreSQL 的采集节点。 |
 | 实例名称 | 是 | 平台内展示的实例名称。 |
@@ -47,13 +49,13 @@ psql --host db.example.com --port 5432 --username monitor --dbname postgres --pa
 - `postgresql_numbackends`
 - `postgresql_xact_commit_rate`
 - `postgresql_deadlocks_rate`
-- `postgresql_blks_hit_rate`
+- `postgresql_cache_hit_ratio`
 
 ## 常见问题
 
 ### 认证或来源地址被拒绝
 
-- 核对 `pg_hba.conf` 是否允许采集节点来源地址、账号和 `postgres` 数据库。
+- 核对 `pg_hba.conf` 是否允许采集节点来源地址、账号和目标数据库。
 - 核对服务器实际使用的密码认证方式与账号配置。
 
 ### 登录成功但数据不完整
@@ -63,4 +65,4 @@ psql --host db.example.com --port 5432 --username monitor --dbname postgres --pa
 
 ### 目标强制 SSL
 
-- 当前模板固定 `sslmode=disable`，页面没有 SSL 字段；强制 SSL 的目标不能用此配置直接接入。
+- 将 SSL 模式设为 `require`（或 `prefer`）。本模板不支持证书路径；需要 `verify-ca` / `verify-full` 的目标暂无法直接接入。

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/language/en.yaml
@@ -39,6 +39,9 @@ monitor_object_metric:
     postgresql_blks_read_rate:
       name: Disk Block Read Rate
       desc: Evaluates disk I/O load and cache misses
+    postgresql_cache_hit_ratio:
+      name: Buffer Cache Hit Ratio
+      desc: Percentage of shared buffer hits among total block accesses; a low ratio usually means more physical I/O
     postgresql_deadlocks_rate:
       name: Deadlock Rate
       desc: Detects transaction deadlock frequency

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/language/zh-Hans.yaml
@@ -37,6 +37,9 @@ monitor_object_metric:
     postgresql_blks_read_rate:
       name: 磁盘数据块读取速率
       desc: 评估磁盘 I/O 负载及缓存不足情况
+    postgresql_cache_hit_ratio:
+      name: 缓存命中率
+      desc: 共享缓冲区命中次数占总块访问次数的百分比，低命中率通常伴随更高的物理 IO
     postgresql_deadlocks_rate:
       name: 死锁发生速率
       desc: 检测事务间死锁发生频率

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/metrics.json
@@ -10,8 +10,8 @@
   "description": "",
   "default_metric": "any({instance_type='postgres'}) by (instance_id)",
   "instance_id_keys": ["instance_id"],
-  "supplementary_indicators": ["postgresql_numbackends", "postgresql_blks_read_rate", "postgresql_temp_files_rate"],
-  "display_fields": [{"name":"活跃连接数","sort_order":0,"metrics":[{"plugin":"Postgres","metric":"postgresql_numbackends"}]}, {"name":"事务提交速率","sort_order":1,"metrics":[{"plugin":"Postgres","metric":"postgresql_xact_commit_rate"}]}, {"name":"缓冲区命中速率","sort_order":2,"metrics":[{"plugin":"Postgres","metric":"postgresql_blks_hit_rate"}]}, {"name":"死锁速率","sort_order":3,"metrics":[{"plugin":"Postgres","metric":"postgresql_deadlocks_rate"}]}],
+  "supplementary_indicators": ["postgresql_numbackends", "postgresql_blks_read_rate", "postgresql_temp_files_rate", "postgresql_cache_hit_ratio"],
+  "display_fields": [{"name":"活跃连接数","sort_order":0,"metrics":[{"plugin":"Postgres","metric":"postgresql_numbackends"}]}, {"name":"事务提交速率","sort_order":1,"metrics":[{"plugin":"Postgres","metric":"postgresql_xact_commit_rate"}]}, {"name":"缓存命中率","sort_order":2,"metrics":[{"plugin":"Postgres","metric":"postgresql_cache_hit_ratio"}]}, {"name":"死锁速率","sort_order":3,"metrics":[{"plugin":"Postgres","metric":"postgresql_deadlocks_rate"}]}],
   "metrics": [
     {
       "metric_group": "Connection",
@@ -172,6 +172,17 @@
       ],
       "description": "Evaluates disk I/O load and cache misses",
       "query": "rate(postgresql_blks_read{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Cache",
+      "name": "postgresql_cache_hit_ratio",
+      "display_name": "Buffer Cache Hit Ratio",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "description": "Ratio of shared buffer cache hits to total block accesses",
+      "query": "100 * sum(rate(postgresql_blks_hit{__$labels__}[5m])) / clamp_min(sum(rate(postgresql_blks_hit{__$labels__}[5m])) + sum(rate(postgresql_blks_read{__$labels__}[5m])), 1e-6)"
     },
     {
       "metric_group": "Concurrency",

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/policy.json
@@ -6,7 +6,7 @@
       "name": "缓存命中率下降",
       "alert_name": "PostgreSQL 实例 ${resource_name} 缓存效率低",
       "description": "监控数据块缓存命中率，低命中率会导致大量物理IO。需优化shared_buffers配置或检查查询模式。",
-      "metric_name": "postgresql_blks_hit_rate",
+      "metric_name": "postgresql_cache_hit_ratio",
       "algorithm": "min_over_time",
       "threshold": [
         {
@@ -105,24 +105,24 @@
     {
       "name": "物理读过高",
       "alert_name": "PostgreSQL 实例 ${resource_name} 物理 IO 压力",
-      "description": "检测块缓存命中率，反映缓存的有效性",
+      "description": "检测磁盘数据块读取速率，过高表明缓存不足或查询触发大量物理 IO。需检查 shared_buffers、查询模式或存储性能。",
       "metric_name": "postgresql_blks_read_rate",
       "algorithm": "max_over_time",
       "threshold": [
         {
           "level": "critical",
-          "value": 85,
-          "method": "<"
+          "value": 1000,
+          "method": ">="
         },
         {
           "level": "error",
-          "value": 95,
-          "method": "<"
+          "value": 500,
+          "method": ">="
         },
         {
           "level": "warning",
-          "value": 99,
-          "method": "<"
+          "value": 200,
+          "method": ">="
         }
       ],
       "group_algorithm": "max"

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/postgres.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/postgres/postgres.child.toml.j2
@@ -1,6 +1,6 @@
 [[inputs.postgresql]]
     startup_error_behavior = "retry"
-    address = "postgres://{{ username | urlencode }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/{{ dbname | default('postgres') | urlencode }}?sslmode=disable"
+    address = "postgres://{{ username | urlencode }}:${PASSWORD__{{ config_id }}}@{{ host }}:{{ port }}/{{ dbname | default('postgres') | urlencode }}?sslmode={{ sslmode | default('disable') }}"
     ignored_databases = ["template0", "template1"]
     interval = "{{ interval }}s"
     [inputs.postgresql.tags]

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -83,6 +83,7 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "send",
     "server",
     "server_url",
+    "sslmode",
     "storage_instance_key",
     "timeout",
     "tls_ca",

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -657,14 +657,13 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
         ...prev,
         ...form.getFieldsValue(true)
       };
+      let unchanged = false;
       try {
-        if (JSON.stringify(prev) === JSON.stringify(next)) {
-          return prev;
-        }
+        unchanged = JSON.stringify(prev) === JSON.stringify(next);
       } catch {
-        // 不可序列化时回退为更新，避免静默跳过
+        unchanged = false;
       }
-      return next;
+      return unchanged ? prev : next;
     });
     // 刻意依赖 defaultFormKey 而非 defaultForm 对象引用。
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stabilize defaultForm identity

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -643,14 +643,32 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     }
   }, [configLoading, formConfig.initTableItems, groupId]);
 
+  // defaultForm 每次 buildPluginUI 都会新建对象引用；用序列化值做依赖，避免
+  // effect 每轮 setFormSnapshot → 重渲染 → 再触发 effect 的死循环卡死页面。
+  const defaultFormKey = JSON.stringify(formConfig?.defaultForm ?? {});
+
   useEffect(() => {
-    if (configLoading || !formConfig?.defaultForm) return;
-    setFormSnapshot((prev) => ({
-      ...formConfig.defaultForm,
-      ...prev,
-      ...form.getFieldsValue(true)
-    }));
-  }, [configLoading, formConfig?.defaultForm, form]);
+    if (configLoading) return;
+    const defaults = formConfig?.defaultForm;
+    if (!defaults) return;
+    setFormSnapshot((prev) => {
+      const next = {
+        ...defaults,
+        ...prev,
+        ...form.getFieldsValue(true)
+      };
+      try {
+        if (JSON.stringify(prev) === JSON.stringify(next)) {
+          return prev;
+        }
+      } catch {
+        // 不可序列化时回退为更新，避免静默跳过
+      }
+      return next;
+    });
+    // 刻意依赖 defaultFormKey 而非 defaultForm 对象引用。
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- stabilize defaultForm identity
+  }, [configLoading, defaultFormKey, form]);
 
   const handleAdd = (key: string) => {
     const index = dataSource.findIndex((item) => item.key === key);

--- a/web/src/app/monitor/hooks/integration/objects/database/postgres.tsx
+++ b/web/src/app/monitor/hooks/integration/objects/database/postgres.tsx
@@ -1,7 +1,88 @@
 export const usePostgresConfig = () => {
   return {
     instance_type: 'postgres',
-    dashboardDisplay: [],
+    dashboardDisplay: [
+      {
+        indexId: 'postgresql_numbackends',
+        displayType: 'single',
+        sortIndex: 0,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%'
+        }
+      },
+      {
+        indexId: 'postgresql_xact_commit_rate',
+        displayType: 'single',
+        sortIndex: 1,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%'
+        }
+      },
+      {
+        indexId: 'postgresql_blks_read_rate',
+        displayType: 'single',
+        sortIndex: 2,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%'
+        }
+      },
+      {
+        indexId: 'postgresql_cache_hit_ratio',
+        displayType: 'single',
+        sortIndex: 3,
+        displayDimension: [],
+        style: {
+          height: '200px',
+          width: '15%'
+        }
+      },
+      {
+        indexId: 'postgresql_numbackends',
+        displayType: 'lineChart',
+        sortIndex: 4,
+        displayDimension: [],
+        style: {
+          height: '260px',
+          width: '48%'
+        }
+      },
+      {
+        indexId: 'postgresql_xact_commit_rate',
+        displayType: 'lineChart',
+        sortIndex: 5,
+        displayDimension: [],
+        style: {
+          height: '260px',
+          width: '48%'
+        }
+      },
+      {
+        indexId: 'postgresql_blks_hit_rate',
+        displayType: 'lineChart',
+        sortIndex: 6,
+        displayDimension: [],
+        style: {
+          height: '260px',
+          width: '48%'
+        }
+      },
+      {
+        indexId: 'postgresql_blks_read_rate',
+        displayType: 'lineChart',
+        sortIndex: 7,
+        displayDimension: [],
+        style: {
+          height: '260px',
+          width: '48%'
+        }
+      }
+    ],
     groupIds: {},
     collectTypes: {
       'Postgres-Exporter': 'exporter',


### PR DESCRIPTION
## Summary
- 修复接入配置页 `formSnapshot` 依赖不稳定 `defaultForm` 对象引用导致的无限重渲染，页面卡死无法切换到「指标」
- 补齐 Postgres 接入表单 `dbname` / `sslmode`，修正 URI 编辑回填，模板白名单增加 `sslmode`
- 注册 `postgresql_cache_hit_ratio`，修正命中率与物理读告警语义，并补齐集成列表 `dashboardDisplay`

## Test plan
- [ ] 打开任意 Telegraf 接入配置页（如 Redis），确认可流畅切换「配置 / 指标」
- [ ] 新建 Postgres 接入，确认可填写数据库名与 SSL 模式，保存后 toml 中 `sslmode` 正确
- [ ] 编辑已有 Postgres 配置，确认用户名/主机/端口/数据库名/sslmode 能正确回填
- [ ] 确认 Postgres 集成列表出现 KPI/趋势卡片；告警模板「缓存命中率下降」绑定命中率指标

## Scope check
- 已审查暂存内容与相对 `master` 的完整 diff：仅 11 个相关文件
- 工作区仍有图标、process 仪表盘等无关改动，**未纳入本次提交/PR**