### PR TITLE
feat(监控): 补齐主机系统运行时长指标、策略与仪表盘

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/metrics.json
@@ -136,6 +136,17 @@
       "description": "Represents the average system load over the last 15 minutes, commonly used to evaluate long-term load stability."
     },
     {
+      "metric_group": "System",
+      "name": "system_uptime",
+      "query": "system_uptime{instance_type=\"os\", __$labels__}",
+      "display_name": "System Uptime",
+      "data_type": "Number",
+      "unit": "s",
+      "dimensions": [],
+      "instance_id_keys": ["instance_id"],
+      "description": "System uptime in seconds since last boot"
+    },
+    {
       "metric_group": "Disk IO",
       "name": "diskio_io_util",
       "query": "diskio_io_util{instance_type=\"os\", __$labels__}",

--- a/server/apps/monitor/support-files/plugins/Telegraf/host/os/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/os/policy.json
@@ -226,6 +226,31 @@
         }
       ],
       "group_algorithm": "max"
+    },
+    {
+      "name": "系统重启",
+      "alert_name": "主机 ${resource_name} 系统运行时间过短",
+      "description": "监控主机系统运行时间，当运行时间过短时触发告警，用于识别异常重启。",
+      "metric_name": "system_uptime",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 300,
+          "method": "<"
+        },
+        {
+          "level": "error",
+          "value": 600,
+          "method": "<"
+        },
+        {
+          "level": "warning",
+          "value": 900,
+          "method": "<"
+        }
+      ],
+      "group_algorithm": "avg"
     }
   ]
 }

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/host/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/host/policy.json
@@ -126,6 +126,31 @@
         }
       ],
       "group_algorithm": "max"
+    },
+    {
+      "name": "系统重启",
+      "alert_name": "主机${instance_id} 系统运行时间过短",
+      "description": "监控主机系统运行时间，当运行时间过短时触发告警，用于识别异常重启。",
+      "metric_name": "system_uptime",
+      "algorithm": "last_over_time",
+      "threshold": [
+        {
+          "level": "critical",
+          "value": 300,
+          "method": "<"
+        },
+        {
+          "level": "error",
+          "value": 600,
+          "method": "<"
+        },
+        {
+          "level": "warning",
+          "value": 900,
+          "method": "<"
+        }
+      ],
+      "group_algorithm": "avg"
     }
   ]
 }

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -1315,6 +1315,19 @@
   font-size: 14px;
 }
 
+// guide Tooltip 挂载在 body：需全局覆盖 ant-tooltip 默认深色底，避免浅色字色/深色底或深色字/深色底对比失效。
+:global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-inner) {
+  background: #ffffff;
+  color: #44566f;
+  border: 1px solid #dbe6f3;
+  box-shadow: 0 14px 34px rgba(23, 42, 79, 0.12);
+}
+
+:global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-arrow::before) {
+  background: #ffffff;
+  border: 1px solid #dbe6f3;
+}
+
 .metricsMode {
   display: flex;
   flex-direction: column;
@@ -1665,4 +1678,16 @@
 :global(html.dark) .metricGuideTooltip,
 :global(html.dark) .uptimeStatusTooltip {
   color: #b8c6d9;
+}
+
+:global(html.dark) :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-inner) {
+  background: #101926;
+  color: rgba(255, 255, 255, 0.74);
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.28);
+}
+
+:global(html.dark) :global(.ant-tooltip.lightMetricTooltip) :global(.ant-tooltip-arrow::before) {
+  background: #101926;
+  border-color: rgba(255, 255, 255, 0.08);
 }

--- a/web/src/app/monitor/dashboards/objects/host/config.ts
+++ b/web/src/app/monitor/dashboards/objects/host/config.ts
@@ -75,6 +75,15 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       color: '#597ef7'
     },
     {
+      name: 'system_uptime',
+      display_name: '运行时长',
+      description: '主机自上次启动以来的持续运行时间，反映主机稳定性。',
+      unit: 's',
+      // ①Telegraf host；②HTTP Remote；③Windows WMI。
+      query: 'system_uptime{instance_type="os", __$labels__} or system_uptime_gauge{instance_type="os", __$labels__} or system_uptime_gauge_value{instance_type="os", config_type="windows_wmi", __$labels__}',
+      color: '#597ef7'
+    },
+    {
       name: 'mem_used_percent',
       display_name: '内存使用率',
       description: '主机内存使用率。',
@@ -166,6 +175,17 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   ],
   summaryCards: [
     {
+      title: '运行时长',
+      metric: 'system_uptime',
+      unit: 's',
+      formatter: 'duration',
+      isUptimeCard: true,
+      icon: 'clock',
+      color: '#597ef7',
+      guide: [{ label: '运行时长', detail: '主机自上次启动后的持续运行时间；期间发生重启会重新计时。' }],
+      footer: [{ label: '启动', metric: 'system_uptime', formatter: 'startedAt' }]
+    },
+    {
       title: 'CPU 使用率',
       metric: 'cpu_usage_total',
       color: '#2f6bff',
@@ -192,17 +212,6 @@ export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [{
         label: '磁盘使用率',
         detail: '取各挂载点中最高的使用率，反映主机最满分区。持续偏高时先清理该分区或扩容，并对照下方磁盘吞吐是否伴随写入压力。'
-      }]
-    },
-    {
-      title: 'I/O Wait 占比',
-      metric: 'cpu_usage_iowait_total',
-      color: '#ff8a1f',
-      icon: 'thunder',
-      compare: true,
-      guide: [{
-        label: 'I/O Wait 占比',
-        detail: 'CPU 等待 I/O 的时间占比（主要适用于 Linux）。持续偏高时对照下方磁盘吞吐与阻塞进程，优先排查慢盘或网络阻塞。Windows 主机通常无对等指标。'
       }]
     },
     {


### PR DESCRIPTION
## Summary
- 为 Telegraf Host Agent 补齐 `system_uptime` 指标目录；为 Host / Host Remote 增加「系统重启」内置策略（对齐 Windows WMI 阈值）
- 主机监控仪表盘增加运行时长 KPI 卡（覆盖 Agent / Remote / WMI 三路时序），并去掉概览中较次要的 I/O Wait 卡片以保持布局
- 修复 `simple-dashboard` 引导气泡缺少 `lightMetricTooltip` 背景样式导致的浅色主题对比度失效（影响所有依赖该共享样式的仪表盘）

## Test plan
- [ ] 执行 `plugin_init`（或 `batch_init`）后，Host / Host Remote 出现 `system_uptime` 指标与「系统重启」内置策略；WMI 原策略不受影响
- [ ] 打开主机监控仪表盘，确认运行时长卡在 Agent / Remote / WMI 采集下可显示，且未把 uptime 写入列表 `display_fields`
- [ ] 浅色 / 暗黑主题下点击 KPI 引导 ⓘ，气泡文字可读
- [ ] 确认工作区无关改动（图标、next 配置等）未纳入本 PR