### PR TITLE
fix(监控): 告警策略采集模板改为可搜索下拉选择

### DIFF
--- a/web/src/app/monitor/(pages)/event/strategy/detail/metricDefinitionForm.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/detail/metricDefinitionForm.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useCallback, useMemo } from 'react';
 import {
   Form,
   Input,
-  Segmented,
   Select,
   Tooltip,
   InputNumber,
@@ -156,9 +155,17 @@ const MetricDefinitionForm: React.FC<MetricDefinitionFormProps> = ({
           }
           rules={[{ required: true, message: t('common.required') }]}
         >
-          <Segmented
-            className="custom-tabs"
+          <Select
+            style={{ width: '100%' }}
+            placeholder={t('monitor.events.collectionTemplate')}
+            showSearch
+            allowClear={false}
             options={pluginList}
+            filterOption={(input, option) =>
+              String(option?.label || '')
+                .toLowerCase()
+                .includes(input.toLowerCase())
+            }
             onChange={onCollectTypeChange}
           />
         </Form.Item>


### PR DESCRIPTION
## Summary
- 告警策略「定义指标」步骤中，采集模板从横向 Segmented 改为可搜索 Select，解决交换机等对象模板过多时横向溢出无法浏览的问题
- 交互对齐同模块查询面板的插件选择（showSearch + 本地 label 过滤）
- 未改动策略下发、`collect_type` 绑定、SNMP Trap 分支及 `metric_unit`/`calculation_unit`/`threshold_unit` 解析逻辑

## Test plan
- [ ] 模板较少（2～3 个）时，下拉可选，切换后指标列表刷新
- [ ] 模板很多（如交换机）时，输入关键词可过滤并选中
- [ ] 选择 SNMP Trap 后仍进入 PromQL 分支
- [ ] 编辑已有策略时 `collect_type` 回显正确
- [ ] 保存策略成功，单位字段行为与改前一致（none/short 仍按既有逻辑清空）