### PR TITLE
fix(opspilot): preview_crontab 按用户时区计算下次执行时间

### DIFF
--- a/server/apps/core/tests/utils/test_time_util.py
+++ b/server/apps/core/tests/utils/test_time_util.py
@@ -9,6 +9,7 @@
 import os
 import time
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -130,3 +131,9 @@ class TestGetCrontabNextRuns:
     def test_空或非字符串抛_valueerror(self, bad):
         with pytest.raises(ValueError):
             get_crontab_next_runs(bad, base_time=self.BASE)
+
+    def test_默认按用户时区解释_now(self, mocker):
+        fixed_utc = datetime(2026, 1, 1, 1, 30, 0, tzinfo=ZoneInfo("UTC"))
+        mocker.patch("django.utils.timezone.now", return_value=fixed_utc)
+        assert get_crontab_next_runs("0 9 * * *", count=1, tz="UTC") == ["2026-01-01 09:00:00"]
+        assert get_crontab_next_runs("0 9 * * *", count=1, tz="Asia/Shanghai") == ["2026-01-02 09:00:00"]

--- a/server/apps/core/utils/time_util.py
+++ b/server/apps/core/utils/time_util.py
@@ -4,9 +4,11 @@
 # @Author: windyzhao
 
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timezone, tzinfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
+from django.utils import timezone as django_timezone
 
 RFC3339_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$")
 
@@ -93,21 +95,37 @@ def format_timestamp(time_str: str):
     return formatted_timestamp
 
 
+def resolve_crontab_timezone(tz: str | tzinfo | None = None) -> tzinfo:
+    """Resolve crontab wall-clock timezone; fall back to Django current timezone."""
+    if isinstance(tz, tzinfo):
+        return tz
+    if isinstance(tz, str) and tz.strip():
+        try:
+            return ZoneInfo(tz.strip())
+        except (ZoneInfoNotFoundError, KeyError, ValueError):
+            pass
+    return django_timezone.get_current_timezone()
+
+
 def get_crontab_next_runs(
     crontab_expression: str,
     count: int = 6,
     base_time: datetime | None = None,
+    tz: str | tzinfo | None = None,
 ) -> list[str]:
     """
     Get the next N execution times for a crontab expression.
 
+    Cron fields are interpreted in ``tz`` (Django current / user timezone by default).
+
     Args:
         crontab_expression: 5-field crontab expression (minute hour day month weekday)
         count: Number of next execution times to return (default: 6)
-        base_time: Base time to calculate from (default: now)
+        base_time: Base time to calculate from (default: now in ``tz``)
+        tz: IANA timezone name or tzinfo; default Django current timezone
 
     Returns:
-        List of datetime strings (YYYY-MM-DD HH:MM:SS) for next executions
+        List of wall-clock datetime strings (YYYY-MM-DD HH:MM:SS) in ``tz``
 
     Raises:
         ValueError: If crontab expression is invalid
@@ -120,14 +138,22 @@ def get_crontab_next_runs(
     if not croniter.is_valid(expression):
         raise ValueError(f"Invalid crontab expression: {expression}")
 
+    resolved_tz = resolve_crontab_timezone(tz)
+
     if base_time is None:
-        base_time = datetime.now()
+        base_time = django_timezone.now().astimezone(resolved_tz)
+    elif base_time.tzinfo is None:
+        base_time = base_time.replace(tzinfo=resolved_tz)
+    else:
+        base_time = base_time.astimezone(resolved_tz)
 
     try:
         cron = croniter(expression, base_time)
         next_runs = []
         for _ in range(count):
             next_time = cron.get_next(datetime)
+            if next_time.tzinfo is not None:
+                next_time = next_time.astimezone(resolved_tz)
             next_runs.append(next_time.strftime("%Y-%m-%d %H:%M:%S"))
         return next_runs
     except Exception as e:

--- a/server/apps/opspilot/tests/test_slice_opbiz_schedule_utils.py
+++ b/server/apps/opspilot/tests/test_slice_opbiz_schedule_utils.py
@@ -4,19 +4,13 @@ ScheduleConfigValidator / CrontabGenerator / convert_legacy_config /
 get_crontab_next_runs 均为纯函数（croniter 为确定性库），直接断言真实行为。
 """
 
-import pydantic.root_model  # noqa
-
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
+import pydantic.root_model  # noqa
 import pytest
 
-from apps.opspilot.utils.schedule_utils import (
-    CrontabGenerator,
-    ScheduleConfigValidator,
-    convert_legacy_config,
-    get_crontab_next_runs,
-)
-
+from apps.opspilot.utils.schedule_utils import CrontabGenerator, ScheduleConfigValidator, convert_legacy_config, get_crontab_next_runs
 
 # ---------------------------------------------------------------------------
 # ScheduleConfigValidator
@@ -211,3 +205,13 @@ class TestNextRuns:
     def test_non_string_raises(self):
         with pytest.raises(ValueError, match="required and must be a string"):
             get_crontab_next_runs(None)  # type: ignore
+
+    def test_same_utc_instant_yields_different_next_run_by_timezone(self, mocker):
+        """Server UTC vs user Asia/Shanghai must not share naive datetime.now()."""
+        fixed_utc = datetime(2026, 1, 1, 1, 30, 0, tzinfo=ZoneInfo("UTC"))
+        mocker.patch("django.utils.timezone.now", return_value=fixed_utc)
+
+        # 01:30 UTC → next local 09:00 same day
+        assert get_crontab_next_runs("0 9 * * *", count=1, tz="UTC") == ["2026-01-01 09:00:00"]
+        # 01:30 UTC = 09:30 Asia/Shanghai → next local 09:00 next day
+        assert get_crontab_next_runs("0 9 * * *", count=1, tz="Asia/Shanghai") == ["2026-01-02 09:00:00"]

--- a/server/apps/opspilot/utils/schedule_utils.py
+++ b/server/apps/opspilot/utils/schedule_utils.py
@@ -30,10 +30,12 @@ Legacy Format (still supported, auto-converted):
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
+from django.utils import timezone as django_timezone
 
 # Valid frequency types
 FREQUENCY_TYPES = ("daily", "weekly", "monthly", "crontab")
@@ -375,21 +377,38 @@ def convert_legacy_config(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+def resolve_crontab_timezone(tz: str | tzinfo | None = None) -> tzinfo:
+    """Resolve crontab wall-clock timezone; fall back to Django current timezone."""
+    if isinstance(tz, tzinfo):
+        return tz
+    if isinstance(tz, str) and tz.strip():
+        try:
+            return ZoneInfo(tz.strip())
+        except (ZoneInfoNotFoundError, KeyError, ValueError):
+            pass
+    return django_timezone.get_current_timezone()
+
+
 def get_crontab_next_runs(
     crontab_expression: str,
     count: int = 6,
     base_time: datetime | None = None,
+    tz: str | tzinfo | None = None,
 ) -> list[str]:
     """
     Get the next N execution times for a crontab expression.
 
+    Cron fields are interpreted in ``tz`` (user timezone by default), matching
+    Celery ``CrontabSchedule`` creation which uses ``timezone.get_current_timezone()``.
+
     Args:
         crontab_expression: 5-field crontab expression (minute hour day month weekday)
         count: Number of next execution times to return (default: 6)
-        base_time: Base time to calculate from (default: now)
+        base_time: Base time to calculate from (default: now in ``tz``)
+        tz: IANA timezone name or tzinfo; default Django current timezone
 
     Returns:
-        List of ISO format datetime strings for next executions
+        List of wall-clock datetime strings (YYYY-MM-DD HH:MM:SS) in ``tz``
 
     Raises:
         ValueError: If crontab expression is invalid
@@ -403,14 +422,22 @@ def get_crontab_next_runs(
     if not croniter.is_valid(expression):
         raise ValueError(f"Invalid crontab expression: {expression}")
 
+    resolved_tz = resolve_crontab_timezone(tz)
+
     if base_time is None:
-        base_time = datetime.now()
+        base_time = django_timezone.now().astimezone(resolved_tz)
+    elif base_time.tzinfo is None:
+        base_time = base_time.replace(tzinfo=resolved_tz)
+    else:
+        base_time = base_time.astimezone(resolved_tz)
 
     try:
         cron = croniter(expression, base_time)
         next_runs = []
         for _ in range(count):
             next_time = cron.get_next(datetime)
+            if next_time.tzinfo is not None:
+                next_time = next_time.astimezone(resolved_tz)
             next_runs.append(next_time.strftime("%Y-%m-%d %H:%M:%S"))
         return next_runs
     except Exception as e:

--- a/server/apps/opspilot/viewsets/bot_view.py
+++ b/server/apps/opspilot/viewsets/bot_view.py
@@ -638,16 +638,19 @@ class BotViewSet(PinMixin, AuthViewSet):
         Returns:
             result: bool - Success flag
             data: list - List of next execution times in "YYYY-MM-DD HH:MM:SS" format
+                (wall clock in the current user's timezone)
             message: str - Error message if failed
         """
         crontab_expression = request.data.get("crontab_expression", "")
         count = min(int(request.data.get("count", 6)), 20)  # Max 20
+        # Prefer profile timezone; auth backend also activates it as Django current TZ.
+        user_timezone = getattr(request.user, "timezone", None) or request.data.get("timezone")
 
         if not crontab_expression:
             message = self.loader.get("error.crontab_expression_required") if self.loader else "crontab_expression is required"
             return JsonResponse({"result": False, "message": message})
         try:
-            next_runs = get_crontab_next_runs(crontab_expression, count=count)
+            next_runs = get_crontab_next_runs(crontab_expression, count=count, tz=user_timezone)
             return JsonResponse({"result": True, "data": next_runs})
         except ValueError:
             template = self.loader.get("error.invalid_crontab_expression") if self.loader else "Invalid crontab expression: {expression}"


### PR DESCRIPTION
原先用无时区 datetime.now()，与 Celery CrontabSchedule 使用 get_current_timezone() 不一致；改为按用户时区（可显式传入）解释 cron 墙钟。