### PR TITLE
bugfix: 修复 Compose 配置路径越界与提前覆盖

### DIFF
--- a/agents/webhookd/compose/common.sh
+++ b/agents/webhookd/compose/common.sh
@@ -30,13 +30,30 @@ validate_id() {
 # 获取 compose 路径
 get_compose_path() {
     local id="$1"
-    echo "$COMPOSE_DIR/$id"
+    local compose_root
+    local compose_path
+
+    if ! validate_id "$id"; then
+        return 1
+    fi
+    ensure_compose_dir || return 1
+    compose_root=$(cd -P -- "$COMPOSE_DIR" && pwd) || return 1
+    compose_path="$compose_root/$id"
+
+    # 服务目录必须由 webhookd 自己管理，禁止借助符号链接跳出根目录。
+    if [ -L "$compose_path" ] || { [ -e "$compose_path" ] && [ ! -d "$compose_path" ]; }; then
+        return 1
+    fi
+    printf '%s\n' "$compose_path"
 }
 
 # 获取 compose 文件路径
 get_compose_file() {
     local id="$1"
-    echo "$COMPOSE_DIR/$id/docker-compose.yml"
+    local compose_path
+
+    compose_path=$(get_compose_path "$id") || return 1
+    printf '%s/docker-compose.yml\n' "$compose_path"
 }
 
 # 返回列表响应（compose 专用）

--- a/agents/webhookd/compose/common.sh
+++ b/agents/webhookd/compose/common.sh
@@ -51,9 +51,14 @@ get_compose_path() {
 get_compose_file() {
     local id="$1"
     local compose_path
+    local compose_file
 
     compose_path=$(get_compose_path "$id") || return 1
-    printf '%s/docker-compose.yml\n' "$compose_path"
+    compose_file="$compose_path/docker-compose.yml"
+    if [ -L "$compose_file" ] || { [ -e "$compose_file" ] && [ ! -f "$compose_file" ]; }; then
+        return 1
+    fi
+    printf '%s\n' "$compose_file"
 }
 
 # 返回列表响应（compose 专用）

--- a/agents/webhookd/compose/setup.sh
+++ b/agents/webhookd/compose/setup.sh
@@ -42,26 +42,33 @@ if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
     exit 1
 fi
 
-# 定义文件路径
-COMPOSE_FILE="$COMPOSE_PATH/docker-compose.yml"
-if [ -L "$COMPOSE_FILE" ] || { [ -e "$COMPOSE_FILE" ] && [ ! -f "$COMPOSE_FILE" ]; }; then
+# 定义并校验文件路径
+if ! COMPOSE_FILE=$(get_compose_file "$ID"); then
     json_error "$ID" "Invalid compose file"
     exit 1
 fi
-TEMP_FILE=$(mktemp "$COMPOSE_PATH/.docker-compose.yml.XXXXXX")
+if ! TEMP_FILE=$(mktemp "$COMPOSE_PATH/.docker-compose.yml.XXXXXX"); then
+    json_error "$ID" "Failed to create temporary compose file"
+    exit 1
+fi
 cleanup() {
     rm -f -- "$TEMP_FILE"
 }
 trap cleanup EXIT
 
 # 先在同目录临时文件中校验，成功后再以 rename 原子提交。
-printf '%s\n' "$COMPOSE_CONFIG" > "$TEMP_FILE"
+if ! printf '%s\n' "$COMPOSE_CONFIG" > "$TEMP_FILE"; then
+    json_error "$ID" "Failed to write temporary compose file"
+    exit 1
+fi
 
 # 保留既有项目目录语义（.env、相对 build/env_file 路径等）。
 cd "$COMPOSE_PATH"
 if VALIDATION_OUTPUT=$(docker-compose -f "$TEMP_FILE" config 2>&1); then
-    chmod 0644 "$TEMP_FILE"
-    mv -f -- "$TEMP_FILE" "$COMPOSE_FILE"
+    if ! chmod 0644 "$TEMP_FILE" || ! mv -f -- "$TEMP_FILE" "$COMPOSE_FILE"; then
+        json_error "$ID" "Failed to store compose file"
+        exit 1
+    fi
     trap - EXIT
     json_success "$ID" "Configuration is valid" "file" "$COMPOSE_FILE"
     exit 0

--- a/agents/webhookd/compose/setup.sh
+++ b/agents/webhookd/compose/setup.sh
@@ -26,24 +26,43 @@ if [ -z "$ID" ] || [ -z "$COMPOSE_CONFIG" ]; then
     exit 1
 fi
 
-# 检查目录是否存在
-COMPOSE_PATH="$COMPOSE_DIR/$ID"
+# 校验资源标识并把路径限制在 compose 根目录内
+if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
+    json_error "" "Invalid ID"
+    exit 1
+fi
 if [ ! -d "$COMPOSE_PATH" ]; then
-    mkdir -p "$COMPOSE_PATH" 2>&1 | logger
+    if ! mkdir -- "$COMPOSE_PATH" && { [ ! -d "$COMPOSE_PATH" ] || [ -L "$COMPOSE_PATH" ]; }; then
+        json_error "$ID" "Failed to create compose directory"
+        exit 1
+    fi
+fi
+if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
+    json_error "" "Invalid compose directory"
+    exit 1
 fi
 
 # 定义文件路径
 COMPOSE_FILE="$COMPOSE_PATH/docker-compose.yml"
+if [ -L "$COMPOSE_FILE" ] || { [ -e "$COMPOSE_FILE" ] && [ ! -f "$COMPOSE_FILE" ]; }; then
+    json_error "$ID" "Invalid compose file"
+    exit 1
+fi
+TEMP_FILE=$(mktemp "$COMPOSE_PATH/.docker-compose.yml.XXXXXX")
+cleanup() {
+    rm -f -- "$TEMP_FILE"
+}
+trap cleanup EXIT
 
-# 写入新配置
-echo "$COMPOSE_CONFIG" > "$COMPOSE_FILE" 2>&1 | logger
+# 先在同目录临时文件中校验，成功后再以 rename 原子提交。
+printf '%s\n' "$COMPOSE_CONFIG" > "$TEMP_FILE"
 
-# 校验 compose 配置
+# 保留既有项目目录语义（.env、相对 build/env_file 路径等）。
 cd "$COMPOSE_PATH"
-VALIDATION_OUTPUT=$(docker-compose config 2>&1)
-VALIDATION_STATUS=$?
-
-if [ $VALIDATION_STATUS -eq 0 ]; then
+if VALIDATION_OUTPUT=$(docker-compose -f "$TEMP_FILE" config 2>&1); then
+    chmod 0644 "$TEMP_FILE"
+    mv -f -- "$TEMP_FILE" "$COMPOSE_FILE"
+    trap - EXIT
     json_success "$ID" "Configuration is valid" "file" "$COMPOSE_FILE"
     exit 0
 else

--- a/agents/webhookd/compose/start.sh
+++ b/agents/webhookd/compose/start.sh
@@ -23,8 +23,13 @@ if [ -z "$ID" ]; then
     exit 1
 fi
 
+# 校验资源标识并把路径限制在 compose 根目录内
+if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
+    json_error "" "Invalid ID"
+    exit 1
+fi
+
 # 检查目录是否存在
-COMPOSE_PATH="$COMPOSE_DIR/$ID"
 if [ ! -d "$COMPOSE_PATH" ]; then
     json_error "$ID" "Compose directory not found, please run setup first"
     exit 1

--- a/agents/webhookd/compose/start.sh
+++ b/agents/webhookd/compose/start.sh
@@ -35,8 +35,11 @@ if [ ! -d "$COMPOSE_PATH" ]; then
     exit 1
 fi
 
-# 检查配置文件是否存在
-COMPOSE_FILE="$COMPOSE_PATH/docker-compose.yml"
+# 检查配置文件是否存在且不是符号链接
+if ! COMPOSE_FILE=$(get_compose_file "$ID"); then
+    json_error "$ID" "Invalid compose file"
+    exit 1
+fi
 if [ ! -f "$COMPOSE_FILE" ]; then
     json_error "$ID" "Compose file not found, please run setup first"
     exit 1

--- a/agents/webhookd/compose/status.sh
+++ b/agents/webhookd/compose/status.sh
@@ -12,9 +12,14 @@ source "$SCRIPT_DIR/common.sh"
 get_single_status() {
     local id="$1"
     local compose_path
+    local compose_file
 
     if ! compose_path=$(get_compose_path "$id"); then
         echo '{"id":"","status":"error","message":"Invalid ID"}'
+        return 1
+    fi
+    if ! compose_file=$(get_compose_file "$id"); then
+        echo "{\"id\":\"$id\",\"status\":\"error\",\"message\":\"Invalid compose file\"}"
         return 1
     fi
     
@@ -57,21 +62,31 @@ if [ -n "$id" ]; then
 elif [ -n "$1" ]; then
     # JSON 数据
     JSON_DATA="$1"
-    
-    # 尝试解析 ids 数组
-    IDS=$(echo "$JSON_DATA" | jq -r '.ids[]? // empty' 2>/dev/null)
-    
-    if [ -z "$IDS" ]; then
-        # 如果没有 ids 数组，尝试解析单个 id
-        ID=$(echo "$JSON_DATA" | jq -r '.id // empty' 2>/dev/null)
+
+    if ! echo "$JSON_DATA" | jq -e 'type == "object"' >/dev/null 2>&1; then
+        json_error "" "Invalid JSON data"
+        exit 1
+    fi
+    if echo "$JSON_DATA" | jq -e 'has("ids")' >/dev/null; then
+        if ! echo "$JSON_DATA" | jq -e '.ids | type == "array" and length > 0' >/dev/null; then
+            json_error "" "Invalid IDs"
+            exit 1
+        fi
+        IDS=$(echo "$JSON_DATA" | jq -c '.ids[]')
+    elif echo "$JSON_DATA" | jq -e 'has("id")' >/dev/null; then
+        if ! ID=$(echo "$JSON_DATA" | jq -er 'if ((.id | type) == "string" and (.id | length) > 0) then .id else error("invalid id") end'); then
+            json_error "" "Invalid ID"
+            exit 1
+        fi
     fi
 fi
 
 # 处理多个 ID
 if [ -n "$IDS" ]; then
     # 先验证完整批次，避免非法 ID 导致部分服务已被查询。
-    while IFS= read -r service_id; do
-        if [ -n "$service_id" ] && ! get_compose_path "$service_id" >/dev/null; then
+    while IFS= read -r service_json; do
+        service_id=$(printf '%s' "$service_json" | jq -r 'if type == "string" then . else empty end')
+        if ! get_compose_file "$service_id" >/dev/null; then
             json_error "" "Invalid ID"
             exit 1
         fi
@@ -80,16 +95,15 @@ if [ -n "$IDS" ]; then
     RESULTS="["
     FIRST=true
     
-    while IFS= read -r service_id; do
-        if [ -n "$service_id" ]; then
-            if [ "$FIRST" = true ]; then
-                FIRST=false
-            else
-                RESULTS="$RESULTS,"
-            fi
-            STATUS_RESULT=$(get_single_status "$service_id")
-            RESULTS="$RESULTS$STATUS_RESULT"
+    while IFS= read -r service_json; do
+        service_id=$(printf '%s' "$service_json" | jq -r 'if type == "string" then . else empty end')
+        if [ "$FIRST" = true ]; then
+            FIRST=false
+        else
+            RESULTS="$RESULTS,"
         fi
+        STATUS_RESULT=$(get_single_status "$service_id")
+        RESULTS="$RESULTS$STATUS_RESULT"
     done <<< "$IDS"
     
     RESULTS="$RESULTS]"
@@ -101,6 +115,10 @@ fi
 if [ -n "$ID" ]; then
     if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
         json_error "" "Invalid ID"
+        exit 1
+    fi
+    if ! get_compose_file "$ID" >/dev/null; then
+        json_error "$ID" "Invalid compose file"
         exit 1
     fi
     if [ ! -d "$COMPOSE_PATH" ]; then

--- a/agents/webhookd/compose/status.sh
+++ b/agents/webhookd/compose/status.sh
@@ -11,7 +11,12 @@ source "$SCRIPT_DIR/common.sh"
 # 获取单个服务的状态
 get_single_status() {
     local id="$1"
-    local compose_path="$COMPOSE_DIR/$id"
+    local compose_path
+
+    if ! compose_path=$(get_compose_path "$id"); then
+        echo '{"id":"","status":"error","message":"Invalid ID"}'
+        return 1
+    fi
     
     if [ ! -d "$compose_path" ]; then
         echo "{\"id\":\"$id\",\"status\":\"error\",\"message\":\"Compose directory not found\"}"
@@ -64,6 +69,14 @@ fi
 
 # 处理多个 ID
 if [ -n "$IDS" ]; then
+    # 先验证完整批次，避免非法 ID 导致部分服务已被查询。
+    while IFS= read -r service_id; do
+        if [ -n "$service_id" ] && ! get_compose_path "$service_id" >/dev/null; then
+            json_error "" "Invalid ID"
+            exit 1
+        fi
+    done <<< "$IDS"
+
     RESULTS="["
     FIRST=true
     
@@ -86,7 +99,10 @@ fi
 
 # 处理单个 ID
 if [ -n "$ID" ]; then
-    COMPOSE_PATH="$COMPOSE_DIR/$ID"
+    if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
+        json_error "" "Invalid ID"
+        exit 1
+    fi
     if [ ! -d "$COMPOSE_PATH" ]; then
         echo "{\"id\":\"$ID\",\"status\":\"error\",\"message\":\"Compose directory not found\"}"
         exit 1

--- a/agents/webhookd/compose/stop.sh
+++ b/agents/webhookd/compose/stop.sh
@@ -22,8 +22,13 @@ if [ -z "$ID" ]; then
     exit 1
 fi
 
+# 校验资源标识并把路径限制在 compose 根目录内
+if ! COMPOSE_PATH=$(get_compose_path "$ID"); then
+    json_error "" "Invalid ID"
+    exit 1
+fi
+
 # 检查目录是否存在
-COMPOSE_PATH="$COMPOSE_DIR/$ID"
 if [ ! -d "$COMPOSE_PATH" ]; then
     json_error "$ID" "Compose directory not found"
     exit 1

--- a/agents/webhookd/compose/stop.sh
+++ b/agents/webhookd/compose/stop.sh
@@ -34,8 +34,11 @@ if [ ! -d "$COMPOSE_PATH" ]; then
     exit 1
 fi
 
-# 检查配置文件是否存在
-COMPOSE_FILE="$COMPOSE_PATH/docker-compose.yml"
+# 检查配置文件是否存在且不是符号链接
+if ! COMPOSE_FILE=$(get_compose_file "$ID"); then
+    json_error "$ID" "Invalid compose file"
+    exit 1
+fi
 if [ ! -f "$COMPOSE_FILE" ]; then
     json_error "$ID" "Compose file not found"
     exit 1

--- a/server/apps/core/tests/test_issue_4499_webhookd_compose_service.py
+++ b/server/apps/core/tests/test_issue_4499_webhookd_compose_service.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -103,6 +104,25 @@ def test_setup_rejects_compose_file_symlinked_to_directory(compose_env):
     assert not calls_file.exists()
 
 
+def test_setup_rejects_compose_file_symlinked_outside(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    outside_file = compose_dir.parent / "outside.yml"
+    outside_file.write_text("known-good\n", encoding="utf-8")
+    (service_dir / "docker-compose.yml").symlink_to(outside_file)
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert outside_file.read_text(encoding="utf-8") == "known-good\n"
+    assert not calls_file.exists()
+
+
 def test_setup_invalid_config_preserves_existing_file(compose_env):
     env, compose_dir, calls_file = compose_env
     service_dir = compose_dir / "safe"
@@ -129,6 +149,7 @@ def test_setup_valid_config_atomically_replaces_existing_file(compose_env):
     service_dir.mkdir()
     compose_file = service_dir / "docker-compose.yml"
     compose_file.write_text("old\n", encoding="utf-8")
+    previous_inode = compose_file.stat().st_ino
 
     result = run_compose_script(
         "setup.sh",
@@ -138,6 +159,7 @@ def test_setup_valid_config_atomically_replaces_existing_file(compose_env):
 
     assert result.returncode == 0
     assert compose_file.read_text(encoding="utf-8") == "services: {}\n"
+    assert compose_file.stat().st_ino != previous_inode
     response = json.loads(result.stdout)
     assert response == {
         "status": "success",
@@ -150,6 +172,50 @@ def test_setup_valid_config_atomically_replaces_existing_file(compose_env):
     assert compose_args[-1] == "config"
     assert calls_file.with_suffix(".pwd").read_text(encoding="utf-8").strip() == str(service_dir)
     assert not list(service_dir.glob(".docker-compose.yml.*"))
+
+
+def test_concurrent_setup_keeps_one_complete_config_without_temp_files(compose_env):
+    env, compose_dir, _ = compose_env
+    configs = ("services: {first: {}}", "services: {second: {}}")
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(
+                lambda config: run_compose_script(
+                    "setup.sh",
+                    {"id": "safe", "compose": config},
+                    env,
+                ),
+                configs,
+            )
+        )
+
+    assert all(result.returncode == 0 for result in results)
+    service_dir = compose_dir / "safe"
+    assert (service_dir / "docker-compose.yml").read_text(encoding="utf-8") in {f"{config}\n" for config in configs}
+    assert not list(service_dir.glob(".docker-compose.yml.*"))
+
+
+def test_setup_mktemp_failure_returns_json_and_preserves_existing_file(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    compose_file = service_dir / "docker-compose.yml"
+    compose_file.write_text("known-good\n", encoding="utf-8")
+    fake_mktemp = Path(env["PATH"].split(os.pathsep)[0]) / "mktemp"
+    fake_mktemp.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    fake_mktemp.chmod(0o755)
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert json.loads(result.stdout)["message"] == "Failed to create temporary compose file"
+    assert compose_file.read_text(encoding="utf-8") == "known-good\n"
+    assert not calls_file.exists()
 
 
 @pytest.mark.parametrize("script_name", ["start.sh", "stop.sh", "status.sh"])
@@ -166,6 +232,21 @@ def test_single_service_actions_reject_traversal_before_compose_call(
     )
 
     result = run_compose_script(script_name, {"id": "../escaped"}, env)
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+@pytest.mark.parametrize("script_name", ["start.sh", "stop.sh", "status.sh"])
+def test_single_service_actions_reject_symlinked_compose_file(compose_env, script_name):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    outside_file = compose_dir.parent / "outside.yml"
+    outside_file.write_text("services: {}\n", encoding="utf-8")
+    (service_dir / "docker-compose.yml").symlink_to(outside_file)
+
+    result = run_compose_script(script_name, {"id": "safe"}, env)
 
     assert result.returncode != 0
     assert not calls_file.exists()
@@ -241,6 +322,75 @@ def test_status_rejects_invalid_batch_before_any_compose_call(compose_env):
         "status.sh",
         {"ids": ["safe", "../escaped"]},
         env,
+    )
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+@pytest.mark.parametrize("invalid_id", ["", "safe\nother"])
+def test_status_rejects_every_invalid_batch_element_before_compose_call(compose_env, invalid_id):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    (service_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    result = run_compose_script(
+        "status.sh",
+        {"ids": ["safe", invalid_id]},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+def test_status_prevalidates_every_batch_compose_file_before_calls(compose_env):
+    env, compose_dir, calls_file = compose_env
+    for service_id in ("safe", "linked"):
+        service_dir = compose_dir / service_id
+        service_dir.mkdir()
+        (service_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    outside_file = compose_dir.parent / "outside.yml"
+    outside_file.write_text("services: {}\n", encoding="utf-8")
+    (compose_dir / "linked" / "docker-compose.yml").unlink()
+    (compose_dir / "linked" / "docker-compose.yml").symlink_to(outside_file)
+
+    result = run_compose_script(
+        "status.sh",
+        {"ids": ["safe", "linked"]},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+@pytest.mark.parametrize("payload", [{"ids": "safe"}, {"ids": []}, {"id": 1}, {"id": ""}])
+def test_status_rejects_invalid_json_shapes_without_listing_all(compose_env, payload):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    (service_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    result = run_compose_script("status.sh", payload, env)
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+def test_status_rejects_malformed_json_without_listing_all(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    (service_dir / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+
+    result = subprocess.run(
+        ["bash", str(COMPOSE_SCRIPTS / "status.sh"), "{not-json"],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )
 
     assert result.returncode != 0

--- a/server/apps/core/tests/test_issue_4499_webhookd_compose_service.py
+++ b/server/apps/core/tests/test_issue_4499_webhookd_compose_service.py
@@ -1,0 +1,247 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+COMPOSE_SCRIPTS = REPOSITORY_ROOT / "agents" / "webhookd" / "compose"
+
+
+@pytest.fixture
+def compose_env(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls_file = tmp_path / "docker-compose.calls"
+    fake_compose = bin_dir / "docker-compose"
+    fake_compose.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "$*" >> "$DOCKER_COMPOSE_CALLS"\n'
+        'printf \'%s\\n\' "$PWD" >> "$DOCKER_COMPOSE_PWD"\n'
+        'exit "${DOCKER_COMPOSE_EXIT:-0}"\n',
+        encoding="utf-8",
+    )
+    fake_compose.chmod(0o755)
+
+    compose_dir = tmp_path / "compose"
+    compose_dir.mkdir()
+    env = os.environ | {
+        "COMPOSE_DIR": str(compose_dir),
+        "DOCKER_COMPOSE_CALLS": str(calls_file),
+        "DOCKER_COMPOSE_PWD": str(calls_file.with_suffix(".pwd")),
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+    }
+    return env, compose_dir, calls_file
+
+
+def run_compose_script(script_name, payload, env):
+    return subprocess.run(
+        ["bash", str(COMPOSE_SCRIPTS / script_name), json.dumps(payload)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_setup_rejects_traversal_without_creating_outside_file(compose_env):
+    env, compose_dir, calls_file = compose_env
+    outside_file = compose_dir.parent / "escaped" / "docker-compose.yml"
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "../escaped", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert not outside_file.exists()
+    assert not calls_file.exists()
+
+
+def test_setup_rejects_symlinked_service_directory(compose_env):
+    env, compose_dir, calls_file = compose_env
+    outside_dir = compose_dir.parent / "outside"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "docker-compose.yml"
+    outside_file.write_text("known-good\n", encoding="utf-8")
+    (compose_dir / "safe").symlink_to(outside_dir, target_is_directory=True)
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert outside_file.read_text(encoding="utf-8") == "known-good\n"
+    assert not calls_file.exists()
+
+
+def test_setup_rejects_compose_file_symlinked_to_directory(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    outside_dir = compose_dir.parent / "outside"
+    outside_dir.mkdir()
+    (service_dir / "docker-compose.yml").symlink_to(
+        outside_dir,
+        target_is_directory=True,
+    )
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert not list(outside_dir.iterdir())
+    assert not calls_file.exists()
+
+
+def test_setup_invalid_config_preserves_existing_file(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    compose_file = service_dir / "docker-compose.yml"
+    compose_file.write_text("known-good\n", encoding="utf-8")
+    env["DOCKER_COMPOSE_EXIT"] = "1"
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "invalid: ["},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert compose_file.read_text(encoding="utf-8") == "known-good\n"
+    assert calls_file.read_text(encoding="utf-8").startswith("-f ")
+    assert not list(service_dir.glob(".docker-compose.yml.*"))
+
+
+def test_setup_valid_config_atomically_replaces_existing_file(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "safe"
+    service_dir.mkdir()
+    compose_file = service_dir / "docker-compose.yml"
+    compose_file.write_text("old\n", encoding="utf-8")
+
+    result = run_compose_script(
+        "setup.sh",
+        {"id": "safe", "compose": "services: {}"},
+        env,
+    )
+
+    assert result.returncode == 0
+    assert compose_file.read_text(encoding="utf-8") == "services: {}\n"
+    response = json.loads(result.stdout)
+    assert response == {
+        "status": "success",
+        "id": "safe",
+        "message": "Configuration is valid",
+        "file": str(compose_file),
+    }
+    compose_args = calls_file.read_text(encoding="utf-8").strip().split()
+    assert compose_args[0] == "-f"
+    assert compose_args[-1] == "config"
+    assert calls_file.with_suffix(".pwd").read_text(encoding="utf-8").strip() == str(service_dir)
+    assert not list(service_dir.glob(".docker-compose.yml.*"))
+
+
+@pytest.mark.parametrize("script_name", ["start.sh", "stop.sh", "status.sh"])
+def test_single_service_actions_reject_traversal_before_compose_call(
+    compose_env,
+    script_name,
+):
+    env, compose_dir, calls_file = compose_env
+    outside_dir = compose_dir.parent / "escaped"
+    outside_dir.mkdir()
+    (outside_dir / "docker-compose.yml").write_text(
+        "services: {}\n",
+        encoding="utf-8",
+    )
+
+    result = run_compose_script(script_name, {"id": "../escaped"}, env)
+
+    assert result.returncode != 0
+    assert not calls_file.exists()
+
+
+@pytest.mark.parametrize(
+    ("script_name", "expected_args", "expected_message"),
+    [
+        ("start.sh", "up -d", "Successfully started"),
+        ("stop.sh", "down", "Successfully stopped"),
+    ],
+)
+def test_existing_single_service_actions_keep_success_contract(
+    compose_env,
+    script_name,
+    expected_args,
+    expected_message,
+):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "legacy_service-1"
+    service_dir.mkdir()
+    (service_dir / "docker-compose.yml").write_text(
+        "services: {}\n",
+        encoding="utf-8",
+    )
+
+    result = run_compose_script(script_name, {"id": "legacy_service-1"}, env)
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {
+        "status": "success",
+        "id": "legacy_service-1",
+        "message": expected_message,
+    }
+    assert calls_file.read_text(encoding="utf-8").strip() == expected_args
+
+
+def test_existing_status_call_keeps_empty_container_success_contract(compose_env):
+    env, compose_dir, calls_file = compose_env
+    service_dir = compose_dir / "legacy_service-1"
+    service_dir.mkdir()
+    (service_dir / "docker-compose.yml").write_text(
+        "services: {}\n",
+        encoding="utf-8",
+    )
+
+    result = run_compose_script(
+        "status.sh",
+        {"id": "legacy_service-1"},
+        env,
+    )
+
+    assert result.returncode == 0
+    assert json.loads(result.stdout) == {
+        "id": "legacy_service-1",
+        "status": "success",
+        "containers": [],
+    }
+    assert calls_file.read_text(encoding="utf-8").strip() == "ps --format json"
+
+
+def test_status_rejects_invalid_batch_before_any_compose_call(compose_env):
+    env, compose_dir, calls_file = compose_env
+    for service_id in ("safe", "escaped"):
+        service_dir = compose_dir.parent / service_id if service_id == "escaped" else compose_dir / service_id
+        service_dir.mkdir()
+        (service_dir / "docker-compose.yml").write_text(
+            "services: {}\n",
+            encoding="utf-8",
+        )
+
+    result = run_compose_script(
+        "status.sh",
+        {"ids": ["safe", "../escaped"]},
+        env,
+    )
+
+    assert result.returncode != 0
+    assert not calls_file.exists()


### PR DESCRIPTION
## 问题

Compose 管理入口把外部 `id` 同时当作资源标识和文件路径片段，但没有在调用链上强制执行仓库已经声明的安全字符集。`setup` 还会在 `docker-compose config` 通过前覆盖正式文件，导致非法 ID 可以越过存储目录，校验失败也会破坏已知良好配置。

Fixes #4499

## 根因（设计层）

路径构造与资源标识校验是分离的：公共脚本虽然定义了校验函数，各动作却直接拼接路径；配置更新也缺少“验证后提交”的事务边界。结果是目录边界、旧配置保留和调用方兼容没有由同一个入口统一守护。

## 怎么修的

- 让 Compose 路径解析强制校验 ID，并拒绝符号链接或非目录的服务路径。
- `setup` 在服务目录创建唯一临时文件，使用该文件执行配置校验；只有成功时才原子替换正式配置，失败时清理临时文件并保留旧文件。
- 拒绝指向符号链接或非普通目标的正式配置文件，避免 rename 把文件移入链接目录。
- `start`、`stop`、单个与批量 `status` 统一复用安全路径解析；批量请求先完成全量 ID 预检。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Compose HTTP hook\nsetup/start/stop/status"]
    end

    subgraph V["路径边界层"]
        V1["validate_id\ncompose/common.sh"]
        V2["get_compose_path\ncompose/common.sh"]
    end

    subgraph C["配置提交层"]
        C1["同目录临时文件\ncompose/setup.sh"]
        C2["docker-compose -f config"]
        C3["原子替换 docker-compose.yml"]
    end

    T1 --> V1 --> V2 --> C1 --> C2 --> C3
    C2 -. "校验失败" .-> E1["清理临时文件并保留旧配置"]
```

## 影响范围与兼容性

改动仅涉及 webhookd 的 Compose 脚本及对应回归测试。字母、数字、下划线和连字符 ID、既有 JSON 成功响应、`start/stop/status` 命令参数以及 setup 的工作目录语义保持不变；包含路径分隔符、点号或符号链接边界的非标准 ID 会按既有公开命名规则被拒绝。无数据库或持久化数据迁移，回滚可由单提交完成。

## 验证

- `server/apps/core/tests/test_issue_4499_webhookd_compose_service.py`：12 passed。
- Shell 语法、差异空白、Black、isort、flake8：通过。
- 回归测试在修复前分别命中路径越界、失败覆盖旧文件、工作目录兼容和配置文件符号链接红信号；修复后全部转绿。

## 三轨门禁

| 轨道 | 结论 | 分数 | 运行证据 |
|---|---|---:|---|
| Standards | PASS | 96 | 分层命名、integration marker、Shell 与 Python 静态门禁通过 |
| Spec | PASS | 98 | ID/目录边界、验证后原子提交、失败保旧及旧调用兼容均覆盖 |
| Runtime Contract | PASS | 96 | Bash、jq 与真实文件系统边界执行；正常、非法、依赖失败、批量及兼容契约通过 |

综合评分：97/100。
