### PR TITLE
fix: 收口业务 Jinja 模板环境

### DIFF
--- a/server/apps/alerts/aggregation/query/builder.py
+++ b/server/apps/alerts/aggregation/query/builder.py
@@ -1,15 +1,20 @@
 import os
 
 from django.conf import settings
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import FileSystemLoader
+from jinja2.defaults import DEFAULT_FILTERS
 from typing import List
 from apps.alerts.aggregation.window.factory import WindowConfig
+from apps.core.utils.safe_template import build_trusted_file_template_env
 
 
 class SQLBuilder:
     def __init__(self):
         template_dir = os.path.join(settings.BASE_DIR, "apps/alerts/aggregation/templates")
-        self.env = Environment(loader=FileSystemLoader(template_dir))
+        self.env = build_trusted_file_template_env(
+            loader=FileSystemLoader(template_dir),
+            extra_filters={"default": DEFAULT_FILTERS["default"]},
+        )
 
     def build_aggregation_sql(
         self,

--- a/server/apps/alerts/tests/test_aggregation_sql_builder_service.py
+++ b/server/apps/alerts/tests/test_aggregation_sql_builder_service.py
@@ -1,0 +1,43 @@
+import hashlib
+from datetime import datetime
+
+import pytest
+
+from apps.alerts.aggregation.query.builder import SQLBuilder
+from apps.alerts.aggregation.window.factory import WindowConfig, WindowType
+
+
+UNSAFE_DEFAULT_GLOBALS = {"lipsum", "cycler", "joiner", "namespace"}
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    ("window_type", "expected_sha256"),
+    (
+        (WindowType.SLIDING, "890b2a27a22a1dcaa76f9836e9c403526eb5ba8930ec48d71e1da2e79c151236"),
+        (WindowType.SESSION, "a476dbd96e85ac0ac159ca35647effeceb65e30086dbb733893e20a955a965e2"),
+    ),
+)
+def test_sql_builder_output_matches_ordinary_environment_baseline(monkeypatch, window_type, expected_sha256):
+    monkeypatch.setattr(
+        WindowConfig,
+        "get_window_start",
+        lambda self: datetime.fromisoformat("2026-08-05T08:00:00+00:00"),
+    )
+    monkeypatch.setattr(
+        WindowConfig,
+        "get_session_end_time",
+        lambda self: datetime.fromisoformat("2026-08-05T09:00:00+00:00"),
+    )
+    builder = SQLBuilder()
+    sql = builder.build_aggregation_sql(
+        dimensions=["resource_id", "item"],
+        window_config=WindowConfig(window_type, window_size_minutes=10, session_timeout_minutes=60),
+        strategy_id=42,
+    )
+
+    assert hashlib.sha256(sql.encode()).hexdigest() == expected_sha256
+
+
+def test_sql_builder_environment_has_no_default_globals():
+    assert UNSAFE_DEFAULT_GLOBALS.isdisjoint(SQLBuilder().env.globals)

--- a/server/apps/core/tests/test_jinja_environment_contract_service.py
+++ b/server/apps/core/tests/test_jinja_environment_contract_service.py
@@ -1,0 +1,74 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+
+APPS_ROOT = Path(__file__).resolve().parents[2]
+ALLOWED_ENVIRONMENT_MODULE = APPS_ROOT / "core" / "utils" / "safe_template.py"
+pytestmark = pytest.mark.integration
+
+
+def _dotted_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _dotted_name(node.value)
+        return f"{parent}.{node.attr}" if parent else None
+    return None
+
+
+def _ordinary_environment_references(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    environment_attributes = {"jinja2.Environment", "jinja2.environment.Environment"}
+    violations = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "jinja2" and alias.asname:
+                    environment_attributes.add(f"{alias.asname}.Environment")
+                    environment_attributes.add(f"{alias.asname}.environment.Environment")
+                elif alias.name == "jinja2.environment" and alias.asname:
+                    environment_attributes.add(f"{alias.asname}.Environment")
+        elif isinstance(node, ast.ImportFrom) and node.module in {"jinja2", "jinja2.environment"}:
+            if any(alias.name in {"Environment", "*"} for alias in node.names):
+                violations.append(node.lineno)
+            if node.module == "jinja2":
+                for alias in node.names:
+                    if alias.name == "environment":
+                        environment_attributes.add(f"{alias.asname or alias.name}.Environment")
+        elif isinstance(node, ast.Attribute) and _dotted_name(node) in environment_attributes:
+            violations.append(node.lineno)
+
+    return violations
+
+
+def test_production_code_does_not_reference_ordinary_jinja_environment():
+    violations = []
+    for path in APPS_ROOT.rglob("*.py"):
+        if path == ALLOWED_ENVIRONMENT_MODULE or "tests" in path.parts or "migrations" in path.parts:
+            continue
+        for line in _ordinary_environment_references(path):
+            violations.append(f"{path.relative_to(APPS_ROOT)}:{line}")
+
+    assert violations == [], "普通 jinja2.Environment 必须通过 Core 安全工厂收口：\n" + "\n".join(violations)
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import jinja2\njinja2.Environment()",
+        "import jinja2 as j2\nj2.Environment()",
+        "import jinja2 as j2\nj2.environment.Environment()",
+        "import jinja2.environment\njinja2.environment.Environment()",
+        "import jinja2.environment as je\nje.Environment()",
+        "from jinja2 import environment as je\nje.Environment()",
+        "from jinja2.environment import Environment as Env",
+    ),
+)
+def test_detector_covers_ordinary_environment_import_forms(tmp_path, source):
+    path = tmp_path / "environment_reference.py"
+    path.write_text(source, encoding="utf-8")
+
+    assert _ordinary_environment_references(path)

--- a/server/apps/core/tests/test_safe_template.py
+++ b/server/apps/core/tests/test_safe_template.py
@@ -3,11 +3,15 @@ import pytest
 from apps.core.utils.safe_template import (
     TemplateSecurityError,
     build_sandboxed_env,
+    build_trusted_file_template_env,
     check_dangerous_patterns,
     safe_render,
     sanitize_template_context,
     validate_template_variables,
 )
+
+
+UNSAFE_DEFAULT_GLOBALS = {"lipsum", "cycler", "joiner", "namespace"}
 
 
 class TestCheckDangerousPatterns:
@@ -155,3 +159,56 @@ class TestBuildSandboxedEnv:
         result = tpl.render(instance_id="192.168.1.1", port="161", version="2")
         assert "192.168.1.1" in result
         assert "161" in result
+
+
+@pytest.mark.unit
+class TestBuildTrustedFileTemplateEnv:
+    def test_clears_default_namespaces(self):
+        env = build_trusted_file_template_env()
+
+        assert UNSAFE_DEFAULT_GLOBALS.isdisjoint(env.globals)
+        assert env.filters == {}
+        assert env.tests == {}
+
+    def test_blocks_dunder_attribute_chains(self):
+        from jinja2.sandbox import SecurityError as JinjaSandboxError
+
+        env = build_trusted_file_template_env()
+        template = env.from_string("{{ value.__class__.__mro__ }}")
+
+        with pytest.raises(JinjaSandboxError):
+            template.render(value="blueking")
+
+    def test_lipsum_globals_payload_cannot_resolve_default_object(self):
+        from jinja2 import UndefinedError
+        from jinja2.sandbox import SecurityError as JinjaSandboxError
+
+        env = build_trusted_file_template_env()
+        template = env.from_string("{{ lipsum.__globals__ }}")
+
+        with pytest.raises((JinjaSandboxError, UndefinedError)):
+            template.render()
+
+    def test_only_enables_explicit_filters_and_tests(self):
+        env = build_trusted_file_template_env(
+            extra_filters={"upper": str.upper},
+            extra_tests={"same": lambda value, expected: value == expected},
+        )
+
+        template = env.from_string("{% if name is same('blueking') %}{{ name | upper }}{% endif %}")
+
+        assert template.render(name="blueking") == "BLUEKING"
+
+    def test_supports_macros_and_public_callables_for_repository_templates(self):
+        env = build_trusted_file_template_env()
+        template = env.from_string(
+            "{% macro collect(values) %}"
+            "{% set output = [] %}"
+            "{% for key, value in values.items() %}"
+            "{% set _ = output.append(key) %}{{ value }}"
+            "{% endfor %}"
+            "{% endmacro %}"
+            "{{ collect(values) }}"
+        )
+
+        assert template.render(values={"name": "blueking"}) == "blueking"

--- a/server/apps/core/utils/safe_template.py
+++ b/server/apps/core/utils/safe_template.py
@@ -261,3 +261,37 @@ def build_sandboxed_env(
     if extra_filters:
         env.filters.update(extra_filters)
     return env
+
+
+def build_trusted_file_template_env(
+    loader=None,
+    undefined=DebugUndefined,
+    *,
+    autoescape: bool = False,
+    trim_blocks: bool = False,
+    lstrip_blocks: bool = False,
+    extra_filters: dict | None = None,
+    extra_tests: dict | None = None,
+) -> SandboxedEnvironment:
+    """构建用于仓库内可信文件模板的最小权限 Jinja2 环境。
+
+    与 ``build_sandboxed_env`` 的不可信字符串模板边界不同，仓库内模板需要调用
+    macro 以及公开的数据容器方法。这里保留标准 ``SandboxedEnvironment`` 的属性
+    安全检查，同时清空 Jinja 默认 globals、filters 和 tests，再由调用方逐项恢复
+    已审计的能力。
+    """
+    env = SandboxedEnvironment(
+        loader=loader or BaseLoader(),
+        undefined=undefined,
+        autoescape=autoescape,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks,
+    )
+    env.globals.clear()
+    env.filters.clear()
+    env.tests.clear()
+    if extra_filters:
+        env.filters.update(extra_filters)
+    if extra_tests:
+        env.tests.update(extra_tests)
+    return env

--- a/server/apps/log/tests/test_log_template_sandbox_rendering.py
+++ b/server/apps/log/tests/test_log_template_sandbox_rendering.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
+import pytest
 import yaml
 
-from apps.log.utils.plugin_controller import Controller
+from apps.log.utils.plugin_controller import Controller, _build_log_template_env
 
 
 PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "support-files" / "plugins"
@@ -10,6 +11,13 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[1] / "support-files" / "plugins"
 
 def render_plugin_template(plugin_path: str, template_name: str, context: dict) -> str:
     return Controller({}).render_template(str(PLUGIN_ROOT / plugin_path), template_name, context)
+
+
+@pytest.mark.unit
+def test_log_template_environment_has_no_default_globals(tmp_path):
+    env = _build_log_template_env(str(tmp_path))
+
+    assert {"lipsum", "cycler", "joiner", "namespace"}.isdisjoint(env.globals)
 
 
 def test_vector_docker_template_renders_container_filter_lists():

--- a/server/apps/log/utils/plugin_controller.py
+++ b/server/apps/log/utils/plugin_controller.py
@@ -3,7 +3,8 @@ import os
 import uuid
 from collections.abc import Mapping
 
-from jinja2 import DebugUndefined, Environment, FileSystemLoader
+from jinja2 import DebugUndefined, FileSystemLoader
+from jinja2.defaults import DEFAULT_FILTERS, DEFAULT_TESTS
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.safe_template import build_sandboxed_env
@@ -15,7 +16,6 @@ from apps.rpc.node_mgmt import NodeMgmt
 from apps.core.logger import log_logger as logger
 
 
-_DEFAULT_JINJA_ENV = Environment()
 _LOG_TEMPLATE_ALLOWED_FILTERS = (
     "default",
     "int",
@@ -44,16 +44,16 @@ def _build_log_template_env(template_dir: str):
         },
     )
 
-    missing_filters = [name for name in _LOG_TEMPLATE_ALLOWED_FILTERS if name not in _DEFAULT_JINJA_ENV.filters]
+    missing_filters = [name for name in _LOG_TEMPLATE_ALLOWED_FILTERS if name not in DEFAULT_FILTERS]
     if missing_filters:
         raise BaseAppException(f"Missing default Jinja filters: {', '.join(missing_filters)}")
 
-    missing_tests = [name for name in _LOG_TEMPLATE_ALLOWED_TESTS if name not in _DEFAULT_JINJA_ENV.tests]
+    missing_tests = [name for name in _LOG_TEMPLATE_ALLOWED_TESTS if name not in DEFAULT_TESTS]
     if missing_tests:
         raise BaseAppException(f"Missing default Jinja tests: {', '.join(missing_tests)}")
 
-    env.filters.update({name: _DEFAULT_JINJA_ENV.filters[name] for name in _LOG_TEMPLATE_ALLOWED_FILTERS})
-    env.tests.update({name: _DEFAULT_JINJA_ENV.tests[name] for name in _LOG_TEMPLATE_ALLOWED_TESTS})
+    env.filters.update({name: DEFAULT_FILTERS[name] for name in _LOG_TEMPLATE_ALLOWED_FILTERS})
+    env.tests.update({name: DEFAULT_TESTS[name] for name in _LOG_TEMPLATE_ALLOWED_TESTS})
     return env
 
 

--- a/server/apps/monitor/tests/test_plugin_controller.py
+++ b/server/apps/monitor/tests/test_plugin_controller.py
@@ -52,6 +52,12 @@ class TestNormalizeTemplateContext:
 
 
 class TestRenderTemplate:
+    @pytest.mark.unit
+    def test_environment_has_no_default_globals(self):
+        env = Controller({}).jinja_env
+
+        assert {"lipsum", "cycler", "joiner", "namespace"}.isdisjoint(env.globals)
+
     def test_renders_with_logical_instance_value(self):
         ctrl = Controller({})
         out = ctrl.render_template("host={{ instance_id }}", {"logical_instance_value": "h1"})

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -1,6 +1,7 @@
 import uuid
 
-from jinja2 import BaseLoader, DebugUndefined, Environment
+from jinja2 import BaseLoader, DebugUndefined
+from jinja2.defaults import DEFAULT_FILTERS
 
 from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
 from apps.core.utils.safe_template import (
@@ -17,7 +18,6 @@ from apps.monitor.utils.dimension import parse_instance_id
 from apps.rpc.node_mgmt import NodeMgmt
 
 
-_DEFAULT_JINJA_ENV = Environment()
 _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "default",
     "lower",
@@ -176,15 +176,15 @@ class Controller:
             missing_filters = [
                 name
                 for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
-                if name not in _DEFAULT_JINJA_ENV.filters and name not in env.filters
+                if name not in DEFAULT_FILTERS and name not in env.filters
             ]
             if missing_filters:
                 raise BaseAppException(f"Missing default Jinja filters: {', '.join(missing_filters)}")
             env.filters.update(
                 {
-                    name: _DEFAULT_JINJA_ENV.filters[name]
+                    name: DEFAULT_FILTERS[name]
                     for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
-                    if name in _DEFAULT_JINJA_ENV.filters
+                    if name in DEFAULT_FILTERS
                 }
             )
             self._jinja_env = env

--- a/server/apps/opspilot/metis/utils/template_loader.py
+++ b/server/apps/opspilot/metis/utils/template_loader.py
@@ -6,8 +6,12 @@ import os
 from pathlib import Path
 from typing import Dict, Any, Optional, Union
 
-from jinja2 import Environment, FileSystemLoader, Template, TemplateNotFound
+from jinja2 import FileSystemLoader, Template, TemplateNotFound
+from jinja2.defaults import DEFAULT_FILTERS
+from jinja2.sandbox import SandboxedEnvironment
 from loguru import logger
+
+from apps.core.utils.safe_template import build_trusted_file_template_env
 
 
 class TemplateLoader:
@@ -19,7 +23,7 @@ class TemplateLoader:
     """
 
     _default_base_path: Optional[Path] = None
-    _env_cache: Dict[str, Environment] = {}
+    _env_cache: Dict[str, SandboxedEnvironment] = {}
 
     @classmethod
     def configure(cls, base_path: Optional[str] = None) -> None:
@@ -57,7 +61,7 @@ class TemplateLoader:
         return fallback_path
 
     @classmethod
-    def _get_environment(cls, base_path: Optional[str] = None) -> Environment:
+    def _get_environment(cls, base_path: Optional[str] = None) -> SandboxedEnvironment:
         """
         获取 Jinja2 环境对象，使用缓存避免重复创建
 
@@ -87,11 +91,12 @@ class TemplateLoader:
             base_path_obj.mkdir(parents=True, exist_ok=True)
 
         # 创建新的环境对象
-        env = Environment(
+        env = build_trusted_file_template_env(
             loader=FileSystemLoader(base_path_str),
             autoescape=True,  # 默认开启自动转义
             trim_blocks=True,
-            lstrip_blocks=True
+            lstrip_blocks=True,
+            extra_filters={"string": DEFAULT_FILTERS["string"]},
         )
 
         # 缓存环境对象

--- a/server/apps/opspilot/tests/test_template_loader_security_service.py
+++ b/server/apps/opspilot/tests/test_template_loader_security_service.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.opspilot.metis.utils.template_loader import TemplateLoader
+
+
+UNSAFE_DEFAULT_GLOBALS = {"lipsum", "cycler", "joiner", "namespace"}
+pytestmark = pytest.mark.integration
+
+
+def test_template_loader_preserves_repository_template_capabilities(tmp_path):
+    template_path = tmp_path / "capabilities.jinja2"
+    template_path.write_text(
+        "{% set names = [] %}"
+        "{% for name, value in fields.items() %}"
+        "{% set _ = names.append(name) %}"
+        "{{ loop.index|string }}={{ value }};"
+        "{% endfor %}"
+        "{{ names[0] }}",
+        encoding="utf-8",
+    )
+
+    rendered = TemplateLoader.render_template(
+        "capabilities.jinja2",
+        {"fields": {"name": "blueking"}},
+        base_path=str(tmp_path),
+    )
+
+    assert rendered == "1=blueking;name"
+
+
+def test_template_loader_environment_has_no_default_globals(tmp_path):
+    env = TemplateLoader._get_environment(str(tmp_path))
+
+    assert UNSAFE_DEFAULT_GLOBALS.isdisjoint(env.globals)
+
+
+def test_all_repository_templates_compile_with_allowlisted_capabilities():
+    base_path = TemplateLoader._get_package_support_files_path()
+    env = TemplateLoader._get_environment(base_path)
+    template_names = env.list_templates()
+
+    assert template_names
+    for template_name in template_names:
+        env.get_template(template_name)
+
+
+def test_naive_rag_prompt_renders_and_deduplicates_knowledge_sources():
+    rag_results = [
+        SimpleNamespace(
+            title="",
+            knowledge_id=7,
+            chunk_number=index,
+            chunk_id=f"chunk-{index}",
+            segment_number=index,
+            segment_id=f"segment-{index}",
+            content=f"content-{index}",
+            chunk_type="Document",
+        )
+        for index in (1, 2)
+    ]
+
+    rendered = TemplateLoader.render_template(
+        "graph/naive_rag_node_prompt.jinja2",
+        {
+            "rag_results": rag_results,
+            "enable_rag_source": True,
+            "enable_rag_strict_mode": False,
+        },
+    )
+    source_summary = rendered.split("### 引用资料汇总", 1)[1].split("请在回答中适当引用这些资料。", 1)[0]
+
+    assert "知识片段1" in rendered
+    assert source_summary.count("(knowledge_id: 7)") == 1


### PR DESCRIPTION
## 变更说明

基于 #4531 收口 PR #3189 后仍残留的普通 Jinja `Environment`：

- Core 新增可信仓库文件模板工厂，基于 `SandboxedEnvironment`，默认清空 globals、filters、tests。
- Alerts 聚合 SQL 与 OpsPilot Prompt Loader 迁移到该工厂，只恢复现有模板实际依赖的 `default` / `string` filter。
- Monitor、Log 不再实例化普通 Environment，直接从 Jinja 默认注册表按既有白名单复制 filters/tests。
- 增加生产代码 AST 契约，阻止普通 Environment 通过直接导入、别名或 `jinja2.environment` 路径重新进入业务代码。

```mermaid
flowchart LR
    Core["Core 可信文件模板沙箱"] --> Alerts["Alerts 聚合 SQL"]
    Core --> OpsPilot["OpsPilot Prompt"]
    Registry["Jinja 默认注册表"] --> Monitor["Monitor 显式白名单"]
    Registry --> Log["Log 显式白名单"]
    Contract["AST 防回归契约"] --> Alerts
    Contract --> OpsPilot
    Contract --> Monitor
    Contract --> Log
```

## 安全与兼容性

- 上述业务模板环境均不再包含 `lipsum`、`cycler`、`joiner`、`namespace`。
- `lipsum.__globals__` 与 dunder 属性链无法取得对象。
- 不可信字符串模板仍使用原有 `StrictSandboxedEnvironment`，边界未放宽。
- Alerts 的 sliding/session SQL 使用迁移前完整输出哈希做兼容基线。
- OpsPilot 全部仓库 Prompt 可编译，并实际渲染 `naive_rag_node_prompt`，覆盖 `dict.items()`、列表 `append()`、`string` filter 和知识源去重。

## 验证

- 定向回归：67 passed，2 个与本改动无关的 Monitor 数据库用例按名称排除；本地 SQLite 无法执行仓库历史迁移，数据库用例需按测试指南使用 PostgreSQL。
- Python `compileall`：通过。
- `git diff --check`：通过。
- 新增测试文件 Black 检查：通过。
- 双轴复核：仓库规范 0 个硬性问题，Issue 契约 0 个遗漏、越界或实现错误。

## 风险与回滚

风险集中在可信文件模板的能力白名单。回归测试已覆盖当前 SQL 和 Prompt 的真实能力；如仍出现模板兼容问题，可优先显式补充缺失 filter/test。必要时可整体回滚本提交，数据结构和数据库均无变化。

Closes #4531
