### PR TITLE
fix(监控): 无单位指标配置策略时不再强制选择单位

### DIFF
--- a/web/scripts/monitor-strategy-detail-logic-test.ts
+++ b/web/scripts/monitor-strategy-detail-logic-test.ts
@@ -11,12 +11,14 @@ import {
   getThresholdUnitOnCalculationUnitChange,
   getThresholdUnitOptions,
   getValidThresholdUnitOptions,
+  isVacantThresholdUnit,
   resolveFormulaResultUnit,
   resolveEffectiveCalculationUnit,
   resolveInitialMetricPluginId,
   resolveMetricDisplayUnit,
   resolvePreviewChartUnit,
   resolveThresholdUnit,
+  resolveUnitOnMetricSelect,
   restoreCalculationUnitState,
   shouldShowThresholdUnitSelector,
 } from '../src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils';
@@ -257,10 +259,20 @@ assert.deepEqual(
   { metricUnit: '', calculationUnit: '', thresholdUnit: '' }
 );
 
+assert.equal(isVacantThresholdUnit(null), true);
+assert.equal(isVacantThresholdUnit(undefined), true);
+assert.equal(isVacantThresholdUnit(''), true);
+assert.equal(isVacantThresholdUnit('none'), true);
+assert.equal(isVacantThresholdUnit('short'), true);
+assert.equal(isVacantThresholdUnit('bytes'), false);
+assert.equal(isVacantThresholdUnit('counts'), false);
+
 assert.equal(
   shouldShowThresholdUnitSelector({
     isFormulaMode: false,
     isEnumMetric: false,
+    calculationUnit: 'bytes',
+    unitList,
   }),
   true
 );
@@ -268,6 +280,8 @@ assert.equal(
   shouldShowThresholdUnitSelector({
     isFormulaMode: true,
     isEnumMetric: false,
+    calculationUnit: 'percent',
+    unitList,
   }),
   true
 );
@@ -275,6 +289,46 @@ assert.equal(
   shouldShowThresholdUnitSelector({
     isFormulaMode: false,
     isEnumMetric: true,
+    calculationUnit: 'bytes',
+    unitList,
+  }),
+  false
+);
+// none/short/空：不展示单位下拉
+assert.equal(
+  shouldShowThresholdUnitSelector({
+    isFormulaMode: false,
+    isEnumMetric: false,
+    calculationUnit: 'none',
+    unitList,
+  }),
+  false
+);
+assert.equal(
+  shouldShowThresholdUnitSelector({
+    isFormulaMode: false,
+    isEnumMetric: false,
+    calculationUnit: null,
+    unitList,
+  }),
+  false
+);
+assert.equal(
+  shouldShowThresholdUnitSelector({
+    isFormulaMode: false,
+    isEnumMetric: false,
+    calculationUnit: 'short',
+    unitList,
+  }),
+  false
+);
+// 有效 unit_id 但不在单位表可选集中：隐藏，避免空下拉+必填
+assert.equal(
+  shouldShowThresholdUnitSelector({
+    isFormulaMode: false,
+    isEnumMetric: false,
+    calculationUnit: 'unknown-unit',
+    unitList,
   }),
   false
 );
@@ -452,6 +506,14 @@ assert.equal(
   filterInvalidCalculationUnit('[{"id":1,"name":"up"}]'),
   null
 );
+
+// resolveUnitOnMetricSelect: none/short 不得回落到 cps 等独立单位
+assert.equal(resolveUnitOnMetricSelect('none'), null);
+assert.equal(resolveUnitOnMetricSelect('short'), null);
+assert.equal(resolveUnitOnMetricSelect(null), null);
+assert.equal(resolveUnitOnMetricSelect('cps'), 'cps');
+assert.equal(resolveUnitOnMetricSelect('bytes'), 'bytes');
+assert.equal(resolveUnitOnMetricSelect('[{"id":1,"name":"up"}]'), null);
 
 // getReverseModeCalculationUnit
 assert.equal(

--- a/web/scripts/monitor-strategy-detail-logic-test.ts
+++ b/web/scripts/monitor-strategy-detail-logic-test.ts
@@ -259,6 +259,26 @@ assert.deepEqual(
   { metricUnit: '', calculationUnit: '', thresholdUnit: '' }
 );
 
+// none/short：保存时三字段均为空，避免后端 get_effective_units 提升后校验失败
+assert.deepEqual(
+  resolveMetricExpressionUnits({
+    queryType: 'metric',
+    metricUnit: 'none',
+    calculationUnit: null,
+    thresholdUnit: null,
+  }),
+  { metricUnit: '', calculationUnit: '', thresholdUnit: '' }
+);
+assert.deepEqual(
+  resolveMetricExpressionUnits({
+    queryType: 'metric',
+    metricUnit: 'short',
+    calculationUnit: null,
+    thresholdUnit: null,
+  }),
+  { metricUnit: '', calculationUnit: '', thresholdUnit: '' }
+);
+
 assert.equal(isVacantThresholdUnit(null), true);
 assert.equal(isVacantThresholdUnit(undefined), true);
 assert.equal(isVacantThresholdUnit(''), true);

--- a/web/src/app/monitor/(pages)/event/strategy/detail/alertConditionsForm.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/alertConditionsForm.tsx
@@ -86,14 +86,21 @@ const AlertConditionsForm: React.FC<AlertConditionsFormProps> = ({
     [unitList, thresholdFilterBase, isEnumMetric]
   );
 
-  // 验证阈值
+  const showUnitSelector = shouldShowThresholdUnitSelector({
+    isFormulaMode,
+    isEnumMetric,
+    calculationUnit: thresholdFilterBase,
+    unitList
+  });
+
+  // 验证阈值：仅在展示单位选择器时要求 thresholdUnit
   const validateThreshold = async () => {
     if (
       threshold.length &&
       (threshold.some((item) => {
         return !item.method;
       }) ||
-        (!isEnumMetric && !thresholdUnit))
+        (showUnitSelector && !thresholdUnit))
     ) {
       return Promise.reject(new Error(t('monitor.events.thresholdValidate')));
     }
@@ -132,10 +139,7 @@ const AlertConditionsForm: React.FC<AlertConditionsFormProps> = ({
                   unitOptions={filteredUnitOptions}
                   isEnumMetric={isEnumMetric}
                   enumOptions={enumOptions}
-                  showUnitSelector={shouldShowThresholdUnitSelector({
-                    isFormulaMode,
-                    isEnumMetric
-                  })}
+                  showUnitSelector={showUnitSelector}
                 />
               </Form.Item>
 

--- a/web/src/app/monitor/(pages)/event/strategy/detail/formulaExpressionUtils.ts
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/formulaExpressionUtils.ts
@@ -59,14 +59,23 @@ export const resolveMetricExpressionUnits = ({
   metricUnit: string | null | undefined;
   calculationUnit: string | null | undefined;
   thresholdUnit: string | null | undefined;
-}): { metricUnit: string; calculationUnit: string; thresholdUnit: string } => ({
-  metricUnit:
-    queryType === 'formula' || isStringArray(metricUnit || '')
+}): { metricUnit: string; calculationUnit: string; thresholdUnit: string } => {
+  // none/short 与后端批量创建一致：不作为可配置 metric_unit，避免 serializer
+  // get_effective_units 提升后被 is_known_unit 拒绝（「结果单位无效」）。
+  const normalizedMetricUnit =
+    !metricUnit ||
+    metricUnit === 'none' ||
+    metricUnit === 'short' ||
+    queryType === 'formula' ||
+    isStringArray(metricUnit)
       ? ''
-      : metricUnit || '',
-  calculationUnit: calculationUnit || '',
-  thresholdUnit: thresholdUnit || calculationUnit || ''
-});
+      : metricUnit;
+  return {
+    metricUnit: normalizedMetricUnit,
+    calculationUnit: calculationUnit || '',
+    thresholdUnit: thresholdUnit || calculationUnit || ''
+  };
+};
 
 export const createMetricRow = (
   index: number,

--- a/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/page.tsx
@@ -52,13 +52,13 @@ import {
 } from '@/app/monitor/constants/event';
 import {
   buildMetricUnitCascaderOptions,
-  filterInvalidCalculationUnit,
   getCalculationUnitOnMetricRowsChange,
   getReverseModeCalculationUnit,
   getThresholdUnitOnCalculationUnitChange,
   resolveEffectiveCalculationUnit,
   resolveInitialMetricPluginId,
   resolveThresholdUnit,
+  resolveUnitOnMetricSelect,
   restoreCalculationUnitState
 } from './strategyDetailUtils';
 import { MetricExpressionRow } from './metricExpressionTypes';
@@ -73,9 +73,6 @@ import {
   toMetricExpressionStateFromQueryCondition
 } from './formulaExpressionUtils';
 const defaultGroup = ['instance_id'];
-
-// 过滤无效的单位值（none 、 short 和 JSON 字符串格式 已从单位列表中移除，不能作为单位值）
-// 已上提至 strategyDetailUtils.filterInvalidCalculationUnit
 
 const StrategyOperation = () => {
   const { t } = useTranslation();
@@ -280,7 +277,7 @@ const StrategyOperation = () => {
           const target = initMetricData.find((item) => item.name === _metricId);
           if (target) {
             const _labels = getMetricDimensionNames(target?.dimensions);
-            const initialBuiltInUnit = filterInvalidCalculationUnit(target?.unit);
+            const initialBuiltInUnit = resolveUnitOnMetricSelect(target?.unit);
             setCalculationUnit(initialBuiltInUnit);
             // 计算完整的分组维度选项列表并设置为所有选项
             const fixedList =
@@ -610,30 +607,10 @@ const StrategyOperation = () => {
 
     // 选择指标后触发验证，清除错误信息（包括指标、条件维度和告警阈值）
     form.validateFields(['metric', 'threshold']);
-    // 自动设置告警阈值单位为指标的默认单位（过滤掉 none 和 short）
-    const filteredUnit = filterInvalidCalculationUnit(target?.unit);
-    if (filteredUnit) {
-      setCalculationUnit(filteredUnit);
-      setThresholdUnit(filteredUnit);
-      return;
-    }
-    const unitList = commonContext?.unitList || [];
-    const baseFilteredList = unitList.filter(
-      (item) => !['none', 'short'].includes(item.unit_id)
-    );
-    const metricUnitItem = unitList.find(
-      (item) => item.unit_id === target?.unit
-    );
-    let defaultUnit: string | null = null;
-    if (metricUnitItem) {
-      // 找到相同 system 的第一个单位
-      const sameSystemUnit = baseFilteredList.find(
-        (item) => item.system === metricUnitItem.system
-      );
-      defaultUnit = sameSystemUnit?.unit_id || null;
-    }
-    setCalculationUnit(defaultUnit);
-    setThresholdUnit(defaultUnit);
+    // none/short/枚举 → null，禁止再按 system===null 回落到 cps 等独立单位
+    const nextUnit = resolveUnitOnMetricSelect(target?.unit);
+    setCalculationUnit(nextUnit);
+    setThresholdUnit(nextUnit);
   };
 
   const getMetrics = async (params = {}, type = '') => {

--- a/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/strategyDetailUtils.ts
@@ -12,6 +12,11 @@ export const FORMULA_DEFAULT_RESULT_UNIT = 'percent';
 
 const INVALID_THRESHOLD_UNIT_IDS = new Set(['none', 'short']);
 
+/** 无量纲 / 不参与阈值单位选配的单位（none、short、空） */
+export const isVacantThresholdUnit = (
+  unit: string | null | undefined
+): boolean => !unit || INVALID_THRESHOLD_UNIT_IDS.has(unit);
+
 export const resolveInitialMetricPluginId = ({
   type,
   pluginList,
@@ -141,11 +146,30 @@ export const getMetricThresholdEnumState = ({
 };
 
 export const shouldShowThresholdUnitSelector = ({
-  isEnumMetric
+  isEnumMetric,
+  calculationUnit,
+  unitList = [],
 }: {
   isFormulaMode: boolean;
   isEnumMetric: boolean;
-}): boolean => !isEnumMetric;
+  calculationUnit?: string | null;
+  unitList?: UnitListItem[];
+}): boolean => {
+  if (isEnumMetric) return false;
+  if (isVacantThresholdUnit(calculationUnit)) return false;
+  // 单位表就绪但无可选阈值单位时也不展示（避免空下拉 + 必填）
+  if (
+    unitList.length > 0 &&
+    !getThresholdUnitOptions({
+      unitList,
+      metricUnit: calculationUnit ?? null,
+      isEnumMetric: false,
+    }).length
+  ) {
+    return false;
+  }
+  return true;
+};
 
 export const getThresholdUnitOptions = ({
   unitList,
@@ -156,7 +180,9 @@ export const getThresholdUnitOptions = ({
   metricUnit: string | null;
   isEnumMetric: boolean;
 }): UnitListItem[] => {
-  if (isEnumMetric || !metricUnit) return [];
+  if (isEnumMetric || !metricUnit || isVacantThresholdUnit(metricUnit)) {
+    return [];
+  }
 
   const validUnits = getValidThresholdUnitOptions(unitList);
   const baseUnit = validUnits.find((item) => item.unit_id === metricUnit);
@@ -221,7 +247,7 @@ export const resolveMetricDisplayUnit = (
   unit: string | null | undefined,
   unitList: UnitListItem[]
 ): string => {
-  if (!unit || INVALID_THRESHOLD_UNIT_IDS.has(unit) || isStringArray(unit)) {
+  if (isVacantThresholdUnit(unit) || isStringArray(unit || '')) {
     return '';
   }
 
@@ -250,11 +276,19 @@ export const buildMetricSelectOption = (
 export const filterInvalidCalculationUnit = (
   unit: string | null | undefined
 ): string | null => {
-  if (!unit || unit === 'none' || unit === 'short' || isStringArray(unit)) {
+  if (isVacantThresholdUnit(unit) || isStringArray(unit || '')) {
     return null;
   }
-  return unit;
+  return unit ?? null;
 };
+
+/**
+ * 指标切换时解析 calculation/threshold 单位。
+ * none/short/枚举/空 → null，禁止再按 system===null 回落到 cps 等独立单位。
+ */
+export const resolveUnitOnMetricSelect = (
+  metricUnit: string | null | undefined
+): string | null => filterInvalidCalculationUnit(metricUnit);
 
 export const restoreCalculationUnitState = (
   unit: string | null | undefined


### PR DESCRIPTION
## Summary
- 修复监控策略配置中 `unit=none/short` 指标仍强制选择单位的问题
- 无量纲指标隐藏阈值单位下拉，并跳过单位必填校验
- 去掉指标切换时按 `system===null` 误回落到 `cps` 等独立单位的逻辑

## Test plan
- [x] `pnpm exec tsx scripts/monitor-strategy-detail-logic-test.ts` 通过
- [x] Chrome 验证：Host 指标 `system_load1`(none) 不展示单位下拉
- [x] Chrome 验证：Host 指标 `cpu_usage_total`(percent) 仍展示单位 `%`
- [ ] 手工抽查 `counts` 指标策略配置仍展示 counts

## Scope note
仅提交策略单位相关 4 个文件；本地图标、next 配置等无关改动未纳入本 PR。