### PR TITLE
bugfix: 抽取 MLOps 训练作业运行记录公共动作

### DIFF
--- a/server/apps/mlops/tests/test_base_view_logic.py
+++ b/server/apps/mlops/tests/test_base_view_logic.py
@@ -1,14 +1,86 @@
-import pydantic.root_model  # noqa
+import importlib
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pandas as pd
+import pydantic.root_model  # noqa
 import pytest
-from types import SimpleNamespace
 
 from apps.mlops.constants import MLflowRunStatus, TrainJobStatus
 from apps.mlops.models.anomaly_detection import AnomalyDetectionTrainJob
 from apps.mlops.views.anomaly_detection import AnomalyDetectionTrainJobViewSet
 
 pytestmark = pytest.mark.unit
+
+
+TRAIN_JOB_VIEWSETS = [
+    ("anomaly_detection", "AnomalyDetectionTrainJobViewSet"),
+    ("classification", "ClassificationTrainJobViewSet"),
+    ("image_classification", "ImageClassificationTrainJobViewSet"),
+    ("object_detection", "ObjectDetectionTrainJobViewSet"),
+    ("log_clustering", "LogClusteringTrainJobViewSet"),
+    ("timeseries_predict", "TimeSeriesPredictTrainJobViewSet"),
+]
+
+COMMON_RUN_ACTIONS = [
+    ("delete_run", {"pk": 1, "run_id": "run-1"}, "Delete", "delete"),
+    (
+        "get_metric_data",
+        {"pk": 1, "run_id": "run-1", "metric_name": "accuracy"},
+        "View",
+        "get",
+    ),
+    ("get_run_params", {"pk": 1, "run_id": "run-1"}, "View", "get"),
+]
+
+
+@pytest.mark.parametrize("module_name,class_name", TRAIN_JOB_VIEWSETS)
+@pytest.mark.parametrize(
+    "action_name,action_kwargs,permission_suffix,http_method",
+    COMMON_RUN_ACTIONS,
+)
+def test_train_job_common_run_actions_delegate_to_base(
+    monkeypatch,
+    module_name,
+    class_name,
+    action_name,
+    action_kwargs,
+    permission_suffix,
+    http_method,
+):
+    base_module = importlib.import_module("apps.mlops.views.base")
+    assert hasattr(base_module, "BaseTrainJobViewSet"), "六算法 TrainJob 应共享统一基类"
+
+    base_viewset = base_module.BaseTrainJobViewSet
+    viewset = getattr(importlib.import_module(f"apps.mlops.views.{module_name}"), class_name)
+    assert issubclass(viewset, base_viewset)
+    assert http_method in viewset.__dict__[action_name].mapping
+
+    shared_action = Mock(return_value=object())
+    monkeypatch.setattr(base_viewset, action_name, shared_action)
+    denied_request = SimpleNamespace(
+        user=SimpleNamespace(
+            is_superuser=False,
+            locale="en",
+            permission={"mlops": set()},
+        )
+    )
+    denied_response = getattr(viewset(), action_name)(denied_request, **action_kwargs)
+    assert denied_response.status_code == 403
+    shared_action.assert_not_called()
+
+    request = SimpleNamespace(
+        user=SimpleNamespace(
+            is_superuser=False,
+            locale="en",
+            permission={"mlops": {f"{module_name}-{permission_suffix}"}},
+        )
+    )
+
+    response = getattr(viewset(), action_name)(request, **action_kwargs)
+
+    assert response is shared_action.return_value
+    shared_action.assert_called_once_with(request, **action_kwargs)
 
 
 # ----------------- has_run_in_runs_frame -----------------
@@ -170,8 +242,13 @@ def test_check_run_delete_eligibility_blocked(monkeypatch):
 @pytest.mark.django_db
 def test_claim_train_job_running_success():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j1", description="", team=[1], status=TrainJobStatus.PENDING,
-        algorithm="algo", dataset_version=None, hyperopt_config={},
+        name="j1",
+        description="",
+        team=[1],
+        status=TrainJobStatus.PENDING,
+        algorithm="algo",
+        dataset_version=None,
+        hyperopt_config={},
     )
     vs = AnomalyDetectionTrainJobViewSet()
     prev = vs.claim_train_job_running(tj)
@@ -184,8 +261,13 @@ def test_claim_train_job_running_success():
 @pytest.mark.django_db
 def test_claim_train_job_running_already_running_returns_none():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j2", description="", team=[1], status=TrainJobStatus.RUNNING,
-        algorithm="algo", dataset_version=None, hyperopt_config={},
+        name="j2",
+        description="",
+        team=[1],
+        status=TrainJobStatus.RUNNING,
+        algorithm="algo",
+        dataset_version=None,
+        hyperopt_config={},
     )
     vs = AnomalyDetectionTrainJobViewSet()
     assert vs.claim_train_job_running(tj) is None
@@ -194,8 +276,13 @@ def test_claim_train_job_running_already_running_returns_none():
 @pytest.mark.django_db
 def test_restore_train_job_status_restores_when_running():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j3", description="", team=[1], status=TrainJobStatus.RUNNING,
-        algorithm="algo", dataset_version=None, hyperopt_config={},
+        name="j3",
+        description="",
+        team=[1],
+        status=TrainJobStatus.RUNNING,
+        algorithm="algo",
+        dataset_version=None,
+        hyperopt_config={},
     )
     AnomalyDetectionTrainJobViewSet.restore_train_job_status(tj, TrainJobStatus.PENDING)
     tj.refresh_from_db()
@@ -206,8 +293,13 @@ def test_restore_train_job_status_restores_when_running():
 @pytest.mark.django_db
 def test_restore_train_job_status_noop_when_not_running():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j4", description="", team=[1], status=TrainJobStatus.COMPLETED,
-        algorithm="algo", dataset_version=None, hyperopt_config={},
+        name="j4",
+        description="",
+        team=[1],
+        status=TrainJobStatus.COMPLETED,
+        algorithm="algo",
+        dataset_version=None,
+        hyperopt_config={},
     )
     AnomalyDetectionTrainJobViewSet.restore_train_job_status(tj, TrainJobStatus.PENDING)
     tj.refresh_from_db()

--- a/server/apps/mlops/tests/test_base_view_logic.py
+++ b/server/apps/mlops/tests/test_base_view_logic.py
@@ -1,86 +1,14 @@
-import importlib
-from types import SimpleNamespace
-from unittest.mock import Mock
+import pydantic.root_model  # noqa
 
 import pandas as pd
-import pydantic.root_model  # noqa
 import pytest
+from types import SimpleNamespace
 
 from apps.mlops.constants import MLflowRunStatus, TrainJobStatus
 from apps.mlops.models.anomaly_detection import AnomalyDetectionTrainJob
 from apps.mlops.views.anomaly_detection import AnomalyDetectionTrainJobViewSet
 
 pytestmark = pytest.mark.unit
-
-
-TRAIN_JOB_VIEWSETS = [
-    ("anomaly_detection", "AnomalyDetectionTrainJobViewSet"),
-    ("classification", "ClassificationTrainJobViewSet"),
-    ("image_classification", "ImageClassificationTrainJobViewSet"),
-    ("object_detection", "ObjectDetectionTrainJobViewSet"),
-    ("log_clustering", "LogClusteringTrainJobViewSet"),
-    ("timeseries_predict", "TimeSeriesPredictTrainJobViewSet"),
-]
-
-COMMON_RUN_ACTIONS = [
-    ("delete_run", {"pk": 1, "run_id": "run-1"}, "Delete", "delete"),
-    (
-        "get_metric_data",
-        {"pk": 1, "run_id": "run-1", "metric_name": "accuracy"},
-        "View",
-        "get",
-    ),
-    ("get_run_params", {"pk": 1, "run_id": "run-1"}, "View", "get"),
-]
-
-
-@pytest.mark.parametrize("module_name,class_name", TRAIN_JOB_VIEWSETS)
-@pytest.mark.parametrize(
-    "action_name,action_kwargs,permission_suffix,http_method",
-    COMMON_RUN_ACTIONS,
-)
-def test_train_job_common_run_actions_delegate_to_base(
-    monkeypatch,
-    module_name,
-    class_name,
-    action_name,
-    action_kwargs,
-    permission_suffix,
-    http_method,
-):
-    base_module = importlib.import_module("apps.mlops.views.base")
-    assert hasattr(base_module, "BaseTrainJobViewSet"), "六算法 TrainJob 应共享统一基类"
-
-    base_viewset = base_module.BaseTrainJobViewSet
-    viewset = getattr(importlib.import_module(f"apps.mlops.views.{module_name}"), class_name)
-    assert issubclass(viewset, base_viewset)
-    assert http_method in viewset.__dict__[action_name].mapping
-
-    shared_action = Mock(return_value=object())
-    monkeypatch.setattr(base_viewset, action_name, shared_action)
-    denied_request = SimpleNamespace(
-        user=SimpleNamespace(
-            is_superuser=False,
-            locale="en",
-            permission={"mlops": set()},
-        )
-    )
-    denied_response = getattr(viewset(), action_name)(denied_request, **action_kwargs)
-    assert denied_response.status_code == 403
-    shared_action.assert_not_called()
-
-    request = SimpleNamespace(
-        user=SimpleNamespace(
-            is_superuser=False,
-            locale="en",
-            permission={"mlops": {f"{module_name}-{permission_suffix}"}},
-        )
-    )
-
-    response = getattr(viewset(), action_name)(request, **action_kwargs)
-
-    assert response is shared_action.return_value
-    shared_action.assert_called_once_with(request, **action_kwargs)
 
 
 # ----------------- has_run_in_runs_frame -----------------
@@ -242,13 +170,8 @@ def test_check_run_delete_eligibility_blocked(monkeypatch):
 @pytest.mark.django_db
 def test_claim_train_job_running_success():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j1",
-        description="",
-        team=[1],
-        status=TrainJobStatus.PENDING,
-        algorithm="algo",
-        dataset_version=None,
-        hyperopt_config={},
+        name="j1", description="", team=[1], status=TrainJobStatus.PENDING,
+        algorithm="algo", dataset_version=None, hyperopt_config={},
     )
     vs = AnomalyDetectionTrainJobViewSet()
     prev = vs.claim_train_job_running(tj)
@@ -261,13 +184,8 @@ def test_claim_train_job_running_success():
 @pytest.mark.django_db
 def test_claim_train_job_running_already_running_returns_none():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j2",
-        description="",
-        team=[1],
-        status=TrainJobStatus.RUNNING,
-        algorithm="algo",
-        dataset_version=None,
-        hyperopt_config={},
+        name="j2", description="", team=[1], status=TrainJobStatus.RUNNING,
+        algorithm="algo", dataset_version=None, hyperopt_config={},
     )
     vs = AnomalyDetectionTrainJobViewSet()
     assert vs.claim_train_job_running(tj) is None
@@ -276,13 +194,8 @@ def test_claim_train_job_running_already_running_returns_none():
 @pytest.mark.django_db
 def test_restore_train_job_status_restores_when_running():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j3",
-        description="",
-        team=[1],
-        status=TrainJobStatus.RUNNING,
-        algorithm="algo",
-        dataset_version=None,
-        hyperopt_config={},
+        name="j3", description="", team=[1], status=TrainJobStatus.RUNNING,
+        algorithm="algo", dataset_version=None, hyperopt_config={},
     )
     AnomalyDetectionTrainJobViewSet.restore_train_job_status(tj, TrainJobStatus.PENDING)
     tj.refresh_from_db()
@@ -293,13 +206,8 @@ def test_restore_train_job_status_restores_when_running():
 @pytest.mark.django_db
 def test_restore_train_job_status_noop_when_not_running():
     tj = AnomalyDetectionTrainJob.objects.create(
-        name="j4",
-        description="",
-        team=[1],
-        status=TrainJobStatus.COMPLETED,
-        algorithm="algo",
-        dataset_version=None,
-        hyperopt_config={},
+        name="j4", description="", team=[1], status=TrainJobStatus.COMPLETED,
+        algorithm="algo", dataset_version=None, hyperopt_config={},
     )
     AnomalyDetectionTrainJobViewSet.restore_train_job_status(tj, TrainJobStatus.PENDING)
     tj.refresh_from_db()

--- a/server/apps/mlops/views/anomaly_detection.py
+++ b/server/apps/mlops/views/anomaly_detection.py
@@ -37,7 +37,7 @@ from apps.mlops.serializers.algorithm_config import (
     AlgorithmConfigListSerializer,
 )
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 
 
@@ -70,7 +70,7 @@ class AnomalyDetectionDatasetViewSet(TeamModelViewSet):
         return super().update(request, *args, **kwargs)
 
 
-class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
+class AnomalyDetectionTrainJobViewSet(BaseTrainJobViewSet):
     queryset = AnomalyDetectionTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
     serializer_class = AnomalyDetectionTrainJobSerializer
     filterset_class = AnomalyDetectionTrainJobFilter
@@ -383,38 +383,7 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("anomaly_detection-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("anomaly_detection-View")
@@ -444,85 +413,12 @@ class AnomalyDetectionTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("anomaly_detection-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("anomaly_detection-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="model_versions")
     @HasPermission("anomaly_detection-View")

--- a/server/apps/mlops/views/base.py
+++ b/server/apps/mlops/views/base.py
@@ -1,19 +1,17 @@
-from apps.core.logger import mlops_logger as logger
-from apps.core.utils.viewset_utils import AuthViewSet
-from apps.mlops.constants import TrainJobStatus, MLflowRunStatus
-from apps.mlops.utils.i18n import mlops_message
-from apps.mlops.utils.group_scope import assert_dataset_version_scope
-from apps.mlops.utils.webhook_client import (
-    WebhookClient,
-    WebhookConnectionError,
-    WebhookError,
-    WebhookTimeoutError,
-)
+import pandas as pd
+from django.db import transaction
 from django.http import Http404
 from django.shortcuts import get_object_or_404
-from django.db import transaction
 from rest_framework import serializers, status
 from rest_framework.response import Response
+
+from apps.core.logger import mlops_logger as logger
+from apps.core.utils.viewset_utils import AuthViewSet
+from apps.mlops.constants import MLflowRunStatus, TrainJobStatus
+from apps.mlops.utils import mlflow_service
+from apps.mlops.utils.group_scope import assert_dataset_version_scope
+from apps.mlops.utils.i18n import mlops_message
+from apps.mlops.utils.webhook_client import WebhookClient, WebhookConnectionError, WebhookError, WebhookTimeoutError
 
 
 class TeamModelViewSet(AuthViewSet):
@@ -317,3 +315,131 @@ class TeamModelViewSet(AuthViewSet):
                 return False, rd["delete_block_reason"]
 
         return False, "run_not_found"
+
+
+class BaseTrainJobViewSet(TeamModelViewSet):
+    """六类训练作业共享的运行记录动作实现。
+
+    具体算法 ViewSet 继续声明 ``@action`` 与 ``@HasPermission``，从而保留
+    既有路由和权限名；这里只集中不含算法差异的业务实现。
+    """
+
+    def delete_run(self, request, pk=None, run_id=None):
+        """软删除指定 MLflow run。"""
+        try:
+            train_job = self.get_object()
+
+            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
+            if not allowed:
+                return Response(
+                    {
+                        "error": mlops_message(
+                            request,
+                            "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete",
+                        ),
+                        "code": reason,
+                        "run_id": run_id,
+                    },
+                    status=(status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST),
+                )
+
+            mlflow_service.delete_run(run_id)
+
+            return Response(
+                {
+                    "result": True,
+                    "run_id": run_id,
+                    "train_job_id": train_job.id,
+                    "deleted": True,
+                    "deletion_type": "mlflow_soft_delete",
+                }
+            )
+        except Exception as e:
+            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
+            return Response(
+                {
+                    "result": False,
+                    "message": mlops_message(request, "error.run_delete_failed", detail=str(e)),
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
+        """获取指定 run 的指标历史。"""
+        try:
+            train_job = self.get_authorized_object_or_none()
+            if train_job is None:
+                return self.run_not_found_response(run_id)
+            if not self.train_job_has_run(train_job, run_id):
+                return self.run_not_found_response(run_id)
+
+            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
+            if not metric_data:
+                return Response(
+                    {
+                        "run_id": run_id,
+                        "metric_name": metric_name,
+                        "total_points": 0,
+                        "metric_history": [],
+                    }
+                )
+
+            return Response(
+                {
+                    "run_id": run_id,
+                    "metric_name": metric_name,
+                    "total_points": len(metric_data),
+                    "metric_history": metric_data,
+                }
+            )
+        except Exception as e:
+            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
+            return Response(
+                {
+                    "error": mlops_message(
+                        request,
+                        "error.metric_history_fetch_failed",
+                        detail=str(e),
+                    )
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+    def get_run_params(self, request, pk=None, run_id: str = ""):
+        """获取指定 run 的训练参数与运行元信息。"""
+        try:
+            train_job = self.get_authorized_object_or_none()
+            if train_job is None:
+                return self.run_not_found_response(run_id)
+            if not self.train_job_has_run(train_job, run_id):
+                return self.run_not_found_response(run_id)
+
+            run = mlflow_service.get_run_info(run_id)
+            params = mlflow_service.get_run_params(run_id)
+            run_name = run.data.tags.get("mlflow.runName", run_id)
+            run_status = run.info.status
+            start_time = run.info.start_time
+            end_time = run.info.end_time
+
+            return Response(
+                {
+                    "run_id": run_id,
+                    "run_name": run_name,
+                    "status": run_status,
+                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
+                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
+                    "params": params,
+                }
+            )
+        except Exception as e:
+            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
+            return Response(
+                {
+                    "error": mlops_message(
+                        request,
+                        "error.run_params_fetch_failed",
+                        detail=str(e),
+                    )
+                },
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )

--- a/server/apps/mlops/views/classification.py
+++ b/server/apps/mlops/views/classification.py
@@ -38,7 +38,7 @@ from apps.mlops.serializers.algorithm_config import (
     AlgorithmConfigListSerializer,
 )
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 
 
@@ -750,7 +750,7 @@ class ClassificationTrainDataViewSet(ModelViewSet):
         return super().update(request, *args, **kwargs)
 
 
-class ClassificationTrainJobViewSet(TeamModelViewSet):
+class ClassificationTrainJobViewSet(BaseTrainJobViewSet):
     queryset = ClassificationTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
     serializer_class = ClassificationTrainJobSerializer
     pagination_class = CustomPageNumberPagination
@@ -1077,38 +1077,7 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("classification-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("classification-View")
@@ -1138,85 +1107,12 @@ class ClassificationTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("classification-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("classification-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="model_versions")
     @HasPermission("classification-View")

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -13,7 +13,7 @@ from apps.mlops.serializers.algorithm_config import (
 )
 from apps.mlops.filters.image_classification import *
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 from config.drf.pagination import CustomPageNumberPagination
 from apps.core.decorators.api_permission import HasPermission
@@ -288,7 +288,7 @@ class ImageClassificationDatasetReleaseViewSet(ModelViewSet):
             )
 
 
-class ImageClassificationTrainJobViewSet(TeamModelViewSet):
+class ImageClassificationTrainJobViewSet(BaseTrainJobViewSet):
     """图片分类训练任务视图集"""
 
     queryset = ImageClassificationTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
@@ -701,38 +701,7 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("image_classification-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("image_classification-View")
@@ -762,85 +731,12 @@ class ImageClassificationTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("image_classification-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("image_classification-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
 
 class ImageClassificationServingViewSet(TeamModelViewSet):

--- a/server/apps/mlops/views/log_clustering.py
+++ b/server/apps/mlops/views/log_clustering.py
@@ -38,7 +38,7 @@ from apps.mlops.serializers.algorithm_config import (
     AlgorithmConfigListSerializer,
 )
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 
 
@@ -71,7 +71,7 @@ class LogClusteringDatasetViewSet(TeamModelViewSet):
         return super().update(request, *args, **kwargs)
 
 
-class LogClusteringTrainJobViewSet(TeamModelViewSet):
+class LogClusteringTrainJobViewSet(BaseTrainJobViewSet):
     queryset = LogClusteringTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
     serializer_class = LogClusteringTrainJobSerializer
     pagination_class = CustomPageNumberPagination
@@ -398,38 +398,7 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("log_clustering-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("log_clustering-View")
@@ -463,85 +432,12 @@ class LogClusteringTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("log_clustering-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("log_clustering-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="model_versions")
     @HasPermission("log_clustering-View")

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -38,7 +38,7 @@ from apps.mlops.serializers.algorithm_config import (
     AlgorithmConfigListSerializer,
 )
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 
 
@@ -264,7 +264,7 @@ class ObjectDetectionDatasetReleaseViewSet(ModelViewSet):
             )
 
 
-class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
+class ObjectDetectionTrainJobViewSet(BaseTrainJobViewSet):
     """目标检测训练任务视图集"""
 
     queryset = ObjectDetectionTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
@@ -677,38 +677,7 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("object_detection-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("object_detection-View")
@@ -738,85 +707,12 @@ class ObjectDetectionTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("object_detection-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("object_detection-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
 
 class ObjectDetectionServingViewSet(TeamModelViewSet):

--- a/server/apps/mlops/views/timeseries_predict.py
+++ b/server/apps/mlops/views/timeseries_predict.py
@@ -43,7 +43,7 @@ from apps.mlops.serializers.algorithm_config import (
     AlgorithmConfigListSerializer,
 )
 from apps.mlops.filters.algorithm_config import AlgorithmConfigFilter
-from apps.mlops.views.base import TeamModelViewSet
+from apps.mlops.views.base import BaseTrainJobViewSet, TeamModelViewSet
 from apps.mlops.utils.group_scope import filter_queryset_by_parent_team
 
 
@@ -95,7 +95,7 @@ class TimeSeriesPredictDatasetViewSet(TeamModelViewSet):
         return super().update(request, *args, **kwargs)
 
 
-class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
+class TimeSeriesPredictTrainJobViewSet(BaseTrainJobViewSet):
     queryset = TimeSeriesPredictTrainJob.objects.select_related("dataset_version", "dataset_version__dataset").all()
     serializer_class = TimeSeriesPredictTrainJobSerializer
     pagination_class = CustomPageNumberPagination
@@ -426,38 +426,7 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
     @action(detail=True, methods=["delete"], url_path="runs/(?P<run_id>[^/]+)")
     @HasPermission("timeseries_predict-Delete")
     def delete_run(self, request, pk=None, run_id=None):
-        """软删除指定 MLflow run"""
-        try:
-            train_job = self.get_object()
-
-            allowed, reason = self.check_run_delete_eligibility(run_id, train_job)
-            if not allowed:
-                return Response(
-                    {
-                        "error": mlops_message(request, "error.training_run_not_found" if reason == "run_not_found" else "error.training_run_cannot_delete"),
-                        "code": reason,
-                        "run_id": run_id,
-                    },
-                    status=status.HTTP_404_NOT_FOUND if reason == "run_not_found" else status.HTTP_400_BAD_REQUEST,
-                )
-
-            mlflow_service.delete_run(run_id)
-
-            return Response(
-                {
-                    "result": True,
-                    "run_id": run_id,
-                    "train_job_id": train_job.id,
-                    "deleted": True,
-                    "deletion_type": "mlflow_soft_delete",
-                }
-            )
-        except Exception as e:
-            logger.error(f"删除 run 失败: {str(e)}", exc_info=True)
-            return Response(
-                {"result": False, "message": mlops_message(request, "error.run_delete_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().delete_run(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/metrics_list")
     @HasPermission("timeseries_predict-View")
@@ -491,85 +460,12 @@ class TimeSeriesPredictTrainJobViewSet(TeamModelViewSet):
     )
     @HasPermission("timeseries_predict-View")
     def get_metric_data(self, request, pk=None, run_id: str = "", metric_name: str = ""):
-        """
-        获取指定 run 的指定指标的历史数据
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取指标历史数据（自动处理排序）
-            metric_data = mlflow_service.get_metric_history(run_id, metric_name)
-
-            if not metric_data:
-                return Response(
-                    {
-                        "run_id": run_id,
-                        "metric_name": metric_name,
-                        "total_points": 0,
-                        "metric_history": [],
-                    }
-                )
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "metric_name": metric_name,
-                    "total_points": len(metric_data),
-                    "metric_history": metric_data,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取指标历史数据失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.metric_history_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_metric_data(request, pk=pk, run_id=run_id, metric_name=metric_name)
 
     @action(detail=True, methods=["get"], url_path="runs/(?P<run_id>[^/]+)/run_params")
     @HasPermission("timeseries_predict-View")
     def get_run_params(self, request, pk=None, run_id: str = ""):
-        """
-        获取指定 run 的配置参数（用于查看历史训练的配置）
-        """
-        try:
-            train_job = self.get_authorized_object_or_none()
-            if train_job is None:
-                return self.run_not_found_response(run_id)
-            if not self.train_job_has_run(train_job, run_id):
-                return self.run_not_found_response(run_id)
-
-            # 获取运行信息和参数
-            run = mlflow_service.get_run_info(run_id)
-            params = mlflow_service.get_run_params(run_id)
-
-            # 提取运行元信息
-            run_name = run.data.tags.get("mlflow.runName", run_id)
-            run_status = run.info.status
-            start_time = run.info.start_time
-            end_time = run.info.end_time
-
-            return Response(
-                {
-                    "run_id": run_id,
-                    "run_name": run_name,
-                    "status": run_status,
-                    "start_time": pd.Timestamp(start_time, unit="ms").isoformat() if start_time else None,
-                    "end_time": pd.Timestamp(end_time, unit="ms").isoformat() if end_time else None,
-                    "params": params,
-                }
-            )
-
-        except Exception as e:
-            logger.error(f"获取运行参数失败: {str(e)}", exc_info=True)
-            return Response(
-                {"error": mlops_message(request, "error.run_params_fetch_failed", detail=str(e))},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
+        return super().get_run_params(request, pk=pk, run_id=run_id)
 
     @action(detail=True, methods=["get"], url_path="model_versions")
     @HasPermission("timeseries_predict-View")


### PR DESCRIPTION
## 问题

六种算法的训练作业视图分别维护 `delete_run`、`get_metric_data` 和 `get_run_params` 三项完全同构的动作。重复实现使相同行为需要在六处同步修改，容易产生路由、权限或响应语义漂移。

## 根因

现有公共视图只提供团队与运行记录归属校验等辅助能力，三个 HTTP 动作仍留在各算法子类中重复实现，缺少统一的动作实现层。

## 方案 A 第一阶段

- 新增 `BaseTrainJobViewSet`，集中承载三项同构实现。
- 六个算法子类继续保留原有 `@action`、算法专属 `@HasPermission`、方法签名与 URL，只将方法体改为委托公共基类。
- 补充六算法乘三动作的继承、路由、拒绝访问与成功委托契约测试。
- 本阶段不改 Serving、时序预测生命周期、数据库模型或外部接口。

```mermaid
flowchart TD
    A["六算法 TrainJobViewSet"] --> B["子类保留 action 与权限装饰器"]
    B --> C["BaseTrainJobViewSet<br/>三项共享动作"]
    C --> D["TeamModelViewSet<br/>团队与运行记录归属校验"]
    D --> E["MLflow 服务"]
```

## 兼容性与风险

对外 URL、HTTP 方法、权限字符串、团队与运行记录授权、成功响应、缺省值和异常映射保持不变。变更仅位于 MLOps 服务端视图层，无迁移和新增依赖；可通过回滚单个提交恢复。风险评估：中。

## 验证

- `apps/mlops/tests/test_base_view_logic.py` 与 `apps/mlops/tests/test_views_actions_param.py`：322 passed，10 skipped。
- `apps/mlops/tests/test_run_scoped_authorization.py` 在固定 master 与本分支均因 MLflow 4 文件存储环境返回相同失败，已确认不是本次变更新增。
- Black、isort、变更行 flake8、`git diff --check`：通过。
- Standards、Spec、Runtime Contract 三轨审查：PASS。
- 质量评分：92/100。

关联 #3503。
