### PR TITLE
fix(监控): 将 OS 分类显示名由「主机资源」改回「操作系统」

### DIFF
--- a/server/apps/monitor/migrations/0059_rename_monitor_object_type_host_resource_to_os.py
+++ b/server/apps/monitor/migrations/0059_rename_monitor_object_type_host_resource_to_os.py
@@ -1,0 +1,28 @@
+"""将监控对象分类「主机资源」恢复为「操作系统」。
+
+与 0044_rename_monitor_object_type_os_to_host_resource 对冲：
+视图层优先从 i18n 读取 type 显示名，i18n 缺失时回退到 MonitorObjectType.name；
+同步更新 DB 兜底字段，避免 admin 等入口仍展示旧值。
+"""
+from django.db import migrations
+
+
+def rename_os_type_name(apps, schema_editor):
+    MonitorObjectType = apps.get_model('monitor', 'MonitorObjectType')
+    MonitorObjectType.objects.filter(id='os', name='主机资源').update(name='操作系统')
+
+
+def reverse_rename(apps, schema_editor):
+    MonitorObjectType = apps.get_model('monitor', 'MonitorObjectType')
+    MonitorObjectType.objects.filter(id='os', name='操作系统').update(name='主机资源')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('monitor', '0058_metric_is_ifmib'),
+    ]
+
+    operations = [
+        migrations.RunPython(rename_os_type_name, reverse_code=reverse_rename),
+    ]

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/language/en.yaml
@@ -5,7 +5,7 @@ Host:
 monitor_object:
   Host: Host
 monitor_object_type:
-  OS: Host Resource
+  OS: Operating System
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/language/zh-Hans.yaml
@@ -4,7 +4,7 @@ Host:
 monitor_object:
   Host: 主机
 monitor_object_type:
-  OS: 主机资源
+  OS: 操作系统
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/process/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/process/language/en.yaml
@@ -4,7 +4,7 @@ Process:
 monitor_object:
   Process: Process
 monitor_object_type:
-  OS: Host Resource
+  OS: Operating System
 monitor_object_metric:
   Process:
     process_cpu_usage:

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/process/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/process/language/zh-Hans.yaml
@@ -4,7 +4,7 @@ Process:
 monitor_object:
   Process: 进程
 monitor_object_type:
-  OS: 主机资源
+  OS: 操作系统
 monitor_object_metric:
   Process:
     process_cpu_usage:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/language/en.yaml
@@ -5,7 +5,7 @@ Host Remote:
 monitor_object:
   Host: Host
 monitor_object_type:
-  OS: Host Resource
+  OS: Operating System
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/language/zh-Hans.yaml
@@ -4,7 +4,7 @@ Host Remote:
 monitor_object:
   Host: 主机
 monitor_object_type:
-  OS: 主机资源
+  OS: 操作系统
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/en.yaml
@@ -5,7 +5,7 @@ Windows WMI:
 monitor_object:
   Host: Host
 monitor_object_type:
-  OS: Host Resource
+  OS: Operating System
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/windows_wmi/language/zh-Hans.yaml
@@ -4,7 +4,7 @@ Windows WMI:
 monitor_object:
   Host: 主机
 monitor_object_type:
-  OS: 主机资源
+  OS: 操作系统
 monitor_object_metric:
   Host:
     cpu_usage_total:

--- a/web/src/app/monitor/dashboards/metadata.ts
+++ b/web/src/app/monitor/dashboards/metadata.ts
@@ -5,7 +5,7 @@ import { normalizeDashboardKey } from './shared/utils';
 export const PROFESSIONAL_DASHBOARD_GROUPS = {
   hardware: { label: '硬件设备', order: 10 },
   container: { label: '容器', order: 15 },
-  os: { label: '主机资源', order: 20 },
+  os: { label: '操作系统', order: 20 },
   network: { label: '网络', order: 30 },
   database: { label: '数据库', order: 40 },
   middleware: { label: '中间件', order: 50 }


### PR DESCRIPTION
## Summary
- 将 Host/Process 等相关插件 i18n 中 `monitor_object_type.OS` 由「主机资源」改回「操作系统」（en: Operating System）
- 专业仪表板分组 label 同步改回「操作系统」
- 新增 migration `0059`，把 `MonitorObjectType(id=os)` 的 DB 兜底名称从「主机资源」恢复为「操作系统」

## Scope check
- 仅提交上述 10 个相关文件
- 未纳入本地无关改动：web icons、next 配置、AGENTS.md、system_mgmt enterprise 删除等

## Test plan
- [x] 本地 LanguageLoader 校验：`zh=操作系统`、`en=Operating System`
- [ ] CI 通过
- [ ] 部署后执行 migration，刷新监控资产/视图侧栏，确认分组名为「操作系统」