### PR TITLE
fix(log): 修复加权 LCS 重复 token 计分

### DIFF
--- a/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
@@ -1174,16 +1174,16 @@ class SpellModel(BaseLogClusterModel):
         return lcs
 
     def _get_lcs_match_indices(self, sequence: List[str], lcs: List[str]) -> Set[int]:
-        """返回 LCS 在原序列中按顺序匹配到的位置。"""
+        """返回 LCS 在原序列中按回溯顺序匹配到的位置。"""
         matched_indices: Set[int] = set()
-        lcs_position = 0
+        lcs_position = len(lcs) - 1
 
-        for sequence_position, token in enumerate(sequence):
-            if lcs_position >= len(lcs):
+        for sequence_position in range(len(sequence) - 1, -1, -1):
+            if lcs_position < 0:
                 break
-            if token == lcs[lcs_position]:
+            if sequence[sequence_position] == lcs[lcs_position]:
                 matched_indices.add(sequence_position)
-                lcs_position += 1
+                lcs_position -= 1
 
         return matched_indices
     

--- a/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
@@ -1172,6 +1172,20 @@ class SpellModel(BaseLogClusterModel):
             self.lcs_cache[key] = lcs
         
         return lcs
+
+    def _get_lcs_match_indices(self, sequence: List[str], lcs: List[str]) -> Set[int]:
+        """返回 LCS 在原序列中按顺序匹配到的位置。"""
+        matched_indices: Set[int] = set()
+        lcs_position = 0
+
+        for sequence_position, token in enumerate(sequence):
+            if lcs_position >= len(lcs):
+                break
+            if token == lcs[lcs_position]:
+                matched_indices.add(sequence_position)
+                lcs_position += 1
+
+        return matched_indices
     
     def _get_position_weight(self, position: int, length: int) -> float:
         """获取位置权重
@@ -1219,14 +1233,14 @@ class SpellModel(BaseLogClusterModel):
             return len(lcs) / len(seq1)
         
         # 位置加权相似度
-        lcs_set = set(lcs)
+        matched_indices = self._get_lcs_match_indices(seq1, lcs)
         total_weight = 0.0
         max_weight = 0.0
-        
-        for i, token in enumerate(seq1):
+
+        for i in range(len(seq1)):
             weight = self._get_position_weight(i, len(seq1))
             max_weight += weight
-            if token in lcs_set:
+            if i in matched_indices:
                 total_weight += weight
         
         return total_weight / max_weight if max_weight > 0 else 0.0
@@ -1434,20 +1448,20 @@ class SpellModel(BaseLogClusterModel):
         # 计算相似度和匹配详情
         similarity = self._lcs_similarity(tokens, template)
         lcs = self._compute_lcs(tokens, template)
-        lcs_set = set(lcs)
+        matched_indices = self._get_lcs_match_indices(tokens, lcs)
         
         # 分析匹配和不匹配的 token
         matched_tokens = []
         unmatched_tokens = []
         
-        for token in tokens:
-            if token in lcs_set:
+        for index, token in enumerate(tokens):
+            if index in matched_indices:
                 matched_tokens.append(token)
             else:
                 unmatched_tokens.append(token)
-        
+
         # 构建字段格式输出
-        match_details = self._format_match_details(tokens, template, lcs_set)
+        match_details = self._format_match_details(tokens, template, matched_indices)
         
         # 位置权重信息（如果启用）
         position_weights = None
@@ -1480,14 +1494,14 @@ class SpellModel(BaseLogClusterModel):
         self, 
         tokens: List[str], 
         template: List[str], 
-        lcs_set: Set[str]
+        matched_indices: Set[int]
     ) -> str:
         """格式化匹配详情为字段格式输出
         
         Args:
             tokens: 日志 token 列表
             template: 模板 token 列表
-            lcs_set: LCS token 集合
+            matched_indices: LCS 在日志序列中匹配到的位置
         
         Returns:
             格式化的匹配详情字符串
@@ -1499,8 +1513,8 @@ class SpellModel(BaseLogClusterModel):
         
         # 标记匹配状态
         match_markers = []
-        for token in tokens:
-            if token in lcs_set:
+        for index in range(len(tokens)):
+            if index in matched_indices:
                 match_markers.append('✓')
             else:
                 match_markers.append('✗')
@@ -1511,7 +1525,7 @@ class SpellModel(BaseLogClusterModel):
         if len(tokens) == len(template):
             lines.append("\nToken 对齐:")
             for i, (log_token, tpl_token) in enumerate(zip(tokens, template)):
-                marker = '✓' if log_token in lcs_set else '✗'
+                marker = '✓' if i in matched_indices else '✗'
                 if log_token == tpl_token:
                     lines.append(f"  [{i}] {marker} {log_token} == {tpl_token}")
                 elif tpl_token == '<*>':

--- a/algorithms/classify_log_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_log_server/tests/test_schema_and_predict.py
@@ -246,6 +246,7 @@ class TestSpellModel:
             }
         )
         assert position_model._lcs_similarity(["A", "B", "A"], ["B", "A"]) == pytest.approx(3 / 7)
+        assert position_model._lcs_similarity(["A", "X", "A"], ["A"]) == pytest.approx(2 / 7)
 
     def test_lcs_match_indices_handle_empty_and_unmatched_sequences(self):
         """空 LCS 或完全不匹配时不应产生匹配位置。"""
@@ -254,6 +255,7 @@ class TestSpellModel:
         assert model._get_lcs_match_indices([], []) == set()
         assert model._get_lcs_match_indices(["A", "B"], []) == set()
         assert model._get_lcs_match_indices(["A", "B"], ["C"]) == set()
+        assert model._get_lcs_match_indices(["A", "X", "A"], ["A"]) == {2}
 
     def test_explanation_uses_the_same_lcs_occurrence_matches(self):
         """解释输出应与相似度使用同一组 LCS 匹配位置。"""
@@ -265,7 +267,7 @@ class TestSpellModel:
 
         assert explanation["matched_tokens"] == ["A", "B"]
         assert explanation["unmatched_tokens"] == ["A"]
-        assert "匹配:   ✓ ✗ ✓" in explanation["match_details"]
+        assert "匹配:   ✗ ✓ ✓" in explanation["match_details"]
 
 
 # ---------------------------------------------------------------------------

--- a/algorithms/classify_log_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_log_server/tests/test_schema_and_predict.py
@@ -229,6 +229,44 @@ class TestSpellModel:
         result = model.predict([""])
         assert result[0] == -1
 
+    def test_weighted_lcs_counts_each_matched_occurrence_once(self):
+        """重复 token 只能按 LCS 实际匹配的出现次数计权。"""
+        model = SpellModel()
+
+        assert model._lcs_similarity(["A", "A", "B"], ["A", "B"]) == pytest.approx(2 / 3)
+        assert model._lcs_similarity(["A", "A", "A"], ["A"]) == pytest.approx(1 / 3)
+
+        position_model = SpellModel(
+            position_weight_config={
+                "head_count": 1,
+                "head_weight": 4.0,
+                "tail_count": 1,
+                "tail_weight": 2.0,
+                "middle_weight": 1.0,
+            }
+        )
+        assert position_model._lcs_similarity(["A", "B", "A"], ["B", "A"]) == pytest.approx(3 / 7)
+
+    def test_lcs_match_indices_handle_empty_and_unmatched_sequences(self):
+        """空 LCS 或完全不匹配时不应产生匹配位置。"""
+        model = SpellModel()
+
+        assert model._get_lcs_match_indices([], []) == set()
+        assert model._get_lcs_match_indices(["A", "B"], []) == set()
+        assert model._get_lcs_match_indices(["A", "B"], ["C"]) == set()
+
+    def test_explanation_uses_the_same_lcs_occurrence_matches(self):
+        """解释输出应与相似度使用同一组 LCS 匹配位置。"""
+        model = SpellModel()
+        model.clusters = [{"template": ["A", "B"]}]
+        model.is_trained = True
+
+        explanation = model.explain_prediction("A A B", cluster_id=0)
+
+        assert explanation["matched_tokens"] == ["A", "B"]
+        assert explanation["unmatched_tokens"] == ["A"]
+        assert "匹配:   ✓ ✗ ✓" in explanation["match_details"]
+
 
 # ---------------------------------------------------------------------------
 # MLService.predict() 集成路径测试


### PR DESCRIPTION
关联 Issue #4495。

## 问题

Spell 的加权 LCS 相似度应让每个 LCS 出现位置恰好参与一次计权。原实现将 LCS 降为普通 token 集合；当原序列包含重复 token 时，未被 LCS 选中的同值位置也会重复获得权重，导致相似度偏高，并可能改变日志聚类选择。

## 根因（设计层）

位置加权契约需要保留“出现次数、子序列顺序、原序列位置”三项信息。普通集合只保留 token 值，无法表达同值 token 的不同出现位置，因此计分和解释输出都绕过了 LCS 的位置约束。

## 怎么修的

- 保留现有 LCS 计算、缓存结构和模型序列化格式不变。
- 按 LCS 顺序单调消费原序列，生成实际匹配位置集合；每个 LCS 出现只对应一个位置。
- 相似度计权和解释输出复用同一组匹配位置，避免展示结果与聚类判断不一致。

## 影响范围

改动仅限日志聚类算法的 Spell 模型及其回归测试，不改变服务 API、模型文件字段、配置格式、阈值或缓存键值。含重复 token 的日志会按正确 LCS 位置得到更低且有界的相似度；不含重复 token、完全匹配与空输入契约保持不变。新增位置扫描为 O(n)，不改变 LCS 的 O(mn) 主复杂度。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["SpellModel.fit / predict\nspell_model.py"]
        T2["SpellModel.explain_prediction\nspell_model.py"]
    end

    subgraph N["LCS 处理层"]
        N1["_lcs_similarity"]
        N2["_compute_lcs"]
        N3["_get_lcs_match_indices"]
        N4["_get_position_weight"]
    end

    T1 --> N1 --> N2 --> N3 --> N4
    T2 --> N2
    T2 --> N3
```

## 验证

- `algorithms/classify_log_server/tests/test_schema_and_predict.py` 的 `TestSpellModel`：9 passed。
- TDD 回归覆盖：重复 token 计数、全重复、跨头/中/尾位置权重、空 LCS、空序列、完全无匹配、解释一致性。
- 运行契约覆盖：重复计数为 `2/3`、全重复为 `1/3`、交错重复位置权重为 `3/7`、完全匹配为 `1.0`、空输入为 `0.0`。
- 同一测试文件当前另有 4 个与本 PR 无关的 master 基线 `MLService` 请求形态失败；本 PR 未触及该路径，目标用例无新增失败。

## 三轨门禁

- Standards：PASS（97/100）。
- Spec：PASS（96/100）。
- Runtime Contract：PASS。
- G6 综合评分：96/100，SCORE_PASS。
