### PR TITLE
bugfix: 修复 Windows 控制器安装时安装目录被自身占用导致失败

### DIFF
--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -1539,6 +1539,28 @@ func writeWindowsInstallFence(fencePath string, content []byte) error {
 	return replaceFileAtomically(temporaryPath, fencePath)
 }
 
+// discardEmptyWindowsInstallDir removes an installation directory that exists but
+// holds nothing. Launchers such as the NSIS GUI may create it before the worker
+// runs; treating that empty directory as a previous installation would push a
+// fresh install through the backup, rollback and service-restart path it does not
+// need. A running installation always has files, so this never discards one.
+func discardEmptyWindowsInstallDir(installDir string) error {
+	entries, err := os.ReadDir(installDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if len(entries) > 0 {
+		return nil
+	}
+	if err := os.Remove(installDir); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func installWindowsPackage(cfg *Config, zipPath string, controller windowsServiceController) error {
 	installDir := filepath.Clean(cfg.InstallDir)
 	stagingDir := installDir + ".bklite-staging"
@@ -1580,6 +1602,9 @@ func installWindowsPackage(cfg *Config, zipPath string, controller windowsServic
 		}
 	} else if !os.IsNotExist(err) {
 		return err
+	}
+	if err := discardEmptyWindowsInstallDir(installDir); err != nil {
+		return fmt.Errorf("discard empty installation directory: %w", err)
 	}
 	if err := os.RemoveAll(stagingDir); err != nil {
 		return fmt.Errorf("clean staging directory: %w", err)

--- a/agents/sidecar-installer/setup-worker_test.go
+++ b/agents/sidecar-installer/setup-worker_test.go
@@ -121,6 +121,29 @@ func (fake *fakeWindowsServiceController) Remove() error {
 	return nil
 }
 
+// observingWindowsServiceController records whether a backup directory was in
+// place when the new service was started, which is the only moment where a
+// transactional upgrade is distinguishable from a fresh install.
+type observingWindowsServiceController struct {
+	backupDir            string
+	backupExistedOnStart bool
+}
+
+func (fake *observingWindowsServiceController) Stop() (bool, error) {
+	return false, nil
+}
+
+func (fake *observingWindowsServiceController) Start(_ string, _ bool) error {
+	if _, err := os.Stat(fake.backupDir); err == nil {
+		fake.backupExistedOnStart = true
+	}
+	return nil
+}
+
+func (fake *observingWindowsServiceController) Remove() error {
+	return nil
+}
+
 func writeControllerZip(t *testing.T, files map[string]string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "controller.zip")
@@ -293,6 +316,50 @@ func TestInstallerStepPositionUsesNewEightStepProtocol(t *testing.T) {
 	index, total := installerStepPosition("download_package")
 	if index != 4 || total != 8 {
 		t.Fatalf("expected download step 4/8, got %d/%d", index, total)
+	}
+}
+
+func TestInstallWindowsPackageTreatsPreCreatedEmptyDirectoryAsFreshInstall(t *testing.T) {
+	installDir := filepath.Join(t.TempDir(), "fusion-collectors")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	zipPath := writeControllerZip(t, map[string]string{
+		"controller/collector-sidecar.exe": "new-binary",
+	})
+	controller := &observingWindowsServiceController{backupDir: installDir + ".bklite-backup"}
+	cfg := &Config{
+		ServerURL:  "https://bk.example",
+		APIToken:   "token",
+		NodeID:     "node-1",
+		NodeName:   "node-1",
+		ZoneID:     "1",
+		GroupID:    "1",
+		OS:         "windows",
+		InstallDir: installDir,
+		Package:    PackageConfig{CPUArchitecture: "x86_64"},
+	}
+
+	if err := installWindowsPackage(cfg, zipPath, controller); err != nil {
+		t.Fatalf("install Windows package: %v", err)
+	}
+	if controller.backupExistedOnStart {
+		t.Fatal("fresh install must not back up the pre-created empty directory")
+	}
+	if _, err := os.Stat(installDir + ".bklite-backup"); !os.IsNotExist(err) {
+		t.Fatalf("fresh install must not leave a backup directory: %v", err)
+	}
+	for _, marker := range []string{windowsActivationPendingMarker, windowsActivationCommittedMarker} {
+		if _, err := os.Stat(filepath.Join(installDir, marker)); !os.IsNotExist(err) {
+			t.Fatalf("fresh install must not leave activation marker %s: %v", marker, err)
+		}
+	}
+	content, err := os.ReadFile(filepath.Join(installDir, "collector-sidecar.exe"))
+	if err != nil {
+		t.Fatalf("read installed binary: %v", err)
+	}
+	if string(content) != "new-binary" {
+		t.Fatalf("new installation was not activated: %q", content)
 	}
 }
 

--- a/agents/sidecar-installer/setup.nsi
+++ b/agents/sidecar-installer/setup.nsi
@@ -188,7 +188,10 @@ Section "Install" SecInstall
     IfFileExists "$PLUGINSDIR\setup-worker.exe" +2
         File "setup-worker.exe"
 
-    SetOutPath "$INSTDIR"
+    ; Do not SetOutPath to $INSTDIR before the worker runs: it would create the
+    ; directory up front (making a fresh install look like an upgrade) and pin
+    ; the installer's working directory inside it, so the worker could not
+    ; rename $INSTDIR during transactional activation.
     DetailPrint "Install: $INSTDIR"
     DetailPrint ""
 	FileOpen $R0 "$PLUGINSDIR\installer-session.url" w
@@ -211,6 +214,10 @@ Section "Install" SecInstall
 
     DetailPrint ""
     DetailPrint "Done!"
+
+    ; The worker has finished renaming $INSTDIR into place, so it is now safe to
+    ; make it the output directory for the icon written below.
+    SetOutPath "$INSTDIR"
 
     ; Registry
     WriteRegStr HKLM "Software\FusionCollectors\Sidecar" "InstallDir" "$INSTDIR"

--- a/agents/sidecar-installer/setup.nsi
+++ b/agents/sidecar-installer/setup.nsi
@@ -1,6 +1,8 @@
 ; Collector Sidecar Installer
 ; NSIS + Go worker architecture
-; Key: Worker runs from $INSTDIR (not TEMP) to avoid malware detection
+; Key: Worker runs from $PLUGINSDIR, never from $INSTDIR, because it activates
+; Windows packages by renaming $INSTDIR and cannot rename a directory that the
+; installer or the worker itself is running from or working in.
 
 !include "MUI2.nsh"
 !include "nsDialogs.nsh"

--- a/agents/sidecar-installer/setup_nsi_test.go
+++ b/agents/sidecar-installer/setup_nsi_test.go
@@ -24,6 +24,39 @@ func TestWindowsGUIRunsWorkerOutsideInstallationDirectory(t *testing.T) {
 	}
 }
 
+func TestWindowsGUIKeepsWorkingDirectoryOutsideInstallationDirectoryDuringActivation(t *testing.T) {
+	content, err := os.ReadFile("setup.nsi")
+	if err != nil {
+		t.Fatalf("read setup.nsi: %v", err)
+	}
+	script := string(content)
+
+	sectionStart := strings.Index(script, `Section "Install" SecInstall`)
+	if sectionStart < 0 {
+		t.Fatal("install section not found")
+	}
+	sectionEnd := strings.Index(script[sectionStart:], "SectionEnd")
+	if sectionEnd < 0 {
+		t.Fatal("install section end not found")
+	}
+	section := script[sectionStart : sectionStart+sectionEnd]
+
+	workerCall := strings.Index(section, `nsExec::ExecToLog '"$PLUGINSDIR\setup-worker.exe"`)
+	if workerCall < 0 {
+		t.Fatal("install section must run the worker from the isolated plugin directory")
+	}
+
+	if strings.Contains(section[:workerCall], `SetOutPath "$INSTDIR"`) {
+		t.Fatal("install section must not make $INSTDIR the working directory before the worker renames it during activation")
+	}
+	if !strings.Contains(section[workerCall:], `SetOutPath "$INSTDIR"`) {
+		t.Fatal("install section must switch output to $INSTDIR after activation so the icon lands in the installation directory")
+	}
+	if strings.Index(section[workerCall:], `SetOutPath "$INSTDIR"`) > strings.Index(section[workerCall:], `File "installer.ico"`) {
+		t.Fatal("icon must be written after $INSTDIR becomes the output directory")
+	}
+}
+
 func TestNSISTargetBuildsEmbeddedPrerequisites(t *testing.T) {
 	content, err := os.ReadFile("Makefile")
 	if err != nil {


### PR DESCRIPTION
## 问题

Windows 控制器安装稳定失败：

```
Transactional Windows installation failed: backup existing installation:
rename C:\fusion-collectors C:\fusion-collectors.bklite-backup:
The process cannot access the file because it is being used by another process.
```

## 根因

`setup.nsi` 的 Install section 在调用 `setup-worker.exe` 之前执行了 `SetOutPath "$INSTDIR"`。该指令做两件事：

1. **创建** `C:\fusion-collectors`；
2. 把安装进程的当前工作目录 `SetCurrentDirectory` 到该目录，`nsExec` 拉起的 worker 也继承这个 CWD。

Windows 上进程 CWD 会对目录持有不含 `FILE_SHARE_DELETE` 的句柄，该目录无法被 rename。worker 的事务式激活恰恰要 `os.Rename(installDir, backupDir)`，于是必然 `ERROR_SHARING_VIOLATION` —— 占用安装目录的"另一个进程"就是安装程序自己。

同时，提前创建目录让 worker 的 `os.Stat(installDir)` 成功，全新安装被判定为升级，白白走备份、回滚和服务重启路径。

## 引入过程

- `d420210b9`（初版）：`SetOutPath "$INSTDIR"` + worker 从 `$INSTDIR` 运行。当时 worker 直接解压覆盖，不重命名目录，无害。
- `b286c877c`（支持 Windows 控制器远程安装）：引入事务式安装（`.bklite-backup` + 目录 rename），**只改 Go 未同步改 nsi**，缺陷从此产生。
- `62a2c5927`：已意识到冲突并把 worker exe 移出 `$INSTDIR`，但漏掉 `SetOutPath "$INSTDIR"`，隔离没做干净。

## 修改

- **setup.nsi**：`SetOutPath "$INSTDIR"` 移到 worker 执行之后，仅用于释放 `installer.ico`；worker 运行期间工作目录保持在 `$PLUGINSDIR`。
- **setup-worker.go**：新增 `discardEmptyWindowsInstallDir`，安装前丢弃空的安装目录，使启动器预建的空目录不再被当作既有安装。运行中的安装目录必然非空，既有升级路径不受影响。
- **测试**：新增两条回归用例，分别约束 NSIS 脚本的工作目录时序、以及空目录必须走新装路径（不产生 backup）。两条用例均已用还原旧代码的方式确认能复现失败。

## 验证

- `go vet ./... && go test ./...` 全绿（本地 macOS + builder 10.10.24.35）。
- 在 builder 上 `make icons worker nsis` 完整出包成功，产物 `bklite-controller-installer.exe`（3.2M，sha256 `2ede4c53ca61b762e447c551eae1dcc6c0cd83630fe42d67634e4bbd8ed4118d`）。
- **已在真实 Windows 环境用该产物完成端到端安装验证，问题不再复现。**

## 已知遗留（本 PR 未处理）

sidecar 服务停止后，其拉起的 collector 子进程（`C:\fusion-collectors\bin\*`，`collector_shutdown_timeout: 10s`）可能成为孤儿并继续持有 exe 映像句柄，仍会造成同类 rename 失败。建议后续补充：停服务后 drain 安装目录下的残留进程、rename 失败时有限重试、以及在错误信息中带上占用进程列表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)