### PR TITLE
feat(监控): 支持点击一级分类查看该类全部集成能力

### DIFF
--- a/server/apps/monitor/filters/plugin.py
+++ b/server/apps/monitor/filters/plugin.py
@@ -11,6 +11,11 @@ class MonitorPluginFilter(FilterSet):
         required=False,  # 设置为非必填
         method="filter_monitor_object",  # 使用自定义过滤方法
     )
+    monitor_object_type = CharFilter(
+        label="监控对象分类",
+        required=False,
+        method="filter_monitor_object_type",
+    )
     # 注意:已移除 name 字段的 icontains 过滤
     # 改为由 views/plugin.py 的 list 视图,在 i18n 翻译后对五字段
     # (name / display_name / description / display_description / parent_object_display_name)
@@ -25,6 +30,12 @@ class MonitorPluginFilter(FilterSet):
             return queryset.filter(monitor_object=value)
         return queryset
 
+    def filter_monitor_object_type(self, queryset, name, value):
+        """按监控对象分类 ID 过滤（如 database），用于左侧树点一级分类看该类全部能力。"""
+        if value:
+            return queryset.filter(monitor_object__type_id=value).distinct()
+        return queryset
+
     class Meta:
         model = MonitorPlugin
-        fields = ["monitor_object_id", "template_type", "template_id"]
+        fields = ["monitor_object_id", "monitor_object_type", "template_type", "template_id"]

--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -76,6 +76,7 @@ const Integration = () => {
   const [pluginList, setPluginList] = useState<ObjectItem[]>([]);
   const [treeLoading, setTreeLoading] = useState<boolean>(false);
   const [objectId, setObjectId] = useState<React.Key>('');
+  const [objectType, setObjectType] = useState<string>('');
   const [pagination, setPagination] = useState<Pagination>({
     current: 1,
     total: 0,
@@ -91,7 +92,7 @@ const Integration = () => {
   useEffect(() => {
     if (isLoading) return;
     getPluginList();
-  }, [isLoading, objectId, pagination.current, pagination.pageSize]);
+  }, [isLoading, objectId, objectType, pagination.current, pagination.pageSize]);
 
   useEffect(() => {
     return () => {
@@ -115,15 +116,34 @@ const Integration = () => {
     pluginAbortControllerRef.current?.abort();
   };
 
+  const isTypeNodeKey = (key: string) => {
+    const keyStr = String(key);
+    if (keyStr === 'all') return false;
+    // 叶子节点 key 为对象数字 id；一级分类 key 为 MonitorObjectType.id（如 database）
+    return objects.some((item) => String(item.type) === keyStr);
+  };
+
   const handleObjectChange = async (id: string) => {
     cancelAllRequests();
     setPagination((prev) => ({ ...prev, current: 1 }));
-    setObjectId(id === 'all' ? '' : id);
+    if (id === 'all' || !id) {
+      setObjectId('');
+      setObjectType('');
+      return;
+    }
+    if (isTypeNodeKey(String(id))) {
+      setObjectId('');
+      setObjectType(String(id));
+      return;
+    }
+    setObjectType('');
+    setObjectId(id);
   };
 
   const getPluginList = async (
     params: {
       monitor_object_id?: React.Key | null;
+      monitor_object_type?: string | null;
       keyword?: string;
       page?: number;
     } = {}
@@ -138,12 +158,20 @@ const Integration = () => {
     setExportDisabled(true);
     setPageLoading(true);
     try {
+      const monitorObjectId =
+        params.monitor_object_id !== undefined
+          ? params.monitor_object_id
+          : objectId;
+      const monitorObjectType =
+        params.monitor_object_type !== undefined
+          ? params.monitor_object_type
+          : objectType;
       const data = await getMonitorPlugin(
         {
-          monitor_object_id:
-            params.monitor_object_id !== undefined
-              ? params.monitor_object_id
-              : objectId,
+          ...(monitorObjectId ? { monitor_object_id: monitorObjectId } : {}),
+          ...(monitorObjectType
+            ? { monitor_object_type: monitorObjectType }
+            : {}),
           keyword: params.keyword !== undefined ? params.keyword : searchText,
           page,
           page_size: pagination.pageSize
@@ -260,6 +288,7 @@ const Integration = () => {
     setPagination((prev) => ({ ...prev, current: 1 }));
     getPluginList({
       monitor_object_id: objectId,
+      monitor_object_type: objectType,
       keyword: searchText,
       page: 1
     });
@@ -270,6 +299,7 @@ const Integration = () => {
     setPagination((prev) => ({ ...prev, current: 1 }));
     getPluginList({
       monitor_object_id: objectId,
+      monitor_object_type: objectType,
       keyword: '',
       page: 1
     });
@@ -389,6 +419,7 @@ const Integration = () => {
         <div className="h-[calc(100vh-146px)] pt-5 px-2.5 pb-2.5 bg-[var(--color-bg-1)] overflow-y-auto">
           <TreeSelector
             showAllMenu
+            allowParentSelect
             data={treeData}
             defaultSelectedKey={
               searchParams.get('objId')

--- a/web/src/app/monitor/api/index.ts
+++ b/web/src/app/monitor/api/index.ts
@@ -154,6 +154,8 @@ const useMonitorApi = () => {
   const getMonitorPlugin = async (
     params: {
       monitor_object_id?: React.Key | null;
+      /** 按监控对象分类 ID 过滤（如 database），与 monitor_object_id 互斥由调用方保证 */
+      monitor_object_type?: string | null;
       // 搜索关键字(后端在 i18n 翻译完成后,对 name / display_name /
       // display_description / parent_object_display_name 做 icontains 内存匹配)
       keyword?: string;

--- a/web/src/app/monitor/components/treeSelector/index.tsx
+++ b/web/src/app/monitor/components/treeSelector/index.tsx
@@ -16,6 +16,8 @@ interface TreeComponentProps {
   loading?: boolean;
   draggable?: boolean;
   showAllMenu?: boolean;
+  /** 允许选中带 children 的一级分类（如「数据库」），用于按分类展示全部能力 */
+  allowParentSelect?: boolean;
   onNodeSelect?: (key: string) => void;
   onNodeDrag?: (sortNodes: TreeSortData[], nodes: TreeDataNode[]) => void;
 }
@@ -26,6 +28,7 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
   loading = false,
   draggable = false,
   showAllMenu = false,
+  allowParentSelect = false,
   onNodeSelect,
   onNodeDrag
 }) => {
@@ -61,8 +64,9 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
   };
 
   const handleSelect = (selectedKeys: React.Key[], info: any) => {
-    const isFirstLevel = !!info.node?.children?.length;
-    if (!isFirstLevel && selectedKeys?.length) {
+    const hasChildren = !!info.node?.children?.length;
+    // 默认仅叶子可选；allowParentSelect 时一级分类也可选（如点「数据库」看该类全部能力）
+    if ((!hasChildren || allowParentSelect) && selectedKeys?.length) {
       setSelectedKeys(selectedKeys);
       onNodeSelect?.(selectedKeys[0] as string);
     }


### PR DESCRIPTION
## Summary
- 集成列表左侧树支持选中一级分类（如「数据库」），右侧展示该分类下全部插件/能力卡片
- 后端 `monitor_plugin` 列表新增 `monitor_object_type` 过滤；TreeSelector 增加可选的 `allowParentSelect`（默认不影响其它页面）

## Test plan
- [ ] 打开监控「集成」页，点击「全部」仍展示全部能力
- [ ] 点击「数据库」等一级分类，右侧仅展示该分类下能力，且分类节点高亮
- [ ] 点击具体对象（如 MySQL）仍按单对象过滤
- [ ] 分类选中后搜索/翻页仍限定在该分类内
- [ ] 资产/分组等其它使用 TreeSelector 的页面，一级分类仍不可选（未开启 `allowParentSelect`）