### PR TITLE
bugfix: 修复 Windows 控制器远程升级后卸载入口失效

### DIFF
--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -1296,6 +1296,12 @@ func (controller *scWindowsServiceController) Remove() error {
 
 var windowsRuntimeDirectories = []string{"cache", "logs", "generated"}
 
+// uninstall.exe 与 installer.ico 由 NSIS 安装器写入安装目录，控制器包本身不含这两个
+// 文件。GUI 安装时 NSIS 会在 worker 结束后重新写入，但服务端远程安装直接执行
+// bootstrap worker，不经过 NSIS；事务式激活把旧目录整体改名后，若不迁回这两个文件，
+// 卸载注册表项 UninstallString / DisplayIcon 指向的文件就不复存在，控制面板卸载入口失效。
+var windowsPreservedInstallerFiles = []string{"uninstall.exe", "installer.ico"}
+
 const (
 	windowsActivationPendingMarker   = ".bklite-activation-pending"
 	windowsActivationCommittedMarker = ".bklite-activation-committed"
@@ -1312,6 +1318,25 @@ func moveWindowsRuntimeData(backupDir, installDir string) ([]string, error) {
 		}
 		target := filepath.Join(installDir, name)
 		if err := os.RemoveAll(target); err != nil {
+			return moved, err
+		}
+		if err := os.Rename(source, target); err != nil {
+			return moved, err
+		}
+		moved = append(moved, name)
+	}
+	for _, name := range windowsPreservedInstallerFiles {
+		source := filepath.Join(backupDir, name)
+		if _, err := os.Stat(source); os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return moved, err
+		}
+		target := filepath.Join(installDir, name)
+		if _, err := os.Stat(target); err == nil {
+			// 新包自带同名文件时以新包为准，不用旧文件覆盖。
+			continue
+		} else if !os.IsNotExist(err) {
 			return moved, err
 		}
 		if err := os.Rename(source, target); err != nil {
@@ -1422,7 +1447,8 @@ func recoverInterruptedWindowsInstallation(
 		}
 	}
 	movedRuntimeDirectories := []string{}
-	for _, name := range windowsRuntimeDirectories {
+	preservedEntries := append(append([]string{}, windowsRuntimeDirectories...), windowsPreservedInstallerFiles...)
+	for _, name := range preservedEntries {
 		source := filepath.Join(installDir, name)
 		target := filepath.Join(backupDir, name)
 		if _, sourceErr := os.Stat(source); sourceErr != nil {

--- a/agents/sidecar-installer/setup-worker_test.go
+++ b/agents/sidecar-installer/setup-worker_test.go
@@ -672,6 +672,120 @@ func TestInstallWindowsPackagePreservesRuntimeDataAfterSuccessfulActivation(t *t
 	}
 }
 
+func TestInstallWindowsPackagePreservesUninstallEntrypointAfterSuccessfulActivation(t *testing.T) {
+	installDir := filepath.Join(t.TempDir(), "fusion-collectors")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "collector-sidecar.exe"), []byte("old-binary"), 0644); err != nil {
+		t.Fatalf("write old binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "uninstall.exe"), []byte("nsis-uninstaller"), 0644); err != nil {
+		t.Fatalf("write uninstaller: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "installer.ico"), []byte("icon"), 0644); err != nil {
+		t.Fatalf("write installer icon: %v", err)
+	}
+	zipPath := writeControllerZip(t, map[string]string{
+		"controller/collector-sidecar.exe": "new-binary",
+	})
+	controller := &fakeWindowsServiceController{serviceExisted: true}
+	cfg := &Config{
+		ServerURL:  "https://bk.example",
+		APIToken:   "token",
+		NodeID:     "node-1",
+		NodeName:   "node-1",
+		ZoneID:     "1",
+		GroupID:    "1",
+		OS:         "windows",
+		InstallDir: installDir,
+		Package:    PackageConfig{CPUArchitecture: "x86_64"},
+	}
+
+	if err := installWindowsPackage(cfg, zipPath, controller); err != nil {
+		t.Fatalf("install Windows package: %v", err)
+	}
+	newBinary, err := os.ReadFile(filepath.Join(installDir, "collector-sidecar.exe"))
+	if err != nil || string(newBinary) != "new-binary" {
+		t.Fatalf("new binary was not activated: %q, %v", newBinary, err)
+	}
+	uninstaller, err := os.ReadFile(filepath.Join(installDir, "uninstall.exe"))
+	if err != nil || string(uninstaller) != "nsis-uninstaller" {
+		t.Fatalf("uninstaller was not preserved: %q, %v", uninstaller, err)
+	}
+	icon, err := os.ReadFile(filepath.Join(installDir, "installer.ico"))
+	if err != nil || string(icon) != "icon" {
+		t.Fatalf("installer icon was not preserved: %q, %v", icon, err)
+	}
+}
+
+func TestInstallWindowsPackageKeepsPackageProvidedInstallerFiles(t *testing.T) {
+	installDir := filepath.Join(t.TempDir(), "fusion-collectors")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatalf("create install dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "collector-sidecar.exe"), []byte("old-binary"), 0644); err != nil {
+		t.Fatalf("write old binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "uninstall.exe"), []byte("old-uninstaller"), 0644); err != nil {
+		t.Fatalf("write old uninstaller: %v", err)
+	}
+	zipPath := writeControllerZip(t, map[string]string{
+		"controller/collector-sidecar.exe": "new-binary",
+		"controller/uninstall.exe":         "packaged-uninstaller",
+	})
+	controller := &fakeWindowsServiceController{serviceExisted: true}
+	cfg := &Config{
+		ServerURL:  "https://bk.example",
+		APIToken:   "token",
+		NodeID:     "node-1",
+		NodeName:   "node-1",
+		ZoneID:     "1",
+		GroupID:    "1",
+		OS:         "windows",
+		InstallDir: installDir,
+		Package:    PackageConfig{CPUArchitecture: "x86_64"},
+	}
+
+	if err := installWindowsPackage(cfg, zipPath, controller); err != nil {
+		t.Fatalf("install Windows package: %v", err)
+	}
+	uninstaller, err := os.ReadFile(filepath.Join(installDir, "uninstall.exe"))
+	if err != nil || string(uninstaller) != "packaged-uninstaller" {
+		t.Fatalf("package-provided uninstaller must win: %q, %v", uninstaller, err)
+	}
+}
+
+func TestInstallWindowsPackageSucceedsWithoutPreviousUninstaller(t *testing.T) {
+	installDir := filepath.Join(t.TempDir(), "fusion-collectors")
+	zipPath := writeControllerZip(t, map[string]string{
+		"controller/collector-sidecar.exe": "new-binary",
+	})
+	controller := &fakeWindowsServiceController{}
+	cfg := &Config{
+		ServerURL:  "https://bk.example",
+		APIToken:   "token",
+		NodeID:     "node-1",
+		NodeName:   "node-1",
+		ZoneID:     "1",
+		GroupID:    "1",
+		OS:         "windows",
+		InstallDir: installDir,
+		Package:    PackageConfig{CPUArchitecture: "x86_64"},
+	}
+
+	if err := installWindowsPackage(cfg, zipPath, controller); err != nil {
+		t.Fatalf("first Windows installation: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "uninstall.exe")); !os.IsNotExist(err) {
+		t.Fatalf("first installation must not fabricate an uninstaller: %v", err)
+	}
+	newBinary, err := os.ReadFile(filepath.Join(installDir, "collector-sidecar.exe"))
+	if err != nil || string(newBinary) != "new-binary" {
+		t.Fatalf("new binary was not activated: %q, %v", newBinary, err)
+	}
+}
+
 func TestInstallWindowsPackagePreservesExistingServiceRegistration(t *testing.T) {
 	installDir := filepath.Join(t.TempDir(), "fusion-collectors")
 	if err := os.MkdirAll(installDir, 0755); err != nil {


### PR DESCRIPTION
## 问题

Windows 控制器经服务端远程升级后，控制面板「程序和功能」里的卸载入口失效——点击无反应，注册表 `UninstallString` 指向的 `C:\fusion-collectors\uninstall.exe` 已不存在。

## 根因

`uninstall.exe` 和 `installer.ico` 由 NSIS 写入安装目录，控制器包本身不含这两个文件：

- `setup.nsi` 的 `Section "Install"` 在 worker 执行完之后才 `WriteUninstaller "$INSTDIR\uninstall.exe"`、`File "installer.ico"`，并把注册表 `HKLM\Software\Microsoft\Windows\CurrentVersion\Uninstall\CollectorSidecar` 的 `UninstallString` / `DisplayIcon` 指向它们。

而 `setup-worker.go` 的 `installWindowsPackage` 是事务式激活：

1. 旧安装目录整体 `rename` 成 `C:\fusion-collectors.bklite-backup`；
2. staging 目录 `rename` 成安装目录；
3. `moveWindowsRuntimeData` 只把 `cache` / `logs` / `generated` 三个目录从 backup 迁回；
4. 提交后 `cleanupActivatedWindowsBackup` 删除 backup。

两条安装链路的结果因此不同：

- **GUI 安装**（`setup.nsi`）：worker 跑完后 NSIS 会重新写入这两个文件，无感知。
- **服务端远程安装**（`server/apps/node_mgmt/services/windows_remote_bootstrap.py`）：通过 `ansible.windows.win_command` 直接执行 bootstrap worker（`bklite-controller-bootstrap.exe`，即 `setup-worker.exe`），**不经过 NSIS**。目录 rename 之后新安装目录里没有这两个文件，随后连同 backup 一起被清理，注册表项却仍然指向它们——卸载入口就此失效。

即：升级把 GUI 安装写入的卸载资产吃掉了，且注册表未同步失效，留下一个指向空文件的死入口。

## 修改

`agents/sidecar-installer/setup-worker.go`：

- 新增 `windowsPreservedInstallerFiles = []string{"uninstall.exe", "installer.ico"}`，与 `windowsRuntimeDirectories` 分开，因为二者语义不同。
- `moveWindowsRuntimeData` 增加文件迁移分支：
  - 源不存在则跳过——首次远程安装本来就没有 `uninstall.exe`，天然无害；
  - **目标已存在则跳过**，即新包若自带同名文件以新包为准（目录那套是 `RemoveAll(target)` 后覆盖，文件不能沿用这个语义）；
  - 迁移成功的文件名同样进 `moved` 列表，回滚路径 `restoreWindowsRuntimeData` 逐项反向 `rename`，对文件天然适用。
- `recoverInterruptedWindowsInstallation` 中判定「哪些条目已被迁走」的循环改为遍历目录 + 文件的合并清单。否则中断恢复时这两个文件会滞留在新目录里，随失败的安装一起被删除。

## 测试

`agents/sidecar-installer/setup-worker_test.go` 新增三条用例：

- `TestInstallWindowsPackagePreservesUninstallEntrypointAfterSuccessfulActivation`——升级后两个文件的内容原样保留；
- `TestInstallWindowsPackageKeepsPackageProvidedInstallerFiles`——包内自带同名文件时以包为准，不被旧文件覆盖；
- `TestInstallWindowsPackageSucceedsWithoutPreviousUninstaller`——首次安装（无旧目录、无 uninstaller）正常成功，且不伪造文件。

## 验证

- `go vet ./...` 干净，`go test ./...` 全绿（本地 macOS）。
- 已把 `setup-worker.go` 还原到 master 验证复现能力：`TestInstallWindowsPackagePreservesUninstallEntrypointAfterSuccessfulActivation` 失败并精确复现问题——`uninstaller was not preserved: open .../fusion-collectors/uninstall.exe: no such file or directory`。另两条用例在修复前本就通过，作用是约束语义不回退（包内文件优先、首装不伪造文件），不是复现用例。
- 因单测在 macOS 上运行，Windows 特有的文件占用（`ERROR_SHARING_VIOLATION`）行为无法由单测覆盖。

## 已知遗留（本 PR 未处理）

**首次纯远程安装从未有过卸载入口**：注册表项和 `uninstall.exe` 都只由 NSIS 写入，远程链路两者都不产生。本 PR 保证的是「原来有就不会丢」，从未装过 GUI 包的机器控制面板里依旧看不到条目。补齐需要让 worker 自行写注册表并提供卸载器，属于独立改动范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
