### PR TITLE
fix(monitor): 采集状态时间线按选中时间窗均分展示

### DIFF
--- a/web/src/app/monitor/components/monitor-dashboard-widgets/collection-status-card.tsx
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/collection-status-card.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import React from 'react';
+import { Tooltip } from 'antd';
+import dayjs from 'dayjs';
 import type { CollectionStatusResult } from '@/app/monitor/components/monitor-dashboard-widgets/types';
 import { COLLECTION_STATUS_LEGEND } from '@/app/monitor/components/monitor-dashboard-widgets/runtime';
 import {
@@ -9,6 +11,12 @@ import {
 } from '@/app/monitor/components/monitor-dashboard-widgets/guide-tooltip';
 
 export type CollectionStatusTone = 'success' | 'warning' | 'error' | 'empty';
+
+export interface CollectionStatusTimelineSegment {
+  tone: CollectionStatusTone;
+  startMs?: number;
+  endMs?: number;
+}
 
 export interface CollectionStatusLegendItem {
   key: CollectionStatusTone;
@@ -30,6 +38,7 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
   collectionStatusValueEmpty?: string;
   collectionStatusTimelineBlock?: string;
   collectionStatusTimelineTitle?: string;
+  collectionStatusTimelineHint?: string;
   collectionStatusTimeline?: string;
   collectionStatusSegment?: string;
   collectionStatusSegmentSuccess?: string;
@@ -44,7 +53,8 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
 
 export interface CollectionStatusCardProps {
   status: CollectionStatusResult;
-  timeline: CollectionStatusTone[];
+  timeline: CollectionStatusTimelineSegment[];
+  timelineHint?: string;
   title?: React.ReactNode;
   timelineTitle?: React.ReactNode;
   statusTone?: CollectionStatusTone;
@@ -54,6 +64,13 @@ export interface CollectionStatusCardProps {
   className?: string;
   styles: CollectionStatusCardStyles;
 }
+
+const TONE_LABEL: Record<CollectionStatusTone, string> = {
+  success: '正常',
+  warning: '警告',
+  error: '异常',
+  empty: '无数据',
+};
 
 const getStatusTone = (
   status: CollectionStatusResult,
@@ -68,15 +85,49 @@ const getStatusTone = (
   return 'empty';
 };
 
+const formatSegmentTooltip = (segment: CollectionStatusTimelineSegment): string => {
+  const label = TONE_LABEL[segment.tone];
+  if (
+    Number.isFinite(segment.startMs) &&
+    Number.isFinite(segment.endMs) &&
+    typeof segment.startMs === 'number' &&
+    typeof segment.endMs === 'number'
+  ) {
+    const start = dayjs(segment.startMs).format('HH:mm:ss');
+    const end = dayjs(segment.endMs).format('HH:mm:ss');
+    return `${start} – ${end}\n${label}`;
+  }
+  return label;
+};
+
+const resolveSegmentClass = (
+  tone: CollectionStatusTone,
+  styles: CollectionStatusCardStyles
+): string => {
+  const suffix =
+    tone === 'success'
+      ? 'Success'
+      : tone === 'warning'
+        ? 'Warning'
+        : tone === 'error'
+          ? 'Error'
+          : 'Empty';
+  return `${styles.collectionStatusSegment} ${styles[`collectionStatusSegment${suffix}` as keyof CollectionStatusCardStyles] || ''}`;
+};
+
 export const CollectionStatusCard = ({
   status,
   timeline,
+  timelineHint,
   title = '采集状态',
   timelineTitle = '状态时间线',
   statusTone,
   guideItems = [
-    { label: '采集状态', detail: '展示最近一段时间内该实例监控采集是否正常、缺失或异常。' },
-    { label: '状态时间线', detail: '绿色表示采集成功，灰色表示暂无数据，红色表示采集或查询异常。' },
+    { label: '采集状态', detail: '展示当前选中时间窗内该实例监控采集是否正常、缺失或异常。' },
+    {
+      label: '状态时间线',
+      detail: '时间线覆盖当前时间窗并均分为若干段；绿色表示该段有采集，灰色表示该段无数据，红色表示采集或查询异常。',
+    },
   ],
   legendItems = COLLECTION_STATUS_LEGEND,
   emptyTimelineText,
@@ -119,28 +170,27 @@ export const CollectionStatusCard = ({
         >
           {status.label}
         </div>
-        <div className={styles.collectionStatusTimelineTitle}>{timelineTitle}</div>
+        <div className={styles.collectionStatusTimelineTitle}>
+          <span>{timelineTitle}</span>
+          {timelineHint ? (
+            <span className={styles.collectionStatusTimelineHint}>{timelineHint}</span>
+          ) : null}
+        </div>
         <div className={styles.collectionStatusTimelineBlock}>
           {timeline.length > 0 ? (
             <>
               <div className={styles.collectionStatusTimeline}>
-                {timeline.map((tone, index) => (
-                  <span
-                    key={`${tone}-${index}`}
-                    className={`${styles.collectionStatusSegment} ${
-                      styles[
-                        `collectionStatusSegment${
-                          tone === 'success'
-                            ? 'Success'
-                            : tone === 'warning'
-                              ? 'Warning'
-                              : tone === 'error'
-                                ? 'Error'
-                                : 'Empty'
-                        }`
-                      ]
-                    }`}
-                  />
+                {timeline.map((segment, index) => (
+                  <Tooltip
+                    key={`${segment.tone}-${segment.startMs ?? index}-${index}`}
+                    title={
+                      <span style={{ whiteSpace: 'pre-line' }}>
+                        {formatSegmentTooltip(segment)}
+                      </span>
+                    }
+                  >
+                    <span className={resolveSegmentClass(segment.tone, styles)} />
+                  </Tooltip>
                 ))}
               </div>
               <div className={styles.collectionStatusLegend}>

--- a/web/src/app/monitor/components/monitor-dashboard-widgets/index.ts
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/index.ts
@@ -13,6 +13,7 @@ export type {
   CollectionStatusCardStyles,
   CollectionStatusTone,
   CollectionStatusLegendItem,
+  CollectionStatusTimelineSegment,
 } from '@/app/monitor/components/monitor-dashboard-widgets/collection-status-card';
 
 export { RingChartPanel } from '@/app/monitor/components/monitor-dashboard-widgets/ring-chart-panel';

--- a/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/dashboard-components.tsx
@@ -256,14 +256,15 @@ export const KpiSection = ({
       <CollectionStatusCard
         status={dashboard.collectionStatus}
         timeline={dashboard.collectionStatusTimeline}
+        timelineHint={dashboard.collectionStatusTimelineHint}
         guideItems={[
           {
             label: '采集状态',
-            detail: `展示最近一段时间内该 ${dashboard.objectFallbackName} 实例监控采集是否正常、缺失或异常。`
+            detail: `展示当前选中时间窗内该 ${dashboard.objectFallbackName} 实例监控采集是否正常、缺失或异常。`
           },
           {
             label: '状态时间线',
-            detail: '绿色表示采集成功，灰色表示暂无数据，红色表示采集或查询异常。'
+            detail: '时间线覆盖当前时间窗并均分为 18 段；绿色表示该段有采集，灰色表示该段无数据，红色表示采集或查询异常。'
           }
         ]}
         styles={styles}

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -25,6 +25,8 @@ import {
   buildMetricItem,
   getCollectionStatus,
   buildCollectionStatusTimeline,
+  formatCollectionStatusTimelineHint,
+  resolveCollectionStatusRange,
   useLoadSequence,
   buildClusterFilterOptions,
   filterInstanceOptionsByCluster,
@@ -359,6 +361,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const [series, setSeries] = useState<Record<string, MetricSeries>>({});
   const [previousSeries, setPreviousSeries] = useState<Record<string, MetricSeries>>({});
   const [collectionStatusMetric, setCollectionStatusMetric] = useState<MetricSeries | null>(null);
+  const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
@@ -498,6 +501,8 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         // 本次刷新冻结一个绝对时间窗,所有序列(含 KPI/采集状态/趋势/对比)复用,
         // 避免每条序列各自现算 now 导致时间戳网格错位、多序列面板 tooltip 只显示一条。
         const frozenTimeValues = freezeTimeValues(timeValues);
+        const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
+        if (frozenRange) setQueryTimeRange(frozenRange);
         const previousTimeValues = buildPreviousPeriodTimeValues(frozenTimeValues);
         const compareMetrics = config.metrics.filter((m) => config.summaryCards.some((c) => c.compare && c.metric === m.name));
 
@@ -599,7 +604,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     setLoading(false);
     // loadMetrics already captures displayMode, idValuesKey, instanceId, timeValues internally.
     // Do NOT add timeValues here to avoid double-trigger infinite loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
   }, [loadMetrics]);
 
   useEffect(() => {
@@ -666,49 +671,49 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
         return !(target?.loadState === 'success' && (!Array.isArray(target.viewData) || target.viewData.length === 0));
       })
       .map((card) => {
-      const hasData = hasMetricData(card.metric);
-      const healthResult = card.formatter === 'enumHealth' && !card.enumMap && hasData
-        ? formatClusterHealth(getLatest(card.metric))
-        : null;
-      const enumResult = card.enumMap && hasData
-        ? formatMappedEnum(getLatest(card.metric), card.enumMap)
-        : null;
+        const hasData = hasMetricData(card.metric);
+        const healthResult = card.formatter === 'enumHealth' && !card.enumMap && hasData
+          ? formatClusterHealth(getLatest(card.metric))
+          : null;
+        const enumResult = card.enumMap && hasData
+          ? formatMappedEnum(getLatest(card.metric), card.enumMap)
+          : null;
 
-      const mainValue = !hasData
-        ? { value: card.emptyValue || '--', unit: '' }
-        : card.formatter === 'duration'
-          ? { value: formatDuration(getLatest(card.metric)), unit: '' }
-          : healthResult
-            ? { value: healthResult.value, unit: healthResult.unit }
-            : enumResult
-              ? { value: enumResult.value, unit: enumResult.unit }
-              : formatMetricValue(getLatest(card.metric), card.unit || metricMap[card.metric]?.unit || 'none');
+        const mainValue = !hasData
+          ? { value: card.emptyValue || '--', unit: '' }
+          : card.formatter === 'duration'
+            ? { value: formatDuration(getLatest(card.metric)), unit: '' }
+            : healthResult
+              ? { value: healthResult.value, unit: healthResult.unit }
+              : enumResult
+                ? { value: enumResult.value, unit: enumResult.unit }
+                : formatMetricValue(getLatest(card.metric), card.unit || metricMap[card.metric]?.unit || 'none');
 
-      const uptimeState = card.isUptimeCard
-        ? !hasData
-          ? { label: '状态未知', tone: 'empty' as const }
-          : countRestartsInRange(metricMap[card.metric]?.viewData || []) > 0
-            ? { label: '期间有重启', tone: 'warning' as const }
-            : { label: '运行正常', tone: 'success' as const }
-        : undefined;
+        const uptimeState = card.isUptimeCard
+          ? !hasData
+            ? { label: '状态未知', tone: 'empty' as const }
+            : countRestartsInRange(metricMap[card.metric]?.viewData || []) > 0
+              ? { label: '期间有重启', tone: 'warning' as const }
+              : { label: '运行正常', tone: 'success' as const }
+          : undefined;
 
-      // 枚举卡失配时趋势线无语义（连续浮点冒充 0/1），清空避免误导。
-      const enumUnresolved = Boolean(card.enumMap && hasData && enumResult?.value === '未知');
+        // 枚举卡失配时趋势线无语义（连续浮点冒充 0/1），清空避免误导。
+        const enumUnresolved = Boolean(card.enumMap && hasData && enumResult?.value === '未知');
 
-      return {
-        card: enumUnresolved ? { ...card, hideTrend: true } : card,
-        mainValue,
-        valueColor: enumResult?.color || healthResult?.color || (!hasData && card.emptyValue ? '#8c95a8' : undefined),
-        // 无数据时 getLatest 会退化成 0，若仍算环比会误显示「较上一周期 0.0%」。
-        compare: card.compare && hasData
-          ? getPeriodCompare(getLatest(card.metric), getLatestChartValue(previousMetricMap[card.metric]?.viewData || []))
-          : null,
-        footerItems: (card.footer || []).map((field) => ({ label: field.label, value: formatField(field) })),
-        trendData: enumUnresolved ? [] : (metricMap[card.metric]?.viewData || []),
-        noDataType: getNoDataType(card.metric),
-        uptimeState
-      };
-    })
+        return {
+          card: enumUnresolved ? { ...card, hideTrend: true } : card,
+          mainValue,
+          valueColor: enumResult?.color || healthResult?.color || (!hasData && card.emptyValue ? '#8c95a8' : undefined),
+          // 无数据时 getLatest 会退化成 0，若仍算环比会误显示「较上一周期 0.0%」。
+          compare: card.compare && hasData
+            ? getPeriodCompare(getLatest(card.metric), getLatestChartValue(previousMetricMap[card.metric]?.viewData || []))
+            : null,
+          footerItems: (card.footer || []).map((field) => ({ label: field.label, value: formatField(field) })),
+          trendData: enumUnresolved ? [] : (metricMap[card.metric]?.viewData || []),
+          noDataType: getNoDataType(card.metric),
+          uptimeState
+        };
+      })
   ), [config.summaryCards, formatField, getLatest, getNoDataType, hasMetricData, metricMap, previousMetricMap]);
 
   const chartPanels = useMemo<PreparedChartPanel[]>(() => (
@@ -855,7 +860,16 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   ), [config.details, formatField, metricMap, getLatest, hasMetricData]);
 
   const collectionStatus = getCollectionStatus(collectionStatusMetric, config.objectFallbackName);
-  const collectionStatusTimeline = buildCollectionStatusTimeline(collectionStatusMetric?.loadState, collectionStatusMetric?.viewData);
+  const activeTimeRange = queryTimeRange ?? resolveCollectionStatusRange(timeValues);
+  const collectionStatusTimeline = buildCollectionStatusTimeline(
+    collectionStatusMetric?.loadState,
+    collectionStatusMetric?.viewData,
+    activeTimeRange?.startMs ?? Date.now() - 15 * 60_000,
+    activeTimeRange?.endMs ?? Date.now()
+  );
+  const collectionStatusTimelineHint = activeTimeRange
+    ? formatCollectionStatusTimelineHint(activeTimeRange.startMs, activeTimeRange.endMs)
+    : undefined;
   const pageTitle = displayMode === 'metrics' ? `${objectDisplayText} 全量指标` : config.pageTitle;
   // 标题头 meta-metric chips:有数据则「label: 值」放对象名后,无数据自动跳过(通用能力)。
   const metaMetricChips = (config.metaMetrics || [])
@@ -911,6 +925,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     idValues,
     collectionStatus,
     collectionStatusTimeline,
+    collectionStatusTimelineHint,
     objectMetaItems,
     objectFallbackName: config.objectFallbackName,
     instanceSelectValue,

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.module.scss
@@ -618,7 +618,18 @@
   font-weight: 700;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
+
+.collectionStatusTimelineHint {
+  flex-shrink: 0;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 
 .collectionStatusTimelineBlock {
   margin-top: 0;
@@ -635,11 +646,14 @@
 }
 
 .collectionStatusSegment {
+  display: block;
   min-width: 0;
+  width: 100%;
   height: 22px;
   border-radius: 4px;
   border: 1px solid transparent;
   background: #d7dfeb;
+  cursor: default;
 }
 
 .collectionStatusSegmentSuccess {

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard.tsx
@@ -55,6 +55,7 @@ export default function SimpleDashboard({ config }: { config: SimpleDashboardCon
     idValues,
     collectionStatus,
     collectionStatusTimeline,
+    collectionStatusTimelineHint,
     objectMetaItems,
     instanceSelectValue,
     instanceLoading,
@@ -115,9 +116,10 @@ export default function SimpleDashboard({ config }: { config: SimpleDashboardCon
                 <CollectionStatusCard
                   status={collectionStatus}
                   timeline={collectionStatusTimeline}
+                  timelineHint={collectionStatusTimelineHint}
                   guideItems={[
-                    { label: '采集状态', detail: `展示最近一段时间内该 ${config.objectFallbackName} 实例监控采集是否正常、缺失或异常。` },
-                    { label: '状态时间线', detail: '绿色表示采集成功，灰色表示暂无数据，红色表示采集或查询异常。' }
+                    { label: '采集状态', detail: `展示当前选中时间窗内该 ${config.objectFallbackName} 实例监控采集是否正常、缺失或异常。` },
+                    { label: '状态时间线', detail: '时间线覆盖当前时间窗并均分为 18 段；绿色表示该段有采集，灰色表示该段无数据，红色表示采集或查询异常。' }
                   ]}
                   styles={styles}
                 />

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -16,6 +16,9 @@ import {
   mergeChartSeries,
   getCollectionStatus,
   buildCollectionStatusTimeline,
+  formatCollectionStatusTimelineHint,
+  resolveCollectionStatusRange,
+  freezeTimeValues,
   buildInstanceDisplayName,
   buildInstanceSearchTokens,
   normalizeDisplayText,
@@ -141,6 +144,7 @@ export default function K3sClusterDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [raw, setRaw] = useState<RawMap>({});
   const [previousRaw, setPreviousRaw] = useState<RawMap>({});
+  const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
@@ -215,15 +219,18 @@ export default function K3sClusterDashboardPage() {
   const loadAll = async (silent = false) => {
     const seq = loadSequence.begin();
     if (!silent) setLoading(true);
-    const heroResults = await runGroup(QUERY_GROUPS.hero, timeValues);
+    const frozenTimeValues = freezeTimeValues(timeValues);
+    const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
+    if (frozenRange) setQueryTimeRange(frozenRange);
+    const heroResults = await runGroup(QUERY_GROUPS.hero, frozenTimeValues);
     if (!loadSequence.isCurrent(seq)) return;
     setRaw((prev) => (silent ? { ...prev, ...Object.fromEntries(heroResults) } : Object.fromEntries(heroResults)));
     if (!silent) setLoading(false);
-    runGroup(QUERY_GROUPS.panels, timeValues).then((panelResults) => {
+    runGroup(QUERY_GROUPS.panels, frozenTimeValues).then((panelResults) => {
       if (loadSequence.isCurrent(seq)) setRaw((prev) => ({ ...prev, ...Object.fromEntries(panelResults) }));
     });
     // KPI 卡「较上一周期」对比:取上一周期同样窗口的计数。
-    const prevTv = buildPreviousPeriodTimeValues(timeValues);
+    const prevTv = buildPreviousPeriodTimeValues(frozenTimeValues);
     runGroup(KPI_COMPARE_KEYS, prevTv).then((prevResults) => {
       if (loadSequence.isCurrent(seq)) setPreviousRaw(Object.fromEntries(prevResults));
     });
@@ -289,7 +296,16 @@ export default function K3sClusterDashboardPage() {
     );
   }, [raw.collection, instanceId, resolvedInstanceName, idValues, instanceIdKeys]);
   const collectionStatus = getCollectionStatus(collectionMetric, objectFallbackName);
-  const collectionTimeline = buildCollectionStatusTimeline(collectionMetric.loadState, collectionMetric.viewData);
+  const collectionStatusRange = queryTimeRange ?? resolveCollectionStatusRange(timeValues);
+  const collectionTimeline = buildCollectionStatusTimeline(
+    collectionMetric.loadState,
+    collectionMetric.viewData,
+    collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
+    collectionStatusRange?.endMs ?? Date.now()
+  );
+  const collectionStatusTimelineHint = collectionStatusRange
+    ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)
+    : undefined;
 
   // 趋势数据
   const trend = useMemo(() => {
@@ -529,7 +545,8 @@ export default function K3sClusterDashboardPage() {
                 <CollectionStatusCard
                   status={collectionStatus}
                   timeline={collectionTimeline}
-                  guideItems={guide('采集状态', '集群监控采集是否正常。')}
+                  timelineHint={collectionStatusTimelineHint}
+                  guideItems={guide('采集状态', '集群监控采集是否正常。时间线覆盖当前时间窗并均分为 18 段；绿=该段有采集，灰=该段无数据，红=查询异常。')}
                   className={styles.span2}
                   styles={styles}
                 />

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -16,6 +16,9 @@ import {
   mergeChartSeries,
   getCollectionStatus,
   buildCollectionStatusTimeline,
+  formatCollectionStatusTimelineHint,
+  resolveCollectionStatusRange,
+  freezeTimeValues,
   buildInstanceDisplayName,
   buildInstanceSearchTokens,
   normalizeDisplayText,
@@ -141,6 +144,7 @@ export default function K8sClusterDashboardPage() {
   const [loading, setLoading] = useState(true);
   const [raw, setRaw] = useState<RawMap>({});
   const [previousRaw, setPreviousRaw] = useState<RawMap>({});
+  const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
@@ -215,15 +219,18 @@ export default function K8sClusterDashboardPage() {
   const loadAll = async (silent = false) => {
     const seq = loadSequence.begin();
     if (!silent) setLoading(true);
-    const heroResults = await runGroup(QUERY_GROUPS.hero, timeValues);
+    const frozenTimeValues = freezeTimeValues(timeValues);
+    const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
+    if (frozenRange) setQueryTimeRange(frozenRange);
+    const heroResults = await runGroup(QUERY_GROUPS.hero, frozenTimeValues);
     if (!loadSequence.isCurrent(seq)) return;
     setRaw((prev) => (silent ? { ...prev, ...Object.fromEntries(heroResults) } : Object.fromEntries(heroResults)));
     if (!silent) setLoading(false);
-    runGroup(QUERY_GROUPS.panels, timeValues).then((panelResults) => {
+    runGroup(QUERY_GROUPS.panels, frozenTimeValues).then((panelResults) => {
       if (loadSequence.isCurrent(seq)) setRaw((prev) => ({ ...prev, ...Object.fromEntries(panelResults) }));
     });
     // KPI 卡「较上一周期」对比:取上一周期同样窗口的计数。
-    const prevTv = buildPreviousPeriodTimeValues(timeValues);
+    const prevTv = buildPreviousPeriodTimeValues(frozenTimeValues);
     runGroup(KPI_COMPARE_KEYS, prevTv).then((prevResults) => {
       if (loadSequence.isCurrent(seq)) setPreviousRaw(Object.fromEntries(prevResults));
     });
@@ -289,7 +296,16 @@ export default function K8sClusterDashboardPage() {
     );
   }, [raw.collection, instanceId, resolvedInstanceName, idValues, instanceIdKeys]);
   const collectionStatus = getCollectionStatus(collectionMetric, objectFallbackName);
-  const collectionTimeline = buildCollectionStatusTimeline(collectionMetric.loadState, collectionMetric.viewData);
+  const collectionStatusRange = queryTimeRange ?? resolveCollectionStatusRange(timeValues);
+  const collectionTimeline = buildCollectionStatusTimeline(
+    collectionMetric.loadState,
+    collectionMetric.viewData,
+    collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
+    collectionStatusRange?.endMs ?? Date.now()
+  );
+  const collectionStatusTimelineHint = collectionStatusRange
+    ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)
+    : undefined;
 
   // 趋势数据
   const trend = useMemo(() => {
@@ -529,7 +545,8 @@ export default function K8sClusterDashboardPage() {
                 <CollectionStatusCard
                   status={collectionStatus}
                   timeline={collectionTimeline}
-                  guideItems={guide('采集状态', '集群监控采集是否正常。')}
+                  timelineHint={collectionStatusTimelineHint}
+                  guideItems={guide('采集状态', '集群监控采集是否正常。时间线覆盖当前时间窗并均分为 18 段；绿=该段有采集，灰=该段无数据，红=查询异常。')}
                   className={styles.span2}
                   styles={styles}
                 />

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -33,6 +33,9 @@ import {
   buildInstanceSearchTokens,
   parseLegacyParamList,
   buildCollectionStatusTimeline,
+  formatCollectionStatusTimelineHint,
+  resolveCollectionStatusRange,
+  freezeTimeValues,
   toMetricSeries,
   buildMetricItem,
   mergeChartSeries,
@@ -136,6 +139,7 @@ export default function MongoDashboardPage() {
   const [series, setSeries] = useState<Record<string, MetricSeries>>({});
   const [previousSeries, setPreviousSeries] = useState<Record<string, MetricSeries>>({});
   const [collectionStatusMetric, setCollectionStatusMetric] = useState<MetricSeries | null>(null);
+  const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
@@ -224,7 +228,7 @@ export default function MongoDashboardPage() {
   const instanceSelectValue =
     currentInstanceOption?.value || (hasReadableInstanceName && instanceId ? String(instanceId) : undefined);
 
-  const loadMetricGroup = async (metricNames: readonly string[]) => {
+  const loadMetricGroup = async (metricNames: readonly string[], targetTimeValues: TimeValuesProps = timeValues) => {
     const metrics = metricNames
       .map((name) => DASHBOARD_METRICS.find((m) => m.name === name))
       .filter((m): m is MongoMetricConfig => Boolean(m));
@@ -232,7 +236,7 @@ export default function MongoDashboardPage() {
       metrics,
       METRIC_QUERY_CONCURRENCY,
       async (metric) =>
-        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
+        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval))
           .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
           .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
     );
@@ -244,15 +248,18 @@ export default function MongoDashboardPage() {
     if (!silent) setLoading(true);
     try {
       if (isDashboardMode) {
-        const previousTimeValues = buildPreviousPeriodTimeValues(timeValues);
+        const frozenTimeValues = freezeTimeValues(timeValues);
+        const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
+        if (frozenRange) setQueryTimeRange(frozenRange);
+        const previousTimeValues = buildPreviousPeriodTimeValues(frozenTimeValues);
         const compareMetrics = DASHBOARD_METRICS.filter((metric) =>
           ['mongodb_connections_current'].includes(metric.name)
         );
 
-        const summaryResultsPromise = loadMetricGroup(MONGODB_METRIC_GROUPS[0].names);
+        const summaryResultsPromise = loadMetricGroup(MONGODB_METRIC_GROUPS[0].names, frozenTimeValues);
 
         const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(
-          buildSearchParams(MONGODB_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval)
+          buildSearchParams(MONGODB_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval)
         )
           .then((result) =>
             toMetricSeries<MongoMetricConfig>(
@@ -318,7 +325,7 @@ export default function MongoDashboardPage() {
         if (!silent) setLoading(false);
 
         MONGODB_METRIC_GROUPS.slice(1).forEach((group) => {
-          loadMetricGroup(group.names).then((results) => {
+          loadMetricGroup(group.names, frozenTimeValues).then((results) => {
             if (!loadSequence.isCurrent(loadSeq)) return;
             setSeries((prev) => ({ ...prev, ...Object.fromEntries(results) }));
           });
@@ -394,7 +401,16 @@ export default function MongoDashboardPage() {
   const userAssert = getLatest('mongodb_assert_user');
 
   const collectionStatus = getCollectionStatus(collectionStatusMetric, 'MongoDB');
-  const collectionStatusTimeline = buildCollectionStatusTimeline(collectionStatusMetric?.loadState, collectionStatusMetric?.viewData);
+  const collectionStatusRange = queryTimeRange ?? resolveCollectionStatusRange(timeValues);
+  const collectionStatusTimeline = buildCollectionStatusTimeline(
+    collectionStatusMetric?.loadState,
+    collectionStatusMetric?.viewData,
+    collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
+    collectionStatusRange?.endMs ?? Date.now()
+  );
+  const collectionStatusTimelineHint = collectionStatusRange
+    ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)
+    : undefined;
 
   const connectionsDisplay = formatMetricValue(currentConnections, 'counts');
   const commandsDisplay = formatMetricValue(commandsRate, 'cps');
@@ -618,7 +634,12 @@ export default function MongoDashboardPage() {
               {/* 分区 1 · 健康概览：采集状态 + 关键 KPI */}
               <div className={styles.sectionLabel}>健康概览</div>
               <div className={styles.primaryGrid}>
-                <CollectionStatusCard styles={styles} status={collectionStatus} timeline={collectionStatusTimeline} />
+                <CollectionStatusCard
+                  styles={styles}
+                  status={collectionStatus}
+                  timeline={collectionStatusTimeline}
+                  timelineHint={collectionStatusTimelineHint}
+                />
                 <StatCard
                   styles={styles}
                   title={<TitleWithGuide styles={styles} title="运行时长" items={[{ label: '运行时长', detail: 'MongoDB 实例自上次启动后的持续运行时间，反映服务稳定性；期间发生重启会重新计时。' }]} className={styles.statTitleWithGuide} />}

--- a/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mongodb/index.module.scss
@@ -538,7 +538,18 @@
   font-weight: 700;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
+
+.collectionStatusTimelineHint {
+  flex-shrink: 0;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 
 .collectionStatusTimeline {
   display: grid;
@@ -548,10 +559,13 @@
 }
 
 .collectionStatusSegment {
+  display: block;
   min-width: 0;
+  width: 100%;
   height: 22px;
   border-radius: 4px;
   border: 1px solid transparent;
+  cursor: default;
 }
 
 .collectionStatusSegmentSuccess {

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -38,6 +38,9 @@ import {
   buildInstanceSearchTokens,
   parseLegacyParamList,
   buildCollectionStatusTimeline,
+  formatCollectionStatusTimelineHint,
+  resolveCollectionStatusRange,
+  freezeTimeValues,
   toMetricSeries,
   buildMetricItem,
   mergeChartSeries,
@@ -284,6 +287,7 @@ export default function MysqlDashboardPage() {
   const [series, setSeries] = useState<Record<string, MetricSeries>>({});
   const [previousSeries, setPreviousSeries] = useState<Record<string, MetricSeries>>({});
   const [collectionStatusMetric, setCollectionStatusMetric] = useState<MetricSeries | null>(null);
+  const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<MysqlInstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
@@ -406,13 +410,16 @@ export default function MysqlDashboardPage() {
 
     try {
       if (isDashboardMode) {
-        const previousTimeValues = buildPreviousPeriodTimeValues(timeValues);
+        const frozenTimeValues = freezeTimeValues(timeValues);
+        const frozenRange = resolveCollectionStatusRange(frozenTimeValues);
+        if (frozenRange) setQueryTimeRange(frozenRange);
+        const previousTimeValues = buildPreviousPeriodTimeValues(frozenTimeValues);
         const compareMetrics = MYSQL_COMPARE_METRICS.map((name) => MYSQL_METRIC_CONFIG_BY_NAME.get(name)).filter(
           (metric): metric is MysqlMetricConfig => Boolean(metric)
         );
-        const summaryResultsPromise = loadMetricGroup(MYSQL_METRIC_GROUPS[0].names, timeValues);
+        const summaryResultsPromise = loadMetricGroup(MYSQL_METRIC_GROUPS[0].names, frozenTimeValues);
 
-        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, timeValues, RAW_VALUE_METRICS, undefined, currentInstanceInterval))
+        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, RAW_VALUE_METRICS, undefined, currentInstanceInterval))
           .then((result) =>
             toMetricSeries(
               {
@@ -483,7 +490,7 @@ export default function MysqlDashboardPage() {
         }
 
         MYSQL_METRIC_GROUPS.slice(1).forEach((group) => {
-          loadMetricGroup(group.names, timeValues).then((results) => {
+          loadMetricGroup(group.names, frozenTimeValues).then((results) => {
             if (!loadSequence.isCurrent(loadSeq)) {
               return;
             }
@@ -593,7 +600,16 @@ export default function MysqlDashboardPage() {
   const logSlaveUpdatesValue = getLatest('mysql_variables_log_slave_updates');
   const statusInfo = getCollectionStatus(collectionStatusMetric);
   const metricEmptyText = statusInfo.label === '异常' ? '查询失败' : '暂无采集数据';
-  const collectionStatusTimeline = buildCollectionStatusTimeline(collectionStatusMetric?.loadState, collectionStatusMetric?.viewData);
+  const collectionStatusRange = queryTimeRange ?? resolveCollectionStatusRange(timeValues);
+  const collectionStatusTimeline = buildCollectionStatusTimeline(
+    collectionStatusMetric?.loadState,
+    collectionStatusMetric?.viewData,
+    collectionStatusRange?.startMs ?? Date.now() - 15 * 60_000,
+    collectionStatusRange?.endMs ?? Date.now()
+  );
+  const collectionStatusTimelineHint = collectionStatusRange
+    ? formatCollectionStatusTimelineHint(collectionStatusRange.startMs, collectionStatusRange.endMs)
+    : undefined;
   const qpsDisplay = formatMetricValue(qpsValue, 'cps');
   const connDisplay = formatMetricValue(connValue, 'percent');
   const slowDisplay = formatMetricValue(slowValue, 'cps');
@@ -1001,6 +1017,7 @@ export default function MysqlDashboardPage() {
                       styles={styles}
                       status={statusInfo}
                       timeline={collectionStatusTimeline}
+                      timelineHint={collectionStatusTimelineHint}
                     />
                     <StatCard
                       styles={styles}

--- a/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
+++ b/web/src/app/monitor/dashboards/objects/mysql/index.module.scss
@@ -545,7 +545,18 @@
   font-weight: 700;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
+
+.collectionStatusTimelineHint {
+  flex-shrink: 0;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
 
 .collectionStatusTimeline {
   display: grid;
@@ -555,10 +566,13 @@
 }
 
 .collectionStatusSegment {
+  display: block;
   min-width: 0;
+  width: 100%;
   height: 22px;
   border-radius: 4px;
   border: 1px solid transparent;
+  cursor: default;
 }
 
 .collectionStatusSegmentSuccess {

--- a/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
@@ -20,6 +20,23 @@ const COLLECTION_STATUS_TONE_LABEL: Record<CollectionStatusTone, string> = {
 /** Prometheus/VM 点时间通常是秒；时间窗用毫秒。 */
 const toTimestampMs = (value: number): number => (value < 1e12 ? value * 1000 : value);
 
+/**
+ * 采样间隔常大于桶宽（如默认 15m / 18 格 ≈ 50s，而 scrape/step 多为 60s），
+ * 仅按「点落在桶内」会出现周期性假灰。用相邻成功点的中位间隔作为覆盖半径。
+ */
+const estimateSampleCoverageMs = (successTimes: number[], bucketWidth: number): number => {
+  if (successTimes.length < 2) return bucketWidth;
+  const gaps: number[] = [];
+  for (let i = 1; i < successTimes.length; i += 1) {
+    const gap = successTimes[i] - successTimes[i - 1];
+    if (gap > 0) gaps.push(gap);
+  }
+  if (gaps.length === 0) return bucketWidth;
+  gaps.sort((a, b) => a - b);
+  const medianGap = gaps[Math.floor(gaps.length / 2)];
+  return Math.max(bucketWidth, medianGap);
+};
+
 export const getCollectionStatusToneLabel = (tone: CollectionStatusTone): string =>
   COLLECTION_STATUS_TONE_LABEL[tone];
 
@@ -73,12 +90,25 @@ export const buildCollectionStatusTimeline = (
   }
 
   const hits = Array.from({ length: count }, () => false);
+  const successTimes: number[] = [];
   if (Array.isArray(viewData)) {
     for (const point of viewData) {
       if (Number(point.value1 ?? 0) <= 0) continue;
       const pointMs = toTimestampMs(Number(point.time));
       if (!Number.isFinite(pointMs) || pointMs < resolvedStart || pointMs > resolvedEnd) continue;
-      const index = Math.min(count - 1, Math.max(0, Math.floor((pointMs - resolvedStart) / bucketWidth)));
+      successTimes.push(pointMs);
+    }
+  }
+  successTimes.sort((a, b) => a - b);
+  const coverageMs = estimateSampleCoverageMs(successTimes, bucketWidth);
+  const halfCoverage = coverageMs / 2;
+  for (const pointMs of successTimes) {
+    const coverStart = Math.max(resolvedStart, pointMs - halfCoverage);
+    const coverEnd = Math.min(resolvedEnd, pointMs + halfCoverage);
+    if (coverEnd <= coverStart) continue;
+    const startIndex = Math.max(0, Math.floor((coverStart - resolvedStart) / bucketWidth));
+    const endIndex = Math.min(count - 1, Math.floor((coverEnd - Number.EPSILON - resolvedStart) / bucketWidth));
+    for (let index = startIndex; index <= endIndex; index += 1) {
       hits[index] = true;
     }
   }

--- a/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/collection-status.ts
@@ -3,6 +3,38 @@ import { getRecentTimeRange } from '@/app/monitor/utils/common';
 import { CollectionStatusResult } from '../types';
 import { COLLECTION_STATUS_SEGMENT_COUNT } from './constants';
 
+export type CollectionStatusTone = 'success' | 'empty' | 'error';
+
+export interface CollectionStatusTimelineSegment {
+  tone: CollectionStatusTone;
+  startMs: number;
+  endMs: number;
+}
+
+const COLLECTION_STATUS_TONE_LABEL: Record<CollectionStatusTone, string> = {
+  success: '正常',
+  empty: '无数据',
+  error: '异常'
+};
+
+/** Prometheus/VM 点时间通常是秒；时间窗用毫秒。 */
+const toTimestampMs = (value: number): number => (value < 1e12 ? value * 1000 : value);
+
+export const getCollectionStatusToneLabel = (tone: CollectionStatusTone): string =>
+  COLLECTION_STATUS_TONE_LABEL[tone];
+
+export const getLatestCollectionTone = (
+  viewData: ChartData[] | undefined
+): 'success' | 'empty' | undefined => {
+  if (!Array.isArray(viewData) || viewData.length === 0) return undefined;
+  const latest = [...viewData]
+    .sort((a, b) => Number(a.time) - Number(b.time))
+    .at(-1);
+  if (!latest) return undefined;
+  return Number(latest.value1 ?? 0) > 0 ? 'success' : 'empty';
+};
+
+/** @deprecated 仅保留兼容；时间线已改为按时间窗均分桶。 */
 export const getCollectionStatusTones = (
   viewData: ChartData[] | undefined,
   segmentCount = COLLECTION_STATUS_SEGMENT_COUNT
@@ -11,23 +43,47 @@ export const getCollectionStatusTones = (
   return [...viewData]
     .sort((a, b) => Number(a.time) - Number(b.time))
     .slice(-segmentCount)
-    .map((point) => (Number(point.value1 ?? 0) > 0 ? 'success' as const : 'empty' as const));
+    .map((point) => (Number(point.value1 ?? 0) > 0 ? ('success' as const) : ('empty' as const)));
 };
 
 export const buildCollectionStatusTimeline = (
   loadState: string | undefined,
   viewData: ChartData[] | undefined,
+  startMs: number,
+  endMs: number,
   segmentCount = COLLECTION_STATUS_SEGMENT_COUNT
-): Array<'success' | 'empty' | 'error'> => {
+): CollectionStatusTimelineSegment[] => {
+  const safeStart = Number(startMs);
+  const safeEnd = Number(endMs);
+  const count = Math.max(1, Math.floor(segmentCount));
+  const hasValidRange = Number.isFinite(safeStart) && Number.isFinite(safeEnd) && safeEnd > safeStart;
+  const resolvedStart = hasValidRange ? safeStart : Date.now() - 15 * 60_000;
+  const resolvedEnd = hasValidRange ? safeEnd : Date.now();
+  const duration = resolvedEnd - resolvedStart;
+  const bucketWidth = duration / count;
+
+  const makeSegment = (index: number, tone: CollectionStatusTone): CollectionStatusTimelineSegment => {
+    const bucketStart = resolvedStart + index * bucketWidth;
+    const bucketEnd = index === count - 1 ? resolvedEnd : resolvedStart + (index + 1) * bucketWidth;
+    return { tone, startMs: bucketStart, endMs: bucketEnd };
+  };
+
   if (loadState === 'error') {
-    return Array.from({ length: segmentCount }, () => 'error' as const);
+    return Array.from({ length: count }, (_, index) => makeSegment(index, 'error'));
   }
-  const tones = getCollectionStatusTones(viewData, segmentCount);
-  if (tones.length >= segmentCount) return tones;
-  return [
-    ...Array.from({ length: segmentCount - tones.length }, () => 'empty' as const),
-    ...tones
-  ];
+
+  const hits = Array.from({ length: count }, () => false);
+  if (Array.isArray(viewData)) {
+    for (const point of viewData) {
+      if (Number(point.value1 ?? 0) <= 0) continue;
+      const pointMs = toTimestampMs(Number(point.time));
+      if (!Number.isFinite(pointMs) || pointMs < resolvedStart || pointMs > resolvedEnd) continue;
+      const index = Math.min(count - 1, Math.max(0, Math.floor((pointMs - resolvedStart) / bucketWidth)));
+      hits[index] = true;
+    }
+  }
+
+  return hits.map((hasData, index) => makeSegment(index, hasData ? 'success' : 'empty'));
 };
 
 export const getCollectionStatus = (
@@ -44,8 +100,7 @@ export const getCollectionStatus = (
     };
   }
 
-  const tones = getCollectionStatusTones(metric?.viewData);
-  const latestTone = tones.at(-1);
+  const latestTone = getLatestCollectionTone(metric?.viewData);
 
   if (latestTone === 'success') {
     return {
@@ -66,12 +121,48 @@ export const getCollectionStatus = (
   };
 };
 
-export const formatCollectionStatusWindow = (timeValues: TimeValuesProps) => {
-  const [startTime, endTime] = getRecentTimeRange(timeValues);
-  if (!startTime || !endTime) return '最近 15 分钟';
-  const totalMinutes = Math.max(Math.round((endTime - startTime) / 60000), 1);
+export const formatDurationApprox = (durationMs: number): string => {
+  const seconds = Math.max(1, Math.round(durationMs / 1000));
+  if (seconds < 60) return `${seconds} 秒`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} 分钟`;
+  const hours = Math.floor(minutes / 60);
+  const remainMinutes = minutes % 60;
+  return remainMinutes > 0 ? `${hours} 小时 ${remainMinutes} 分钟` : `${hours} 小时`;
+};
+
+export const formatCollectionStatusWindowFromMs = (startMs: number, endMs: number): string => {
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) {
+    return '最近 15 分钟';
+  }
+  const totalMinutes = Math.max(Math.round((endMs - startMs) / 60000), 1);
   if (totalMinutes < 60) return `最近 ${totalMinutes} 分钟`;
   const hours = Math.floor(totalMinutes / 60);
   const minutes = totalMinutes % 60;
   return minutes > 0 ? `最近 ${hours} 小时 ${minutes} 分钟` : `最近 ${hours} 小时`;
+};
+
+export const formatCollectionStatusWindow = (timeValues: TimeValuesProps) => {
+  const [startTime, endTime] = getRecentTimeRange(timeValues);
+  return formatCollectionStatusWindowFromMs(Number(startTime), Number(endTime));
+};
+
+export const formatCollectionStatusTimelineHint = (
+  startMs: number,
+  endMs: number,
+  segmentCount = COLLECTION_STATUS_SEGMENT_COUNT
+): string => {
+  const count = Math.max(1, Math.floor(segmentCount));
+  const segmentMs = Math.max(endMs - startMs, 0) / count;
+  return `每格约 ${formatDurationApprox(segmentMs)}`;
+};
+
+export const resolveCollectionStatusRange = (
+  timeValues: TimeValuesProps
+): { startMs: number; endMs: number } | null => {
+  const [startTime, endTime] = getRecentTimeRange(timeValues);
+  const startMs = Number(startTime);
+  const endMs = Number(endTime);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return null;
+  return { startMs, endMs };
 };

--- a/web/src/app/monitor/dashboards/shared/widgets/collection-status-card.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/collection-status-card.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import React from 'react';
+import { Tooltip } from 'antd';
+import dayjs from 'dayjs';
 import { CollectionStatusResult } from '../types';
 import { COLLECTION_STATUS_LEGEND } from '../utils/constants';
+import {
+  CollectionStatusTimelineSegment,
+  getCollectionStatusToneLabel
+} from '../utils/collection-status';
 import { TitleWithGuide, GuideTooltipStyles } from './guide-tooltip';
 
 export interface CollectionStatusCardStyles extends GuideTooltipStyles {
@@ -18,6 +24,7 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
   collectionStatusValueEmpty?: string;
   collectionStatusTimelineBlock?: string;
   collectionStatusTimelineTitle?: string;
+  collectionStatusTimelineHint?: string;
   collectionStatusTimeline?: string;
   collectionStatusSegment?: string;
   collectionStatusSegmentSuccess?: string;
@@ -30,20 +37,34 @@ export interface CollectionStatusCardStyles extends GuideTooltipStyles {
 
 export interface CollectionStatusCardProps {
   status: CollectionStatusResult;
-  timeline: Array<'success' | 'empty' | 'error'>;
+  timeline: CollectionStatusTimelineSegment[];
+  /** 例如「每格约 50 秒」 */
+  timelineHint?: string;
   guideItems?: Array<{ label: string; detail: string }>;
   /** 作为 grid 子项时传入 span* 等栅格类,使其与相邻 StatCard 等高/等宽对齐。 */
   className?: string;
   styles: CollectionStatusCardStyles;
 }
 
+const DEFAULT_GUIDE_ITEMS = [
+  { label: '采集状态', detail: '展示当前选中时间窗内该实例监控采集是否正常、缺失或异常。' },
+  {
+    label: '状态时间线',
+    detail: '时间线覆盖当前时间窗并均分为 18 段；绿色表示该段有采集，灰色表示该段无数据，红色表示采集或查询异常。'
+  }
+];
+
+const formatSegmentTooltip = (segment: CollectionStatusTimelineSegment): string => {
+  const start = dayjs(segment.startMs).format('HH:mm:ss');
+  const end = dayjs(segment.endMs).format('HH:mm:ss');
+  return `${start} – ${end}\n${getCollectionStatusToneLabel(segment.tone)}`;
+};
+
 export const CollectionStatusCard = ({
   status,
   timeline,
-  guideItems = [
-    { label: '采集状态', detail: '展示最近一段时间内该实例监控采集是否正常、缺失或异常。' },
-    { label: '状态时间线', detail: '绿色表示采集成功，灰色表示暂无数据，红色表示采集或查询异常。' }
-  ],
+  timelineHint,
+  guideItems = DEFAULT_GUIDE_ITEMS,
   className,
   styles
 }: CollectionStatusCardProps) => {
@@ -63,11 +84,21 @@ export const CollectionStatusCard = ({
         <div className={`${styles.collectionStatusValue} ${styles[`collectionStatusValue${status.label === '正常' ? 'Success' : status.label === '异常' ? 'Error' : 'Empty'}`]}`}>
           {status.label}
         </div>
-        <div className={styles.collectionStatusTimelineTitle}>状态时间线</div>
+        <div className={styles.collectionStatusTimelineTitle}>
+          <span>状态时间线</span>
+          {timelineHint ? <span className={styles.collectionStatusTimelineHint}>{timelineHint}</span> : null}
+        </div>
         <div className={styles.collectionStatusTimelineBlock}>
           <div className={styles.collectionStatusTimeline}>
-            {timeline.map((tone, index) => (
-              <span key={`${tone}-${index}`} className={`${styles.collectionStatusSegment} ${styles[`collectionStatusSegment${tone === 'success' ? 'Success' : tone === 'error' ? 'Error' : 'Empty'}`]}`} />
+            {timeline.map((segment, index) => (
+              <Tooltip
+                key={`${segment.tone}-${segment.startMs}-${index}`}
+                title={<span style={{ whiteSpace: 'pre-line' }}>{formatSegmentTooltip(segment)}</span>}
+              >
+                <span
+                  className={`${styles.collectionStatusSegment} ${styles[`collectionStatusSegment${segment.tone === 'success' ? 'Success' : segment.tone === 'error' ? 'Error' : 'Empty'}`]}`}
+                />
+              </Tooltip>
             ))}
           </div>
           <div className={styles.collectionStatusLegend}>

--- a/web/src/app/monitor/dashboards/shared/widgets/index.ts
+++ b/web/src/app/monitor/dashboards/shared/widgets/index.ts
@@ -8,7 +8,14 @@ export { StatCard } from './stat-card';
 export type { StatCardProps, StatCardStyles } from './stat-card';
 
 export { CollectionStatusCard } from './collection-status-card';
-export type { CollectionStatusCardProps, CollectionStatusCardStyles } from './collection-status-card';
+export type {
+  CollectionStatusCardProps,
+  CollectionStatusCardStyles
+} from './collection-status-card';
+export type {
+  CollectionStatusTimelineSegment,
+  CollectionStatusTone
+} from '../utils/collection-status';
 
 export { RingChartPanel } from './ring-chart-panel';
 export type { RingChartPanelProps, RingChartPanelStyles, RingChartDataItem, RingChartInfoRow } from './ring-chart-panel';

--- a/web/src/stories/monitor-dashboard-widgets-family.stories.tsx
+++ b/web/src/stories/monitor-dashboard-widgets-family.stories.tsx
@@ -27,6 +27,8 @@ import {
   TrendChartPanel,
   UnackedIcon,
   type CollectionStatusCardStyles,
+  type CollectionStatusTimelineSegment,
+  type CollectionStatusTone,
   type DashboardPageHeaderStyles,
   type DashboardPanelStyles,
   type DashboardInstanceCardStyles,
@@ -198,9 +200,10 @@ const collectionStatusStyles: CollectionStatusCardStyles = {
   collectionStatusTimelineBlock:
     'rounded-[14px] bg-[var(--color-fill-1)] px-4 py-3',
   collectionStatusTimelineTitle:
-    'mb-2 text-[12px] font-medium text-[var(--color-text-3)]',
+    'mb-2 flex items-center justify-between gap-2 text-[12px] font-medium text-[var(--color-text-3)]',
+  collectionStatusTimelineHint: 'shrink-0 text-[11px] font-normal text-[var(--color-text-4)]',
   collectionStatusTimeline: 'mb-3 flex gap-1.5',
-  collectionStatusSegment: 'h-2 flex-1 rounded-full',
+  collectionStatusSegment: 'block h-2 w-full flex-1 cursor-default rounded-full',
   collectionStatusSegmentSuccess: 'bg-[var(--color-success)]',
   collectionStatusSegmentWarning: 'bg-[#f59e0b]',
   collectionStatusSegmentError: 'bg-[#f04438]',
@@ -479,10 +482,23 @@ const collectionStatusGuideItems = [
   },
   {
     label: '状态时间线',
-    detail: '绿色表示正常，橙色表示警告，红色表示严重。',
+    detail: '时间线覆盖当前时间窗并均分为若干段；绿色表示正常，橙色表示警告，红色表示严重。',
   },
 ];
 
+const buildDemoTimeline = (
+  tones: CollectionStatusTone[],
+  windowMinutes = 15
+): CollectionStatusTimelineSegment[] => {
+  const endMs = Date.now();
+  const startMs = endMs - windowMinutes * 60_000;
+  const width = (endMs - startMs) / tones.length;
+  return tones.map((tone, index) => ({
+    tone,
+    startMs: startMs + index * width,
+    endMs: index === tones.length - 1 ? endMs : startMs + (index + 1) * width,
+  }));
+};
 const metricIconItems = [
   { label: 'Health', color: '#16a34a', icon: <HealthIcon /> },
   { label: 'Memory', color: '#2563eb', icon: <MemoryIcon /> },
@@ -701,7 +717,8 @@ const FamilyOverview = () => {
               summary: '采集稳定',
               tagColor: 'success',
             }}
-            timeline={[
+            timelineHint="每格约 75 秒"
+            timeline={buildDemoTimeline([
               'success',
               'success',
               'success',
@@ -714,7 +731,7 @@ const FamilyOverview = () => {
               'success',
               'success',
               'success',
-            ]}
+            ])}
           />
 
           <CollectionStatusCard
@@ -725,7 +742,8 @@ const FamilyOverview = () => {
               summary: '连续缺口',
               tagColor: 'error',
             }}
-            timeline={[
+            timelineHint="每格约 75 秒"
+            timeline={buildDemoTimeline([
               'success',
               'success',
               'error',
@@ -738,7 +756,7 @@ const FamilyOverview = () => {
               'success',
               'error',
               'error',
-            ]}
+            ])}
           />
 
           <CollectionStatusCard
@@ -748,7 +766,8 @@ const FamilyOverview = () => {
               detail: '该实例尚未返回最近时间窗内的指标数据。',
               summary: '等待首次采集',
             }}
-            timeline={Array.from({ length: 12 }, () => 'empty' as const)}
+            timelineHint="每格约 75 秒"
+            timeline={buildDemoTimeline(Array.from({ length: 12 }, () => 'empty' as const))}
           />
 
           <CollectionStatusCard
@@ -762,7 +781,8 @@ const FamilyOverview = () => {
             }}
             statusTone="warning"
             guideItems={collectionStatusGuideItems}
-            timeline={[
+            timelineHint="每格约 75 秒"
+            timeline={buildDemoTimeline([
               'success',
               'success',
               'warning',
@@ -775,7 +795,7 @@ const FamilyOverview = () => {
               'warning',
               'success',
               'success',
-            ]}
+            ])}
             legendItems={[
               { key: 'success', label: '正常', color: '#22c55e' },
               { key: 'warning', label: '警告', color: '#f59e0b' },


### PR DESCRIPTION
## Summary
- 将「采集状态」时间线从最近 18 个采样点改为覆盖当前仪表盘时间窗的 18 等分桶，灰/绿对应该时间片内是否有有效采集。
- 时间线旁展示「每格约 X」时长说明，每格悬停显示起止时间与状态。
- 查询与时间线共用冻结时间窗（含 simple-dashboard / MySQL / MongoDB / K8s / K3s），避免相对时间窗下与 KPI 漂移。

## Test plan
- [ ] 默认最近 15 分钟：提示为「每格约 50 秒」，悬停时间段连续覆盖整窗
- [ ] 有采集数据时末段多为绿；窗内真实空档为灰（不再因点数不足整片左灰）
- [ ] 查询失败时全红且大字为「异常」
- [ ] 切换到更大时间窗（如 1h / 12h）时「每格约 …」同步变化
- [ ] 核对提交范围：仅采集状态时间线相关文件，未包含 Kafka / icons / 本地 tsconfig