### PR TITLE
chore(system_mgmt): 去掉仅改 help_text 的 0045 迁移

### DIFF
--- a/server/apps/system_mgmt/models/network_white_list.py
+++ b/server/apps/system_mgmt/models/network_white_list.py
@@ -22,7 +22,7 @@ class NetworkWhiteList(MaintainerInfo, TimeInfo):
         blank=True,
         default="",
         db_index=True,
-        help_text="私有化域名(全等或 *.example.com)。仅当解析到内网/危险网段时作为例外。与 network 二选一。",
+        help_text="私有化部署域名(如 corp-wecom.example.com)。与 network 二选一。",
     )
     is_build_in = models.BooleanField(default=False, db_index=True)
     remark = models.CharField(max_length=255, blank=True, default="")


### PR DESCRIPTION
domain_name 自 0041 已存在；还原 help_text 与迁移状态一致，避免无库表变更的噪音迁移。