### PR TITLE
fix(web): 恢复详情页叶子菜单的兄弟项回退

### DIFF
--- a/web/src/utils/__tests__/menuHelpers.test.ts
+++ b/web/src/utils/__tests__/menuHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   findMatchedMenuPath,
+  getDeepestMatchedMenuItems,
   getFirstLayerSiblingMenuItems,
   isMenuPathMatch,
 } from '../menuHelpers';
@@ -120,5 +121,55 @@ describe('getFirstLayerSiblingMenuItems', () => {
       .filter((item) => !item.isNotMenuItem)
       .map((item) => item.title);
     expect(siblings).toEqual(['调用链', '端点', '错误']);
+  });
+});
+
+const skillMenus: MenuItem[] = [
+  {
+    title: '智能体',
+    url: '/opspilot/skill',
+    name: 'skill_list',
+    hasDetail: true,
+    children: [
+      {
+        title: '设置',
+        url: '/opspilot/skill/detail/settings',
+        icon: 'shezhi',
+        name: 'skill_setting',
+      },
+      {
+        title: '调用日志',
+        url: '/opspilot/skill/detail/invocationLogs',
+        icon: 'talk-line',
+        name: 'skill_invocation_logs',
+      },
+      {
+        title: '对话',
+        url: '/opspilot/skill/chat',
+        name: 'skill_chat',
+        isNotMenuItem: true,
+      },
+    ],
+  },
+];
+
+describe('getDeepestMatchedMenuItems', () => {
+  it('falls back to parent siblings when current page is a leaf (opspilot skill)', () => {
+    const items = getDeepestMatchedMenuItems(
+      skillMenus,
+      '/opspilot/skill/detail/settings'
+    ).map((item) => item.title);
+    expect(items).toEqual(['设置', '调用日志']);
+  });
+
+  it('still prefers deeper APM routes over app-root /apm when resolving secondary items', () => {
+    const items = getDeepestMatchedMenuItems(apmMenus, '/apm/integration/add').map(
+      (item) => item.title
+    );
+    expect(items).toEqual(['添加接入', '接入实例', '应用管理']);
+  });
+
+  it('returns empty on app-root leaf without siblings (APM home)', () => {
+    expect(getDeepestMatchedMenuItems(apmMenus, '/apm')).toEqual([]);
   });
 });

--- a/web/src/utils/menuHelpers.ts
+++ b/web/src/utils/menuHelpers.ts
@@ -91,9 +91,16 @@ export const shouldRenderSecondLayerMenu = (
   return true;
 };
 
+const filterVisibleMenuItems = (items: MenuItem[] = []): MenuItem[] =>
+  items.filter((item) => !item.isNotMenuItem && !item.isDirectory);
+
 /**
- * Get the deepest matched menu items for the current path.
- * Returns the children of the deepest matched item, or an empty array if no match.
+ * Get secondary menu items for the current path (detail side menus).
+ *
+ * Uses longest-path matching (so app-root menus like `/apm` do not steal
+ * deeper routes). When the deepest match is a leaf page with no children,
+ * fall back to the parent's visible children — the previous WithSideMenuLayout
+ * behavior needed by opspilot skill/studio detail pages.
  */
 export const getDeepestMatchedMenuItems = (
   menus: MenuItem[],
@@ -103,7 +110,16 @@ export const getDeepestMatchedMenuItems = (
   if (!matchedPath || matchedPath.length === 0) return [];
 
   const deepest = matchedPath[matchedPath.length - 1];
-  return deepest.children ?? [];
+  if (deepest.children?.length) {
+    return filterVisibleMenuItems(deepest.children);
+  }
+
+  if (matchedPath.length >= 2) {
+    const parent = matchedPath[matchedPath.length - 2];
+    return filterVisibleMenuItems(parent.children);
+  }
+
+  return [];
 };
 
 /**
@@ -121,9 +137,6 @@ export const getFirstLayerSiblingMenuItems = (
   const firstLayer = matchedPath[0];
   return firstLayer.children ?? [];
 };
-
-const filterVisibleMenuItems = (items: MenuItem[] = []): MenuItem[] =>
-  items.filter((item) => !item.isNotMenuItem && !item.isDirectory);
 
 const findClosestAncestorMenuWithChildren = (
   items: MenuItem[],


### PR DESCRIPTION
保留 APM 最长路径匹配，叶子页无 children 时回退父级可见兄弟项，修复智能体详情左侧栏被吞。