### PR TITLE
fix(监控): 恢复网站拨测等非 IF-MIB 高级配置面板

### DIFF
--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -276,49 +276,56 @@ export const usePluginFromJson = () => {
           {basicFields.map((fieldConfig: any) =>
             renderFormField(fieldConfig, extra.mode)
           )}
-          {advancedFields.length > 0 && (
-            <Form.Item
-              noStyle
-              shouldUpdate={
-                isInterfaceFilterAdvanced
-                  ? (previousValues, currentValues) =>
-                    previousValues.enable_ifmib !== currentValues.enable_ifmib
-                  : false
-              }
-            >
-              {({ getFieldValue }) =>
-                // 未初始化时沿用 enable_ifmib 默认 true；只有明确关闭才隐藏整个区域。
-                !shouldRenderAdvancedFieldsPanel(
-                  isInterfaceFilterAdvanced,
-                  getFieldValue('enable_ifmib')
-                ) ? null : (
-            <Collapse
-              bordered={false}
-              ghost
-              className="mb-4 max-w-[720px] bg-transparent [&_.ant-collapse-header]:!items-center [&_.ant-collapse-header]:!px-0 [&_.ant-collapse-expand-icon]:!me-2 [&_.ant-collapse-content-box]:!px-0 [&_.ant-collapse-content-box]:!pb-1 [&_.ant-collapse-content-box]:!pt-3"
-              expandIconPosition="start"
-              items={[{
-                key: 'advanced-options',
-                label: (
-                  <div>
-                    <div className="text-[13px] font-medium leading-5 text-[var(--color-text-1)]">
-                      {advancedTitle}
-                    </div>
-                    {advancedHint ? (
-                      <div className="mt-0.5 text-[12px] font-normal leading-[18px] text-[var(--color-text-3)]">
-                        {advancedHint}
+          {advancedFields.length > 0 && (() => {
+            // Ant Design：函数子节点的 Form.Item 必须带 truthy 的 shouldUpdate/dependencies，
+            // 否则子节点不会渲染。网站拨测等非 IF-MIB 面板不能写 shouldUpdate={false}。
+            const advancedCollapse = (
+              <Collapse
+                bordered={false}
+                ghost
+                className="mb-4 max-w-[720px] bg-transparent [&_.ant-collapse-header]:!items-center [&_.ant-collapse-header]:!px-0 [&_.ant-collapse-expand-icon]:!me-2 [&_.ant-collapse-content-box]:!px-0 [&_.ant-collapse-content-box]:!pb-1 [&_.ant-collapse-content-box]:!pt-3"
+                expandIconPosition="start"
+                items={[{
+                  key: 'advanced-options',
+                  label: (
+                    <div>
+                      <div className="text-[13px] font-medium leading-5 text-[var(--color-text-1)]">
+                        {advancedTitle}
                       </div>
-                    ) : null}
-                  </div>
-                ),
-                forceRender: true,
-                children: renderAdvancedFieldGroups(advancedFields),
-              }]}
-            />
-                )
-              }
-            </Form.Item>
-          )}
+                      {advancedHint ? (
+                        <div className="mt-0.5 text-[12px] font-normal leading-[18px] text-[var(--color-text-3)]">
+                          {advancedHint}
+                        </div>
+                      ) : null}
+                    </div>
+                  ),
+                  forceRender: true,
+                  children: renderAdvancedFieldGroups(advancedFields),
+                }]}
+              />
+            );
+            if (!isInterfaceFilterAdvanced) {
+              return advancedCollapse;
+            }
+            return (
+              <Form.Item
+                noStyle
+                shouldUpdate={(previousValues, currentValues) =>
+                  previousValues.enable_ifmib !== currentValues.enable_ifmib
+                }
+              >
+                {({ getFieldValue }) =>
+                  // 未初始化时沿用 enable_ifmib 默认 true；只有明确关闭才隐藏整个区域。
+                  !shouldRenderAdvancedFieldsPanel(
+                    isInterfaceFilterAdvanced,
+                    getFieldValue('enable_ifmib')
+                  )
+                    ? null
+                    : advancedCollapse
+                }
+              </Form.Item>
+            );
+          })()}
         </>
       );
 


### PR DESCRIPTION
## Summary
- 修复 Ant Design `Form.Item` 在 `shouldUpdate={false}` 时不渲染函数子节点，导致网站拨测「高级配置」整块消失的问题
- 非 IF-MIB 插件改为直接渲染高级配置 Collapse；IF-MIB 仍按 `enable_ifmib` 显隐
- 已核对提交范围：仅包含 `usePluginFromJson.tsx`；本地无关 icons / 其他 WIP 未纳入

## Test plan
- [ ] 打开网站拨测接入配置页，确认「请求方式」下方出现可折叠「高级配置」
- [ ] 展开后可见请求参数/请求头、认证、期望状态码等高级字段
- [ ] SNMP 带 IF-MIB 过滤的插件：关闭接口表后高级过滤区仍正确隐藏，开启后可见