### PR TITLE
fix(web): 扩大企业版 Turbopack 根目录覆盖范围

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -6,6 +6,25 @@ const enterpriseWebLink = path.resolve(process.cwd(), 'enterprise');
 const enterpriseWebRoot = fs.existsSync(enterpriseWebLink) ? fs.realpathSync(enterpriseWebLink) : '';
 const repositoryRoot = path.resolve(process.cwd(), '..');
 
+// Local enterprise layout keeps WeOpsX-Enterprise as a sibling of bk-lite.
+// Turbopack/file tracing must cover that realpath, not only the BK-Lite repo root.
+function commonFilesystemRoot(left, right) {
+  const leftParts = path.resolve(left).split(path.sep);
+  const rightParts = path.resolve(right).split(path.sep);
+  const shared = [];
+  for (let i = 0; i < Math.min(leftParts.length, rightParts.length); i += 1) {
+    if (leftParts[i] !== rightParts[i]) {
+      break;
+    }
+    shared.push(leftParts[i]);
+  }
+  return shared.length > 1 ? shared.join(path.sep) : path.sep;
+}
+
+const workspaceRoot = enterpriseWebRoot
+  ? commonFilesystemRoot(repositoryRoot, enterpriseWebRoot)
+  : undefined;
+
 const nextConfig = withBundleAnalyzer({
   enabled: process.env.ANALYZE === 'true',
 })({
@@ -22,11 +41,9 @@ const nextConfig = withBundleAnalyzer({
   typescript: {
     tsconfigPath: 'tsconfig.build.json',
   },
-  outputFileTracingRoot: enterpriseWebRoot
-    ? repositoryRoot
-    : undefined,
-  turbopack: enterpriseWebRoot
-    ? { root: repositoryRoot }
+  outputFileTracingRoot: workspaceRoot,
+  turbopack: workspaceRoot
+    ? { root: workspaceRoot }
     : undefined,
   experimental: {
     externalDir: true,

--- a/web/scripts/build-root-scope-test.mjs
+++ b/web/scripts/build-root-scope-test.mjs
@@ -9,15 +9,40 @@ const repositoryRoot = path.resolve(webRoot, '..');
 const enterpriseRoot = fs.realpathSync(path.join(webRoot, 'enterprise'));
 const config = (await import('../next.config.mjs')).default;
 
-assert.equal(config.outputFileTracingRoot, repositoryRoot);
-assert.equal(config.turbopack?.root, repositoryRoot);
+function commonFilesystemRoot(left, right) {
+  const leftParts = path.resolve(left).split(path.sep);
+  const rightParts = path.resolve(right).split(path.sep);
+  const shared = [];
+  for (let i = 0; i < Math.min(leftParts.length, rightParts.length); i += 1) {
+    if (leftParts[i] !== rightParts[i]) {
+      break;
+    }
+    shared.push(leftParts[i]);
+  }
+  return shared.length > 1 ? shared.join(path.sep) : path.sep;
+}
 
-const enterpriseRelativePath = path.relative(repositoryRoot, enterpriseRoot);
+const expectedRoot = commonFilesystemRoot(repositoryRoot, enterpriseRoot);
+
+assert.equal(config.outputFileTracingRoot, expectedRoot);
+assert.equal(config.turbopack?.root, expectedRoot);
+
+const enterpriseRelativePath = path.relative(expectedRoot, enterpriseRoot);
 assert.ok(
   enterpriseRelativePath &&
     !enterpriseRelativePath.startsWith(`..${path.sep}`) &&
+    enterpriseRelativePath !== '..' &&
     !path.isAbsolute(enterpriseRelativePath),
   `enterprise source must remain inside the build root: ${enterpriseRoot}`
 );
 
-console.log('Next build root is limited to the BK-Lite repository');
+const repositoryRelativePath = path.relative(expectedRoot, repositoryRoot);
+assert.ok(
+  repositoryRelativePath === '' ||
+    (!repositoryRelativePath.startsWith(`..${path.sep}`) &&
+      repositoryRelativePath !== '..' &&
+      !path.isAbsolute(repositoryRelativePath)),
+  `BK-Lite repository must remain inside the build root: ${repositoryRoot}`
+);
+
+console.log('Next build root covers BK-Lite and enterprise sources');


### PR DESCRIPTION
## Summary
- 修复企业版本地开发时 Turbopack `leaves the filesystem root` 导致的整站 500
- `turbopack.root` / `outputFileTracingRoot` 改为取 `bk-lite` 与企业仓 realpath 的公共父目录，覆盖同级 `WeOpsX-Enterprise` 布局
- 同步纠正 `build-root-scope-test` 中错误地要求根目录仅限 BK-Lite 仓库的断言

## Test plan
- [x] `cd web && node scripts/build-root-scope-test.mjs`
- [x] `cd web && node scripts/next-config-build-purity-test.mjs`
- [x] 清 `web/.next` 后 `BKLITE_EDITION=enterprise pnpm dev`，访问 `/monitor/integration/list` 返回 HTTP 200，终端无 `leaves the filesystem root`
- [ ] 社区版（无 `web/enterprise` 链接）启动不受影响

## Scope check
- 仅提交 `web/next.config.mjs`、`web/scripts/build-root-scope-test.mjs`
- 未纳入本地图标、`next-env.d.ts`、`tsconfig.json` 及其他无关改动