### PR TITLE
bugfix: 禁止 NATS 错误响应恢复 Python 对象

### DIFF
--- a/server/apps/rpc/tests/test_nats_error_protocol.py
+++ b/server/apps/rpc/tests/test_nats_error_protocol.py
@@ -1,0 +1,112 @@
+import asyncio
+import json
+from unittest import mock
+
+import pytest
+
+from nats_client import clients
+from nats_client.exceptions import NatsClientException
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self.data = json.dumps(payload).encode()
+
+
+class _FakeNatsClient:
+    def __init__(self, payload):
+        self.response = _FakeResponse(payload)
+
+    async def request(self, *_args, **_kwargs):
+        return self.response
+
+    async def close(self):
+        return None
+
+
+def _legacy_exception_payload(message):
+    return json.dumps(
+        {
+            "py/reduce": [
+                {"py/type": "apps.core.exceptions.base_app_exception.BaseAppException"},
+                {"py/tuple": [message]},
+                {"message": message, "data": None},
+            ]
+        }
+    )
+
+
+def test_legacy_exception_parser_treats_recursion_failure_as_unrecognized():
+    with mock.patch.object(clients.json, "loads", side_effect=RecursionError):
+        assert clients._extract_legacy_exception_message("legacy exception") is None
+
+
+@pytest.mark.parametrize("request_func", [clients.request, clients.request_v2])
+def test_nats_request_reads_legacy_exception_message_without_object_restore(request_func):
+    nats_client = _FakeNatsClient(
+        {
+            "success": False,
+            "error": "BaseAppException",
+            "pickled_exc": _legacy_exception_payload("collector default config missing"),
+        }
+    )
+
+    with mock.patch.object(clients, "get_nc_client", return_value=nats_client), mock.patch(
+        "jsonpickle.decode",
+        side_effect=AssertionError("NATS error responses must not restore Python objects"),
+    ) as decode:
+        with pytest.raises(
+            NatsClientException,
+            match="BaseAppException: collector default config missing",
+        ):
+            asyncio.run(request_func("namespace", "method"))
+
+    decode.assert_not_called()
+
+
+@pytest.mark.parametrize("request_func", [clients.request, clients.request_v2])
+def test_nats_request_keeps_message_from_legacy_only_error_response(request_func):
+    nats_client = _FakeNatsClient(
+        {
+            "success": False,
+            "pickled_exc": _legacy_exception_payload("legacy service error"),
+        }
+    )
+
+    with mock.patch.object(clients, "get_nc_client", return_value=nats_client):
+        with pytest.raises(NatsClientException, match=r"^legacy service error$"):
+            asyncio.run(request_func("namespace", "method"))
+
+
+@pytest.mark.parametrize("request_func", [clients.request, clients.request_v2])
+def test_nats_request_ignores_unrecognized_legacy_exception_shape(request_func):
+    nats_client = _FakeNatsClient(
+        {
+            "success": False,
+            "error": "BaseAppException",
+            "pickled_exc": json.dumps({"message": "untrusted detail"}),
+        }
+    )
+
+    with mock.patch.object(clients, "get_nc_client", return_value=nats_client):
+        with pytest.raises(NatsClientException, match=r"^BaseAppException$"):
+            asyncio.run(request_func("namespace", "method"))
+
+
+@pytest.mark.parametrize("request_func", [clients.request, clients.request_v2])
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        (
+            {"success": False, "error": "RemoteError", "message": "request rejected"},
+            "RemoteError: request rejected",
+        ),
+        ({"success": False, "result": "service unavailable"}, "service unavailable"),
+    ],
+)
+def test_nats_request_preserves_structured_error_contract(request_func, payload, expected_message):
+    nats_client = _FakeNatsClient(payload)
+
+    with mock.patch.object(clients, "get_nc_client", return_value=nats_client):
+        with pytest.raises(NatsClientException, match=f"^{expected_message}$"):
+            asyncio.run(request_func("namespace", "method"))

--- a/server/apps/rpc/tests/test_nats_error_protocol_service.py
+++ b/server/apps/rpc/tests/test_nats_error_protocol_service.py
@@ -7,6 +7,8 @@ import pytest
 from nats_client import clients
 from nats_client.exceptions import NatsClientException
 
+pytestmark = pytest.mark.unit
+
 
 class _FakeResponse:
     def __init__(self, payload):
@@ -101,6 +103,10 @@ def test_nats_request_ignores_unrecognized_legacy_exception_shape(request_func):
             {"success": False, "error": "RemoteError", "message": "request rejected"},
             "RemoteError: request rejected",
         ),
+        (
+            {"success": False, "error": "RemoteError", "message": "request rejected", "result": "trace"},
+            "RemoteError: request rejected | Output: trace",
+        ),
         ({"success": False, "result": "service unavailable"}, "service unavailable"),
     ],
 )
@@ -110,3 +116,11 @@ def test_nats_request_preserves_structured_error_contract(request_func, payload,
     with mock.patch.object(clients, "get_nc_client", return_value=nats_client):
         with pytest.raises(NatsClientException, match=f"^{expected_message}$"):
             asyncio.run(request_func("namespace", "method"))
+
+
+@pytest.mark.parametrize("request_func", [clients.request, clients.request_v2])
+def test_nats_request_preserves_success_response(request_func):
+    nats_client = _FakeNatsClient({"success": True, "result": {"value": 1}})
+
+    with mock.patch.object(clients, "get_nc_client", return_value=nats_client):
+        assert asyncio.run(request_func("namespace", "method")) == {"value": 1}

--- a/server/nats_client/clients.py
+++ b/server/nats_client/clients.py
@@ -7,7 +7,6 @@ import queue
 from typing import Optional
 from urllib.parse import unquote, urlsplit, urlunsplit
 
-import jsonpickle
 from django.conf import settings
 from nats.aio.client import Client
 from nats.js.api import DiscardPolicy, StreamConfig
@@ -50,6 +49,38 @@ def _stringify_error_detail(detail) -> str:
     if isinstance(sanitized, str):
         return sanitized
     return str(sanitized)
+
+
+def _extract_legacy_exception_message(serialized_exception) -> Optional[str]:
+    """从旧 jsonpickle 异常结构中只读取字符串消息，不还原 Python 对象。"""
+    if not isinstance(serialized_exception, str):
+        return None
+    try:
+        payload = json.loads(serialized_exception)
+    except (TypeError, json.JSONDecodeError, RecursionError):
+        return None
+
+    if not isinstance(payload, dict) or set(payload) != {"py/reduce"}:
+        return None
+    reduction = payload["py/reduce"]
+    if not isinstance(reduction, list) or len(reduction) != 3:
+        return None
+
+    exception_type, arguments, state = reduction
+    if (
+        not isinstance(exception_type, dict)
+        or set(exception_type) != {"py/type"}
+        or not isinstance(exception_type["py/type"], str)
+        or not isinstance(arguments, dict)
+        or set(arguments) != {"py/tuple"}
+        or not isinstance(arguments["py/tuple"], list)
+        or not arguments["py/tuple"]
+        or not isinstance(state, dict)
+    ):
+        return None
+
+    message = arguments["py/tuple"][0]
+    return message if isinstance(message, str) and message else None
 
 
 def _sanitize_connection_error(error, servers, user=None, password=None) -> str:
@@ -152,22 +183,13 @@ async def request(namespace: str, method_name: str, *args, _timeout: Optional[fl
         return parsed
 
     if not parsed["success"]:
-
-        def _decode_pickled_exception_message() -> Optional[str]:
-            try:
-                decoded_exc = jsonpickle.decode(parsed["pickled_exc"])
-                decoded_message = str(decoded_exc)
-                return decoded_message or None
-            except (TypeError, KeyError):
-                return None
-
         # 优先使用新的error字段（Go服务的规范化错误格式）
         if "error" in parsed and parsed["error"]:
             error_message = parsed["error"]
             if "message" in parsed and parsed["message"]:
                 error_message += f": {_stringify_error_detail(parsed['message'])}"
             elif error_message == "BaseAppException":
-                decoded_message = _decode_pickled_exception_message()
+                decoded_message = _extract_legacy_exception_message(parsed.get("pickled_exc"))
                 if decoded_message:
                     error_message += f": {_stringify_error_detail(decoded_message)}"
             # 如果有result字段，将其作为详细信息添加
@@ -179,7 +201,7 @@ async def request(namespace: str, method_name: str, *args, _timeout: Optional[fl
             exc = NatsClientException(_stringify_error_detail(parsed["result"]))
         else:
             # 向后兼容：尝试使用旧的pickled_exc格式
-            decoded_message = _decode_pickled_exception_message()
+            decoded_message = _extract_legacy_exception_message(parsed.get("pickled_exc"))
             if decoded_message:
                 exc = NatsClientException(_stringify_error_detail(decoded_message))
             else:
@@ -241,22 +263,13 @@ async def request_v2(
         return parsed
 
     if not parsed["success"]:
-
-        def _decode_pickled_exception_message() -> Optional[str]:
-            try:
-                decoded_exc = jsonpickle.decode(parsed["pickled_exc"])
-                decoded_message = str(decoded_exc)
-                return decoded_message or None
-            except (TypeError, KeyError):
-                return None
-
         # 优先使用新的error字段（Go服务的规范化错误格式）
         if "error" in parsed and parsed["error"]:
             error_message = parsed["error"]
             if "message" in parsed and parsed["message"]:
                 error_message += f": {_stringify_error_detail(parsed['message'])}"
             elif error_message == "BaseAppException":
-                decoded_message = _decode_pickled_exception_message()
+                decoded_message = _extract_legacy_exception_message(parsed.get("pickled_exc"))
                 if decoded_message:
                     error_message += f": {_stringify_error_detail(decoded_message)}"
             # 如果有result字段，将其作为详细信息添加
@@ -268,7 +281,7 @@ async def request_v2(
             exc = NatsClientException(_stringify_error_detail(parsed["result"]))
         else:
             # 向后兼容：尝试使用旧的pickled_exc格式
-            decoded_message = _decode_pickled_exception_message()
+            decoded_message = _extract_legacy_exception_message(parsed.get("pickled_exc"))
             if decoded_message:
                 exc = NatsClientException(_stringify_error_detail(decoded_message))
             else:


### PR DESCRIPTION
## 问题

NATS RPC 错误响应跨越消息总线边界后，客户端仍把旧异常字段作为 Python 对象恢复。当前协议已经提供 `error`、`message` 与 `result` 等结构化字段，但旧兼容分支绕过了这条数据边界。

## 根因（设计层）

错误协议同时承担了“向用户传递错误信息”和“恢复远端运行时对象”两种职责，导致本应是纯数据的远端响应与客户端本地类型系统耦合。只要旧字段存在，两个 RPC 客户端都会进入对象恢复路径。

## 怎么修的

- `request` 与 `request_v2` 统一改为只解析 JSON 数据。
- 仅从已知旧异常结构中读取首个字符串消息，不导入类型、不实例化对象。
- 未识别结构和递归解析失败安全降级，继续走既有 `NatsClientException` 错误路径。
- 保留服务端旧字段发布，支持新旧客户端滚动升级；后续可独立退役旧字段。

## 影响范围

改动位于共享 NATS RPC 客户端，覆盖通过 `RpcClient` 与 `OperationAnalysisRpc` 发起的调用。成功响应、原始响应、连接凭据、超时与 `error/message/result` 优先级均保持不变；合法的仅旧字段错误消息仍可读取。服务端未改，旧客户端不受影响；本提交可独立回滚。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["RpcClient.run / OperationAnalysisRpc.run\nserver/apps/rpc/base.py"]
    end

    subgraph N["NATS RPC 客户端"]
        N1["request / request_v2\nserver/nats_client/clients.py"]
        N2["结构化 error/message/result"]
        N3["旧消息 data-only 提取"]
    end

    E["NatsClientException"]

    T1 --> N1 --> N2 --> E
    N2 -. "仅旧字段" .-> N3 --> E
    N3 -. "结构不识别" .-> E
```

## 验证

- `apps/rpc/tests/test_nats_error_protocol.py`：覆盖两个客户端、仅旧字段、结构化错误和安全降级。
- `apps/rpc/tests/test_nats_connection_credentials.py`：覆盖连接失败与业务字段兼容。
- `apps/node_mgmt/tests/test_architecture_support.py`：覆盖现有真实旧异常编码兼容。
- 上述三个具体测试文件合计：137 passed。

## 三轨门禁

- Standards：PASS；最小 diff，无依赖、配置、数据库或格式化污染。
- Spec：PASS；对象恢复已移除，已知新旧错误契约均保留。
- Runtime Contract：PASS；正常结构化错误、仅旧字段、未知结构降级、连接失败与滚动兼容均已验证。

质量评分：98 / 100。

Closes #4485
