### PR TITLE
fix(monitor): 对齐 SNMP 表单协议依赖

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_casa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_casa/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_cdata/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_cdata/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_fiberhome_olt/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_fiberhome_olt/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_harmonic/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_harmonic/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_icotera/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_icotera/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_packetfront/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_packetfront/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_rad/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_rad/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_topvision/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_topvision/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_utstarcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_utstarcom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_vsolution/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_vsolution/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_zhone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_zhone/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_avocent/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_avocent/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_lantronix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_lantronix/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_perle/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_perle/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_raritan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_raritan/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_wti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_wti/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_barracuda/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_barracuda/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_relianoid/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_relianoid/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_allot/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_allot/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_apc/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_apc/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_asentria/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_asentria/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_bluecat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_bluecat/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_deva/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_deva/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_eaton/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_eaton/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_efficientip/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_efficientip/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endace/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endace/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endrun/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endrun/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_enlogic/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_enlogic/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_geist/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_geist/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gude/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gude/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_liebert/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_liebert/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_meinberg/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_meinberg/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nomadix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nomadix/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nti/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_panduit/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_panduit/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_rittal/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_rittal/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_servertech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_servertech/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_socomec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_socomec/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_spectracom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_spectracom/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_tripplite/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_tripplite/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_velocloud/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_velocloud/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_antaira/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_antaira/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_asterfusion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_asterfusion/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_atop/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_atop/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_comtrol/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_comtrol/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_inhand/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_inhand/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ipinfusion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ipinfusion/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_kyland/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_kyland/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lantech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lantech/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_murrelektronik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_murrelektronik/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omnitron/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omnitron/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_rubytech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_rubytech/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquoss/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquoss/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_wago/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_wago/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_weidmuller/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_weidmuller/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_womaster/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_womaster/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_xikestor/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_xikestor/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_alcoma/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_alcoma/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_bridgewave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_bridgewave/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ekinops/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ekinops/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ericsson/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ericsson/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_exalt/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_exalt/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_fibrolan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_fibrolan/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ifotec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ifotec/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_infinera/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_infinera/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_marconi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_marconi/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_mrv/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_mrv/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_packetlight/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_packetlight/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_pandacom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_pandacom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_racom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_racom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_redline/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_redline/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_saftehnika/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_saftehnika/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siklu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siklu/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_smartoptics/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_smartoptics/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_sycamore/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_sycamore/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_tachyon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_tachyon/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_viavi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_viavi/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_acmepacket/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_acmepacket/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_addpac/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_addpac/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_innovaphone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_innovaphone/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_mitel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_mitel/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_patton/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_patton/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_polycom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_polycom/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_ribbon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_ribbon/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_sangoma/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_sangoma/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_yeastar/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_yeastar/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_acksys/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_acksys/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_airspan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_airspan/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ligowave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ligowave/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_mimosa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_mimosa/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_prosoft/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_prosoft/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_password",
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_password",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_radwin/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_radwin/UI.json
@@ -164,8 +164,25 @@
         "placeholder": "认证协议 (MD5/SHA)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.auth_protocol",
@@ -184,8 +201,25 @@
         "placeholder_en": "Auth Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
@@ -204,8 +238,22 @@
         "placeholder": "加密协议 (DES/AES)"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.content.config.priv_protocol",
@@ -224,8 +272,22 @@
         "placeholder_en": "Privacy Password"
       },
       "dependency": {
-        "field": "version",
-        "value": 3
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
       },
       "transform_on_edit": {
         "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
@@ -49,14 +49,22 @@
       "type": "input",
       "required": true,
       "default_value": "public",
-      "label_en": "Community"
+      "label_en": "Community",
+      "dependency": {
+        "field": "version",
+        "value": 2
+      }
     },
     {
       "name": "sec_name",
       "label": "名称",
       "type": "input",
       "required": true,
-      "label_en": "Name"
+      "label_en": "Name",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "sec_level",
@@ -81,7 +89,11 @@
           "label_en": "authPriv"
         }
       ],
-      "label_en": "Level"
+      "label_en": "Level",
+      "dependency": {
+        "field": "version",
+        "value": 3
+      }
     },
     {
       "name": "auth_protocol",
@@ -89,14 +101,56 @@
       "type": "input",
       "required": false,
       "default_value": "SHA",
-      "label_en": "Auth Protocol"
+      "label_en": "Auth Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "in": [
+                "authNoPriv",
+                "authPriv"
+              ]
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "priv_protocol",
@@ -104,14 +158,50 @@
       "type": "input",
       "required": false,
       "default_value": "AES",
-      "label_en": "Privacy Protocol"
+      "label_en": "Privacy Protocol",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "dependency": {
+        "field": [
+          "version",
+          "sec_level"
+        ],
+        "conditions": [
+          [
+            {
+              "equals": 3
+            }
+          ],
+          [
+            {
+              "equals": "authPriv"
+            }
+          ]
+        ]
+      }
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/tests/test_snmp_ui_protocol_dependencies_pure.py
+++ b/server/apps/monitor/tests/test_snmp_ui_protocol_dependencies_pure.py
@@ -1,0 +1,57 @@
+"""Shared protocol-visibility contract for every Telegraf SNMP form."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+SERVER_ROOT = Path(__file__).resolve().parents[3]
+SNMP_ROOT = SERVER_ROOT / "apps" / "monitor" / "support-files" / "plugins" / "Telegraf" / "snmp"
+
+V2_DEPENDENCY = {"field": "version", "value": 2}
+V3_DEPENDENCY = {"field": "version", "value": 3}
+AUTH_DEPENDENCY = {
+    "field": ["version", "sec_level"],
+    "conditions": [[{"equals": 3}], [{"in": ["authNoPriv", "authPriv"]}]],
+}
+PRIV_DEPENDENCY = {
+    "field": ["version", "sec_level"],
+    "conditions": [[{"equals": 3}], [{"equals": "authPriv"}]],
+}
+AUTH_FIELDS = ("auth_protocol", "auth_password", "ENV_AUTH_PASSWORD")
+PRIV_FIELDS = ("priv_protocol", "priv_password", "ENV_PRIV_PASSWORD")
+
+
+def _ui_files():
+    return sorted(SNMP_ROOT.glob("**/UI.json"))
+
+
+def _fields_by_name(path):
+    ui = json.loads(path.read_text(encoding="utf-8"))
+    fields = ui["form_fields"]
+    names = [field["name"] for field in fields]
+    assert len(names) == len(set(names)), f"{path}: duplicate form field name"
+    return {field["name"]: field for field in fields}
+
+
+@pytest.mark.unit
+def test_all_snmp_forms_follow_the_protocol_visibility_contract():
+    ui_files = _ui_files()
+    assert len(ui_files) == 250
+
+    for path in ui_files:
+        fields = _fields_by_name(path)
+        version = fields["version"]
+        assert {option["value"] for option in version["options"]} == {2, 3}, path
+
+        assert fields["community"].get("dependency") == V2_DEPENDENCY, path
+        assert fields["sec_name"].get("dependency") == V3_DEPENDENCY, path
+        assert fields["sec_level"].get("dependency") == V3_DEPENDENCY, path
+
+        for name in AUTH_FIELDS:
+            if name in fields:
+                assert fields[name].get("dependency") == AUTH_DEPENDENCY, f"{path}: {name}"
+        for name in PRIV_FIELDS:
+            if name in fields:
+                assert fields[name].get("dependency") == PRIV_DEPENDENCY, f"{path}: {name}"

--- a/web/src/app/monitor/hooks/integration/__tests__/formFieldDependency.test.ts
+++ b/web/src/app/monitor/hooks/integration/__tests__/formFieldDependency.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type FormFieldDependency,
+  isDependencySatisfied
+} from '../formFieldDependency';
+
+const authDependency: FormFieldDependency = {
+  field: ['version', 'sec_level'],
+  conditions: [[{ equals: 3 }], [{ in: ['authNoPriv', 'authPriv'] }]]
+};
+
+const privDependency: FormFieldDependency = {
+  field: ['version', 'sec_level'],
+  conditions: [[{ equals: 3 }], [{ equals: 'authPriv' }]]
+};
+
+const isVisible = (dependency: FormFieldDependency, values: Record<string, unknown>) =>
+  isDependencySatisfied(dependency, (field) => values[field]);
+
+describe('SNMP form field dependencies', () => {
+  it('hides SNMPv3 authentication and privacy fields for v2c', () => {
+    const values = { version: 2, sec_level: 'authPriv' };
+
+    expect(isVisible(authDependency, values)).toBe(false);
+    expect(isVisible(privDependency, values)).toBe(false);
+  });
+
+  it('hides authentication and privacy fields for SNMPv3 noAuthNoPriv', () => {
+    const values = { version: 3, sec_level: 'noAuthNoPriv' };
+
+    expect(isVisible(authDependency, values)).toBe(false);
+    expect(isVisible(privDependency, values)).toBe(false);
+  });
+
+  it('shows authentication but not privacy fields for SNMPv3 authNoPriv', () => {
+    const values = { version: 3, sec_level: 'authNoPriv' };
+
+    expect(isVisible(authDependency, values)).toBe(true);
+    expect(isVisible(privDependency, values)).toBe(false);
+  });
+
+  it('shows authentication and privacy fields for SNMPv3 authPriv', () => {
+    const values = { version: 3, sec_level: 'authPriv' };
+
+    expect(isVisible(authDependency, values)).toBe(true);
+    expect(isVisible(privDependency, values)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 变更

- 统一 250 个 Telegraf SNMP 模板的 v2c/v3 与 v3 安全级别字段展示依赖。
- 增加全量 UI 协议依赖契约测试及前端多字段依赖单测。
- 不修改采集 TOML 或保存契约。

## 验证

- Pytest：SNMP UI 协议契约测试通过。
- Vitest：4 个 SNMP 依赖场景通过。
- 全量静态扫描：250 模板、0 JSON 错误、0 依赖违规。
- `git diff --check` 通过。

## 范围

已复核提交仅含 250 个 SNMP UI 模板和 2 个测试；工作区既存图标、仪表盘、tsconfig 与测试报告文件均未纳入。