### PR TITLE
fix(监控): SNMP 接口过滤仅对 IF-MIB 能力插件生效

### DIFF
--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -139,16 +139,26 @@ class Command(BaseCommand):
 
         # 厂商实例 collect_type 为 snmp_cisco / snmp_h3c 等；精确匹配 "snmp" 会漏补。
         # 同时仅对 IF-MIB 过滤能力插件补齐，避免 hardware_server 被写入默认 tagdrop。
-        config_ids = [
-            config.id
-            for config in CollectConfig.objects.filter(
-                collect_type__startswith="snmp",
-                is_child=True,
-            ).select_related("monitor_plugin")
-            if is_patchable_snmp_child_config(config)
-        ]
+        # 按 plugin_id 缓存能力判定：_is_network_device_snmp_plugin 含 exists()/manifest I/O，
+        # 不可对每行 CollectConfig 重复调用（management 命令也会踩 N+1）。
+        capable_by_plugin_id: dict[int | None, bool] = {}
+        config_ids: list = []
+        for config in CollectConfig.objects.filter(
+            collect_type__startswith="snmp",
+            is_child=True,
+        ).select_related("monitor_plugin"):
+            plugin = getattr(config, "monitor_plugin", None)
+            plugin_id = getattr(plugin, "pk", None)
+            if plugin_id not in capable_by_plugin_id:
+                capable_by_plugin_id[plugin_id] = is_interface_filter_capable_plugin(plugin)
+            if is_patchable_snmp_child_config(
+                config, capable=capable_by_plugin_id[plugin_id]
+            ):
+                config_ids.append(config.id)
         if not config_ids:
-            self.stdout.write("No SNMP child configs found / 未发现 SNMP 子配置")
+            self.stdout.write(
+                "No IF-MIB-capable SNMP child configs found / 未发现具备 IF-MIB 过滤能力的 SNMP 子配置"
+            )
             return
 
         node_mgmt = NodeMgmt()

--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -4,6 +4,7 @@ from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE, IFTYPE_OID
 from apps.monitor.models import CollectConfig
 from apps.monitor.utils.config_format import ConfigFormat
+from apps.monitor.utils.snmp_ifmib_capability import is_interface_filter_capable_plugin
 from apps.rpc.node_mgmt import NodeMgmt
 
 
@@ -12,6 +13,16 @@ IFTYPE_FIELD = {
     "name": "ifType",
     "is_tag": True,
 }
+
+
+def is_patchable_snmp_child_config(config, *, capable: bool | None = None) -> bool:
+    """Return whether a CollectConfig row should receive IF-MIB filter backfill."""
+    collect_type = str(getattr(config, "collect_type", "") or "")
+    if not collect_type.startswith("snmp"):
+        return False
+    if capable is None:
+        capable = is_interface_filter_capable_plugin(getattr(config, "monitor_plugin", None))
+    return bool(capable)
 
 
 def _table_has_ifdescr(table: dict) -> bool:
@@ -100,9 +111,10 @@ def patch_child_content_dict(content: dict, overwrite_default: bool = False) -> 
 
 class Command(BaseCommand):
     help = (
-        "Idempotently backfill ifType fields and default tagdrop.ifType for existing SNMP child configs; "
+        "Idempotently backfill ifType fields and default tagdrop.ifType for existing "
+        "IF-MIB-capable SNMP child configs (collect_type snmp / snmp_*); "
         "supports --dry-run and compensating rollback on update failure. Not hooked into startup init. "
-        "为存量 SNMP 子配置幂等补齐 ifType 字段与默认 tagdrop.ifType；"
+        "为具备 IF-MIB 过滤能力的存量 SNMP 子配置（collect_type 为 snmp / snmp_*）幂等补齐 ifType 字段与默认 tagdrop.ifType；"
         "支持 --dry-run，更新失败时自动补偿回滚。不挂入启动期初始化。"
     )
 
@@ -125,9 +137,16 @@ class Command(BaseCommand):
         dry_run = options["dry_run"]
         overwrite_default = options["overwrite_default"]
 
-        config_ids = list(
-            CollectConfig.objects.filter(collect_type="snmp", is_child=True).values_list("id", flat=True)
-        )
+        # 厂商实例 collect_type 为 snmp_cisco / snmp_h3c 等；精确匹配 "snmp" 会漏补。
+        # 同时仅对 IF-MIB 过滤能力插件补齐，避免 hardware_server 被写入默认 tagdrop。
+        config_ids = [
+            config.id
+            for config in CollectConfig.objects.filter(
+                collect_type__startswith="snmp",
+                is_child=True,
+            ).select_related("monitor_plugin")
+            if is_patchable_snmp_child_config(config)
+        ]
         if not config_ids:
             self.stdout.write("No SNMP child configs found / 未发现 SNMP 子配置")
             return

--- a/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
+++ b/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
@@ -1,0 +1,56 @@
+"""patch_snmp_interface_filters 选型契约。
+
+须覆盖 snmp_* 厂商 collect_type；仅 Network Device / IF-MIB 能力插件参与补齐，
+避免 hardware_server 等非 capable 存量被写入默认 tagdrop。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
+from apps.monitor.management.commands.patch_snmp_interface_filters import (
+    is_patchable_snmp_child_config,
+    patch_child_content_dict,
+)
+
+
+@pytest.mark.unit
+class TestPatchSnmpInterfaceFilterSelection:
+    def test_vendor_and_generic_snmp_collect_types_are_patchable_when_capable(self):
+        assert is_patchable_snmp_child_config(
+            SimpleNamespace(collect_type="snmp_cisco", monitor_plugin=object()),
+            capable=True,
+        )
+        assert is_patchable_snmp_child_config(
+            SimpleNamespace(collect_type="snmp", monitor_plugin=object()),
+            capable=True,
+        )
+
+    def test_non_snmp_or_non_capable_not_patchable(self):
+        assert not is_patchable_snmp_child_config(
+            SimpleNamespace(collect_type="snmp_cisco", monitor_plugin=None),
+            capable=False,
+        )
+        assert not is_patchable_snmp_child_config(
+            SimpleNamespace(collect_type="http", monitor_plugin=object()),
+            capable=True,
+        )
+
+    def test_patch_child_content_adds_default_tagdrop_for_ifdescr_tables(self):
+        content = {
+            "config": {
+                "table": [
+                    {
+                        "name": "interface",
+                        "field": [{"name": "ifDescr", "oid": "IF-MIB::ifDescr", "is_tag": True}],
+                    }
+                ]
+            }
+        }
+        assert patch_child_content_dict(content) is True
+        assert content["config"]["tagexclude"] == ["ifType"]
+        assert content["config"]["tagdrop"]["ifType"] == list(DEFAULT_IFTYPE_EXCLUDE)
+        assert any(f.get("name") == "ifType" for f in content["config"]["table"][0]["field"])

--- a/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
+++ b/server/apps/monitor/tests/test_patch_snmp_interface_filters_pure.py
@@ -39,6 +39,12 @@ class TestPatchSnmpInterfaceFilterSelection:
             capable=True,
         )
 
+    def test_capable_override_avoids_recomputing_plugin_capability(self):
+        """Command 应按 plugin_id 缓存后传入 capable=，避免对每行再查 M2M。"""
+        config = SimpleNamespace(collect_type="snmp_h3c", monitor_plugin=object())
+        assert is_patchable_snmp_child_config(config, capable=True) is True
+        assert is_patchable_snmp_child_config(config, capable=False) is False
+
     def test_patch_child_content_adds_default_tagdrop_for_ifdescr_tables(self):
         content = {
             "config": {

--- a/server/apps/monitor/tests/test_snmp_ifmib_filter_capability_pure.py
+++ b/server/apps/monitor/tests/test_snmp_ifmib_filter_capability_pure.py
@@ -1,0 +1,78 @@
+"""IF-MIB 过滤注入须与 Network Device 能力对齐。
+
+hardware_server 等非 Network Device SNMP 模板含 ifDescr，但不能静默套用
+默认 ifType 排除；只有 ifmib_capable 插件才注入过滤 Jinja / 默认排除集。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
+from apps.monitor.utils.plugin_controller import Controller
+from apps.monitor.utils.snmp_interface_template import FILTER_MARKER_BEGIN
+
+
+HARDWARE_LIKE_CHILD = """
+[[inputs.snmp]]
+  agents = ["udp://{{ ip }}:161"]
+  [[inputs.snmp.table]]
+    name = "interface"
+    oid = "IF-MIB::ifTable"
+    [[inputs.snmp.table.field]]
+      name = "ifDescr"
+      oid = "IF-MIB::ifDescr"
+      is_tag = true
+"""
+
+
+@pytest.mark.unit
+class TestSnmpInterfaceFilterCapabilityGate:
+    def test_non_capable_hardware_like_template_keeps_interfaces_without_silent_tagdrop(self):
+        rendered = Controller({}).render_template(
+            HARDWARE_LIKE_CHILD,
+            {
+                "ifmib_capable": False,
+                "ip": "10.0.0.1",
+                "instance_id": "('hw-1',)",
+            },
+        )
+
+        assert 'name = "interface"' in rendered
+        assert 'name = "ifDescr"' in rendered
+        assert FILTER_MARKER_BEGIN not in rendered
+        assert "tagdrop" not in rendered
+        assert "tagpass" not in rendered
+
+    def test_capable_plugin_with_default_exclude_renders_tagdrop_when_enabled(self):
+        rendered = Controller({}).render_template(
+            HARDWARE_LIKE_CHILD,
+            {
+                "ifmib_capable": True,
+                "enable_ifmib": True,
+                "iftype_exclude": list(DEFAULT_IFTYPE_EXCLUDE),
+                "ip": "10.0.0.2",
+                "instance_id": "('sw-1',)",
+            },
+        )
+
+        assert FILTER_MARKER_BEGIN in rendered
+        assert "tagdrop" in rendered
+        for value in DEFAULT_IFTYPE_EXCLUDE:
+            assert f'"{value}"' in rendered
+
+    def test_capable_plugin_disabled_ifmib_omits_interface_table_and_filters(self):
+        rendered = Controller({}).render_template(
+            HARDWARE_LIKE_CHILD,
+            {
+                "ifmib_capable": True,
+                "enable_ifmib": False,
+                "iftype_exclude": list(DEFAULT_IFTYPE_EXCLUDE),
+                "ip": "10.0.0.3",
+                "instance_id": "('sw-2',)",
+            },
+        )
+
+        assert 'name = "interface"' not in rendered
+        assert FILTER_MARKER_BEGIN not in rendered
+        assert "tagdrop" not in rendered

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -261,6 +261,7 @@ class Controller:
                     logger.error(f"解析 instance_id 失败: {instance_id}, 错误: {e}")
                     raise ValueError(f"无效的 instance_id 格式: {instance_id}") from e
 
+        from apps.monitor.utils.snmp_ifmib_capability import is_ifmib_capable_render_context
         from apps.monitor.utils.snmp_interface_template import (
             ensure_core_network_ifmib_jinja,
             ensure_snmp_interface_filter_jinja,
@@ -269,8 +270,11 @@ class Controller:
         )
 
         template_content = ensure_core_network_ifmib_jinja(template_content, _context)
-        # SNMP 接口过滤 Jinja 单一真相源：渲染前幂等注入，插件 child 模板无需复制
-        if needs_snmp_interface_filter_jinja(template_content):
+        # 接口过滤与公共 IF-MIB 同能力边界：非 Network Device（如 hardware_server）
+        # 即使模板含 ifDescr，也不得静默注入默认 ifType 排除。
+        if is_ifmib_capable_render_context(_context) and needs_snmp_interface_filter_jinja(
+            template_content
+        ):
             template_content = ensure_snmp_interface_filter_jinja(template_content)
 
         safe_context = sanitize_template_context(_context)
@@ -416,12 +420,14 @@ class Controller:
                         # IF-MIB 是本次下发选项。接入页默认启用；用户可以只对当前
                         # 新实例关闭，已下发实例的 TOML 快照不会受影响。
                         render_context.setdefault("enable_ifmib", True)
+                        # 默认 ifType 排除仅对具备过滤 UI 的 Network Device 注入，
+                        # 避免 hardware_server 等无开关对象静默丢接口。
+                        if "iftype_exclude" not in render_context:
+                            from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
+
+                            render_context["iftype_exclude"] = list(DEFAULT_IFTYPE_EXCLUDE)
                     # 与 IF-MIB 能力判定一致：覆盖 snmp / snmp_h3c 等厂商 collect_type。
                     snmp_collect = str(collect_type or "").startswith("snmp")
-                    if snmp_collect and "iftype_exclude" not in render_context:
-                        from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE
-
-                        render_context["iftype_exclude"] = list(DEFAULT_IFTYPE_EXCLUDE)
                     if snmp_collect and is_child:
                         from apps.monitor.utils.snmp_interface_filters import (
                             assert_snmp_interface_filter_mutex_from_values,


### PR DESCRIPTION
## Summary
- 渲染侧：过滤 Jinja 与 `DEFAULT_IFTYPE_EXCLUDE` 仅在 `ifmib_capable` 时注入，避免 `hardware_server` 等非 Network Device 静默丢接口。
- 存量补丁：`patch_snmp_interface_filters` 匹配 `snmp` / `snmp_*`，且只处理具备 IF-MIB 过滤能力的插件；按 `plugin_id` 缓存能力判定避免 N+1。
- 补充 pure 单测覆盖上述契约。

## Scope check
仅包含上述 4 个文件；工作区其它 icons / metric-views / kafka metrics 等未纳入。

## Test plan
- [x] `uv run pytest apps/monitor/tests/test_snmp_ifmib_filter_capability_pure.py apps/monitor/tests/test_patch_snmp_interface_filters_pure.py -q --no-cov` → 7 passed
- [ ] 本地对 Network Device 下发仍默认排除 ifType
- [ ] `hardware_server` 下发不再出现默认 tagdrop.ifType
- [ ] `--dry-run` 确认 `snmp_cisco` 等厂商类型会被选中、hardware_server 不会