### PR TITLE
feature: Windows 控制器安装事务路径 rename 增加瞬态失败重试

### DIFF
--- a/agents/sidecar-installer/rename_retry.go
+++ b/agents/sidecar-installer/rename_retry.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// Windows 实时防护（如 Defender）在新文件批量落盘后会短暂持有句柄或直接拒绝
+// 目录重命名，表现为 ACCESS_DENIED / SHARING_VIOLATION 的瞬态失败，数秒内自行
+// 消失。事务路径上的 rename 统一走短退避重试，避免整单安装因扫描窗口失败。
+var (
+	transientRenameErrorCheck  = isTransientRenameError
+	windowsRenameRetryAttempts = 10
+	windowsRenameRetryDelay    = 500 * time.Millisecond
+)
+
+func renameWithWindowsTransientRetry(source, target string) error {
+	var lastErr error
+	for attempt := 0; attempt < windowsRenameRetryAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(windowsRenameRetryDelay)
+		}
+		lastErr = os.Rename(source, target)
+		if lastErr == nil {
+			if attempt > 0 {
+				log("rename %s -> %s succeeded after %d transient failures", source, target, attempt)
+			}
+			return nil
+		}
+		if !transientRenameErrorCheck(lastErr) {
+			return lastErr
+		}
+		log("transient rename failure (attempt %d/%d): %v", attempt+1, windowsRenameRetryAttempts, lastErr)
+	}
+	return fmt.Errorf(
+		"%w (still failing after %d attempts over %s; source exists: %t; target exists: %t%s)",
+		lastErr,
+		windowsRenameRetryAttempts,
+		time.Duration(windowsRenameRetryAttempts-1)*windowsRenameRetryDelay,
+		pathExists(source),
+		pathExists(target),
+		renameFailureProcessHints(source, target),
+	)
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/agents/sidecar-installer/rename_retry_test.go
+++ b/agents/sidecar-installer/rename_retry_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func withInjectedTransientRename(t *testing.T, check func(error) bool, delay time.Duration) {
+	t.Helper()
+	previousCheck := transientRenameErrorCheck
+	previousDelay := windowsRenameRetryDelay
+	transientRenameErrorCheck = check
+	windowsRenameRetryDelay = delay
+	t.Cleanup(func() {
+		transientRenameErrorCheck = previousCheck
+		windowsRenameRetryDelay = previousDelay
+	})
+}
+
+func makeDirWithFile(t *testing.T, dir, file string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("create dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(file), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+}
+
+func TestRenameWithWindowsTransientRetryRecoversOnceBlockerClears(t *testing.T) {
+	withInjectedTransientRename(t, func(error) bool { return true }, 10*time.Millisecond)
+	base := t.TempDir()
+	source := filepath.Join(base, "staging")
+	target := filepath.Join(base, "install")
+	makeDirWithFile(t, source, "collector-sidecar.exe")
+	makeDirWithFile(t, target, "scan-blocker")
+
+	go func() {
+		time.Sleep(35 * time.Millisecond)
+		_ = os.RemoveAll(target)
+	}()
+
+	if err := renameWithWindowsTransientRetry(source, target); err != nil {
+		t.Fatalf("rename must succeed once the transient blocker clears: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(target, "collector-sidecar.exe")); err != nil {
+		t.Fatalf("renamed content missing: %v", err)
+	}
+}
+
+func TestRenameWithWindowsTransientRetryFailsFastOnPermanentErrors(t *testing.T) {
+	withInjectedTransientRename(t, func(error) bool { return false }, time.Hour)
+	base := t.TempDir()
+
+	started := time.Now()
+	err := renameWithWindowsTransientRetry(filepath.Join(base, "missing"), filepath.Join(base, "install"))
+
+	if err == nil {
+		t.Fatal("expected failure for missing source")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("permanent errors must not be retried, took %s", elapsed)
+	}
+	if strings.Contains(err.Error(), "attempts") {
+		t.Fatalf("permanent failure must not carry retry diagnostics: %v", err)
+	}
+}
+
+func TestRenameWithWindowsTransientRetryReportsDiagnosticsAfterExhaustion(t *testing.T) {
+	withInjectedTransientRename(t, func(error) bool { return true }, time.Millisecond)
+	base := t.TempDir()
+	source := filepath.Join(base, "staging")
+	target := filepath.Join(base, "install")
+	makeDirWithFile(t, source, "collector-sidecar.exe")
+	makeDirWithFile(t, target, "scan-blocker")
+
+	err := renameWithWindowsTransientRetry(source, target)
+
+	if err == nil {
+		t.Fatal("expected exhaustion failure while target stays blocked")
+	}
+	message := err.Error()
+	if !strings.Contains(message, "10 attempts") {
+		t.Fatalf("error must report retry count: %v", err)
+	}
+	if !strings.Contains(message, "source exists: true") || !strings.Contains(message, "target exists: true") {
+		t.Fatalf("error must report path existence diagnostics: %v", err)
+	}
+}

--- a/agents/sidecar-installer/rename_retry_unix.go
+++ b/agents/sidecar-installer/rename_retry_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package main
+
+// 非 Windows 平台没有实时防护扫描窗口这类瞬态 rename 失败，一次失败即为终态。
+func isTransientRenameError(error) bool {
+	return false
+}
+
+func renameFailureProcessHints(...string) string {
+	return ""
+}

--- a/agents/sidecar-installer/rename_retry_windows.go
+++ b/agents/sidecar-installer/rename_retry_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func isTransientRenameError(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}
+
+// renameFailureProcessHints 尽力列出可执行文件位于受影响路径下的进程，帮助现场
+// 区分"目录被残留进程占用"与"安全软件拦截"。收集失败不影响主错误返回。
+func renameFailureProcessHints(paths ...string) string {
+	output, err := exec.Command(
+		"powershell.exe", "-NoProfile", "-NonInteractive", "-Command",
+		"Get-CimInstance Win32_Process | ForEach-Object { '{0}|{1}' -f $_.ProcessId, $_.ExecutablePath }",
+	).Output()
+	if err != nil {
+		return ""
+	}
+	hints := []string{}
+	for _, line := range strings.Split(string(output), "\n") {
+		pid, executable, found := strings.Cut(strings.TrimSpace(line), "|")
+		if !found || executable == "" {
+			continue
+		}
+		for _, path := range paths {
+			if strings.HasPrefix(strings.ToLower(executable), strings.ToLower(path)+`\`) {
+				hints = append(hints, fmt.Sprintf("%s (pid %s)", executable, pid))
+				break
+			}
+		}
+	}
+	if len(hints) == 0 {
+		return ""
+	}
+	return "; processes inside affected directories: " + strings.Join(hints, ", ")
+}

--- a/agents/sidecar-installer/setup-worker.go
+++ b/agents/sidecar-installer/setup-worker.go
@@ -1320,7 +1320,7 @@ func moveWindowsRuntimeData(backupDir, installDir string) ([]string, error) {
 		if err := os.RemoveAll(target); err != nil {
 			return moved, err
 		}
-		if err := os.Rename(source, target); err != nil {
+		if err := renameWithWindowsTransientRetry(source, target); err != nil {
 			return moved, err
 		}
 		moved = append(moved, name)
@@ -1339,7 +1339,7 @@ func moveWindowsRuntimeData(backupDir, installDir string) ([]string, error) {
 		} else if !os.IsNotExist(err) {
 			return moved, err
 		}
-		if err := os.Rename(source, target); err != nil {
+		if err := renameWithWindowsTransientRetry(source, target); err != nil {
 			return moved, err
 		}
 		moved = append(moved, name)
@@ -1355,7 +1355,7 @@ func restoreWindowsRuntimeData(installDir, backupDir string, moved []string) err
 		if err := os.RemoveAll(target); err != nil {
 			return err
 		}
-		if err := os.Rename(source, target); err != nil {
+		if err := renameWithWindowsTransientRetry(source, target); err != nil {
 			return err
 		}
 	}
@@ -1384,7 +1384,7 @@ func restorePreviousWindowsInstallation(
 				return fmt.Errorf("remove activation marker: %w", err)
 			}
 		}
-		if err := os.Rename(backupDir, installDir); err != nil {
+		if err := renameWithWindowsTransientRetry(backupDir, installDir); err != nil {
 			return fmt.Errorf("restore previous installation: %w", err)
 		}
 	}
@@ -1693,7 +1693,7 @@ func installWindowsPackage(cfg *Config, zipPath string, controller windowsServic
 			}
 			return fmt.Errorf("write activation marker: %w", markerErr)
 		}
-		if err := os.Rename(installDir, backupDir); err != nil {
+		if err := renameWithWindowsTransientRetry(installDir, backupDir); err != nil {
 			backupErr := err
 			removeMarkerErr := os.Remove(pendingMarker)
 			if serviceExisted {
@@ -1709,7 +1709,7 @@ func installWindowsPackage(cfg *Config, zipPath string, controller windowsServic
 	} else if !os.IsNotExist(err) {
 		return err
 	}
-	if err := os.Rename(stagingDir, installDir); err != nil {
+	if err := renameWithWindowsTransientRetry(stagingDir, installDir); err != nil {
 		activationErr := err
 		if restoreErr := restorePreviousWindowsInstallation(controller, installDir, backupDir, installExisted, serviceExisted, nil); restoreErr != nil {
 			return fmt.Errorf("activate staged installation: %v; rollback: %w", activationErr, restoreErr)
@@ -1755,7 +1755,7 @@ func installWindowsPackage(cfg *Config, zipPath string, controller windowsServic
 	if installExisted {
 		pendingMarker := filepath.Join(backupDir, windowsActivationPendingMarker)
 		committedMarker := filepath.Join(backupDir, windowsActivationCommittedMarker)
-		if err := os.Rename(pendingMarker, committedMarker); err != nil {
+		if err := renameWithWindowsTransientRetry(pendingMarker, committedMarker); err != nil {
 			commitErr := err
 			if _, stopErr := controller.Stop(); stopErr != nil {
 				return fmt.Errorf("commit Windows activation: %v; stop new service before rollback: %w", commitErr, stopErr)


### PR DESCRIPTION
## 背景

两台 IDC Windows Server（仅 Microsoft Defender，无第三方杀软）上，修复版 GUI 安装器在激活步骤稳定出现：

```
activate staged installation: rename C:\fusion-collectors.bklite-staging C:\fusion-collectors: Access is denied.
```

现场定性证据：
- 管理员手动执行同样的目录 rename 完全正常（排除 ACL/组策略）；
- 其中一台数分钟后原样重试安装即成功；
- 时序上 rename 发生在 285MB 控制器包（1842 个文件，含大量未签名 exe）落盘后 2 秒内。

结论：Defender 实时防护对新落盘可执行文件的扫描窗口内拦截目录重命名，为瞬态失败，短暂等待后自行消失。

## 修改

- 新增 `renameWithWindowsTransientRetry`：对 `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` 退避重试（10 次 × 500ms），其余错误立即返回；非 Windows 平台判定恒为非瞬态，行为不变。
- 事务路径 6 处 rename（备份、激活、回滚恢复、运行数据迁移 ×2、提交标记）统一接入。
- 重试耗尽后的错误信息附带：重试次数与总时长、源/目标存在性、以及（尽力而为）可执行文件位于受影响目录内的进程列表——现场无需再人肉跑排查清单。
- 单测 3 条：瞬态阻塞解除后重试成功、永久错误不重试快速失败、耗尽后诊断信息完整。`go vet`（darwin + GOOS=windows）与全量测试通过。

## 与既有修复的关系

- #4525 修复了 NSIS 提前锁定安装目录导致的必现自锁；本 PR 处理的是其修复后暴露出的下一层现场问题（安全软件瞬态拦截），两台机器实测均命中。
- 运维侧同时建议将 `C:\fusion-collectors` 加入 Defender 排除路径（`Add-MpPreference -ExclusionPath`），与本重试机制互补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #4578
