### PR TITLE
fix(监控): 归并 IF-MIB 指标分组并置底展示

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
@@ -1,32 +1,78 @@
 import { GroupInfo, MetricItem } from '@/app/monitor/types';
 import { MetricListItem } from '@/app/monitor/types/integration';
 
+const IFMIB_DEVICE_TOTAL_METRICS = new Set([
+  'device_total_incoming_traffic',
+  'device_total_outgoing_traffic'
+]);
+
 export const isIfmibMetric = (metric: MetricItem) => metric.is_ifmib === true;
 
+/** 默认只展开第一个可见分组，避免 IF-MIB 归并后首屏过长。 */
 export const getDefaultMetricGroupOpenState = (groups: MetricListItem[]) => (
-  new Map(groups.map((group) => [group.id, true]))
+  new Map(groups.map((group, index) => [group.id, index === 0]))
+);
+
+const IFMIB_METRIC_GROUPS = [
+  {
+    id: '__ifmib_status_and_speed__',
+    nameKey: 'monitor.integrations.ifmibMetricGroups.overview',
+    metrics: new Set([
+      'interface_ifAdminStatus',
+      'interface_ifOperStatus',
+      'interface_ifSpeed'
+    ])
+  },
+  {
+    id: '__ifmib_traffic__',
+    nameKey: 'monitor.integrations.ifmibMetricGroups.traffic',
+    metrics: new Set([
+      'interface_ifInOctets',
+      'interface_ifOutOctets',
+      'interface_ifHCInOctets',
+      'interface_ifHCOutOctets',
+      ...IFMIB_DEVICE_TOTAL_METRICS
+    ])
+  },
+  {
+    id: '__ifmib_quality_and_packets__',
+    nameKey: 'monitor.integrations.ifmibMetricGroups.packetsAndExceptions',
+    metrics: new Set([
+      'interface_ifInUcastPkts',
+      'interface_ifOutUcastPkts',
+      'interface_ifInErrors',
+      'interface_ifOutErrors',
+      'interface_ifInDiscards',
+      'interface_ifOutDiscards'
+    ])
+  }
+] as const;
+
+const getIfmibMetricGroup = (metric: MetricItem) => (
+  IFMIB_METRIC_GROUPS.find((group) => group.metrics.has(metric.name))
+  // 通用表新增字段时，目录可能尚未声明展示分组；落入报文与异常组以免丢指标。
+  || IFMIB_METRIC_GROUPS[2]
 );
 
 /**
- * 指标页只反映当前下发流程是否采集 IF-MIB。开启时保留模板原有分组，
- * 以单指标来源标签区分公共 IF-MIB；关闭时隐藏该来源及由此产生的空分组。
+ * 指标页只反映当前下发流程是否采集 IF-MIB。
+ * 开启时：厂商/模板指标保持原分组并置顶；公共 IF-MIB 归并为少量业务组并置底，
+ * 以来源组标签标识。关闭时隐藏 IF-MIB 指标及由此产生的空分组。
  */
 export const buildIfmibMetricView = (
   groups: GroupInfo[],
   metrics: MetricItem[],
-  enabled: boolean
+  enabled: boolean,
+  translate?: (key: string) => string
 ): MetricListItem[] => {
-  const visibleMetrics = enabled
-    ? metrics
-    : metrics.filter((metric) => !isIfmibMetric(metric));
-
-  return groups
+  const nonIfmibMetrics = metrics.filter((metric) => !isIfmibMetric(metric));
+  const grouped = groups
     .map((group) => {
-      const child = visibleMetrics
+      const child = nonIfmibMetrics
         .filter((metric) => String(metric.metric_group) === String(group.id))
         .map((metric) => ({
           ...metric,
-          show_ifmib_source_tag: isIfmibMetric(metric)
+          show_ifmib_source_tag: false
         }));
 
       return {
@@ -40,4 +86,31 @@ export const buildIfmibMetricView = (
       };
     })
     .filter((group) => group.child.length > 0) as MetricListItem[];
+
+  if (!enabled) {
+    return grouped;
+  }
+
+  const ifmibGroups = IFMIB_METRIC_GROUPS.map((group) => {
+    const label = translate?.(group.nameKey) || group.nameKey;
+    const child = metrics
+      .filter((metric) => (
+        isIfmibMetric(metric) && getIfmibMetricGroup(metric).id === group.id
+      ))
+      .map((metric) => ({
+        ...metric,
+        show_ifmib_source_tag: false
+      }));
+
+    return {
+      id: group.id,
+      name: label,
+      display_name: label,
+      is_pre: true,
+      is_ifmib_group: true,
+      child
+    };
+  }).filter((group) => group.child.length > 0) as MetricListItem[];
+
+  return [...grouped, ...ifmibGroups];
 };

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -99,11 +99,6 @@ const Configure = () => {
       render: (_, record) => (
         <div className="flex items-center gap-1 overflow-hidden">
           <span className="truncate">{record.display_name || '--'}</span>
-          {record.show_ifmib_source_tag === true && (
-            <Tag className="m-0 shrink-0" color="blue">
-              IF-MIB
-            </Tag>
-          )}
         </div>
       )
     },
@@ -291,7 +286,8 @@ const Configure = () => {
       const metricView = buildIfmibMetricView(
         rawGroupList,
         metricsPage.items,
-        enableIfmib
+        enableIfmib,
+        (key) => t(key)
       );
       const defaultOpenState = getDefaultMetricGroupOpenState(metricView);
       const groupData = metricView.map((group) => ({
@@ -575,6 +571,11 @@ const Configure = () => {
                 title={
                   <div className="flex items-center gap-2">
                     <span>{metricItem.display_name || ''}</span>
+                    {metricItem.is_ifmib_group === true && (
+                      <Tag className="m-0" color="blue">
+                        IF-MIB
+                      </Tag>
+                    )}
                   </div>
                 }
                 isOpen={metricItem.isOpen}


### PR DESCRIPTION
## Summary
- 开启 IF-MIB 时，公共接口指标归并为「接口概况 / 接口流量 / 接口报文与异常」三组，并置于厂商/模板指标下方
- IF-MIB 来源标签改挂在指标组标题，不再逐条标注
- 默认只展开第一个可见分组，避免首屏过长

## Test plan
- [ ] 打开网络设备 SNMP 接入指标页，勾选/选择 IF-MIB
- [ ] 确认厂商指标仍在上方原分组，IF-MIB 三组在底部且组标题带 IF-MIB 标签
- [ ] 关闭 IF-MIB 后公共接口指标与空分组不再展示
- [ ] 本地已跑 `vitest run .../ifmibMetricView.test.ts`（4/4，测试文件未纳入本 PR）

## Scope check
- 仅提交 `ifmibMetricView.ts`、`page.tsx`；本地 next/turbopack、top-menu、icons、测试文件等未纳入