### PR TITLE
bugfix: 限时恢复用户目录 NATS 入口

### DIFF
--- a/server/apps/system_mgmt/nats/users.py
+++ b/server/apps/system_mgmt/nats/users.py
@@ -17,6 +17,9 @@ def _is_persisted_superuser(user_obj):
     return Role.objects.filter(id__in=role_ids, name="admin").filter(Q(app="") | Q(app="system-manager")).exists()
 
 
+# SECURITY COMPATIBILITY: 仅为已知仓外消费者限时恢复；不得新增消费者。
+# 风险接受与 NATS 身份/ACL 迁移跟踪见 #4533，截止 2026-09-04。
+@nats_client.register
 def get_group_users(group=None, include_children=False):
     """
     获取组织下的用户列表
@@ -76,6 +79,8 @@ def _get_actor_user_scope(actor_context, include_children=False):
     return user_obj, authorized_groups
 
 
+# SECURITY COMPATIBILITY: actor_context 仍来自消息体，不构成可信调用身份；见 #4533。
+@nats_client.register
 def get_group_users_scoped(actor_context, group=None, include_children=False):
     """
     在调用方授权范围内查询组织用户列表。
@@ -148,6 +153,8 @@ def get_assignable_groups(actor_context):
     return {"result": True, "data": groups}
 
 
+# SECURITY COMPATIBILITY: 限时风险接受的 legacy subject；见 #4533。
+@nats_client.register
 def get_all_users():
     data = User.objects.all().values(*User.display_fields())
     return {"result": True, "data": list(data)}
@@ -159,6 +166,8 @@ def search_groups(query_params):
     return {"result": True, "data": list(groups)}
 
 
+# SECURITY COMPATIBILITY: 限时风险接受的 legacy subject；见 #4533。
+@nats_client.register
 def search_users(query_params):
     page = int(query_params.get("page", 1))
     page_size = int(query_params.get("page_size", 10))

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -76,10 +76,6 @@ def test_nats_api_compat_exports_local_and_nats_entrypoints():
         "create_default_rule",
         "bk_lite_user_login",
         "wechat_user_register",
-        "get_group_users",
-        "get_group_users_scoped",
-        "get_all_users",
-        "search_users",
     }
     registered_entrypoints = expected_entrypoints - local_only_entrypoints
 

--- a/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
+++ b/server/apps/system_mgmt/tests/test_nats_user_directory_registration.py
@@ -3,7 +3,7 @@ import nats_client
 from apps.system_mgmt import nats_api
 
 
-LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS = {
+LEGACY_REMOTE_USER_DIRECTORY_ENTRYPOINTS = {
     "get_group_users",
     "get_group_users_scoped",
     "get_all_users",
@@ -11,13 +11,14 @@ LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS = {
 }
 
 
-def test_user_directory_entrypoints_are_local_only():
+def test_user_directory_entrypoints_keep_temporary_remote_compatibility():
+    """仓外消费者迁移完成前保留注册；限时风险接受与退出条件见 #4533。"""
     exported_entrypoints = {
-        name for name in LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS if callable(getattr(nats_api, name, None))
+        name for name in LEGACY_REMOTE_USER_DIRECTORY_ENTRYPOINTS if callable(getattr(nats_api, name, None))
     }
     registered_entrypoints = {
         item["name"] for item in nats_client.registry.default_registry.registry.values()
     }
 
-    assert exported_entrypoints == LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS
-    assert LOCAL_ONLY_USER_DIRECTORY_ENTRYPOINTS.isdisjoint(registered_entrypoints)
+    assert exported_entrypoints == LEGACY_REMOTE_USER_DIRECTORY_ENTRYPOINTS
+    assert LEGACY_REMOTE_USER_DIRECTORY_ENTRYPOINTS <= registered_entrypoints


### PR DESCRIPTION
## 问题

PR #4384 下架四个用户目录 NATS subject 后，确认存在仓库外消费者。直接发布会让这些消费者收到 `NoRespondersError` 或请求超时。

## 怎么修的

- 限时恢复 `get_group_users`、`get_group_users_scoped`、`get_all_users`、`search_users` 的 NATS 注册。
- 保留现有本地 `SystemMgmt` / `AppClient` 调用契约。
- 在生产代码和注册契约测试中明确标记临时兼容与风险接受期限。
- NATS 调用身份、独立凭据和 subject ACL 的长期收口由 #4533 跟踪。

## 风险接受

恢复 legacy subject 会暂时重新开放已确认的用户目录枚举风险。该兼容仅用于已知仓外消费者迁移，不得新增消费者；风险接受截止 **2026-09-04 23:59（Asia/Shanghai）**，到期不得静默续期。

## 验证

- 用户目录注册契约、NATS 兼容导出和 `SystemMgmt` 转发：44 passed。
- `git diff --check`：通过。

关联 #3981、#4384、#4533。
