### PR TITLE
fix(监控): 修复 IF-MIB 编辑回显、指标目录与总流量口径

### DIFF
--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -41,6 +41,7 @@ class MetricFilter(FilterSet):
     name_in = CharInFilter(field_name="name", lookup_expr="in", label="指标名称列表")
     keyword = CharFilter(method="filter_keyword", label="指标关键字")
     include_ifmib = BooleanFilter(method="filter_include_ifmib", label="是否包含IF-MIB指标")
+    is_ifmib = BooleanFilter(field_name="is_ifmib", label="是否为IF-MIB指标")
 
     @staticmethod
     def filter_keyword(queryset, _name, value):
@@ -71,4 +72,5 @@ class MetricFilter(FilterSet):
             "name_in",
             "keyword",
             "include_ifmib",
+            "is_ifmib",
         ]

--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -117,7 +117,11 @@ def merge_common_ifmib_metrics(plugin_data):
         if metric_name in common_metrics_by_name:
             # 厂商可能为同一 IF-MIB 指标提供更准确的查询或分组。保留该定义，
             # 仅标记来源，确保目录/API 的厂商优先级不被公共目录覆盖。
-            metric = {**metric, "is_ifmib": True}
+            # device_total_* 强制使用公共 HC 聚合，避免厂商旧 32 位计数器在高速口 wrap。
+            if str(metric_name).startswith("device_total_"):
+                metric = {**common_metrics_by_name[metric_name]}
+            else:
+                metric = {**metric, "is_ifmib": True}
             existing_common_names.add(metric_name)
         merged_metrics.append(metric)
     merged_metrics.extend(

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall/metrics.json
@@ -151,7 +151,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -162,7 +162,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/metrics.json
@@ -361,7 +361,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -374,7 +374,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/metrics.json
@@ -349,7 +349,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -362,7 +362,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/metrics.json
@@ -348,7 +348,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -361,7 +361,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/metrics.json
@@ -282,7 +282,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -295,7 +295,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/metrics.json
@@ -296,7 +296,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/metrics.json
@@ -362,7 +362,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -375,7 +375,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/metrics.json
@@ -296,7 +296,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/metrics.json
@@ -336,7 +336,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -349,7 +349,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/metrics.json
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/metrics.json
@@ -375,7 +375,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -388,7 +388,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/metrics.json
@@ -296,7 +296,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='firewall', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/metrics.json
@@ -147,7 +147,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='hardware_server', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='hardware_server', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -158,7 +158,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='hardware_server', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='hardware_server', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance/metrics.json
@@ -152,7 +152,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -163,7 +163,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/metrics.json
@@ -322,7 +322,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -335,7 +335,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/metrics.json
@@ -284,7 +284,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/metrics.json
@@ -375,7 +375,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -388,7 +388,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/metrics.json
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -322,7 +322,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/metrics.json
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -323,7 +323,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/metrics.json
@@ -296,7 +296,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='loadbalance', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router/metrics.json
@@ -151,7 +151,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -162,7 +162,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/metrics.json
@@ -311,7 +311,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -324,7 +324,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/metrics.json
@@ -297,7 +297,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -310,7 +310,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/metrics.json
@@ -335,7 +335,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -348,7 +348,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/metrics.json
@@ -309,7 +309,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -322,7 +322,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/metrics.json
@@ -311,7 +311,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -324,7 +324,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/metrics.json
@@ -335,7 +335,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -348,7 +348,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='router', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch/metrics.json
@@ -151,7 +151,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -162,7 +162,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/metrics.json
@@ -325,7 +325,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -338,7 +338,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/metrics.json
@@ -325,7 +325,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -338,7 +338,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/metrics.json
@@ -325,7 +325,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -338,7 +338,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/metrics.json
@@ -268,7 +268,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_incoming_traffic",
-      "query": "sum(rate(interface_ifInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCInOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Incoming Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",
@@ -281,7 +281,7 @@
     {
       "metric_group": "Traffic",
       "name": "device_total_outgoing_traffic",
-      "query": "sum(rate(interface_ifOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
+      "query": "sum(rate(interface_ifHCOutOctets{instance_type='switch', __$labels__}[5m])) by (instance_id)",
       "display_name": "Device Total Outgoing Traffic Rate",
       "data_type": "Number",
       "unit": "byteps",

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -135,6 +135,13 @@ def apply_inherited_metric_filters(queryset, query_params):
             | Q(display_name__icontains=keyword)
             | Q(description__icontains=keyword)
         )
+    is_ifmib = query_params.get("is_ifmib")
+    if is_ifmib is not None and str(is_ifmib).strip() != "":
+        normalized = str(is_ifmib).strip().lower()
+        if normalized in {"true", "1"}:
+            queryset = queryset.filter(is_ifmib=True)
+        elif normalized in {"false", "0"}:
+            queryset = queryset.filter(is_ifmib=False)
     return queryset
 
 

--- a/web/src/app/monitor/(pages)/event/alert/alertDetail.tsx
+++ b/web/src/app/monitor/(pages)/event/alert/alertDetail.tsx
@@ -32,6 +32,7 @@ import {
   useAlertTypeMap
 } from '@/app/monitor/hooks';
 import useMonitorApi from '@/app/monitor/api';
+import { fetchAllMonitorMetrics } from '@/app/monitor/api/fetchMetricCatalogPages';
 import useEventApi from '@/app/monitor/api/event';
 import Information from './information';
 import EventHeatMap, { getHeatMapCellColor } from '@/components/heat-map';
@@ -124,7 +125,9 @@ const AlertDetail = forwardRef<ModalRef, ModalConfig>(
     const getMetrics = async (row: TableDataItem, id: React.Key) => {
       setPageLoading(true);
       try {
-        const { items: data } = await getMonitorMetrics({ monitor_object_id: id });
+        const { items: data } = await fetchAllMonitorMetrics(getMonitorMetrics, {
+          monitor_object_id: id
+        });
         const metricInfo =
           data.find(
             (item: MetricItem) =>

--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -3,6 +3,10 @@ import { useEffect, useMemo, useState, useRef } from 'react';
 import { Spin, Button, Form, message, Steps } from 'antd';
 import useApiClient from '@/utils/request';
 import useMonitorApi from '@/app/monitor/api';
+import {
+  fetchAllMetricsGroups,
+  fetchAllMonitorMetrics
+} from '@/app/monitor/api/fetchMetricCatalogPages';
 import useEventApi from '@/app/monitor/api/event';
 import { useTranslation } from '@/utils/i18n';
 import {
@@ -636,8 +640,8 @@ const StrategyOperation = () => {
   const getMetrics = async (params = {}, type = '') => {
     try {
       setMetricsLoading(true);
-      const getGroupList = getMetricsGroup(params);
-      const getMetrics = getMonitorMetrics(params);
+      const getGroupList = fetchAllMetricsGroups(getMetricsGroup, params);
+      const getMetrics = fetchAllMonitorMetrics(getMonitorMetrics, params);
       Promise.all([getGroupList, getMetrics])
         .then((res) => {
           const metricData = cloneDeep(res[1].items);

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -17,6 +17,7 @@ import {
   getSnmpFilterMutexConflicts,
   trackSnmpFilterMutexLastChanged
 } from '@/app/monitor/hooks/integration/snmpFilterMutex';
+import { getSnmpInterfaceFilterModePatch } from '@/app/monitor/hooks/integration/snmpInterfaceFilterMode';
 import { getIfmibSnapshotEnabled } from '../list/detail/configure/ifmibDeploymentState';
 
 interface PluginFormField {
@@ -200,7 +201,14 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
                 name="basic"
                 layout="vertical"
                 onValuesChange={(changed, all) => {
-                  trackSnmpFilterMutexLastChanged(changed, all, form);
+                  const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(changed);
+                  const nextValues = Object.keys(interfaceFilterModePatch).length
+                    ? { ...all, ...interfaceFilterModePatch }
+                    : all;
+                  if (Object.keys(interfaceFilterModePatch).length) {
+                    form.setFieldsValue(interfaceFilterModePatch);
+                  }
+                  trackSnmpFilterMutexLastChanged(changed, nextValues, form);
                 }}
               >
                 {formItems}

--- a/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
@@ -27,6 +27,10 @@ import { PlusOutlined, CloseOutlined } from '@ant-design/icons';
 import { useTranslation } from '@/utils/i18n';
 import GroupTreeSelector from '@/components/group-tree-select';
 import useMonitorApi from '@/app/monitor/api';
+import {
+  fetchAllMetricsGroups,
+  fetchAllMonitorMetrics
+} from '@/app/monitor/api/fetchMetricCatalogPages';
 import { useConditionList } from '@/app/monitor/hooks';
 import { cloneDeep } from 'lodash';
 const { Option } = Select;
@@ -123,8 +127,8 @@ const RuleModal = forwardRef<ModalRef, ModalProps>(
     const getMetrics = async (params = {}) => {
       try {
         setMetricsLoading(true);
-        const getGroupList = getMetricsGroup(params);
-        const getMetrics = getMonitorMetrics(params);
+        const getGroupList = fetchAllMetricsGroups(getMetricsGroup, params);
+        const getMetrics = fetchAllMonitorMetrics(getMonitorMetrics, params);
         Promise.all([getGroupList, getMetrics])
           .then((res) => {
             const metricData = cloneDeep(res[1].items);

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -267,9 +267,25 @@ const Configure = () => {
       manuallyClosedGroupIds.current.clear();
     }
     try {
-      const [groupPage, metricsPage] = await Promise.all([
+      // 厂商指标按页分页；IF-MIB 固定约十余条，单独拉全量后置底归并，避免拆页。
+      const [groupPage, metricsPage, ifmibPage] = await Promise.all([
         getMetricsGroup(params, config),
-        getMonitorMetrics({ ...params, include_ifmib: enableIfmib, page }, config)
+        getMonitorMetrics(
+          { ...params, include_ifmib: false, page },
+          config
+        ),
+        enableIfmib
+          ? getMonitorMetrics(
+            {
+              ...params,
+              include_ifmib: true,
+              is_ifmib: true,
+              page: 1,
+              page_size: 100
+            },
+            config
+          )
+          : Promise.resolve({ count: 0, items: [], metric_groups: [] })
       ]);
       if (abortController.signal.aborted) return;
       const rawGroupList: MetricListItem[] = (
@@ -283,9 +299,12 @@ const Configure = () => {
       }));
       setMetricCount(metricsPage.count);
       setApiGroupList(rawGroupList);
+      const catalogMetrics = enableIfmib
+        ? [...metricsPage.items, ...ifmibPage.items]
+        : metricsPage.items;
       const metricView = buildIfmibMetricView(
         rawGroupList,
-        metricsPage.items,
+        catalogMetrics,
         enableIfmib,
         (key) => t(key)
       );

--- a/web/src/app/monitor/api/fetchMetricCatalogPages.ts
+++ b/web/src/app/monitor/api/fetchMetricCatalogPages.ts
@@ -1,0 +1,67 @@
+import type { GroupInfo, MetricItem } from '@/app/monitor/types';
+import type { MetricCatalogPage, MetricsParam } from './index';
+
+export const METRIC_CATALOG_PAGE_SIZE = 100;
+/** 选择器累计上限：避免异常大目录拖垮页面。 */
+export const METRIC_CATALOG_MAX_ITEMS = 5000;
+
+type GetCatalogPage<T> = (
+  params?: MetricsParam,
+  config?: unknown
+) => Promise<MetricCatalogPage<T>>;
+
+async function fetchAllCatalogPages<T>(
+  getPage: GetCatalogPage<T>,
+  params: MetricsParam = {},
+  config?: unknown
+): Promise<{ items: T[]; truncated: boolean; total: number }> {
+  const pageSize = METRIC_CATALOG_PAGE_SIZE;
+  const maxItems = METRIC_CATALOG_MAX_ITEMS;
+  const items: T[] = [];
+  let page = 1;
+  let total = 0;
+
+  while (items.length < maxItems) {
+    const data = await getPage(
+      {
+        ...params,
+        page,
+        page_size: pageSize
+      },
+      config
+    );
+    const batch = Array.isArray(data?.items) ? data.items : [];
+    total = typeof data?.count === 'number' ? data.count : items.length + batch.length;
+    items.push(...batch);
+    if (batch.length < pageSize || items.length >= total) {
+      break;
+    }
+    page += 1;
+  }
+
+  return {
+    items: items.slice(0, maxItems),
+    truncated: total > Math.min(items.length, maxItems),
+    total
+  };
+}
+
+/**
+ * 分页累加拉取指标目录，替代单次 page_size=-1（后端 max_page_size=100）。
+ */
+export async function fetchAllMonitorMetrics(
+  getMonitorMetrics: GetCatalogPage<MetricItem>,
+  params: MetricsParam = {},
+  config?: unknown
+) {
+  return fetchAllCatalogPages(getMonitorMetrics, params, config);
+}
+
+/** 分页累加拉取指标分组，保证选择器能挂上全部指标。 */
+export async function fetchAllMetricsGroups(
+  getMetricsGroup: GetCatalogPage<GroupInfo>,
+  params: MetricsParam = {},
+  config?: unknown
+) {
+  return fetchAllCatalogPages(getMetricsGroup, params, config);
+}

--- a/web/src/app/monitor/api/index.ts
+++ b/web/src/app/monitor/api/index.ts
@@ -18,6 +18,7 @@ export interface MetricsParam {
   name_in?: string;
   keyword?: string;
   include_ifmib?: boolean;
+  is_ifmib?: boolean;
   page?: number;
   page_size?: number;
 }

--- a/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
+++ b/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
@@ -4,6 +4,35 @@ const EXCLUDE_FIELDS = ['iftype_exclude', 'ifdescr_exclude'] as const;
 const INCLUDE_FIELDS = ['iftype_include', 'ifdescr_include'] as const;
 export const DEFAULT_SNMP_IFTYPE_EXCLUDE = ['24', '53', '131', '135', '136'];
 
+const hasFilterValues = (value: unknown): boolean => {
+  if (value == null || value === '') return false;
+  if (Array.isArray(value)) {
+    return value.some((item) => String(item ?? '').trim());
+  }
+  return String(value)
+    .split(/[,，]/)
+    .some((item) => item.trim());
+};
+
+/**
+ * 从已下发的黑白名单字段反推采集策略。
+ * include 优先于 exclude；两侧皆空视为全部采集。
+ */
+export const resolveSnmpInterfaceFilterMode = (values: {
+  iftype_include?: unknown;
+  iftype_exclude?: unknown;
+  ifdescr_include?: unknown;
+  ifdescr_exclude?: unknown;
+}): SnmpInterfaceFilterMode => {
+  const hasInclude =
+    hasFilterValues(values.iftype_include) || hasFilterValues(values.ifdescr_include);
+  if (hasInclude) return 'include';
+  const hasExclude =
+    hasFilterValues(values.iftype_exclude) || hasFilterValues(values.ifdescr_exclude);
+  if (hasExclude) return 'exclude';
+  return 'all';
+};
+
 export const getSnmpInterfaceFilterModePatch = (
   changedValues: Record<string, unknown>
 ): Record<string, unknown> => {

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -7,6 +7,7 @@ import {
   splitWebsiteRequestUrl,
   validateWebsiteRequestHeaders
 } from './http-request-config';
+import { resolveSnmpInterfaceFilterMode } from './snmpInterfaceFilterMode';
 import useIntegrationApi from '@/app/monitor/api/integration';
 import useApiClient from '@/utils/request';
 import { useTranslation } from '@/utils/i18n';
@@ -393,6 +394,10 @@ export const usePluginFromJson = () => {
                 );
               }
             });
+            // interface_filter_mode 不落库，需从 tagpass/tagdrop 反推，避免编辑回显恒为 exclude。
+            if (formFields?.some((field: any) => field?.name === 'interface_filter_mode')) {
+              formValues.interface_filter_mode = resolveSnmpInterfaceFilterMode(formValues);
+            }
             if (config.instance_type === 'web') {
               const requestUrl = apiData?.child?.content?.config?.urls?.[0];
               if (requestUrl) {


### PR DESCRIPTION
## Summary
- 编辑页从已下发黑白名单反推 `interface_filter_mode`；资产编辑切换策略时清空对侧字段（与接入页一致）
- 告警详情 / 策略 / 规则指标选择改为分页累加拉全量（遵守后端 `max_page_size=100`）
- 接入指标页：厂商指标继续分页，IF-MIB 单独全量拉取后置底归并
- `device_total_*` 合并与厂商 `metrics.json` 统一为 `ifHC*Octets` 聚合

## Test plan
- [ ] 编辑已选「全部采集 / 仅采集 / 排除部分」的 SNMP 实例，确认策略与过滤字段回显正确；切换「全部采集」后保存，TOML 不再残留 tagpass/tagdrop
- [ ] 策略/规则/告警详情指标选择器可见超过 100 条时的 IF-MIB 与厂商指标
- [ ] 接入指标页开启 IF-MIB：厂商指标可翻页，底部始终展示完整 IF-MIB 三组
- [ ] 插件导入后 `device_total_*` 的 query 含 `ifHCInOctets`/`ifHCOutOctets`（存量库需重新 migrate/导入）

## Scope check
- 仅提交上述业务修复与 54 个 metrics.json 口径修正
- 未纳入：本地 next/turbopack、top-menu、icons、测试文件等