### PR TITLE
fix(监控): 修复指标分组 id 类型导致的 web 构建失败

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -14,7 +14,6 @@ import {
   UserItem,
   SegmentedItem,
   TableDataItem,
-  GroupInfo,
   ObjectItem,
   MetricItem,
   IndexViewItem,
@@ -646,21 +645,20 @@ const StrategyOperation = () => {
         .then((res) => {
           const metricData = cloneDeep(res[1].items);
           setMetrics(res[1].items);
-          const groupData = res[0].items.map((item: GroupInfo) => ({
+          const groupData: IndexViewItem[] = res[0].items.map((item) => ({
             ...item,
+            id: Number(item.id),
             child: []
           }));
           metricData.forEach((metric: MetricItem) => {
             const target = groupData.find(
-              (item: GroupInfo) => item.id === metric.metric_group
+              (item) => item.id === metric.metric_group
             );
             if (target) {
-              target.child.push(metric);
+              target.child?.push(metric);
             }
           });
-          const _groupData = groupData.filter(
-            (item: any) => !!item.child?.length
-          );
+          const _groupData = groupData.filter((item) => !!item.child?.length);
           setOriginMetricData(_groupData);
           if (type === 'init') {
             setInitMetricData(res[1].items);

--- a/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/group/ruleModal.tsx
@@ -16,7 +16,6 @@ import useApiClient from '@/utils/request';
 import {
   ModalRef,
   ListItem,
-  GroupInfo,
   ObjectItem,
   MetricItem,
   IndexViewItem,
@@ -133,21 +132,20 @@ const RuleModal = forwardRef<ModalRef, ModalProps>(
           .then((res) => {
             const metricData = cloneDeep(res[1].items);
             setMetrics(res[1].items);
-            const groupData = res[0].items.map((item: GroupInfo) => ({
+            const groupData: IndexViewItem[] = res[0].items.map((item) => ({
               ...item,
+              id: Number(item.id),
               child: []
             }));
             metricData.forEach((metric: MetricItem) => {
               const target = groupData.find(
-                (item: GroupInfo) => item.id === metric.metric_group
+                (item) => item.id === metric.metric_group
               );
               if (target) {
-                target.child.push(metric);
+                target.child?.push(metric);
               }
             });
-            const _groupData = groupData.filter(
-              (item: any) => !!item.child?.length
-            );
+            const _groupData = groupData.filter((item) => !!item.child?.length);
             setOriginMetricData(_groupData);
           })
           .finally(() => {

--- a/web/src/app/monitor/api/fetchMetricCatalogPages.ts
+++ b/web/src/app/monitor/api/fetchMetricCatalogPages.ts
@@ -1,5 +1,9 @@
-import type { GroupInfo, MetricItem } from '@/app/monitor/types';
-import type { MetricCatalogPage, MetricsParam } from './index';
+import type { MetricItem } from '@/app/monitor/types';
+import type {
+  MetricCatalogGroup,
+  MetricCatalogPage,
+  MetricsParam
+} from './index';
 
 export const METRIC_CATALOG_PAGE_SIZE = 100;
 /** 选择器累计上限：避免异常大目录拖垮页面。 */
@@ -59,7 +63,7 @@ export async function fetchAllMonitorMetrics(
 
 /** 分页累加拉取指标分组，保证选择器能挂上全部指标。 */
 export async function fetchAllMetricsGroups(
-  getMetricsGroup: GetCatalogPage<GroupInfo>,
+  getMetricsGroup: GetCatalogPage<MetricCatalogGroup>,
   params: MetricsParam = {},
   config?: unknown
 ) {


### PR DESCRIPTION
## Summary
- 策略详情与规则弹窗将指标分组映射为 `IndexViewItem` 时，用 `Number(item.id)` 对齐 `id: number`，修复 `next build` 的 TS2345。
- `fetchAllMetricsGroups` 泛型从 `GroupInfo` 收紧为 `MetricCatalogGroup`，避免再次把 `id` 加宽为 `string | number`。
- 仅包含上述 3 个文件；本地 `next-env.d.ts`、`tsconfig.json` 与未跟踪图标未纳入本次提交。

## Test plan
- [ ] `pnpm exec tsc -p tsconfig.json --noEmit` 中确认 `strategy/detail/page.tsx`、`ruleModal.tsx`、`IndexViewItem` 相关 TS2345 消失
- [ ] web CI / `pnpm run build` 不再因这两处类型错误失败
- [ ] 打开策略详情与集成分组规则弹窗，确认指标分组选择器仍可正常加载