### PR TITLE
feat: 恢复进程专业监控仪表盘

### DIFF
--- a/web/src/app/monitor/constants/menu.json
+++ b/web/src/app/monitor/constants/menu.json
@@ -52,6 +52,11 @@
           "isNotMenuItem": true
         },
         {
+          "url": "/monitor/view/dashboard/process",
+          "name": "process_dashboard",
+          "isNotMenuItem": true
+        },
+        {
           "url": "/monitor/view/dashboard/website",
           "name": "website_dashboard",
           "isNotMenuItem": true
@@ -211,6 +216,11 @@
         {
           "url": "/monitor/view/dashboard/host",
           "name": "host_dashboard",
+          "isNotMenuItem": true
+        },
+        {
+          "url": "/monitor/view/dashboard/process",
+          "name": "process_dashboard",
           "isNotMenuItem": true
         },
         {

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -9,6 +9,7 @@ import useViewApi from '@/app/monitor/api/view';
 import {
   normalizeDisplayText,
   resolveDashboardInstanceIdentity,
+  encodeInstanceIdValuesParam,
   buildInstanceDisplayName,
   buildInstanceSearchTokens,
   formatEnumValue,
@@ -88,6 +89,14 @@ export interface SummaryCardConfig {
   enumMap?: MetricEnumMap;
   /** 标记为运行时长卡片，启用 relaxed 布局 + 运行状态指示器 */
   isUptimeCard?: boolean;
+  /**
+   * 无序列时主值文案（缺省 '--'）。用于可选能力（如未配置端口探测）明示「未配置」而非空白。
+   */
+  emptyValue?: string;
+  /**
+   * 指标已成功返回且无序列时不展示该 KPI（可选采集项）；加载中/失败仍保留卡片避免闪烁。
+   */
+  hideWhenNoData?: boolean;
 }
 
 export interface ChartConfig {
@@ -648,16 +657,24 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   }, [getTransformedValue, hasMetricData, metricMap]);
 
   const summaryCards = useMemo<PreparedSummaryCard[]>(() => (
-    config.summaryCards.map((card) => {
-      const healthResult = card.formatter === 'enumHealth' && !card.enumMap && hasMetricData(card.metric)
+    config.summaryCards
+      .filter((card) => {
+        if (!card.hideWhenNoData) return true;
+        const target = metricMap[card.metric];
+        // 仅在查询成功且无序列时隐藏；加载中/失败保留卡片，避免可选指标闪烁。
+        return !(target?.loadState === 'success' && (!Array.isArray(target.viewData) || target.viewData.length === 0));
+      })
+      .map((card) => {
+      const hasData = hasMetricData(card.metric);
+      const healthResult = card.formatter === 'enumHealth' && !card.enumMap && hasData
         ? formatClusterHealth(getLatest(card.metric))
         : null;
-      const enumResult = card.enumMap && hasMetricData(card.metric)
+      const enumResult = card.enumMap && hasData
         ? formatMappedEnum(getLatest(card.metric), card.enumMap)
         : null;
 
-      const mainValue = !hasMetricData(card.metric)
-        ? { value: '--', unit: '' }
+      const mainValue = !hasData
+        ? { value: card.emptyValue || '--', unit: '' }
         : card.formatter === 'duration'
           ? { value: formatDuration(getLatest(card.metric)), unit: '' }
           : healthResult
@@ -667,7 +684,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
               : formatMetricValue(getLatest(card.metric), card.unit || metricMap[card.metric]?.unit || 'none');
 
       const uptimeState = card.isUptimeCard
-        ? !hasMetricData(card.metric)
+        ? !hasData
           ? { label: '状态未知', tone: 'empty' as const }
           : countRestartsInRange(metricMap[card.metric]?.viewData || []) > 0
             ? { label: '期间有重启', tone: 'warning' as const }
@@ -677,7 +694,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
       return {
         card,
         mainValue,
-        valueColor: enumResult?.color || healthResult?.color,
+        valueColor: enumResult?.color || healthResult?.color || (!hasData && card.emptyValue ? '#8c95a8' : undefined),
         compare: card.compare
           ? getPeriodCompare(getLatest(card.metric), getLatestChartValue(previousMetricMap[card.metric]?.viewData || []))
           : null,
@@ -855,7 +872,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     const params = new URLSearchParams(searchParams.toString());
     params.set('instance_id', value);
     params.set('instance_name', String(target?.label || normalizedInstanceName || resolvedInstanceName || ''));
-    params.set('instance_id_values', (target?.instanceIdValues || [value]).join(','));
+    params.set('instance_id_values', encodeInstanceIdValuesParam(target?.instanceIdValues || [value]));
     router.push(`/monitor/view/dashboard/${config.routeKey}?${params.toString()}`);
   };
   const onClusterFilterChange = (cluster: string) => {

--- a/web/src/app/monitor/dashboards/objects/process/config.ts
+++ b/web/src/app/monitor/dashboards/objects/process/config.ts
@@ -1,0 +1,213 @@
+import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
+import type { MetricEnumMap } from '../../shared/types';
+
+const PROCESS_ALIVE_ENUM: MetricEnumMap = {
+  0: { label: '失活', color: '#ff4d4f' },
+  1: { label: '存活', color: '#1ac44a' }
+};
+
+const PROCESS_PORT_ALIVE_ENUM: MetricEnumMap = {
+  0: { label: '失活', color: '#ff4d4f' },
+  0.5: { label: '部分失活', color: '#faad14' },
+  1: { label: '存活', color: '#1ac44a' }
+};
+
+export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
+  routeKey: 'process',
+  pageTitle: '进程监控仪表盘',
+  objectFallbackName: '进程',
+  instanceType: 'process',
+  collectionStatusQuery:
+    "count({instance_type='process', collect_type='host', __$labels__}) by (instance_id, process_name)",
+  metaItems: ['OS', 'process'],
+  metrics: [
+    {
+      name: 'process_alive',
+      display_name: '进程存活',
+      description: '是否至少有一个匹配进程正在上报指标。',
+      unit: 'none',
+      query:
+        'clamp_max(count(procstat_cpu_usage{instance_type="process", __$labels__}) by (instance_id, process_name), 1)',
+      color: '#1ac44a'
+    },
+    {
+      name: 'process_port_alive',
+      display_name: '端口存活',
+      description: '已配置端口的存活状态：1=全部存活，0=全部失活，0.5=部分失活；无系列表示未采集端口。',
+      unit: 'none',
+      query:
+        '((floor(((avg(clamp_max(net_response_result_code{instance_type="process", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type="process", __$labels__})) + ceil(((avg(clamp_max(net_response_result_code{instance_type="process", __$labels__}, 1) == bool 0) by (instance_id, process_name)) or process_port_alive{instance_type="process", __$labels__}))) / 2)',
+      color: '#faad14'
+    },
+    {
+      name: 'process_cpu_usage',
+      display_name: '进程 CPU 使用率',
+      description: '匹配进程的 CPU 使用率合计（按 process_name 聚合）。',
+      unit: 'percent',
+      query:
+        'sum(procstat_cpu_usage{instance_type="process", __$labels__}) by (instance_id, process_name)',
+      color: '#2f6bff'
+    },
+    {
+      name: 'process_mem_usage',
+      display_name: '应用内存使用率',
+      description: '匹配进程相对系统内存的使用率合计（按 process_name 聚合）。',
+      unit: 'percent',
+      query:
+        'sum(procstat_memory_usage{instance_type="process", __$labels__}) by (instance_id, process_name)',
+      color: '#27c274'
+    },
+    {
+      name: 'process_memory_rss',
+      display_name: '内存 RSS',
+      description: '匹配进程常驻集大小合计（字节）。',
+      unit: 'bytes',
+      query:
+        'sum(procstat_memory_rss{instance_type="process", __$labels__}) by (instance_id, process_name)',
+      color: '#13c2c2'
+    },
+    {
+      name: 'process_num_threads',
+      display_name: '线程数',
+      description: '匹配进程的线程数合计。',
+      unit: 'counts',
+      query:
+        'sum(procstat_num_threads{instance_type="process", __$labels__}) by (instance_id, process_name)',
+      color: '#597ef7'
+    },
+    {
+      name: 'process_num_fds',
+      display_name: '打开文件数',
+      description: '匹配进程打开的文件描述符数量合计；可能需要提升权限才能采集。',
+      unit: 'counts',
+      query:
+        'sum(procstat_num_fds{instance_type="process", __$labels__}) by (instance_id, process_name)',
+      color: '#ff8a1f'
+    }
+  ],
+  summaryCards: [
+    {
+      title: '进程存活',
+      metric: 'process_alive',
+      unit: 'none',
+      color: '#1ac44a',
+      icon: 'health',
+      enumMap: PROCESS_ALIVE_ENUM,
+      guide: [
+        {
+          label: '进程存活',
+          detail: '至少有一个匹配进程正在上报 procstat 指标时为存活；无数据表示当前窗口未采到该进程。'
+        }
+      ]
+    },
+    {
+      title: '端口存活',
+      metric: 'process_port_alive',
+      unit: 'none',
+      color: '#faad14',
+      icon: 'api',
+      enumMap: PROCESS_PORT_ALIVE_ENUM,
+      // 端口探测为可选：未配置 ports 时无系列，隐藏卡片，避免误读为「存活」。
+      hideWhenNoData: true,
+      emptyValue: '未配置',
+      hideTrend: true,
+      guide: [
+        {
+          label: '端口存活',
+          detail: '仅在采集配置了 ports 时展示。全部存活 / 部分失活 / 全部失活；未配置端口时不展示本卡片。'
+        }
+      ]
+    },
+    {
+      title: 'CPU',
+      metric: 'process_cpu_usage',
+      unit: 'percent',
+      color: '#2f6bff',
+      icon: 'thunder',
+      compare: true,
+      guide: [
+        {
+          label: '进程 CPU',
+          detail: '匹配进程 CPU 使用率合计。持续偏高时对照线程数与主机 CPU，区分单进程打满与主机整体争用。'
+        }
+      ]
+    },
+    {
+      title: '应用内存',
+      metric: 'process_mem_usage',
+      unit: 'percent',
+      color: '#27c274',
+      icon: 'memory',
+      compare: true,
+      guide: [
+        {
+          label: '应用内存',
+          detail: '相对系统内存的进程内存占比合计。可与下方 RSS 趋势对照判断绝对占用与相对压力。'
+        }
+      ],
+      footer: [{ label: '内存 RSS', metric: 'process_memory_rss', unit: 'bytes' }]
+    }
+  ],
+  charts: [
+    {
+      title: '资源使用趋势',
+      subtitle: 'CPU 与应用内存',
+      metric: 'process_cpu_usage',
+      guide: [
+        {
+          label: '资源使用',
+          detail: '对比进程 CPU 使用率与应用内存使用率随时间的变化。'
+        }
+      ],
+      series: [
+        { metric: 'process_cpu_usage', label: 'CPU 使用率', color: '#2f6bff', unit: 'percent' },
+        { metric: 'process_mem_usage', label: '应用内存使用率', color: '#27c274', unit: 'percent' }
+      ]
+    },
+    {
+      title: '内存 RSS 趋势',
+      subtitle: '常驻集大小',
+      metric: 'process_memory_rss',
+      guide: [
+        {
+          label: '内存 RSS',
+          detail: '进程常驻物理内存合计。持续抬升需关注泄漏或缓存膨胀。'
+        }
+      ],
+      series: [
+        { metric: 'process_memory_rss', label: '内存 RSS', color: '#13c2c2', unit: 'bytes' }
+      ]
+    },
+    {
+      title: '线程数趋势',
+      subtitle: '匹配进程合计',
+      metric: 'process_num_threads',
+      guide: [
+        {
+          label: '线程数',
+          detail: '匹配进程线程数合计。异常飙升可能伴随 CPU 争用或线程泄漏。'
+        }
+      ],
+      series: [
+        { metric: 'process_num_threads', label: '线程数', color: '#597ef7', unit: 'counts' }
+      ]
+    },
+    {
+      title: '打开文件数趋势',
+      subtitle: '文件描述符',
+      metric: 'process_num_fds',
+      guide: [
+        {
+          label: '打开文件数',
+          detail: '打开的文件描述符数量合计。持续逼近 ulimit 时优先排查泄漏；无数据时检查采集权限。'
+        }
+      ],
+      series: [
+        { metric: 'process_num_fds', label: '打开文件数', color: '#ff8a1f', unit: 'counts' }
+      ]
+    }
+  ],
+  ringPanels: [],
+  barPanels: [],
+  details: []
+};

--- a/web/src/app/monitor/dashboards/objects/process/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/process/dashboard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React from 'react';
+import { useSimpleDashboardData } from '../common/simple-dashboard-core';
+import {
+  DashboardShell,
+  FlexiblePanelSection,
+  KpiSection,
+  useFilteredChartPanels
+} from '../common/dashboard-components';
+import { TrendChartPanel } from '../../shared/widgets';
+import { PROCESS_DASHBOARD_CONFIG } from './config';
+import styles from './index.module.scss';
+
+const RESOURCE_CHART_TITLES = ['资源使用趋势', '内存 RSS 趋势'];
+const CONCURRENCY_CHART_TITLES = ['线程数趋势', '打开文件数趋势'];
+
+export default function ProcessDashboardPage() {
+  const dashboard = useSimpleDashboardData(PROCESS_DASHBOARD_CONFIG);
+  const resourceCharts = useFilteredChartPanels(dashboard.chartPanels, RESOURCE_CHART_TITLES);
+  const concurrencyCharts = useFilteredChartPanels(dashboard.chartPanels, CONCURRENCY_CHART_TITLES);
+
+  return (
+    <DashboardShell
+      dashboard={dashboard}
+      styles={styles}
+      dashboardContent={
+        <>
+          <div className={styles.sectionLabel}>健康概览</div>
+          <KpiSection dashboard={dashboard} summaryCards={dashboard.summaryCards} styles={styles} />
+
+          <div className={styles.sectionLabel}>资源趋势</div>
+          <FlexiblePanelSection styles={styles}>
+            {resourceCharts.map((chart) => (chart ? (
+              <TrendChartPanel
+                key={chart.chart.title}
+                title={chart.chart.title}
+                subtitle={chart.chart.subtitle}
+                guide={chart.chart.guide}
+                legends={chart.legends}
+                data={chart.data}
+                metric={chart.metric}
+                unit={chart.unit}
+                loading={dashboard.loading}
+                seriesStyles={chart.seriesStyles}
+                onXRangeChange={dashboard.onXRangeChange}
+                className={`${styles.span6} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null))}
+          </FlexiblePanelSection>
+
+          <div className={styles.sectionLabel}>并发与句柄</div>
+          <FlexiblePanelSection styles={styles}>
+            {concurrencyCharts.map((chart) => (chart ? (
+              <TrendChartPanel
+                key={chart.chart.title}
+                title={chart.chart.title}
+                subtitle={chart.chart.subtitle}
+                guide={chart.chart.guide}
+                legends={chart.legends}
+                data={chart.data}
+                metric={chart.metric}
+                unit={chart.unit}
+                loading={dashboard.loading}
+                seriesStyles={chart.seriesStyles}
+                onXRangeChange={dashboard.onXRangeChange}
+                className={`${styles.span6} ${styles.compactTrend}`}
+                styles={styles}
+              />
+            ) : null))}
+          </FlexiblePanelSection>
+        </>
+      }
+    />
+  );
+}

--- a/web/src/app/monitor/dashboards/objects/process/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/process/index.module.scss
@@ -1,0 +1,42 @@
+@use '../common/simple-dashboard.module.scss';
+
+.sectionLabel {
+  margin: 2px 2px 4px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #eceff4;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8c95a8;
+}
+
+.dashboardSection + .sectionLabel {
+  margin-top: 8px;
+}
+
+:global(html.dark) .sectionLabel {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.compactTrend {
+  .chartWrap {
+    height: 164px;
+  }
+}
+
+@media (max-width: 768px) {
+  .compactTrend {
+    .chartWrap {
+      height: 138px;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .compactTrend {
+    .chartWrap {
+      height: 120px;
+    }
+  }
+}

--- a/web/src/app/monitor/dashboards/objects/process/index.ts
+++ b/web/src/app/monitor/dashboards/objects/process/index.ts
@@ -1,0 +1,3 @@
+import ProcessDashboardPage from './dashboard';
+
+export default ProcessDashboardPage;

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -3,6 +3,7 @@ import MongodbDashboard from './objects/mongodb';
 import RedisDashboard from './objects/redis';
 import ElasticsearchDashboard from './objects/elasticsearch';
 import HostDashboard from './objects/host';
+import ProcessDashboard from './objects/process';
 import MssqlDashboard from './objects/mssql';
 import NginxDashboard from './objects/nginx';
 import DockerDashboard from './objects/docker';
@@ -181,6 +182,15 @@ const COMMUNITY_DASHBOARDS: ProfessionalDashboardRegistryItem[] = [
     objectDisplayName: '主机',
     inheritedPermissionPath: '/monitor/view',
     component: HostDashboard
+  },
+  {
+    key: 'process',
+    aliases: ['进程'],
+    groupKey: 'os',
+    objectName: 'Process',
+    objectDisplayName: '进程',
+    inheritedPermissionPath: '/monitor/view',
+    component: ProcessDashboard
   },
   {
     key: 'website',

--- a/web/src/app/monitor/dashboards/shared/utils/format.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/format.ts
@@ -135,6 +135,12 @@ export const formatEnumValue = (value: number, enumMap?: MetricEnumMap) => {
     return { value: '--', color: undefined as string | undefined };
   }
 
+  // 优先精确匹配（如端口部分失活 0.5），避免 Math.round(0.5)→1 误映射为存活。
+  const exactMatch = enumMap[value];
+  if (exactMatch) {
+    return { value: exactMatch.label, color: exactMatch.color };
+  }
+
   const normalizedValue = Math.round(value);
   const match = enumMap[normalizedValue];
   if (match) {


### PR DESCRIPTION
## Summary
- 为 Process 对象补齐 Host 同款专业仪表盘（KPI + 资源/并发趋势）
- 注册 `/monitor/view/dashboard/process`（registry + menu zh/en）
- 实例切换写入 `encodeInstanceIdValuesParam`，端口枚举精确匹配 `0.5`；未配置端口时隐藏端口存活 KPI

## Test plan
- [ ] 进程列表「查看仪表盘」进入 `/monitor/view/dashboard/process`
- [ ] KPI：进程存活 / CPU / 应用内存；有 ports 时显示端口存活，无 ports 时不显示该卡
- [ ] 含逗号/引号/括号的进程名切换实例 URL 不损坏
- [ ] 端口部分失活 `0.5` 显示为「部分失活」而非「存活」

## Scope note
- 仅含仪表盘相关 8 个文件；不含集成列表性能等其他 WIP。