### PR TITLE
feat(监控): 统一网络设备 IF-MIB 采集

### DIFF
--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -1,23 +1,74 @@
-from django_filters import CharFilter, FilterSet
+from django.db.models import Q
+from django_filters import BaseInFilter, BooleanFilter, CharFilter, FilterSet, NumberFilter
 
-from apps.monitor.models.monitor_metrics import MetricGroup, Metric
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 
 
 class MetricGroupFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
     monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID")
     monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID")
+    name = CharFilter(field_name="name", lookup_expr="exact", label="指标分组名称")
+    keyword = CharFilter(method="filter_keyword", label="指标分组关键字")
+
+    @staticmethod
+    def filter_keyword(queryset, _name, value):
+        keyword = str(value or "").strip()
+        if not keyword:
+            return queryset
+        return queryset.filter(Q(name__icontains=keyword) | Q(description__icontains=keyword))
 
     class Meta:
         model = MetricGroup
-        fields = ["monitor_object_name", "monitor_object_id", "monitor_plugin_id"]
+        fields = ["monitor_object_name", "monitor_object_id", "monitor_plugin_id", "name", "keyword"]
+
+
+class NumberInFilter(BaseInFilter, NumberFilter):
+    pass
+
+
+class CharInFilter(BaseInFilter, CharFilter):
+    pass
 
 
 class MetricFilter(FilterSet):
     monitor_object_name = CharFilter(field_name="monitor_object__name", lookup_expr="exact", label="指标对象名称")
     monitor_object_id = CharFilter(field_name="monitor_object_id", lookup_expr="exact", label="指标对象ID")
     monitor_plugin_id = CharFilter(field_name="monitor_plugin_id", lookup_expr="exact", label="插件ID")
+    id = NumberFilter(field_name="id", lookup_expr="exact", label="指标ID")
+    id_in = NumberInFilter(field_name="id", lookup_expr="in", label="指标ID列表")
+    name = CharFilter(field_name="name", lookup_expr="exact", label="指标名称")
+    name_in = CharInFilter(field_name="name", lookup_expr="in", label="指标名称列表")
+    keyword = CharFilter(method="filter_keyword", label="指标关键字")
+    include_ifmib = BooleanFilter(method="filter_include_ifmib", label="是否包含IF-MIB指标")
+
+    @staticmethod
+    def filter_keyword(queryset, _name, value):
+        keyword = str(value or "").strip()
+        if not keyword:
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=keyword)
+            | Q(display_name__icontains=keyword)
+            | Q(description__icontains=keyword)
+        )
+
+    @staticmethod
+    def filter_include_ifmib(queryset, _name, value):
+        if value is False:
+            return queryset.filter(is_ifmib=False)
+        return queryset
 
     class Meta:
         model = Metric
-        fields = ["monitor_object_name", "monitor_object_id", "monitor_plugin_id"]
+        fields = [
+            "monitor_object_name",
+            "monitor_object_id",
+            "monitor_plugin_id",
+            "id",
+            "id_in",
+            "name",
+            "name_in",
+            "keyword",
+            "include_ifmib",
+        ]

--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -1,5 +1,6 @@
 import json
 import re
+from copy import deepcopy
 from pathlib import Path
 
 from apps.core.logger import monitor_logger as logger
@@ -11,6 +12,7 @@ from apps.monitor.management.utils import (
     parse_template_filename,
 )
 from apps.monitor.services.plugin import MonitorPluginService
+from apps.monitor.utils.snmp_ifmib_capability import is_ifmib_capable_plugin_data
 from apps.rpc.node_mgmt import NodeMgmt
 
 TEMPLATE_COLLECT_TYPE_PATTERN = re.compile(r"""collect_type\s*=\s*["']([^"']+)["']""")
@@ -21,6 +23,110 @@ METRICS_MODULES_TOML_LINE_PATTERN = re.compile(r'(?m)^(\s*metrics_modules\s*=\s*
 LOCAL_TEMPLATE_ASSET_PATTERN = re.compile(
     r"(?m)^[ \t]*# @bk_include_file (?P<path>\S+)[ \t]*$"
 )
+COMMON_IFMIB_TABLE_DIRECTIVE = "# @bk_include_ifmib_table"
+COMMON_IFMIB_TABLE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
+)
+
+# IF-MIB 是所有 Network Device SNMP 模板共享的采集契约。此处只维护一次指标目录，
+# 导入时合并到每个厂商模板，避免为了显示指标而新增一个可被用户接入的公共插件。
+COMMON_IFMIB_METRICS = (
+    (
+        "Status", "interface_ifAdminStatus", "Interface Admin Status", "Enum",
+        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},{"name":"testing","id":3,"color":"#faad14"}]',
+        "Interface administrative status.",
+    ),
+    (
+        "Status", "interface_ifOperStatus", "Interface Oper Status", "Enum",
+        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},{"name":"testing","id":3,"color":"#faad14"}]',
+        "Actual interface operational status.",
+    ),
+    ("Bandwidth", "interface_ifSpeed", "Interface Bandwidth", "Number", "bitps", "Maximum supported interface speed."),
+    ("Packet Error", "interface_ifInErrors", "Incoming Errors Rate", "Number", "cps", "Average inbound error packets per second over five minutes."),
+    ("Packet Error", "interface_ifOutErrors", "Outgoing Errors Rate", "Number", "cps",
+     "Average outbound error packets per second over five minutes."),
+    ("Packet Loss", "interface_ifInDiscards", "Incoming Discards Rate", "Number", "cps",
+     "Average inbound discarded packets per second over five minutes."),
+    ("Packet Loss", "interface_ifOutDiscards", "Outgoing Discards Rate", "Number", "cps",
+     "Average outbound discarded packets per second over five minutes."),
+    ("Packet", "interface_ifInUcastPkts", "Incoming Unicast Packets Rate", "Number", "cps",
+     "Average inbound unicast packets per second over five minutes."),
+    ("Packet", "interface_ifOutUcastPkts", "Outgoing Unicast Packets Rate", "Number", "cps",
+     "Average outbound unicast packets per second over five minutes."),
+    ("Traffic", "interface_ifInOctets", "Interface Incoming Traffic Rate", "Number", "byteps",
+     "Average inbound interface bytes per second over five minutes."),
+    ("Traffic", "interface_ifOutOctets", "Interface Outgoing Traffic Rate", "Number", "byteps",
+     "Average outbound interface bytes per second over five minutes."),
+    ("Traffic", "interface_ifHCInOctets", "Interface Incoming Traffic Rate (HC)", "Number", "byteps",
+     "Average inbound 64-bit interface bytes per second over five minutes."),
+    ("Traffic", "interface_ifHCOutOctets", "Interface Outgoing Traffic Rate (HC)", "Number", "byteps",
+     "Average outbound 64-bit interface bytes per second over five minutes."),
+    ("Traffic", "device_total_incoming_traffic", "Device Total Incoming Traffic Rate", "Number", "byteps",
+     "Total inbound interface bytes per second over five minutes."),
+    ("Traffic", "device_total_outgoing_traffic", "Device Total Outgoing Traffic Rate", "Number", "byteps",
+     "Total outbound interface bytes per second over five minutes."),
+)
+
+
+def _build_common_ifmib_metrics(instance_type):
+    """Build the complete public IF-MIB metric catalog for one runtime object."""
+    metrics = []
+    for group, name, display_name, data_type, unit, description in COMMON_IFMIB_METRICS:
+        if name.startswith("device_total_"):
+            direction = "In" if name.endswith("incoming_traffic") else "Out"
+            query = f"sum(rate(interface_ifHC{direction}Octets{{instance_type='{instance_type}', __$labels__}}[5m])) by (instance_id)"
+            dimensions = []
+        elif name in {"interface_ifAdminStatus", "interface_ifOperStatus", "interface_ifSpeed"}:
+            query = f"{name}{{instance_type='{instance_type}', __$labels__}}"
+            dimensions = [{"name": "ifDescr", "description": "ifDescr"}]
+        else:
+            query = f"rate({name}{{instance_type='{instance_type}', __$labels__}}[5m])"
+            dimensions = [{"name": "ifDescr", "description": "ifDescr"}]
+        metrics.append(
+            {
+                "metric_group": group,
+                "name": name,
+                "query": query,
+                "display_name": display_name,
+                "data_type": data_type,
+                "unit": unit,
+                "dimensions": dimensions,
+                "instance_id_keys": ["instance_id"],
+                "description": description,
+                "is_ifmib": True,
+            }
+        )
+    return metrics
+
+
+def merge_common_ifmib_metrics(plugin_data):
+    """Inject the internal IF-MIB metric catalog into every Network Device SNMP template."""
+    result = deepcopy(plugin_data)
+    if not is_ifmib_capable_plugin_data(result):
+        return result
+
+    common_metrics = _build_common_ifmib_metrics(
+        re.sub(r"(?<!^)(?=[A-Z])", "_", result["name"]).lower()
+    )
+    common_metrics_by_name = {metric["name"]: metric for metric in common_metrics}
+    merged_metrics = []
+    existing_common_names = set()
+    for metric in result.get("metrics", []):
+        metric_name = metric.get("name")
+        if metric_name in common_metrics_by_name:
+            # 厂商可能为同一 IF-MIB 指标提供更准确的查询或分组。保留该定义，
+            # 仅标记来源，确保目录/API 的厂商优先级不被公共目录覆盖。
+            metric = {**metric, "is_ifmib": True}
+            existing_common_names.add(metric_name)
+        merged_metrics.append(metric)
+    merged_metrics.extend(
+        metric
+        for metric in common_metrics
+        if metric["name"] not in existing_common_names
+    )
+    result["metrics"] = merged_metrics
+    return result
 
 
 class PluginIdentityValidationError(ValueError):
@@ -40,7 +146,14 @@ def _expand_local_template_assets(content: str, plugin_dir: Path) -> str:
             raise ValueError(f"插件资源不存在: {relative_path}")
         return asset_path.read_text(encoding="utf-8").rstrip("\n")
 
-    return LOCAL_TEMPLATE_ASSET_PATTERN.sub(replace, content)
+    expanded = LOCAL_TEMPLATE_ASSET_PATTERN.sub(replace, content)
+    if COMMON_IFMIB_TABLE_DIRECTIVE not in expanded:
+        return expanded
+    try:
+        common_ifmib_table = COMMON_IFMIB_TABLE_PATH.read_text(encoding="utf-8").rstrip("\n")
+    except OSError as exc:
+        raise ValueError(f"通用 IF-MIB 模板不存在: {COMMON_IFMIB_TABLE_PATH}") from exc
+    return expanded.replace(COMMON_IFMIB_TABLE_DIRECTIVE, common_ifmib_table)
 
 
 def _clean_identity_value(value):
@@ -135,6 +248,7 @@ def _import_plugins_from_files(path_list):
 
             collector, collect_type = _resolve_plugin_identity(file_path, plugin_data)
             _validate_plugin_identity(file_path, collector, collect_type)
+            plugin_data = merge_common_ifmib_metrics(plugin_data)
 
             plugin_name = plugin_data.get("plugin")
             plugin_data["_mark_objects_builtin"] = True
@@ -350,7 +464,7 @@ def _process_ui_templates(plugin_dir, plugin_obj, db_ui_template):
             ):
                 from apps.monitor.utils.snmp_interface_template import merge_snmp_interface_filter_ui
 
-                ui_data = merge_snmp_interface_filter_ui(ui_data) or ui_data
+                ui_data = merge_snmp_interface_filter_ui(ui_data, plugin=plugin_obj) or ui_data
 
             if db_ui_template:
                 if db_ui_template.content != ui_data:

--- a/server/apps/monitor/migrations/0058_metric_is_ifmib.py
+++ b/server/apps/monitor/migrations/0058_metric_is_ifmib.py
@@ -1,0 +1,42 @@
+from django.db import migrations, models
+
+
+IFMIB_METRIC_NAMES = (
+    "interface_ifAdminStatus",
+    "interface_ifOperStatus",
+    "interface_ifSpeed",
+    "interface_ifInErrors",
+    "interface_ifOutErrors",
+    "interface_ifInDiscards",
+    "interface_ifOutDiscards",
+    "interface_ifInUcastPkts",
+    "interface_ifOutUcastPkts",
+    "interface_ifInOctets",
+    "interface_ifOutOctets",
+    "interface_ifHCInOctets",
+    "interface_ifHCOutOctets",
+    "device_total_incoming_traffic",
+    "device_total_outgoing_traffic",
+)
+
+
+def mark_existing_ifmib_metrics(apps, schema_editor):
+    Metric = apps.get_model("monitor", "Metric")
+    Metric.objects.filter(
+        is_pre=True,
+        name__in=IFMIB_METRIC_NAMES,
+        monitor_plugin__collect_type__startswith="snmp",
+    ).update(is_ifmib=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("monitor", "0057_monitorinstance_node_id_cmdb_id")]
+
+    operations = [
+        migrations.AddField(
+            model_name="metric",
+            name="is_ifmib",
+            field=models.BooleanField(default=False, verbose_name="是否来自公共IF-MIB"),
+        ),
+        migrations.RunPython(mark_existing_ifmib_metrics, migrations.RunPython.noop),
+    ]

--- a/server/apps/monitor/models/monitor_metrics.py
+++ b/server/apps/monitor/models/monitor_metrics.py
@@ -34,6 +34,7 @@ class Metric(TimeInfo, MaintainerInfo):
     description = models.TextField(blank=True, null=True, verbose_name="指标描述")
     dimensions = models.JSONField(default=list, verbose_name="维度")
     instance_id_keys = models.JSONField(default=list, verbose_name="实例ID键(由指标维度组成)")
+    is_ifmib = models.BooleanField(default=False, verbose_name="是否来自公共IF-MIB")
     is_pre = models.BooleanField(default=True, verbose_name="是否预定义")
     sort_order = models.IntegerField(default=0, verbose_name="排序")
 

--- a/server/apps/monitor/serializers/monitor_metrics.py
+++ b/server/apps/monitor/serializers/monitor_metrics.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from apps.monitor.models.monitor_metrics import MetricGroup, Metric
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.utils.instance_id_keys import resolve_metric_instance_id_keys
 
 
@@ -10,7 +10,21 @@ class MetricGroupSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = MetricGroup
-        fields = "__all__"
+        fields = [
+            "id",
+            "monitor_object",
+            "monitor_plugin",
+            "name",
+            "description",
+            "is_pre",
+            "sort_order",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "domain",
+            "updated_by_domain",
+        ]
 
     def validate(self, attrs):
         attrs = super().validate(attrs)
@@ -47,11 +61,37 @@ class MetricGroupSerializer(serializers.ModelSerializer):
 class MetricSerializer(serializers.ModelSerializer):
     # 这里定义 is_pre 但不给默认值，防止用户传递该字段
     is_pre = serializers.BooleanField(read_only=True)
+    is_ifmib = serializers.BooleanField(read_only=True)
     monitor_plugin_name = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Metric
-        fields = "__all__"
+        fields = [
+            "id",
+            "monitor_object",
+            "monitor_plugin",
+            "monitor_plugin_name",
+            "metric_group",
+            "name",
+            "display_name",
+            "query",
+            "view_query",
+            "view_config",
+            "unit",
+            "data_type",
+            "description",
+            "dimensions",
+            "instance_id_keys",
+            "is_ifmib",
+            "is_pre",
+            "sort_order",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "domain",
+            "updated_by_domain",
+        ]
 
     def _resolve_instance_id_keys(self, attrs, default_metric_keys=None):
         monitor_object = attrs.get("monitor_object", getattr(self.instance, "monitor_object", None))

--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -1009,9 +1009,16 @@ class InstanceConfigService:
                 except ValueError as exc:
                     raise BaseAppException(str(exc)) from exc
             if (config_obj.collect_type or "").startswith("snmp"):
+                from apps.monitor.utils.config_format import ConfigFormat
                 from apps.monitor.utils.snmp_interface_filters import normalize_snmp_interface_filter_config
+                from apps.monitor.utils.snmp_interface_template import has_interface_collection
 
-                child_info["content"] = normalize_snmp_interface_filter_config(child_info.get("content"))
+                # IF-MIB 是模板能力，而不是实例环境变量。child content 是首次下发时
+                # 已渲染的快照；编辑其他配置时不可按当前模板状态重建它，避免后续
+                # 关闭模板 IF-MIB 反向改变已开启实例的实际采集。
+                child_content = child_info.get("content")
+                if has_interface_collection(ConfigFormat.json_to_toml(child_content)):
+                    child_info["content"] = normalize_snmp_interface_filter_config(child_content)
             if (config_obj.config_type or "").lower() == "kafka":
                 from apps.monitor.utils.kafka_collect_timeouts import (
                     assert_kafka_group_metrics_timeout_lt_interval,

--- a/server/apps/monitor/services/plugin.py
+++ b/server/apps/monitor/services/plugin.py
@@ -269,6 +269,7 @@ class MonitorPluginService:
                 existing_metric.description = metric["description"]
                 existing_metric.dimensions = metric["dimensions"]
                 existing_metric.instance_id_keys = metric_instance_id_keys
+                existing_metric.is_ifmib = bool(metric.get("is_ifmib", False))
                 metrics_to_update.append(existing_metric)
             else:
                 metrics_to_create.append(
@@ -286,13 +287,26 @@ class MonitorPluginService:
                         description=metric["description"],
                         dimensions=metric["dimensions"],
                         instance_id_keys=metric_instance_id_keys,
+                        is_ifmib=bool(metric.get("is_ifmib", False)),
                     )
                 )
 
         if metrics_to_update:
             Metric.objects.bulk_update(
                 metrics_to_update,
-                ["metric_group_id", "display_name", "query", "view_query", "view_config", "unit", "data_type", "description", "dimensions", "instance_id_keys"],
+                [
+                    "metric_group_id",
+                    "display_name",
+                    "query",
+                    "view_query",
+                    "view_config",
+                    "unit",
+                    "data_type",
+                    "description",
+                    "dimensions",
+                    "instance_id_keys",
+                    "is_ifmib",
+                ],
                 batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
             )
 

--- a/server/apps/monitor/services/ui_template_locale.py
+++ b/server/apps/monitor/services/ui_template_locale.py
@@ -348,7 +348,11 @@ def enrich_ui_template_from_plugin_files(content: dict | None, plugin: MonitorPl
                             column[key] = deepcopy(value)
 
     if should_inject_snmp_interface_filters(plugin, enriched):
-        enriched = merge_snmp_interface_filter_ui(enriched)
+        enriched = merge_snmp_interface_filter_ui(enriched, plugin=plugin)
+    elif plugin is not None and str(getattr(plugin, "collect_type", "")).startswith("snmp"):
+        # 清除早期「所有 SNMP 都注入」遗留的 IF-MIB/过滤字段；没有公共接口表的
+        # 模板不能继续展示这些无效配置。
+        enriched = merge_snmp_interface_filter_ui(enriched, plugin=plugin)
 
     return enriched
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml
@@ -1,0 +1,47 @@
+[[inputs.snmp.table]]
+    oid = "1.3.6.1.2.1.2.2"
+    name = "interface"
+    inherit_tags = ["source"]
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.2"
+    name = "ifDescr"
+    is_tag = true
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.5"
+    name = "ifSpeed"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.7"
+    name = "ifAdminStatus"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.8"
+    name = "ifOperStatus"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.10"
+    name = "ifInOctets"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.11"
+    name = "ifInUcastPkts"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.13"
+    name = "ifInDiscards"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.14"
+    name = "ifInErrors"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.16"
+    name = "ifOutOctets"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.17"
+    name = "ifOutUcastPkts"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.19"
+    name = "ifOutDiscards"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.20"
+    name = "ifOutErrors"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.31.1.1.1.6"
+    name = "ifHCInOctets"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.31.1.1.1.10"
+    name = "ifHCOutOctets"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/firewall.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/firewall.child.toml.j2
@@ -30,11 +30,4 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    [[inputs.snmp.table]]
-        oid = "1.3.6.1.2.1.2.2"
-        name = "interface"
-        inherit_tags = ["source"]
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.2.2.1.2"
-        name = "ifDescr"
-        is_tag = true
+# @bk_include_ifmib_table

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/loadbalance.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/loadbalance.child.toml.j2
@@ -30,11 +30,4 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    [[inputs.snmp.table]]
-        oid = "1.3.6.1.2.1.2.2"
-        name = "interface"
-        inherit_tags = ["source"]
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.2.2.1.2"
-        name = "ifDescr"
-        is_tag = true
+# @bk_include_ifmib_table

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/router.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/router.child.toml.j2
@@ -30,11 +30,4 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    [[inputs.snmp.table]]
-        oid = "1.3.6.1.2.1.2.2"
-        name = "interface"
-        inherit_tags = ["source"]
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.2.2.1.2"
-        name = "ifDescr"
-        is_tag = true
+# @bk_include_ifmib_table

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/switch.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/switch.child.toml.j2
@@ -30,11 +30,4 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    [[inputs.snmp.table]]
-        oid = "1.3.6.1.2.1.2.2"
-        name = "interface"
-        inherit_tags = ["source"]
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.2.2.1.2"
-        name = "ifDescr"
-        is_tag = true
+# @bk_include_ifmib_table

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
@@ -32,7 +32,6 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    # ---- Interfaces (generic IF-MIB, auto-walked column names) ----
     [[inputs.snmp.table]]
         oid = "1.3.6.1.2.1.2.2"
         name = "interface"

--- a/server/apps/monitor/tests/test_metric_rest_plugin_contract.py
+++ b/server/apps/monitor/tests/test_metric_rest_plugin_contract.py
@@ -12,8 +12,8 @@ from apps.monitor.views.monitor_metrics import MetricViewSet
 
 
 @pytest.mark.django_db
-def test_metric_list_returns_monitor_plugin_name():
-    """展示列按 plugin+metric 解析元数据时，REST 指标列表必须返回插件内部名。"""
+def test_metric_list_returns_paginated_monitor_plugin_name():
+    """展示列按 plugin+metric 解析元数据时，分页指标接口仍返回插件内部名。"""
     monitor_object = MonitorObject.objects.create(
         name="MetricRestContractHost",
         display_name="MetricRestContractHost",
@@ -48,6 +48,7 @@ def test_metric_list_returns_monitor_plugin_name():
 
     response = MetricViewSet.as_view({"get": "list"})(request)
     payload = json.loads(response.content)
-    result = next(item for item in payload["data"] if item["id"] == metric.id)
+    result = next(item for item in payload["data"]["items"] if item["id"] == metric.id)
 
+    assert payload["data"]["count"] == 1
     assert result["monitor_plugin_name"] == plugin.name

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -26,6 +26,11 @@ _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "to_toml_str_array",
 )
 _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
+    # SNMP 接口过滤运行时注入片段的固定 Jinja 局部变量。
+    "_ifdescr_exclude",
+    "_ifdescr_include",
+    "_iftype_exclude",
+    "_iftype_include",
     "ENV_BEARER_TOKEN",
     "ENV_PASSWORD",
     "agents",
@@ -42,11 +47,13 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "dbname",
     "disk_exclude_fstypes",
     "disk_include_fstypes",
+    "enable_ifmib",
     "endpoint",
     "expect",
     "host",
     "ifdescr_exclude",
     "ifdescr_include",
+    "ifmib_capable",
     "iftype_exclude",
     "iftype_include",
     "insecure_skip_verify",
@@ -255,10 +262,13 @@ class Controller:
                     raise ValueError(f"无效的 instance_id 格式: {instance_id}") from e
 
         from apps.monitor.utils.snmp_interface_template import (
+            ensure_core_network_ifmib_jinja,
             ensure_snmp_interface_filter_jinja,
             needs_snmp_interface_filter_jinja,
+            validate_rendered_core_network_ifmib,
         )
 
+        template_content = ensure_core_network_ifmib_jinja(template_content, _context)
         # SNMP 接口过滤 Jinja 单一真相源：渲染前幂等注入，插件 child 模板无需复制
         if needs_snmp_interface_filter_jinja(template_content):
             template_content = ensure_snmp_interface_filter_jinja(template_content)
@@ -274,7 +284,9 @@ class Controller:
             raise BaseAppException(f"采集模板包含未授权变量: {e}") from e
 
         template = self.jinja_env.from_string(template_content)
-        return template.render(safe_context)
+        rendered_template = template.render(safe_context)
+        validate_rendered_core_network_ifmib(rendered_template, _context)
+        return rendered_template
 
     def format_configs(self):
         """
@@ -348,8 +360,9 @@ class Controller:
 
         plugin_id = self.data.get("monitor_plugin_id")
         plugin_template_id = None
+        plugin_obj = None
         if plugin_id:
-            plugin_obj = MonitorPlugin.objects.filter(id=plugin_id).only("template_id").first()
+            plugin_obj = MonitorPlugin.objects.filter(id=plugin_id).prefetch_related("monitor_object").first()
             if plugin_obj:
                 plugin_template_id = plugin_obj.template_id
         configs = self.format_configs()
@@ -391,6 +404,13 @@ class Controller:
                         "plugin_id": plugin_template_id or plugin_id,
                         "monitor_plugin_id": plugin_id,
                     }
+                    from apps.monitor.utils.snmp_ifmib_capability import is_ifmib_capable_plugin
+
+                    render_context["ifmib_capable"] = is_ifmib_capable_plugin(plugin_obj)
+                    if render_context["ifmib_capable"]:
+                        # IF-MIB 是本次下发选项。接入页默认启用；用户可以只对当前
+                        # 新实例关闭，已下发实例的 TOML 快照不会受影响。
+                        render_context.setdefault("enable_ifmib", True)
                     if collect_type == "snmp" and "iftype_exclude" not in render_context:
                         from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
 

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -411,11 +411,13 @@ class Controller:
                         # IF-MIB 是本次下发选项。接入页默认启用；用户可以只对当前
                         # 新实例关闭，已下发实例的 TOML 快照不会受影响。
                         render_context.setdefault("enable_ifmib", True)
-                    if collect_type == "snmp" and "iftype_exclude" not in render_context:
+                    # 与 IF-MIB 能力判定一致：覆盖 snmp / snmp_h3c 等厂商 collect_type。
+                    snmp_collect = str(collect_type or "").startswith("snmp")
+                    if snmp_collect and "iftype_exclude" not in render_context:
                         from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
 
                         render_context["iftype_exclude"] = list(DEFAULT_IFTYPE_EXCLUDE)
-                    if collect_type == "snmp" and is_child:
+                    if snmp_collect and is_child:
                         from apps.monitor.utils.snmp_interface_filters import (
                             assert_snmp_interface_filter_mutex_from_values,
                         )

--- a/server/apps/monitor/utils/snmp_ifmib_capability.py
+++ b/server/apps/monitor/utils/snmp_ifmib_capability.py
@@ -1,0 +1,92 @@
+"""公共 IF-MIB 能力与指标来源的唯一判定入口。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from django.db import DatabaseError
+
+from apps.core.logger import monitor_logger as logger
+
+NETWORK_DEVICE_TYPE_ID = "Network Device"
+COMMON_IFMIB_METRIC_NAMES = frozenset(
+    {
+        "interface_ifAdminStatus", "interface_ifOperStatus", "interface_ifSpeed",
+        "interface_ifInErrors", "interface_ifOutErrors", "interface_ifInDiscards",
+        "interface_ifOutDiscards", "interface_ifInUcastPkts", "interface_ifOutUcastPkts",
+        "interface_ifInOctets", "interface_ifOutOctets", "interface_ifHCInOctets",
+        "interface_ifHCOutOctets", "device_total_incoming_traffic",
+        "device_total_outgoing_traffic",
+    }
+)
+
+# 公共 IF-MIB 指标在中文控制台的唯一展示目录。采集器字段名保持 RFC/Prometheus
+# 命名，页面只通过此目录取得中文名称和说明。
+IFMIB_ZH_DISPLAY_TEXTS = {
+    "interface_ifAdminStatus": ("接口管理状态", "接口在设备配置中的启用或关闭状态。"),
+    "interface_ifOperStatus": ("接口运行状态", "接口当前实际运行状态。"),
+    "interface_ifSpeed": ("接口带宽", "接口支持的最大速率。"),
+    "interface_ifInErrors": ("接口接收错包速率", "按最近 5 分钟计算的每秒平均接收错误报文数。"),
+    "interface_ifOutErrors": ("接口发送错包速率", "按最近 5 分钟计算的每秒平均发送错误报文数。"),
+    "interface_ifInDiscards": ("接口接收丢弃包速率", "按最近 5 分钟计算的每秒平均接收丢弃报文数。"),
+    "interface_ifOutDiscards": ("接口发送丢弃包速率", "按最近 5 分钟计算的每秒平均发送丢弃报文数。"),
+    "interface_ifInUcastPkts": ("接口接收单播包速率", "按最近 5 分钟计算的每秒平均接收单播报文数。"),
+    "interface_ifOutUcastPkts": ("接口发送单播包速率", "按最近 5 分钟计算的每秒平均发送单播报文数。"),
+    "interface_ifInOctets": ("接口接收流量速率（32 位）", "按最近 5 分钟计算的每秒平均接收字节数。"),
+    "interface_ifOutOctets": ("接口发送流量速率（32 位）", "按最近 5 分钟计算的每秒平均发送字节数。"),
+    "interface_ifHCInOctets": ("接口接收流量速率（64 位）", "按最近 5 分钟计算的每秒平均接收字节数。"),
+    "interface_ifHCOutOctets": ("接口发送流量速率（64 位）", "按最近 5 分钟计算的每秒平均发送字节数。"),
+    "device_total_incoming_traffic": ("设备接收总流量速率", "按最近 5 分钟计算的所有接口每秒平均接收字节数。"),
+    "device_total_outgoing_traffic": ("设备发送总流量速率", "按最近 5 分钟计算的所有接口每秒平均发送字节数。"),
+}
+
+
+def _is_network_device_snmp_plugin(plugin: Any) -> bool:
+    """Return the single capability decision used by IF-MIB and interface filters."""
+    if plugin is None or not str(getattr(plugin, "collect_type", "")).startswith("snmp"):
+        return False
+    try:
+        if plugin.monitor_object.filter(type_id=NETWORK_DEVICE_TYPE_ID).exists():
+            return True
+    except (AttributeError, DatabaseError, TypeError) as exc:
+        logger.warning(f"读取 SNMP 模板对象能力失败: {exc}")
+
+    # 通用模板的存量数据库对象可能尚未补齐 type_id；回退到内置 manifest，避免
+    # 已固有 IF-MIB 接口表的 Router/Firewall 等模板失去接口过滤。
+    try:
+        from apps.monitor.services.plugin_guide import PluginGuideService
+
+        plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
+        metrics_file = Path(plugin_dir) / "metrics.json" if plugin_dir else None
+        if metrics_file is None or not metrics_file.is_file():
+            return False
+        return json.loads(metrics_file.read_text(encoding="utf-8")).get("type") == NETWORK_DEVICE_TYPE_ID
+    except (AttributeError, OSError, ValueError, TypeError) as exc:
+        logger.warning(f"读取 SNMP 模板内置能力失败: {exc}")
+        return False
+
+
+def is_ifmib_capable_plugin(plugin: Any) -> bool:
+    """Return whether a network-device SNMP plugin supports public IF-MIB."""
+    return _is_network_device_snmp_plugin(plugin)
+
+
+def is_interface_filter_capable_plugin(plugin: Any) -> bool:
+    """Only templates with IF-MIB may expose filters for the injected interface table."""
+    return _is_network_device_snmp_plugin(plugin)
+
+
+def is_ifmib_capable_plugin_data(plugin_data: dict[str, Any]) -> bool:
+    """Metadata-file adapter for the importer, with the same capability contract."""
+    collect_type = str(plugin_data.get("collect_type") or "")
+    return (
+        str(plugin_data.get("type") or "") == NETWORK_DEVICE_TYPE_ID
+        and (not collect_type or collect_type.startswith("snmp"))
+    )
+
+
+def is_ifmib_capable_render_context(context: dict[str, Any]) -> bool:
+    """Runtime adapter; Controller resolves plugin capability before template rendering."""
+    return context.get("ifmib_capable") is True

--- a/server/apps/monitor/utils/snmp_interface_template.py
+++ b/server/apps/monitor/utils/snmp_interface_template.py
@@ -3,21 +3,32 @@
 from __future__ import annotations
 
 import re
+import tomllib
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.monitor.constants.snmp_interface import (
     DEFAULT_IFTYPE_EXCLUDE,
     FILTER_TEMPLATE_VARS,
     IFTYPE_OID,
     IFTYPE_OPTIONS,
 )
+from apps.monitor.utils.snmp_ifmib_capability import (
+    is_ifmib_capable_plugin,
+    is_ifmib_capable_render_context,
+    is_interface_filter_capable_plugin,
+)
 
 FILTER_MARKER_BEGIN = "# ---- BK-Lite SNMP interface dimension filters (begin) ----"
 FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
 
+IFMIB_MARKER_BEGIN = "# ---- BK-Lite core IF-MIB collection (begin) ----"
+IFMIB_MARKER_END = "# ---- BK-Lite core IF-MIB collection (end) ----"
+
 FILTER_JINJA_BLOCK = f"""\
+{{% if enable_ifmib | default(true) %}}
     tagexclude = ["ifType"]
 {FILTER_MARKER_BEGIN}
 {{# ifType/ifDescr 黑白名单：空规则不输出对应键；默认排除由页面/创建注入，模板不做静默 fallback #}}
@@ -45,16 +56,70 @@ FILTER_JINJA_BLOCK = f"""\
 {{% endif %}}
 {{% endif %}}
 {FILTER_MARKER_END}
+{{% endif %}}
 """
 
 UI_ADVANCED_PANEL = {
-    "title": "接口过滤",
-    "title_en": "Interface Filters",
-    "hint": "按接口类型（ifType）和名称（ifDescr）配置排除或仅采集",
-    "hint_en": "Configure exclude or include filters by ifType and ifDescr",
+    "title": "接口采集与过滤",
+    "title_en": "Interface Collection and Filters",
+    "hint": "控制标准 IF-MIB 接口指标采集，并可按接口类型（ifType）和名称（ifDescr）过滤",
+    "hint_en": "Control standard IF-MIB collection and filter interfaces by ifType and ifDescr",
+}
+
+_UI_IFMIB_FIELD = {
+    "name": "enable_ifmib",
+    "label": "采集标准接口指标（IF-MIB）",
+    "label_en": "Collect Standard Interface Metrics (IF-MIB)",
+    "type": "switch",
+    "required": True,
+    "editable": True,
+    "advanced": False,
+    "default_value": True,
+    "description": "默认开启。用于采集标准接口状态、流量、错包和丢包。",
+    "description_en": "Enabled by default. Collects standard interface status, traffic, errors and discards.",
+    "tooltip": (
+        "建议开启：需要查看端口在线/关闭、接口速率与流量、错包或丢包时。\n\n"
+        "采集指标：接口名称和类型（ifDescr、ifType）、管理/运行状态、接口速率、入/出字节、"
+        "错误包、丢弃包、单播包，以及 64 位高速流量计数器（ifHCInOctets、ifHCOutOctets）。\n\n"
+        "适用场景：大多数支持标准 SNMP IF-MIB 的网络设备；开启后可在下方按接口类型或名称过滤。\n\n"
+        "建议关闭：设备不支持 IF-MIB、接口数量很大且只需厂商 CPU/内存/硬件健康指标，或希望减少采集量时。\n\n"
+        "作用范围：仅影响本次下发。复用内置公共模板，不会创建第二份采集配置；"
+        "关闭后厂商私有指标仍会采集。"
+    ),
+    "tooltip_en": (
+        "Recommended when you need port up/down state, interface speed and traffic, errors, or discards.\n\n"
+        "Metrics: interface name and type (ifDescr, ifType), admin/oper status, speed, inbound/outbound bytes, "
+        "errors, discards, unicast packets, and 64-bit high-capacity traffic counters (ifHCInOctets, ifHCOutOctets).\n\n"
+        "Use it for most network devices that support standard SNMP IF-MIB; when enabled, you can filter interfaces below by type or name.\n\n"
+        "Turn it off when the device does not support IF-MIB, has too many interfaces and you need only vendor "
+        "CPU/memory/hardware health, or you need to reduce collection volume.\n\n"
+        "Scope: this deployment only. It reuses the built-in common template and does not create a second collector "
+        "config. Vendor-private metrics remain collected when it is off."
+    ),
+}
+
+_UI_INTERFACE_FILTER_MODE_FIELD = {
+    "name": "interface_filter_mode",
+    "label": "接口采集策略",
+    "label_en": "Interface Collection Strategy",
+    "type": "segmented",
+    "required": False,
+    "editable": True,
+    "advanced": True,
+    "section": "interface_filter",
+    "default_value": "exclude",
+    "description": "默认排除虚拟接口；切换策略会清空另一侧的过滤条件。",
+    "description_en": "Virtual interfaces are excluded by default. Changing the strategy clears filters from the opposite strategy.",
+    "options": [
+        {"value": "all", "label": "全部采集", "label_en": "Collect All"},
+        {"value": "exclude", "label": "排除部分", "label_en": "Exclude Some"},
+        {"value": "include", "label": "仅采集部分", "label_en": "Include Only"},
+    ],
+    "dependency": {"field": "enable_ifmib", "value": True},
 }
 
 _UI_FILTER_FIELDS: list[dict[str, Any]] = [
+    _UI_INTERFACE_FILTER_MODE_FIELD,
     {
         "name": "iftype_exclude",
         "label": "排除的接口类型（ifType）",
@@ -64,8 +129,10 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
         "advanced": True,
         "section": "interface_filter",
         "default_value": list(DEFAULT_IFTYPE_EXCLUDE),
-        "description": "默认排除 Loopback/Virtual/Tunnel/L2VLAN/L3VLAN；清空则不再按类型排除。与「仅采集」互斥，不可选择相同类型。",
-        "description_en": "Defaults exclude Loopback/Virtual/Tunnel/L2VLAN/L3VLAN. Clear to disable type exclusion. Mutually exclusive with include list.",
+        "description": ("默认排除 Loopback/Virtual/Tunnel/L2VLAN/L3VLAN；清空则不再按类型排除。"
+                        "与「仅采集」互斥，不可选择相同类型。"),
+        "description_en": ("Defaults exclude Loopback/Virtual/Tunnel/L2VLAN/L3VLAN. Clear to disable type exclusion. "
+                           "Mutually exclusive with include list."),
         "options": IFTYPE_OPTIONS,
         "widget_props": {
             "mode": "tags",
@@ -96,8 +163,12 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
         "advanced": True,
         "section": "interface_filter",
         "default_value": [],
-        "description": "留空表示不限制类型。非空时只保留所选 ifType；与排除列表互斥。填写后本配置中的非接口指标将不再采集，一般建议优先使用排除黑名单。",
-        "description_en": "Leave empty for no type restriction. Mutually exclusive with exclude list. Non-empty keeps only matching interface metrics; non-interface metrics from this config will not be collected.",
+        "description": (
+            "留空表示不限制类型。非空时只保留所选 ifType；与排除列表互斥。填写后本配置中的非接口指标"
+            "将不再采集，一般建议优先使用排除黑名单。"
+        ),
+        "description_en": ("Leave empty for no type restriction. Mutually exclusive with exclude list. Non-empty keeps only "
+                           "matching interface metrics; non-interface metrics from this config will not be collected."),
         "options": IFTYPE_OPTIONS,
         "widget_props": {
             "mode": "tags",
@@ -128,7 +199,8 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
         "advanced": True,
         "section": "interface_filter",
         "default_value": "",
-        "description": "逗号分隔，支持通配符，例如 Loopback*,Vlan*,Null*。与「仅采集」名称列表互斥，不可填写相同条目。",
+        "description": ("逗号分隔，支持通配符，例如 Loopback*,Vlan*,Null*。与「仅采集」名称列表互斥，"
+                        "不可填写相同条目。"),
         "description_en": "Comma-separated globs, e.g. Loopback*,Vlan*,Null*. Mutually exclusive with include name list.",
         "widget_props": {
             "placeholder": "例如 Loopback*,Vlan*,Null*",
@@ -157,7 +229,8 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
         "advanced": True,
         "section": "interface_filter",
         "default_value": "",
-        "description": "留空表示不限制名称。非空时只保留名称匹配的接口；与排除名称列表互斥。与 ifType 白名单同时填写时需同时命中（AND）。",
+        "description": ("留空表示不限制名称。非空时只保留名称匹配的接口；与排除名称列表互斥。"
+                        "与 ifType 白名单同时填写时需同时命中（AND）。"),
         "description_en": "Leave empty for no name restriction. Mutually exclusive with exclude name list. Combined with ifType include uses AND.",
         "widget_props": {
             "placeholder": "不限制；例如 GigabitEthernet*,Eth-Trunk*",
@@ -190,6 +263,10 @@ INTERFACE_HINT_RE = re.compile(
     r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.2\.2"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.31\.1\.1"',
     re.MULTILINE,
 )
+IFMIB_HINT_RE = re.compile(
+    r'name\s*=\s*"ifDescr"|oid\s*=\s*"1\.3\.6\.1\.2\.1\.(?:2\.2|31\.1\.1)"',
+    re.MULTILINE,
+)
 TABLE_BLOCK_RE = re.compile(
     r"^[ \t]*\[\[inputs\.snmp\.table\]\][^\n]*\n.*?"
     r"(?=^[ \t]*\[\[(?!inputs\.snmp\.table\.field\]\])|\Z)",
@@ -205,10 +282,50 @@ FILTER_BLOCK_RE = re.compile(
     re.DOTALL,
 )
 TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
+SNMP_INPUT_RE = re.compile(r"^\s*\[\[inputs\.snmp\]\]", re.MULTILINE)
+
+# 所有网络设备共用这一个 IF-MIB 模板；它仅声明 ifDescr tag，Telegraf walk 完整接口表。
+COMMON_IFMIB_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[1] / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
+)
 
 
-def get_ui_filter_fields() -> list[dict[str, Any]]:
-    return deepcopy(_UI_FILTER_FIELDS)
+def get_common_ifmib_table_block() -> str:
+    """从唯一通用 IF-MIB 模板读取接口表，供厂商单 child 配置复用。"""
+    try:
+        interface_table = COMMON_IFMIB_TEMPLATE_PATH.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise RuntimeError(f"无法读取通用 IF-MIB 模板: {COMMON_IFMIB_TEMPLATE_PATH}") from exc
+    if not IFMIB_HINT_RE.search(interface_table):
+        raise RuntimeError(f"通用 IF-MIB 模板缺少接口表: {COMMON_IFMIB_TEMPLATE_PATH}")
+    return interface_table
+
+
+def get_common_ifmib_jinja_block() -> str:
+    return (
+        f"{IFMIB_MARKER_BEGIN}\n"
+        "{% if enable_ifmib | default(true) %}\n"
+        f"{get_common_ifmib_table_block()}\n"
+        f"{IFTYPE_FIELD_BLOCK.rstrip()}\n"
+        "{% endif %}\n"
+        f"{IFMIB_MARKER_END}"
+    )
+
+
+def get_ui_filter_fields(include_ifmib: bool = False) -> list[dict[str, Any]]:
+    fields = [deepcopy(_UI_IFMIB_FIELD)] if include_ifmib else []
+    fields.extend(deepcopy(_UI_FILTER_FIELDS))
+    for field in fields:
+        if field.get("name") in FILTER_TEMPLATE_VARS:
+            if not include_ifmib:
+                field.pop("dependency", None)
+                continue
+            mode = "include" if field["name"].endswith("_include") else "exclude"
+            field["dependency"] = {
+                "field": ["enable_ifmib", "interface_filter_mode"],
+                "conditions": [[{"equals": True}], [{"equals": mode}]],
+            }
+    return fields
 
 
 def get_ui_advanced_panel() -> dict[str, Any]:
@@ -219,32 +336,90 @@ def has_interface_collection(template_content: str) -> bool:
     return bool(INTERFACE_HINT_RE.search(template_content or ""))
 
 
+def _strip_ifmib_tables(template_content: str) -> str:
+    """删除各厂商复制的 IF-MIB table，绝不删除私有 OID table。"""
+
+    def strip_table(table_match: re.Match[str]) -> str:
+        table_text = table_match.group(0)
+        return "" if IFMIB_HINT_RE.search(table_text) else table_text
+
+    text = TABLE_BLOCK_RE.sub(strip_table, template_content)
+    text = re.sub(
+        re.escape(IFMIB_MARKER_BEGIN) + r".*?" + re.escape(IFMIB_MARKER_END) + r"\n?",
+        "",
+        text,
+        flags=re.DOTALL,
+    )
+    return re.sub(r"\n{3,}", "\n\n", text)
+
+
+def should_manage_core_network_ifmib(context: dict[str, Any]) -> bool:
+    return is_ifmib_capable_render_context(context)
+
+
+def ensure_core_network_ifmib_jinja(template_content: str, context: dict[str, Any]) -> str:
+    """复用通用 SNMP 模板的 IF-MIB 表，厂商模板仅保留私有 OID。"""
+    if not should_manage_core_network_ifmib(context):
+        return template_content
+
+    text = _strip_ifmib_tables(template_content)
+    return f"{text.rstrip()}\n\n{get_common_ifmib_jinja_block()}\n"
+
+
+def _get_snmp_input_tables(config: dict[str, Any]) -> list[dict[str, Any]]:
+    inputs = config.get("inputs")
+    if not isinstance(inputs, dict):
+        return []
+    snmp_inputs = inputs.get("snmp")
+    if not isinstance(snmp_inputs, list):
+        return []
+    return [table for snmp_input in snmp_inputs if isinstance(snmp_input, dict) for table in snmp_input.get("table", []) if isinstance(table, dict)]
+
+
+def validate_rendered_core_network_ifmib(template_content: str, context: dict[str, Any]) -> None:
+    """在下发前校验最终 SNMP TOML，拒绝公共 IF-MIB 与厂商配置的结构冲突。"""
+    if not should_manage_core_network_ifmib(context) or not SNMP_INPUT_RE.search(template_content):
+        return
+
+    try:
+        config = tomllib.loads(template_content)
+    except tomllib.TOMLDecodeError as exc:
+        message = "SNMP IF-MIB 配置冲突：最终 TOML 无法解析，请检查重复的接口表或 tagpass/tagdrop 段"
+        raise ValidationAppException(f"{message}：{exc}") from exc
+
+    interface_tables = [table for table in _get_snmp_input_tables(config) if table.get("name") == "interface"]
+    enabled = context.get("enable_ifmib", True) is not False
+    if enabled:
+        if len(interface_tables) != 1:
+            raise ValidationAppException(
+                "SNMP IF-MIB 配置冲突：启用标准接口监控时必须且只能有一张接口表，"
+                f"当前为 {len(interface_tables)} 张"
+            )
+
+        fields = interface_tables[0].get("field")
+        if not isinstance(fields, list):
+            raise ValidationAppException("SNMP IF-MIB 配置冲突：公共接口表缺少字段定义")
+        field_names = [field.get("name") for field in fields if isinstance(field, dict)]
+        if len(field_names) != len(set(field_names)):
+            raise ValidationAppException("SNMP IF-MIB 配置冲突：公共接口表存在重复字段")
+        if field_names.count("ifType") != 1:
+            raise ValidationAppException("SNMP IF-MIB 配置冲突：公共接口表必须且只能包含一个 ifType 过滤标签")
+        return
+
+    if interface_tables:
+        raise ValidationAppException("SNMP IF-MIB 配置冲突：关闭标准接口监控后仍渲染了接口表")
+
+    for table in _get_snmp_input_tables(config):
+        fields = table.get("field")
+        if isinstance(fields, list) and any(field.get("name") == "ifType" for field in fields if isinstance(field, dict)):
+            raise ValidationAppException("SNMP IF-MIB 配置冲突：关闭标准接口监控后仍渲染了 ifType 过滤标签")
+
+
 def should_inject_snmp_interface_filters(plugin: Any, content: dict | None = None) -> bool:
-    """判断是否应注入接口过滤 UI（collect_type / 表单指纹 / 插件目录）。"""
-    if plugin is not None and getattr(plugin, "collect_type", None) == "snmp":
-        return True
-
-    if isinstance(content, dict):
-        names = {
-            str(field.get("name") or "")
-            for field in (content.get("form_fields") or [])
-            if isinstance(field, dict)
-        }
-        if {"port", "version", "community"} <= names:
-            return True
-        if {"port", "version", "sec_name"} <= names:
-            return True
-
-    if plugin is not None:
-        try:
-            from apps.monitor.services.plugin_guide import PluginGuideService
-
-            plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
-        except Exception:
-            plugin_dir = None
-        if plugin_dir is not None and "snmp" in Path(plugin_dir).parts:
-            return True
-    return False
+    """仅对会渲染公共 IF-MIB 表的网络设备注入接口过滤 UI。"""
+    # 过滤依赖公共接口表内的 ifDescr / ifType。不能仅凭「这是 SNMP」就注入，
+    # 否则未采集接口指标的模板会出现无效过滤项。
+    return is_interface_filter_capable_plugin(plugin)
 
 
 def needs_snmp_interface_filter_jinja(template_content: str) -> bool:
@@ -290,7 +465,9 @@ def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
     if not needs_snmp_interface_filter_jinja(template_content):
         return template_content
 
-    text = ensure_iftype_tag_fields(template_content)
+    # 核心网络模板的公共 IF-MIB 条件块已在同一块内声明 ifType；再次用
+    # 正则插入会跨越 Jinja endif，把字段遗留在关闭块之外。
+    text = template_content if IFMIB_MARKER_BEGIN in template_content else ensure_iftype_tag_fields(template_content)
     text = FILTER_BLOCK_RE.sub("", text)
     text = TAGEXCLUDE_IFTYPE_RE.sub("", text)
     text = re.sub(r"\n{3,}", "\n\n", text)
@@ -305,7 +482,7 @@ def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
     return f"{before}\n\n{block}\n"
 
 
-def merge_snmp_interface_filter_ui(content: dict | None) -> dict | None:
+def merge_snmp_interface_filter_ui(content: dict | None, plugin: Any = None) -> dict | None:
     """用常量四字段 + advanced_panel 覆盖/补齐 UI 模板（SNMP 运行时注入）。"""
     if not content:
         return content
@@ -316,13 +493,18 @@ def merge_snmp_interface_filter_ui(content: dict | None) -> dict | None:
         form_fields = []
         enriched["form_fields"] = form_fields
 
-    filter_names = set(FILTER_TEMPLATE_VARS)
+    include_ifmib = is_ifmib_capable_plugin(plugin)
+    include_filters = is_interface_filter_capable_plugin(plugin)
+    filter_names = set(FILTER_TEMPLATE_VARS) | {"enable_ifmib", "interface_filter_mode"}
     kept = [
         field
         for field in form_fields
         if not (isinstance(field, dict) and field.get("name") in filter_names)
     ]
-    kept.extend(get_ui_filter_fields())
     enriched["form_fields"] = kept
+    if not include_filters:
+        return enriched
+
+    enriched["form_fields"].extend(get_ui_filter_fields(include_ifmib=include_ifmib))
     enriched["advanced_panel"] = get_ui_advanced_panel()
     return enriched

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -1,17 +1,181 @@
+from django.db.models import Q, Subquery
 from rest_framework import viewsets
 from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
 
-from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.web_utils import WebUtils
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.constants.language import LanguageConstants
-from apps.monitor.filters.monitor_metrics import MetricGroupFilter, MetricFilter
+from apps.monitor.filters.monitor_metrics import MetricFilter, MetricGroupFilter
+from apps.monitor.models import MonitorPlugin
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
-from apps.monitor.models.monitor_metrics import MetricGroup, Metric
+from apps.monitor.utils.snmp_ifmib_capability import IFMIB_ZH_DISPLAY_TEXTS
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
-from config.drf.pagination import CustomPageNumberPagination
+
+
+class MetricCatalogPagination(PageNumberPagination):
+    """Bound metric catalog requests so a template cannot trigger an unbounded read."""
+
+    page_size = 100
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+    def get_paginated_response(self, data):
+        return Response({"count": self.page.paginator.count, "items": data})
+
+
+IFMIB_RATE_DISPLAY_NAMES = {
+    "interface_ifInOctets": {
+        "zh-Hans": "接口接收流量速率（32 位）",
+        "en": "Interface Incoming Traffic Rate (32-bit)",
+    },
+    "interface_ifOutOctets": {
+        "zh-Hans": "接口发送流量速率（32 位）",
+        "en": "Interface Outgoing Traffic Rate (32-bit)",
+    },
+    "interface_ifHCInOctets": {
+        "zh-Hans": "接口接收流量速率（64 位）",
+        "en": "Interface Incoming Traffic Rate (64-bit)",
+    },
+    "interface_ifHCOutOctets": {
+        "zh-Hans": "接口发送流量速率（64 位）",
+        "en": "Interface Outgoing Traffic Rate (64-bit)",
+    },
+    "device_total_incoming_traffic": {
+        "zh-Hans": "设备接收总流量速率",
+        "en": "Device Total Incoming Traffic Rate",
+    },
+    "device_total_outgoing_traffic": {
+        "zh-Hans": "设备发送总流量速率",
+        "en": "Device Total Outgoing Traffic Rate",
+    },
+}
+
+
+def get_ifmib_rate_display_name(metric_name, locale):
+    """Return an unambiguous IF-MIB rate label independent of vendor-local translations."""
+    translations = IFMIB_RATE_DISPLAY_NAMES.get(metric_name)
+    if translations is None:
+        return None
+    return translations["zh-Hans"] if str(locale).startswith("zh") else translations["en"]
+
+
+def get_ifmib_display_text(metric_name, locale):
+    """Return localized public IF-MIB label and description without vendor fallbacks."""
+    if not str(locale).startswith("zh"):
+        return None
+    return IFMIB_ZH_DISPLAY_TEXTS.get(metric_name)
+
+
+def get_optional_query_param_id(request, param_name):
+    """Read an optional positive integer query parameter without leaking ORM errors."""
+    return parse_optional_positive_id(request.query_params.get(param_name), param_name)
+
+
+def get_snmp_base_plugin(request, monitor_object_id):
+    """返回厂商 SNMP 模板应复用的同对象通用 SNMP 指标插件。"""
+    plugin_id = get_optional_query_param_id(request, "monitor_plugin_id")
+    if not plugin_id:
+        return None
+    plugin = MonitorPlugin.objects.filter(id=plugin_id, monitor_object__id=monitor_object_id).first()
+    if (
+        plugin is None
+        or plugin.collect_type == "snmp"
+        or not str(plugin.collect_type or "").startswith("snmp_")
+        or plugin.template_type != "builtin"
+        or not plugin.monitor_object.filter(type_id="Network Device").exists()
+    ):
+        return None
+    return (
+        MonitorPlugin.objects.filter(
+            monitor_object__id=monitor_object_id,
+            collector="Telegraf",
+            collect_type="snmp",
+            template_type="builtin",
+        )
+        .order_by("id")
+        .first()
+    )
+
+
+def apply_inherited_group_filters(queryset, query_params):
+    """Apply user-facing group filters to the inherited public catalog."""
+    name = query_params.get("name")
+    if name:
+        queryset = queryset.filter(name=name)
+    keyword = str(query_params.get("keyword") or "").strip()
+    if keyword:
+        queryset = queryset.filter(Q(name__icontains=keyword) | Q(description__icontains=keyword))
+    return queryset
+
+
+def apply_inherited_metric_filters(queryset, query_params):
+    """Apply the same catalog filters to inherited IF-MIB metrics without the vendor plugin constraint."""
+    metric_id = parse_optional_positive_id(query_params.get("id"), "id")
+    if metric_id:
+        queryset = queryset.filter(id=metric_id)
+    metric_ids = parse_optional_positive_id_list(query_params.get("id_in"), "id_in")
+    if metric_ids:
+        queryset = queryset.filter(id__in=metric_ids)
+    name = query_params.get("name")
+    if name:
+        queryset = queryset.filter(name=name)
+    names = query_params.get("name_in")
+    if names:
+        queryset = queryset.filter(name__in=[value for value in names.split(",") if value])
+    keyword = str(query_params.get("keyword") or "").strip()
+    if keyword:
+        queryset = queryset.filter(
+            Q(name__icontains=keyword)
+            | Q(display_name__icontains=keyword)
+            | Q(description__icontains=keyword)
+        )
+    return queryset
+
+
+def parse_optional_positive_id(value, param_name):
+    if value in (None, ""):
+        return None
+    try:
+        normalized_value = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValidationAppException(f"{param_name} 必须为正整数") from exc
+    if normalized_value <= 0:
+        raise ValidationAppException(f"{param_name} 必须为正整数")
+    return normalized_value
+
+
+def parse_optional_positive_id_list(value, param_name):
+    if value in (None, ""):
+        return None
+    raw_values = [item.strip() for item in str(value).split(",") if item.strip()]
+    if not raw_values:
+        return None
+    return [parse_optional_positive_id(item, param_name) for item in raw_values]
+
+
+def merge_inherited_metric_groups(vendor_groups, base_groups):
+    """Compatibility helper for pure callers; list endpoints merge in SQL instead."""
+    vendor_names = {group.name for group in vendor_groups}
+    return [*vendor_groups, *(group for group in base_groups if group.name not in vendor_names)]
+
+
+def merge_inherited_metrics(vendor_metrics, base_metrics, vendor_groups_by_name, base_groups_by_id):
+    """Compatibility helper for pure callers; list endpoints merge in SQL instead."""
+    vendor_names = {metric.name for metric in vendor_metrics}
+    merged = list(vendor_metrics)
+    for metric in base_metrics:
+        if metric.name not in vendor_names:
+            target_group = vendor_groups_by_name.get(base_groups_by_id.get(metric.metric_group_id))
+            if target_group is not None:
+                metric.metric_group_id = target_group.id
+            merged.append(metric)
+    return merged
 
 
 def collect_vm_field_names(metric_obj):
@@ -44,7 +208,7 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
     queryset = MetricGroup.objects.all().order_by("sort_order")
     serializer_class = MetricGroupSerializer
     filterset_class = MetricGroupFilter
-    pagination_class = CustomPageNumberPagination
+    pagination_class = MetricCatalogPagination
 
     @staticmethod
     def _ensure_modifiable(metric_group):
@@ -64,8 +228,26 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        serializer = self.get_serializer(queryset, many=True)
+        monitor_object_id = get_optional_query_param_id(request, "monitor_object_id")
+        vendor_groups = self.filter_queryset(self.get_queryset()).order_by()
+        base_plugin = get_snmp_base_plugin(request, monitor_object_id)
+        if base_plugin is not None:
+            vendor_group_names = MetricGroup.objects.filter(
+                monitor_object_id=monitor_object_id,
+                monitor_plugin_id=request.query_params.get("monitor_plugin_id"),
+            )
+            base_groups = MetricGroup.objects.filter(
+                monitor_object_id=monitor_object_id,
+                monitor_plugin=base_plugin,
+            ).order_by()
+            base_groups = apply_inherited_group_filters(base_groups, request.query_params)
+            queryset = vendor_groups.union(
+                base_groups.exclude(name__in=Subquery(vendor_group_names.values("name")))
+            ).order_by("sort_order", "id")
+        else:
+            queryset = vendor_groups.order_by("sort_order", "id")
+        page = self.paginate_queryset(queryset)
+        serializer = self.get_serializer(page, many=True)
         results = serializer.data
 
         # 获取监控对象ID与名称的映射
@@ -87,7 +269,7 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
             # 获取语言配置值
             result["display_name"] = lan.get(lan_key) or result["name"]
 
-        return WebUtils.response_success(results)
+        return WebUtils.response_success(self.get_paginated_response(results).data)
 
     @action(detail=False, methods=["post"])
     def set_order(self, request, *args, **kwargs):
@@ -109,7 +291,7 @@ class MetricViewSet(viewsets.ModelViewSet):
     queryset = Metric.objects.select_related("monitor_object", "monitor_plugin").all().order_by("sort_order")
     serializer_class = MetricSerializer
     filterset_class = MetricFilter
-    pagination_class = CustomPageNumberPagination
+    pagination_class = MetricCatalogPagination
 
     @staticmethod
     def _ensure_modifiable(metric):
@@ -129,8 +311,55 @@ class MetricViewSet(viewsets.ModelViewSet):
         return super().destroy(request, *args, **kwargs)
 
     def list(self, request, *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        serializer = self.get_serializer(queryset, many=True)
+        # Do not union a select_related queryset: joins would make the two SELECT
+        # column sets differ. The bounded page is hydrated below in one query.
+        monitor_object_id = get_optional_query_param_id(request, "monitor_object_id")
+        vendor_metrics = self.filter_queryset(Metric.objects.all()).order_by()
+        base_plugin = get_snmp_base_plugin(request, monitor_object_id)
+        if str(request.query_params.get("include_ifmib", "true")).lower() == "false":
+            base_plugin = None
+        if base_plugin is not None:
+            vendor_metric_names = Metric.objects.filter(
+                monitor_object_id=monitor_object_id,
+                monitor_plugin_id=request.query_params.get("monitor_plugin_id"),
+            )
+            base_metrics = Metric.objects.filter(
+                monitor_object_id=monitor_object_id,
+                monitor_plugin=base_plugin,
+            ).order_by()
+            base_metrics = apply_inherited_metric_filters(base_metrics, request.query_params)
+            queryset = vendor_metrics.union(
+                base_metrics.exclude(name__in=Subquery(vendor_metric_names.values("name")))
+            ).order_by("sort_order", "id")
+        else:
+            queryset = vendor_metrics.order_by("sort_order", "id")
+        page = self.paginate_queryset(queryset)
+        page_metric_ids = [metric.id for metric in page]
+        page_metrics = Metric.objects.filter(id__in=page_metric_ids).select_related(
+            "metric_group", "monitor_object", "monitor_plugin"
+        )
+        metrics_by_id = {metric.id: metric for metric in page_metrics}
+        page = [metrics_by_id[metric_id] for metric_id in page_metric_ids]
+
+        if base_plugin is not None:
+            base_group_names = {
+                metric.metric_group.name
+                for metric in page
+                if metric.monitor_plugin_id == base_plugin.id
+            }
+            vendor_groups_by_name = {
+                group.name: group.id
+                for group in MetricGroup.objects.filter(
+                    monitor_object_id=monitor_object_id,
+                    monitor_plugin_id=request.query_params.get("monitor_plugin_id"),
+                    name__in=base_group_names,
+                )
+            }
+            for metric in page:
+                if metric.monitor_plugin_id == base_plugin.id:
+                    metric.metric_group_id = vendor_groups_by_name.get(metric.metric_group.name, metric.metric_group_id)
+
+        serializer = self.get_serializer(page, many=True)
         results = serializer.data
 
         # 获取监控对象ID与名称的映射
@@ -149,11 +378,33 @@ class MetricViewSet(viewsets.ModelViewSet):
                 continue
             # 组装语言配置Key（基于监控对象名称）
             lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC}.{object_name}.{result['name']}"
-            # 获取语言配置值
-            result["display_name"] = lan.get(f"{lan_key}.name") or result["display_name"]
-            result["display_description"] = lan.get(f"{lan_key}.desc") or result["description"]
+            # HC 与 32 位计数器必须在名称中直接区分，不能被厂商旧翻译覆盖为同名。
+            ifmib_text = get_ifmib_display_text(result["name"], request.user.locale) if result.get("is_ifmib") else None
+            result["display_name"] = (
+                (ifmib_text[0] if ifmib_text else None)
+                or get_ifmib_rate_display_name(result["name"], request.user.locale)
+                or lan.get(f"{lan_key}.name")
+                or result["display_name"]
+            )
+            result["display_description"] = (
+                (ifmib_text[1] if ifmib_text else None)
+                or lan.get(f"{lan_key}.desc")
+                or result["description"]
+            )
 
-        return WebUtils.response_success(results)
+        metric_groups = MetricGroup.objects.filter(
+            id__in={metric.metric_group_id for metric in page}
+        ).order_by("sort_order", "id")
+        metric_group_results = MetricGroupSerializer(metric_groups, many=True).data
+        for result in metric_group_results:
+            object_name = object_map.get(result.get("monitor_object"))
+            if object_name:
+                lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC_GROUP}.{object_name}.{result['name']}"
+                result["display_name"] = lan.get(lan_key) or result["name"]
+
+        response_data = self.get_paginated_response(results).data
+        response_data["metric_groups"] = metric_group_results
+        return WebUtils.response_success(response_data)
 
     @action(detail=False, methods=["post"])
     def set_order(self, request, *args, **kwargs):

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -33,6 +33,16 @@ class Sidecar:
     CONVERGE_DEBOUNCE_SECONDS = 5
     CPU_ARCHITECTURE_TAG = "cpu_architecture"
     INSTALL_TASK_NODE_TAG = "install_task_node"
+    BASE_CONFIG_HEADER = "# ---- BK-Lite collector base configuration (shared by all monitoring templates) ----\n"
+    INSTANCE_CONFIG_HEADER = "# ---- BK-Lite instance collection configurations (per monitoring template) ----\n"
+
+    @classmethod
+    def add_config_section_headers(cls, config_template: str, has_child_configs: bool) -> str:
+        """为最终下发文件标明采集器基础配置与实例采集配置的边界。"""
+        merged_template = f"{cls.BASE_CONFIG_HEADER}{(config_template or '').lstrip()}"
+        if has_child_configs:
+            merged_template += f"\n{cls.INSTANCE_CONFIG_HEADER}"
+        return merged_template
 
     @staticmethod
     def generate_etag(data):
@@ -650,15 +660,17 @@ class Sidecar:
         node = assignment.node
         configuration = assignment.collector_config
 
-        # 合并子配置内容到模板
-        merged_template = configuration.config_template
-
         collector = configuration.collector
         section_headers = {}
         if collector.default_config:
             section_headers = collector.default_config.get("config_section", {})
 
         child_configs = list(configuration.childconfig_set.all())
+        # 合并子配置内容到模板。显式分段避免将采集器的全局监听/处理逻辑误认为某个实例模板。
+        merged_template = Sidecar.add_config_section_headers(
+            configuration.config_template,
+            has_child_configs=bool(child_configs),
+        )
         child_render_variables = Sidecar.collect_child_render_variables(child_configs)
 
         if child_configs and section_headers:

--- a/server/apps/node_mgmt/tests/test_b75_sidecar_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_sidecar_service.py
@@ -95,6 +95,13 @@ def test_get_node_or_404_missing():
 # --------------------------------------------------------------------------- #
 # configuration_bound_to_node / get_bound_*
 # --------------------------------------------------------------------------- #
+def test_config_section_headers_separate_base_and_instance_templates():
+    template = Sidecar.add_config_section_headers("\n[[inputs.netflow]]", has_child_configs=True)
+
+    assert template.index(Sidecar.BASE_CONFIG_HEADER.strip()) < template.index("[[inputs.netflow]]")
+    assert template.index(Sidecar.INSTANCE_CONFIG_HEADER.strip()) > template.index("[[inputs.netflow]]")
+
+
 @pytest.mark.django_db
 def test_configuration_bound_to_node(node):
     collector = Collector.objects.create(

--- a/web/src/app/monitor/(pages)/event/alert/alertDetail.tsx
+++ b/web/src/app/monitor/(pages)/event/alert/alertDetail.tsx
@@ -124,7 +124,7 @@ const AlertDetail = forwardRef<ModalRef, ModalConfig>(
     const getMetrics = async (row: TableDataItem, id: React.Key) => {
       setPageLoading(true);
       try {
-        const data = await getMonitorMetrics({ monitor_object_id: id });
+        const { items: data } = await getMonitorMetrics({ monitor_object_id: id });
         const metricInfo =
           data.find(
             (item: MetricItem) =>

--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -640,9 +640,9 @@ const StrategyOperation = () => {
       const getMetrics = getMonitorMetrics(params);
       Promise.all([getGroupList, getMetrics])
         .then((res) => {
-          const metricData = cloneDeep(res[1] || []);
-          setMetrics(res[1] || []);
-          const groupData = res[0].map((item: GroupInfo) => ({
+          const metricData = cloneDeep(res[1].items);
+          setMetrics(res[1].items);
+          const groupData = res[0].items.map((item: GroupInfo) => ({
             ...item,
             child: []
           }));
@@ -659,7 +659,7 @@ const StrategyOperation = () => {
           );
           setOriginMetricData(_groupData);
           if (type === 'init') {
-            setInitMetricData(res[1] || []);
+            setInitMetricData(res[1].items);
           }
         })
         .finally(() => {

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -1,5 +1,5 @@
 import { ModalRef, ModalProps, TableDataItem } from '@/app/monitor/types';
-import { Form, Button, message, Spin, Empty } from 'antd';
+import { Form, Button, message, Spin, Empty, Alert } from 'antd';
 import { cloneDeep } from 'lodash';
 import React, {
   useState,
@@ -17,6 +17,15 @@ import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
 } from '@/app/monitor/hooks/integration/snmpFilterMutex';
+import { getIfmibSnapshotEnabled } from '../list/detail/configure/ifmibDeploymentState';
+
+interface PluginFormField {
+  name?: string;
+}
+
+interface PluginConfig {
+  form_fields?: PluginFormField[];
+}
 
 const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const [form] = Form.useForm();
@@ -29,7 +38,7 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const [modalVisible, setModalVisible] = useState<boolean>(false);
   const [title, setTitle] = useState<string>('');
   const [configForm, setConfigForm] = useState<TableDataItem>({});
-  const [currentConfig, setCurrentConfig] = useState<any>(null);
+  const [currentConfig, setCurrentConfig] = useState<PluginConfig | null>(null);
   const [configLoading, setConfigLoading] = useState<boolean>(false);
 
   useImperativeHandle(ref, () => ({
@@ -80,6 +89,11 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
   const formItems = useMemo(() => {
     return configsInfo.formItems;
   }, [configsInfo]);
+  const supportsIfmib = Boolean(currentConfig?.form_fields?.some((field) => field.name === 'enable_ifmib'));
+  const ifmibSnapshotEnabled = getIfmibSnapshotEnabled(
+    configForm as Record<string, unknown>,
+    supportsIfmib,
+  );
 
   useEffect(() => {
     if (configsInfo?.getDefaultForm && configForm && !configLoading) {
@@ -89,6 +103,13 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
 
   const initData = (row: TableDataItem) => {
     const activeFormData = configsInfo.getDefaultForm?.(row) || {};
+    const snapshotEnabled = getIfmibSnapshotEnabled(
+      row as Record<string, unknown>,
+      Boolean(currentConfig?.form_fields?.some((field) => field.name === 'enable_ifmib')),
+    );
+    if (snapshotEnabled !== undefined) {
+      activeFormData.enable_ifmib = snapshotEnabled;
+    }
     form.setFieldsValue(activeFormData);
     // 用当前值初始化互斥追踪基线，避免默认排除被误判为“后填写”
     trackSnmpFilterMutexLastChanged({}, form.getFieldsValue(true), form);
@@ -123,8 +144,9 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
       message.success(t('common.successfullyModified'));
       handleCancel();
       onSuccess();
-    } catch (error: any) {
-      message.error(error?.message || t('common.operationFailed'));
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : '';
+      message.error(errorMessage || t('common.operationFailed'));
     } finally {
       setConfirmLoading(false);
     }
@@ -158,6 +180,17 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
       <div className="px-[10px]">
         <Spin spinning={configLoading} className="w-full">
           <div style={{ minHeight: configLoading ? '200px' : 'auto' }}>
+            {ifmibSnapshotEnabled !== undefined && (
+              <Alert
+                className="mb-3"
+                type={ifmibSnapshotEnabled ? 'info' : 'warning'}
+                showIcon
+                message={t(ifmibSnapshotEnabled
+                  ? 'monitor.integrations.ifmibSnapshotEnabled'
+                  : 'monitor.integrations.ifmibSnapshotDisabled')}
+                description={t('monitor.integrations.ifmibSnapshotDescription')}
+              />
+            )}
             {showEmpty ? (
               <Empty description={t('monitor.integrations.noConfigData')} />
             ) : (

--- a/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
@@ -127,9 +127,9 @@ const RuleModal = forwardRef<ModalRef, ModalProps>(
         const getMetrics = getMonitorMetrics(params);
         Promise.all([getGroupList, getMetrics])
           .then((res) => {
-            const metricData = cloneDeep(res[1] || []);
-            setMetrics(res[1] || []);
-            const groupData = res[0].map((item: GroupInfo) => ({
+            const metricData = cloneDeep(res[1].items);
+            setMetrics(res[1].items);
+            const groupData = res[0].items.map((item: GroupInfo) => ({
               ...item,
               child: []
             }));

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -47,6 +47,11 @@ import {
   FormFieldDependency,
   isDependencySatisfied
 } from '@/app/monitor/hooks/integration/formFieldDependency';
+import {
+  applyIfmibDeploymentState,
+  getIfmibDeploymentPatch
+} from './ifmibDeploymentState';
+import { getSnmpInterfaceFilterModePatch } from '@/app/monitor/hooks/integration/snmpInterfaceFilterMode';
 const { confirm } = Modal;
 
 interface CollectDetectState {
@@ -83,6 +88,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
   const groupId = [currentGroup?.current?.id || ''];
   const pluginId = searchParams.get('plugin_id') || '';
   const objectId = searchParams.get('id') || '';
+  const enableIfmibFromUrl = searchParams.get('enable_ifmib') !== 'false';
   // URL 常见参数：name / plugin_name；兼容历史 plugin_display_name。
   const pluginDisplayName =
     searchParams.get('plugin_display_name') ||
@@ -98,6 +104,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
   const [initTableItems, setInitTableItems] =
     useState<IntegrationMonitoredObject>({});
   const [isTableInitialized, setIsTableInitialized] = useState<boolean>(false);
+  const hasInitializedFormRef = useRef(false);
   const [currentConfig, setCurrentConfig] = useState<any>(null);
   const [configLoading, setConfigLoading] = useState<boolean>(false);
   const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
@@ -632,8 +639,11 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
   useEffect(() => {
     if (isLoading) return;
     getNodeList();
-    initData();
   }, [isLoading]);
+
+  useEffect(() => {
+    hasInitializedFormRef.current = false;
+  }, [pluginId]);
 
   useEffect(() => {
     if (
@@ -660,6 +670,18 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     if (configLoading) return;
     const defaults = formConfig?.defaultForm;
     if (!defaults) return;
+    if (!hasInitializedFormRef.current) {
+      const initialValues = applyIfmibDeploymentState(defaults, enableIfmibFromUrl);
+      form.setFieldsValue(initialValues);
+      trackSnmpFilterMutexLastChanged({}, form.getFieldsValue(true), form);
+      hasInitializedFormRef.current = true;
+    }
+    // UI 字段可能在首次初始化后才挂载；其自身 default_value=true 会覆盖前一次
+    // 空表单初始化。因此只在 IF-MIB 字段真实可用时，以 URL 中当前下发流程状态回填。
+    const ifmibPatch = getIfmibDeploymentPatch(defaults, enableIfmibFromUrl);
+    if (Object.keys(ifmibPatch).length) {
+      form.setFieldsValue(ifmibPatch);
+    }
     setFormSnapshot((prev) => {
       const next = {
         ...defaults,
@@ -676,7 +698,7 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     });
     // 刻意依赖 defaultFormKey 而非 defaultForm 对象引用。
     // eslint-disable-next-line react-hooks/exhaustive-deps -- stabilize defaultForm identity
-  }, [configLoading, defaultFormKey, form]);
+  }, [configLoading, defaultFormKey, enableIfmibFromUrl, form]);
 
   const handleAdd = (key: string) => {
     const index = dataSource.findIndex((item) => item.key === key);
@@ -805,15 +827,6 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
     onChange: (newSelectedRowKeys: React.Key[]) => {
       setSelectedRowKeys(newSelectedRowKeys);
     }
-  };
-
-  const initData = () => {
-    form.setFieldsValue({
-      ...(formConfig?.defaultForm || {})
-    });
-    const values = form.getFieldsValue(true);
-    setFormSnapshot(values);
-    trackSnmpFilterMutexLastChanged({}, values, form);
   };
 
   const getNodeList = async () => {
@@ -970,14 +983,26 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       layout="vertical"
       onValuesChange={(changed, all) => {
         clearCollectDetectState();
-        trackSnmpFilterMutexLastChanged(changed, all, form);
+        const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(changed);
+        const nextValues = Object.keys(interfaceFilterModePatch).length
+          ? { ...all, ...interfaceFilterModePatch }
+          : all;
+        if (Object.keys(interfaceFilterModePatch).length) {
+          form.setFieldsValue(interfaceFilterModePatch);
+        }
+        trackSnmpFilterMutexLastChanged(changed, nextValues, form);
+        if (Object.prototype.hasOwnProperty.call(changed, 'enable_ifmib')) {
+          const params = new URLSearchParams(searchParams);
+          params.set('enable_ifmib', String(changed.enable_ifmib !== false));
+          router.replace(`/monitor/integration/list/detail/configure?${params.toString()}`);
+        }
         if (
           !tableDependencyFields.length ||
           tableDependencyFields.some((field) =>
             Object.prototype.hasOwnProperty.call(changed, field)
           )
         ) {
-          setFormSnapshot(all);
+          setFormSnapshot(nextValues);
         }
       }}
     >

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/fieldGuideTip.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/fieldGuideTip.tsx
@@ -22,7 +22,7 @@ const FieldGuideTip: React.FC<FieldGuideTipProps> = ({ short }) => {
       mouseEnterDelay={0.15}
       color="var(--color-bg)"
       overlayInnerStyle={{
-        maxWidth: 320,
+        maxWidth: 420,
         padding: '10px 12px',
         color: 'var(--color-text-1)',
         border: '1px solid var(--color-border-1)',
@@ -45,7 +45,8 @@ const FieldGuideTip: React.FC<FieldGuideTipProps> = ({ short }) => {
             style={{
               fontSize: 12,
               lineHeight: '20px',
-              color: 'var(--color-text-2)'
+              color: 'var(--color-text-2)',
+              whiteSpace: 'pre-line'
             }}
           >
             {short}

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
@@ -23,6 +23,57 @@ export const getIfmibDeploymentPatch = (
   return { enable_ifmib: enableIfmibFromUrl };
 };
 
+const hasInterfaceTable = (tables: unknown): boolean => (
+  Array.isArray(tables)
+  && tables.some((table) => (
+    typeof table === 'object'
+    && table !== null
+    && (table as Record<string, unknown>).name === 'interface'
+  ))
+);
+
+const snmpInputHasInterfaceTable = (input: unknown): boolean => {
+  if (typeof input !== 'object' || input === null) return false;
+  return hasInterfaceTable((input as Record<string, unknown>).table);
+};
+
+/**
+ * Collect SNMP input objects from child content.
+ *
+ * ConfigFormat.toml_to_dict stores Telegraf child as:
+ *   { plugin, config: <first snmp input>, _toml_document: <full TOML> }
+ * Legacy/raw shapes may still expose content.inputs.snmp.
+ */
+const collectSnmpInputs = (
+  content: Record<string, unknown>
+): unknown[] | undefined => {
+  const document = content._toml_document;
+  if (typeof document === 'object' && document !== null) {
+    const inputs = (document as Record<string, unknown>).inputs;
+    if (typeof inputs === 'object' && inputs !== null) {
+      const snmpInputs = (inputs as Record<string, unknown>).snmp;
+      if (Array.isArray(snmpInputs)) {
+        return snmpInputs;
+      }
+    }
+  }
+
+  const config = content.config;
+  if (typeof config === 'object' && config !== null) {
+    return [config];
+  }
+
+  const inputs = content.inputs;
+  if (typeof inputs === 'object' && inputs !== null) {
+    const snmpInputs = (inputs as Record<string, unknown>).snmp;
+    if (Array.isArray(snmpInputs)) {
+      return snmpInputs;
+    }
+  }
+
+  return undefined;
+};
+
 export const getIfmibSnapshotEnabled = (
   configContent: Record<string, unknown>,
   supportsIfmib: boolean
@@ -32,17 +83,8 @@ export const getIfmibSnapshotEnabled = (
   if (typeof child !== 'object' || child === null) return undefined;
   const content = (child as Record<string, unknown>).content;
   if (typeof content !== 'object' || content === null) return undefined;
-  const inputs = (content as Record<string, unknown>).inputs;
-  if (typeof inputs !== 'object' || inputs === null) return undefined;
-  const snmpInputs = (inputs as Record<string, unknown>).snmp;
-  if (!Array.isArray(snmpInputs)) return undefined;
-  return snmpInputs.some((input) => {
-    if (typeof input !== 'object' || input === null) return false;
-    const tables = (input as Record<string, unknown>).table;
-    return Array.isArray(tables) && tables.some((table) => (
-      typeof table === 'object'
-      && table !== null
-      && (table as Record<string, unknown>).name === 'interface'
-    ));
-  });
+
+  const snmpInputs = collectSnmpInputs(content as Record<string, unknown>);
+  if (snmpInputs === undefined) return undefined;
+  return snmpInputs.some(snmpInputHasInterfaceTable);
 };

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
@@ -1,0 +1,48 @@
+export const applyIfmibDeploymentState = (
+  defaultForm: Record<string, unknown>,
+  enableIfmibFromUrl: boolean
+) => {
+  if (!Object.prototype.hasOwnProperty.call(defaultForm, 'enable_ifmib')) {
+    return defaultForm;
+  }
+
+  return {
+    ...defaultForm,
+    enable_ifmib: enableIfmibFromUrl
+  };
+};
+
+export const getIfmibDeploymentPatch = (
+  defaultForm: Record<string, unknown>,
+  enableIfmibFromUrl: boolean
+) => {
+  if (!Object.prototype.hasOwnProperty.call(defaultForm, 'enable_ifmib')) {
+    return {};
+  }
+
+  return { enable_ifmib: enableIfmibFromUrl };
+};
+
+export const getIfmibSnapshotEnabled = (
+  configContent: Record<string, unknown>,
+  supportsIfmib: boolean
+): boolean | undefined => {
+  if (!supportsIfmib) return undefined;
+  const child = configContent.child;
+  if (typeof child !== 'object' || child === null) return undefined;
+  const content = (child as Record<string, unknown>).content;
+  if (typeof content !== 'object' || content === null) return undefined;
+  const inputs = (content as Record<string, unknown>).inputs;
+  if (typeof inputs !== 'object' || inputs === null) return undefined;
+  const snmpInputs = (inputs as Record<string, unknown>).snmp;
+  if (!Array.isArray(snmpInputs)) return undefined;
+  return snmpInputs.some((input) => {
+    if (typeof input !== 'object' || input === null) return false;
+    const tables = (input as Record<string, unknown>).table;
+    return Array.isArray(tables) && tables.some((table) => (
+      typeof table === 'object'
+      && table !== null
+      && (table as Record<string, unknown>).name === 'interface'
+    ));
+  });
+};

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
@@ -1,0 +1,43 @@
+import { GroupInfo, MetricItem } from '@/app/monitor/types';
+import { MetricListItem } from '@/app/monitor/types/integration';
+
+export const isIfmibMetric = (metric: MetricItem) => metric.is_ifmib === true;
+
+export const getDefaultMetricGroupOpenState = (groups: MetricListItem[]) => (
+  new Map(groups.map((group) => [group.id, true]))
+);
+
+/**
+ * 指标页只反映当前下发流程是否采集 IF-MIB。开启时保留模板原有分组，
+ * 以单指标来源标签区分公共 IF-MIB；关闭时隐藏该来源及由此产生的空分组。
+ */
+export const buildIfmibMetricView = (
+  groups: GroupInfo[],
+  metrics: MetricItem[],
+  enabled: boolean
+): MetricListItem[] => {
+  const visibleMetrics = enabled
+    ? metrics
+    : metrics.filter((metric) => !isIfmibMetric(metric));
+
+  return groups
+    .map((group) => {
+      const child = visibleMetrics
+        .filter((metric) => String(metric.metric_group) === String(group.id))
+        .map((metric) => ({
+          ...metric,
+          show_ifmib_source_tag: isIfmibMetric(metric)
+        }));
+
+      return {
+        ...group,
+        id: String(group.id),
+        name: group.name || '',
+        display_name: (group as MetricListItem).display_name || group.name || '',
+        is_pre: (group as MetricListItem).is_pre,
+        is_ifmib_group: false,
+        child
+      };
+    })
+    .filter((group) => group.child.length > 0) as MetricListItem[];
+};

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
@@ -18,6 +18,7 @@ import {
   InputNumber,
   ColorPicker,
   Descriptions,
+  Tag,
   theme
 } from 'antd';
 import { AggregationColor } from 'antd/es/color-picker/color';
@@ -26,7 +27,8 @@ import { useCommon } from '@/app/monitor/context/common';
 import OperateModal from '@/components/operate-modal';
 import type { FormInstance } from 'antd';
 import useApiClient from '@/utils/request';
-import { ModalRef, ListItem, CascaderItem } from '@/app/monitor/types';
+import useMonitorApi from '@/app/monitor/api';
+import { ModalRef, ListItem } from '@/app/monitor/types';
 import { MetricInfo } from '@/app/monitor/types/integration';
 import { DimensionItem, EnumItem } from '@/app/monitor/types/integration';
 import { useTranslation } from '@/utils/i18n';
@@ -58,6 +60,7 @@ const INIT_UNIT_ITEM = { name: null, id: null, color: '#000000' };
 const MetricModal = forwardRef<ModalRef, ModalProps>(
   ({ onSuccess, groupList, monitorObject, pluginId }, ref) => {
     const { post, put } = useApiClient();
+    const { getMetricsGroup } = useMonitorApi();
     const { t } = useTranslation();
     const { token } = theme.useToken();
     const presets = genPresets({
@@ -78,6 +81,12 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
     const [groupVisible, setGroupVisible] = useState<boolean>(false);
     const [confirmLoading, setConfirmLoading] = useState<boolean>(false);
     const [groupForm, setGroupForm] = useState<MetricInfo>({});
+    const [groupOptions, setGroupOptions] = useState<ListItem[]>(groupList);
+    const [groupLoading, setGroupLoading] = useState(false);
+    const groupSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const selectedGroupIdRef = useRef<React.Key | null>(null);
+    const allowInheritedGroupsRef = useRef(false);
+    const groupRequestGenerationRef = useRef(0);
     const [title, setTitle] = useState<string>('');
     const [type, setType] = useState<string>('');
     const [dimensions, setDimensions] = useState<DimensionItem[]>([
@@ -87,11 +96,68 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
     const [enumList, setEnumList] = useState<EnumItem[]>([]);
     const isView = type === 'view';
 
+    const loadGroupOptions = async (keyword = '') => {
+      const generation = groupRequestGenerationRef.current + 1;
+      groupRequestGenerationRef.current = generation;
+      setGroupLoading(true);
+      try {
+        const page = await getMetricsGroup({
+          monitor_object_id: monitorObject,
+          monitor_plugin_id: pluginId,
+          ...(keyword.trim() ? { keyword: keyword.trim() } : {})
+        });
+        const items = page.items.filter(
+          (item) =>
+            allowInheritedGroupsRef.current ||
+            String(item.monitor_plugin) === String(pluginId)
+        ) as ListItem[];
+        const selectedGroup = groupList.find(
+          (item) => String(item.id) === String(selectedGroupIdRef.current)
+        );
+        if (groupRequestGenerationRef.current !== generation) return;
+        setGroupOptions(
+          selectedGroup && !items.some((item) => item.id === selectedGroup.id)
+            ? [...items, selectedGroup]
+            : items
+        );
+      } catch {
+        if (groupRequestGenerationRef.current === generation) {
+          setGroupOptions(groupList);
+        }
+      } finally {
+        if (groupRequestGenerationRef.current === generation) {
+          setGroupLoading(false);
+        }
+      }
+    };
+
+    const handleGroupSearch = (value: string) => {
+      if (groupSearchTimerRef.current) {
+        clearTimeout(groupSearchTimerRef.current);
+      }
+      groupSearchTimerRef.current = setTimeout(() => {
+        loadGroupOptions(value);
+      }, 300);
+    };
+
+    useEffect(() => () => {
+      if (groupSearchTimerRef.current) {
+        clearTimeout(groupSearchTimerRef.current);
+      }
+    }, []);
+
+    useEffect(() => {
+      setGroupOptions(groupList);
+    }, [groupList]);
+
     useImperativeHandle(ref, () => ({
       showModal: ({ type, form, title }) => {
         // 开启弹窗的交互
         const formData = cloneDeep(form);
+        allowInheritedGroupsRef.current = type === 'view';
+        selectedGroupIdRef.current = (formData.metric_group as React.Key) || null;
         setGroupVisible(true);
+        void loadGroupOptions();
         setType(type);
         setTitle(title);
         try {
@@ -274,10 +340,17 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
                 {groupForm.name || '--'}
               </Descriptions.Item>
               <Descriptions.Item label={t('common.name')}>
-                {groupForm.display_name || '--'}
+                <div className="flex items-center gap-2">
+                  <span>{groupForm.display_name || '--'}</span>
+                  {groupForm.is_ifmib === true && (
+                    <Tag className="m-0" color="blue">
+                      IF-MIB
+                    </Tag>
+                  )}
+                </div>
               </Descriptions.Item>
               <Descriptions.Item label={t('monitor.integrations.metricGroup')}>
-                {groupList.find(
+                {groupOptions.find(
                   (item) => String(item.id) === String(groupForm.metric_group)
                 )?.display_name || '--'}
               </Descriptions.Item>
@@ -338,8 +411,14 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
               name="metric_group"
               rules={[{ required: true, message: t('common.required') }]}
             >
-              <Select showSearch optionFilterProp="children">
-                {groupList.map((item) => (
+              <Select
+                showSearch
+                filterOption={false}
+                loading={groupLoading}
+                onSearch={handleGroupSearch}
+                onDropdownVisibleChange={(open) => !open && handleGroupSearch('')}
+              >
+                {groupOptions.map((item) => (
                   <Option key={item.id} value={item.id}>
                     {item.display_name}
                   </Option>

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -8,7 +8,9 @@ import {
   message,
   Spin,
   Segmented,
-  Empty
+  Empty,
+  Pagination,
+  Tag
 } from 'antd';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
@@ -19,7 +21,6 @@ import CustomTable from '@/components/custom-table';
 import {
   ColumnItem,
   ModalRef,
-  GroupInfo,
   IntegrationItem,
   ObjectItem,
   MetricItem
@@ -35,6 +36,7 @@ import {
   getObjectTypeByName
 } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
+import { buildIfmibMetricView, getDefaultMetricGroupOpenState } from './ifmibMetricView';
 
 const Configure = () => {
   const { isLoading } = useApiClient();
@@ -52,6 +54,7 @@ const Configure = () => {
   const groupId = searchParams.get('id');
   const pluginID = searchParams.get('plugin_id') || '';
   const templateType = searchParams.get('template_type') || '';
+  const enableIfmib = searchParams.get('enable_ifmib') !== 'false';
   const groupRef = useRef<ModalRef>(null);
   const metricRef = useRef<ModalRef>(null);
   const [searchText, setSearchText] = useState<string>('');
@@ -61,7 +64,10 @@ const Configure = () => {
   >([]);
   const [metrics, setMetrics] = useState<MetricItem[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
-  const [groupList, setGroupList] = useState<MetricListItem[]>([]);
+  const [metricPage, setMetricPage] = useState(1);
+  const [metricCount, setMetricCount] = useState(0);
+  // 保留接口返回的真实分组供指标编辑使用。
+  const [apiGroupList, setApiGroupList] = useState<MetricListItem[]>([]);
   const [activeTab, setActiveTab] = useState<string>('');
   const [items, setItems] = useState<IntegrationItem[]>([]);
   const [draggingItemId, setDraggingItemId] = useState<string | null>(null);
@@ -69,6 +75,12 @@ const Configure = () => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [groupConfirmLoading, setGroupConfirmLoading] = useState(false);
   const [showTabs, setShowTabs] = useState<boolean>(false);
+  const metricTableRef = useRef<HTMLDivElement>(null);
+  const manuallyClosedGroupIds = useRef<Set<string>>(new Set());
+  const metricCatalogAbortRef = useRef<AbortController | null>(null);
+  const canReorderCatalog = metricCount <= 100 && !searchText.trim();
+
+  useEffect(() => () => metricCatalogAbortRef.current?.abort(), []);
 
   const columns: ColumnItem[] = [
     {
@@ -83,7 +95,17 @@ const Configure = () => {
       dataIndex: 'display_name',
       width: 120,
       key: 'display_name',
-      ellipsis: true
+      ellipsis: true,
+      render: (_, record) => (
+        <div className="flex items-center gap-1 overflow-hidden">
+          <span className="truncate">{record.display_name || '--'}</span>
+          {record.show_ifmib_source_tag === true && (
+            <Tag className="m-0 shrink-0" color="blue">
+              IF-MIB
+            </Tag>
+          )}
+        </div>
+      )
     },
     {
       title: t('monitor.integrations.dimension'),
@@ -105,7 +127,14 @@ const Configure = () => {
       title: t('monitor.integrations.dataType'),
       dataIndex: 'data_type',
       key: 'data_type',
-      width: 100
+      width: 100,
+      render: (value: string) => (
+        <>{value === 'Enum'
+          ? t('monitor.integrations.enum')
+          : value === 'Number'
+            ? t('monitor.integrations.number')
+            : value}</>
+      )
     },
     {
       title: t('common.unit'),
@@ -166,7 +195,7 @@ const Configure = () => {
   useEffect(() => {
     if (isLoading) return;
     getObjects();
-  }, [isLoading]);
+  }, [isLoading, enableIfmib]);
 
   const getObjects = async () => {
     setLoading(true);
@@ -218,83 +247,71 @@ const Configure = () => {
     }
   };
 
-  const getInitData = async (objId = activeTab, preserveState = false) => {
+  const getInitData = async (
+    objId = activeTab,
+    preserveState = false,
+    page = metricPage,
+    keyword = searchText.trim()
+  ) => {
     const params = {
       monitor_object_id: +objId,
-      monitor_plugin_id: +pluginID
+      monitor_plugin_id: +pluginID,
+      ...(keyword ? { keyword } : {})
     };
-    const getGroupList = getMetricsGroup(params);
-
-    const getMetrics = getMonitorMetrics({
-      ...params,
-      monitor_plugin_id: +pluginID
-    });
+    metricCatalogAbortRef.current?.abort();
+    const abortController = new AbortController();
+    metricCatalogAbortRef.current = abortController;
+    const config = { signal: abortController.signal };
     setLoading(true);
-    const currentSearchText = preserveState ? searchText : '';
     const currentOpenState = preserveState
       ? new Map(filteredMetricData.map((g) => [g.id, g.isOpen]))
       : null;
 
     if (!preserveState) {
       setSearchText('');
+      manuallyClosedGroupIds.current.clear();
     }
     try {
-      Promise.all([getGroupList, getMetrics])
-        .then((res) => {
-          const groupData = res[0].map((item: GroupInfo, index: number) => ({
-            ...item,
-            child: [],
-            isOpen: currentOpenState
-              ? (currentOpenState.get(item.id as string) ?? false)
-              : !index
-          }));
-          const metricData = res[1];
-          setMetrics(res[1] || []);
-          metricData.forEach((metric: MetricItem) => {
-            const target = groupData.find(
-              (item: GroupInfo) => item.id === metric.metric_group
-            );
-            if (target) {
-              target.child.push(metric);
-            }
-          });
-          setGroupList(groupData);
-          setMetricData(groupData);
-          if (preserveState && currentSearchText.trim()) {
-            const lowerSearchText = currentSearchText.toLowerCase();
-            const filtered = groupData
-              .map((group: MetricListItem) => {
-                const filteredChild = (group.child || []).filter(
-                  (metric: MetricItem) => {
-                    const name = metric.name?.toLowerCase() || '';
-                    const displayName =
-                      metric.display_name?.toLowerCase() || '';
-                    return (
-                      name.includes(lowerSearchText) ||
-                      displayName.includes(lowerSearchText)
-                    );
-                  }
-                );
-                if (filteredChild.length > 0) {
-                  return {
-                    ...group,
-                    child: filteredChild,
-                    isOpen: currentOpenState?.get(group.id) ?? true
-                  };
-                }
-                return null;
-              })
-              .filter(Boolean) as MetricListItem[];
-            setFilteredMetricData(filtered);
-          } else {
-            setFilteredMetricData(groupData);
-          }
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+      const [groupPage, metricsPage] = await Promise.all([
+        getMetricsGroup(params, config),
+        getMonitorMetrics({ ...params, include_ifmib: enableIfmib, page }, config)
+      ]);
+      if (abortController.signal.aborted) return;
+      const rawGroupList: MetricListItem[] = (
+        metricsPage.metric_groups || groupPage.items
+      ).map((group) => ({
+        ...group,
+        id: String(group.id),
+        name: group.name || '',
+        is_pre: group.is_pre === true,
+        child: []
+      }));
+      setMetricCount(metricsPage.count);
+      setApiGroupList(rawGroupList);
+      const metricView = buildIfmibMetricView(
+        rawGroupList,
+        metricsPage.items,
+        enableIfmib
+      );
+      const defaultOpenState = getDefaultMetricGroupOpenState(metricView);
+      const groupData = metricView.map((group) => ({
+        ...group,
+        isOpen: currentOpenState
+          ? (currentOpenState.get(group.id) ?? defaultOpenState.get(group.id))
+          : defaultOpenState.get(group.id)
+      }));
+      setMetrics(groupData.flatMap((group) => group.child));
+      setMetricData(groupData);
+      setFilteredMetricData(groupData);
     } catch {
-      setLoading(false);
+      if (!abortController.signal.aborted) {
+        setMetricData([]);
+        setFilteredMetricData([]);
+      }
+    } finally {
+      if (metricCatalogAbortRef.current === abortController) {
+        setLoading(false);
+      }
     }
   };
 
@@ -302,48 +319,15 @@ const Configure = () => {
     setSearchText(e.target.value);
   };
 
-  const filterMetricData = (text: string) => {
-    if (!text.trim()) {
-      const restored = metricData.map((group, index) => ({
-        ...group,
-        isOpen: !index
-      }));
-      setFilteredMetricData(restored);
-      return;
-    }
-    const lowerSearchText = text.toLowerCase();
-    const filtered = metricData
-      .map((group) => {
-        const filteredChild = (group.child || []).filter(
-          (metric: MetricItem) => {
-            const name = metric.name?.toLowerCase() || '';
-            const displayName = metric.display_name?.toLowerCase() || '';
-            return (
-              name.includes(lowerSearchText) ||
-              displayName.includes(lowerSearchText)
-            );
-          }
-        );
-        if (filteredChild.length > 0) {
-          return {
-            ...group,
-            child: filteredChild,
-            isOpen: true
-          };
-        }
-        return null;
-      })
-      .filter(Boolean) as MetricListItem[];
-    setFilteredMetricData(filtered);
-  };
-
   const onTxtPressEnter = () => {
-    filterMetricData(searchText);
+    setMetricPage(1);
+    getInitData(activeTab, true, 1, searchText.trim());
   };
 
   const onTxtClear = () => {
     setSearchText('');
-    filterMetricData('');
+    setMetricPage(1);
+    getInitData(activeTab, true, 1, '');
   };
 
   const openGroupModal = (type: string, row = {}) => {
@@ -385,7 +369,13 @@ const Configure = () => {
   const onTabChange = (val: string) => {
     setMetricData([]);
     setActiveTab(val);
-    getInitData(val);
+    setMetricPage(1);
+    getInitData(val, false, 1);
+  };
+
+  const onMetricPageChange = (page: number) => {
+    setMetricPage(page);
+    getInitData(activeTab, true, page, searchText.trim());
   };
 
   const onDragStart = (e: React.DragEvent<HTMLDivElement>, id: string) => {
@@ -422,22 +412,23 @@ const Configure = () => {
   ) => {
     e.preventDefault();
     setDragOverTargetId(null);
+    if (!canReorderCatalog) return;
     if (draggingItemId && draggingItemId !== targetId) {
       const draggingIndex = metricData.findIndex(
         (item) => item.id === draggingItemId
       );
       const targetIndex = metricData.findIndex((item) => item.id === targetId);
-      const reorderedData: any = cloneDeep(metricData);
-      const [draggedItem] = reorderedData.splice(draggingIndex, 1);
-      reorderedData.splice(targetIndex, 0, draggedItem);
       if (draggingIndex !== -1 && targetIndex !== -1) {
+        const reorderedData = cloneDeep<MetricListItem[]>(metricData);
+        const [draggedItem] = reorderedData.splice(draggingIndex, 1);
+        reorderedData.splice(targetIndex, 0, draggedItem);
         try {
           setLoading(true);
           const updatedOrder = reorderedData
             .filter((item: MetricListItem) => !item.is_pre)
             .map(
-              (item: MetricItem, index: number) => ({
-                id: item.id,
+              (item: MetricListItem, index: number) => ({
+                id: Number(item.id),
                 sort_order: index
               })
             );
@@ -452,16 +443,18 @@ const Configure = () => {
     }
   };
 
-  const onRowDragEnd = async (data: any) => {
+  const onRowDragEnd = async (data?: MetricItem[]) => {
+    if (!canReorderCatalog) return;
     setLoading(true);
+    const orderedData = [...(data || [])];
     metrics
       .filter((metricItem) => !metricItem.is_pre)
       .forEach((metricItem) => {
-        if (!data.map((item: MetricItem) => item.id).includes(metricItem.id)) {
-          data.push(metricItem);
+        if (!orderedData.map((item) => item.id).includes(metricItem.id)) {
+          orderedData.push(metricItem);
         }
       });
-    const updatedOrder = data
+    const updatedOrder = orderedData
       .filter((item: MetricItem) => !item.is_pre)
       .map((item: MetricItem, index: number) => ({
         id: item.id,
@@ -479,12 +472,43 @@ const Configure = () => {
   };
 
   const onToggle = (id: string, isOpen: boolean) => {
+    if (isOpen) {
+      manuallyClosedGroupIds.current.delete(id);
+    } else {
+      manuallyClosedGroupIds.current.add(id);
+    }
     setMetricData((prev) =>
       prev.map((item) => (item.id === id ? { ...item, isOpen } : item))
     );
     setFilteredMetricData((prev) =>
       prev.map((item) => (item.id === id ? { ...item, isOpen } : item))
     );
+  };
+
+  const autoExpandVisibleGroups = () => {
+    const container = metricTableRef.current;
+    if (!container || searchText.trim()) return;
+    const containerRect = container.getBoundingClientRect();
+    const visibleGroupIds = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-metric-group-id]')
+    )
+      .filter((element) => {
+        const rect = element.getBoundingClientRect();
+        return rect.top < containerRect.bottom && rect.bottom > containerRect.top;
+      })
+      .map((element) => element.dataset.metricGroupId)
+      .filter((id): id is string => Boolean(id));
+
+    if (!visibleGroupIds.length) return;
+    const shouldOpen = new Set(
+      visibleGroupIds.filter((id) => !manuallyClosedGroupIds.current.has(id))
+    );
+    if (!shouldOpen.size) return;
+    const openVisibleGroups = (groups: MetricListItem[]) => groups.map((group) => (
+      shouldOpen.has(group.id) && !group.isOpen ? { ...group, isOpen: true } : group
+    ));
+    setMetricData(openVisibleGroups);
+    setFilteredMetricData(openVisibleGroups);
   };
 
   return (
@@ -525,6 +549,8 @@ const Configure = () => {
       </div>
       <Spin spinning={loading}>
         <div
+          ref={metricTableRef}
+          onScroll={autoExpandVisibleGroups}
           className={metricStyle.metricTable}
           style={{
             height: showTabs ? 'calc(100vh - 396px)' : 'calc(100vh - 346px)'
@@ -532,21 +558,25 @@ const Configure = () => {
         >
           {!!filteredMetricData.length ? (
             filteredMetricData.map((metricItem) => (
-              <Collapse
+              <div key={metricItem.id} data-metric-group-id={metricItem.id}>
+                <Collapse
                 className={`mb-[10px] ${
                   dragOverTargetId === metricItem.id &&
                   draggingItemId !== dragOverTargetId
                     ? 'border-t-[1px] border-blue-200'
                     : ''
                 }`}
-                key={metricItem.id}
-                sortable={!metricItem.is_pre}
+                sortable={!metricItem.is_pre && canReorderCatalog}
                 dragHandleOnly
                 onDragStart={(e) => onDragStart(e, metricItem.id)}
                 onDragEnd={onDragEnd}
                 onDragOver={(e) => onDragOver(e, metricItem.id)}
                 onDrop={(e) => onDrop(e, metricItem.id)}
-                title={metricItem.display_name || ''}
+                title={
+                  <div className="flex items-center gap-2">
+                    <span>{metricItem.display_name || ''}</span>
+                  </div>
+                }
                 isOpen={metricItem.isOpen}
                 onToggle={(isOpen) => onToggle(metricItem.id, isOpen)}
                 icon={
@@ -588,18 +618,31 @@ const Configure = () => {
                   columns={columns}
                   rowKey="id"
                   rowDraggable={
+                    canReorderCatalog &&
                     metricItem.child?.length > 1 &&
                     metricItem.child.every((item) => !item.is_pre)
                   }
                   onRowDragEnd={onRowDragEnd}
                 />
-              </Collapse>
+                </Collapse>
+              </div>
             ))
           ) : (
             <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
           )}
         </div>
       </Spin>
+      {metricCount > 100 && (
+        <div className="mt-[16px] flex justify-end">
+          <Pagination
+            current={metricPage}
+            pageSize={100}
+            showSizeChanger={false}
+            total={metricCount}
+            onChange={onMetricPageChange}
+          />
+        </div>
+      )}
       <GroupModal
         ref={groupRef}
         monitorObject={+activeTab}
@@ -610,7 +653,7 @@ const Configure = () => {
         ref={metricRef}
         monitorObject={+activeTab}
         pluginId={+pluginID}
-        groupList={groupList}
+        groupList={apiGroupList}
         onSuccess={operateMtric}
       />
     </div>

--- a/web/src/app/monitor/(pages)/integration/object/api.ts
+++ b/web/src/app/monitor/(pages)/integration/object/api.ts
@@ -10,6 +10,26 @@ import {
   MetricOption
 } from './types';
 
+export interface MetricCatalogPage<T> {
+  count: number;
+  items: T[];
+}
+
+interface ObjectMetricQuery {
+  signal?: AbortSignal;
+  page?: number;
+  keyword?: string;
+  name_in?: string;
+}
+
+const isMetricCatalogPage = <T,>(value: unknown): value is MetricCatalogPage<T> => (
+  typeof value === 'object'
+  && value !== null
+  && 'count' in value
+  && 'items' in value
+  && Array.isArray(value.items)
+);
+
 const useObjectApi = () => {
   const { get, post, patch, del } = useApiClient();
 
@@ -247,12 +267,23 @@ const useObjectApi = () => {
   const getObjectMetrics = async (
     objectId: number,
     pluginId: number | string,
-    signal?: AbortSignal
-  ): Promise<MetricOption[]> => {
-    return await get('/monitor/api/metrics/', {
-      params: { monitor_object_id: objectId, monitor_plugin_id: pluginId },
-      signal
+    query: ObjectMetricQuery = {}
+  ): Promise<MetricCatalogPage<MetricOption>> => {
+    const response: unknown = await get('/monitor/api/metrics/', {
+      params: {
+        monitor_object_id: objectId,
+        monitor_plugin_id: pluginId,
+        page: query.page || 1,
+        ...(query.keyword ? { keyword: query.keyword } : {}),
+        ...(query.name_in ? { name_in: query.name_in } : {}),
+        page_size: 100
+      },
+      signal: query.signal
     });
+    if (!isMetricCatalogPage<MetricOption>(response)) {
+      return { count: 0, items: [] };
+    }
+    return response;
   };
 
   const getMetricVmFields = async (

--- a/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/object/displayFieldsModal.tsx
@@ -54,6 +54,12 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
     const dirtyRef = useRef<Set<number>>(new Set());
     const [pluginsMap, setPluginsMap] = useState<Record<number, PluginOption[]>>({});
     const [metricsMap, setMetricsMap] = useState<Record<string, MetricOption[]>>({});
+    const [metricSearchOptionsMap, setMetricSearchOptionsMap] = useState<
+      Record<string, MetricOption[]>
+    >({});
+    const [selectedMetricOptionsMap, setSelectedMetricOptionsMap] = useState<
+      Record<string, MetricOption>
+    >({});
     const [fieldPicker, setFieldPicker] = useState<{
       visible: boolean;
       loading: boolean;
@@ -72,6 +78,14 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
     const pluginsMapRef = useRef<Record<number, PluginOption[]>>({});
     // 正在请求中的指标 key，避免预热与下拉懒加载并发重复请求同一插件
     const inflightMetricsRef = useRef<Set<string>>(new Set());
+    const metricSearchTimerRef = useRef<Record<string, ReturnType<typeof setTimeout>>>(
+      {}
+    );
+    const metricSearchGenerationRef = useRef<Record<string, number>>({});
+
+    useEffect(() => () => {
+      Object.values(metricSearchTimerRef.current).forEach((timer) => clearTimeout(timer));
+    }, []);
 
     useEffect(() => {
       pluginsMapRef.current = pluginsMap;
@@ -101,6 +115,8 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
         setColumnsMap({});
         setPluginsMap({});
         setMetricsMap({});
+        setMetricSearchOptionsMap({});
+        setSelectedMetricOptionsMap({});
         setFieldPicker({
           visible: false,
           loading: false,
@@ -233,9 +249,31 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
       if (!pluginOpt) return [];
       inflightMetricsRef.current.add(key);
       try {
-        const metrics = await getObjectMetrics(activeId, pluginOpt.id);
-        setMetricsMap((prev) => ({ ...prev, [key]: metrics || [] }));
-        return metrics || [];
+        const boundMetricNames = currentColumns
+          .flatMap((column) => column.metrics)
+          .filter((binding) => binding.plugin === plugin && binding.metric)
+          .map((binding) => binding.metric);
+        const uniqueBoundMetricNames = [...new Set(boundMetricNames)];
+        const boundMetricNameChunks = Array.from(
+          { length: Math.ceil(uniqueBoundMetricNames.length / 100) },
+          (_, index) => uniqueBoundMetricNames.slice(index * 100, (index + 1) * 100)
+        );
+        const [firstPage, selectedPages] = await Promise.all([
+          getObjectMetrics(activeId, pluginOpt.id),
+          Promise.all(
+            boundMetricNameChunks.map((names) =>
+              getObjectMetrics(activeId, pluginOpt.id, { name_in: names.join(',') })
+            )
+          )
+        ]);
+        const metrics = [...firstPage.items];
+        selectedPages.flatMap((page) => page.items).forEach((metric) => {
+          if (!metrics.some((item) => item.id === metric.id)) {
+            metrics.push(metric);
+          }
+        });
+        setMetricsMap((prev) => ({ ...prev, [key]: metrics }));
+        return metrics;
       } catch {
         message.error(t('common.operationFailed'));
         return [];
@@ -288,6 +326,20 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
       bindIdx: number,
       metric: string
     ) => {
+      const binding = currentColumns[colIdx]?.metrics[bindIdx];
+      if (activeId != null && binding?.plugin) {
+        const key = metricsKey(activeId, binding.plugin);
+        const searchKey = `${key}|${colIdx}|${bindIdx}`;
+        const selected = (metricSearchOptionsMap[searchKey] || []).find(
+          (item) => item.name === metric
+        );
+        if (selected) {
+          setSelectedMetricOptionsMap((prev) => ({
+            ...prev,
+            [searchKey]: selected
+          }));
+        }
+      }
       setCurrentColumns(
         currentColumns.map((c, i) =>
           i === colIdx
@@ -302,6 +354,42 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
             : c
         )
       );
+    };
+
+    const searchMetricOptions = (
+      plugin: string,
+      colIdx: number,
+      bindIdx: number,
+      keyword: string
+    ) => {
+      if (activeId == null || !plugin) return;
+      const pluginOpt = currentPlugins.find((item) => item.name === plugin);
+      if (!pluginOpt) return;
+      const searchKey = `${metricsKey(activeId, plugin)}|${colIdx}|${bindIdx}`;
+      const generation = (metricSearchGenerationRef.current[searchKey] || 0) + 1;
+      metricSearchGenerationRef.current[searchKey] = generation;
+      const previousTimer = metricSearchTimerRef.current[searchKey];
+      if (previousTimer) clearTimeout(previousTimer);
+      if (!keyword.trim()) {
+        setMetricSearchOptionsMap((prev) => {
+          const next = { ...prev };
+          delete next[searchKey];
+          return next;
+        });
+        return;
+      }
+      metricSearchTimerRef.current[searchKey] = setTimeout(async () => {
+        try {
+          const { items } = await getObjectMetrics(activeId, pluginOpt.id, {
+            keyword: keyword.trim()
+          });
+          if (metricSearchGenerationRef.current[searchKey] !== generation) return;
+          setMetricSearchOptionsMap((prev) => ({ ...prev, [searchKey]: items }));
+        } catch {
+          if (metricSearchGenerationRef.current[searchKey] !== generation) return;
+          setMetricSearchOptionsMap((prev) => ({ ...prev, [searchKey]: [] }));
+        }
+      }, 300);
     };
 
     const updateBindingField = (
@@ -323,8 +411,12 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
       );
     };
 
-    const findMetricOption = (plugin: string, metric: string) =>
-      metricsOptions(plugin).find((m) => m.name === metric);
+    const findMetricOption = (
+      plugin: string,
+      metric: string,
+      colIdx?: number,
+      bindIdx?: number
+    ) => metricsOptions(plugin, colIdx, bindIdx).find((m) => m.name === metric);
 
     const openFieldPicker = async (colIdx: number, bindIdx: number) => {
       const binding = currentColumns[colIdx]?.metrics[bindIdx];
@@ -335,7 +427,7 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
       const metrics = await ensureMetrics(binding.plugin);
       const metricOpt =
         metrics.find((m) => m.name === binding.metric) ||
-        findMetricOption(binding.plugin, binding.metric);
+        findMetricOption(binding.plugin, binding.metric, colIdx, bindIdx);
       if (!metricOpt) {
         message.warning(t('monitor.object.selectMetricFirst'));
         return;
@@ -432,8 +524,19 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
 
     const showTree = nodes.length > 1;
 
-    const metricsOptions = (plugin: string) =>
-      activeId != null ? metricsMap[metricsKey(activeId, plugin)] || [] : [];
+    const metricsOptions = (plugin: string, colIdx?: number, bindIdx?: number) => {
+      if (activeId == null) return [];
+      const key = metricsKey(activeId, plugin);
+      if (colIdx != null && bindIdx != null) {
+        const bindingKey = `${key}|${colIdx}|${bindIdx}`;
+        const options = metricSearchOptionsMap[bindingKey] || metricsMap[key] || [];
+        const selected = selectedMetricOptionsMap[bindingKey];
+        return selected && !options.some((item) => item.id === selected.id)
+          ? [...options, selected]
+          : options;
+      }
+      return metricsMap[key] || [];
+    };
 
     return (
       <OperateModal
@@ -540,17 +643,24 @@ const DisplayFieldsModal = forwardRef<ModalRef, DisplayFieldsModalProps>(
                       <Select
                         className="flex-1"
                         showSearch
-                        optionFilterProp="label"
+                        filterOption={false}
                         value={binding.metric || undefined}
                         placeholder={t('monitor.object.selectMetric')}
                         disabled={!binding.plugin}
-                        onDropdownVisibleChange={(open) =>
-                          open && ensureMetrics(binding.plugin)
-                        }
-                        options={metricsOptions(binding.plugin).map((m) => ({
+                        options={metricsOptions(binding.plugin, colIdx, bindIdx).map((m) => ({
                           label: m.display_name || m.name,
                           value: m.name
                         }))}
+                        onSearch={(value) =>
+                          searchMetricOptions(binding.plugin, colIdx, bindIdx, value)
+                        }
+                        onDropdownVisibleChange={(open) => {
+                          if (open) {
+                            ensureMetrics(binding.plugin);
+                          } else {
+                            searchMetricOptions(binding.plugin, colIdx, bindIdx, '');
+                          }
+                        }}
                         onChange={(v) =>
                           updateBindingMetric(colIdx, bindIdx, v)
                         }

--- a/web/src/app/monitor/(pages)/search/queryPanel.tsx
+++ b/web/src/app/monitor/(pages)/search/queryPanel.tsx
@@ -34,8 +34,7 @@ import {
   ListItem,
   MetricItem,
   IndexViewItem,
-  ObjectItem,
-  GroupInfo
+  ObjectItem
 } from '@/app/monitor/types';
 import {
   buildGroupedMetricSelectOptions,
@@ -123,6 +122,12 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     const [metricsGroupMap, setMetricsGroupMap] = useState<
       Record<string, IndexViewItem[]>
     >({});
+    const [metricSearchResultMap, setMetricSearchResultMap] = useState<
+      Record<string, IndexViewItem[]>
+    >({});
+    const [selectedMetricMap, setSelectedMetricMap] = useState<
+      Record<string, MetricItem>
+    >({});
     const [metricSearchMap, setMetricSearchMap] = useState<
       Record<string, string>
     >({});
@@ -151,6 +156,9 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     const metricsAbortControllerRef = useRef<Record<string, AbortController>>(
       {}
     );
+    const metricSearchTimerRef = useRef<Record<string, ReturnType<typeof setTimeout>>>(
+      {}
+    );
     const instanceAbortControllerRef = useRef<Record<string, AbortController>>(
       {}
     );
@@ -170,10 +178,22 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
       objects.forEach((obj) => {
         objectsMap[String(obj.id)] = obj;
       });
+      const payloadMetricsMap = { ...metricsMap };
+      queryGroups.forEach((group) => {
+        const selectedMetric = selectedMetricMap[group.id];
+        if (!selectedMetric) return;
+        const key = getMetricsMapKey(group.object, group.plugin);
+        const current = payloadMetricsMap[key] || [];
+        payloadMetricsMap[key] = current.some(
+          (metric) => metric.id === selectedMetric.id
+        )
+          ? current
+          : [...current, selectedMetric];
+      });
       return {
         queryGroups,
         activeGroup,
-        metricsMap,
+        metricsMap: payloadMetricsMap,
         instancesMap,
         pluginsMap,
         objectsMap
@@ -196,6 +216,9 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
         );
         Object.values(instanceAbortControllerRef.current).forEach((c) =>
           c?.abort()
+        );
+        Object.values(metricSearchTimerRef.current).forEach((timer) =>
+          clearTimeout(timer)
         );
       };
     }, []);
@@ -240,6 +263,9 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
             Boolean(initialMetricId && !/^\d+$/.test(initialMetricId)),
             initialMetricId && !/^\d+$/.test(initialMetricId)
               ? initialMetricId
+              : null,
+            initialMetricId && /^\d+$/.test(initialMetricId)
+              ? Number(initialMetricId)
               : null
           );
         }
@@ -302,7 +328,8 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
       groupId?: string,
       preferredPluginId?: React.Key | null,
       allowFirstPluginFallback = false,
-      legacyMetricName?: string | null
+      legacyMetricName?: string | null,
+      preferredMetricId?: React.Key | null
     ): Promise<PluginItem[]> => {
       const key = String(objectId);
       pluginAbortControllerRef.current[key]?.abort();
@@ -324,7 +351,13 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
           (allowFirstPluginFallback ? plugins[0]?.id : null);
         if (groupId && selectedPlugin) {
           updateQueryGroup(groupId, { plugin: selectedPlugin });
-          getMetrics(objectId, selectedPlugin, groupId, legacyMetricName);
+          getMetrics(
+            objectId,
+            selectedPlugin,
+            groupId,
+            legacyMetricName,
+            preferredMetricId
+          );
           getInstList(objectId, selectedPlugin);
         }
         return plugins;
@@ -339,48 +372,97 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
       objectId: React.Key,
       pluginId?: React.Key | null,
       groupId?: string,
-      legacyMetricName?: string | null
+      legacyMetricName?: string | null,
+      selectedMetricId?: React.Key | null,
+      keyword = ''
     ): Promise<MetricItem[]> => {
       const key = getMetricsMapKey(objectId, pluginId);
-      metricsAbortControllerRef.current[key]?.abort();
+      const requestKey = keyword.trim() && groupId ? `${key}|${groupId}` : key;
+      metricsAbortControllerRef.current[requestKey]?.abort();
       const abortController = new AbortController();
-      metricsAbortControllerRef.current[key] = abortController;
+      metricsAbortControllerRef.current[requestKey] = abortController;
       try {
         setMetricsLoading((prev) => ({ ...prev, [key]: true }));
         const config = { signal: abortController.signal };
         const params = {
           monitor_object_id: String(objectId),
-          ...(pluginId ? { monitor_plugin_id: String(pluginId) } : {})
+          ...(pluginId ? { monitor_plugin_id: String(pluginId) } : {}),
+          ...(keyword.trim() ? { keyword: keyword.trim() } : {})
         };
-        const [groupList, metricsList] = await Promise.all([
+        const [groupList, firstMetricsPage] = await Promise.all([
           getMetricsGroup(params, config),
           getMonitorMetrics(params, config)
         ]);
-        const metricData = cloneDeep(metricsList || []);
-        setMetricsMap((prev) => ({ ...prev, [key]: metricsList || [] }));
-        const groupData = groupList.map((item: GroupInfo) => ({
+        if (abortController.signal.aborted) return [];
+        let metricsList = firstMetricsPage;
+        const selectedMetricExists = metricsList.items.some(
+          (metric) => String(metric.id) === String(selectedMetricId)
+        );
+        const legacyMetricExists = legacyMetricName
+          ? metricsList.items.some((metric) => metric.name === legacyMetricName)
+          : true;
+        if (!keyword.trim() && ((!selectedMetricExists && selectedMetricId) || !legacyMetricExists)) {
+          const selectedPage = await getMonitorMetrics(
+            {
+              monitor_object_id: String(objectId),
+              ...(pluginId ? { monitor_plugin_id: String(pluginId) } : {}),
+              ...(!selectedMetricExists && selectedMetricId
+                ? { id: selectedMetricId }
+                : { name: legacyMetricName || '' })
+            },
+            config
+          );
+          if (abortController.signal.aborted) return [];
+          metricsList = {
+            ...metricsList,
+            items: [...metricsList.items, ...selectedPage.items],
+            metric_groups: [
+              ...(metricsList.metric_groups || []),
+              ...(selectedPage.metric_groups || [])
+            ]
+          };
+        }
+        const metricData = cloneDeep(metricsList.items);
+        if (!keyword.trim()) {
+          setMetricsMap((prev) => ({ ...prev, [key]: metricsList.items }));
+        }
+        const groupData: IndexViewItem[] = (
+          metricsList.metric_groups || groupList.items
+        ).map((item) => ({
           ...item,
+          id: Number(item.id),
           child: []
         }));
         metricData.forEach((metric: MetricItem) => {
           const target = groupData.find(
-            (item: GroupInfo) => item.id === metric.metric_group
+            (item) => item.id === metric.metric_group
           );
           if (target) {
             target.child.push(metric);
           }
         });
-        const filteredGroupData = groupData.filter(
-          (item: IndexViewItem) => !!item.child?.length
-        );
-        setMetricsGroupMap((prev) => ({ ...prev, [key]: filteredGroupData }));
+        const filteredGroupData = groupData.filter((item) => !!item.child?.length);
+        if (keyword.trim() && groupId) {
+          setMetricSearchResultMap((prev) => ({
+            ...prev,
+            [groupId]: filteredGroupData
+          }));
+        } else {
+          setMetricsGroupMap((prev) => ({ ...prev, [key]: filteredGroupData }));
+          if (groupId) {
+            setMetricSearchResultMap((prev) => ({
+              ...prev,
+              [groupId]: filteredGroupData
+            }));
+          }
+        }
         const group = groupId
           ? queryGroups.find((item) => item.id === groupId)
           : null;
         const legacyName = legacyMetricName || group?.legacyMetricName;
         if (legacyName && !group?.metric) {
           const legacyMetric = resolveMetricSelection(
-            metricsList || [],
+            metricsList.items,
             legacyName
           );
           if (legacyMetric && (group?.id || groupId)) {
@@ -390,11 +472,13 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
             });
           }
         }
-        return metricsList || [];
+        return metricsList.items;
       } catch {
         return [];
       } finally {
-        setMetricsLoading((prev) => ({ ...prev, [key]: false }));
+        if (metricsAbortControllerRef.current[requestKey] === abortController) {
+          setMetricsLoading((prev) => ({ ...prev, [key]: false }));
+        }
       }
     };
 
@@ -463,6 +547,11 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
           queryGroups[0].id === groupId ? queryGroups[1]?.id : queryGroups[0].id
         );
       }
+      setSelectedMetricMap((prev) => {
+        const next = { ...prev };
+        delete next[groupId];
+        return next;
+      });
     };
 
     const duplicateQueryGroup = (groupId: string) => {
@@ -474,6 +563,12 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
         name: generateGroupName(queryGroups.length)
       };
       setQueryGroups((prev) => [...prev, newGroup]);
+      if (selectedMetricMap[groupId]) {
+        setSelectedMetricMap((prev) => ({
+          ...prev,
+          [newGroup.id]: selectedMetricMap[groupId]
+        }));
+      }
     };
 
     const toggleGroupCollapse = (groupId: string) => {
@@ -490,6 +585,11 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     };
 
     const handleObjectChange = (groupId: string, objectId: React.Key) => {
+      setSelectedMetricMap((prev) => {
+        const next = { ...prev };
+        delete next[groupId];
+        return next;
+      });
       updateQueryGroup(groupId, {
         object: objectId,
         plugin: null,
@@ -509,6 +609,11 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     ) => {
       const group = queryGroups.find((g) => g.id === groupId);
       if (!group) return;
+      setSelectedMetricMap((prev) => {
+        const next = { ...prev };
+        delete next[groupId];
+        return next;
+      });
       updateQueryGroup(groupId, {
         plugin: pluginId,
         instanceIds: [],
@@ -525,14 +630,38 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     const handleMetricChange = (groupId: string, metricId: React.Key) => {
       const group = queryGroups.find((g) => g.id === groupId);
       if (!group) return;
-      const metrics =
-        metricsMap[getMetricsMapKey(group.object, group.plugin)] || [];
+      const dataKey = getMetricsMapKey(group.object, group.plugin);
+      const searchMetrics = (metricSearchResultMap[groupId] || []).flatMap(
+        (item) => item.child || []
+      );
+      const metrics = [...searchMetrics, ...(metricsMap[dataKey] || [])];
       const target = resolveMetricSelection(metrics, metricId);
+      if (target) {
+        setSelectedMetricMap((prev) => ({ ...prev, [groupId]: target }));
+      }
       updateQueryGroup(groupId, {
         metric: target?.id || metricId,
         legacyMetricName: null,
         conditions: []
       });
+    };
+
+    const handleMetricSearch = (group: QueryGroup, value: string) => {
+      setMetricSearchMap((prev) => ({ ...prev, [group.id]: value }));
+      const previousTimer = metricSearchTimerRef.current[group.id];
+      if (previousTimer) {
+        clearTimeout(previousTimer);
+      }
+      metricSearchTimerRef.current[group.id] = setTimeout(() => {
+        getMetrics(
+          group.object,
+          group.plugin,
+          group.id,
+          null,
+          selectedMetricMap[group.id]?.id || group.metric,
+          value
+        );
+      }, 300);
     };
 
     const getConditionValueOptionsKey = (
@@ -695,7 +824,8 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
         metricsMap,
         instancesMap,
         loadPlugins: getPlugins,
-        loadMetrics: (objectId, pluginId) => getMetrics(objectId, pluginId),
+        loadMetrics: (objectId, pluginId, selectedMetricId) =>
+          getMetrics(objectId, pluginId, undefined, null, selectedMetricId),
         loadInstances: getInstList,
         getResourceKey: getMetricsMapKey,
         resolvePlugin: (plugins, group) =>
@@ -732,11 +862,14 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
     const renderQueryGroup = (group: QueryGroup) => {
       const pluginOptions = pluginsMap[String(group.object)] || [];
       const dataKey = getMetricsMapKey(group.object, group.plugin);
-      const groupMetrics = metricsGroupMap[dataKey] || [];
+      const groupMetrics =
+        metricSearchResultMap[group.id] || metricsGroupMap[dataKey] || [];
       const groupInstances = instancesMap[dataKey] || [];
       // 直接从当前指标定义取维度，避免 URL 深链只填 metric、未走 handleMetricChange 时标签为空。
       const selectedMetric = resolveMetricSelection(
-        metricsMap[dataKey] || [],
+        [selectedMetricMap[group.id], ...(metricsMap[dataKey] || [])].filter(
+          (metric): metric is MetricItem => Boolean(metric)
+        ),
         group.metric
       );
       const groupLabels = resolveMetricDimensionLabels(selectedMetric);
@@ -967,18 +1100,10 @@ const QueryPanel = forwardRef<QueryPanelRef, QueryPanelProps>(
                   groupMetrics,
                   metricSearchMap[group.id] || '',
                 )}
-                onSearch={(value) =>
-                  setMetricSearchMap((prev) => ({
-                    ...prev,
-                    [group.id]: value,
-                  }))
-                }
+                onSearch={(value) => handleMetricSearch(group, value)}
                 onDropdownVisibleChange={(open) => {
                   if (!open) {
-                    setMetricSearchMap((prev) => ({
-                      ...prev,
-                      [group.id]: '',
-                    }));
+                    handleMetricSearch(group, '');
                   }
                 }}
                 onChange={(val) => handleMetricChange(group.id, String(val))}

--- a/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
+++ b/web/src/app/monitor/(pages)/search/savedQueryLoading.ts
@@ -15,7 +15,8 @@ interface LoadSavedQueryResourcesArgs {
   loadPlugins: (objectId: React.Key) => Promise<PluginItem[]>;
   loadMetrics: (
     objectId: React.Key,
-    pluginId: React.Key | null
+    pluginId: React.Key | null,
+    selectedMetricId?: React.Key | null
   ) => Promise<MetricItem[]>;
   loadInstances: (
     objectId: React.Key,
@@ -90,10 +91,13 @@ export const loadSavedQueryResources = async ({
           const pluginId = resolvePlugin(plugins, group);
           if (pluginId && !group.plugin) group.plugin = pluginId;
           const resourceKey = getResourceKey(objectId, pluginId);
-          const metricsPromise = loadedMetricsMap[resourceKey]
+          const metricRequestKey = `${resourceKey}|${String(group.metric || '')}`;
+          const metricsPromise = loadedMetricsMap[resourceKey]?.some(
+            (metric) => String(metric.id) === String(group.metric)
+          )
             ? Promise.resolve(loadedMetricsMap[resourceKey])
-            : getOrCreateRequest(metricRequests, resourceKey, () =>
-              loadMetrics(objectId, pluginId)
+            : getOrCreateRequest(metricRequests, metricRequestKey, () =>
+              loadMetrics(objectId, pluginId, group.metric)
             );
           const instancesPromise = loadedInstancesMap[resourceKey]
             ? Promise.resolve(loadedInstancesMap[resourceKey])

--- a/web/src/app/monitor/(pages)/view/detail/overview.tsx
+++ b/web/src/app/monitor/(pages)/view/detail/overview.tsx
@@ -93,13 +93,18 @@ const Overview: React.FC<ViewDetailProps> = ({
   const getInitData = async () => {
     setLoading(true);
     const indexList = getDashboardDisplay(monitorObjectName);
+    const interfaceConfig = indexList.find(
+      (item: TableDataItem) => item.indexId === 'interfaces'
+    );
+    const metricNames = [
+      ...indexList.map((item: TableDataItem) => item.indexId),
+      ...(interfaceConfig?.displayDimension || [])
+    ].filter((name): name is string => Boolean(name));
     try {
       getMonitorMetrics({
-        monitor_object_id: monitorObjectId
-      }).then((res) => {
-        const interfaceConfig = indexList.find(
-          (item: TableDataItem) => item.indexId === 'interfaces'
-        );
+        monitor_object_id: monitorObjectId,
+        name_in: [...new Set(metricNames)].join(',')
+      }).then(({ items: res }) => {
         const _metricData = res
           .filter((item: MetricItem) =>
             indexList.find(

--- a/web/src/app/monitor/(pages)/view/monitorView.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Spin, Select, Segmented } from 'antd';
+import { Pagination, Spin, Select, Segmented } from 'antd';
 import TimeSelector from '@/components/time-selector';
 import Collapse from '@/components/collapse';
 import useApiClient from '@/utils/request';
@@ -10,7 +10,6 @@ import {
   TableDataItem,
   TimeSelectorDefaultValue,
   TimeValuesProps,
-  GroupInfo,
   MetricItem,
   IndexViewItem,
 } from '@/app/monitor/types';
@@ -49,6 +48,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
     useMonitorApi();
   const { t } = useTranslation();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const metricSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [metricId, setMetricId] = useState<number | null>();
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({
@@ -67,6 +67,9 @@ const MonitorView: React.FC<ViewModalProps> = ({
   const [frequence, setFrequence] = useState<number>(0);
   const [metricData, setMetricData] = useState<IndexViewItem[]>([]);
   const [originMetricData, setOriginMetricData] = useState<IndexViewItem[]>([]);
+  const [metricPage, setMetricPage] = useState(1);
+  const [metricCount, setMetricCount] = useState(0);
+  const [metricKeyword, setMetricKeyword] = useState('');
   const [activeTab, setActiveTab] = useState<string>('');
   const [tabOptions, setTabOptions] = useState(plugins);
   const [processObjectId, setProcessObjectId] = useState('');
@@ -99,6 +102,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
   // 请求并发控制：与指标详情页一致，排队而非取消最早请求。
   const MAX_CONCURRENT_REQUESTS = 4;
   const activeRequestsRef = useRef<Map<number, AbortController>>(new Map());
+  const metricCatalogAbortRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
   const visibleMetricIdsRef = useRef<Set<number>>(new Set());
   const metricDataRef = useRef<IndexViewItem[]>([]);
@@ -205,7 +209,11 @@ const MonitorView: React.FC<ViewModalProps> = ({
   useEffect(() => {
     return () => {
       cancelAllRequests();
+      metricCatalogAbortRef.current?.abort();
       clearTimer();
+      if (metricSearchTimerRef.current) {
+        clearTimeout(metricSearchTimerRef.current);
+      }
     };
   }, []);
 
@@ -248,8 +256,13 @@ const MonitorView: React.FC<ViewModalProps> = ({
   }, [isProcessMetricsView, processObjectId, hostLogicalId]);
 
   const onTabChange = (val: string) => {
+    if (metricSearchTimerRef.current) {
+      clearTimeout(metricSearchTimerRef.current);
+    }
     setActiveTab(val);
     setMetricId(null);
+    setMetricPage(1);
+    setMetricKeyword('');
     setProcessFilterNames([]);
     cancelAllRequests();
     setResetCounter((prev) => prev + 1);
@@ -257,13 +270,15 @@ const MonitorView: React.FC<ViewModalProps> = ({
     setVisibleMetricIds(new Set());
 
     // 切换tab时重新初始化（需要重新获取该tab下的数据）
-    getInitData(val);
+    getInitData(val, undefined, 1, '');
   };
 
   // 初始化数据，包括分组和指标列表（只在弹窗时调用一次）
   const getInitData = async (
     tab: string,
-    processTarget?: { processObjectId: string; processPluginId: string }
+    processTarget?: { processObjectId: string; processPluginId: string },
+    page = 1,
+    keyword = ''
   ) => {
     const processOid = processTarget?.processObjectId || processObjectId;
     const processPid = processTarget?.processPluginId || processPluginId;
@@ -277,49 +292,52 @@ const MonitorView: React.FC<ViewModalProps> = ({
     const params = {
       monitor_object_id: String(processTab ? processOid : monitorObject),
       monitor_plugin_id: processTab ? processPid : tab,
+      page,
+      ...(keyword.trim() ? { keyword: keyword.trim() } : {})
     };
-    const getGroupList = getMetricsGroup(params);
-    const getMetrics = getMonitorMetrics(params);
+    metricCatalogAbortRef.current?.abort();
+    const abortController = new AbortController();
+    metricCatalogAbortRef.current = abortController;
+    const config = { signal: abortController.signal };
     setLoading(true);
     try {
-      Promise.all([getGroupList, getMetrics])
-        .then((res) => {
-          const groupData = res[0].map((item: GroupInfo) => ({
-            ...item,
-            isLoading: false,
-            child: [],
-          }));
-          const metricData = res[1];
-          metricData.forEach((metric: MetricItem) => {
-            const target = groupData.find(
-              (item: GroupInfo) => item.id === metric.metric_group
-            );
-            if (target) {
-              target.child.push({
-                ...metric,
-                viewData: [],
-              });
-            }
-          });
-          const _groupData = groupData.filter(
-            (item: IndexViewItem) => !!item.child?.length
-          );
-          setMetricData(_groupData);
-          setOriginMetricData(_groupData);
-          if (_groupData.length > 0) {
-            // 默认展开全部分组，避免用户逐个点开；具体指标卡仍靠滚入视图懒加载。
-            setExpandedIds(new Set(_groupData.map((group: IndexViewItem) => group.id)));
-          }
-          setLoadedMetricIds(new Set());
-          setLoadingMetricIds(new Set());
-          setCancelledMetricIds(new Set());
-          setVisibleMetricIds(new Set());
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+      const res = await Promise.all([
+        getMetricsGroup(params, config),
+        getMonitorMetrics(params, config)
+      ]);
+      if (abortController.signal.aborted) return;
+      const groupData: IndexViewItem[] = (
+        res[1].metric_groups || res[0].items
+      ).map((item) => ({
+        ...item,
+        id: Number(item.id),
+        isLoading: false,
+        child: [],
+      }));
+      res[1].items.forEach((metric: MetricItem) => {
+        const target = groupData.find((item) => item.id === metric.metric_group);
+        if (target) {
+          target.child.push({ ...metric, viewData: [] });
+        }
+      });
+      const nextGroups = groupData.filter((item) => !!item.child?.length);
+      setMetricCount(res[1].count);
+      setMetricData(nextGroups);
+      setOriginMetricData(nextGroups);
+      setExpandedIds(new Set(nextGroups.map((group) => group.id)));
+      setLoadedMetricIds(new Set());
+      setLoadingMetricIds(new Set());
+      setCancelledMetricIds(new Set());
+      setVisibleMetricIds(new Set());
     } catch {
-      setLoading(false);
+      if (!abortController.signal.aborted) {
+        setMetricData([]);
+        setOriginMetricData([]);
+      }
+    } finally {
+      if (metricCatalogAbortRef.current === abortController) {
+        setLoading(false);
+      }
     }
   };
 
@@ -651,6 +669,27 @@ const MonitorView: React.FC<ViewModalProps> = ({
     }
   };
 
+  const handleMetricKeywordChange = (value: string) => {
+    setMetricKeyword(value);
+    if (metricSearchTimerRef.current) {
+      clearTimeout(metricSearchTimerRef.current);
+    }
+    metricSearchTimerRef.current = setTimeout(() => {
+      setMetricPage(1);
+      setMetricId(null);
+      cancelAllRequests();
+      getInitData(activeTab, undefined, 1, value);
+    }, 300);
+  };
+
+  const handleMetricPageChange = (page: number) => {
+    setMetricPage(page);
+    setMetricId(null);
+    cancelAllRequests();
+    setResetCounter((prev) => prev + 1);
+    getInitData(activeTab, undefined, page, metricKeyword);
+  };
+
   const handleProcessFilterChange = (names: string[]) => {
     setProcessFilterNames(names);
     cancelAllRequests();
@@ -786,6 +825,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
             allowClear
             {...metricSelect.selectSearchProps}
             options={metricSelect.options}
+            onSearch={handleMetricKeywordChange}
             onChange={handleMetricIdChange}
           />
           {isProcessMetricsView ? (
@@ -852,6 +892,17 @@ const MonitorView: React.FC<ViewModalProps> = ({
           ))}
         </Spin>
       </div>
+      {metricCount > 100 && (
+        <div className="mt-4 flex justify-end">
+          <Pagination
+            current={metricPage}
+            pageSize={100}
+            showSizeChanger={false}
+            total={metricCount}
+            onChange={handleMetricPageChange}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/app/monitor/(pages)/view/viewHive.tsx
+++ b/web/src/app/monitor/(pages)/view/viewHive.tsx
@@ -213,13 +213,14 @@ const ViewHive: React.FC<ViewListProps> = ({ objects, objectId }) => {
   const getInitData = async (name: string) => {
     const params = getParams();
     const objParams = {
-      monitor_object_id: String(objectId)
+      monitor_object_id: String(objectId),
+      name: isPod ? 'pod_status_phase' : 'node_status_condition'
     };
     const getInstList = await getInstanceSearch(objectId, params);
     const getQueryParams = await getInstanceQueryParams(name, objParams);
     setTableLoading(true);
     try {
-      const metricsData = await getMonitorMetrics(objParams);
+      const { items: metricsData } = await getMonitorMetrics(objParams);
       setMertics(metricsData || []);
       const tagetMerticItem = metricsData.find(
         (item: MetricItem) =>

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -494,7 +494,19 @@ const ViewList: React.FC<ViewListProps> = ({
     const targetObject = objects.find((item) => item.id === objectId);
     const objName = targetObject?.name;
     const config = { signal: abortController.signal };
-    const getMetrics = getMonitorMetrics(objParams, config);
+    const displayMetricNames = (targetObject?.display_fields || [])
+      .flatMap((column) => column.metrics || [])
+      .map((binding) => binding.metric)
+      .filter(Boolean);
+    const getMetrics = getMonitorMetrics(
+      {
+        ...objParams,
+        ...(displayMetricNames.length
+          ? { name_in: [...new Set(displayMetricNames)].join(',') }
+          : {})
+      },
+      config
+    );
     const shouldFetchQueryParams =
       showMultipleConditions || needsAssetIpFilter;
     setTableLoading(true);
@@ -553,9 +565,9 @@ const ViewList: React.FC<ViewListProps> = ({
           setColony(resolved);
         }
       }
-      setMetrics(res[0] || []);
+      setMetrics(res[0].items);
       if (objName) {
-        const allMetrics: MetricItem[] = res[0] || [];
+        const allMetrics: MetricItem[] = res[0].items;
         // 解析某行在某列应展示的绑定指标值（按绑定顺序取首个有值），保留插件信息以精确定位指标元数据。
         const resolveCell = (record: TableDataItem, col: DisplayCol) => {
           for (const binding of col.metrics || []) {

--- a/web/src/app/monitor/api/index.ts
+++ b/web/src/app/monitor/api/index.ts
@@ -1,36 +1,90 @@
 import useApiClient from '@/utils/request';
 import React from 'react';
 import { AxiosRequestConfig } from 'axios';
-import { InstanceParam } from '@/app/monitor/types';
+import {
+  GroupInfo,
+  InstanceParam,
+  MetricItem,
+  ObjectItem
+} from '@/app/monitor/types';
 
-interface MetricsParam {
+export interface MetricsParam {
   monitor_object_id?: React.Key;
   monitor_plugin_id?: string | number;
   monitor_object_name?: string;
+  id?: React.Key;
+  id_in?: string;
   name?: string;
+  name_in?: string;
+  keyword?: string;
+  include_ifmib?: boolean;
+  page?: number;
+  page_size?: number;
 }
+
+export interface MetricCatalogPage<T> {
+  count: number;
+  items: T[];
+  metric_groups?: MetricCatalogGroup[];
+}
+
+export interface MetricCatalogGroup extends GroupInfo {
+  id: number;
+  monitor_plugin?: React.Key;
+  display_name?: string;
+  is_pre?: boolean;
+}
+
+const isMetricCatalogPage = <T,>(value: unknown): value is MetricCatalogPage<T> => (
+  typeof value === 'object'
+  && value !== null
+  && 'count' in value
+  && 'items' in value
+  && Array.isArray(value.items)
+);
 
 const useMonitorApi = () => {
   const { get, patch } = useApiClient();
+
+  const getMetricCatalogPage = async <T,>(
+    url: string,
+    params: MetricsParam,
+    config?: AxiosRequestConfig
+  ): Promise<MetricCatalogPage<T>> => {
+    const response: unknown = await get(url, {
+      ...config,
+      params: {
+        ...params,
+        page: params.page ?? 1,
+        page_size: params.page_size ?? 100
+      }
+    });
+    if (!isMetricCatalogPage<T>(response)) {
+      return { count: 0, items: [] };
+    }
+    return response;
+  };
 
   const getMonitorMetrics = async (
     params: MetricsParam = {},
     config?: AxiosRequestConfig
   ) => {
-    return await get(`/monitor/api/metrics/`, {
+    return getMetricCatalogPage<MetricItem>(
+      `/monitor/api/metrics/`,
       params,
-      ...config
-    });
+      config
+    );
   };
 
   const getMetricsGroup = async (
     params: MetricsParam = {},
     config?: AxiosRequestConfig
   ) => {
-    return await get(`/monitor/api/metrics_group/`, {
+    return getMetricCatalogPage<MetricCatalogGroup>(
+      `/monitor/api/metrics_group/`,
       params,
-      ...config
-    });
+      config
+    );
   };
 
   const getMonitorObject = async (
@@ -47,7 +101,7 @@ const useMonitorApi = () => {
     });
     // 默认过滤掉不可见对象（is_visible=false）
     if (!include_invisible && Array.isArray(result)) {
-      return result.filter((item: any) => item.is_visible !== false);
+      return result.filter((item: ObjectItem) => item.is_visible !== false);
     }
     return result;
   };

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { Spin, Select, Segmented } from 'antd';
+import { Pagination, Spin, Select, Segmented } from 'antd';
 import TimeSelector from '@/components/time-selector';
 import Collapse from '@/components/collapse';
 import useApiClient from '@/utils/request';
@@ -10,7 +10,6 @@ import {
   TableDataItem,
   TimeSelectorDefaultValue,
   TimeValuesProps,
-  GroupInfo,
   IntegrationItem,
   MetricItem,
   IndexViewItem
@@ -126,6 +125,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   const { get } = useApiClient();
   const { t } = useTranslation();
   const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const metricSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [metricId, setMetricId] = useState<number | null>();
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({
@@ -140,6 +140,9 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   const [frequence, setFrequence] = useState<number>(0);
   const [metricData, setMetricData] = useState<IndexViewItem[]>([]);
   const [originMetricData, setOriginMetricData] = useState<IndexViewItem[]>([]);
+  const [metricPage, setMetricPage] = useState(1);
+  const [metricCount, setMetricCount] = useState(0);
+  const [metricKeyword, setMetricKeyword] = useState('');
   const [activeTab, setActiveTab] = useState<string>('');
   const [plugins, setPlugins] = useState<{ label: string; value: string }[]>([]);
   const [processObjectId, setProcessObjectId] = useState('');
@@ -174,6 +177,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   // 只允许可视区域及下一行卡片以最多四路请求排队加载。
   const MAX_CONCURRENT_REQUESTS = 4;
   const activeRequestsRef = useRef<Map<number, AbortController>>(new Map());
+  const metricCatalogAbortRef = useRef<AbortController | null>(null);
   const requestGenerationRef = useRef(0);
   const visibleMetricIdsRef = useRef<Set<number>>(new Set());
   const metricDataRef = useRef<IndexViewItem[]>([]);
@@ -285,7 +289,11 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   useEffect(() => {
     return () => {
       cancelAllRequests();
+      metricCatalogAbortRef.current?.abort();
       clearTimer();
+      if (metricSearchTimerRef.current) {
+        clearTimeout(metricSearchTimerRef.current);
+      }
     };
   }, []);
 
@@ -386,19 +394,26 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   };
 
   const onTabChange = (val: string) => {
+    if (metricSearchTimerRef.current) {
+      clearTimeout(metricSearchTimerRef.current);
+    }
     setActiveTab(val);
     setMetricId(null);
+    setMetricPage(1);
+    setMetricKeyword('');
     setProcessFilterNames([]);
     cancelAllRequests();
     setResetCounter((prev) => prev + 1);
     setNeedsRefreshOnExpand(true);
     setVisibleMetricIds(new Set());
-    getInitData(val);
+    getInitData(val, undefined, 1, '');
   };
 
   const getInitData = async (
     tab: string,
-    processTarget?: { processObjectId: string; processPluginId: string }
+    processTarget?: { processObjectId: string; processPluginId: string },
+    page = 1,
+    keyword = ''
   ) => {
     const processOid = processTarget?.processObjectId || processObjectId;
     const processPid = processTarget?.processPluginId || processPluginId;
@@ -411,24 +426,35 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     }
     const params = {
       monitor_object_id: processTab ? processOid : String(monitorObjectId),
-      monitor_plugin_id: processTab ? processPid : tab
+      monitor_plugin_id: processTab ? processPid : tab,
+      page,
+      ...(keyword.trim() ? { keyword: keyword.trim() } : {})
     };
+    metricCatalogAbortRef.current?.abort();
+    const abortController = new AbortController();
+    metricCatalogAbortRef.current = abortController;
+    const config = { signal: abortController.signal };
     setLoading(true);
     try {
       const res = await Promise.all([
-        getMetricsGroup(params),
-        getMonitorMetrics(params)
+        getMetricsGroup(params, config),
+        getMonitorMetrics(params, config)
       ]);
-      const groupData = res[0].map((item: GroupInfo) => ({
+      if (abortController.signal.aborted) return;
+      const groupData: IndexViewItem[] = (
+        res[1].metric_groups || res[0].items
+      ).map((item) => ({
         ...item,
+        id: Number(item.id),
         display_name: getDisplayName(item),
         isLoading: false,
         child: []
       }));
-      const metricsList = res[1];
+      const metricsList = res[1].items;
+      setMetricCount(res[1].count);
       metricsList.forEach((metric: MetricItem) => {
         const target = groupData.find(
-          (item: GroupInfo) => item.id === metric.metric_group
+          (item) => item.id === metric.metric_group
         );
         if (target) {
           target.child.push({
@@ -438,24 +464,26 @@ const MetricViews: React.FC<ViewDetailProps> = ({
           });
         }
       });
-      const _groupData = groupData.filter(
-        (item: IndexViewItem) => !!item.child?.length
-      );
+      const _groupData = groupData.filter((item) => !!item.child?.length);
       setMetricData(_groupData);
       setOriginMetricData(_groupData);
       if (_groupData.length > 0) {
         // 默认展开全部分组，避免用户逐个点开；具体指标卡仍靠滚入视图懒加载。
-        setExpandedIds(new Set(_groupData.map((group: IndexViewItem) => group.id)));
+        setExpandedIds(new Set(_groupData.map((group) => group.id)));
       }
       setLoadedMetricIds(new Set());
       setLoadingMetricIds(new Set());
       setCancelledMetricIds(new Set());
       setVisibleMetricIds(new Set());
     } catch {
-      setMetricData([]);
-      setOriginMetricData([]);
+      if (!abortController.signal.aborted) {
+        setMetricData([]);
+        setOriginMetricData([]);
+      }
     } finally {
-      setLoading(false);
+      if (metricCatalogAbortRef.current === abortController) {
+        setLoading(false);
+      }
     }
   };
 
@@ -828,6 +856,27 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     }
   };
 
+  const handleMetricKeywordChange = (value: string) => {
+    setMetricKeyword(value);
+    if (metricSearchTimerRef.current) {
+      clearTimeout(metricSearchTimerRef.current);
+    }
+    metricSearchTimerRef.current = setTimeout(() => {
+      setMetricPage(1);
+      setMetricId(null);
+      cancelAllRequests();
+      getInitData(activeTab, undefined, 1, value);
+    }, 300);
+  };
+
+  const handleMetricPageChange = (page: number) => {
+    setMetricPage(page);
+    setMetricId(null);
+    cancelAllRequests();
+    setResetCounter((prev) => prev + 1);
+    getInitData(activeTab, undefined, page, metricKeyword);
+  };
+
   const handleProcessFilterChange = (names: string[]) => {
     setProcessFilterNames(names);
     cancelAllRequests();
@@ -946,6 +995,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
             allowClear
             {...metricSelect.selectSearchProps}
             options={metricSelect.options}
+            onSearch={handleMetricKeywordChange}
             onChange={handleMetricIdChange}
           />
           {isProcessMetricsView ? (
@@ -1007,6 +1057,17 @@ const MetricViews: React.FC<ViewDetailProps> = ({
           ))}
         </Spin>
       </div>
+      {metricCount > 100 && (
+        <div className="mt-4 flex justify-end">
+          <Pagination
+            current={metricPage}
+            pageSize={100}
+            showSizeChanger={false}
+            total={metricCount}
+            onChange={handleMetricPageChange}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
+++ b/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
@@ -1,0 +1,28 @@
+export type SnmpInterfaceFilterMode = 'all' | 'exclude' | 'include';
+
+const EXCLUDE_FIELDS = ['iftype_exclude', 'ifdescr_exclude'] as const;
+const INCLUDE_FIELDS = ['iftype_include', 'ifdescr_include'] as const;
+export const DEFAULT_SNMP_IFTYPE_EXCLUDE = ['24', '53', '131', '135', '136'];
+
+export const getSnmpInterfaceFilterModePatch = (
+  changedValues: Record<string, unknown>
+): Record<string, unknown> => {
+  const mode = changedValues.interface_filter_mode as SnmpInterfaceFilterMode | undefined;
+  if (!mode) return {};
+
+  const fieldsToClear =
+    mode === 'all'
+      ? [...EXCLUDE_FIELDS, ...INCLUDE_FIELDS]
+      : mode === 'exclude'
+        ? INCLUDE_FIELDS
+        : EXCLUDE_FIELDS;
+
+  const patch = Object.fromEntries(
+    fieldsToClear.map((field) => [field, field.startsWith('iftype') ? [] : ''])
+  );
+  // 切回“排除部分”时恢复产品默认的虚拟接口排除，避免策略名称与实际规则不一致。
+  if (mode === 'exclude') {
+    patch.iftype_exclude = DEFAULT_SNMP_IFTYPE_EXCLUDE;
+  }
+  return patch;
+};

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -7,7 +7,8 @@ import {
   Checkbox,
   Button,
   Tooltip,
-  Switch
+  Switch,
+  Segmented
 } from 'antd';
 import { ExclamationCircleFilled, MinusCircleOutlined, PlusOutlined } from '@ant-design/icons';
 import Password from '@/components/password';
@@ -375,6 +376,19 @@ export const useConfigRenderer = () => {
 
         case 'switch':
           return <Switch {...widget_props} className="mr-[10px]" />;
+
+        case 'segmented':
+          return (
+            <Segmented
+              {...widget_props}
+              disabled={Boolean(locked || widget_props.disabled)}
+              options={options.map((option: { label: string; value: string | number }) => ({
+                label: option.label,
+                value: option.value
+              }))}
+              className="mr-[10px]"
+            />
+          );
 
         case 'checkbox_group':
           return (

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from 'react';
-import { Collapse } from 'antd';
+import { Collapse, Form } from 'antd';
 import { useConfigRenderer } from './useConfigRenderer';
 import { DataMapper } from './useDataMapper';
 import {
@@ -34,6 +34,55 @@ export const fillOptionalFormFields = (
   });
   return result;
 };
+
+const INTERFACE_FILTER_FIELD_NAMES = new Set([
+  'interface_filter_mode',
+  'iftype_exclude',
+  'iftype_include',
+  'ifdescr_exclude',
+  'ifdescr_include'
+]);
+
+interface FieldDependency {
+  field?: string | string[];
+  value?: unknown;
+  conditions?: Array<Array<{ equals?: unknown }>>;
+}
+
+interface AdvancedFormField {
+  name: string;
+  section?: string;
+  dependency?: FieldDependency;
+}
+
+/**
+ * IF-MIB 的接口过滤只在接口表启用时才有意义。此处识别这一类独占高级面板，
+ * 供外层直接随 enable_ifmib 隐藏整个折叠区，避免留下没有字段的空面板。
+ */
+export const isIfmibFilterAdvancedPanel = (advancedFields: AdvancedFormField[]) =>
+  advancedFields.length > 0 &&
+  advancedFields.every(
+    (field) => {
+      const dependency = field.dependency;
+      const enableIfmibIndex = Array.isArray(dependency?.field)
+        ? dependency.field.indexOf('enable_ifmib')
+        : -1;
+      const dependsOnEnabledIfmib =
+        (dependency?.field === 'enable_ifmib' && dependency?.value === true) ||
+        (enableIfmibIndex >= 0 && dependency?.conditions?.[enableIfmibIndex]?.some(
+          (condition) => condition?.equals === true
+        ));
+      return (
+        (field.section === 'interface_filter' || INTERFACE_FILTER_FIELD_NAMES.has(field.name)) &&
+        dependsOnEnabledIfmib
+      );
+    }
+  );
+
+export const shouldRenderAdvancedFieldsPanel = (
+  isIfmibFilterPanel: boolean,
+  enableIfmib: unknown
+) => !isIfmibFilterPanel || enableIfmib !== false;
 
 export const usePluginFromJson = () => {
   const { isLoading } = useApiClient();
@@ -148,7 +197,10 @@ export const usePluginFromJson = () => {
               if (field.visible_in === 'auto' && mode === 'edit') return null;
               if (field.visible_in === 'edit' && mode === 'auto') return null;
             }
-            if (mode === 'edit' && field.editable === false) {
+            if (
+              mode === 'edit'
+              && (field.editable === false || field.name === 'enable_ifmib')
+            ) {
               fieldCopy.widget_props = {
                 ...field.widget_props,
                 disabled: true
@@ -164,16 +216,7 @@ export const usePluginFromJson = () => {
       const basicFields = formFields?.filter((field: any) => !field.advanced) || [];
       const ADVANCED_SECTION_ORDER = ['request', 'auth', 'response', 'tls', 'interface_filter'];
       const advancedPanel = config.advanced_panel || {};
-      const isInterfaceFilterAdvanced =
-        Boolean(advancedPanel.title) ||
-        (advancedFields.length > 0 &&
-          advancedFields.every(
-            (field: any) =>
-              field.section === 'interface_filter' ||
-              ['iftype_exclude', 'iftype_include', 'ifdescr_exclude', 'ifdescr_include'].includes(
-                field.name
-              )
-          ));
+      const isInterfaceFilterAdvanced = isIfmibFilterAdvancedPanel(advancedFields);
       const advancedTitle =
         advancedPanel.title ||
         (isInterfaceFilterAdvanced
@@ -233,6 +276,21 @@ export const usePluginFromJson = () => {
             renderFormField(fieldConfig, extra.mode)
           )}
           {advancedFields.length > 0 && (
+            <Form.Item
+              noStyle
+              shouldUpdate={
+                isInterfaceFilterAdvanced
+                  ? (previousValues, currentValues) =>
+                    previousValues.enable_ifmib !== currentValues.enable_ifmib
+                  : false
+              }
+            >
+              {({ getFieldValue }) =>
+                // 未初始化时沿用 enable_ifmib 默认 true；只有明确关闭才隐藏整个区域。
+                !shouldRenderAdvancedFieldsPanel(
+                  isInterfaceFilterAdvanced,
+                  getFieldValue('enable_ifmib')
+                ) ? null : (
             <Collapse
               bordered={false}
               ghost
@@ -256,6 +314,9 @@ export const usePluginFromJson = () => {
                 children: renderAdvancedFieldGroups(advancedFields),
               }]}
             />
+                )
+              }
+            </Form.Item>
           )}
         </>
       );

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -400,6 +400,14 @@
       "rule": "Rule",
       "dbNameDes": "The specific name of the database required for access",
       "configuration": "Configuration",
+      "ifmibSnapshotEnabled": "Deployment snapshot: Standard Interface Monitoring (IF-MIB) enabled",
+      "ifmibSnapshotDisabled": "Deployment snapshot: Standard Interface Monitoring (IF-MIB) disabled",
+      "ifmibSnapshotDescription": "This status comes from the deployed configuration. Changing the template or returning to the integration page will not change it.",
+      "ifmibMetricGroups": {
+        "overview": "Interface Overview",
+        "traffic": "Interface Traffic",
+        "packetsAndExceptions": "Interface Packets and Exceptions"
+      },
       "fieldGuideTip": "Field Tip",
       "configureStep1": "Define collection targets",
       "reportingStatus": "Reporting Status",
@@ -592,6 +600,7 @@
       "advancedConfigurationHint": "Configure request payload, authentication, and expected response checks as needed",
       "advancedFilterConfiguration": "Interface Filters",
       "advancedFilterConfigurationHint": "Configure exclude or include filters by ifType and ifDescr",
+      "viewInterfaceMetrics": "View Interface Metrics",
       "filterMutexConflict": "\"{left}\" and \"{right}\" cannot be set together. Clear one side first",
       "filterMutexOptionDisabled": "Already selected in \"{peer}\"",
       "filterMutexPeerOccupied": "\"{peer}\" is already set; cannot configure both",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -400,6 +400,14 @@
       "rule": "规则",
       "dbNameDes": "访问所需数据库的具体名字",
       "configuration": "采集配置",
+      "ifmibSnapshotEnabled": "此实例下发快照：已启用标准接口监控（IF-MIB）",
+      "ifmibSnapshotDisabled": "此实例下发快照：未启用标准接口监控（IF-MIB）",
+      "ifmibSnapshotDescription": "该状态来自已下发配置；修改模板或重新进入接入页不会改变它。",
+      "ifmibMetricGroups": {
+        "overview": "接口概况",
+        "traffic": "接口流量",
+        "packetsAndExceptions": "接口报文与异常"
+      },
       "fieldGuideTip": "填写说明",
       "configureStep1": "定义收集目标",
       "reportingStatus": "上报状态",
@@ -592,6 +600,7 @@
       "advancedConfigurationHint": "按需配置请求内容、认证方式与期望响应判断",
       "advancedFilterConfiguration": "接口过滤",
       "advancedFilterConfigurationHint": "按接口类型（ifType）和名称（ifDescr）配置排除或仅采集",
+      "viewInterfaceMetrics": "查看接口指标",
       "filterMutexConflict": "「{left}」与「{right}」不能同时配置，请先清空其中一侧",
       "filterMutexOptionDisabled": "「{peer}」已选中该值",
       "filterMutexPeerOccupied": "「{peer}」已填写，不能同时配置",

--- a/web/src/app/monitor/types/index.ts
+++ b/web/src/app/monitor/types/index.ts
@@ -293,6 +293,7 @@ export interface MetricItem {
   unit?: string;
   displayType?: string;
   description?: string;
+  is_ifmib?: boolean;
   viewData?: ChartData[] | InterfaceTableItem[];
   displayUnit?: string;
   seriesBudget?: {

--- a/web/src/app/monitor/types/integration.ts
+++ b/web/src/app/monitor/types/integration.ts
@@ -47,6 +47,7 @@ export interface MetricInfo {
   unit?: string;
   description?: string;
   dimensions?: string[];
+  is_ifmib?: boolean;
 }
 
 export interface FilterItem {
@@ -91,10 +92,13 @@ export interface ObjectInstItem {
 export interface MetricListItem {
   id: string;
   name: string;
+  monitor_plugin?: React.Key;
   child: MetricItem[];
   display_name?: string;
   isOpen?: boolean;
   is_pre: boolean;
+  /** 当前分组内的指标是否全部由公共 IF-MIB 表提供。 */
+  is_ifmib_group?: boolean;
 }
 
 export interface DimensionItem {


### PR DESCRIPTION
## 变更
- 复用内部公共 IF-MIB 表，为 Network Device SNMP 模板按本次下发开关注入一份接口采集与过滤配置。
- 补齐接口状态、速率、流量、错包与丢包指标目录和展示状态。
- 限制指标目录分页查询，修复详情页参数重复及 IF-MIB 预览/编辑边界。

## 验证
- 目标前端 ESLint、IF-MIB Vitest（14 项）、Python compileall、JSON 与 diff 检查通过。
- 后端 pytest 受本地 django_celery_beat 初始化配置阻断，未纳入本 PR 的未跟踪测试未提交。

## 范围
- 相对 TencentBlueKing/bk-lite:master：6 个提交、35 个任务相关文件；未包含本地开发文件、图标、报告或未跟踪测试。