### PR TITLE
bugfix: 约束 MLOps 容器镜像引用

### DIFF
--- a/agents/webhookd/mlops/kubernetes/common.sh
+++ b/agents/webhookd/mlops/kubernetes/common.sh
@@ -101,7 +101,8 @@ validate_container_image_reference() {
     local reference="$1"
     local domain_component='([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])'
     local domain="${domain_component}(\\.${domain_component})*"
-    local registry="${domain}(:[0-9]+)?"
+    local ipv6_address='\[[A-Fa-f0-9:]+\]'
+    local registry="(${domain}|${ipv6_address})(:[0-9]+)?"
     local path_component='[a-z0-9]+(([._]|__|-+)[a-z0-9]+)*'
     local tag='[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}'
     local digest_algorithm='[A-Za-z][A-Za-z0-9]*([+._-][A-Za-z][A-Za-z0-9]*)*'

--- a/agents/webhookd/mlops/kubernetes/common.sh
+++ b/agents/webhookd/mlops/kubernetes/common.sh
@@ -96,6 +96,41 @@ json_error() {
     fi
 }
 
+# 校验单行 OCI/Docker 风格容器镜像引用。
+validate_container_image_reference() {
+    local reference="$1"
+    local domain_component='([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])'
+    local domain="${domain_component}(\\.${domain_component})*"
+    local registry="${domain}(:[0-9]+)?"
+    local path_component='[a-z0-9]+(([._]|__|-+)[a-z0-9]+)*'
+    local tag='[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}'
+    local digest_algorithm='[A-Za-z][A-Za-z0-9]*([+._-][A-Za-z][A-Za-z0-9]*)*'
+    local digest="${digest_algorithm}:[0-9A-Fa-f]{32,}"
+    local pattern="^((${registry})/)?${path_component}(/${path_component})*(:${tag})?(@${digest})?$"
+
+    [ -n "$reference" ] && [ "${#reference}" -le 255 ] && [[ "$reference" =~ $pattern ]]
+}
+
+# 在 Bash 命令替换前检查 JSON 字符串中的控制字符，避免边界字符被静默归一化。
+validate_container_image_json_boundary() {
+    local json_data="$1"
+
+    printf '%s' "$json_data" | jq -e -s '
+        length == 1 and (
+            .[0] |
+            if type != "object" then
+                false
+            elif .train_image == null then
+                true
+            elif (.train_image | type) != "string" then
+                false
+            else
+                (.train_image | explode | all(. >= 32 and . != 127))
+            end
+        )
+    ' >/dev/null 2>&1
+}
+
 # 检查 Kubernetes 集群是否有 GPU 节点
 check_gpu_available_k8s() {
     local gpu_count=$(kubectl get nodes -o json 2>/dev/null | \

--- a/agents/webhookd/mlops/kubernetes/serve.sh
+++ b/agents/webhookd/mlops/kubernetes/serve.sh
@@ -165,7 +165,7 @@ spec:
     spec:
       containers:
       - name: serve
-        image: ${TRAIN_IMAGE}
+        image: "${TRAIN_IMAGE}"
         ports:
         - containerPort: ${CONTAINER_PORT}
           name: http

--- a/agents/webhookd/mlops/kubernetes/serve.sh
+++ b/agents/webhookd/mlops/kubernetes/serve.sh
@@ -37,6 +37,10 @@ ID=$(echo "$JSON_DATA" | jq -r '.id // empty' 2>/dev/null) || {
     json_error "JSON_PARSE_FAILED" "" "Failed to parse JSON data"
     exit 1
 }
+if ! validate_container_image_json_boundary "$JSON_DATA"; then
+    json_error "INVALID_TRAIN_IMAGE" "${ID:-unknown}" "train_image must be a valid container image reference"
+    exit 1
+fi
 MLFLOW_TRACKING_URI=$(echo "$JSON_DATA" | jq -r '.mlflow_tracking_uri // empty')
 MLFLOW_MODEL_URI=$(echo "$JSON_DATA" | jq -r '.mlflow_model_uri // empty')
 WORKERS=$(echo "$JSON_DATA" | jq -r '.workers // "2"')
@@ -61,6 +65,11 @@ fi
 
 if [ -z "$TRAIN_IMAGE" ]; then
     json_error "MISSING_TRAIN_IMAGE" "$ID" "Missing required field: train_image"
+    exit 1
+fi
+
+if ! validate_container_image_reference "$TRAIN_IMAGE"; then
+    json_error "INVALID_TRAIN_IMAGE" "$ID" "train_image must be a valid container image reference"
     exit 1
 fi
 

--- a/agents/webhookd/mlops/kubernetes/train.sh
+++ b/agents/webhookd/mlops/kubernetes/train.sh
@@ -178,7 +178,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: train
-        image: ${TRAIN_IMAGE}
+        image: "${TRAIN_IMAGE}"
         command: ["/apps/support-files/scripts/train-model.sh"]
         args: ["${BUCKET}", "${DATASET}", "${CONFIG}"]
         env:

--- a/agents/webhookd/mlops/kubernetes/train.sh
+++ b/agents/webhookd/mlops/kubernetes/train.sh
@@ -37,6 +37,10 @@ ID=$(echo "$JSON_DATA" | jq -r '.id // empty' 2>/dev/null) || {
     json_error "JSON_PARSE_FAILED" "" "Failed to parse JSON data"
     exit 1
 }
+if ! validate_container_image_json_boundary "$JSON_DATA"; then
+    json_error "INVALID_TRAIN_IMAGE" "${ID:-unknown}" "train_image must be a valid container image reference"
+    exit 1
+fi
 BUCKET=$(echo "$JSON_DATA" | jq -r '.bucket // empty')
 DATASET=$(echo "$JSON_DATA" | jq -r '.dataset // empty')
 CONFIG=$(echo "$JSON_DATA" | jq -r '.config // empty')
@@ -79,6 +83,11 @@ fi
 
 if [ -z "$TRAIN_IMAGE" ]; then
     json_error "MISSING_TRAIN_IMAGE" "$ID" "Missing required field: train_image"
+    exit 1
+fi
+
+if ! validate_container_image_reference "$TRAIN_IMAGE"; then
+    json_error "INVALID_TRAIN_IMAGE" "$ID" "train_image must be a valid container image reference"
     exit 1
 fi
 

--- a/server/apps/mlops/language/en.yaml
+++ b/server/apps/mlops/language/en.yaml
@@ -83,6 +83,7 @@ error:
   system_configuration_error: "System configuration error. Please contact an administrator."
   mlflow_tracker_url_not_configured: "MLFLOW_TRACKER_URL environment variable is not configured"
   algorithm_config_not_found: "Algorithm configuration was not found: {algorithm}"
+  container_image_reference_invalid: "Enter a valid container image reference"
   form_config_must_be_object: "form_config must be an object"
   hyperopt_config_must_be_array: "hyperopt_config must be an array"
   hyperopt_config_item_must_be_object: "Each item in hyperopt_config must be an object"

--- a/server/apps/mlops/language/zh-Hans.yaml
+++ b/server/apps/mlops/language/zh-Hans.yaml
@@ -83,6 +83,7 @@ error:
   system_configuration_error: "系统配置错误，请联系管理员"
   mlflow_tracker_url_not_configured: "环境变量 MLFLOW_TRACKER_URL 未配置"
   algorithm_config_not_found: "未找到算法配置：{algorithm}"
+  container_image_reference_invalid: "请输入合法的容器镜像引用"
   form_config_must_be_object: "form_config 必须是一个对象"
   hyperopt_config_must_be_array: "hyperopt_config 必须是一个数组"
   hyperopt_config_item_must_be_object: "hyperopt_config 中的每项必须是对象"

--- a/server/apps/mlops/management/commands/init_algorithm_config.py
+++ b/server/apps/mlops/management/commands/init_algorithm_config.py
@@ -6,6 +6,7 @@ from django.core.management.base import BaseCommand
 
 from apps.core.logger import mlops_logger as logger
 from apps.mlops.models import AlgorithmConfig
+from apps.mlops.utils.container_image import is_valid_container_image_reference
 
 
 class Command(BaseCommand):
@@ -100,6 +101,9 @@ class Command(BaseCommand):
             if field_name != "scenario_description" and not payload[field_name].strip():
                 return False, {}, f"{field_name} 不能为空字符串"
 
+        if not is_valid_container_image_reference(payload["image"]):
+            return False, {}, "image 不是合法的容器镜像引用"
+
         if payload["name"] != config_file.stem:
             return False, {}, "name 必须与文件名 stem 完全一致"
 
@@ -110,9 +114,6 @@ class Command(BaseCommand):
         self.stderr.write(message)
 
     def _write_summary(self, created_count: int, skipped_existing_count: int, skipped_invalid_count: int):
-        summary = (
-            f"初始化完成: created={created_count}, "
-            f"skipped_existing={skipped_existing_count}, skipped_invalid={skipped_invalid_count}"
-        )
+        summary = f"初始化完成: created={created_count}, " f"skipped_existing={skipped_existing_count}, skipped_invalid={skipped_invalid_count}"
         self.stdout.write(summary)
         logger.info(summary)

--- a/server/apps/mlops/serializers/algorithm_config.py
+++ b/server/apps/mlops/serializers/algorithm_config.py
@@ -1,15 +1,14 @@
 from rest_framework import serializers
 
 from apps.mlops.models import AlgorithmConfig
+from apps.mlops.utils.container_image import is_valid_container_image_reference
 from apps.mlops.utils.i18n import serializer_message
 
 
 class AlgorithmConfigSerializer(serializers.ModelSerializer):
     """算法配置序列化器"""
 
-    algorithm_type_display = serializers.CharField(
-        source="get_algorithm_type_display", read_only=True
-    )
+    algorithm_type_display = serializers.CharField(source="get_algorithm_type_display", read_only=True)
 
     class Meta:
         model = AlgorithmConfig
@@ -18,6 +17,16 @@ class AlgorithmConfigSerializer(serializers.ModelSerializer):
             "created_by": {"read_only": True},
             "updated_by": {"read_only": True},
         }
+
+    def validate_image(self, value):
+        if not is_valid_container_image_reference(value):
+            raise serializers.ValidationError(
+                serializer_message(
+                    self,
+                    "error.container_image_reference_invalid",
+                )
+            )
+        return value
 
     def validate_form_config(self, value):
         """
@@ -67,9 +76,7 @@ class AlgorithmConfigSerializer(serializers.ModelSerializer):
 class AlgorithmConfigListSerializer(serializers.ModelSerializer):
     """算法配置列表序列化器 - 用于下拉选择，不返回完整的 form_config"""
 
-    algorithm_type_display = serializers.CharField(
-        source="get_algorithm_type_display", read_only=True
-    )
+    algorithm_type_display = serializers.CharField(source="get_algorithm_type_display", read_only=True)
 
     class Meta:
         model = AlgorithmConfig

--- a/server/apps/mlops/tests/test_container_image_reference.py
+++ b/server/apps/mlops/tests/test_container_image_reference.py
@@ -1,0 +1,234 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from apps.mlops.management.commands.init_algorithm_config import Command
+from apps.mlops.serializers.algorithm_config import AlgorithmConfigSerializer
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+KUBERNETES_DIR = REPO_ROOT / "agents/webhookd/mlops/kubernetes"
+
+VALID_IMAGE_REFERENCES = [
+    "ubuntu",
+    "library/ubuntu:22.04",
+    "registry.example.com:5000/team/service:v1.2_3",
+    "localhost:5000/team/service:release-1",
+    f"registry.example.com/team/service@sha256:{'a' * 64}",
+    f"registry.example.com/team/service:v1@sha256:{'b' * 64}",
+]
+
+INVALID_IMAGE_REFERENCES = [
+    "https://registry.example.com/team/service:v1",
+    "registry.example.com/Team/service:v1",
+    "registry.example.com/team//service:v1",
+    "registry.example.com/team/service:tag:extra",
+    f"registry.example.com/team/service:{'a' * 129}",
+    "registry.example.com/team/service:v1\nnot-an-image",
+    "registry.example.com/team/service:v1\x1fnot-an-image",
+]
+
+
+class _ImageOnlyAlgorithmConfigSerializer(AlgorithmConfigSerializer):
+    class Meta(AlgorithmConfigSerializer.Meta):
+        validators = []
+
+
+def _serializer(image, locale="en"):
+    request = SimpleNamespace(user=SimpleNamespace(locale=locale))
+    return _ImageOnlyAlgorithmConfigSerializer(
+        data={"image": image},
+        partial=True,
+        context={"request": request},
+    )
+
+
+@pytest.mark.parametrize("image", VALID_IMAGE_REFERENCES)
+def test_algorithm_config_serializer_accepts_legacy_image_references(image):
+    serializer = _serializer(image)
+
+    assert serializer.is_valid(), serializer.errors
+
+
+@pytest.mark.parametrize("image", INVALID_IMAGE_REFERENCES)
+def test_algorithm_config_serializer_rejects_invalid_image_references(image):
+    serializer = _serializer(image)
+
+    assert not serializer.is_valid()
+    assert serializer.errors["image"] == ["Enter a valid container image reference"]
+
+
+def test_init_algorithm_config_rejects_invalid_image_reference(tmp_path):
+    config_file = tmp_path / "Example.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "name": "Example",
+                "display_name": "Example",
+                "image": "registry.example.com/team/service:v1\nnot-an-image",
+                "scenario_description": "",
+                "form_config": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    valid, _, reason = Command()._load_and_validate_file(config_file)
+
+    assert valid is False
+    assert reason == "image 不是合法的容器镜像引用"
+
+
+@pytest.mark.parametrize("image", VALID_IMAGE_REFERENCES)
+def test_init_algorithm_config_accepts_legacy_image_references(tmp_path, image):
+    config_file = tmp_path / "Example.json"
+    payload = {
+        "name": "Example",
+        "display_name": "Example",
+        "image": image,
+        "scenario_description": "",
+        "form_config": {},
+    }
+    config_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert Command()._load_and_validate_file(config_file) == (True, payload, "")
+
+
+def _shell_validation_result(image):
+    env = os.environ.copy()
+    env["IMAGE_UNDER_TEST"] = image
+    return subprocess.run(
+        [
+            "bash",
+            "-c",
+            'source "$1" && validate_container_image_reference "$IMAGE_UNDER_TEST"',
+            "_",
+            str(KUBERNETES_DIR / "common.sh"),
+        ],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("image", VALID_IMAGE_REFERENCES)
+def test_webhookd_validator_accepts_legacy_image_references(image):
+    result = _shell_validation_result(image)
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("image", INVALID_IMAGE_REFERENCES)
+def test_webhookd_validator_rejects_invalid_image_references(image):
+    result = _shell_validation_result(image)
+
+    assert result.returncode != 0
+
+
+def _write_executable(path, source):
+    path.write_text(source, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _run_kubernetes_script(tmp_path, script_name, image, payload_suffix=""):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls_file = tmp_path / "kubectl-calls"
+    _write_executable(
+        bin_dir / "kubectl",
+        """#!/bin/bash
+echo "$*" >> "$CALLS_FILE"
+case "$1 $2" in
+  "get namespace") exit 0 ;;
+  "get job"|"get deployment") exit 1 ;;
+  "create secret") exit 0 ;;
+  "apply -f") cat >/dev/null; exit 0 ;;
+  "get svc") echo "31001"; exit 0 ;;
+esac
+exit 0
+""",
+    )
+    payloads = {
+        "train.sh": {
+            "id": "train-proof",
+            "bucket": "datasets",
+            "dataset": "data.zip",
+            "config": "config.yml",
+            "minio_endpoint": "http://minio:9000",
+            "mlflow_tracking_uri": "http://mlflow:15000",
+            "minio_access_key": "access",
+            "minio_secret_key": "secret",
+            "device": "cpu",
+            "train_image": image,
+        },
+        "serve.sh": {
+            "id": "serve-proof",
+            "mlflow_tracking_uri": "http://mlflow:15000",
+            "mlflow_model_uri": "models:/example/1",
+            "device": "cpu",
+            "train_image": image,
+        },
+    }
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["CALLS_FILE"] = str(calls_file)
+    result = subprocess.run(
+        ["bash", str(KUBERNETES_DIR / script_name), json.dumps(payloads[script_name]) + payload_suffix],
+        capture_output=True,
+        check=False,
+        env=env,
+        text=True,
+    )
+    calls = calls_file.read_text(encoding="utf-8") if calls_file.exists() else ""
+    return result, calls
+
+
+@pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
+@pytest.mark.parametrize("invalid_suffix", ["\nnot-an-image", "\n", "\x00"])
+def test_kubernetes_entrypoint_rejects_invalid_image_before_kubectl(tmp_path, script_name, invalid_suffix):
+    result, calls = _run_kubernetes_script(
+        tmp_path,
+        script_name,
+        f"registry.example.com/team/service:v1{invalid_suffix}",
+    )
+
+    assert result.returncode != 0
+    assert json.loads(result.stdout)["code"] == "INVALID_TRAIN_IMAGE"
+    assert calls == ""
+
+
+@pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
+@pytest.mark.parametrize("invalid_suffix", ["\n", "\x00"])
+def test_kubernetes_entrypoint_rejects_control_character_with_multiple_json_values(
+    tmp_path,
+    script_name,
+    invalid_suffix,
+):
+    result, calls = _run_kubernetes_script(
+        tmp_path,
+        script_name,
+        f"registry.example.com/team/service:v1{invalid_suffix}",
+        payload_suffix="\n{}",
+    )
+
+    assert result.returncode != 0
+    assert json.loads(result.stdout)["code"] == "INVALID_TRAIN_IMAGE"
+    assert calls == ""
+
+
+@pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
+def test_kubernetes_entrypoint_keeps_legacy_image_reference_working(tmp_path, script_name):
+    result, calls = _run_kubernetes_script(
+        tmp_path,
+        script_name,
+        "registry.example.com:5000/team/service:v1.2_3",
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "apply -f -" in calls

--- a/server/apps/mlops/tests/test_container_image_reference_service.py
+++ b/server/apps/mlops/tests/test_container_image_reference_service.py
@@ -1,24 +1,29 @@
 import json
 import os
 import subprocess
+from io import StringIO
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from apps.mlops.management.commands.init_algorithm_config import Command
+from apps.mlops.models import AlgorithmConfig
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigSerializer
 
-pytestmark = pytest.mark.unit
+pytestmark = pytest.mark.integration
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 KUBERNETES_DIR = REPO_ROOT / "agents/webhookd/mlops/kubernetes"
+ALGORITHM_CONFIG_DIR = REPO_ROOT / "server/apps/mlops/support-files/algorithm-configs"
 
 VALID_IMAGE_REFERENCES = [
     "ubuntu",
     "library/ubuntu:22.04",
     "registry.example.com:5000/team/service:v1.2_3",
     "localhost:5000/team/service:release-1",
+    "[2001:db8::1]:5000/team/service:v1",
     f"registry.example.com/team/service@sha256:{'a' * 64}",
     f"registry.example.com/team/service:v1@sha256:{'b' * 64}",
 ]
@@ -131,6 +136,50 @@ def test_webhookd_validator_rejects_invalid_image_references(image):
     assert result.returncode != 0
 
 
+def test_checked_in_algorithm_config_images_remain_compatible():
+    config_files = sorted(ALGORITHM_CONFIG_DIR.glob("*/*.json"))
+
+    assert config_files
+    for config_file in config_files:
+        image = json.loads(config_file.read_text(encoding="utf-8"))["image"]
+        assert _serializer(image).is_valid(), config_file
+        assert _shell_validation_result(image).returncode == 0, config_file
+
+
+def test_init_algorithm_config_skips_invalid_image_and_reports_reason(monkeypatch):
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        def get_or_create(self, **kwargs):
+            self.calls.append(kwargs)
+            return object(), False
+
+    stdout = StringIO()
+    stderr = StringIO()
+    command = Command(stdout=stdout, stderr=stderr)
+    original_loader = command._load_and_validate_file
+    invalidated = False
+
+    def load_with_one_invalid_image(config_file):
+        nonlocal invalidated
+        if not invalidated:
+            invalidated = True
+            return False, {}, "image 不是合法的容器镜像引用"
+        return original_loader(config_file)
+
+    manager = FakeManager()
+    monkeypatch.setattr(AlgorithmConfig, "objects", manager, raising=False)
+    monkeypatch.setattr(command, "_load_and_validate_file", load_with_one_invalid_image)
+
+    command.handle()
+
+    config_count = sum(1 for _ in ALGORITHM_CONFIG_DIR.glob("*/*.json"))
+    assert len(manager.calls) == config_count - 1
+    assert "image 不是合法的容器镜像引用" in stderr.getvalue()
+    assert "skipped_existing=9, skipped_invalid=1" in stdout.getvalue()
+
+
 def _write_executable(path, source):
     path.write_text(source, encoding="utf-8")
     path.chmod(0o755)
@@ -140,6 +189,7 @@ def _run_kubernetes_script(tmp_path, script_name, image, payload_suffix=""):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     calls_file = tmp_path / "kubectl-calls"
+    manifest_file = tmp_path / "manifest.yaml"
     _write_executable(
         bin_dir / "kubectl",
         """#!/bin/bash
@@ -148,7 +198,7 @@ case "$1 $2" in
   "get namespace") exit 0 ;;
   "get job"|"get deployment") exit 1 ;;
   "create secret") exit 0 ;;
-  "apply -f") cat >/dev/null; exit 0 ;;
+  "apply -f") cat > "$MANIFEST_FILE"; exit 0 ;;
   "get svc") echo "31001"; exit 0 ;;
 esac
 exit 0
@@ -178,6 +228,7 @@ exit 0
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}:{env['PATH']}"
     env["CALLS_FILE"] = str(calls_file)
+    env["MANIFEST_FILE"] = str(manifest_file)
     result = subprocess.run(
         ["bash", str(KUBERNETES_DIR / script_name), json.dumps(payloads[script_name]) + payload_suffix],
         capture_output=True,
@@ -186,13 +237,14 @@ exit 0
         text=True,
     )
     calls = calls_file.read_text(encoding="utf-8") if calls_file.exists() else ""
-    return result, calls
+    manifest = manifest_file.read_text(encoding="utf-8") if manifest_file.exists() else ""
+    return result, calls, manifest
 
 
 @pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
 @pytest.mark.parametrize("invalid_suffix", ["\nnot-an-image", "\n", "\x00"])
 def test_kubernetes_entrypoint_rejects_invalid_image_before_kubectl(tmp_path, script_name, invalid_suffix):
-    result, calls = _run_kubernetes_script(
+    result, calls, manifest = _run_kubernetes_script(
         tmp_path,
         script_name,
         f"registry.example.com/team/service:v1{invalid_suffix}",
@@ -201,6 +253,7 @@ def test_kubernetes_entrypoint_rejects_invalid_image_before_kubectl(tmp_path, sc
     assert result.returncode != 0
     assert json.loads(result.stdout)["code"] == "INVALID_TRAIN_IMAGE"
     assert calls == ""
+    assert manifest == ""
 
 
 @pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
@@ -210,7 +263,7 @@ def test_kubernetes_entrypoint_rejects_control_character_with_multiple_json_valu
     script_name,
     invalid_suffix,
 ):
-    result, calls = _run_kubernetes_script(
+    result, calls, manifest = _run_kubernetes_script(
         tmp_path,
         script_name,
         f"registry.example.com/team/service:v1{invalid_suffix}",
@@ -220,15 +273,26 @@ def test_kubernetes_entrypoint_rejects_control_character_with_multiple_json_valu
     assert result.returncode != 0
     assert json.loads(result.stdout)["code"] == "INVALID_TRAIN_IMAGE"
     assert calls == ""
+    assert manifest == ""
 
 
 @pytest.mark.parametrize("script_name", ["train.sh", "serve.sh"])
-def test_kubernetes_entrypoint_keeps_legacy_image_reference_working(tmp_path, script_name):
-    result, calls = _run_kubernetes_script(
+@pytest.mark.parametrize(
+    "image",
+    [
+        "registry.example.com:5000/team/service:v1.2_3",
+        "[2001:db8::1]:5000/team/service:v1",
+    ],
+)
+def test_kubernetes_entrypoint_keeps_legacy_image_reference_working(tmp_path, script_name, image):
+    result, calls, manifest = _run_kubernetes_script(
         tmp_path,
         script_name,
-        "registry.example.com:5000/team/service:v1.2_3",
+        image,
     )
 
     assert result.returncode == 0, result.stderr
     assert "apply -f -" in calls
+    documents = [document for document in yaml.safe_load_all(manifest) if document]
+    workload = next(document for document in documents if document["kind"] in {"Job", "Deployment"})
+    assert workload["spec"]["template"]["spec"]["containers"][0]["image"] == image

--- a/server/apps/mlops/utils/container_image.py
+++ b/server/apps/mlops/utils/container_image.py
@@ -1,0 +1,21 @@
+"""容器镜像引用格式校验。"""
+
+import re
+
+_DOMAIN_COMPONENT = r"(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
+_DOMAIN = rf"{_DOMAIN_COMPONENT}(?:\.{_DOMAIN_COMPONENT})*"
+_REGISTRY = rf"{_DOMAIN}(?::[0-9]+)?"
+_PATH_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*"
+_NAME = rf"(?:(?:{_REGISTRY})/)?{_PATH_COMPONENT}(?:/{_PATH_COMPONENT})*"
+_TAG = r"[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}"
+_DIGEST_ALGORITHM = r"[A-Za-z][A-Za-z0-9]*(?:[+._-][A-Za-z][A-Za-z0-9]*)*"
+_DIGEST = rf"{_DIGEST_ALGORITHM}:[0-9A-Fa-f]{{32,}}"
+_CONTAINER_IMAGE_REFERENCE = re.compile(
+    rf"{_NAME}(?::{_TAG})?(?:@{_DIGEST})?\Z",
+    re.ASCII,
+)
+
+
+def is_valid_container_image_reference(value: str) -> bool:
+    """判断字符串是否为单行 OCI/Docker 风格镜像引用。"""
+    return isinstance(value, str) and 0 < len(value) <= 255 and _CONTAINER_IMAGE_REFERENCE.fullmatch(value) is not None

--- a/server/apps/mlops/utils/container_image.py
+++ b/server/apps/mlops/utils/container_image.py
@@ -4,7 +4,8 @@ import re
 
 _DOMAIN_COMPONENT = r"(?:[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])"
 _DOMAIN = rf"{_DOMAIN_COMPONENT}(?:\.{_DOMAIN_COMPONENT})*"
-_REGISTRY = rf"{_DOMAIN}(?::[0-9]+)?"
+_IPV6_ADDRESS = r"\[[A-Fa-f0-9:]+\]"
+_REGISTRY = rf"(?:{_DOMAIN}|{_IPV6_ADDRESS})(?::[0-9]+)?"
 _PATH_COMPONENT = r"[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*"
 _NAME = rf"(?:(?:{_REGISTRY})/)?{_PATH_COMPONENT}(?:/{_PATH_COMPONENT})*"
 _TAG = r"[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}"

--- a/specs/changes/mlops-container-image-reference-validation/spec.md
+++ b/specs/changes/mlops-container-image-reference-validation/spec.md
@@ -1,0 +1,42 @@
+# MLOps 容器镜像引用边界
+
+## 目标
+
+算法配置写入和 Kubernetes 训练、推理执行使用同一套 OCI/Docker 风格镜像引用契约。
+含换行、控制字符、多个 JSON 值或非法引用的输入必须在任何 `kubectl` 资源操作前失败，
+避免镜像字段越出 YAML scalar 并注入额外资源。
+
+## 调用方与存量盘点
+
+- 六类 MLOps 场景均通过 `get_image_by_prefix` 读取 `AlgorithmConfig.image`，再调用
+  `WebhookClient.train` / `WebhookClient.serve`。
+- Kubernetes 运行时最终进入 `agents/webhookd/mlops/kubernetes/train.sh` 或 `serve.sh`；
+  Docker 运行时不经过 Kubernetes heredoc，但新写入仍受 Server serializer 约束。
+- 仓库内置的 10 条算法配置种子全部符合新契约，并由关联测试逐条在 Python 与 Shell 两端验证。
+- 既有数据库记录不自动改写，也没有 schema migration；默认镜像、短名称、registry 端口、
+  多级路径、tag、digest、tag+digest 和方括号 IPv6 registry 保持可用。
+
+## 失败与兼容契约
+
+- API 创建或更新非法镜像时返回字段级本地化校验错误；合法旧调用保持原行为。
+- 初始化命令遇到非法种子时记录文件和具体原因、计入 `skipped_invalid`，并继续处理其余配置，
+  不扩大 `batch_init` 的启动失败面。
+- Kubernetes 入口对非法或边界不完整的 `train_image` 返回 `INVALID_TRAIN_IMAGE`，且不得调用 `kubectl`。
+- Server 与 webhookd 可独立部署，因此两端各自保留校验实现；同一组兼容/拒绝语料和真实脚本入口测试
+  用于防止规则漂移。
+
+## 升级与迁移
+
+1. 升级前通过 Django ORM 读取现有 `AlgorithmConfig`，使用
+   `apps.mlops.utils.container_image.is_valid_container_image_reference` 审计镜像字段；禁止 raw SQL。
+2. 对审计出的非法记录，先确认实际 registry、path、tag 或 digest，再通过现有算法配置编辑接口改为合法引用。
+   该操作可重复执行，不删除记录、不改变关联任务。
+3. 未完成迁移的非法记录仍可读取和编辑，但 Kubernetes 训练/推理会在资源操作前明确失败；
+   修正镜像后可直接重试，不产生半完成 Kubernetes 资源。
+4. 发布时先部署 webhookd 执行边界，再部署 Server 写入校验；这样存量非法记录在混合版本期间也会在
+   Kubernetes 资源操作前失败，且新 webhookd 仍能处理旧 Server 传入的合法引用。
+
+## 回滚
+
+代码可整体 revert，无数据库回滚步骤。若分阶段回滚，先回滚 Server、再回滚 webhookd；
+已修正为合法格式的 AlgorithmConfig 无需恢复。回滚后应重新运行存量审计，确认没有依赖非法格式的配置。


### PR DESCRIPTION
## 问题

MLOps 算法镜像配置缺少统一的容器镜像引用约束。配置值会沿 Server、Webhook 与 Kubernetes 执行链传递，异常格式直到资源生成阶段才暴露，且执行层对输入边界缺少独立保护。

## 根因

镜像字段是跨模块执行参数，但原设计只有必填检查，没有在配置写入边界和 Kubernetes 资源操作边界建立一致的格式契约。Shell 命令替换还可能归一化字符串尾部字符，因此仅校验提取后的值不足以覆盖原始输入。

## 修复

- 在 Server 增加复用的单行 OCI/Docker 风格镜像引用校验，并应用于算法配置 API 与初始化命令。
- 保留既有 registry、port、path、tag、digest 合法形式，不改写已有数据库记录。
- 在 Kubernetes 训练与推理入口要求输入为单一 JSON 对象，并在字符串提取前校验原始字段边界。
- 在任何 `kubectl` 资源查询或变更前拒绝非法镜像引用，返回稳定的 `INVALID_TRAIN_IMAGE` 错误。
- 增加中英文校验提示和覆盖 Server、初始化、Shell 校验、训练及推理入口的回归测试。

## 调用链

```mermaid
flowchart TD
    subgraph S["配置入口"]
        A["算法配置 API"]
        B["初始化命令"]
    end
    V["镜像引用格式校验"]
    R["算法镜像读取"]
    W["Webhook 调用"]
    subgraph K["Kubernetes 执行层"]
        J["单一 JSON 对象及原始字段边界校验"]
        C["镜像引用格式校验"]
        D["训练或推理资源生成"]
    end
    A --> V
    B --> V
    V --> R --> W --> J --> C --> D
    J -- "非法输入" --> E["INVALID_TRAIN_IMAGE"]
    C -- "非法输入" --> E
```

## 影响与兼容性

- 风险：中。变更覆盖配置写入与 Kubernetes 执行边界，但不包含数据库迁移。
- 兼容：已验证既有短名称、registry 端口、多级路径、tag、digest 以及 tag 与 digest 组合形式。
- 已有不合法记录不会被自动改写；调用训练或推理时会在资源操作前被明确拒绝。
- 回滚：可整体回滚本提交，无数据回滚步骤。

## 验证

- `server/apps/mlops/tests/test_container_image_reference.py`、`test_algorithm_config_serializer.py`、`test_timeseries_timeout_service.py`：79 passed。
- Black、isort、flake8：通过。
- 训练、推理及公共 Shell 脚本语法检查：通过。
- Git diff 完整性检查：通过。

## 三轨审查

- Standards：PASS，98/100。
- Spec：PASS，98/100。
- Runtime Contract：PASS，98/100。
- Critical / Important / Minor：均无未解决项。

Closes #4496
