### PR TITLE
fix: 修复 master 上 web 构建与运行镜像的三处阻断

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -48,6 +48,9 @@ COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./
+# pnpm 11 在 run script 前校验依赖状态；必须带上声明 verifyDepsBeforeRun: false
+# 的 pnpm-workspace.yaml 与 lockfile，否则运行期触发交互式重装直接崩溃
+COPY --from=builder /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
 
 CMD ["pnpm", "run", "start"]
 # 或者直接写明端口（如需更显式可改为：CMD ["pnpm", "exec", "next", "start", "-p", "3001"]）

--- a/web/src/app/apm/services/[serviceId]/page.tsx
+++ b/web/src/app/apm/services/[serviceId]/page.tsx
@@ -617,7 +617,7 @@ export default function ApmServiceDetailPage() {
                       />
                     ) : (
                       <CatalogState
-                        kind={tracesState === 'ready' ? 'error' : tracesState}
+                        kind={tracesState}
                         description={tracesState === 'empty' ? '当前时间窗暂无调用链样本。' : undefined}
                       />
                     )}

--- a/web/src/app/apm/traces/page.tsx
+++ b/web/src/app/apm/traces/page.tsx
@@ -82,7 +82,7 @@ function parseFilters(text: string, fallback: TraceFilters): TraceFilters {
     minDurationMs: null,
     maxDurationMs: null,
   };
-  const tokens = text.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [];
+  const tokens: string[] = text.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [];
   tokens.forEach((token) => {
     const cleaned = token.replace(/^"|"$/g, '');
     const sep = cleaned.indexOf(':');
@@ -589,7 +589,7 @@ export default function ApmTracesPage() {
       <div className="flex flex-col gap-3">
         <ApmSurface padding="compact">
           <div className="flex flex-wrap items-center gap-3">
-            <Segmented
+            <Segmented<EntityMode>
               size="small"
               aria-label="调用链查询粒度"
               options={[


### PR DESCRIPTION
master 当前无法产出可运行的 web 镜像：TypeScript 检查两处报错阻断 `next build`，且即使构建通过，pnpm 11 升级后的运行镜像启动即崩。本 PR 三个 commit 各修一处：

## 1. APM 服务详情页 TS2367（cd690a9）

`services/[serviceId]/page.tsx` 的调用链空态在 `tracesState !== 'ready'` 分支内再次比较 `tracesState === 'ready'`——类型已收窄为 `CatalogStateKind`，与 `'ready'` 无重叠（TS2367），三元 `'error'` 分支不可达。直接传收窄后的 `tracesState`，行为不变。

## 2. APM 调用链探索页 TS2339 / TS2345（2b3c886）

- `parseFilters` 中 `text.match(...) ?? []` 推断为 `RegExpMatchArray | never[]`，联合数组的 `forEach` 回调参数交叉为 `never`，`token.replace` 报 TS2339 → 给 `tokens` 显式标注 `string[]`；
- `Segmented` 未带泛型参数时 `onChange` 拿到宽类型 `string`，不可赋给 `SetStateAction<EntityMode>`（TS2345）→ 补 `Segmented<EntityMode>`。

## 3. 运行镜像启动即崩（20affcf）

d3e46d5ab 升级 pnpm 11 后，`pnpm run` 会在执行 script 前校验依赖状态；e8e388f72 在 `pnpm-workspace.yaml` 加了 `verifyDepsBeforeRun: false` 压制，**但 Dockerfile 运行阶段未 COPY 该文件**，配置进不了运行容器：容器启动触发校验 → 试图重装 node_modules → 无 TTY → `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`，Pod CrashLoop。此前未暴露是因为 pnpm 11 升级后 web 构建一直挂在 TS 检查、未出过镜像。运行阶段补 COPY `pnpm-workspace.yaml` 与 `pnpm-lock.yaml`。

## 验证

- 含本 PR 的 docker build（企业 overlay 场景，内网 registry）：TypeScript 检查 0 错误、构建成功；
- 修复后镜像已在 TKE 集群实测：Pod 正常启动并服务流量（修复前同镜像必现 CrashLoop）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)