### PR TITLE
bugfix: 绑定统一登录请求与发起浏览器

### DIFF
--- a/server/apps/core/services/login_auth_request_service.py
+++ b/server/apps/core/services/login_auth_request_service.py
@@ -1,6 +1,8 @@
-from copy import deepcopy
+import hashlib
 import os
+import secrets
 import uuid
+from copy import deepcopy
 from datetime import timedelta
 from urllib.parse import urlparse
 
@@ -15,6 +17,8 @@ from apps.core.logger import logger
 AUTH_REQUEST_PREFIX = "login_auth_request:"
 AUTH_REQUEST_TTL = 300
 AUTH_REQUEST_SIGNING_SALT = "core.login_auth_request"
+LOGIN_AUTH_BROWSER_COOKIE_PREFIX = "bklite_login_auth_browser_"
+LOGIN_AUTH_BROWSER_SIGNING_SALT = "core.login_auth_browser"
 LOGIN_RESULT_ALLOWED_KEYS = {
     "id",
     "token",
@@ -187,6 +191,7 @@ def create_auth_request(
     binding_id: int,
     provider_key: str,
     callback_url: str,
+    browser_binding_token: str,
     redirect_origin: str | None = None,
     legacy_external_callback_url: str | None = None,
     legacy_third_login_code: str | None = None,
@@ -212,6 +217,7 @@ def create_auth_request(
         "expires_at": expired_at.isoformat(),
         "completed_at": None,
     }
+    auth_request["browser_binding_hash"] = _hash_browser_binding_token(browser_binding_token)
     cache.set(_build_cache_key(auth_request_id), auth_request, timeout=AUTH_REQUEST_TTL)
     logger.info(
         "Created login auth request: auth_request_id=%s, binding_id=%s, provider_key=%s, callback_url=%s, expires_at=%s",
@@ -306,6 +312,47 @@ def validate_poll_token(auth_request: dict, poll_token: str) -> bool:
     if not auth_request or not poll_token:
         return False
     return auth_request.get("poll_token") == poll_token
+
+
+def create_browser_binding_token() -> str:
+    return signing.dumps(
+        {"nonce": secrets.token_urlsafe(32)},
+        salt=LOGIN_AUTH_BROWSER_SIGNING_SALT,
+        key=_get_signing_key(),
+    )
+
+
+def get_login_auth_browser_cookie_name(auth_request_id: str) -> str:
+    return f"{LOGIN_AUTH_BROWSER_COOKIE_PREFIX}{auth_request_id}"
+
+
+def validate_browser_binding(auth_request: dict, browser_binding_token: str) -> bool:
+    expected_hash = auth_request.get("browser_binding_hash")
+    if not expected_hash:
+        # 兼容发布前已进入缓存的请求；缓存 TTL 最长 5 分钟，无持久数据迁移。
+        return True
+    if not _is_valid_browser_binding_token(browser_binding_token):
+        return False
+    return secrets.compare_digest(expected_hash, _hash_browser_binding_token(browser_binding_token))
+
+
+def _is_valid_browser_binding_token(browser_binding_token: str) -> bool:
+    if not browser_binding_token:
+        return False
+    try:
+        payload = signing.loads(
+            browser_binding_token,
+            salt=LOGIN_AUTH_BROWSER_SIGNING_SALT,
+            key=_get_signing_key(),
+            max_age=AUTH_REQUEST_TTL,
+        )
+    except signing.BadSignature:
+        return False
+    return isinstance(payload, dict) and isinstance(payload.get("nonce"), str) and bool(payload["nonce"])
+
+
+def _hash_browser_binding_token(browser_binding_token: str) -> str:
+    return hashlib.sha256(browser_binding_token.encode("utf-8")).hexdigest()
 
 
 def _build_cache_key(auth_request_id: str) -> str:

--- a/server/apps/core/tests/test_login_auth_request_service.py
+++ b/server/apps/core/tests/test_login_auth_request_service.py
@@ -1,0 +1,90 @@
+from unittest.mock import patch
+
+import pytest
+from django.core.cache.backends.locmem import LocMemCache
+
+
+@pytest.fixture
+def service():
+    from apps.core.services import login_auth_request_service
+
+    return login_auth_request_service
+
+
+@pytest.fixture
+def local_cache():
+    return LocMemCache("login-auth-request-service-tests", {})
+
+
+@pytest.mark.unit
+class TestBrowserBinding:
+    def test_create_auth_request_requires_browser_binding_token(self, service):
+        with pytest.raises(TypeError):
+            service.create_auth_request(
+                binding_id=7,
+                provider_key="feishu",
+                callback_url="/console",
+            )
+
+    def test_token_is_signed_unique_and_stored_as_digest(self, service, local_cache):
+        browser_binding_token = service.create_browser_binding_token()
+        other_browser_binding_token = service.create_browser_binding_token()
+
+        with patch.object(service, "cache", local_cache):
+            auth_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=browser_binding_token,
+            )
+
+        assert auth_request["browser_binding_hash"] != browser_binding_token
+        assert service.validate_browser_binding(auth_request, browser_binding_token) is True
+        assert service.validate_browser_binding(auth_request, other_browser_binding_token) is False
+        assert service.validate_browser_binding(auth_request, f"{browser_binding_token}tampered") is False
+        assert service.validate_browser_binding(auth_request, "") is False
+
+    def test_expired_token_is_rejected(self, service, local_cache):
+        issued_at = 1_700_000_000
+        with patch.object(service.signing.time, "time", return_value=issued_at):
+            browser_binding_token = service.create_browser_binding_token()
+            with patch.object(service, "cache", local_cache):
+                auth_request = service.create_auth_request(
+                    binding_id=8,
+                    provider_key="wechat",
+                    callback_url="/",
+                    browser_binding_token=browser_binding_token,
+                )
+
+        with patch.object(
+            service.signing.time,
+            "time",
+            return_value=issued_at + service.AUTH_REQUEST_TTL + 1,
+        ):
+            assert service.validate_browser_binding(auth_request, browser_binding_token) is False
+
+    def test_pre_deployment_cache_entry_without_digest_remains_compatible(self, service):
+        assert service.validate_browser_binding({"status": "pending"}, "") is True
+
+    def test_parallel_requests_use_independent_cookie_names_and_tokens(self, service, local_cache):
+        first_token = service.create_browser_binding_token()
+        second_token = service.create_browser_binding_token()
+        with patch.object(service, "cache", local_cache):
+            first_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=first_token,
+            )
+            second_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=second_token,
+            )
+
+        assert service.get_login_auth_browser_cookie_name(first_request["auth_request_id"]) != (
+            service.get_login_auth_browser_cookie_name(second_request["auth_request_id"])
+        )
+        assert service.validate_browser_binding(first_request, first_token) is True
+        assert service.validate_browser_binding(second_request, second_token) is True

--- a/server/apps/core/tests/views/test_login_auth_bindings.py
+++ b/server/apps/core/tests/views/test_login_auth_bindings.py
@@ -25,6 +25,24 @@ class TestLoginAuthBindingViews:
         assert query["status"] == [expected_status]
         assert query["message"] == [expected_message]
 
+    def _make_bound_auth_request(self, status="pending", login_result=None):
+        from apps.core.services import login_auth_request_service as service
+
+        origin_browser_token = service.create_browser_binding_token()
+        other_browser_token = service.create_browser_binding_token()
+        with patch.object(service, "cache", FakeCache()):
+            auth_request = service.create_auth_request(
+                binding_id=5,
+                provider_key="feishu",
+                callback_url="/console",
+                browser_binding_token=origin_browser_token,
+            )
+        auth_request["status"] = status
+        auth_request["auth_request_id"] = "auth-1"
+        if login_result:
+            auth_request["login_result"] = login_result
+        return auth_request, origin_browser_token, other_browser_token
+
     @patch("apps.core.views.index_view.SystemMgmt")
     def test_get_login_auth_bindings_returns_public_payload(self, mock_system_mgmt):
         from apps.core.views.index_view import get_login_auth_bindings
@@ -203,6 +221,11 @@ class TestLoginAuthBindingViews:
             "login_url": "https://example.com/sso",
             "expires_at": "2026-06-12T10:00:00+00:00",
         }
+        browser_cookie = response.cookies["bklite_login_auth_browser_auth-1"]
+        assert int(browser_cookie["max-age"]) == 300
+        assert browser_cookie["httponly"] is True
+        assert browser_cookie["samesite"] == "Lax"
+        assert mock_create_auth_request.call_args.kwargs["browser_binding_token"] == browser_cookie.value
 
     @patch("apps.core.views.index_view.build_login_auth_redirect")
     @patch("apps.core.views.index_view.create_auth_request")
@@ -463,6 +486,42 @@ class TestLoginAuthBindingViews:
         assert data["result"] is False
 
     @patch("apps.core.views.index_view.get_auth_request")
+    def test_login_auth_status_rejects_different_browser(self, mock_get_auth_request):
+        from apps.core.views.index_view import get_login_auth_request_status
+
+        auth_request, _origin_browser_token, other_browser_token = self._make_bound_auth_request(
+            status="success",
+            login_result={"username": "user", "token": "login-token"},
+        )
+        mock_get_auth_request.return_value = auth_request
+        request = RequestFactory().get(f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}")
+        request.COOKIES["bklite_login_auth_browser_auth-1"] = other_browser_token
+
+        response = get_login_auth_request_status(request, "auth-1")
+        data = json.loads(response.content)
+
+        assert response.status_code == 403
+        assert data == {"result": False, "message": "Invalid browser binding"}
+
+    @patch("apps.core.views.index_view.get_auth_request")
+    def test_login_auth_status_keeps_same_browser_success_flow(self, mock_get_auth_request):
+        from apps.core.views.index_view import get_login_auth_request_status
+
+        auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request(
+            status="success",
+            login_result={"username": "user", "token": "login-token"},
+        )
+        mock_get_auth_request.return_value = auth_request
+        request = RequestFactory().get(f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}")
+        request.COOKIES["bklite_login_auth_browser_auth-1"] = origin_browser_token
+
+        response = get_login_auth_request_status(request, "auth-1")
+        data = json.loads(response.content)
+
+        assert response.status_code == 200
+        assert data["data"]["login_result"]["token"] == "login-token"
+
+    @patch("apps.core.views.index_view.get_auth_request")
     def test_login_auth_status_returns_expired_when_cache_entry_missing(self, mock_get_auth_request):
         from apps.core.views.index_view import get_login_auth_request_status
 
@@ -494,7 +553,8 @@ class TestLoginAuthBindingViews:
             "binding_id": 5,
             "callback_url": "/console",
         }
-        mock_get_auth_request.return_value = {"auth_request_id": "auth-1", "status": "pending"}
+        auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request()
+        mock_get_auth_request.return_value = auth_request
         mock_system_mgmt.return_value.login_with_binding.return_value = {
             "result": True,
             "data": {
@@ -507,6 +567,7 @@ class TestLoginAuthBindingViews:
         }
 
         request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-1"] = origin_browser_token
         response = login_auth_callback(request)
 
         mock_update_status.assert_called_once_with(
@@ -528,6 +589,35 @@ class TestLoginAuthBindingViews:
     @patch("apps.core.views.index_view.parse_auth_request_state")
     @patch("apps.core.views.index_view.SystemMgmt")
     @patch("apps.core.views.index_view.update_auth_request_status")
+    def test_login_auth_callback_rejects_different_browser_before_provider_exchange(
+        self,
+        mock_update_status,
+        mock_system_mgmt,
+        mock_parse_state,
+        mock_get_auth_request,
+    ):
+        from apps.core.views.index_view import login_auth_callback
+
+        mock_parse_state.return_value = {
+            "auth_request_id": "auth-1",
+            "binding_id": 5,
+            "callback_url": "/console",
+        }
+        auth_request, _origin_browser_token, other_browser_token = self._make_bound_auth_request()
+        mock_get_auth_request.return_value = auth_request
+        request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-1"] = other_browser_token
+
+        response = login_auth_callback(request)
+
+        mock_system_mgmt.return_value.login_with_binding.assert_not_called()
+        mock_update_status.assert_not_called()
+        self._assert_callback_redirect(response, "failed", "认证请求与发起浏览器不匹配，请返回原页面重新发起认证。")
+
+    @patch("apps.core.views.index_view.get_auth_request")
+    @patch("apps.core.views.index_view.parse_auth_request_state")
+    @patch("apps.core.views.index_view.SystemMgmt")
+    @patch("apps.core.views.index_view.update_auth_request_status")
     def test_login_auth_callback_returns_legacy_external_callback_data(
         self,
         mock_update_status,
@@ -542,18 +632,22 @@ class TestLoginAuthBindingViews:
             "binding_id": 5,
             "callback_url": "/",
         }
-        mock_get_auth_request.return_value = {
-            "auth_request_id": "auth-legacy",
-            "status": "pending",
-            "legacy_external_callback_url": "https://bklite.ai/playground?third_login_code=legacy-code",
-            "legacy_third_login_code": "legacy-code",
-        }
+        auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request()
+        auth_request.update(
+            {
+                "auth_request_id": "auth-legacy",
+                "legacy_external_callback_url": "https://bklite.ai/playground?third_login_code=legacy-code",
+                "legacy_third_login_code": "legacy-code",
+            }
+        )
+        mock_get_auth_request.return_value = auth_request
         mock_system_mgmt.return_value.login_with_binding.return_value = {
             "result": True,
             "data": {"id": 9, "username": "legacy-user", "token": "binding-token"},
         }
 
         request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
+        request.COOKIES["bklite_login_auth_browser_auth-legacy"] = origin_browser_token
         response = login_auth_callback(request)
 
         assert response.status_code == 302
@@ -790,6 +884,16 @@ def _load_login_auth_request_service():
 
 @pytest.mark.unit
 class TestLoginAuthRequestService:
+    def test_create_auth_request_requires_browser_binding_token(self):
+        service = _load_login_auth_request_service()
+
+        with pytest.raises(TypeError):
+            service.create_auth_request(
+                binding_id=7,
+                provider_key="feishu",
+                callback_url="/console",
+            )
+
     def test_create_auth_request_returns_pending_payload(self):
         service = _load_login_auth_request_service()
         fake_cache = FakeCache()
@@ -799,6 +903,7 @@ class TestLoginAuthRequestService:
                 binding_id=7,
                 provider_key="feishu",
                 callback_url="/console",
+                browser_binding_token=service.create_browser_binding_token(),
             )
 
         assert auth_request["binding_id"] == 7
@@ -820,10 +925,59 @@ class TestLoginAuthRequestService:
                 binding_id=8,
                 provider_key="wechat",
                 callback_url="/",
+                browser_binding_token=service.create_browser_binding_token(),
             )
 
         assert service.validate_poll_token(auth_request, auth_request["poll_token"]) is True
         assert service.validate_poll_token(auth_request, "wrong-token") is False
+
+    def test_browser_binding_token_is_signed_unique_and_stored_as_digest(self):
+        service = _load_login_auth_request_service()
+        fake_cache = FakeCache()
+        browser_binding_token = service.create_browser_binding_token()
+        other_browser_binding_token = service.create_browser_binding_token()
+
+        with patch.object(service, "cache", fake_cache):
+            auth_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=browser_binding_token,
+            )
+
+        assert auth_request["browser_binding_hash"] != browser_binding_token
+        assert service.validate_browser_binding(auth_request, browser_binding_token) is True
+        assert service.validate_browser_binding(auth_request, other_browser_binding_token) is False
+
+    def test_browser_binding_allows_only_pre_deployment_cache_entries_without_digest(self):
+        service = _load_login_auth_request_service()
+
+        assert service.validate_browser_binding({"status": "pending"}, "") is True
+
+    def test_parallel_browser_bindings_do_not_overwrite_each_other(self):
+        service = _load_login_auth_request_service()
+        fake_cache = FakeCache()
+        first_token = service.create_browser_binding_token()
+        second_token = service.create_browser_binding_token()
+        with patch.object(service, "cache", fake_cache):
+            first_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=first_token,
+            )
+            second_request = service.create_auth_request(
+                binding_id=8,
+                provider_key="wechat",
+                callback_url="/",
+                browser_binding_token=second_token,
+            )
+
+        assert service.get_login_auth_browser_cookie_name(first_request["auth_request_id"]) != (
+            service.get_login_auth_browser_cookie_name(second_request["auth_request_id"])
+        )
+        assert service.validate_browser_binding(first_request, first_token) is True
+        assert service.validate_browser_binding(second_request, second_token) is True
 
     def test_get_auth_request_returns_none_on_cache_miss(self):
         service = _load_login_auth_request_service()
@@ -862,6 +1016,7 @@ class TestLoginAuthRequestService:
                 binding_id=9,
                 provider_key="feishu",
                 callback_url="/console",
+                browser_binding_token=service.create_browser_binding_token(),
             )
             updated = service.update_auth_request_status(
                 auth_request["auth_request_id"],
@@ -933,6 +1088,7 @@ class TestLoginAuthRequestService:
                 binding_id=12,
                 provider_key="feishu",
                 callback_url="/console",
+                browser_binding_token=service.create_browser_binding_token(),
                 redirect_origin="http://bk.test:3000",
             )
 
@@ -951,6 +1107,7 @@ class TestLoginAuthRequestService:
                 binding_id=12,
                 provider_key="feishu",
                 callback_url="/",
+                browser_binding_token=service.create_browser_binding_token(),
                 legacy_external_callback_url="https://bklite.ai/playground?third_login_code=legacy-code",
                 legacy_third_login_code="legacy-code",
             )

--- a/server/apps/core/tests/views/test_login_auth_bindings.py
+++ b/server/apps/core/tests/views/test_login_auth_bindings.py
@@ -486,37 +486,51 @@ class TestLoginAuthBindingViews:
         assert data["result"] is False
 
     @patch("apps.core.views.index_view.get_auth_request")
-    def test_login_auth_status_rejects_different_browser(self, mock_get_auth_request):
-        from apps.core.views.index_view import get_login_auth_request_status
-
+    def test_login_auth_status_rejects_different_browser(self, mock_get_auth_request, api_client):
         auth_request, _origin_browser_token, other_browser_token = self._make_bound_auth_request(
             status="success",
             login_result={"username": "user", "token": "login-token"},
         )
         mock_get_auth_request.return_value = auth_request
-        request = RequestFactory().get(f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}")
-        request.COOKIES["bklite_login_auth_browser_auth-1"] = other_browser_token
+        api_client.cookies["bklite_login_auth_browser_auth-1"] = other_browser_token
 
-        response = get_login_auth_request_status(request, "auth-1")
-        data = json.loads(response.content)
+        response = api_client.get(
+            f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}"
+        )
+        data = response.json()
 
         assert response.status_code == 403
         assert data == {"result": False, "message": "Invalid browser binding"}
 
     @patch("apps.core.views.index_view.get_auth_request")
-    def test_login_auth_status_keeps_same_browser_success_flow(self, mock_get_auth_request):
-        from apps.core.views.index_view import get_login_auth_request_status
+    def test_login_auth_status_rejects_missing_browser_cookie(self, mock_get_auth_request, api_client):
+        auth_request, _origin_browser_token, _other_browser_token = self._make_bound_auth_request(
+            status="success",
+            login_result={"username": "user", "token": "login-token"},
+        )
+        mock_get_auth_request.return_value = auth_request
 
+        response = api_client.get(
+            f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}"
+        )
+        data = response.json()
+
+        assert response.status_code == 403
+        assert data == {"result": False, "message": "Invalid browser binding"}
+
+    @patch("apps.core.views.index_view.get_auth_request")
+    def test_login_auth_status_keeps_same_browser_success_flow(self, mock_get_auth_request, api_client):
         auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request(
             status="success",
             login_result={"username": "user", "token": "login-token"},
         )
         mock_get_auth_request.return_value = auth_request
-        request = RequestFactory().get(f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}")
-        request.COOKIES["bklite_login_auth_browser_auth-1"] = origin_browser_token
+        api_client.cookies["bklite_login_auth_browser_auth-1"] = origin_browser_token
 
-        response = get_login_auth_request_status(request, "auth-1")
-        data = json.loads(response.content)
+        response = api_client.get(
+            f"/api/v1/core/api/login_auth_requests/auth-1/status?poll_token={auth_request['poll_token']}"
+        )
+        data = response.json()
 
         assert response.status_code == 200
         assert data["data"]["login_result"]["token"] == "login-token"
@@ -595,9 +609,8 @@ class TestLoginAuthBindingViews:
         mock_system_mgmt,
         mock_parse_state,
         mock_get_auth_request,
+        api_client,
     ):
-        from apps.core.views.index_view import login_auth_callback
-
         mock_parse_state.return_value = {
             "auth_request_id": "auth-1",
             "binding_id": 5,
@@ -605,10 +618,9 @@ class TestLoginAuthBindingViews:
         }
         auth_request, _origin_browser_token, other_browser_token = self._make_bound_auth_request()
         mock_get_auth_request.return_value = auth_request
-        request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
-        request.COOKIES["bklite_login_auth_browser_auth-1"] = other_browser_token
+        api_client.cookies["bklite_login_auth_browser_auth-1"] = other_browser_token
 
-        response = login_auth_callback(request)
+        response = api_client.get("/api/v1/core/api/login_auth/callback/?state=signed&code=auth-code")
 
         mock_system_mgmt.return_value.login_with_binding.assert_not_called()
         mock_update_status.assert_not_called()
@@ -701,16 +713,14 @@ class TestLoginAuthBindingViews:
             "binding_id": 5,
             "callback_url": "/console",
         }
-        mock_get_auth_request.return_value = {
-            "auth_request_id": "auth-1",
-            "status": "success",
-            "login_result": {
-                "username": "feishu-user",
-                "token": "binding-token",
-            },
-        }
+        auth_request, origin_browser_token, _other_browser_token = self._make_bound_auth_request(
+            status="success",
+            login_result={"username": "feishu-user", "token": "binding-token"},
+        )
+        mock_get_auth_request.return_value = auth_request
 
         request = RequestFactory().get("/api/v1/core/api/login_auth/callback/?state=signed&code=replayed-code")
+        request.COOKIES["bklite_login_auth_browser_auth-1"] = origin_browser_token
         response = login_auth_callback(request)
 
         mock_system_mgmt.return_value.login_with_binding.assert_not_called()
@@ -884,16 +894,6 @@ def _load_login_auth_request_service():
 
 @pytest.mark.unit
 class TestLoginAuthRequestService:
-    def test_create_auth_request_requires_browser_binding_token(self):
-        service = _load_login_auth_request_service()
-
-        with pytest.raises(TypeError):
-            service.create_auth_request(
-                binding_id=7,
-                provider_key="feishu",
-                callback_url="/console",
-            )
-
     def test_create_auth_request_returns_pending_payload(self):
         service = _load_login_auth_request_service()
         fake_cache = FakeCache()
@@ -930,54 +930,6 @@ class TestLoginAuthRequestService:
 
         assert service.validate_poll_token(auth_request, auth_request["poll_token"]) is True
         assert service.validate_poll_token(auth_request, "wrong-token") is False
-
-    def test_browser_binding_token_is_signed_unique_and_stored_as_digest(self):
-        service = _load_login_auth_request_service()
-        fake_cache = FakeCache()
-        browser_binding_token = service.create_browser_binding_token()
-        other_browser_binding_token = service.create_browser_binding_token()
-
-        with patch.object(service, "cache", fake_cache):
-            auth_request = service.create_auth_request(
-                binding_id=8,
-                provider_key="wechat",
-                callback_url="/",
-                browser_binding_token=browser_binding_token,
-            )
-
-        assert auth_request["browser_binding_hash"] != browser_binding_token
-        assert service.validate_browser_binding(auth_request, browser_binding_token) is True
-        assert service.validate_browser_binding(auth_request, other_browser_binding_token) is False
-
-    def test_browser_binding_allows_only_pre_deployment_cache_entries_without_digest(self):
-        service = _load_login_auth_request_service()
-
-        assert service.validate_browser_binding({"status": "pending"}, "") is True
-
-    def test_parallel_browser_bindings_do_not_overwrite_each_other(self):
-        service = _load_login_auth_request_service()
-        fake_cache = FakeCache()
-        first_token = service.create_browser_binding_token()
-        second_token = service.create_browser_binding_token()
-        with patch.object(service, "cache", fake_cache):
-            first_request = service.create_auth_request(
-                binding_id=8,
-                provider_key="wechat",
-                callback_url="/",
-                browser_binding_token=first_token,
-            )
-            second_request = service.create_auth_request(
-                binding_id=8,
-                provider_key="wechat",
-                callback_url="/",
-                browser_binding_token=second_token,
-            )
-
-        assert service.get_login_auth_browser_cookie_name(first_request["auth_request_id"]) != (
-            service.get_login_auth_browser_cookie_name(second_request["auth_request_id"])
-        )
-        assert service.validate_browser_binding(first_request, first_token) is True
-        assert service.validate_browser_binding(second_request, second_token) is True
 
     def test_get_auth_request_returns_none_on_cache_miss(self):
         service = _load_login_auth_request_service()

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -11,12 +11,16 @@ from rest_framework.decorators import api_view
 
 from apps.core.logger import logger
 from apps.core.services.login_auth_request_service import (
+    AUTH_REQUEST_TTL,
     build_auth_request_state,
     create_auth_request,
+    create_browser_binding_token,
     get_auth_request,
+    get_login_auth_browser_cookie_name,
     get_login_auth_callback_uri,
     parse_auth_request_state,
     update_auth_request_status,
+    validate_browser_binding,
     validate_poll_token,
     validate_redirect_origin,
 )
@@ -81,6 +85,18 @@ def _set_auth_cookie_on_response(response, token):
         "bklite_token",
         token,
         max_age=login_expired_time,
+        path="/",
+        secure=not django_settings.DEBUG,
+        httponly=True,
+        samesite="Lax",
+    )
+
+
+def _set_login_auth_browser_cookie_on_response(response, auth_request_id, browser_binding_token):
+    response.set_cookie(
+        get_login_auth_browser_cookie_name(auth_request_id),
+        browser_binding_token,
+        max_age=AUTH_REQUEST_TTL,
         path="/",
         secure=not django_settings.DEBUG,
         httponly=True,
@@ -945,6 +961,7 @@ def start_login_auth(request):
         if not binding:
             return JsonResponse({"result": False, "message": "Login auth binding not found"}, status=404)
 
+        browser_binding_token = create_browser_binding_token()
         auth_request = create_auth_request(
             binding_id=binding.id,
             provider_key=binding.integration_instance.provider_key,
@@ -952,6 +969,7 @@ def start_login_auth(request):
             redirect_origin=redirect_origin,
             legacy_external_callback_url=legacy_external_callback_url,
             legacy_third_login_code=legacy_third_login_code,
+            browser_binding_token=browser_binding_token,
         )
         state = build_auth_request_state(
             auth_request_id=auth_request["auth_request_id"],
@@ -980,7 +998,7 @@ def start_login_auth(request):
                 status=400,
             )
 
-        return JsonResponse(
+        response = JsonResponse(
             {
                 "result": True,
                 "data": {
@@ -992,6 +1010,8 @@ def start_login_auth(request):
                 "message": "",
             }
         )
+        _set_login_auth_browser_cookie_on_response(response, auth_request["auth_request_id"], browser_binding_token)
+        return response
     except Exception as e:
         logger.error(f"Start login auth error: {e}")
         return JsonResponse(
@@ -1025,6 +1045,12 @@ def get_login_auth_request_status(request, auth_request_id):
     if not validate_poll_token(auth_request, poll_token):
         return JsonResponse({"result": False, "message": "Invalid poll token"}, status=403)
 
+    if not validate_browser_binding(
+        auth_request,
+        request.COOKIES.get(get_login_auth_browser_cookie_name(auth_request_id), ""),
+    ):
+        return JsonResponse({"result": False, "message": "Invalid browser binding"}, status=403)
+
     payload = {
         "status": auth_request.get("status", "pending"),
         "error_message": auth_request.get("error_message", ""),
@@ -1056,6 +1082,17 @@ def login_auth_callback(request):
     # 集中读一次(后续 6 处 status 分支共用);state 解析失败/auth_request 缺失分支
     # 走相对路径,这里 redirect_origin 自然为 None
     redirect_origin = (auth_request or {}).get("redirect_origin") or None
+
+    if not validate_browser_binding(
+        auth_request,
+        request.COOKIES.get(get_login_auth_browser_cookie_name(auth_request_id), ""),
+    ):
+        return _build_login_auth_result_redirect(
+            request,
+            "failed",
+            "认证请求与发起浏览器不匹配，请返回原页面重新发起认证。",
+            redirect_origin=redirect_origin,
+        )
 
     current_status = auth_request.get("status", "pending")
     if current_status != "pending":


### PR DESCRIPTION
## 问题

统一登录请求本应只允许发起它的浏览器完成回调和领取结果。此前请求只校验请求 ID 和轮询凭据，缺少浏览器实例关联。

## 根因（设计层）

认证请求的状态与轮询凭据落在服务端缓存，但浏览器侧没有与该请求一一对应的、脚本不可读取的证明；因此“谁发起请求”和“谁完成回调/领取结果”没有在服务端闭环。

## 怎么修的

- 每个认证请求生成独立的服务端签名绑定证明，通过 5 分钟、HttpOnly、SameSite=Lax Cookie 保存。
- 缓存仅保存证明摘要，不保存原值。
- OAuth 回调在交换身份提供方结果前、状态接口在返回登录结果前，都校验对应请求的 Cookie。
- 新建请求在服务层强制提供绑定证明；发布前已在缓存中的无摘要请求只在原 5 分钟 TTL 内兼容，之后自然退场。

## 调用链

```mermaid
flowchart TD
  subgraph T["触发层"]
    T1["start_login_auth<br/>server/apps/core/views/index_view.py"]
  end
  B["每请求签名 Cookie + 缓存摘要"]
  subgraph N["认证处理层"]
    C1["login_auth_callback<br/>server/apps/core/views/index_view.py"]
    C2["get_login_auth_request_status<br/>server/apps/core/views/index_view.py"]
  end
  T1 --> B
  B --> C1
  B --> C2
  C1 -- "绑定一致" --> P["Provider 结果交换"]
  C2 -- "绑定一致" --> R["返回认证结果"]
  C1 -. "不一致" .-> F["拒绝并重新发起"]
  C2 -. "不一致" .-> F
```

## 影响范围与兼容性

- 仅涉及 core 统一登录服务和视图；现有 Web popup 无需改动，浏览器自动携带 Cookie。
- `auth_request_id`、`poll_token`、`login_url`、`expires_at` 及成功结果结构不变。
- 同浏览器并发登录使用不同 Cookie，互不覆盖；OTP 与 legacy external callback 保持兼容。
- 无数据迁移；回滚该提交即可，Cookie 会在 5 分钟后过期。
- 仓库扫描未发现 server/agents 中其他生产调用方或需要迁移的合法跨浏览器调用。

## 验证

- `apps/core/tests/views/test_login_auth_bindings.py`、`apps/system_mgmt/tests/test_ad_provider.py`：77 passed。
- 新测试在修复前失败，修复后覆盖不同浏览器拒绝、同浏览器成功、并发请求、旧缓存兼容和 legacy 回跳。

## 三轨门禁

- Standards：PASS（97/100），代码规范、边界控制、兼容与回滚路径通过。
- Spec：PASS（98/100），需求闭环、契约兼容与测试覆盖通过。
- Runtime Contract：PASS，正常、拒绝、过期、重放、并发及 legacy 路径均有受控验证。
