### PR TITLE
perf: 加速监控集成列表首屏加载

### DIFF
--- a/server/apps/monitor/serializers/plugin.py
+++ b/server/apps/monitor/serializers/plugin.py
@@ -113,4 +113,29 @@ class MonitorPluginSerializer(serializers.ModelSerializer):
                 CustomPullPluginService.initialize_templates(plugin)
             elif template_type == "snmp":
                 CustomSnmpPluginService.initialize_templates(plugin)
-        return plugin
+            return plugin
+
+
+class MonitorPluginListSerializer(serializers.ModelSerializer):
+    """集成卡片 / 下拉等 list 场景专用:只序列化可见字段,缩小 payload。"""
+
+    is_pre = serializers.BooleanField(read_only=True)
+    parent_monitor_object = serializers.SerializerMethodField(read_only=True)
+
+    class Meta:
+        model = MonitorPlugin
+        fields = (
+            "id",
+            "name",
+            "display_name",
+            "description",
+            "template_type",
+            "template_id",
+            "collect_type",
+            "collector",
+            "is_pre",
+            "parent_monitor_object",
+        )
+
+    def get_parent_monitor_object(self, obj):
+        return MonitorPluginSerializer.get_parent_monitor_object(self, obj)

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -1,5 +1,5 @@
 from django.db import ProgrammingError
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from rest_framework import viewsets
 from rest_framework.decorators import action
 
@@ -11,11 +11,12 @@ from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.filters.plugin import MonitorPluginFilter
 from apps.monitor.models import MonitorPlugin, MonitorPluginUITemplate
 from apps.monitor.models.monitor_object import MonitorObject
-from apps.monitor.serializers.plugin import MonitorPluginSerializer
+from apps.monitor.serializers.plugin import MonitorPluginListSerializer, MonitorPluginSerializer
 from apps.monitor.services.custom_snmp_plugin import CustomSnmpPluginService
 from apps.monitor.services.plugin import MonitorPluginService
 from apps.monitor.services.plugin_guide import PluginGuideService
 from apps.monitor.services.template_access_guide import TemplateAccessGuideService
+from apps.monitor.utils.pagination import parse_page_params
 from config.drf.pagination import CustomPageNumberPagination
 
 
@@ -34,6 +35,11 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         """内置插件只读，禁止修改 / 删除（BL-NEW-005）。"""
         if getattr(plugin, "is_pre", False):
             raise BaseAppException("内置插件为只读，禁止修改或删除")
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return MonitorPluginListSerializer
+        return MonitorPluginSerializer
 
     @HasPermission("integration_configure-Add")
     def create(self, request, *args, **kwargs):
@@ -66,76 +72,162 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         "parent_object_display_name",
     )
 
-    def list(self, request, *args, **kwargs):
+    @staticmethod
+    def _parent_prefetch():
         # 一次 Prefetch 把「父监控对象」(parent__isnull=True) 全部拉到内存,
         # 缓存到 plugin.parent_objects(to_attr),供下面两个消费者复用:
         #   1. serializer.get_parent_monitor_object  — 取第一个父对象 id
         #   2. 本视图 — 拼 id -> obj 字典,供 result['parent_object_display_name'] 用
-        # 必须用 to_attr 而不是普通 prefetch_related('monitor_object'),
-        # 因为 serializer 内部是 .filter(parent__isnull=True),该 filter 不在普通 prefetch 缓存里,
-        # 会绕过缓存重新发 SQL(每个 plugin 一次 N+1)。
-        parent_prefetch = Prefetch(
+        return Prefetch(
             "monitor_object",
             queryset=MonitorObject.objects.filter(parent__isnull=True),
             to_attr="parent_objects",
         )
-        # 同时预取默认关联 + 父对象子集:
-        # - "monitor_object"  填充 obj.monitor_object 默认缓存,供 DRF __all__ 序列化用
-        #                   (ManyToMany 关系,DRF 会调 .all() 取 PK 列表,否则每条 plugin 一次 SQL)
-        # - parent_prefetch  填充 obj.parent_objects(to_attr),供 get_parent_monitor_object 与本视图用
-        # 两个 prefetch 在 Django 层是独立查询,但都是单次 SQL,
-        # 整 list 视图稳定 3 次 SQL:1 主查询 + 2 预取,与插件数无关。
-        queryset = self.filter_queryset(self.get_queryset()).prefetch_related(
-            "monitor_object",
-            parent_prefetch,
-        )
-        serializer = self.get_serializer(queryset, many=True)
-        results = serializer.data
 
-        lan = LanguageLoader(app=LanguageConstants.APP, default_lang=request.user.locale)
-
-        # 把 prefetch 出的父对象拼成 id -> obj 字典,后续 O(1) 查表
-        # 直接读 to_attr 缓存,不再发 SQL
+    @staticmethod
+    def _build_parent_obj_by_id(plugins) -> dict:
         parent_obj_by_id: dict = {}
-        for plugin in queryset:
+        for plugin in plugins:
             for obj in getattr(plugin, "parent_objects", []):
                 parent_obj_by_id[obj.id] = obj
+        return parent_obj_by_id
 
-        # keyword 优先;name 作为兼容 alias(老调用方可能还在用 ?name=xxx)
-        # 两者走完全相同的翻译后内存搜索逻辑,行为对齐
-        keyword = (request.query_params.get("keyword") or request.query_params.get("name") or "").strip()
-        kw = keyword.lower()
+    @classmethod
+    def _apply_keyword_coarse_filter(cls, queryset, kw: str, lan):
+        """缩小 keyword 候选集后再做完整序列化。
 
+        1) DB 粗筛:name / display_name / description / 父对象 name|display_name
+           (description 仅扩候选;精筛仍用 display_description,避免 3Com MIB 误命中)
+        2) 轻量 i18n 扫描:只读 id/name/display_name/description/template_type,
+           用 lan.get 补中文翻译命中(DB 无中文时不会漏「华为」等)
+        完整 DRF 序列化 + M2M prefetch 只对候选 id 执行。
+        """
+        if not kw:
+            return queryset
+
+        db_ids = set(
+            queryset.filter(
+                Q(name__icontains=kw)
+                | Q(display_name__icontains=kw)
+                | Q(description__icontains=kw)
+                | Q(monitor_object__parent__isnull=True, monitor_object__display_name__icontains=kw)
+                | Q(monitor_object__parent__isnull=True, monitor_object__name__icontains=kw)
+            ).values_list("id", flat=True)
+        )
+
+        # i18n 可能未回写 DB:对剩余插件做轻量扫描(无 M2M / 无完整 serializer)
+        for plugin in queryset.only(
+            "id", "name", "display_name", "description", "template_type"
+        ).iterator(chunk_size=200):
+            if plugin.id in db_ids:
+                continue
+            plugin_key = f"{LanguageConstants.MONITOR_OBJECT_PLUGIN}.{plugin.name}"
+            if plugin.template_type in {"api", "pull"}:
+                display_name = plugin.display_name or plugin.name
+                display_description = (
+                    lan.get(f"{plugin_key}.desc") or plugin.description or plugin.name
+                )
+            else:
+                display_name = lan.get(f"{plugin_key}.name") or plugin.display_name or plugin.name
+                display_description = (
+                    lan.get(f"{plugin_key}.desc") or plugin.description or plugin.name
+                )
+            haystacks = (
+                plugin.name or "",
+                display_name or "",
+                display_description or "",
+            )
+            if any(kw in value.lower() for value in haystacks):
+                db_ids.add(plugin.id)
+
+        if not db_ids:
+            return queryset.none()
+        return queryset.filter(id__in=db_ids)
+
+    def _enrich_plugin_results(self, results, lan, parent_obj_by_id: dict):
+        """补齐 display_* / is_custom / parent_object_display_name(原地修改)。"""
         for result in results:
             if result.get("template_type") in {"api", "pull"}:
                 result["display_name"] = result.get("display_name") or result["name"]
-                # 优先 i18n 翻译,fallback DB 字段(避免强制覆盖)
                 result["display_description"] = (
-                    lan.get(f"{LanguageConstants.MONITOR_OBJECT_PLUGIN}.{result['name']}.desc") or result["description"] or result["name"]
+                    lan.get(f"{LanguageConstants.MONITOR_OBJECT_PLUGIN}.{result['name']}.desc")
+                    or result["description"]
+                    or result["name"]
                 )
             else:
                 plugin_key = f"{LanguageConstants.MONITOR_OBJECT_PLUGIN}.{result['name']}"
-                # 始终优先使用 i18n 翻译,DB 字段只作为最终 fallback
-                result["display_name"] = lan.get(f"{plugin_key}.name") or result.get("display_name") or result["name"]
-                # 同 display_name:优先 i18n 翻译,fallback DB 字段(可能多语言混合),最后 fallback 到 name
-                result["display_description"] = lan.get(f"{plugin_key}.desc") or result["description"] or result["name"]
+                result["display_name"] = (
+                    lan.get(f"{plugin_key}.name") or result.get("display_name") or result["name"]
+                )
+                result["display_description"] = (
+                    lan.get(f"{plugin_key}.desc") or result["description"] or result["name"]
+                )
             result["is_custom"] = result.get("template_type") in {"api", "pull", "snmp"}
 
-            # 父监控对象 display_name(用于关键字搜索覆盖卡片上的「交换机/路由器」tag)
             parent_id = result.get("parent_monitor_object")
             parent_obj = parent_obj_by_id.get(parent_id) if parent_id is not None else None
             if parent_obj is not None:
-                # MonitorObject.display_name 是 DB 字段,无需 i18n
                 result["parent_object_display_name"] = parent_obj.display_name or parent_obj.name
             else:
                 result["parent_object_display_name"] = ""
+        return results
 
-        # 「所见即所搜」:在 i18n 翻译完成后再做内存过滤,覆盖所有卡片可见字段
-        # 必须放在 i18n 之后,否则 DB 侧裁掉的就再也回不来了
+    def _serialize_and_enrich(self, queryset, lan):
+        plugins = list(queryset.prefetch_related("monitor_object", self._parent_prefetch()))
+        results = self.get_serializer(plugins, many=True).data
+        parent_obj_by_id = self._build_parent_obj_by_id(plugins)
+        return self._enrich_plugin_results(results, lan, parent_obj_by_id)
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset()).order_by("id")
+        lan = LanguageLoader(app=LanguageConstants.APP, default_lang=request.user.locale)
+
+        keyword = (request.query_params.get("keyword") or request.query_params.get("name") or "").strip()
+        kw = keyword.lower()
+
+        page_size_raw = request.query_params.get("page_size")
+        use_pagination = page_size_raw not in (None, "", "0", "-1")
+
+        if use_pagination and not kw:
+            page, page_size = parse_page_params(
+                request.query_params,
+                default_page=1,
+                default_page_size=20,
+                allow_page_size_all=True,
+            )
+            if page_size != -1:
+                page_size = min(page_size, CustomPageNumberPagination.max_page_size)
+            count = queryset.count()
+            start = (page - 1) * page_size
+            end = start + page_size
+            items = self._serialize_and_enrich(queryset[start:end], lan)
+            return WebUtils.response_success({"count": count, "items": items})
+
         if kw:
-            results = [r for r in results if any(kw in (r.get(f) or "").lower() for f in self.KEYWORD_FIELDS)]
+            queryset = self._apply_keyword_coarse_filter(queryset, kw, lan)
 
-        return WebUtils.response_success(results)
+        results = self._serialize_and_enrich(queryset, lan)
+
+        if kw:
+            results = [
+                r for r in results if any(kw in (r.get(f) or "").lower() for f in self.KEYWORD_FIELDS)
+            ]
+
+        if not use_pagination:
+            return WebUtils.response_success(results)
+
+        page, page_size = parse_page_params(
+            request.query_params,
+            default_page=1,
+            default_page_size=20,
+            allow_page_size_all=True,
+        )
+        if page_size != -1:
+            page_size = min(page_size, CustomPageNumberPagination.max_page_size)
+        count = len(results)
+        start = (page - 1) * page_size
+        end = start + page_size
+        return WebUtils.response_success({"count": count, "items": results[start:end]})
 
     @HasPermission("integration_list-Setting")
     def destroy(self, request, *args, **kwargs):

--- a/web/scripts/monitor-common-context-loader-test.ts
+++ b/web/scripts/monitor-common-context-loader-test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {
+  clearMonitorCommonDataCache,
   loadMonitorCommonData,
   shouldLoadMonitorCommonData,
 } from '../src/app/monitor/context/commonDataLoader';
@@ -32,7 +33,9 @@ assert.equal(
 );
 
 async function main() {
+  clearMonitorCommonDataCache();
   const data = await loadMonitorCommonData({
+    cacheKey: 'case-users-ok',
     getAllUsers: async () => [{ id: '1', username: 'alice', display_name: 'Alice' }],
     getUnitList: async () => {
       throw new Error('unit api failed');
@@ -43,7 +46,22 @@ async function main() {
   assert.deepEqual(data.units, []);
   assert.deepEqual(data.groupedUnits, []);
 
+  // 同 key 命中会话缓存,不再打 API
+  let secondUsersCalls = 0;
+  const cached = await loadMonitorCommonData({
+    cacheKey: 'case-users-ok',
+    getAllUsers: async () => {
+      secondUsersCalls += 1;
+      return [];
+    },
+    getUnitList: async () => [],
+  });
+  assert.equal(secondUsersCalls, 0);
+  assert.deepEqual(cached.users, data.users);
+
+  clearMonitorCommonDataCache();
   const grouped = await loadMonitorCommonData({
+    cacheKey: 'case-grouped',
     getAllUsers: async () => [],
     getUnitList: async () => [
       {

--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -38,6 +38,7 @@ import NotificationForm from './notificationForm';
 import MetricPreview from './metricPreview';
 import VariablesTable from './variablesTable';
 import { isStringArray } from '@/app/monitor/utils/common';
+import { loadMonitorPluginsByObjectCached } from '@/app/monitor/utils/monitorPluginCache';
 import {
   getMetricDimensionNames,
   sanitizeGroupBy
@@ -383,10 +384,12 @@ const StrategyOperation = () => {
   };
 
   const getPlugins = async () => {
-    const data = await getMonitorPlugin({
-      monitor_object_id: monitorObjId
-    });
-    const plugins = data
+    const plugins = await loadMonitorPluginsByObjectCached(monitorObjId, () =>
+      getMonitorPlugin({
+        monitor_object_id: monitorObjId
+      })
+    );
+    const options = plugins
       .sort((a: PluginItem, b: PluginItem) => {
         const order = (item: PluginItem) =>
           item.is_pre ? 0 : !item.is_custom ? 1 : 2;
@@ -397,7 +400,7 @@ const StrategyOperation = () => {
         value: item.id,
         name: item.name
       }));
-    setPluginList(plugins);
+    setPluginList(options);
   };
 
   const dealDetail = (data: StrategyFields) => {

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
@@ -5,7 +5,8 @@ import React, {
   useRef,
   forwardRef,
   useImperativeHandle,
-  useEffect
+  useEffect,
+  useMemo
 } from 'react';
 import {
   Input,
@@ -66,11 +67,13 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
     });
     const formRef = useRef<FormInstance>(null);
     const commonContext = useCommon();
-    const unitList = useRef<CascaderItem[]>(
-      (commonContext?.groupedUnitList || []).map((item: any) => ({
-        ...item,
-        value: item.label
-      }))
+    const unitList = useMemo(
+      () =>
+        (commonContext?.groupedUnitList || []).map((item: any) => ({
+          ...item,
+          value: item.label
+        })),
+      [commonContext?.groupedUnitList]
     );
     const [groupVisible, setGroupVisible] = useState<boolean>(false);
     const [confirmLoading, setConfirmLoading] = useState<boolean>(false);
@@ -104,7 +107,7 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
             );
             if (formData.data_type === 'Number') {
               formData.unit = findCascaderPath(
-                unitList.current,
+                unitList,
                 formData.unit as string
               );
             } else {
@@ -412,7 +415,7 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
                     name="unit"
                     rules={[{ required: true, message: t('common.required') }]}
                   >
-                    <Cascader showSearch options={unitList.current} />
+                    <Cascader showSearch options={unitList} />
                   </Form.Item>
                 ) : (
                   <Form.Item<MetricInfo>

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -7,7 +7,8 @@ import {
   Tag,
   message,
   Empty,
-  Modal
+  Modal,
+  Pagination as AntPagination
 } from 'antd';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
@@ -21,7 +22,8 @@ import {
   TableDataItem,
   TreeItem,
   TreeSortData,
-  ObjectItem
+  ObjectItem,
+  Pagination
 } from '@/app/monitor/types';
 import ImportModal from './importModal';
 import axios from 'axios';
@@ -36,6 +38,12 @@ import { isDerivativeObject } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
 import CreateTemplateModal from './createTemplateModal';
 import ResizableSidebar from '@/app/monitor/components/resizableSidebar';
+import {
+  invalidateMonitorObjectsCache,
+  loadMonitorObjectsCached
+} from '@/app/monitor/utils/monitorObjectCache';
+import { unwrapMonitorPluginList } from '@/app/monitor/utils/monitorPluginList';
+import { invalidateMonitorPluginCache } from '@/app/monitor/utils/monitorPluginCache';
 
 const { confirm } = Modal;
 
@@ -68,16 +76,22 @@ const Integration = () => {
   const [pluginList, setPluginList] = useState<ObjectItem[]>([]);
   const [treeLoading, setTreeLoading] = useState<boolean>(false);
   const [objectId, setObjectId] = useState<React.Key>('');
+  const [pagination, setPagination] = useState<Pagination>({
+    current: 1,
+    total: 0,
+    pageSize: 20
+  });
 
+  // objects 与 plugins 并行:plugins 不再等 objects 就绪
   useEffect(() => {
     if (isLoading) return;
     getObjects();
   }, [isLoading]);
 
   useEffect(() => {
-    if (isLoading || !objects?.length) return;
-    getPluginList({ monitor_object_id: objectId });
-  }, [objectId, isLoading, objects]);
+    if (isLoading) return;
+    getPluginList();
+  }, [isLoading, objectId, pagination.current, pagination.pageSize]);
 
   useEffect(() => {
     return () => {
@@ -90,7 +104,8 @@ const Integration = () => {
       setTreeLoading(true);
       await updateMonitorObject(data);
       message.success(t('common.updateSuccess'));
-      getObjects();
+      invalidateMonitorObjectsCache();
+      getObjects({ force: true });
     } catch {
       setTreeLoading(false);
     }
@@ -102,37 +117,54 @@ const Integration = () => {
 
   const handleObjectChange = async (id: string) => {
     cancelAllRequests();
+    setPagination((prev) => ({ ...prev, current: 1 }));
     setObjectId(id === 'all' ? '' : id);
   };
 
-  const getPluginList = async (params = {}) => {
+  const getPluginList = async (
+    params: {
+      monitor_object_id?: React.Key | null;
+      keyword?: string;
+      page?: number;
+    } = {}
+  ) => {
     pluginAbortControllerRef.current?.abort();
     const abortController = new AbortController();
     pluginAbortControllerRef.current = abortController;
     const currentRequestId = ++pluginRequestIdRef.current;
-    setPluginList([]);
+    const page = params.page ?? pagination.current;
+    // 翻页保留旧列表,仅 Spin overlay,避免闪 Empty
     setSelectedApp(null);
     setExportDisabled(true);
     setPageLoading(true);
     try {
-      const data = await getMonitorPlugin(params, {
-        signal: abortController.signal
-      });
+      const data = await getMonitorPlugin(
+        {
+          monitor_object_id:
+            params.monitor_object_id !== undefined
+              ? params.monitor_object_id
+              : objectId,
+          keyword: params.keyword !== undefined ? params.keyword : searchText,
+          page,
+          page_size: pagination.pageSize
+        },
+        {
+          signal: abortController.signal
+        }
+      );
       if (currentRequestId !== pluginRequestIdRef.current) return;
-      // 根据objects的顺序对插件列表进行排序
-      const sortedData = data.sort((a: ObjectItem, b: ObjectItem) => {
-        const indexA = objects.findIndex(
-          (obj) => obj.id === a.parent_monitor_object
-        );
-        const indexB = objects.findIndex(
-          (obj) => obj.id === b.parent_monitor_object
-        );
-        // 如果找不到对应的object,放在最后
-        if (indexA === -1) return 1;
-        if (indexB === -1) return -1;
-        return indexA - indexB;
-      });
-      setPluginList(sortedData);
+      const items = unwrapMonitorPluginList<ObjectItem>(data);
+      const count = Array.isArray(data)
+        ? data.length
+        : typeof data?.count === 'number'
+          ? data.count
+          : 0;
+      setPluginList(items);
+      setPagination((prev) => ({
+        ...prev,
+        current: page,
+        total: count
+      }));
     } finally {
       if (currentRequestId === pluginRequestIdRef.current) {
         setPageLoading(false);
@@ -140,10 +172,13 @@ const Integration = () => {
     }
   };
 
-  const getObjects = async () => {
+  const getObjects = async (options: { force?: boolean } = {}) => {
     try {
       setTreeLoading(true);
-      const data: ObjectItem[] = await getMonitorObject();
+      if (options.force) {
+        invalidateMonitorObjectsCache();
+      }
+      const data = await loadMonitorObjectsCached(() => getMonitorObject());
       const _treeData = getTreeData(cloneDeep(data));
       setTreeData(_treeData);
       setObjects(data);
@@ -190,16 +225,15 @@ const Integration = () => {
     try {
       setExportLoading(true);
       const response = await axios({
-        url: `/api/proxy/monitor/api/monitor_plugin/export/${selectedApp.id}/`, // 替换为你的导出数据的API端点
+        url: `/api/proxy/monitor/api/monitor_plugin/export/${selectedApp.id}/`,
         method: 'GET',
-        responseType: 'blob', // 确保响应类型为blob
+        responseType: 'blob',
         headers: {
           Authorization: `Bearer ${tokenRef.current}`
         }
       });
       const text = await response.data.text();
       const json = JSON.parse(text);
-      // 将data对象转换为JSON字符串并创建Blob对象
       const blob = new Blob([JSON.stringify(json.data, null, 2)], {
         type: 'application/json'
       });
@@ -223,19 +257,30 @@ const Integration = () => {
   };
 
   const onTxtPressEnter = () => {
-    const params = {
-      monitor_object_id: objectId === 'all' ? '' : objectId,
-      keyword: searchText
-    };
-    getPluginList(params);
+    setPagination((prev) => ({ ...prev, current: 1 }));
+    getPluginList({
+      monitor_object_id: objectId,
+      keyword: searchText,
+      page: 1
+    });
   };
 
   const onTxtClear = () => {
     setSearchText('');
+    setPagination((prev) => ({ ...prev, current: 1 }));
     getPluginList({
-      monitor_object_id: objectId === 'all' ? '' : objectId,
-      keyword: ''
+      monitor_object_id: objectId,
+      keyword: '',
+      page: 1
     });
+  };
+
+  const handlePageChange = (page: number, pageSize: number) => {
+    setPagination((prev) => ({
+      ...prev,
+      current: page,
+      pageSize
+    }));
   };
 
   const openImportModal = () => {
@@ -272,12 +317,14 @@ const Integration = () => {
       await createCustomTemplate(values);
       message.success(t('common.addSuccess'));
     }
+    invalidateMonitorPluginCache(objectId);
     onTxtClear();
   };
 
   const handleDeleteTemplate = async (id: number) => {
     await deleteCustomTemplate(id);
     message.success(t('common.deleteSuccess'));
+    invalidateMonitorPluginCache(objectId);
     onTxtClear();
   };
 
@@ -319,7 +366,7 @@ const Integration = () => {
 
   const onAppClick = (app: ObjectItem) => {
     setSelectedApp(app);
-    setExportDisabled(false); // Enable the export button
+    setExportDisabled(false);
   };
 
   const buildTemplateActionItems = (app: ObjectItem): MoreActionsDropdownItem[] => [
@@ -391,105 +438,121 @@ const Integration = () => {
           </Permission>
         </div>
         <Spin spinning={pageLoading}>
-          {!pluginList.length ? (
+          {!pluginList.length && !pageLoading ? (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
+          ) : !pluginList.length ? (
+            <div className="h-[calc(100vh-280px)]" />
           ) : (
-            <div
-              className="grid gap-4 w-full h-[calc(100vh-236px)] overflow-y-auto"
-              style={{
-                gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-                alignContent: 'start'
-              }}
-            >
-              {pluginList.map((app) => {
-                const parentObject: any = objects.find(
-                  (item) => item.id === app.parent_monitor_object
-                );
-                const objectName = parentObject?.name || '';
+            <>
+              <div
+                className="grid gap-4 w-full h-[calc(100vh-280px)] overflow-y-auto"
+                style={{
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
+                  alignContent: 'start'
+                }}
+              >
+                {pluginList.map((app) => {
+                  const parentObject: any = objects.find(
+                    (item) => item.id === app.parent_monitor_object
+                  );
+                  const objectName = parentObject?.name || '';
 
-                return (
-                  <div
-                    key={app.id}
-                    className="p-2"
-                    onClick={() => onAppClick(app)}
-                  >
-                    <div className="bg-[var(--color-bg-1)] shadow-sm hover:shadow-md transition-shadow duration-300 ease-in-out rounded-lg p-4 relative cursor-pointer group border">
-                      <div className="flex items-center space-x-4 my-2">
-                        <div className="w-14 h-14 min-w-[56px] rounded-lg flex items-center justify-center bg-[var(--color-fill-1)]">
-                          <img
-                            src={`/assets/icons/${getPluginBrandIcon(app.name) || getIconByObjectName(objectName, objects)}.svg`}
-                            alt={objectName}
-                            className="w-12 h-12"
-                            onError={(e) => {
-                              (e.target as HTMLImageElement).src =
-                                '/assets/icons/cc-default_默认.svg';
+                  return (
+                    <div
+                      key={app.id}
+                      className="p-2"
+                      onClick={() => onAppClick(app)}
+                    >
+                      <div className="bg-[var(--color-bg-1)] shadow-sm hover:shadow-md transition-shadow duration-300 ease-in-out rounded-lg p-4 relative cursor-pointer group border">
+                        <div className="flex items-center space-x-4 my-2">
+                          <div className="w-14 h-14 min-w-[56px] rounded-lg flex items-center justify-center bg-[var(--color-fill-1)]">
+                            <img
+                              src={`/assets/icons/${getPluginBrandIcon(app.name) || getIconByObjectName(objectName, objects)}.svg`}
+                              alt={objectName}
+                              className="w-12 h-12"
+                              onError={(e) => {
+                                (e.target as HTMLImageElement).src =
+                                  '/assets/icons/cc-default_默认.svg';
+                              }}
+                            />
+                          </div>
+                          <div
+                            style={{
+                              width: 'calc(100% - 60px)'
                             }}
-                          />
-                        </div>
-                        <div
-                          style={{
-                            width: 'calc(100% - 60px)'
-                          }}
-                        >
-                          <h2
-                            title={app.display_name}
-                            className="text-xl font-bold m-0 hide-text"
                           >
-                            {app.display_name || '--'}
-                          </h2>
-                          <Tag className="mt-[4px]">
-                            {parentObject?.display_name ||
-                              app.collect_type ||
-                              '--'}
-                          </Tag>
-                          {app.is_custom && (
-                            <Tag className="mt-[4px] ml-[6px]">
-                              {t('monitor.integrations.selfBuilt')}
+                            <h2
+                              title={app.display_name}
+                              className="text-xl font-bold m-0 hide-text"
+                            >
+                              {app.display_name || '--'}
+                            </h2>
+                            <Tag className="mt-[4px]">
+                              {parentObject?.display_name ||
+                                app.collect_type ||
+                                '--'}
                             </Tag>
-                          )}
+                            {app.is_custom && (
+                              <Tag className="mt-[4px] ml-[6px]">
+                                {t('monitor.integrations.selfBuilt')}
+                              </Tag>
+                            )}
+                          </div>
                         </div>
-                      </div>
-                      <p
-                        className="mb-[15px] text-[var(--color-text-3)] text-[13px] h-[54px] overflow-hidden line-clamp-3"
-                        title={app.display_description || '--'}
-                      >
-                        {app.display_description || '--'}
-                      </p>
-                      {app.is_custom && (
-                        <div
-                          className="absolute top-[12px] right-[12px]"
-                          onClick={(e) => e.stopPropagation()}
+                        <p
+                          className="mb-[15px] text-[var(--color-text-3)] text-[13px] h-[54px] overflow-hidden line-clamp-3"
+                          title={app.display_description || '--'}
                         >
-                          <MoreActionsDropdown
-                            items={buildTemplateActionItems(app)}
-                            placement="bottomRight"
-                            stopPropagation
-                          />
-                        </div>
-                      )}
-                      <div className="w-full h-[32px] flex justify-center items-end">
-                        <Permission
-                          requiredPermissions={['Setting']}
-                          className="w-full"
-                        >
-                          <Button
-                            icon={<PlusOutlined />}
-                            type="primary"
-                            className="w-full rounded-md transition-opacity duration-300"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              linkToDetial(app);
-                            }}
+                          {app.display_description || '--'}
+                        </p>
+                        {app.is_custom && (
+                          <div
+                            className="absolute top-[12px] right-[12px]"
+                            onClick={(e) => e.stopPropagation()}
                           >
-                            {t('monitor.integrations.access')}
-                          </Button>
-                        </Permission>
+                            <MoreActionsDropdown
+                              items={buildTemplateActionItems(app)}
+                              placement="bottomRight"
+                              stopPropagation
+                            />
+                          </div>
+                        )}
+                        <div className="w-full h-[32px] flex justify-center items-end">
+                          <Permission
+                            requiredPermissions={['Setting']}
+                            className="w-full"
+                          >
+                            <Button
+                              icon={<PlusOutlined />}
+                              type="primary"
+                              className="w-full rounded-md transition-opacity duration-300"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                linkToDetial(app);
+                              }}
+                            >
+                              {t('monitor.integrations.access')}
+                            </Button>
+                          </Permission>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                );
-              })}
-            </div>
+                  );
+                })}
+              </div>
+              <div className="mt-4 flex justify-end">
+                <AntPagination
+                  current={pagination.current}
+                  pageSize={pagination.pageSize}
+                  total={pagination.total}
+                  showSizeChanger
+                  showTotal={(total) =>
+                    `${t('common.total')} ${total} ${t('common.items')}`
+                  }
+                  onChange={handlePageChange}
+                />
+              </div>
+            </>
           )}
         </Spin>
       </div>

--- a/web/src/app/monitor/(pages)/layout.tsx
+++ b/web/src/app/monitor/(pages)/layout.tsx
@@ -2,13 +2,13 @@
 
 import CommonProvider from '@/app/monitor/context/common';
 import '@/app/monitor/styles/index.css';
-import useApiClient from '@/utils/request';
 
 export default function RootMonitor({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const { isLoading } = useApiClient();
-  return <CommonProvider>{isLoading ? null : children}</CommonProvider>;
+  // 不再等 useApiClient token 就绪才渲染子树,避免点「集成」白屏;
+  // 各页面 effect 仍用 isLoading 自行等待发请求。
+  return <CommonProvider>{children}</CommonProvider>;
 }

--- a/web/src/app/monitor/(pages)/search/queryPanel.tsx
+++ b/web/src/app/monitor/(pages)/search/queryPanel.tsx
@@ -40,6 +40,7 @@ import {
   buildGroupedMetricSelectOptions,
   METRIC_SELECT_POPUP_CLASSNAME,
 } from '@/app/monitor/components/metricSelectOptions';
+import { loadMonitorPluginsByObjectCached } from '@/app/monitor/utils/monitorPluginCache';
 import {
   InstanceItem,
   PluginItem,
@@ -308,11 +309,13 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
       pluginAbortControllerRef.current[key] = abortController;
       try {
         setPluginLoading((prev) => ({ ...prev, [key]: true }));
-        const data = await getMonitorPlugin(
-          { monitor_object_id: objectId },
-          { signal: abortController.signal }
-        );
-        const plugins = (data || []) as PluginItem[];
+        const plugins = (await loadMonitorPluginsByObjectCached(
+          objectId,
+          () => getMonitorPlugin({ monitor_object_id: objectId })
+        )) as PluginItem[];
+        if (abortController.signal.aborted) {
+          return [];
+        }
         setPluginsMap((prev) => ({ ...prev, [key]: plugins }));
         const selectedPlugin =
           preferredPluginId ||

--- a/web/src/app/monitor/api/index.ts
+++ b/web/src/app/monitor/api/index.ts
@@ -102,6 +102,9 @@ const useMonitorApi = () => {
       // 搜索关键字(后端在 i18n 翻译完成后,对 name / display_name /
       // display_description / parent_object_display_name 做 icontains 内存匹配)
       keyword?: string;
+      // 传 page_size>0 时后端返回 {count, items};不传或 -1/0 仍返回全量数组
+      page?: number;
+      page_size?: number;
     } = {},
     config?: AxiosRequestConfig
   ) => {

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -23,6 +23,7 @@ import {
   renderChart,
   getRecentTimeRange
 } from '@/app/monitor/utils/common';
+import { loadMonitorPluginsByObjectCached } from '@/app/monitor/utils/monitorPluginCache';
 import { calculateQueryStep } from '@/app/monitor/utils/queryStep';
 import { attachGapIntervals, buildGapDetectionParams } from '@/app/monitor/utils/gapIntervals';
 
@@ -307,12 +308,13 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       // 外部已指定 queryInstanceIdKeys 时（纯进程对象视图）直接拉插件列表。
       if (queryInstanceIdKeys?.length && !isHostView) {
         try {
-          const pluginResp = await getMonitorPlugin({
-            monitor_object_id: monitorObjectId
-          });
-          const list = Array.isArray(pluginResp)
-            ? pluginResp
-            : pluginResp?.items || pluginResp?.results || [];
+          const list = await loadMonitorPluginsByObjectCached(
+            monitorObjectId,
+            () =>
+              getMonitorPlugin({
+                monitor_object_id: monitorObjectId
+              })
+          );
           responseData = list as IntegrationItem[];
         } catch {
           responseData = [];

--- a/web/src/app/monitor/context/common.tsx
+++ b/web/src/app/monitor/context/common.tsx
@@ -8,7 +8,6 @@ import {
   UnitListItem,
   GroupedUnitList,
 } from '@/app/monitor/types';
-import Spin from '@/components/spin';
 import { useUserInfoContext } from '@/context/userInfo';
 import { transformTreeData } from '@/app/monitor/utils/common';
 import monitorApi from '@/app/monitor/api';
@@ -22,6 +21,8 @@ interface CommonContextType {
   authOrganizations: Organization[];
   unitList: UnitListItem[];
   groupedUnitList: GroupedUnitList[];
+  /** 公共数据后台加载中;集成列表等不依赖方无需等待 */
+  commonLoading: boolean;
 }
 
 const CommonContext = createContext<CommonContextType | null>(null);
@@ -33,7 +34,7 @@ const CommonContextProvider = ({ children }: { children: React.ReactNode }) => {
   const [userList, setUserList] = useState<UserItem[]>([]);
   const [unitList, setUnitList] = useState<UnitListItem[]>([]);
   const [groupedUnitList, setGroupedUnitList] = useState<GroupedUnitList[]>([]);
-  const [pageLoading, setPageLoading] = useState(false);
+  const [commonLoading, setCommonLoading] = useState(false);
 
   useEffect(() => {
     if (!shouldLoadMonitorCommonData({
@@ -47,27 +48,30 @@ const CommonContextProvider = ({ children }: { children: React.ReactNode }) => {
   }, [isLoading, commonContext.loading, commonContext.selectedGroup?.id]);
 
   const getPermissionGroups = async () => {
-    setPageLoading(true);
+    setCommonLoading(true);
     try {
+      const cacheKey = String(commonContext.selectedGroup?.id ?? '');
       const { users, units, groupedUnits } = await loadMonitorCommonData({
         getAllUsers,
         getUnitList,
+        cacheKey,
       });
       setUserList(users);
       setUnitList(units);
       setGroupedUnitList(groupedUnits);
     } finally {
-      setPageLoading(false);
+      setCommonLoading(false);
     }
   };
-  return pageLoading ? (
-    <Spin />
-  ) : (
+
+  // 不再用全屏 Spin 挡住子路由:集成列表等可先渲染,公共数据后台补齐
+  return (
     <CommonContext.Provider
       value={{
         userList,
         unitList,
         groupedUnitList,
+        commonLoading,
         authOrganizations: transformTreeData(
           commonContext?.groups || []
         ) as any,

--- a/web/src/app/monitor/context/commonDataLoader.ts
+++ b/web/src/app/monitor/context/commonDataLoader.ts
@@ -16,6 +16,16 @@ interface LoadMonitorCommonDataParams {
   getUnitList: () => Promise<UnitListItem[]>;
 }
 
+export interface MonitorCommonData {
+  users: UserItem[];
+  units: UnitListItem[];
+  groupedUnits: GroupedUnitList[];
+}
+
+// 会话级缓存:同组织下只拉一次 user_all / unit/list
+const commonDataCache = new Map<string, MonitorCommonData>();
+const commonDataInflight = new Map<string, Promise<MonitorCommonData>>();
+
 export const shouldLoadMonitorCommonData = ({
   requestLoading,
   userInfoLoading,
@@ -50,23 +60,52 @@ export const buildGroupedUnitList = (units: UnitListItem[]): GroupedUnitList[] =
 export const loadMonitorCommonData = async ({
   getAllUsers,
   getUnitList,
-}: LoadMonitorCommonDataParams) => {
-  const [usersResult, unitsResult] = await Promise.allSettled([
-    getAllUsers(),
-    getUnitList(),
-  ]);
-  const users =
-    usersResult.status === 'fulfilled' && Array.isArray(usersResult.value)
-      ? usersResult.value
-      : [];
-  const units =
-    unitsResult.status === 'fulfilled' && Array.isArray(unitsResult.value)
-      ? unitsResult.value
-      : [];
+  cacheKey,
+}: LoadMonitorCommonDataParams & { cacheKey?: string }): Promise<MonitorCommonData> => {
+  const key = cacheKey || '__default__';
+  const cached = commonDataCache.get(key);
+  if (cached) {
+    return cached;
+  }
 
-  return {
-    users,
-    units,
-    groupedUnits: buildGroupedUnitList(units),
-  };
+  const inflight = commonDataInflight.get(key);
+  if (inflight) {
+    return inflight;
+  }
+
+  const request = (async () => {
+    const [usersResult, unitsResult] = await Promise.allSettled([
+      getAllUsers(),
+      getUnitList(),
+    ]);
+    const users =
+      usersResult.status === 'fulfilled' && Array.isArray(usersResult.value)
+        ? usersResult.value
+        : [];
+    const units =
+      unitsResult.status === 'fulfilled' && Array.isArray(unitsResult.value)
+        ? unitsResult.value
+        : [];
+
+    const data: MonitorCommonData = {
+      users,
+      units,
+      groupedUnits: buildGroupedUnitList(units),
+    };
+    commonDataCache.set(key, data);
+    return data;
+  })();
+
+  commonDataInflight.set(key, request);
+  try {
+    return await request;
+  } finally {
+    commonDataInflight.delete(key);
+  }
+};
+
+/** 测试或切换组织后清空会话缓存 */
+export const clearMonitorCommonDataCache = () => {
+  commonDataCache.clear();
+  commonDataInflight.clear();
 };

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -897,17 +897,30 @@ const getEnterpriseBrands = (): Array<{ match: RegExp; label: string; icon?: str
   return [];
 };
 
+const brandIconCache = new Map<string, string | undefined>();
+const brandLabelCache = new Map<string, string | undefined>();
+
 // 按插件名取品牌 logo 图标;命中 CE BRANDS 或运行时注入的 EE __ENTERPRISE_BRANDS 任一即返回。
 // 失败降级:都未命中 → undefined,调用方回退到监控对象 icon。
 export const getPluginBrandIcon = (pluginName = ''): string | undefined => {
+  if (brandIconCache.has(pluginName)) {
+    return brandIconCache.get(pluginName);
+  }
   const all = [...BRANDS, ...getEnterpriseBrands()];
-  return all.find((brand) => brand.match.test(pluginName))?.icon;
+  const icon = all.find((brand) => brand.match.test(pluginName))?.icon;
+  brandIconCache.set(pluginName, icon);
+  return icon;
 };
 
 // 按名称(实例名/插件名)取品牌标签,用于仪表盘头部标识;同 getPluginBrandIcon 拼接策略。
 export const getBrandLabel = (text = ''): string | undefined => {
+  if (brandLabelCache.has(text)) {
+    return brandLabelCache.get(text);
+  }
   const all = [...BRANDS, ...getEnterpriseBrands()];
-  return all.find((brand) => brand.match.test(text))?.label;
+  const label = all.find((brand) => brand.match.test(text))?.label;
+  brandLabelCache.set(text, label);
+  return label;
 };
 
 export const getRecentTimeRange = (timeValues: TimeValuesProps) => {

--- a/web/src/app/monitor/utils/monitorObjectCache.ts
+++ b/web/src/app/monitor/utils/monitorObjectCache.ts
@@ -1,0 +1,38 @@
+import { ObjectItem } from '@/app/monitor/types';
+
+/** 监控对象会话缓存:集成列表左侧树可复用,拖拽排序后需 invalidate */
+let cachedObjects: ObjectItem[] | null = null;
+let inflight: Promise<ObjectItem[]> | null = null;
+
+export const getCachedMonitorObjects = (): ObjectItem[] | null => cachedObjects;
+
+export const setCachedMonitorObjects = (objects: ObjectItem[]) => {
+  cachedObjects = objects;
+};
+
+export const invalidateMonitorObjectsCache = () => {
+  cachedObjects = null;
+  inflight = null;
+};
+
+export const loadMonitorObjectsCached = async (
+  fetcher: () => Promise<ObjectItem[]>
+): Promise<ObjectItem[]> => {
+  if (cachedObjects) {
+    return cachedObjects;
+  }
+  if (inflight) {
+    return inflight;
+  }
+  inflight = (async () => {
+    const data = await fetcher();
+    const list = Array.isArray(data) ? data : [];
+    cachedObjects = list;
+    return list;
+  })();
+  try {
+    return await inflight;
+  } finally {
+    inflight = null;
+  }
+};

--- a/web/src/app/monitor/utils/monitorPluginCache.ts
+++ b/web/src/app/monitor/utils/monitorPluginCache.ts
@@ -1,0 +1,52 @@
+import { unwrapMonitorPluginList } from './monitorPluginList';
+
+type PluginRow = Record<string, any>;
+
+/** 按监控对象缓存插件下拉(搜索/策略等),与集成列表分页路径隔离 */
+const pluginCache = new Map<string, PluginRow[]>();
+const inflight = new Map<string, Promise<PluginRow[]>>();
+
+const cacheKey = (monitorObjectId: string | number | null | undefined) =>
+  monitorObjectId == null || monitorObjectId === ''
+    ? '__all__'
+    : String(monitorObjectId);
+
+export const invalidateMonitorPluginCache = (
+  monitorObjectId?: string | number | null
+) => {
+  if (monitorObjectId === undefined) {
+    pluginCache.clear();
+    inflight.clear();
+    return;
+  }
+  const key = cacheKey(monitorObjectId);
+  pluginCache.delete(key);
+  inflight.delete(key);
+};
+
+export const loadMonitorPluginsByObjectCached = async (
+  monitorObjectId: string | number | null | undefined,
+  fetcher: () => Promise<unknown>
+): Promise<PluginRow[]> => {
+  const key = cacheKey(monitorObjectId);
+  const cached = pluginCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  const pending = inflight.get(key);
+  if (pending) {
+    return pending;
+  }
+  const request = (async () => {
+    const data = await fetcher();
+    const list = unwrapMonitorPluginList<PluginRow>(data);
+    pluginCache.set(key, list);
+    return list;
+  })();
+  inflight.set(key, request);
+  try {
+    return await request;
+  } finally {
+    inflight.delete(key);
+  }
+};

--- a/web/src/app/monitor/utils/monitorPluginList.ts
+++ b/web/src/app/monitor/utils/monitorPluginList.ts
@@ -1,0 +1,16 @@
+/** 兼容 monitor_plugin list:全量数组 或 分页 {count, items} */
+export function unwrapMonitorPluginList<T = any>(data: unknown): T[] {
+  if (Array.isArray(data)) {
+    return data as T[];
+  }
+  if (data && typeof data === 'object') {
+    const record = data as { items?: unknown; results?: unknown };
+    if (Array.isArray(record.items)) {
+      return record.items as T[];
+    }
+    if (Array.isArray(record.results)) {
+      return record.results as T[];
+    }
+  }
+  return [];
+}


### PR DESCRIPTION
## Summary
- 插件列表支持 opt-in 分页（`page`/`page_size` → `{count,items}`），无分页参数仍返回全量数组以兼容现有调用方
- 列表瘦字段序列化 + keyword DB/i18n 候选粗筛；集成页默认每页 20，翻页保留旧数据
- 去掉 CommonProvider/layout 全屏门闩，并增加 objects/plugins 会话缓存，降低重复请求

## Test plan
- [x] `pytest apps/monitor/tests/test_plugin_search.py apps/monitor/tests/test_plugin_list_pagination.py`（24 passed，分页用例本地验证未提交）
- [ ] 打开监控「集成」：首屏 Network 插件约 20 条；翻页/搜索/切对象正常
- [ ] 搜索面板、策略详情插件下拉仍可用

## Scope check
已排除无关 icon / `__enterprise-brands.js` / `tsconfig.json`；测试文件按仓库规则未纳入 commit。