### PR TITLE
fix(监控): 修复更新采集配置时 ConfigFormat UnboundLocalError

### DIFF
--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -1013,7 +1013,6 @@ class InstanceConfigService:
                 except ValueError as exc:
                     raise BaseAppException(str(exc)) from exc
             if (config_obj.collect_type or "").startswith("snmp"):
-                from apps.monitor.utils.config_format import ConfigFormat
                 from apps.monitor.utils.snmp_interface_filters import normalize_snmp_interface_filter_config
                 from apps.monitor.utils.snmp_interface_template import has_interface_collection
 


### PR DESCRIPTION
## Summary
- 删除 `update_instance_config` snmp 分支内多余的局部 `ConfigFormat` import，改用模块级已有导入
- 修复非 snmp（host/process/web/kafka）修改实例配置时的 `UnboundLocalError`（由 IF-MIB 统一采集引入）
- Code review 扫描：5 路检查均无高置信度问题

## Test plan
- [x] 本地复现 Python 作用域坑（非 snmp 路径 UnboundLocalError）
- [x] 删除局部 import 后，非 snmp + snmp 子配置更新路径验证通过
- [ ] 在环境中分别修改 host 与 snmp 实例采集配置，确认均可保存

## Scope check
- 仅提交 `server/apps/monitor/services/node_mgmt.py` 一处删除
- 回归测试文件与仪表盘/图标等本地改动未纳入本 PR