### PR TITLE
bugfix: 修复 Linux 公告多包遗漏

### DIFF
--- a/server/apps/patch_mgmt/migrations/0006_linuxpatchdetail_packages.py
+++ b/server/apps/patch_mgmt/migrations/0006_linuxpatchdetail_packages.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("patch_mgmt", "0005_add_requirement_assessment_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="linuxpatchdetail",
+            name="packages",
+            field=models.JSONField(default=list, verbose_name="关联软件包列表"),
+        ),
+    ]

--- a/server/apps/patch_mgmt/models/patch.py
+++ b/server/apps/patch_mgmt/models/patch.py
@@ -160,6 +160,7 @@ class LinuxPatchDetail(models.Model):
 
     pkg_name = models.CharField(max_length=256, blank=True, default="", verbose_name="包名")
     pkg_version = models.CharField(max_length=128, blank=True, default="", verbose_name="包版本")
+    packages = models.JSONField(default=list, verbose_name="关联软件包列表")
     distro_name = models.CharField(max_length=64, blank=True, default="", verbose_name="发行版名称")
     os_version_range = models.CharField(max_length=128, blank=True, default="", verbose_name="系统版本范围")
     architectures = models.JSONField(default=list, verbose_name="适用架构")
@@ -182,3 +183,36 @@ class LinuxPatchDetail(models.Model):
 
     def __str__(self) -> str:
         return f"[Linux] {self.patch.title}"
+
+    def package_items(self) -> list[dict[str, str]]:
+        """返回去重后的有效软件包，并兼容迁移前及手工创建的单包详情。"""
+        items: list[dict[str, str]] = []
+        seen: set[tuple[str, str, str]] = set()
+        for raw in self.packages or []:
+            if not isinstance(raw, dict):
+                continue
+            item = {
+                "name": str(raw.get("name") or "").strip(),
+                "version": str(raw.get("version") or "").strip(),
+                "arch": str(raw.get("arch") or "").strip(),
+            }
+            if not item["name"]:
+                continue
+            key = (item["name"], item["version"], item["arch"])
+            if key in seen:
+                continue
+            seen.add(key)
+            items.append(item)
+        if items or not self.pkg_name.strip():
+            return items
+        return [
+            {
+                "name": self.pkg_name.strip(),
+                "version": self.pkg_version.strip(),
+                "arch": str((self.architectures or [""])[0] or "").strip(),
+            }
+        ]
+
+    def package_names(self) -> list[str]:
+        """返回保持源顺序的唯一包名列表。"""
+        return list(dict.fromkeys(item["name"] for item in self.package_items()))

--- a/server/apps/patch_mgmt/serializers/patch.py
+++ b/server/apps/patch_mgmt/serializers/patch.py
@@ -64,7 +64,16 @@ class LinuxPatchDetailSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = LinuxPatchDetail
-        fields = ["pkg_name", "pkg_version", "distro_name", "os_version_range", "architectures", "repo_type"]
+        fields = [
+            "pkg_name",
+            "pkg_version",
+            "packages",
+            "distro_name",
+            "os_version_range",
+            "architectures",
+            "repo_type",
+        ]
+        read_only_fields = ["packages"]
 
 
 class PatchListSerializer(PatchPermissionSerializer):
@@ -204,8 +213,22 @@ class PatchListSerializer(PatchPermissionSerializer):
                 patch=patch, defaults=windows_detail_data
             )
         if patch.os_type == "linux" and linux_detail_data:
+            defaults = dict(linux_detail_data)
+            try:
+                detail = patch.linux_detail
+            except LinuxPatchDetail.DoesNotExist:
+                detail = None
+            if detail is not None and detail.packages:
+                packages = [
+                    dict(item) if isinstance(item, dict) else item
+                    for item in detail.packages
+                ]
+                if packages and isinstance(packages[0], dict):
+                    packages[0]["name"] = defaults.get("pkg_name", detail.pkg_name)
+                    packages[0]["version"] = defaults.get("pkg_version", detail.pkg_version)
+                    defaults["packages"] = packages
             LinuxPatchDetail.objects.update_or_create(
-                patch=patch, defaults=linux_detail_data
+                patch=patch, defaults=defaults
             )
 
 

--- a/server/apps/patch_mgmt/serializers/patch.py
+++ b/server/apps/patch_mgmt/serializers/patch.py
@@ -2,6 +2,7 @@
 
 import re
 
+from django.db import transaction
 from rest_framework import serializers
 
 from apps.patch_mgmt.constants import PackageManagerType
@@ -213,23 +214,16 @@ class PatchListSerializer(PatchPermissionSerializer):
                 patch=patch, defaults=windows_detail_data
             )
         if patch.os_type == "linux" and linux_detail_data:
-            defaults = dict(linux_detail_data)
-            try:
-                detail = patch.linux_detail
-            except LinuxPatchDetail.DoesNotExist:
-                detail = None
-            if detail is not None and detail.packages:
-                packages = [
-                    dict(item) if isinstance(item, dict) else item
-                    for item in detail.packages
-                ]
-                if packages and isinstance(packages[0], dict):
-                    packages[0]["name"] = defaults.get("pkg_name", detail.pkg_name)
-                    packages[0]["version"] = defaults.get("pkg_version", detail.pkg_version)
-                    defaults["packages"] = packages
-            LinuxPatchDetail.objects.update_or_create(
-                patch=patch, defaults=defaults
-            )
+            with transaction.atomic():
+                detail = LinuxPatchDetail.objects.select_for_update().filter(patch=patch).first()
+                defaults = dict(linux_detail_data)
+                if detail is not None and detail.packages:
+                    packages = [dict(item) if isinstance(item, dict) else item for item in detail.packages]
+                    if packages and isinstance(packages[0], dict):
+                        packages[0]["name"] = defaults.get("pkg_name", detail.pkg_name)
+                        packages[0]["version"] = defaults.get("pkg_version", detail.pkg_version)
+                        defaults["packages"] = packages
+                LinuxPatchDetail.objects.update_or_create(patch=patch, defaults=defaults)
 
 
 class PatchDetailSerializer(PatchListSerializer):

--- a/server/apps/patch_mgmt/services/assess_parsers.py
+++ b/server/apps/patch_mgmt/services/assess_parsers.py
@@ -297,19 +297,18 @@ def assess_linux_requirements(stdout: str, requirements: Iterable) -> dict[int, 
     requirement_facts = _parse_linux_requirement_facts(stdout)
     result: dict[int, RequirementAssessment] = {}
     for requirement_id, specs in _linux_specs(requirements).items():
-        assessments = [
-            evaluate_requirements(
-                [spec],
-                HostAssessmentFacts(
-                    linux_packages={
-                        spec.identifier: requirement_facts[(requirement_id, spec_index, spec.identifier)]
-                    }
-                )
-                if (requirement_id, spec_index, spec.identifier) in requirement_facts
-                else facts,
-            )[requirement_id]
-            for spec_index, spec in enumerate(specs)
-        ]
+        assessments = []
+        for spec_index, spec in enumerate(specs):
+            fact_key = (requirement_id, spec_index, spec.identifier)
+            if fact_key in requirement_facts:
+                spec_facts = HostAssessmentFacts(linux_packages={spec.identifier: requirement_facts[fact_key]})
+            elif requirement_facts:
+                # 新格式按要求与规格序号隔离；已有结构化事实时，缺失规格不得回退复用同名包的其他规格结果。
+                spec_facts = HostAssessmentFacts(linux_packages={})
+            else:
+                # 兼容升级前已下发、尚未完成的旧格式评估输出。
+                spec_facts = facts
+            assessments.append(evaluate_requirements([spec], spec_facts)[requirement_id])
         if len(assessments) == 1:
             result[requirement_id] = assessments[0]
             continue

--- a/server/apps/patch_mgmt/services/assess_parsers.py
+++ b/server/apps/patch_mgmt/services/assess_parsers.py
@@ -178,63 +178,182 @@ def _detect_linux_parser(stdout: str):
     return parse_yum_dnf_upgradable
 
 
-def _linux_specs(requirements: list) -> list[RequirementSpec]:
-    specs = []
+def _linux_specs(requirements: list) -> dict[int, list[RequirementSpec]]:
+    specs: dict[int, list[RequirementSpec]] = {}
     for requirement in requirements:
         try:
             detail = requirement.patch.linux_detail
-            package_name = (getattr(detail, "pkg_name", "") or "").strip()
-            required_version = (getattr(detail, "pkg_version", "") or "").strip()
-            configuration_error = "" if package_name else "missing package name"
+            package_items = getattr(detail, "package_items", None)
+            if callable(package_items):
+                items = package_items()
+            else:
+                package_name = (getattr(detail, "pkg_name", "") or "").strip()
+                items = [
+                    {
+                        "name": package_name,
+                        "version": (getattr(detail, "pkg_version", "") or "").strip(),
+                    }
+                ] if package_name else []
         except Exception:  # noqa: BLE001
-            package_name = ""
-            required_version = ""
-            configuration_error = "missing linux_detail"
-        specs.append(
+            specs[requirement.id] = [
+                RequirementSpec(
+                    requirement.id,
+                    OSType.LINUX,
+                    "",
+                    configuration_error="missing linux_detail",
+                )
+            ]
+            continue
+        if not items:
+            specs[requirement.id] = [
+                RequirementSpec(
+                    requirement.id,
+                    OSType.LINUX,
+                    "",
+                    configuration_error="missing package name",
+                )
+            ]
+            continue
+        specs[requirement.id] = [
             RequirementSpec(
                 requirement.id,
                 OSType.LINUX,
-                package_name,
-                required_version=required_version,
-                configuration_error=configuration_error,
+                item["name"],
+                required_version=item["version"],
             )
-        )
+            for item in items
+        ]
     return specs
+
+
+def _parse_linux_fact_line(raw_line: str) -> tuple[int | None, int | None, str, LinuxPackageFact] | None:
+    if not raw_line.startswith("BKPATCH_LINUX|"):
+        return None
+    parts = raw_line.split("|", 7)
+    if len(parts) == 8:
+        _, requirement_id, spec_index, package_name, state, installed_version, comparison, error = parts
+        try:
+            fact_key = (int(requirement_id), int(spec_index))
+        except ValueError:
+            fact_key = (None, None)
+    elif len(parts) == 7:
+        _, _requirement_id, package_name, state, installed_version, comparison, error = parts
+        fact_key = (None, None)
+    else:
+        return None
+    package_name = package_name.strip()
+    if not package_name:
+        return None
+    parsed_comparison = None
+    if comparison.strip() in {"-1", "0", "1"}:
+        parsed_comparison = int(comparison.strip())
+    installed = {"installed": True, "absent": False}.get(state.strip())
+    return (
+        fact_key[0],
+        fact_key[1],
+        package_name,
+        LinuxPackageFact(
+            installed=installed,
+            installed_version=installed_version.strip(),
+            comparison=parsed_comparison,
+            error=error.strip(),
+        ),
+    )
 
 
 def _parse_linux_facts(stdout: str) -> HostAssessmentFacts:
     packages: dict[str, LinuxPackageFact] = {}
     parsed_lines = 0
     for raw_line in stdout.splitlines():
-        if not raw_line.startswith("BKPATCH_LINUX|"):
+        parsed = _parse_linux_fact_line(raw_line)
+        if parsed is None:
             continue
-        parts = raw_line.split("|", 6)
-        if len(parts) != 7:
-            continue
-        _, _requirement_id, package_name, state, installed_version, comparison, error = parts
+        _, _, package_name, fact = parsed
         package_name = package_name.strip()
-        if not package_name:
-            continue
         parsed_lines += 1
-        parsed_comparison = None
-        if comparison.strip() in {"-1", "0", "1"}:
-            parsed_comparison = int(comparison.strip())
-        installed = {"installed": True, "absent": False}.get(state.strip())
-        packages[package_name] = LinuxPackageFact(
-            installed=installed,
-            installed_version=installed_version.strip(),
-            comparison=parsed_comparison,
-            error=error.strip(),
-        )
+        packages[package_name] = fact
     if parsed_lines == 0:
         return HostAssessmentFacts(collection_error="评估输出缺少结构化 Linux 包事实")
     return HostAssessmentFacts(linux_packages=packages)
 
 
+def _parse_linux_requirement_facts(stdout: str) -> dict[tuple[int, int, str], LinuxPackageFact]:
+    facts: dict[tuple[int, int, str], LinuxPackageFact] = {}
+    for raw_line in stdout.splitlines():
+        parsed = _parse_linux_fact_line(raw_line)
+        if parsed is None:
+            continue
+        requirement_id, spec_index, package_name, fact = parsed
+        if requirement_id is None or spec_index is None:
+            continue
+        facts[(requirement_id, spec_index, package_name)] = fact
+    return facts
+
+
 def assess_linux_requirements(stdout: str, requirements: Iterable) -> dict[int, RequirementAssessment]:
     """使用目标机原生版本比较结果评估 Linux 基线要求。"""
     requirements = list(requirements)
-    return evaluate_requirements(_linux_specs(requirements), _parse_linux_facts(stdout))
+    facts = _parse_linux_facts(stdout)
+    requirement_facts = _parse_linux_requirement_facts(stdout)
+    result: dict[int, RequirementAssessment] = {}
+    for requirement_id, specs in _linux_specs(requirements).items():
+        assessments = [
+            evaluate_requirements(
+                [spec],
+                HostAssessmentFacts(
+                    linux_packages={
+                        spec.identifier: requirement_facts[(requirement_id, spec_index, spec.identifier)]
+                    }
+                )
+                if (requirement_id, spec_index, spec.identifier) in requirement_facts
+                else facts,
+            )[requirement_id]
+            for spec_index, spec in enumerate(specs)
+        ]
+        if len(assessments) == 1:
+            result[requirement_id] = assessments[0]
+            continue
+
+        missing_pkg_names = [
+            spec.identifier
+            for spec, assessment in zip(specs, assessments)
+            if assessment.status == RequirementAssessmentStatus.MISSING
+        ]
+        unknown_pkg_names = [
+            spec.identifier
+            for spec, assessment in zip(specs, assessments)
+            if assessment.status == RequirementAssessmentStatus.UNKNOWN
+        ]
+        if missing_pkg_names:
+            status = RequirementAssessmentStatus.MISSING
+            reason = f"{'、'.join(missing_pkg_names)} 未满足最低版本要求"
+        elif unknown_pkg_names:
+            status = RequirementAssessmentStatus.UNKNOWN
+            reason = f"无法确认 {'、'.join(unknown_pkg_names)} 的合规状态"
+        else:
+            status = RequirementAssessmentStatus.SATISFIED
+            reason = f"{'、'.join(spec.identifier for spec in specs)} 均满足版本要求"
+        result[requirement_id] = RequirementAssessment(
+            requirement_id=requirement_id,
+            status=status,
+            evidence={
+                "pkg_name": specs[0].identifier,
+                "pkg_names": [spec.identifier for spec in specs],
+                "missing_pkg_names": missing_pkg_names,
+                "unknown_pkg_names": unknown_pkg_names,
+                "packages": [
+                    {
+                        "name": spec.identifier,
+                        "required_version": spec.required_version,
+                        "status": assessment.status,
+                        **assessment.evidence,
+                    }
+                    for spec, assessment in zip(specs, assessments)
+                ],
+            },
+            reason=reason,
+        )
+    return result
 
 
 def _replacement_kbs(requirement) -> tuple[str, ...]:

--- a/server/apps/patch_mgmt/services/patch_execution_service.py
+++ b/server/apps/patch_mgmt/services/patch_execution_service.py
@@ -460,14 +460,14 @@ def _install_commands(
 
     pkg_names: list[str] = []
     for p in patches:
-        pkg_name = ''
         try:
-            pkg_name = (p.linux_detail.pkg_name or '').strip()
+            patch_pkg_names = p.linux_detail.package_names()
         except Exception:
-            pass
-        if not pkg_name or not _PKG_NAME_RE.match(pkg_name):
-            continue
-        pkg_names.append(pkg_name)
+            patch_pkg_names = []
+        for pkg_name in patch_pkg_names:
+            if not _PKG_NAME_RE.match(pkg_name) or pkg_name in pkg_names:
+                continue
+            pkg_names.append(pkg_name)
 
     if not pkg_names:
         return ['echo no installable package mapped']
@@ -505,18 +505,34 @@ def _assess_command(os_type: str, requirements: list | None = None) -> str:
             '"===HOTFIX===";'
             'Get-HotFix | ForEach-Object { $_.HotFixID }'
         )
-    commands: list[str] = []
+    package_requirements: list[tuple[int, int, str, str]] = []
     for requirement in requirements or []:
         try:
             detail = requirement.patch.linux_detail
-            package_name = (detail.pkg_name or '').strip()
-            required_version = (detail.pkg_version or '').strip()
+            package_items = getattr(detail, 'package_items', None)
+            if callable(package_items):
+                items = package_items()
+            else:
+                package_name = (getattr(detail, 'pkg_name', '') or '').strip()
+                items = [{
+                    'name': package_name,
+                    'version': (getattr(detail, 'pkg_version', '') or '').strip(),
+                }] if package_name else []
         except Exception:  # noqa: BLE001
-            package_name = ''
-            required_version = ''
+            items = []
+        if not items:
+            package_requirements.append((int(requirement.id), 0, '', ''))
+            continue
+        package_requirements.extend(
+            (int(requirement.id), spec_index, item['name'], item['version'])
+            for spec_index, item in enumerate(items)
+        )
+
+    commands: list[str] = []
+    for requirement_id, spec_index, package_name, required_version in package_requirements:
         if not package_name or not _PKG_NAME_RE.match(package_name):
             commands.append(
-                f"printf 'BKPATCH_LINUX|{int(requirement.id)}||unknown|||invalid_package_name\\n'"
+                f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}||unknown|||invalid_package_name\\n'"
             )
             continue
         package_q = shlex.quote(package_name)
@@ -524,32 +540,32 @@ def _assess_command(os_type: str, requirements: list | None = None) -> str:
         commands.append(
             f"pkg={package_q}; required={version_q}; "
             "if [ -z \"$required\" ]; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|unknown|||missing_required_version\\n'; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|unknown|||missing_required_version\\n'; "
             "elif command -v dpkg-query >/dev/null 2>&1; then "
             "value=$(dpkg-query -W -f='${db:Status-Abbrev}|${Version}' -- \"$pkg\" 2>/dev/null); rc=$?; "
             "if [ $rc -ne 0 ]; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|absent|||\\n'; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|absent|||\\n'; "
             "else state=${value%%|*}; installed=${value#*|}; "
             "if [ \"$state\" != 'ii ' ]; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|absent|%s||\\n' \"$installed\"; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|absent|%s||\\n' \"$installed\"; "
             "elif dpkg --compare-versions \"$installed\" ge \"$required\"; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|installed|%s|0|\\n' \"$installed\"; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|installed|%s|0|\\n' \"$installed\"; "
             "else "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|installed|%s|-1|\\n' \"$installed\"; fi; fi; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|installed|%s|-1|\\n' \"$installed\"; fi; fi; "
             "elif command -v rpm >/dev/null 2>&1; then "
             "installed=$(rpm -q --qf '%{EVR}' \"$pkg\" 2>/dev/null); rc=$?; "
             "if [ $rc -ne 0 ]; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|absent|||\\n'; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|absent|||\\n'; "
             "else comparison=$(env BKPATCH_INSTALLED=\"$installed\" BKPATCH_REQUIRED=\"$required\" "
             "rpm --eval '%{lua: print(rpm.vercmp(os.getenv(\"BKPATCH_INSTALLED\"), os.getenv(\"BKPATCH_REQUIRED\")))}' 2>/dev/null); compare_rc=$?; "
             "if [ $compare_rc -ne 0 ] || ! printf '%s' \"$comparison\" | grep -Eq '^-?[0-9]+$'; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|unknown|%s||rpm_version_compare_failed\\n' \"$installed\"; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|unknown|%s||rpm_version_compare_failed\\n' \"$installed\"; "
             "elif [ \"$comparison\" -ge 0 ]; then "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|installed|%s|0|\\n' \"$installed\"; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|installed|%s|0|\\n' \"$installed\"; "
             "else "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|installed|%s|-1|\\n' \"$installed\"; fi; fi; "
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|installed|%s|-1|\\n' \"$installed\"; fi; fi; "
             "else "
-            f"printf 'BKPATCH_LINUX|{int(requirement.id)}|{package_name}|unknown|||unsupported_package_manager\\n'; fi"
+            f"printf 'BKPATCH_LINUX|{requirement_id}|{spec_index}|{package_name}|unknown|||unsupported_package_manager\\n'; fi"
         )
     if not commands:
         return "printf 'BKPATCH_COLLECTION_ERROR|no_linux_requirements\\n'"
@@ -688,9 +704,9 @@ def _collect_install_impact(
     pkg_names = []
     for req in missing_requirements:
         try:
-            pkg_name = req.patch.linux_detail.pkg_name
-            if pkg_name:
-                pkg_names.append(pkg_name)
+            for pkg_name in req.patch.linux_detail.package_names():
+                if pkg_name not in pkg_names:
+                    pkg_names.append(pkg_name)
         except Exception:
             pass
 

--- a/server/apps/patch_mgmt/services/patch_execution_service.py
+++ b/server/apps/patch_mgmt/services/patch_execution_service.py
@@ -578,7 +578,9 @@ def _dry_run_command(os_type: str, pkg_names: list[str]) -> str:
         return ''
     if os_type == OSType.WINDOWS:
         return ''  # Windows WUA 原子安装，不需要 dry-run
-    pkgs = ' '.join(pkg_names)
+    pkgs = ' '.join(shlex.quote(name) for name in pkg_names if _PKG_NAME_RE.match(name))
+    if not pkgs:
+        return ''
     # 用 if/elif 检测包管理器，避免 || 链导致 dnf --assumeno (exit 1) 触发 fallback
     # dnf/yum --assumeno 退出码 1 表示用户取消，属于正常行为；追加 || true 确保退出码 0
     return (

--- a/server/apps/patch_mgmt/services/source_sync_service.py
+++ b/server/apps/patch_mgmt/services/source_sync_service.py
@@ -7,6 +7,7 @@
 import logging
 from typing import Optional
 
+from django.db import transaction
 from django.utils import timezone
 
 from apps.patch_mgmt.constants import (
@@ -20,6 +21,50 @@ from apps.patch_mgmt.services.patch_source_service import PatchSourceService
 from apps.patch_mgmt.utils.architecture import X86_64, normalize_architecture, normalize_architectures
 
 logger = logging.getLogger("app")
+
+
+def _normalize_linux_packages(packages, *, fallback_arch: str) -> list[dict[str, str]]:
+    """把公告软件包规范化为稳定、去重、可持久化的列表。"""
+    canonical_fallback = normalize_architecture(fallback_arch, default=X86_64)
+    normalized: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for package in packages or []:
+        name = str(getattr(package, "name", "") or "").strip()
+        if not name:
+            continue
+        version = str(getattr(package, "version", "") or "").strip()
+        arch = normalize_architecture(
+            getattr(package, "arch", ""),
+            default=canonical_fallback,
+        )
+        key = (name, version, arch)
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append({"name": name, "version": version, "arch": arch})
+    return normalized
+
+
+def _linux_detail_defaults(advisory, source) -> dict:
+    """构造 Linux 详情写入值，并保留首包字段兼容旧 API。"""
+    packages = _normalize_linux_packages(
+        advisory.packages,
+        fallback_arch=source.arch or X86_64,
+    )
+    first_package = packages[0] if packages else None
+    return {
+        "pkg_name": first_package["name"] if first_package else "",
+        "pkg_version": first_package["version"] if first_package else "",
+        "packages": packages,
+        "distro_name": source.distro_name or "",
+        "os_version_range": source.os_version or "",
+        "architectures": normalize_architectures(
+            (package["arch"] for package in packages),
+            fallback=source.arch or X86_64,
+        ),
+        "repo_type": PackageManagerType.normalize(source.source_type),
+        "install_deps": advisory.install_deps or {},
+    }
 
 
 class SourceSyncError(Exception):
@@ -158,43 +203,32 @@ class SourceSyncService:
         for adv in advisories:
             patch_type = PatchType.SECURITY if adv.adv_type == "security" else PatchType.GENERIC
             severity = sev_map.get(adv.severity.lower(), PatchSeverity.MODERATE) if adv.severity else PatchSeverity.MODERATE
-            patch, is_new = Patch.objects.get_or_create(
-                title=adv.advisory_id,
-                os_type=OSType.LINUX,
-                defaults={
-                    "patch_type": patch_type,
-                    "severity": severity,
-                    "cve_list": adv.cve_list,
-                    "team": list(source.team or []),
-                    "pkg_status": PackageStatus.READY,
-                    "released_at": None,
-                },
-            )
-            patch.sources.add(source)
-            # 同步成功后统一标记为就绪，安装时再从源下载。
-            patch.patch_type = patch_type
-            patch.severity = severity
-            patch.cve_list = adv.cve_list
-            patch.pkg_status = PackageStatus.READY
-            patch.last_synced_at = now
-            patch.save(update_fields=["patch_type", "severity", "cve_list", "pkg_status", "last_synced_at", "updated_at"])
+            with transaction.atomic():
+                patch, is_new = Patch.objects.get_or_create(
+                    title=adv.advisory_id,
+                    os_type=OSType.LINUX,
+                    defaults={
+                        "patch_type": patch_type,
+                        "severity": severity,
+                        "cve_list": adv.cve_list,
+                        "team": list(source.team or []),
+                        "pkg_status": PackageStatus.READY,
+                        "released_at": None,
+                    },
+                )
+                patch.sources.add(source)
+                # 同步成功后统一标记为就绪，安装时再从源下载。
+                patch.patch_type = patch_type
+                patch.severity = severity
+                patch.cve_list = adv.cve_list
+                patch.pkg_status = PackageStatus.READY
+                patch.last_synced_at = now
+                patch.save(update_fields=["patch_type", "severity", "cve_list", "pkg_status", "last_synced_at", "updated_at"])
 
-            first_pkg = adv.packages[0] if adv.packages else None
-            LinuxPatchDetail.objects.update_or_create(
-                patch=patch,
-                defaults={
-                    "pkg_name": first_pkg.name if first_pkg else "",
-                    "pkg_version": first_pkg.version if first_pkg else "",
-                    "distro_name": source.distro_name or "",
-                    "os_version_range": source.os_version or "",
-                    "architectures": normalize_architectures(
-                        (p.arch for p in adv.packages),
-                        fallback=source.arch or X86_64,
-                    ),
-                    "repo_type": PackageManagerType.normalize(source.source_type),
-                    "install_deps": adv.install_deps or {},
-                },
-            )
+                LinuxPatchDetail.objects.update_or_create(
+                    patch=patch,
+                    defaults=_linux_detail_defaults(adv, source),
+                )
             if is_new:
                 created += 1
             else:
@@ -263,17 +297,19 @@ class SourceSyncService:
             )
             candidates = []
             for adv in advisories:
-                first_pkg = adv.packages[0] if adv.packages else None
+                packages = _normalize_linux_packages(
+                    adv.packages,
+                    fallback_arch=source.arch or X86_64,
+                )
+                first_pkg = packages[0] if packages else None
                 candidates.append({
                     "key": adv.advisory_id,
-                    "name": first_pkg.name if first_pkg else adv.advisory_id,
+                    "name": first_pkg["name"] if first_pkg else adv.advisory_id,
                     "title": adv.title,
-                    "version": first_pkg.version if first_pkg else "",
+                    "version": first_pkg["version"] if first_pkg else "",
+                    "packages": packages,
                     "dist": source.distro_name or "",
-                    "arch": normalize_architecture(
-                        first_pkg.arch if first_pkg and first_pkg.arch else source.arch,
-                        default=X86_64,
-                    ),
+                    "arch": first_pkg["arch"] if first_pkg else normalize_architecture(source.arch, default=X86_64),
                     "added": adv.advisory_id in existing_titles or adv.title in existing_titles,
                     "severity": adv.severity or "",
                 })
@@ -385,51 +421,40 @@ class SourceSyncService:
                     severity = sev_map.get(adv.severity.lower(), PatchSeverity.MODERATE)
                 else:
                     severity = PatchSeverity.MODERATE
-                patch, is_new = Patch.objects.get_or_create(
-                    title=adv.advisory_id,
-                    os_type=OSType.LINUX,
-                    defaults={
-                        "patch_type": patch_type,
-                        "severity": severity,
-                        "cve_list": adv.cve_list,
-                        "team": initial_teams(),
-                        "pkg_status": PackageStatus.READY,
-                    },
-                )
-                patch.sources.add(source)
-                patch.patch_type = patch_type
-                patch.severity = severity
-                patch.cve_list = adv.cve_list
-                patch.pkg_status = PackageStatus.READY
-                patch.last_synced_at = now
-                update_fields = [
-                    "patch_type",
-                    "severity",
-                    "cve_list",
-                    "pkg_status",
-                    "last_synced_at",
-                    "updated_at",
-                ]
-                if add_ingest_team(patch):
-                    update_fields.append("team")
-                patch.save(update_fields=update_fields)
+                with transaction.atomic():
+                    patch, is_new = Patch.objects.get_or_create(
+                        title=adv.advisory_id,
+                        os_type=OSType.LINUX,
+                        defaults={
+                            "patch_type": patch_type,
+                            "severity": severity,
+                            "cve_list": adv.cve_list,
+                            "team": initial_teams(),
+                            "pkg_status": PackageStatus.READY,
+                        },
+                    )
+                    patch.sources.add(source)
+                    patch.patch_type = patch_type
+                    patch.severity = severity
+                    patch.cve_list = adv.cve_list
+                    patch.pkg_status = PackageStatus.READY
+                    patch.last_synced_at = now
+                    update_fields = [
+                        "patch_type",
+                        "severity",
+                        "cve_list",
+                        "pkg_status",
+                        "last_synced_at",
+                        "updated_at",
+                    ]
+                    if add_ingest_team(patch):
+                        update_fields.append("team")
+                    patch.save(update_fields=update_fields)
 
-                first_pkg = adv.packages[0] if adv.packages else None
-                LinuxPatchDetail.objects.update_or_create(
-                    patch=patch,
-                    defaults={
-                        "pkg_name": first_pkg.name if first_pkg else "",
-                        "pkg_version": first_pkg.version if first_pkg else "",
-                        "distro_name": source.distro_name or "",
-                        "os_version_range": source.os_version or "",
-                        "architectures": normalize_architectures(
-                            (p.arch for p in adv.packages),
-                            fallback=source.arch or X86_64,
-                        ),
-                        "repo_type": PackageManagerType.normalize(source.source_type),
-                        "install_deps": adv.install_deps or {},
-                    },
-                )
+                    LinuxPatchDetail.objects.update_or_create(
+                        patch=patch,
+                        defaults=_linux_detail_defaults(adv, source),
+                    )
                 if is_new:
                     created += 1
                 else:

--- a/server/apps/patch_mgmt/services/source_sync_service.py
+++ b/server/apps/patch_mgmt/services/source_sync_service.py
@@ -22,17 +22,29 @@ from apps.patch_mgmt.utils.architecture import X86_64, normalize_architecture, n
 
 logger = logging.getLogger("app")
 
+MAX_LINUX_PACKAGES_PER_ADVISORY = 128
+MAX_LINUX_PACKAGE_NAME_LENGTH = 256
+MAX_LINUX_PACKAGE_VERSION_LENGTH = 128
+
+
+class SourceSyncError(Exception):
+    """补丁源同步异常基类"""
+
 
 def _normalize_linux_packages(packages, *, fallback_arch: str) -> list[dict[str, str]]:
     """把公告软件包规范化为稳定、去重、可持久化的列表。"""
     canonical_fallback = normalize_architecture(fallback_arch, default=X86_64)
     normalized: list[dict[str, str]] = []
     seen: set[tuple[str, str, str]] = set()
-    for package in packages or []:
+    for index, package in enumerate(packages or []):
+        if index >= MAX_LINUX_PACKAGES_PER_ADVISORY:
+            raise SourceSyncError(f"单条 Linux 公告的软件包数量不能超过 {MAX_LINUX_PACKAGES_PER_ADVISORY}")
         name = str(getattr(package, "name", "") or "").strip()
         if not name:
             continue
         version = str(getattr(package, "version", "") or "").strip()
+        if len(name) > MAX_LINUX_PACKAGE_NAME_LENGTH or len(version) > MAX_LINUX_PACKAGE_VERSION_LENGTH:
+            raise SourceSyncError("Linux 公告的软件包名称或版本过长")
         arch = normalize_architecture(
             getattr(package, "arch", ""),
             default=canonical_fallback,
@@ -65,10 +77,6 @@ def _linux_detail_defaults(advisory, source) -> dict:
         "repo_type": PackageManagerType.normalize(source.source_type),
         "install_deps": advisory.install_deps or {},
     }
-
-
-class SourceSyncError(Exception):
-    """补丁源同步异常基类"""
 
 
 class SourceSyncService:

--- a/server/apps/patch_mgmt/tests/test_assess_parsers.py
+++ b/server/apps/patch_mgmt/tests/test_assess_parsers.py
@@ -106,6 +106,7 @@ def test_assess_linux_requirements():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_assess_linux_requirements_checks_every_advisory_package():
     baseline = PatchBaseline.objects.create(name="multi-package", os_type=OSType.LINUX, team=[1])
     patch = Patch.objects.create(title="multi package advisory", os_type=OSType.LINUX, team=[1])
@@ -138,6 +139,7 @@ def test_assess_linux_requirements_checks_every_advisory_package():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_assess_linux_requirements_keeps_same_package_version_facts_distinct():
     baseline = PatchBaseline.objects.create(name="same-package-versions", os_type=OSType.LINUX, team=[1])
     patch = Patch.objects.create(title="openssl advisory", os_type=OSType.LINUX, team=[1])
@@ -159,6 +161,29 @@ def test_assess_linux_requirements_keeps_same_package_version_facts_distinct():
 
     assert result[req.id].status == RequirementAssessmentStatus.MISSING
     assert result[req.id].evidence["missing_pkg_names"] == ["openssl"]
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
+def test_assess_linux_requirements_does_not_reuse_another_structured_spec_fact():
+    baseline = PatchBaseline.objects.create(name="partial-output", os_type=OSType.LINUX, team=[1])
+    patch = Patch.objects.create(title="openssl advisory", os_type=OSType.LINUX, team=[1])
+    detail = LinuxPatchDetail.objects.create(patch=patch, pkg_name="openssl", pkg_version="3.0")
+    detail.packages = [
+        {"name": "openssl", "version": "3.0", "arch": "x86_64"},
+        {"name": "openssl", "version": "2.0", "arch": "x86_64"},
+    ]
+    detail.save(update_fields=["packages"])
+    req = BaselineRequirement.objects.create(baseline=baseline, patch=patch)
+
+    result = parsers.assess_requirements(
+        OSType.LINUX,
+        f"BKPATCH_LINUX|{req.id}|1|openssl|installed|2.5|0|",
+        [req],
+    )
+
+    assert result[req.id].status == RequirementAssessmentStatus.UNKNOWN
+    assert result[req.id].evidence["unknown_pkg_names"] == ["openssl"]
 
 
 @pytest.mark.django_db

--- a/server/apps/patch_mgmt/tests/test_assess_parsers.py
+++ b/server/apps/patch_mgmt/tests/test_assess_parsers.py
@@ -106,6 +106,62 @@ def test_assess_linux_requirements():
 
 
 @pytest.mark.django_db
+def test_assess_linux_requirements_checks_every_advisory_package():
+    baseline = PatchBaseline.objects.create(name="multi-package", os_type=OSType.LINUX, team=[1])
+    patch = Patch.objects.create(title="multi package advisory", os_type=OSType.LINUX, team=[1])
+    detail = LinuxPatchDetail.objects.create(
+        patch=patch,
+        pkg_name="not-upgradable",
+        pkg_version="1.0",
+    )
+    detail.packages = [
+        {"name": "not-upgradable", "version": "1.0", "arch": "x86_64"},
+        {"name": "openssl", "version": "3.0", "arch": "x86_64"},
+        {"name": "openssl", "version": "3.0", "arch": "x86_64"},
+        {"name": "", "version": "ignored", "arch": "x86_64"},
+    ]
+    detail.save(update_fields=["packages"])
+    req = BaselineRequirement.objects.create(baseline=baseline, patch=patch)
+
+    stdout = "\n".join(
+        [
+            f"BKPATCH_LINUX|{req.id}|not-upgradable|installed|1.0|0|",
+            f"BKPATCH_LINUX|{req.id}|openssl|installed|2.9|-1|",
+        ]
+    )
+    result = parsers.assess_requirements(OSType.LINUX, stdout, [req])
+
+    assert result[req.id].satisfied is False
+    assert result[req.id].evidence["pkg_names"] == ["not-upgradable", "openssl"]
+    assert result[req.id].evidence["missing_pkg_names"] == ["openssl"]
+    assert result[req.id].reason == "openssl 未满足最低版本要求"
+
+
+@pytest.mark.django_db
+def test_assess_linux_requirements_keeps_same_package_version_facts_distinct():
+    baseline = PatchBaseline.objects.create(name="same-package-versions", os_type=OSType.LINUX, team=[1])
+    patch = Patch.objects.create(title="openssl advisory", os_type=OSType.LINUX, team=[1])
+    detail = LinuxPatchDetail.objects.create(patch=patch, pkg_name="openssl", pkg_version="3.0")
+    detail.packages = [
+        {"name": "openssl", "version": "3.0", "arch": "x86_64"},
+        {"name": "openssl", "version": "2.0", "arch": "x86_64"},
+    ]
+    detail.save(update_fields=["packages"])
+    req = BaselineRequirement.objects.create(baseline=baseline, patch=patch)
+    stdout = "\n".join(
+        [
+            f"BKPATCH_LINUX|{req.id}|0|openssl|installed|2.5|-1|",
+            f"BKPATCH_LINUX|{req.id}|1|openssl|installed|2.5|0|",
+        ]
+    )
+
+    result = parsers.assess_requirements(OSType.LINUX, stdout, [req])
+
+    assert result[req.id].status == RequirementAssessmentStatus.MISSING
+    assert result[req.id].evidence["missing_pkg_names"] == ["openssl"]
+
+
+@pytest.mark.django_db
 def test_assess_windows_requirements():
     baseline = PatchBaseline.objects.create(name="win-baseline", os_type=OSType.WINDOWS, team=[1])
     patch_present = Patch.objects.create(title="present kb", os_type=OSType.WINDOWS, team=[1])

--- a/server/apps/patch_mgmt/tests/test_linux_repo_sync.py
+++ b/server/apps/patch_mgmt/tests/test_linux_repo_sync.py
@@ -51,7 +51,12 @@ UPDATEINFO = """<?xml version="1.0"?>
       <reference href="h" id="CVE-2024-0002" type="cve" title="CVE-2024-0002"/>
     </references>
     <pkglist>
-      <collection short="s"><package name="openssl" version="1.1.1k" release="7.el8" arch="x86_64"/></collection>
+      <collection short="s">
+        <package name="openssl" version="1.1.1k" release="7.el8" arch="x86_64"/>
+        <package name="openssl-libs" version="1.1.1k" release="7.el8" arch="x86_64"/>
+        <package name="openssl-libs" version="1.1.1k" release="7.el8" arch="x86_64"/>
+        <package name="" version="1.1.1k" release="7.el8" arch="x86_64"/>
+      </collection>
     </pkglist>
   </update>
   <update type="bugfix" version="1">
@@ -102,6 +107,12 @@ class TestFetchAdvisories:
         assert sec.packages[0].name == "openssl"
         assert sec.packages[0].version == "1.1.1k-7.el8"
         assert sec.packages[0].arch == "x86_64"
+        assert [package.name for package in sec.packages] == [
+            "openssl",
+            "openssl-libs",
+            "openssl-libs",
+            "",
+        ]
 
     def test_no_updateinfo_returns_empty(self, mocker):
         _make_get(mocker, repomd=REPOMD_NO_UPDATEINFO)
@@ -335,6 +346,42 @@ class TestSyncLinuxRepo:
         assert detail.distro_name == "centos"
         assert detail.repo_type == PackageManagerType.YUM
         assert detail.architectures == ["x86_64"]
+        assert getattr(detail, "packages", []) == [
+            {"name": "openssl", "version": "1.1.1k-7.el8", "arch": "x86_64"},
+            {"name": "openssl-libs", "version": "1.1.1k-7.el8", "arch": "x86_64"},
+        ]
+
+    def test_preview_exposes_all_unique_packages_without_changing_legacy_name(
+        self, mocker
+    ):
+        _make_get(mocker)
+        source = _source()
+
+        candidates = SourceSyncService.preview_sync_candidates(source)
+
+        candidate = candidates[0]
+        assert candidate["name"] == "openssl"
+        assert candidate["version"] == "1.1.1k-7.el8"
+        assert candidate["packages"] == [
+            {"name": "openssl", "version": "1.1.1k-7.el8", "arch": "x86_64"},
+            {"name": "openssl-libs", "version": "1.1.1k-7.el8", "arch": "x86_64"},
+        ]
+
+    def test_sync_rolls_back_advisory_when_detail_persistence_fails(
+        self, mocker
+    ):
+        _make_get(mocker)
+        source = _source()
+        mocker.patch.object(
+            LinuxPatchDetail.objects,
+            "update_or_create",
+            side_effect=RuntimeError("detail write failed"),
+        )
+
+        with pytest.raises(RuntimeError, match="detail write failed"):
+            SourceSyncService.sync_linux_repo(source)
+
+        assert Patch.objects.filter(title="RHSA-2024:0001").exists() is False
 
     def test_bugfix_maps_to_generic_moderate(self, mocker):
         _make_get(mocker)
@@ -351,6 +398,8 @@ class TestSyncLinuxRepo:
         result2 = SourceSyncService.sync_linux_repo(source)
         assert result2 == {"total": 2, "created": 0, "updated": 2}
         assert Patch.objects.filter(sources=source).count() == 2
+        detail = LinuxPatchDetail.objects.get(patch__title="RHSA-2024:0001")
+        assert len(getattr(detail, "packages", [])) == 2
 
     def test_non_linux_source_raises(self, mocker):
         _make_get(mocker)

--- a/server/apps/patch_mgmt/tests/test_linux_repo_sync.py
+++ b/server/apps/patch_mgmt/tests/test_linux_repo_sync.py
@@ -26,7 +26,13 @@ from apps.patch_mgmt.services.linux_repo_sync import (
     RepoSyncError,
     fetch_advisories,
 )
-from apps.patch_mgmt.services.source_sync_service import SourceSyncError, SourceSyncService
+from apps.patch_mgmt.services.source_sync_service import (
+    MAX_LINUX_PACKAGE_NAME_LENGTH,
+    MAX_LINUX_PACKAGE_VERSION_LENGTH,
+    MAX_LINUX_PACKAGES_PER_ADVISORY,
+    SourceSyncError,
+    SourceSyncService,
+)
 
 REPOMD = """<?xml version="1.0" encoding="UTF-8"?>
 <repomd xmlns="http://linux.duke.edu/metadata/repo">
@@ -237,6 +243,7 @@ Description: SSL library
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 class TestSyncLinuxRepo:
     @pytest.mark.parametrize(
         ("source_type", "expected_repo_type"),
@@ -257,7 +264,10 @@ class TestSyncLinuxRepo:
             title=f"{expected_repo_type} security update",
             adv_type="security",
             severity="Important",
-            packages=[ParsedPackage("kernel", "1.0", "x86_64")],
+            packages=[
+                ParsedPackage("kernel", "1.0", "x86_64"),
+                ParsedPackage("kernel-tools", "1.0", "x86_64"),
+            ],
         )
         mocker.patch(
             "apps.patch_mgmt.services.linux_repo_sync.fetch_advisories",
@@ -273,6 +283,10 @@ class TestSyncLinuxRepo:
         assert result == {"created": 1, "updated": 0, "skipped": 0, "total": 1}
         detail = LinuxPatchDetail.objects.get(patch__title=advisory.advisory_id)
         assert detail.repo_type == expected_repo_type
+        assert detail.packages == [
+            {"name": "kernel", "version": "1.0", "arch": "x86_64"},
+            {"name": "kernel-tools", "version": "1.0", "arch": "x86_64"},
+        ]
 
     def test_ingest_selected_adds_current_team_idempotently_for_builtin_source(
         self, mocker
@@ -382,6 +396,47 @@ class TestSyncLinuxRepo:
             SourceSyncService.sync_linux_repo(source)
 
         assert Patch.objects.filter(title="RHSA-2024:0001").exists() is False
+
+    @pytest.mark.parametrize(
+        ("packages", "error"),
+        [
+            ([ParsedPackage(f"pkg-{index}", "1.0", "x86_64") for index in range(MAX_LINUX_PACKAGES_PER_ADVISORY + 1)], "数量"),
+            ([ParsedPackage("p" * (MAX_LINUX_PACKAGE_NAME_LENGTH + 1), "1.0", "x86_64")], "名称或版本过长"),
+            ([ParsedPackage("kernel", "1" * (MAX_LINUX_PACKAGE_VERSION_LENGTH + 1), "x86_64")], "名称或版本过长"),
+        ],
+    )
+    def test_sync_rejects_invalid_package_bounds_without_partial_persistence(self, mocker, packages, error):
+        advisory = ParsedAdvisory(
+            advisory_id="ADV-TOO-MANY",
+            title="oversized advisory",
+            adv_type="security",
+            severity="Important",
+            packages=packages,
+        )
+        mocker.patch("apps.patch_mgmt.services.linux_repo_sync.fetch_advisories", return_value=[advisory])
+
+        with pytest.raises(SourceSyncError, match=error):
+            SourceSyncService.sync_linux_repo(_source())
+
+        assert not Patch.objects.filter(title=advisory.advisory_id).exists()
+
+    def test_preview_and_selected_ingest_reject_oversized_version_without_persistence(self, mocker):
+        advisory = ParsedAdvisory(
+            advisory_id="ADV-TOO-MANY",
+            title="oversized advisory",
+            adv_type="security",
+            severity="Important",
+            packages=[ParsedPackage("kernel", "1" * (MAX_LINUX_PACKAGE_VERSION_LENGTH + 1), "x86_64")],
+        )
+        mocker.patch("apps.patch_mgmt.services.linux_repo_sync.fetch_advisories", return_value=[advisory])
+        source = _source()
+
+        with pytest.raises(SourceSyncError, match="名称或版本过长"):
+            SourceSyncService.preview_sync_candidates(source)
+        with pytest.raises(SourceSyncError, match="名称或版本过长"):
+            SourceSyncService.ingest_selected(source, [advisory.advisory_id])
+
+        assert not Patch.objects.filter(title=advisory.advisory_id).exists()
 
     def test_bugfix_maps_to_generic_moderate(self, mocker):
         _make_get(mocker)

--- a/server/apps/patch_mgmt/tests/test_patch_execution_service.py
+++ b/server/apps/patch_mgmt/tests/test_patch_execution_service.py
@@ -103,6 +103,47 @@ def test_install_commands_multiple_pkgs_one_command():
 
 
 @pytest.mark.django_db
+def test_install_commands_include_every_package_from_one_advisory():
+    patch = Patch.objects.create(title='multi-package', os_type=OSType.LINUX)
+    detail = LinuxPatchDetail.objects.create(patch=patch, pkg_name='pkg-a')
+    detail.packages = [
+        {'name': 'pkg-a', 'version': '1.0', 'arch': 'x86_64'},
+        {'name': 'pkg-b', 'version': '1.0', 'arch': 'x86_64'},
+        {'name': 'pkg-b', 'version': '1.0', 'arch': 'x86_64'},
+        {'name': 'pkg with space', 'version': '1.0', 'arch': 'x86_64'},
+        {'name': '', 'version': '1.0', 'arch': 'x86_64'},
+    ]
+    detail.save(update_fields=['packages'])
+
+    commands = pes._install_commands([patch], OSType.LINUX)
+
+    assert len(commands) == 1
+    assert commands[0].count('pkg-a') == 3
+    assert commands[0].count('pkg-b') == 3
+    assert 'pkg with space' not in commands[0]
+
+
+@pytest.mark.django_db
+def test_assess_command_collects_every_package_from_one_advisory():
+    baseline = PatchBaseline.objects.create(name='multi-package', os_type=OSType.LINUX)
+    patch = Patch.objects.create(title='multi-package', os_type=OSType.LINUX)
+    detail = LinuxPatchDetail.objects.create(patch=patch, pkg_name='pkg-a', pkg_version='1.0')
+    detail.packages = [
+        {'name': 'pkg-a', 'version': '1.0', 'arch': 'x86_64'},
+        {'name': 'pkg-b', 'version': '2.0', 'arch': 'x86_64'},
+    ]
+    detail.save(update_fields=['packages'])
+    requirement = BaselineRequirement.objects.create(baseline=baseline, patch=patch)
+
+    command = pes._assess_command(OSType.LINUX, [requirement])
+
+    assert f'BKPATCH_LINUX|{requirement.id}|0|pkg-a|' in command
+    assert f'BKPATCH_LINUX|{requirement.id}|1|pkg-b|' in command
+    assert 'required=1.0' in command
+    assert 'required=2.0' in command
+
+
+@pytest.mark.django_db
 def test_install_commands_skips_invalid_pkg_name():
     p1 = Patch.objects.create(title='apt-1', os_type=OSType.LINUX)
     p2 = Patch.objects.create(title='apt-2', os_type=OSType.LINUX)

--- a/server/apps/patch_mgmt/tests/test_patch_execution_service.py
+++ b/server/apps/patch_mgmt/tests/test_patch_execution_service.py
@@ -103,6 +103,7 @@ def test_install_commands_multiple_pkgs_one_command():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_install_commands_include_every_package_from_one_advisory():
     patch = Patch.objects.create(title='multi-package', os_type=OSType.LINUX)
     detail = LinuxPatchDetail.objects.create(patch=patch, pkg_name='pkg-a')
@@ -124,6 +125,7 @@ def test_install_commands_include_every_package_from_one_advisory():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_assess_command_collects_every_package_from_one_advisory():
     baseline = PatchBaseline.objects.create(name='multi-package', os_type=OSType.LINUX)
     patch = Patch.objects.create(title='multi-package', os_type=OSType.LINUX)
@@ -141,6 +143,27 @@ def test_assess_command_collects_every_package_from_one_advisory():
     assert f'BKPATCH_LINUX|{requirement.id}|1|pkg-b|' in command
     assert 'required=1.0' in command
     assert 'required=2.0' in command
+
+
+@pytest.mark.unit
+def test_collect_install_impact_dry_run_includes_every_valid_package(monkeypatch):
+    detail = SimpleNamespace(package_names=lambda: ['pkg-a', 'pkg-b', 'pkg;rm'])
+    requirement = SimpleNamespace(id=17, patch=SimpleNamespace(linux_detail=detail))
+    target = SimpleNamespace(id=23, os_type=OSType.LINUX)
+    executed = []
+
+    def execute_command(_target, command, **_kwargs):
+        executed.append(command)
+        return {'stdout': '2 upgraded, 0 newly installed, 0 to remove'}
+
+    monkeypatch.setattr(pes, '_execute_command', execute_command)
+
+    impact = pes._collect_install_impact(target, [requirement], 'dry-run-1')
+
+    assert len(executed) == 1
+    assert 'pkg-a' in executed[0] and 'pkg-b' in executed[0]
+    assert 'pkg;rm' not in executed[0]
+    assert impact[requirement.id]['summary'] == '2 upgraded, 0 newly installed, 0 to remove'
 
 
 @pytest.mark.django_db

--- a/server/apps/patch_mgmt/tests/test_views.py
+++ b/server/apps/patch_mgmt/tests/test_views.py
@@ -378,6 +378,7 @@ class TestPatchSourceViewApi:
         assert resp.data == {"items": [], "total": 0, "page": 1, "page_size": 20}
         preview.assert_called_once_with(source)
 
+    @pytest.mark.integration
     def test_linux_preview_search_matches_any_advisory_package(self, su_client, mocker):
         source = PatchSource.objects.create(
             name="YUM-Test",
@@ -546,6 +547,7 @@ class TestPatchViewApi:
         assert data["linux_detail"]["repo_type"] == "yum"
         assert data["linux_detail"]["os_version_range"] == ">=7"
 
+    @pytest.mark.integration
     def test_update_linux_legacy_fields_keeps_package_snapshot_in_sync(self, su_client):
         from apps.patch_mgmt.models import LinuxPatchDetail
 

--- a/server/apps/patch_mgmt/tests/test_views.py
+++ b/server/apps/patch_mgmt/tests/test_views.py
@@ -378,7 +378,7 @@ class TestPatchSourceViewApi:
         assert resp.data == {"items": [], "total": 0, "page": 1, "page_size": 20}
         preview.assert_called_once_with(source)
 
-    def test_linux_preview_search_matches_package_name_only(self, su_client, mocker):
+    def test_linux_preview_search_matches_any_advisory_package(self, su_client, mocker):
         source = PatchSource.objects.create(
             name="YUM-Test",
             source_type=PatchSourceType.YUM_REPO,
@@ -393,6 +393,10 @@ class TestPatchSourceViewApi:
                     "name": "kernel",
                     "title": "Important: kernel security update",
                     "version": "1.0-1",
+                    "packages": [
+                        {"name": "kernel", "version": "1.0-1", "arch": "x86_64"},
+                        {"name": "kernel-tools", "version": "1.0-1", "arch": "x86_64"},
+                    ],
                 },
                 {
                     "key": "RLSA-BPFTOOL",
@@ -405,7 +409,7 @@ class TestPatchSourceViewApi:
 
         resp = su_client.post(
             f"{PATCH_SOURCE_URL}{source.id}/preview_sync/",
-            {"search": "kernel", "page": 1, "page_size": 20},
+            {"search": "kernel-tools", "page": 1, "page_size": 20},
             format="json",
         )
 
@@ -541,6 +545,47 @@ class TestPatchViewApi:
         assert data["linux_detail"]["pkg_version"] == "1.1.1k-7"
         assert data["linux_detail"]["repo_type"] == "yum"
         assert data["linux_detail"]["os_version_range"] == ">=7"
+
+    def test_update_linux_legacy_fields_keeps_package_snapshot_in_sync(self, su_client):
+        from apps.patch_mgmt.models import LinuxPatchDetail
+
+        patch = Patch.objects.create(title="openssl", os_type=OSType.LINUX, team=[1])
+        LinuxPatchDetail.objects.create(
+            patch=patch,
+            pkg_name="openssl",
+            pkg_version="1.0",
+            packages=[
+                {"name": "openssl", "version": "1.0", "arch": "x86_64"},
+                {"name": "openssl-libs", "version": "1.0", "arch": "x86_64"},
+            ],
+        )
+
+        response = su_client.put(
+            f"{PATCH_URL}{patch.id}/",
+            {
+                "title": "openssl",
+                "os_type": OSType.LINUX,
+                "team": [1],
+                "linux_detail": {
+                    "pkg_name": "openssl3",
+                    "pkg_version": "3.0",
+                    "distro_name": "",
+                    "os_version_range": "",
+                    "architectures": ["x86_64"],
+                    "repo_type": "yum",
+                },
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        patch.linux_detail.refresh_from_db()
+        assert patch.linux_detail.pkg_name == "openssl3"
+        assert patch.linux_detail.pkg_version == "3.0"
+        assert patch.linux_detail.packages == [
+            {"name": "openssl3", "version": "3.0", "arch": "x86_64"},
+            {"name": "openssl-libs", "version": "1.0", "arch": "x86_64"},
+        ]
 
 
 # ── PatchTarget ViewSet ────────────────────────────────────────────────────────

--- a/server/apps/patch_mgmt/views/patch_source.py
+++ b/server/apps/patch_mgmt/views/patch_source.py
@@ -304,6 +304,11 @@ class PatchSourceViewSet(AuthViewSet):
             candidates = [
                 c for c in candidates
                 if search in c.get("name", "").lower()
+                or any(
+                    search in str(package.get("name") or "").lower()
+                    for package in c.get("packages", [])
+                    if isinstance(package, dict)
+                )
             ]
 
         total = len(candidates)


### PR DESCRIPTION
## 问题

Linux 安全公告是一条公告关联多个软件包，但同步链路只把首包写入单值详情。预览看不到其余包，基线评估与安装也只处理首包，导致同一公告的后续受影响包被遗漏。

## 根因

公告数据在进入补丁域时被压缩成 `pkg_name/pkg_version` 单包契约，后续同步、评估和执行又分别复用了这组单值字段。缺少统一的多包快照与兼容读取边界，使一对多信息在持久化入口即丢失。

## 怎么修的

- 为 Linux 补丁详情增加规范化的 `packages` 快照，按包名、版本、架构去重；保留 `pkg_name/pkg_version` 作为首包兼容字段。
- 完整同步和选择入库按公告事务写入 Patch 与详情，详情失败时整条公告回滚。
- 预览、结构化实时评估、安装与 dry-run 均读取全部唯一包；评估事实按要求与稳定规格序号隔离，同包多版本不会相互覆盖，任一包不满足时公告对应要求即不满足。
- 旧数据在 `packages` 为空时自动回退单包字段；既有详情编辑入口会同步更新快照首包，避免显示值与实际评估/执行分叉。
- 迁移接续当前 patch_mgmt 最新迁移链，新增字段使用空列表默认值，回滚可直接撤销该字段。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["补丁源同步 / 选择入库\nsource_sync_service.py"]
        T2["实时评估 / 安装\npatch_execution_service.py"]
    end

    subgraph N["多包处理层"]
        N1["规范化与去重\n_normalize_linux_packages"]
        N2["兼容读取\nLinuxPatchDetail.package_items"]
        N3["逐包评估聚合\nassess_linux_requirements"]
    end

    DB["LinuxPatchDetail.packages\nJSON 多包快照"]
    C1["公告级事务回滚"]

    T1 --> N1 --> DB
    DB --> N2 --> N3
    N2 --> T2
    N1 -. "详情写入失败" .-> C1
```

## 影响范围与兼容性

改动限定在 `patch_mgmt`。对外保留原有首包字段与既有写入方式，新增 `packages` 为只读响应字段；旧记录、手工创建记录和轻量测试替身继续走单包回退。未改变权限、团队可见范围、NATS/RPC、安装命令返回结构或 Windows 补丁路径。

## 验证

以下具体测试文件在 fresh 数据库上共 `206 passed`：

- `apps/patch_mgmt/tests/test_assess_parsers.py`
- `apps/patch_mgmt/tests/test_linux_repo_sync.py`
- `apps/patch_mgmt/tests/test_patch_execution_service.py`
- `apps/patch_mgmt/tests/test_views.py`
- `apps/patch_mgmt/tests/test_uncovered_patch_contracts.py`

覆盖多包、重复包、同包多版本、空包名、完整同步、选择入库、预览搜索、事务回滚、实时结构化评估、安装命令、旧单包回退和既有详情编辑兼容。修复前多包结构化评估用例稳定失败，修复后通过。

## 三轨门禁

- Standards：通过。ORM、迁移链、事务边界、兼容写路径与最小范围均已复核。
- Spec：通过。同步、预览、入库、评估和执行均覆盖公告全部软件包。
- Runtime Contract：通过。fresh 数据库迁移、HTTP 预览/编辑、同步失败回滚、结构化评估和安装命令均有可执行测试证据。

关联 Issue #4487。
