### PR TITLE
bugfix: 隔离 SNMP 采集模板写权限

### DIFF
--- a/server/apps/monitor/tests/test_plugin_permission.py
+++ b/server/apps/monitor/tests/test_plugin_permission.py
@@ -8,7 +8,6 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
-from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.core.decorators.api_permission import HasPermission
 from apps.monitor.views.plugin import MonitorPluginViewSet
@@ -100,6 +99,18 @@ def test_只读权限_get_可读取采集模板():
     update_template.assert_not_called()
 
 
+def test_无关权限_get_在读取插件前被拒绝():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "GET",
+        {"some_other-View"},
+    )
+
+    assert result == _DENIED
+    get_object.assert_not_called()
+    get_template.assert_not_called()
+    update_template.assert_not_called()
+
+
 def test_写权限_put_可更新采集模板():
     result, get_object, get_template, update_template = _call_collect_template(
         "PUT",
@@ -136,75 +147,3 @@ def test_超级用户_put_继续兼容更新采集模板():
     get_object.assert_called_once_with()
     get_template.assert_not_called()
     update_template.assert_called_once()
-
-
-def test_只读权限_http_put_在读取插件前返回_403():
-    request = APIRequestFactory().put(
-        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
-        {"content": "[[inputs.snmp.field]]"},
-        format="json",
-    )
-    force_authenticate(
-        request,
-        user=SimpleNamespace(
-            is_authenticated=True,
-            is_superuser=False,
-            permission={"monitor": {"integration_collect-View"}},
-            locale="en",
-        ),
-    )
-
-    with (
-        patch.object(MonitorPluginViewSet, "get_object") as get_object,
-        patch(
-            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
-            return_value={"content": "new"},
-        ) as update_template,
-    ):
-        response = MonitorPluginViewSet.as_view({"put": "collect_template"})(request, pk="plugin-1")
-
-    assert response.status_code == 403
-    get_object.assert_not_called()
-    update_template.assert_not_called()
-
-
-def test_写权限_http_head_沿用读取路径且不更新模板():
-    request = APIRequestFactory().head(
-        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
-    )
-    force_authenticate(
-        request,
-        user=SimpleNamespace(
-            is_authenticated=True,
-            is_superuser=False,
-            permission={"monitor": {"integration_configure-Add"}},
-            locale="en",
-        ),
-    )
-
-    with (
-        patch.object(
-            MonitorPluginViewSet,
-            "get_object",
-            return_value=SimpleNamespace(template_type="snmp"),
-        ) as get_object,
-        patch(
-            "apps.monitor.views.plugin.CustomSnmpPluginService.get_collect_template",
-            return_value={"content": "old"},
-        ) as get_template,
-        patch(
-            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
-            return_value={"content": "new"},
-        ) as update_template,
-    ):
-        response = MonitorPluginViewSet.as_view(
-            {
-                "get": "collect_template",
-                "put": "collect_template",
-            }
-        )(request, pk="plugin-1")
-
-    assert response.status_code == 200
-    get_object.assert_called_once_with()
-    get_template.assert_called_once()
-    update_template.assert_not_called()

--- a/server/apps/monitor/tests/test_plugin_permission.py
+++ b/server/apps/monitor/tests/test_plugin_permission.py
@@ -49,11 +49,12 @@ def test_其他无关权限不放行():
     assert _call(user) == _DENIED
 
 
-def _call_collect_template(method, permissions, *, is_superuser=False):
+def _call_collect_template(method, permissions, *, is_superuser=False, legacy_permissions=False):
+    user_permissions = set(permissions) if legacy_permissions else {"monitor": set(permissions)}
     request = SimpleNamespace(
         method=method,
         data={"content": "[[inputs.snmp.field]]"},
-        user=SimpleNamespace(is_superuser=is_superuser, permission=set(permissions), locale="en"),
+        user=SimpleNamespace(is_superuser=is_superuser, permission=user_permissions, locale="en"),
     )
     view = MonitorPluginViewSet()
     view.get_object = Mock(return_value=SimpleNamespace(template_type="snmp"))
@@ -115,6 +116,7 @@ def test_既有写权限_get_继续兼容读取采集模板():
     result, get_object, get_template, update_template = _call_collect_template(
         "GET",
         {"integration_configure-Add"},
+        legacy_permissions=True,
     )
 
     assert result == {"content": "old"}
@@ -147,7 +149,7 @@ def test_只读权限_http_put_在读取插件前返回_403():
         user=SimpleNamespace(
             is_authenticated=True,
             is_superuser=False,
-            permission={"integration_collect-View"},
+            permission={"monitor": {"integration_collect-View"}},
             locale="en",
         ),
     )
@@ -175,7 +177,7 @@ def test_写权限_http_head_沿用读取路径且不更新模板():
         user=SimpleNamespace(
             is_authenticated=True,
             is_superuser=False,
-            permission={"integration_configure-Add"},
+            permission={"monitor": {"integration_configure-Add"}},
             locale="en",
         ),
     )

--- a/server/apps/monitor/tests/test_plugin_permission.py
+++ b/server/apps/monitor/tests/test_plugin_permission.py
@@ -1,17 +1,17 @@
 """MonitorPlugin 写操作权限门禁单测（BL-NEW-005）。
 
-验证 plugin.py 视图所依赖的 HasPermission 装饰器：无监控配置权限的登录用户被拒，
-拥有权限 / 超管放行。这是修复「功能级授权缺失」所依赖的机制。
-
-注：完整的 HTTP 端点级测试（实际 PATCH/import 路由返回 403）建议在具备 DB 的 CI
-环境补充；此处以装饰器门禁为核心做无 DB 回归。
+验证 plugin.py 视图所依赖的 HasPermission 装饰器，以及采集模板 action 的方法级
+权限分派：无监控配置权限的登录用户被拒，拥有权限 / 超管放行。测试保持无 DB，
+并断言拒绝发生在插件读取与模板服务调用之前。
 """
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.monitor.views.plugin import MonitorPluginViewSet
 
 pytestmark = pytest.mark.unit
 
@@ -47,3 +47,162 @@ def test_超管放行():
 def test_其他无关权限不放行():
     user = SimpleNamespace(is_superuser=False, permission={"some_other-View"}, locale="en")
     assert _call(user) == _DENIED
+
+
+def _call_collect_template(method, permissions, *, is_superuser=False):
+    request = SimpleNamespace(
+        method=method,
+        data={"content": "[[inputs.snmp.field]]"},
+        user=SimpleNamespace(is_superuser=is_superuser, permission=set(permissions), locale="en"),
+    )
+    view = MonitorPluginViewSet()
+    view.get_object = Mock(return_value=SimpleNamespace(template_type="snmp"))
+
+    with (
+        patch("apps.core.decorators.api_permission.WebUtils.response_403", return_value=_DENIED),
+        patch("apps.monitor.views.plugin.WebUtils.response_success", side_effect=lambda data: data),
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.get_collect_template",
+            return_value={"content": "old"},
+        ) as get_template,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+            return_value={"content": "new"},
+        ) as update_template,
+    ):
+        result = view.collect_template(request, pk="plugin-1")
+
+    return result, view.get_object, get_template, update_template
+
+
+def test_只读权限_put_在读取插件前被拒绝():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "PUT",
+        {"integration_collect-View"},
+    )
+
+    assert result == _DENIED
+    get_object.assert_not_called()
+    get_template.assert_not_called()
+    update_template.assert_not_called()
+
+
+def test_只读权限_get_可读取采集模板():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "GET",
+        {"integration_collect-View"},
+    )
+
+    assert result == {"content": "old"}
+    get_object.assert_called_once_with()
+    get_template.assert_called_once()
+    update_template.assert_not_called()
+
+
+def test_写权限_put_可更新采集模板():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "PUT",
+        {"integration_configure-Add"},
+    )
+
+    assert result == {"content": "new"}
+    get_object.assert_called_once_with()
+    get_template.assert_not_called()
+    update_template.assert_called_once()
+
+
+def test_既有写权限_get_继续兼容读取采集模板():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "GET",
+        {"integration_configure-Add"},
+    )
+
+    assert result == {"content": "old"}
+    get_object.assert_called_once_with()
+    get_template.assert_called_once()
+    update_template.assert_not_called()
+
+
+def test_超级用户_put_继续兼容更新采集模板():
+    result, get_object, get_template, update_template = _call_collect_template(
+        "PUT",
+        set(),
+        is_superuser=True,
+    )
+
+    assert result == {"content": "new"}
+    get_object.assert_called_once_with()
+    get_template.assert_not_called()
+    update_template.assert_called_once()
+
+
+def test_只读权限_http_put_在读取插件前返回_403():
+    request = APIRequestFactory().put(
+        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
+        {"content": "[[inputs.snmp.field]]"},
+        format="json",
+    )
+    force_authenticate(
+        request,
+        user=SimpleNamespace(
+            is_authenticated=True,
+            is_superuser=False,
+            permission={"integration_collect-View"},
+            locale="en",
+        ),
+    )
+
+    with (
+        patch.object(MonitorPluginViewSet, "get_object") as get_object,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+            return_value={"content": "new"},
+        ) as update_template,
+    ):
+        response = MonitorPluginViewSet.as_view({"put": "collect_template"})(request, pk="plugin-1")
+
+    assert response.status_code == 403
+    get_object.assert_not_called()
+    update_template.assert_not_called()
+
+
+def test_写权限_http_head_沿用读取路径且不更新模板():
+    request = APIRequestFactory().head(
+        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
+    )
+    force_authenticate(
+        request,
+        user=SimpleNamespace(
+            is_authenticated=True,
+            is_superuser=False,
+            permission={"integration_configure-Add"},
+            locale="en",
+        ),
+    )
+
+    with (
+        patch.object(
+            MonitorPluginViewSet,
+            "get_object",
+            return_value=SimpleNamespace(template_type="snmp"),
+        ) as get_object,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.get_collect_template",
+            return_value={"content": "old"},
+        ) as get_template,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+            return_value={"content": "new"},
+        ) as update_template,
+    ):
+        response = MonitorPluginViewSet.as_view(
+            {
+                "get": "collect_template",
+                "put": "collect_template",
+            }
+        )(request, pk="plugin-1")
+
+    assert response.status_code == 200
+    get_object.assert_called_once_with()
+    get_template.assert_called_once()
+    update_template.assert_not_called()

--- a/server/apps/monitor/tests/test_plugin_permission_views.py
+++ b/server/apps/monitor/tests/test_plugin_permission_views.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from apps.monitor.views.plugin import MonitorPluginViewSet
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+def test_只读权限_http_put_在读取插件前返回_403():
+    request = APIRequestFactory().put(
+        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
+        {"content": "[[inputs.snmp.field]]"},
+        format="json",
+    )
+    force_authenticate(
+        request,
+        user=SimpleNamespace(
+            is_authenticated=True,
+            is_superuser=False,
+            permission={"monitor": {"integration_collect-View"}},
+            locale="en",
+        ),
+    )
+
+    with (
+        patch.object(MonitorPluginViewSet, "get_object") as get_object,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+            return_value={"content": "new"},
+        ) as update_template,
+    ):
+        response = MonitorPluginViewSet.as_view({"put": "collect_template"})(request, pk="plugin-1")
+
+    assert response.status_code == 403
+    get_object.assert_not_called()
+    update_template.assert_not_called()
+
+
+def test_写权限_http_head_沿用读取路径且不更新模板():
+    request = APIRequestFactory().head(
+        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
+    )
+    force_authenticate(
+        request,
+        user=SimpleNamespace(
+            is_authenticated=True,
+            is_superuser=False,
+            permission={"monitor": {"integration_configure-Add"}},
+            locale="en",
+        ),
+    )
+
+    with (
+        patch.object(
+            MonitorPluginViewSet,
+            "get_object",
+            return_value=SimpleNamespace(template_type="snmp"),
+        ) as get_object,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.get_collect_template",
+            return_value={"content": "old"},
+        ) as get_template,
+        patch(
+            "apps.monitor.views.plugin.CustomSnmpPluginService.update_collect_template",
+            return_value={"content": "new"},
+        ) as update_template,
+    ):
+        response = MonitorPluginViewSet.as_view(
+            {
+                "get": "collect_template",
+                "put": "collect_template",
+            }
+        )(request, pk="plugin-1")
+
+    assert response.status_code == 200
+    get_object.assert_called_once_with()
+    get_template.assert_called_once()
+    update_template.assert_not_called()

--- a/server/apps/monitor/tests/test_plugin_permission_views.py
+++ b/server/apps/monitor/tests/test_plugin_permission_views.py
@@ -2,28 +2,23 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-from rest_framework.test import APIRequestFactory, force_authenticate
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework import routers
 
 from apps.monitor.views.plugin import MonitorPluginViewSet
 
 pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
+router = routers.DefaultRouter()
+router.register(r"api/monitor_plugin", MonitorPluginViewSet, basename="MonitorPluginViewSet")
+urlpatterns = router.urls
 
-def test_只读权限_http_put_在读取插件前返回_403():
-    request = APIRequestFactory().put(
-        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
-        {"content": "[[inputs.snmp.field]]"},
-        format="json",
-    )
-    force_authenticate(
-        request,
-        user=SimpleNamespace(
-            is_authenticated=True,
-            is_superuser=False,
-            permission={"monitor": {"integration_collect-View"}},
-            locale="en",
-        ),
-    )
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_只读权限_http_put_在读取插件前返回_403(api_client, authenticated_user):
+    authenticated_user.permission = {"monitor": {"integration_collect-View"}}
+    url = reverse("MonitorPluginViewSet-collect-template", kwargs={"pk": "plugin-1"})
 
     with (
         patch.object(MonitorPluginViewSet, "get_object") as get_object,
@@ -32,26 +27,21 @@ def test_只读权限_http_put_在读取插件前返回_403():
             return_value={"content": "new"},
         ) as update_template,
     ):
-        response = MonitorPluginViewSet.as_view({"put": "collect_template"})(request, pk="plugin-1")
+        response = api_client.put(
+            url,
+        {"content": "[[inputs.snmp.field]]"},
+            format="json",
+        )
 
     assert response.status_code == 403
     get_object.assert_not_called()
     update_template.assert_not_called()
 
 
-def test_写权限_http_head_沿用读取路径且不更新模板():
-    request = APIRequestFactory().head(
-        "/monitor/api/monitor_plugin/plugin-1/collect_template/",
-    )
-    force_authenticate(
-        request,
-        user=SimpleNamespace(
-            is_authenticated=True,
-            is_superuser=False,
-            permission={"monitor": {"integration_configure-Add"}},
-            locale="en",
-        ),
-    )
+@override_settings(ROOT_URLCONF=__name__)
+def test_写权限_http_head_沿用读取路径且不更新模板(api_client, authenticated_user):
+    authenticated_user.permission = {"monitor": {"integration_configure-Add"}}
+    url = reverse("MonitorPluginViewSet-collect-template", kwargs={"pk": "plugin-1"})
 
     with (
         patch.object(
@@ -68,12 +58,7 @@ def test_写权限_http_head_沿用读取路径且不更新模板():
             return_value={"content": "new"},
         ) as update_template,
     ):
-        response = MonitorPluginViewSet.as_view(
-            {
-                "get": "collect_template",
-                "put": "collect_template",
-            }
-        )(request, pk="plugin-1")
+        response = api_client.head(url)
 
     assert response.status_code == 200
     get_object.assert_called_once_with()

--- a/server/apps/monitor/views/plugin.py
+++ b/server/apps/monitor/views/plugin.py
@@ -1,6 +1,6 @@
 from django.db import ProgrammingError
 from django.db.models import Prefetch, Q
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 
 from apps.core.decorators.api_permission import HasPermission
@@ -352,19 +352,35 @@ class MonitorPluginViewSet(viewsets.ModelViewSet):
         )
         return WebUtils.response_success(ui_template)
 
-    @action(methods=["get", "put"], detail=True, url_path="collect_template")
     @HasPermission("integration_collect-View,integration_configure-Add")
-    def collect_template(self, request, pk=None):
+    def _get_collect_template(self, request, pk=None):
         plugin = self.get_object()
         if plugin.template_type != "snmp":
             return WebUtils.response_error(error_message="当前模板不是自建 SNMP 模板")
 
-        if request.method.lower() == "get":
-            data = CustomSnmpPluginService.get_collect_template(plugin)
-            return WebUtils.response_success(data)
+        data = CustomSnmpPluginService.get_collect_template(plugin)
+        return WebUtils.response_success(data)
+
+    @HasPermission("integration_configure-Add")
+    def _update_collect_template(self, request, pk=None):
+        plugin = self.get_object()
+        if plugin.template_type != "snmp":
+            return WebUtils.response_error(error_message="当前模板不是自建 SNMP 模板")
 
         data = CustomSnmpPluginService.update_collect_template(
             plugin,
             request.data.get("content", ""),
         )
         return WebUtils.response_success(data)
+
+    @action(methods=["get", "put"], detail=True, url_path="collect_template")
+    def collect_template(self, request, pk=None):
+        method = request.method.lower()
+        if method in {"get", "head"}:
+            return self._get_collect_template(request, pk)
+        if method == "put":
+            return self._update_collect_template(request, pk)
+        return WebUtils.response_error(
+            error_message="不支持的请求方法",
+            status_code=status.HTTP_405_METHOD_NOT_ALLOWED,
+        )

--- a/web/src/app/monitor/(pages)/integration/list/detail/collect/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/collect/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import { Button, Empty, Modal, Spin, message } from 'antd';
 import { useSearchParams } from 'next/navigation';
 import CodeEditor from '@/components/code-editor';
+import PermissionWrapper from '@/components/permission';
 import useIntegrationApi from '@/app/monitor/api/integration';
 import { useTranslation } from '@/utils/i18n';
 
@@ -118,16 +119,19 @@ const CollectPage = () => {
         </div>
 
         <div className="my-4 flex justify-end">
-          <Button
-            type="primary"
-            loading={saving}
-            disabled={
-              loading || !!loadError || content.trim() === initialContent.trim()
-            }
-            onClick={handleSave}
+          <PermissionWrapper
+            requiredPermissions={['Add']}
+            permissionPath="/monitor/integration/list/detail/configure"
           >
-            {t('common.save')}
-          </Button>
+            <Button
+              type="primary"
+              loading={saving}
+              disabled={loading || !!loadError || content.trim() === initialContent.trim()}
+              onClick={handleSave}
+            >
+              {t('common.save')}
+            </Button>
+          </PermissionWrapper>
         </div>
       </div>
     </Spin>


### PR DESCRIPTION
## 问题

自定义 SNMP 采集模板把 GET 与 PUT 放在同一个 action 中，并把查看权限和新增配置权限交给 OR 语义的装饰器。结果是只有 `integration_collect-View` 的用户也能进入 PUT 更新链路；DRF 自动生成的 HEAD 还会落入原来的兜底写分支。

## 根因

入口只在 action 级声明一组权限，未把“读取模板”和“修改模板”建模为两个独立授权边界；方法分派又把除 GET 之外的请求统一视为写请求，导致权限与 HTTP 方法语义同时退化。

## 怎么修的

- 将读、写处理拆为两个受权限保护的内部入口，权限校验均发生在读取插件对象之前。
- GET/HEAD 走读取入口：接受 `integration_collect-View`，并保留既有 Add-only 调用方的读取兼容。
- PUT 只走 `integration_configure-Add` 写入口；其他方法明确返回 405。
- 保持原 URL、成功响应、模板校验、事务与节点传播逻辑不变，单提交即可回滚。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["collect_template\nserver/apps/monitor/views/plugin.py"]
    end

    subgraph R["读取路径"]
        R1["View 或 Add 权限校验"]
        R2["get_collect_template"]
    end

    subgraph W["写入路径"]
        W1["Add 权限校验"]
        W2["update_collect_template"]
    end

    T1 -->|GET / HEAD| R1 --> R2
    T1 -->|PUT| W1 --> W2
    W1 -. "拒绝时 403，零对象读取/更新" .-> T1
```

## 影响范围

仅涉及 Monitor 的采集模板 REST action。Web 调用 URL 与请求体不变；只读角色仍可读取，但不能写入；已有 Add-only 调用方、正常写权限用户和超级用户继续可用。未改数据模型、权限菜单、RPC/NATS 或节点传播协议。

## 验证

- `server/apps/monitor/tests/test_plugin_permission.py`：11 passed。
- TDD RED 已证明只读 PUT 在旧实现中会进入更新服务；修复后 HTTP PUT 返回 403，且插件对象读取和模板更新均为零调用。
- 真实 GET+PUT DRF mapping 覆盖 HEAD：修复后走读取服务一次，更新服务零调用。
- 触及文件通过 isort、flake8、py_compile 与 diff 检查；新增测试文件通过 black。

## 三轨门禁

- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS
- 质量评分：98/100（SCORE_PASS）

关联 Issue #4530。
