### PR TITLE
fix(日志): 系统日志仪表盘去掉实例筛选并对齐真实字段

### DIFF
--- a/web/src/app/log/(pages)/analysis/dashBoard/index.tsx
+++ b/web/src/app/log/(pages)/analysis/dashBoard/index.tsx
@@ -73,7 +73,8 @@ const Dashboard = forwardRef<DashboardRef, DashboardProps>(
     const [containerNames, setContainerNames] = useState<React.Key[]>([]);
     const [containerLoading, setContainerLoading] = useState(false);
     const collectTypeName = selectedDashboard?.collectTypeName || '';
-    const showInstanceFilter = !!collectTypeName;
+    const showInstanceFilter =
+      !!collectTypeName && selectedDashboard?.filters?.instance !== false;
     const showContainerFilter = collectTypeName === 'docker';
 
     // 初始化分组数据（仅首次加载）

--- a/web/src/app/log/hooks/analysis/syslogDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/syslogDashboard.tsx
@@ -2,9 +2,8 @@ import { useTranslation } from '@/utils/i18n';
 import { Progress } from 'antd';
 import { v4 as uuidv4 } from 'uuid';
 
-const SYSLOG_BASE =
-  'collect_type:"syslog" service.name:"bk-lite-analysis-sample" event.dataset:"syslog"';
-const SYSLOG_HOST = 'host.name';
+const SYSLOG_BASE = 'collect_type:"syslog"';
+const SYSLOG_HOST = 'hostname';
 const SYSLOG_APP = 'appname';
 const SYSLOG_FACILITY = 'facility';
 const SYSLOG_SEVERITY = 'severity';
@@ -79,7 +78,7 @@ export const useSyslogDashboard = () => {
     category: 'middleware',
     categoryName: t('log.analysis.category.middleware'),
     collectTypeName: 'syslog',
-    filters: { group: true, instance: true },
+    filters: { group: true, instance: false },
     other: {},
     view_sets: [
       {
@@ -206,7 +205,7 @@ export const useSyslogDashboard = () => {
           dataSource: 1,
           showIndex: true,
           columns: [
-            { title: '主机', dataIndex: 'host.name', key: 'host.name', width: 150 },
+            { title: '主机', dataIndex: 'hostname', key: 'hostname', width: 150 },
             { title: '总日志数 (条)', dataIndex: 'total_count', key: 'total_count', width: 110 },
             { title: '高危日志数 (条)', dataIndex: 'high_count', key: 'high_count', width: 120 },
             { title: '高危占比', dataIndex: 'ratio', key: 'ratio', width: 140, render: renderRatioProgress }
@@ -273,7 +272,7 @@ export const useSyslogDashboard = () => {
           showIndex: false,
           columns: [
             { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
-            { title: '主机', dataIndex: 'host.name', key: 'host.name', width: 140 },
+            { title: '主机', dataIndex: 'hostname', key: 'hostname', width: 140 },
             { title: '应用', dataIndex: 'appname', key: 'appname', width: 120 },
             { title: 'Facility', dataIndex: 'facility', key: 'facility', width: 90 },
             { title: 'Severity', dataIndex: 'severity', key: 'severity', width: 96, render: renderSyslogSeverity },
@@ -300,7 +299,7 @@ export const useSyslogDashboard = () => {
           showIndex: false,
           columns: [
             { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
-            { title: '主机', dataIndex: 'host.name', key: 'host.name', width: 140 },
+            { title: '主机', dataIndex: 'hostname', key: 'hostname', width: 140 },
             { title: '应用', dataIndex: 'appname', key: 'appname', width: 120 },
             { title: 'Facility', dataIndex: 'facility', key: 'facility', width: 90 },
             { title: 'Severity', dataIndex: 'severity', key: 'severity', width: 96, render: renderSyslogSeverity },


### PR DESCRIPTION
## Summary
- syslog 为主动上报，仪表盘不再展示「实例」筛选（`filters.instance: false`，并尊重该声明）
- 查询基线去掉示例条件 `service.name` / `event.dataset`，主机字段改为真实上报的 `hostname`
- 已检查提交范围：仅含上述 2 个前端文件；工作区无关图标/本地配置未纳入

## Test plan
- [ ] `/log/analysis` →「系统日志」：无实例下拉，有日志分组与时间选择
- [ ] 切换「网络流量」等其他类型：实例筛选仍在
- [ ] 有真实 syslog 时 KPI/趋势可出数
- [ ] 切到系统日志时网络面板无 `collect_instances/search` 请求