### PR TITLE
fix: 策略初始化跳过无效模板

### DIFF
--- a/server/apps/monitor/config.py
+++ b/server/apps/monitor/config.py
@@ -5,6 +5,10 @@
 from celery.schedules import crontab
 
 CELERY_BEAT_SCHEDULE = {
+    "reconcile_snmp_interface_filters": {
+        "task": "apps.monitor.tasks.snmp_ifmib_reconcile.reconcile_snmp_interface_filters",
+        "schedule": crontab(minute="*"),
+    },
     'sync_instance_and_group': {
         'task': 'apps.monitor.tasks.grouping_rule.sync_instance_and_group',
         'schedule': crontab(minute='*/10'),  # 每10分钟执行一次
@@ -14,4 +18,3 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': crontab(minute='*/5'),  # 每5分钟执行一次
     },
 }
-

--- a/server/apps/monitor/filters/monitor_metrics.py
+++ b/server/apps/monitor/filters/monitor_metrics.py
@@ -2,6 +2,7 @@ from django.db.models import Q
 from django_filters import BaseInFilter, BooleanFilter, CharFilter, FilterSet, NumberFilter
 
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
+from apps.monitor.utils.snmp_ifmib_capability import get_ifmib_metric_names_matching_keyword
 
 
 class MetricGroupFilter(FilterSet):
@@ -43,15 +44,14 @@ class MetricFilter(FilterSet):
     include_ifmib = BooleanFilter(method="filter_include_ifmib", label="是否包含IF-MIB指标")
     is_ifmib = BooleanFilter(field_name="is_ifmib", label="是否为IF-MIB指标")
 
-    @staticmethod
-    def filter_keyword(queryset, _name, value):
+    def filter_keyword(self, queryset, _name, value):
         keyword = str(value or "").strip()
         if not keyword:
             return queryset
+        locale = getattr(getattr(self.request, "user", None), "locale", "")
+        localized_names = get_ifmib_metric_names_matching_keyword(keyword, locale)
         return queryset.filter(
-            Q(name__icontains=keyword)
-            | Q(display_name__icontains=keyword)
-            | Q(description__icontains=keyword)
+            Q(name__icontains=keyword) | Q(display_name__icontains=keyword) | Q(description__icontains=keyword) | Q(name__in=localized_names)
         )
 
     @staticmethod

--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -1,18 +1,90 @@
-from django.core.management.base import BaseCommand
+import argparse
+import json
+import os
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+from django.utils.dateparse import parse_datetime
 
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.snmp_interface import DEFAULT_IFTYPE_EXCLUDE, IFTYPE_OID
 from apps.monitor.models import CollectConfig
 from apps.monitor.utils.config_format import ConfigFormat
-from apps.monitor.utils.snmp_ifmib_capability import is_interface_filter_capable_plugin
+from apps.monitor.utils.snmp_ifmib_capability import (
+    IFMIBCapabilityResolutionError,
+    is_interface_filter_capable_plugin,
+    resolve_interface_filter_capability_for_migration,
+)
+from apps.monitor.utils.snmp_interface_template import (
+    get_common_ifmib_table,
+    has_managed_ifmib_section,
+    is_public_ifmib_table,
+)
 from apps.rpc.node_mgmt import NodeMgmt
 
+# v6：缺省 tagdrop 仅补「从未配置过滤」的存量；不得覆盖全部采集 / 仅名称白名单等故意清空。
+CHECKPOINT_VERSION = 6
+IFTYPE_FIELD = {"oid": IFTYPE_OID, "name": "ifType", "is_tag": True}
 
-IFTYPE_FIELD = {
-    "oid": IFTYPE_OID,
-    "name": "ifType",
-    "is_tag": True,
-}
+
+class SnmpIfmibReconcilePartialError(CommandError):
+    """部分 child 内容无效；健康配置已继续处理，但本轮不得标记完成。"""
+
+
+def _load_checkpoint(checkpoint_path: Path, *, overwrite_default: bool) -> tuple[datetime, str] | None:
+    if not checkpoint_path.exists():
+        return None
+    try:
+        checkpoint = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CommandError(f"Invalid checkpoint file / 断点文件无效: {checkpoint_path}: {exc}") from exc
+    if checkpoint.get("version") != CHECKPOINT_VERSION:
+        raise CommandError(f"Unsupported checkpoint version / 不支持的断点版本: {checkpoint_path}")
+    if bool(checkpoint.get("overwrite_default")) != overwrite_default:
+        raise CommandError("Checkpoint options do not match --overwrite-default / 断点参数与 --overwrite-default 不一致")
+    cursor = checkpoint.get("cursor")
+    if cursor is None:
+        return None
+    if not isinstance(cursor, dict):
+        raise CommandError(f"Invalid checkpoint cursor / 断点游标无效: {checkpoint_path}")
+    created_at = parse_datetime(str(cursor.get("created_at") or ""))
+    config_id = cursor.get("id")
+    if created_at is None or config_id in (None, ""):
+        raise CommandError(f"Invalid checkpoint cursor / 断点游标无效: {checkpoint_path}")
+    return created_at, str(config_id)
+
+
+def _save_checkpoint(checkpoint_path: Path, *, cursor: tuple[datetime, str], overwrite_default: bool) -> None:
+    checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=checkpoint_path.parent,
+            prefix=f".{checkpoint_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            json.dump(
+                {
+                    "version": CHECKPOINT_VERSION,
+                    "cursor": {"created_at": cursor[0].isoformat(), "id": cursor[1]},
+                    "overwrite_default": overwrite_default,
+                },
+                temp_file,
+                ensure_ascii=False,
+            )
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        temp_path.replace(checkpoint_path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
 
 
 def is_patchable_snmp_child_config(config, *, capable: bool | None = None) -> bool:
@@ -25,53 +97,90 @@ def is_patchable_snmp_child_config(config, *, capable: bool | None = None) -> bo
     return bool(capable)
 
 
-def _table_has_ifdescr(table: dict) -> bool:
-    for field in table.get("field") or []:
-        if isinstance(field, dict) and field.get("name") == "ifDescr":
-            return True
-    return False
-
-
-def _table_has_iftype(table: dict) -> bool:
-    for field in table.get("field") or []:
-        if isinstance(field, dict) and (
-            field.get("name") == "ifType" or field.get("oid") == IFTYPE_OID
-        ):
-            return True
-    return False
-
-
-def _config_has_ifdescr(config: dict) -> bool:
-    tables = config.get("table")
-    return isinstance(tables, list) and any(
-        isinstance(table, dict) and _table_has_ifdescr(table) for table in tables
-    )
-
-
-def _ensure_iftype_fields(config: dict) -> bool:
+def _reconcile_common_ifmib_fields(config: dict) -> bool:
+    common_table = get_common_ifmib_table()
+    common_fields = common_table.get("field") or []
+    if not any(field.get("name") == "ifType" for field in common_fields):
+        insert_at = next(
+            (index + 1 for index, field in enumerate(common_fields) if field.get("name") == "ifDescr"),
+            len(common_fields),
+        )
+        common_fields.insert(insert_at, dict(IFTYPE_FIELD))
     changed = False
     tables = config.get("table")
     if not isinstance(tables, list):
         return False
-    for table in tables:
-        if not isinstance(table, dict) or not _table_has_ifdescr(table):
+    public_tables = [table for table in tables if isinstance(table, dict) and is_public_ifmib_table(table)]
+    if not public_tables:
+        return False
+    existing_fields = []
+    merged_table = dict(public_tables[0])
+    for table in public_tables:
+        fields = table.get("field", [])
+        if not isinstance(fields, list) or any(not isinstance(field, dict) for field in fields):
+            raise ValueError("invalid interface table field: expected an object array")
+        existing_fields.extend(fields)
+        for key, value in table.items():
+            if key != "field" and key not in merged_table:
+                merged_table[key] = value
+    for key, value in common_table.items():
+        if key != "field":
+            merged_table[key] = value
+
+    consumed_indexes: set[int] = set()
+    reconciled_fields = []
+    for common_field in common_fields:
+        matched_index = next(
+            (
+                index
+                for index, field in enumerate(existing_fields)
+                if index not in consumed_indexes
+                and (field.get("name") == common_field.get("name") or field.get("oid") == common_field.get("oid"))
+            ),
+            None,
+        )
+        if matched_index is None:
+            reconciled_fields.append(dict(common_field))
             continue
-        if _table_has_iftype(table):
-            continue
-        fields = table.setdefault("field", [])
-        # insert after ifDescr
-        insert_at = 0
-        for idx, field in enumerate(fields):
-            if isinstance(field, dict) and field.get("name") == "ifDescr":
-                insert_at = idx + 1
-                break
-        fields.insert(insert_at, dict(IFTYPE_FIELD))
+        consumed_indexes.add(matched_index)
+        reconciled_fields.append({**existing_fields[matched_index], **common_field})
+    common_names = {field.get("name") for field in common_fields}
+    common_oids = {field.get("oid") for field in common_fields}
+    reconciled_fields.extend(
+        field
+        for index, field in enumerate(existing_fields)
+        if index not in consumed_indexes and field.get("name") not in common_names and field.get("oid") not in common_oids
+    )
+    merged_table["field"] = reconciled_fields
+
+    first_public_index = next(index for index, table in enumerate(tables) if table in public_tables)
+    reconciled_tables = [table for table in tables if table not in public_tables]
+    reconciled_tables.insert(first_public_index, merged_table)
+    if reconciled_tables != tables:
+        config["table"] = reconciled_tables
         changed = True
     return changed
 
 
+def _filter_values_present(value) -> bool:
+    return value not in (None, [], "")
+
+
 def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
+    """补齐存量缺省排除；已有过滤脚手架或白名单时不得静默改写用户选择。
+
+    模板注释约定：默认排除由页面/创建注入，渲染不做静默 fallback。对账同样遵守：
+    - 从未出现 tagexclude/tagpass/tagdrop 的老存量 → 补默认 ifType 排除
+    - 「全部采集」或仅 ifDescr 白名单等故意不配 ifType 排除 → 保持原样
+    - --overwrite-default 才强制写回产品默认排除
+    """
     changed = False
+    previously_managed = (
+        (isinstance(config.get("tagexclude"), list) and "ifType" in config["tagexclude"])
+        or isinstance(config.get("tagpass"), dict)
+        or isinstance(config.get("tagdrop"), dict)
+    )
+
     tagexclude = config.get("tagexclude")
     if tagexclude is None:
         config["tagexclude"] = ["ifType"]
@@ -79,42 +188,328 @@ def _ensure_default_tagdrop(config: dict, overwrite: bool = False) -> bool:
     elif "ifType" not in tagexclude:
         tagexclude.append("ifType")
         changed = True
-    tagpass = config.get("tagpass")
-    if isinstance(tagpass, dict) and tagpass.get("ifType") not in (None, [], ""):
+
+    tagpass = config.get("tagpass") if isinstance(config.get("tagpass"), dict) else {}
+    # 任意白名单都表示用户已选「仅采集」策略，不能再塞默认排除。
+    if _filter_values_present(tagpass.get("ifType")) or _filter_values_present(tagpass.get("ifDescr")):
         return changed
+
     tagdrop = config.get("tagdrop")
     if not isinstance(tagdrop, dict):
         tagdrop = {}
-        config["tagdrop"] = tagdrop
-        changed = True
     existing = tagdrop.get("ifType")
-    if overwrite or existing in (None, [], ""):
+
+    if overwrite:
         if existing != DEFAULT_IFTYPE_EXCLUDE:
             tagdrop["ifType"] = list(DEFAULT_IFTYPE_EXCLUDE)
+            config["tagdrop"] = tagdrop
             changed = True
+        return changed
+
+    if _filter_values_present(existing):
+        return changed
+
+    # 已有过滤脚手架（含全部采集清空后的 tagexclude）或仅名称排除：视为故意不配 ifType 排除。
+    if previously_managed:
+        return changed
+
+    tagdrop["ifType"] = list(DEFAULT_IFTYPE_EXCLUDE)
+    config["tagdrop"] = tagdrop
+    changed = True
     return changed
+
+
+def _iter_snmp_input_configs(content: dict) -> list[dict]:
+    """返回全部 SNMP input。tagpass 隔离后公共 IF-MIB 可能不在 snmp[0]。"""
+    document = content.get("_toml_document") if isinstance(content, dict) else None
+    if isinstance(document, dict):
+        snmp_inputs = document.get("inputs", {}).get("snmp") if isinstance(document.get("inputs"), dict) else None
+        if isinstance(snmp_inputs, list):
+            return [item for item in snmp_inputs if isinstance(item, dict)]
+        if isinstance(snmp_inputs, dict):
+            return [snmp_inputs]
+    config = content.get("config") if isinstance(content, dict) else None
+    return [config] if isinstance(config, dict) else []
+
+
+def _validate_snmp_filter_structure(config: dict) -> None:
+    expected_filter_types = {
+        "tagexclude": list,
+        "tagpass": dict,
+        "tagdrop": dict,
+    }
+    for key, expected_type in expected_filter_types.items():
+        value = config.get(key)
+        if value is not None and not isinstance(value, expected_type):
+            raise ValueError(f"invalid {key}: expected {expected_type.__name__}")
+        if key == "tagexclude" and isinstance(value, list) and any(not isinstance(item, str) for item in value):
+            raise ValueError("invalid tagexclude: expected a string array")
+        if key in {"tagpass", "tagdrop"} and isinstance(value, dict):
+            if any(
+                not isinstance(tag_name, str) or not isinstance(patterns, list) or any(not isinstance(pattern, str) for pattern in patterns)
+                for tag_name, patterns in value.items()
+            ):
+                raise ValueError(f"invalid {key}: expected string-array values")
+
+
+def _snmp_tables(config: dict) -> list:
+    tables = config.get("table")
+    if tables is None:
+        return []
+    if not isinstance(tables, list) or any(not isinstance(table, dict) for table in tables):
+        raise ValueError("invalid table: expected an object array")
+    return tables
+
+
+def _public_tables_in_config(config: dict) -> list[dict]:
+    return [table for table in _snmp_tables(config) if is_public_ifmib_table(table)]
+
+
+def _snmp_input_filter_score(config: dict) -> tuple[bool, bool]:
+    """优先保留承载接口过滤/仅公共表的 input，便于去掉重复注入。"""
+    has_filters = "ifType" in (config.get("tagexclude") or []) or any(
+        filter_name in (config.get(filter_key) or {})
+        for filter_key in ("tagpass", "tagdrop")
+        for filter_name in ("ifType", "ifDescr")
+    )
+    tables = _snmp_tables(config)
+    only_public = bool(tables) and all(is_public_ifmib_table(table) for table in tables)
+    return has_filters, only_public
 
 
 def patch_child_content_dict(content: dict, overwrite_default: bool = False) -> bool:
     if not isinstance(content, dict) or not isinstance(content.get("config"), dict):
         return False
-    config = content["config"]
-    if not _config_has_ifdescr(config):
+
+    snmp_configs = _iter_snmp_input_configs(content)
+    if not snmp_configs:
         return False
-    tagexclude = config.get("tagexclude")
-    if tagexclude is not None and not isinstance(tagexclude, list):
-        return False
-    changed = _ensure_iftype_fields(config)
-    changed = _ensure_default_tagdrop(config, overwrite=overwrite_default) or changed
+
+    common_table = get_common_ifmib_table()
+    for config in snmp_configs:
+        _validate_snmp_filter_structure(config)
+        tables = _snmp_tables(config)
+        public_tables = [table for table in tables if is_public_ifmib_table(table)]
+        if any(
+            table.get("name") == common_table.get("name")
+            and table.get("oid") in (None, "")
+            and table not in public_tables
+            for table in tables
+        ):
+            raise ValueError("ambiguous interface table: public IF-MIB identity cannot be proven")
+
+    public_owners = [config for config in snmp_configs if _public_tables_in_config(config)]
+    changed = False
+
+    # tagpass 隔离后公共表常在 snmp[1]；若多处都有，保留过滤承载方并去掉重复公共表。
+    if len(public_owners) > 1:
+        keep = sorted(public_owners, key=_snmp_input_filter_score, reverse=True)[0]
+        for config in public_owners:
+            if config is keep:
+                continue
+            tables = _snmp_tables(config)
+            remaining = [table for table in tables if not is_public_ifmib_table(table)]
+            if remaining != tables:
+                config["table"] = remaining
+                changed = True
+        public_owners = [keep]
+
+    # capable 且未关闭的缺表存量直接补公共表。enable_ifmib=false 的快照会保留
+    # IF-MIB 管理区间标记，由调用方在原始 TOML 上识别并跳过，避免误开启。
+    if not public_owners:
+        config = content["config"]
+        tables = _snmp_tables(config)
+        config["table"] = tables
+        tables.append(common_table)
+        public_owners = [config]
+        changed = True
+
+    for config in public_owners:
+        changed = _reconcile_common_ifmib_fields(config) or changed
+        changed = _ensure_default_tagdrop(config, overwrite=overwrite_default) or changed
     return changed
+
+
+def _config_has_public_ifmib_table(content: dict) -> bool:
+    return any(_public_tables_in_config(config) for config in _iter_snmp_input_configs(content))
+
+
+def should_skip_closed_ifmib_backfill(raw_content: str | None, content: dict) -> bool:
+    """已渲染过 IF-MIB 管理区间且当前无公共表 → 视为实例关闭，禁止回填误开启。"""
+    return has_managed_ifmib_section(raw_content) and not _config_has_public_ifmib_table(content)
+
+
+def _get_keyset_page(queryset, cursor: tuple[datetime, str] | None, batch_size: int):
+    page = queryset
+    if cursor is not None:
+        cursor_created_at, cursor_id = cursor
+        page = page.filter(Q(created_at__gt=cursor_created_at) | Q(created_at=cursor_created_at, pk__gt=cursor_id))
+    return list(page.order_by("created_at", "pk")[:batch_size])
+
+
+def _select_patchable_config_ids(configs, capable_by_plugin_id: dict[int | None, bool], *, continue_on_item_error: bool = False):
+    config_ids = []
+    failed_config_ids = []
+    for config in configs:
+        plugin = getattr(config, "monitor_plugin", None)
+        plugin_id = getattr(plugin, "pk", None)
+        if plugin_id not in capable_by_plugin_id:
+            try:
+                capable_by_plugin_id[plugin_id] = resolve_interface_filter_capability_for_migration(plugin)
+            except IFMIBCapabilityResolutionError as exc:
+                if continue_on_item_error:
+                    failed_config_ids.append(str(config.id))
+                    logger.exception(
+                        "Skipping SNMP config with unresolved IF-MIB capability / 跳过能力未知的 SNMP 配置: config_id=%s",
+                        config.id,
+                    )
+                    continue
+                raise CommandError("Unable to resolve IF-MIB capability / 无法判定 IF-MIB 能力: " f"plugin_id={plugin_id}") from exc
+        if is_patchable_snmp_child_config(config, capable=capable_by_plugin_id[plugin_id]):
+            config_ids.append(config.id)
+    return config_ids, failed_config_ids
+
+
+def _fetch_complete_child_configs(node_mgmt, config_ids, *, continue_on_missing: bool = False):
+    try:
+        child_configs = node_mgmt.get_child_configs_by_ids(config_ids) or []
+    except Exception as exc:
+        logger.error("Failed to fetch SNMP child configs / 获取 SNMP 子配置失败: %s", exc)
+        raise
+    returned_ids = [str(child.get("id")) for child in child_configs if child.get("id")]
+    expected_ids = [str(config_id) for config_id in config_ids]
+    missing_ids = sorted(set(expected_ids) - set(returned_ids))
+    unexpected_ids = sorted(set(returned_ids) - set(expected_ids))
+    if len(returned_ids) != len(set(returned_ids)) or unexpected_ids:
+        raise CommandError(
+            "NodeMgmt returned an incomplete child-config snapshot / NodeMgmt 返回的子配置快照不完整: " f"missing={missing_ids}, unexpected={unexpected_ids}"
+        )
+    if missing_ids and not continue_on_missing:
+        raise CommandError("NodeMgmt returned an incomplete child-config snapshot / NodeMgmt 返回的子配置快照不完整: " f"missing={missing_ids}, unexpected=[]")
+    if missing_ids:
+        logger.error("Skipping missing SNMP child configs / 跳过缺失的 SNMP 子配置: %s", missing_ids)
+    return child_configs, missing_ids
+
+
+def _build_pending_updates(child_configs, *, overwrite_default: bool, write_patch, continue_on_item_error: bool = False):
+    pending_updates: list[tuple[str, str, str]] = []
+    failed_config_ids: list[str] = []
+    for child in child_configs:
+        config_id = str(child.get("id") or "")
+        raw_content = child.get("content")
+        if not config_id or not raw_content:
+            error = CommandError(f"NodeMgmt returned empty child config content / NodeMgmt 返回空子配置: config_id={config_id}")
+            if continue_on_item_error:
+                failed_config_ids.append(config_id or "<missing-id>")
+                logger.error("Skipping invalid SNMP child config / 跳过无效 SNMP 子配置: %s", error)
+                continue
+            raise error
+        try:
+            content = ConfigFormat.toml_to_dict(raw_content)
+        except Exception as exc:
+            logger.exception("Failed to parse child config / 解析子配置失败 config_id=%s", config_id)
+            if continue_on_item_error:
+                failed_config_ids.append(config_id)
+                continue
+            raise CommandError(f"Unable to parse child config / 无法解析子配置: config_id={config_id}: {exc}") from exc
+        if should_skip_closed_ifmib_backfill(raw_content, content):
+            # 保留用户关闭态；即使仍残留过滤键也不能按证据回填误开启。
+            continue
+        try:
+            changed = patch_child_content_dict(content, overwrite_default=overwrite_default)
+        except ValueError as exc:
+            if continue_on_item_error:
+                failed_config_ids.append(config_id)
+                logger.exception("Skipping invalid SNMP child config / 跳过无效 SNMP 子配置: config_id=%s", config_id)
+                continue
+            raise CommandError("Invalid child config filter structure / 子配置过滤结构无效: " f"config_id={config_id}: {exc}") from exc
+        if not changed:
+            continue
+        try:
+            updated_content = ConfigFormat.json_to_toml(content)
+        except Exception as exc:
+            if continue_on_item_error:
+                failed_config_ids.append(config_id)
+                logger.exception("Skipping unserializable SNMP child config / 跳过无法序列化的 SNMP 子配置: config_id=%s", config_id)
+                continue
+            raise CommandError(f"Unable to serialize child config / 无法序列化子配置: config_id={config_id}: {exc}") from exc
+        pending_updates.append((config_id, raw_content, updated_content))
+        write_patch(f"patch: {config_id}")
+    return pending_updates, failed_config_ids
+
+
+def _apply_pending_updates(node_mgmt, pending_updates, *, compare_and_swap=None):
+    if compare_and_swap is None:
+        def compare_and_swap(client, config_id, expected, content):
+            return client.compare_and_swap_child_config_content_local(
+                config_id,
+                expected,
+                content,
+            )
+    attempted: list[tuple[str, str, str]] = []
+    try:
+        for config_id, original_content, updated_content in pending_updates:
+            try:
+                updated = compare_and_swap(
+                    node_mgmt,
+                    config_id,
+                    original_content,
+                    updated_content,
+                )
+            except Exception:
+                # 远端调用异常时无法确定请求是否已提交，必须把当前项纳入条件回滚。
+                attempted.append((config_id, original_content, updated_content))
+                raise
+            if not updated:
+                raise CommandError("Concurrent child config change / 子配置发生并发修改: " f"config_id={config_id}")
+            attempted.append((config_id, original_content, updated_content))
+    except Exception as exc:
+        if not attempted:
+            raise
+        logger.error(
+            "Failed to update child config; rolling back attempted configs / " "更新 SNMP 子配置失败，开始回滚已尝试配置 config_id=%s: %s",
+            config_id,
+            exc,
+        )
+        attempted_ids = [attempted_id for attempted_id, _, _ in attempted]
+        try:
+            current_configs, _ = _fetch_complete_child_configs(node_mgmt, attempted_ids)
+        except Exception as verify_exc:
+            raise CommandError(
+                "Unable to verify compensating rollback / 无法校验补偿回滚; " f"uncertain configs / 状态不确定配置: {', '.join(attempted_ids)}"
+            ) from verify_exc
+        current_content_by_id = {str(child["id"]): child.get("content") or "" for child in current_configs}
+        rollback_errors: list[str] = []
+        for attempted_id, original_content, updated_content in reversed(attempted):
+            current_content = current_content_by_id[attempted_id]
+            if current_content == original_content:
+                continue
+            if current_content != updated_content:
+                rollback_errors.append(f"{attempted_id}: concurrent content change")
+                continue
+            try:
+                rolled_back = compare_and_swap(
+                    node_mgmt,
+                    attempted_id,
+                    updated_content,
+                    original_content,
+                )
+                if not rolled_back:
+                    rollback_errors.append(f"{attempted_id}: concurrent content change")
+            except Exception as rollback_exc:
+                rollback_errors.append(f"{attempted_id}: {rollback_exc}")
+        if rollback_errors:
+            logger.error("Failed to roll back SNMP child configs / 回滚 SNMP 子配置失败: %s", "; ".join(rollback_errors))
+            raise CommandError("Compensating rollback failed / 补偿回滚失败; " f"uncertain configs / 状态不确定配置: {'; '.join(rollback_errors)}") from exc
+        raise
 
 
 class Command(BaseCommand):
     help = (
-        "Idempotently backfill ifType fields and default tagdrop.ifType for existing "
+        "Idempotently reconcile the public IF-MIB table and default tagdrop.ifType for existing "
         "IF-MIB-capable SNMP child configs (collect_type snmp / snmp_*); "
         "supports --dry-run and compensating rollback on update failure. Not hooked into startup init. "
-        "为具备 IF-MIB 过滤能力的存量 SNMP 子配置（collect_type 为 snmp / snmp_*）幂等补齐 ifType 字段与默认 tagdrop.ifType；"
+        "为具备 IF-MIB 过滤能力的存量 SNMP 子配置（collect_type 为 snmp / snmp_*）幂等补齐公共 IF-MIB 表与默认 tagdrop.ifType；"
         "支持 --dry-run，更新失败时自动补偿回滚。不挂入启动期初始化。"
     )
 
@@ -125,112 +520,120 @@ class Command(BaseCommand):
             help="Print config_ids that would change only / 只打印将变更的 config_id",
         )
         parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=100,
+            help="CollectConfig keyset batch size / CollectConfig 主键游标批次大小（默认 100）",
+        )
+        parser.add_argument(
+            "--checkpoint-file",
+            type=Path,
+            help="Persist the last successful keyset cursor for resume / 保存最后成功批次游标以便断点续跑",
+        )
+        parser.add_argument(
             "--overwrite-default",
             action="store_true",
-            help=(
-                "Reset tagdrop.ifType to the default exclude set even if already set "
-                "(use with care) / 即使已有 tagdrop.ifType 也重置为默认排除集（慎用）"
-            ),
+            help=("Reset tagdrop.ifType to the default exclude set even if already set " "(use with care) / 即使已有 tagdrop.ifType 也重置为默认排除集（慎用）"),
         )
+        # 仅供同进程运行期补偿任务传入共享断点与租约续期回调；CLI 不暴露 Python 对象参数。
+        parser.add_argument("--initial-cursor", help=argparse.SUPPRESS)
+        parser.add_argument("--batch-completed", help=argparse.SUPPRESS)
+        parser.add_argument("--compare-and-swap", help=argparse.SUPPRESS)
+        parser.add_argument("--continue-on-item-error", action="store_true", help=argparse.SUPPRESS)
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         overwrite_default = options["overwrite_default"]
+        batch_size = max(int(options["batch_size"]), 1)
+        checkpoint_path = options.get("checkpoint_file") if not dry_run else None
+        initial_cursor = options.get("initial_cursor") if not dry_run else None
+        batch_completed = options.get("batch_completed") if not dry_run else None
+        compare_and_swap = options.get("compare_and_swap") if not dry_run else None
+        continue_on_item_error = bool(options.get("continue_on_item_error")) and not dry_run
+        if checkpoint_path is not None and initial_cursor is not None:
+            raise CommandError("--checkpoint-file cannot be combined with a runtime initial cursor")
+        if initial_cursor is not None and (
+            not isinstance(initial_cursor, tuple)
+            or len(initial_cursor) != 2
+            or not isinstance(initial_cursor[0], datetime)
+            or initial_cursor[1] in (None, "")
+        ):
+            raise CommandError("Invalid runtime initial cursor")
+        if batch_completed is not None and not callable(batch_completed):
+            raise CommandError("Invalid runtime batch-completed callback")
+        if compare_and_swap is not None and not callable(compare_and_swap):
+            raise CommandError("Invalid runtime compare-and-swap callback")
 
         # 厂商实例 collect_type 为 snmp_cisco / snmp_h3c 等；精确匹配 "snmp" 会漏补。
         # 同时仅对 IF-MIB 过滤能力插件补齐，避免 hardware_server 被写入默认 tagdrop。
         # 按 plugin_id 缓存能力判定：_is_network_device_snmp_plugin 含 exists()/manifest I/O，
         # 不可对每行 CollectConfig 重复调用（management 命令也会踩 N+1）。
         capable_by_plugin_id: dict[int | None, bool] = {}
-        config_ids: list = []
-        for config in CollectConfig.objects.filter(
+        queryset = CollectConfig.objects.filter(
             collect_type__startswith="snmp",
             is_child=True,
-        ).select_related("monitor_plugin"):
-            plugin = getattr(config, "monitor_plugin", None)
-            plugin_id = getattr(plugin, "pk", None)
-            if plugin_id not in capable_by_plugin_id:
-                capable_by_plugin_id[plugin_id] = is_interface_filter_capable_plugin(plugin)
-            if is_patchable_snmp_child_config(
-                config, capable=capable_by_plugin_id[plugin_id]
-            ):
-                config_ids.append(config.id)
-        if not config_ids:
-            self.stdout.write(
-                "No IF-MIB-capable SNMP child configs found / 未发现具备 IF-MIB 过滤能力的 SNMP 子配置"
+        ).select_related("monitor_plugin")
+
+        # 回填是 server 内部运维命令，强制走同进程 AppClient。CAS 写接口不暴露为
+        # 远程 NATS handler，避免出现一个无用户/组织上下文的系统级写入口。
+        node_mgmt = NodeMgmt(is_local_client=True)
+        cursor = _load_checkpoint(checkpoint_path, overwrite_default=overwrite_default) if checkpoint_path is not None else initial_cursor
+        scanned_count = 0
+        changed_count = 0
+        failed_config_ids: list[str] = []
+        found_capable = False
+        while True:
+            configs = _get_keyset_page(queryset, cursor, batch_size)
+            if not configs:
+                break
+            cursor = (configs[-1].created_at, configs[-1].pk)
+            scanned_count += len(configs)
+            config_ids, selection_failed_ids = _select_patchable_config_ids(
+                configs,
+                capable_by_plugin_id,
+                continue_on_item_error=continue_on_item_error,
             )
-            return
-
-        node_mgmt = NodeMgmt()
-        try:
-            child_configs = node_mgmt.get_child_configs_by_ids(config_ids) or []
-        except Exception as exc:
-            logger.error("Failed to fetch SNMP child configs / 获取 SNMP 子配置失败: %s", exc)
-            raise
-
-        pending_updates: list[tuple[str, str, str]] = []
-        for child in child_configs:
-            config_id = child.get("id")
-            raw_content = child.get("content")
-            if not config_id or not raw_content:
+            failed_config_ids.extend(selection_failed_ids)
+            if not config_ids:
+                if checkpoint_path is not None and not failed_config_ids:
+                    _save_checkpoint(checkpoint_path, cursor=cursor, overwrite_default=overwrite_default)
+                if batch_completed is not None:
+                    batch_completed(None if failed_config_ids else cursor)
                 continue
-            try:
-                content = ConfigFormat.toml_to_dict(raw_content)
-            except Exception as exc:
-                logger.error(
-                    "Failed to parse child config / 解析子配置失败 config_id=%s: %s",
-                    config_id,
-                    exc,
-                )
-                continue
-
-            changed = patch_child_content_dict(
-                content,
+            found_capable = True
+            child_configs, missing_config_ids = _fetch_complete_child_configs(
+                node_mgmt,
+                config_ids,
+                continue_on_missing=continue_on_item_error,
+            )
+            failed_config_ids.extend(missing_config_ids)
+            pending_updates, batch_failed_config_ids = _build_pending_updates(
+                child_configs,
                 overwrite_default=overwrite_default,
+                write_patch=self.stdout.write,
+                continue_on_item_error=continue_on_item_error,
             )
-            if not changed:
-                continue
+            failed_config_ids.extend(batch_failed_config_ids)
+            changed_count += len(pending_updates)
+            if not dry_run:
+                _apply_pending_updates(node_mgmt, pending_updates, compare_and_swap=compare_and_swap)
+                # 文件断点只能指向所有项目均成功的安全前缀。一旦出现毒数据，
+                # 即使继续处理后续健康项也不得越过失败位置，否则续跑会永久漏掉它。
+                if checkpoint_path is not None and not failed_config_ids:
+                    _save_checkpoint(checkpoint_path, cursor=cursor, overwrite_default=overwrite_default)
+                if batch_completed is not None:
+                    batch_completed(None if failed_config_ids else cursor)
 
-            pending_updates.append((config_id, raw_content, ConfigFormat.json_to_toml(content)))
-            self.stdout.write(f"patch: {config_id}")
+        if failed_config_ids:
+            raise SnmpIfmibReconcilePartialError("Some SNMP child configs remain invalid / 部分 SNMP 子配置仍无效: " + ", ".join(failed_config_ids))
 
-        if dry_run:
-            self.stdout.write(
-                self.style.SUCCESS(
-                    f"Done (dry-run), changed {len(pending_updates)}/{len(child_configs)} / "
-                    f"完成 (dry-run)，变更 {len(pending_updates)}/{len(child_configs)}"
-                )
-            )
+        if not found_capable:
+            self.stdout.write("No IF-MIB-capable SNMP child configs found / 未发现具备 IF-MIB 过滤能力的 SNMP 子配置")
             return
-
-        attempted: list[tuple[str, str]] = []
-        try:
-            for config_id, original_content, updated_content in pending_updates:
-                attempted.append((config_id, original_content))
-                node_mgmt.update_child_config_content(config_id, updated_content)
-        except Exception as exc:
-            logger.error(
-                "Failed to update child config; rolling back attempted configs / "
-                "更新 SNMP 子配置失败，开始回滚已尝试配置 config_id=%s: %s",
-                config_id,
-                exc,
-            )
-            rollback_errors: list[str] = []
-            for attempted_id, original_content in reversed(attempted):
-                try:
-                    node_mgmt.update_child_config_content(attempted_id, original_content)
-                except Exception as rollback_exc:
-                    rollback_errors.append(f"{attempted_id}: {rollback_exc}")
-            if rollback_errors:
-                logger.error(
-                    "Failed to roll back SNMP child configs / 回滚 SNMP 子配置失败: %s",
-                    "; ".join(rollback_errors),
-                )
-            raise
 
         self.stdout.write(
             self.style.SUCCESS(
-                f"Done (applied), changed {len(pending_updates)}/{len(child_configs)} / "
-                f"完成 (applied)，变更 {len(pending_updates)}/{len(child_configs)}"
+                f"Done ({'dry-run' if dry_run else 'applied'}), changed {changed_count}/{scanned_count} / "
+                f"完成 ({'dry-run' if dry_run else 'applied'})，变更 {changed_count}/{scanned_count}"
             )
         )

--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -12,7 +12,8 @@ from apps.monitor.management.utils import (
     parse_template_filename,
 )
 from apps.monitor.services.plugin import MonitorPluginService
-from apps.monitor.utils.snmp_ifmib_capability import is_ifmib_capable_plugin_data
+from apps.monitor.utils.snmp_ifmib_capability import IFMIB_METRIC_CATALOG, is_ifmib_capable_plugin_data
+from apps.monitor.utils.snmp_interface_template import COMMON_IFMIB_TABLE_PATH
 from apps.rpc.node_mgmt import NodeMgmt
 
 TEMPLATE_COLLECT_TYPE_PATTERN = re.compile(r"""collect_type\s*=\s*["']([^"']+)["']""")
@@ -24,65 +25,44 @@ LOCAL_TEMPLATE_ASSET_PATTERN = re.compile(
     r"(?m)^[ \t]*# @bk_include_file (?P<path>\S+)[ \t]*$"
 )
 COMMON_IFMIB_TABLE_DIRECTIVE = "# @bk_include_ifmib_table"
-COMMON_IFMIB_TABLE_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
-)
+
 
 # IF-MIB 是所有 Network Device SNMP 模板共享的采集契约。此处只维护一次指标目录，
 # 导入时合并到每个厂商模板，避免为了显示指标而新增一个可被用户接入的公共插件。
-COMMON_IFMIB_METRICS = (
-    (
-        "Status", "interface_ifAdminStatus", "Interface Admin Status", "Enum",
-        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},{"name":"testing","id":3,"color":"#faad14"}]',
-        "Interface administrative status.",
-    ),
-    (
-        "Status", "interface_ifOperStatus", "Interface Oper Status", "Enum",
-        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},{"name":"testing","id":3,"color":"#faad14"}]',
-        "Actual interface operational status.",
-    ),
-    ("Bandwidth", "interface_ifSpeed", "Interface Bandwidth", "Number", "bitps", "Maximum supported interface speed."),
-    ("Packet Error", "interface_ifInErrors", "Incoming Errors Rate", "Number", "cps", "Average inbound error packets per second over five minutes."),
-    ("Packet Error", "interface_ifOutErrors", "Outgoing Errors Rate", "Number", "cps",
-     "Average outbound error packets per second over five minutes."),
-    ("Packet Loss", "interface_ifInDiscards", "Incoming Discards Rate", "Number", "cps",
-     "Average inbound discarded packets per second over five minutes."),
-    ("Packet Loss", "interface_ifOutDiscards", "Outgoing Discards Rate", "Number", "cps",
-     "Average outbound discarded packets per second over five minutes."),
-    ("Packet", "interface_ifInUcastPkts", "Incoming Unicast Packets Rate", "Number", "cps",
-     "Average inbound unicast packets per second over five minutes."),
-    ("Packet", "interface_ifOutUcastPkts", "Outgoing Unicast Packets Rate", "Number", "cps",
-     "Average outbound unicast packets per second over five minutes."),
-    ("Traffic", "interface_ifInOctets", "Interface Incoming Traffic Rate", "Number", "byteps",
-     "Average inbound interface bytes per second over five minutes."),
-    ("Traffic", "interface_ifOutOctets", "Interface Outgoing Traffic Rate", "Number", "byteps",
-     "Average outbound interface bytes per second over five minutes."),
-    ("Traffic", "interface_ifHCInOctets", "Interface Incoming Traffic Rate (HC)", "Number", "byteps",
-     "Average inbound 64-bit interface bytes per second over five minutes."),
-    ("Traffic", "interface_ifHCOutOctets", "Interface Outgoing Traffic Rate (HC)", "Number", "byteps",
-     "Average outbound 64-bit interface bytes per second over five minutes."),
-    ("Traffic", "device_total_incoming_traffic", "Device Total Incoming Traffic Rate", "Number", "byteps",
-     "Total inbound interface bytes per second over five minutes."),
-    ("Traffic", "device_total_outgoing_traffic", "Device Total Outgoing Traffic Rate", "Number", "byteps",
-     "Total outbound interface bytes per second over five minutes."),
-)
-
-
 def _build_common_ifmib_metrics(instance_type):
     """Build the complete public IF-MIB metric catalog for one runtime object."""
     metrics = []
-    for group, name, display_name, data_type, unit, description in COMMON_IFMIB_METRICS:
+    interface_dimensions = [
+        {"name": "ifIndex", "description": "ifIndex"},
+        {"name": "ifDescr", "description": "ifDescr"},
+    ]
+    for group, name, display_name, data_type, unit, description in IFMIB_METRIC_CATALOG:
         if name.startswith("device_total_"):
             direction = "In" if name.endswith("incoming_traffic") else "Out"
-            query = f"sum(rate(interface_ifHC{direction}Octets{{instance_type='{instance_type}', __$labels__}}[5m])) by (instance_id)"
+            query = (
+                f"sum(rate(interface_ifHC{direction}Octets{{instance_type='{instance_type}', __$labels__}}[5m]) "
+                f"or rate(interface_if{direction}Octets{{instance_type='{instance_type}', __$labels__}}[5m])) by (instance_id)"
+            )
             dimensions = []
-        elif name in {"interface_ifAdminStatus", "interface_ifOperStatus", "interface_ifSpeed"}:
+        elif name == "interface_ifSpeed":
+            query = (
+                f"(interface_ifHighSpeed{{instance_type='{instance_type}', __$labels__}} > 0) * 1000000 "
+                f"or interface_ifSpeed{{instance_type='{instance_type}', __$labels__}}"
+            )
+            dimensions = interface_dimensions
+        elif name in {"interface_ifAdminStatus", "interface_ifOperStatus"}:
             query = f"{name}{{instance_type='{instance_type}', __$labels__}}"
-            dimensions = [{"name": "ifDescr", "description": "ifDescr"}]
+            dimensions = interface_dimensions
+        elif name in {"interface_ifInUcastPkts", "interface_ifOutUcastPkts"}:
+            direction = "In" if "InUcast" in name else "Out"
+            query = (
+                f"rate(interface_ifHC{direction}UcastPkts{{instance_type='{instance_type}', __$labels__}}[5m]) "
+                f"or rate({name}{{instance_type='{instance_type}', __$labels__}}[5m])"
+            )
+            dimensions = interface_dimensions
         else:
             query = f"rate({name}{{instance_type='{instance_type}', __$labels__}}[5m])"
-            dimensions = [{"name": "ifDescr", "description": "ifDescr"}]
+            dimensions = interface_dimensions
         metrics.append(
             {
                 "metric_group": group,
@@ -115,13 +95,9 @@ def merge_common_ifmib_metrics(plugin_data):
     for metric in result.get("metrics", []):
         metric_name = metric.get("name")
         if metric_name in common_metrics_by_name:
-            # 厂商可能为同一 IF-MIB 指标提供更准确的查询或分组。保留该定义，
-            # 仅标记来源，确保目录/API 的厂商优先级不被公共目录覆盖。
-            # device_total_* 强制使用公共 HC 聚合，避免厂商旧 32 位计数器在高速口 wrap。
-            if str(metric_name).startswith("device_total_"):
-                metric = {**common_metrics_by_name[metric_name]}
-            else:
-                metric = {**metric, "is_ifmib": True}
+            if metric_name in existing_common_names:
+                continue
+            metric = {**common_metrics_by_name[metric_name]}
             existing_common_names.add(metric_name)
         merged_metrics.append(metric)
     merged_metrics.extend(
@@ -383,7 +359,7 @@ def _load_templates_to_memory():
     # 按插件 ID 分组的 UI 模板
     all_ui_templates = {tpl.plugin_id: tpl for tpl in MonitorPluginUITemplate.objects.select_related("plugin").all()}
 
-    logger.info(f"已加载配置模板和 UI 模板到内存")
+    logger.info("已加载配置模板和 UI 模板到内存")
     return all_config_templates, all_ui_templates
 
 
@@ -624,7 +600,7 @@ def _cleanup_removed_plugins(path_list):
             removed_plugins.delete()
 
         logger.info(f"已删除 {removed_count} 个从内置目录中移除的插件: {removed_names}")
-        logger.info(f"关联的配置模板和 UI 模板已自动级联删除")
+        logger.info("关联的配置模板和 UI 模板已自动级联删除")
 
 
 def _cleanup_orphan_objects():
@@ -643,7 +619,7 @@ def _cleanup_orphan_objects():
             orphan_objects.delete()
 
         logger.info(f"已删除 {orphan_count} 个没有关联插件的监控对象: {orphan_names}")
-        logger.info(f"关联的指标组、指标、监控实例已自动级联删除")
+        logger.info("关联的指标组、指标、监控实例已自动级联删除")
 
 
 def _cleanup_empty_builtin_metric_groups():

--- a/server/apps/monitor/management/services/policy_migrate.py
+++ b/server/apps/monitor/management/services/policy_migrate.py
@@ -4,7 +4,62 @@ from pathlib import Path
 from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.plugin import PluginConstants
 from apps.monitor.management.utils import find_files_by_pattern
+from apps.monitor.models import MonitorObject, MonitorPlugin
 from apps.monitor.services.policy import PolicyService
+
+
+def _is_legacy_policy_document(policy_data):
+    """识别仅供旧版策略引擎使用、无法转换为内置模板的配置。"""
+    return policy_data == {} or (
+        isinstance(policy_data, dict)
+        and "policy" in policy_data
+        and not policy_data.get("object")
+        and not policy_data.get("plugin")
+    )
+
+
+def _filter_unavailable_policy_documents(documents):
+    valid_documents = []
+    skipped_count = 0
+    seen_pairs = set()
+    seen_keys = set()
+    for file_path, data in documents:
+        try:
+            normalized = PolicyService._normalize_builtin_documents([data])
+        except Exception as e:
+            logger.warning("跳过不符合内置模板契约的策略配置: %s, 错误: %s", file_path, e)
+            skipped_count += 1
+            continue
+        pair = (str(data["object"]).strip(), str(data["plugin"]).strip())
+        keys = {item["key"] for item in normalized}
+        if pair in seen_pairs or keys & seen_keys:
+            logger.warning("跳过与先前文件重复定义内置模板的策略配置: %s", file_path)
+            skipped_count += 1
+            continue
+        seen_pairs.add(pair)
+        seen_keys.update(keys)
+        valid_documents.append((file_path, data))
+
+    object_names = {str(data["object"]).strip() for _, data in valid_documents}
+    plugin_names = {str(data["plugin"]).strip() for _, data in valid_documents}
+    available_objects = set(MonitorObject.objects.filter(name__in=object_names).values_list("name", flat=True))
+    available_plugins = set(MonitorPlugin.objects.filter(name__in=plugin_names).values_list("name", flat=True))
+
+    available_documents = []
+    for file_path, data in valid_documents:
+        object_name = str(data["object"]).strip()
+        plugin_name = str(data["plugin"]).strip()
+        if object_name not in available_objects or plugin_name not in available_plugins:
+            logger.warning(
+                "跳过引用未导入监控对象或插件的策略配置: %s, object=%s, plugin=%s",
+                file_path,
+                object_name,
+                plugin_name,
+            )
+            skipped_count += 1
+            continue
+        available_documents.append(data)
+    return available_documents, skipped_count
 
 
 def migrate_policy():
@@ -21,28 +76,35 @@ def migrate_policy():
     logger.info(f'找到 {len(path_list)} 个策略配置文件')
 
     documents = []
-    error_count = 0
+    skipped_count = 0
     for file_path in sorted(path_list):
         try:
             policy_data = json.loads(Path(file_path).read_text(encoding='utf-8'))
             if policy_data == []:
                 logger.info(f'跳过空策略配置: {file_path}')
                 continue
-            documents.append(policy_data)
+            if _is_legacy_policy_document(policy_data):
+                logger.warning(f'跳过不兼容的遗留策略配置: {file_path}')
+                skipped_count += 1
+                continue
+            documents.append((file_path, policy_data))
         except Exception as e:
             logger.error(f'读取策略配置失败: {file_path}, 错误: {e}')
-            error_count += 1
-    if error_count:
-        logger.error(f"策略配置读取失败，保留上一次有效内置模板: 失败={error_count}")
+            skipped_count += 1
+    documents, unavailable_count = _filter_unavailable_policy_documents(documents)
+    skipped_count += unavailable_count
+    if not documents:
+        logger.error("没有可同步的内置策略模板，保留上一次有效内置模板")
         return
     try:
-        result = PolicyService.sync_builtin_policy_templates(documents)
+        result = PolicyService.sync_builtin_policy_templates(documents, delete_missing=not skipped_count)
     except Exception as e:
         logger.error(f"策略模板校验或对账失败，保留上一次有效内置模板: {e}")
         return
     logger.info(
-        "策略模板对账完成: 创建=%s, 更新=%s, 删除=%s",
+        "策略模板对账完成: 创建=%s, 更新=%s, 删除=%s, 跳过=%s",
         result["created_count"],
         result["updated_count"],
         result["deleted_count"],
+        skipped_count,
     )

--- a/server/apps/monitor/migrations/0060_snmpifmibreconcilestate.py
+++ b/server/apps/monitor/migrations/0060_snmpifmibreconcilestate.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("monitor", "0059_rename_monitor_object_type_host_resource_to_os"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SnmpIfmibReconcileState",
+            fields=[
+                ("version", models.PositiveIntegerField(primary_key=True, serialize=False)),
+                ("owner_token", models.CharField(blank=True, default="", max_length=64)),
+                ("lease_expires_at", models.DateTimeField(blank=True, null=True)),
+                ("cursor_created_at", models.DateTimeField(blank=True, null=True)),
+                ("cursor_config_id", models.CharField(blank=True, default="", max_length=255)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={"db_table": "monitor_snmp_ifmib_reconcile_state"},
+        ),
+    ]

--- a/server/apps/monitor/models/__init__.py
+++ b/server/apps/monitor/models/__init__.py
@@ -6,3 +6,4 @@ from apps.monitor.models.collect_config import *
 from apps.monitor.models.collect_detect import *
 from apps.monitor.models.monitor_condition import *
 from apps.monitor.models.view_column_preference import *
+from apps.monitor.models.snmp_ifmib_reconcile import *

--- a/server/apps/monitor/models/snmp_ifmib_reconcile.py
+++ b/server/apps/monitor/models/snmp_ifmib_reconcile.py
@@ -1,0 +1,16 @@
+from django.db import models
+
+
+class SnmpIfmibReconcileState(models.Model):
+    """IF-MIB 存量配置补偿的持久游标与数据库所有权凭证。"""
+
+    version = models.PositiveIntegerField(primary_key=True)
+    owner_token = models.CharField(max_length=64, blank=True, default="")
+    lease_expires_at = models.DateTimeField(null=True, blank=True)
+    cursor_created_at = models.DateTimeField(null=True, blank=True)
+    cursor_config_id = models.CharField(max_length=255, blank=True, default="")
+    completed_at = models.DateTimeField(null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "monitor_snmp_ifmib_reconcile_state"

--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -301,6 +301,11 @@ class InstanceConfigService:
             config = configs[0]
             if config_obj.file_type == "toml":
                 config["content"] = ConfigFormat.toml_to_dict(config[content_key])
+                if (config_obj.collect_type or "").startswith("snmp"):
+                    from apps.monitor.utils.snmp_interface_filters import expose_snmp_interface_filters_for_edit
+
+                    # tagpass 隔离后过滤在 snmp[1]；表单只读 content.config，需投影回显。
+                    config["content"] = expose_snmp_interface_filters_for_edit(config["content"])
             elif config_obj.file_type == "yaml":
                 config["content"] = ConfigFormat.yaml_to_dict(config[content_key])
             else:

--- a/server/apps/monitor/services/plugin_guide.py
+++ b/server/apps/monitor/services/plugin_guide.py
@@ -33,23 +33,27 @@ class PluginGuideService:
     @staticmethod
     def _lookup_plugin_dir(collector: str, collect_type: str, plugin_name: str) -> Optional[Path]:
         for root in (PluginConstants.DIRECTORY, PluginConstants.ENTERPRISE_DIRECTORY):
-            base = Path(root) / collector / collect_type
-            if not base.is_dir():
-                continue
+            collector_root = Path(root) / collector
+            candidate_bases = [collector_root / collect_type]
+            if collect_type.startswith("snmp"):
+                candidate_bases.append(collector_root / "snmp")
             matched_by_name: Optional[Path] = None
-            for child in sorted(base.iterdir()):
-                if not child.is_dir():
+            for base in dict.fromkeys(candidate_bases):
+                if not base.is_dir():
                     continue
-                metrics_file = child / "metrics.json"
-                if metrics_file.is_file():
-                    try:
-                        data = json.loads(metrics_file.read_text(encoding="utf-8"))
-                    except (OSError, json.JSONDecodeError):
-                        data = {}
-                    if data.get("plugin") == plugin_name:
-                        return child
-                if child.name.lower() == plugin_name.lower():
-                    matched_by_name = child
+                for child in sorted(base.iterdir()):
+                    if not child.is_dir():
+                        continue
+                    metrics_file = child / "metrics.json"
+                    if metrics_file.is_file():
+                        try:
+                            data = json.loads(metrics_file.read_text(encoding="utf-8"))
+                        except (OSError, json.JSONDecodeError):
+                            data = {}
+                        if data.get("plugin") == plugin_name:
+                            return child
+                    if child.name.lower() == plugin_name.lower():
+                        matched_by_name = child
             if matched_by_name is not None:
                 return matched_by_name
         return None

--- a/server/apps/monitor/services/policy.py
+++ b/server/apps/monitor/services/policy.py
@@ -107,7 +107,7 @@ class PolicyService:
         return normalized
 
     @staticmethod
-    def sync_builtin_policy_templates(documents):
+    def sync_builtin_policy_templates(documents, delete_missing=True):
         normalized = PolicyService._normalize_builtin_documents(documents)
         object_names = {item["object_name"] for item in normalized}
         plugin_names = {item["plugin_name"] for item in normalized}
@@ -131,9 +131,11 @@ class PolicyService:
                 )
                 created_count += int(created)
                 updated_count += int(not created)
-            deleted_count, _ = PolicyTemplate.objects.filter(
-                template_type=PolicyTemplate.TYPE_BUILTIN
-            ).exclude(key__in=expected_keys).delete()
+            deleted_count = 0
+            if delete_missing:
+                deleted_count, _ = PolicyTemplate.objects.filter(
+                    template_type=PolicyTemplate.TYPE_BUILTIN
+                ).exclude(key__in=expected_keys).delete()
         return {
             "created_count": created_count,
             "updated_count": updated_count,

--- a/server/apps/monitor/services/snmp_ifmib_reconcile_state.py
+++ b/server/apps/monitor/services/snmp_ifmib_reconcile_state.py
@@ -1,0 +1,131 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.monitor.models.snmp_ifmib_reconcile import SnmpIfmibReconcileState
+
+
+@dataclass(frozen=True)
+class ReconcileClaim:
+    status: str
+    cursor: tuple[datetime, str] | None = None
+
+
+@dataclass(frozen=True)
+class OwnedWriteResult:
+    executed: bool
+    value: object = None
+
+
+class SnmpIfmibReconcileStateService:
+    """用单行条件更新约束 IF-MIB 对账的 owner、租约、游标与完成态。"""
+
+    @staticmethod
+    def claim(*, version: int, owner_token: str, lease_seconds: int) -> ReconcileClaim:
+        current_time = timezone.now()
+        lease_until = current_time + timedelta(seconds=lease_seconds)
+        with transaction.atomic():
+            SnmpIfmibReconcileState.objects.get_or_create(version=version)
+            state = SnmpIfmibReconcileState.objects.select_for_update().get(version=version)
+            if state.completed_at is not None:
+                return ReconcileClaim(status="completed")
+            if state.owner_token and state.lease_expires_at and state.lease_expires_at > current_time:
+                return ReconcileClaim(status="running")
+            cursor = (state.cursor_created_at, state.cursor_config_id) if state.cursor_created_at is not None and state.cursor_config_id else None
+            state.owner_token = owner_token
+            state.lease_expires_at = lease_until
+            state.save(update_fields=["owner_token", "lease_expires_at", "updated_at"])
+            return ReconcileClaim(status="claimed", cursor=cursor)
+
+    @staticmethod
+    def renew_progress(
+        *,
+        version: int,
+        owner_token: str,
+        lease_seconds: int,
+        cursor: tuple[datetime, str] | None,
+    ) -> bool:
+        current_time = timezone.now()
+        updates = {
+            "lease_expires_at": current_time + timedelta(seconds=lease_seconds),
+            "updated_at": current_time,
+        }
+        if cursor is not None:
+            updates.update(
+                cursor_created_at=cursor[0],
+                cursor_config_id=str(cursor[1]),
+            )
+        return bool(
+            SnmpIfmibReconcileState.objects.filter(
+                version=version,
+                owner_token=owner_token,
+                completed_at__isnull=True,
+                lease_expires_at__gt=current_time,
+            ).update(**updates)
+        )
+
+    @staticmethod
+    def run_owned_write(
+        *,
+        version: int,
+        owner_token: str,
+        lease_seconds: int,
+        write: Callable[[], object],
+    ) -> OwnedWriteResult:
+        """锁住租约行执行一次写入；过期 owner 不得进入外部 CAS。"""
+        current_time = timezone.now()
+        with transaction.atomic():
+            state = (
+                SnmpIfmibReconcileState.objects.select_for_update()
+                .filter(
+                    version=version,
+                    owner_token=owner_token,
+                    completed_at__isnull=True,
+                    lease_expires_at__gt=current_time,
+                )
+                .first()
+            )
+            if state is None:
+                return OwnedWriteResult(executed=False)
+            state.lease_expires_at = current_time + timedelta(seconds=lease_seconds)
+            state.save(update_fields=["lease_expires_at", "updated_at"])
+            return OwnedWriteResult(executed=True, value=write())
+
+    @staticmethod
+    def finish(*, version: int, owner_token: str) -> bool:
+        current_time = timezone.now()
+        return bool(
+            SnmpIfmibReconcileState.objects.filter(
+                version=version,
+                owner_token=owner_token,
+                completed_at__isnull=True,
+                lease_expires_at__gt=current_time,
+            ).update(
+                owner_token="",
+                lease_expires_at=None,
+                cursor_created_at=None,
+                cursor_config_id="",
+                completed_at=current_time,
+                updated_at=current_time,
+            )
+        )
+
+    @staticmethod
+    def reset_cursor(*, version: int, owner_token: str) -> bool:
+        """仅当前未过期 owner 可清空游标，供毒数据隔离扫描后重新检查全量。"""
+        current_time = timezone.now()
+        return bool(
+            SnmpIfmibReconcileState.objects.filter(
+                version=version,
+                owner_token=owner_token,
+                completed_at__isnull=True,
+                lease_expires_at__gt=current_time,
+            ).update(
+                cursor_created_at=None,
+                cursor_config_id="",
+                updated_at=current_time,
+            )
+        )

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml
@@ -3,12 +3,19 @@
     name = "interface"
     inherit_tags = ["source"]
 [[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.2.2.1.1"
+    name = "ifIndex"
+    is_tag = true
+[[inputs.snmp.table.field]]
     oid = "1.3.6.1.2.1.2.2.1.2"
     name = "ifDescr"
     is_tag = true
 [[inputs.snmp.table.field]]
     oid = "1.3.6.1.2.1.2.2.1.5"
     name = "ifSpeed"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.31.1.1.1.15"
+    name = "ifHighSpeed"
 [[inputs.snmp.table.field]]
     oid = "1.3.6.1.2.1.2.2.1.7"
     name = "ifAdminStatus"
@@ -43,5 +50,11 @@
     oid = "1.3.6.1.2.1.31.1.1.1.6"
     name = "ifHCInOctets"
 [[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.31.1.1.1.7"
+    name = "ifHCInUcastPkts"
+[[inputs.snmp.table.field]]
     oid = "1.3.6.1.2.1.31.1.1.1.10"
     name = "ifHCOutOctets"
+[[inputs.snmp.table.field]]
+    oid = "1.3.6.1.2.1.31.1.1.1.11"
+    name = "ifHCOutUcastPkts"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
@@ -32,22 +32,6 @@
         oid = "1.3.6.1.2.1.1.5.0"
         name = "source"
         is_tag = true
-    [[inputs.snmp.table]]
-        oid = "1.3.6.1.2.1.2.2"
-        name = "interface"
-        inherit_tags = ["source"]
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.2.2.1.2"
-        name = "ifDescr"
-        is_tag = true
-    # ---- 64-bit IF-MIB HC traffic counters (ifXTable, wrap-safe on high-speed ports) ----
-    # 待现网核验：ifHCInOctets 1.3.6.1.2.1.31.1.1.1.6 / ifHCOutOctets ...1.10，按 ifIndex 与上表接口行对齐。
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.31.1.1.1.6"
-        name = "ifHCInOctets"
-    [[inputs.snmp.table.field]]
-        oid = "1.3.6.1.2.1.31.1.1.1.10"
-        name = "ifHCOutOctets"
     # ---- H3C/HPE Comware CPU (HH3C-ENTITY-EXT-MIB hh3cEntityExtCpuUsage, %, per-entity table, PEN 25506) ----
     # 待现网核验：列 OID 1.3.6.1.4.1.25506.2.6.1.1.1.1.6（每实体 CPU%；多数实体返0,载 CPU 实体非0,snmprec hpe5900 ent192=5/a5500 ent65=8）。
     # device_cpu_usage 在 metrics.json 用 max() by instance_id 取活跃实体,避免零稀释。

--- a/server/apps/monitor/tasks/__init__.py
+++ b/server/apps/monitor/tasks/__init__.py
@@ -1,3 +1,4 @@
-from apps.monitor.tasks.collect_detect import run_collect_detect_task
-from apps.monitor.tasks.grouping_rule import sync_instance_and_group
-from apps.monitor.tasks.monitor_policy import scan_policy_task
+from apps.monitor.tasks.collect_detect import run_collect_detect_task  # noqa: F401
+from apps.monitor.tasks.grouping_rule import sync_instance_and_group  # noqa: F401
+from apps.monitor.tasks.monitor_policy import scan_policy_task  # noqa: F401
+from apps.monitor.tasks.snmp_ifmib_reconcile import reconcile_snmp_interface_filters  # noqa: F401

--- a/server/apps/monitor/tasks/snmp_ifmib_reconcile.py
+++ b/server/apps/monitor/tasks/snmp_ifmib_reconcile.py
@@ -1,0 +1,80 @@
+from uuid import uuid4
+
+from celery import shared_task
+from django.core.management import call_command
+
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.management.commands.patch_snmp_interface_filters import CHECKPOINT_VERSION, SnmpIfmibReconcilePartialError
+from apps.monitor.services.snmp_ifmib_reconcile_state import SnmpIfmibReconcileStateService
+
+IFMIB_RECONCILE_VERSION = CHECKPOINT_VERSION
+IFMIB_RECONCILE_LOCK_TIMEOUT = 900
+
+
+@shared_task
+def reconcile_snmp_interface_filters():
+    """运行期幂等补偿存量 IF-MIB 子配置；失败不参与 Server 启动。"""
+    owner_token = uuid4().hex
+    claim = SnmpIfmibReconcileStateService.claim(
+        version=IFMIB_RECONCILE_VERSION,
+        owner_token=owner_token,
+        lease_seconds=IFMIB_RECONCILE_LOCK_TIMEOUT,
+    )
+    if claim.status == "completed":
+        return {"status": "skipped", "reason": "already_completed"}
+    if claim.status != "claimed":
+        return {"status": "skipped", "reason": "already_running"}
+
+    def persist_progress(cursor):
+        renewed = SnmpIfmibReconcileStateService.renew_progress(
+            version=IFMIB_RECONCILE_VERSION,
+            owner_token=owner_token,
+            lease_seconds=IFMIB_RECONCILE_LOCK_TIMEOUT,
+            cursor=cursor,
+        )
+        if not renewed:
+            raise RuntimeError("IF-MIB reconcile lease ownership lost")
+
+    def compare_and_swap(node_mgmt, config_id, expected_content, content):
+        result = SnmpIfmibReconcileStateService.run_owned_write(
+            version=IFMIB_RECONCILE_VERSION,
+            owner_token=owner_token,
+            lease_seconds=IFMIB_RECONCILE_LOCK_TIMEOUT,
+            write=lambda: node_mgmt.compare_and_swap_child_config_content_local(
+                config_id,
+                expected_content,
+                content,
+            ),
+        )
+        if not result.executed:
+            raise RuntimeError("IF-MIB reconcile lease ownership lost before child write")
+        return bool(result.value)
+
+    try:
+        call_command(
+            "patch_snmp_interface_filters",
+            batch_size=100,
+            initial_cursor=claim.cursor,
+            batch_completed=persist_progress,
+            compare_and_swap=compare_and_swap,
+            continue_on_item_error=True,
+        )
+        if not SnmpIfmibReconcileStateService.finish(
+            version=IFMIB_RECONCILE_VERSION,
+            owner_token=owner_token,
+        ):
+            raise RuntimeError("IF-MIB reconcile lease ownership lost before completion")
+        logger.info("IF-MIB 存量子配置运行期补偿完成")
+        return {"status": "completed"}
+    except SnmpIfmibReconcilePartialError:
+        if not SnmpIfmibReconcileStateService.reset_cursor(
+            version=IFMIB_RECONCILE_VERSION,
+            owner_token=owner_token,
+        ):
+            logger.error("IF-MIB 毒数据扫描后重置游标失败：任务已失去租约所有权")
+        logger.exception("IF-MIB 存量子配置仍含无效项；健康配置已处理，将在租约过期后重新检查")
+        raise
+    except Exception:
+        # 不释放失败租约；到期后下一次 Beat 原子接管，并从最后成功批次游标继续。
+        logger.exception("IF-MIB 存量子配置运行期补偿失败，将在租约过期后从断点重试")
+        raise

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -141,6 +141,7 @@ def normalize_filter_list(value):
 
     return _normalize_filter_list(value)
 
+
 def _escape_toml_context_strings(value):
     if isinstance(value, str):
         return _escape_toml_string(value)
@@ -265,6 +266,7 @@ class Controller:
         from apps.monitor.utils.snmp_interface_template import (
             ensure_core_network_ifmib_jinja,
             ensure_snmp_interface_filter_jinja,
+            isolate_snmp_interface_tagpass,
             needs_snmp_interface_filter_jinja,
             validate_rendered_core_network_ifmib,
         )
@@ -289,6 +291,7 @@ class Controller:
 
         template = self.jinja_env.from_string(template_content)
         rendered_template = template.render(safe_context)
+        rendered_template = isolate_snmp_interface_tagpass(rendered_template, _context)
         validate_rendered_core_network_ifmib(rendered_template, _context)
         return rendered_template
 

--- a/server/apps/monitor/utils/snmp_ifmib_capability.py
+++ b/server/apps/monitor/utils/snmp_ifmib_capability.py
@@ -11,16 +11,119 @@ from django.db import DatabaseError
 from apps.core.logger import monitor_logger as logger
 
 NETWORK_DEVICE_TYPE_ID = "Network Device"
-COMMON_IFMIB_METRIC_NAMES = frozenset(
-    {
-        "interface_ifAdminStatus", "interface_ifOperStatus", "interface_ifSpeed",
-        "interface_ifInErrors", "interface_ifOutErrors", "interface_ifInDiscards",
-        "interface_ifOutDiscards", "interface_ifInUcastPkts", "interface_ifOutUcastPkts",
-        "interface_ifInOctets", "interface_ifOutOctets", "interface_ifHCInOctets",
-        "interface_ifHCOutOctets", "device_total_incoming_traffic",
+CORE_IFMIB_OBJECT_NAMES = frozenset({"Switch", "Router", "Firewall", "Loadbalance"})
+IFMIB_METRIC_CATALOG = (
+    (
+        "Status",
+        "interface_ifAdminStatus",
+        "Interface Admin Status",
+        "Enum",
+        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},{"name":"testing","id":3,"color":"#faad14"}]',
+        "Interface administrative status.",
+    ),
+    (
+        "Status",
+        "interface_ifOperStatus",
+        "Interface Oper Status",
+        "Enum",
+        '[{"name":"up","id":1,"color":"#1ac44a"},{"name":"down","id":2,"color":"#ff4d4f"},'
+        '{"name":"testing","id":3,"color":"#faad14"},{"name":"unknown","id":4,"color":"#8c8c8c"},'
+        '{"name":"dormant","id":5,"color":"#faad14"},{"name":"notPresent","id":6,"color":"#8c8c8c"},'
+        '{"name":"lowerLayerDown","id":7,"color":"#ff4d4f"}]',
+        "Actual interface operational status.",
+    ),
+    ("Bandwidth", "interface_ifSpeed", "Interface Bandwidth", "Number", "bitps", "Maximum supported interface speed."),
+    ("Packet Error", "interface_ifInErrors", "Incoming Errors Rate", "Number", "cps", "Average inbound error packets per second over five minutes."),
+    (
+        "Packet Error",
+        "interface_ifOutErrors",
+        "Outgoing Errors Rate",
+        "Number",
+        "cps",
+        "Average outbound error packets per second over five minutes.",
+    ),
+    (
+        "Packet Loss",
+        "interface_ifInDiscards",
+        "Incoming Discards Rate",
+        "Number",
+        "cps",
+        "Average inbound discarded packets per second over five minutes.",
+    ),
+    (
+        "Packet Loss",
+        "interface_ifOutDiscards",
+        "Outgoing Discards Rate",
+        "Number",
+        "cps",
+        "Average outbound discarded packets per second over five minutes.",
+    ),
+    (
+        "Packet",
+        "interface_ifInUcastPkts",
+        "Incoming Unicast Packets Rate",
+        "Number",
+        "cps",
+        "Average inbound unicast packets per second over five minutes.",
+    ),
+    (
+        "Packet",
+        "interface_ifOutUcastPkts",
+        "Outgoing Unicast Packets Rate",
+        "Number",
+        "cps",
+        "Average outbound unicast packets per second over five minutes.",
+    ),
+    (
+        "Traffic",
+        "interface_ifInOctets",
+        "Interface Incoming Traffic Rate",
+        "Number",
+        "byteps",
+        "Average inbound interface bytes per second over five minutes.",
+    ),
+    (
+        "Traffic",
+        "interface_ifOutOctets",
+        "Interface Outgoing Traffic Rate",
+        "Number",
+        "byteps",
+        "Average outbound interface bytes per second over five minutes.",
+    ),
+    (
+        "Traffic",
+        "interface_ifHCInOctets",
+        "Interface Incoming Traffic Rate (HC)",
+        "Number",
+        "byteps",
+        "Average inbound 64-bit interface bytes per second over five minutes.",
+    ),
+    (
+        "Traffic",
+        "interface_ifHCOutOctets",
+        "Interface Outgoing Traffic Rate (HC)",
+        "Number",
+        "byteps",
+        "Average outbound 64-bit interface bytes per second over five minutes.",
+    ),
+    (
+        "Traffic",
+        "device_total_incoming_traffic",
+        "Device Total Incoming Traffic Rate",
+        "Number",
+        "byteps",
+        "Total inbound interface bytes per second over five minutes.",
+    ),
+    (
+        "Traffic",
         "device_total_outgoing_traffic",
-    }
+        "Device Total Outgoing Traffic Rate",
+        "Number",
+        "byteps",
+        "Total outbound interface bytes per second over five minutes.",
+    ),
 )
+COMMON_IFMIB_METRIC_NAMES = frozenset(metric[1] for metric in IFMIB_METRIC_CATALOG)
 
 # 公共 IF-MIB 指标在中文控制台的唯一展示目录。采集器字段名保持 RFC/Prometheus
 # 命名，页面只通过此目录取得中文名称和说明。
@@ -43,14 +146,36 @@ IFMIB_ZH_DISPLAY_TEXTS = {
 }
 
 
-def _is_network_device_snmp_plugin(plugin: Any) -> bool:
+def get_ifmib_metric_names_matching_keyword(keyword: str, locale: str) -> set[str]:
+    """Return metric IDs whose localized public catalog text contains ``keyword``."""
+    normalized_keyword = str(keyword or "").strip().casefold()
+    if not normalized_keyword or not str(locale or "").startswith("zh"):
+        return set()
+    return {
+        metric_name
+        for metric_name, display_text in IFMIB_ZH_DISPLAY_TEXTS.items()
+        if normalized_keyword in metric_name.casefold() or any(normalized_keyword in str(text or "").casefold() for text in display_text)
+    }
+
+
+class IFMIBCapabilityResolutionError(RuntimeError):
+    """Raised when neither database metadata nor the manifest can decide capability."""
+
+
+def _is_network_device_snmp_plugin(plugin: Any, *, raise_on_unknown: bool = False) -> bool:
     """Return the single capability decision used by IF-MIB and interface filters."""
     if plugin is None or not str(getattr(plugin, "collect_type", "")).startswith("snmp"):
         return False
+    database_error = None
     try:
-        if plugin.monitor_object.filter(type_id=NETWORK_DEVICE_TYPE_ID).exists():
+        if plugin.monitor_object.filter(type_id=NETWORK_DEVICE_TYPE_ID, name__in=CORE_IFMIB_OBJECT_NAMES).exists():
             return True
+        if raise_on_unknown:
+            identities = set(plugin.monitor_object.values_list("type_id", "name"))
+            if identities and all(type_id is not None and name for type_id, name in identities):
+                return False
     except (AttributeError, DatabaseError, TypeError) as exc:
+        database_error = exc
         logger.warning(f"读取 SNMP 模板对象能力失败: {exc}")
 
     # 通用模板的存量数据库对象可能尚未补齐 type_id；回退到内置 manifest，避免
@@ -61,10 +186,14 @@ def _is_network_device_snmp_plugin(plugin: Any) -> bool:
         plugin_dir = PluginGuideService.resolve_plugin_dir(plugin)
         metrics_file = Path(plugin_dir) / "metrics.json" if plugin_dir else None
         if metrics_file is None or not metrics_file.is_file():
+            if raise_on_unknown:
+                raise IFMIBCapabilityResolutionError("Unable to resolve IF-MIB capability: manifest is unavailable") from database_error
             return False
-        return json.loads(metrics_file.read_text(encoding="utf-8")).get("type") == NETWORK_DEVICE_TYPE_ID
+        return is_ifmib_capable_plugin_data(json.loads(metrics_file.read_text(encoding="utf-8")))
     except (AttributeError, OSError, ValueError, TypeError) as exc:
         logger.warning(f"读取 SNMP 模板内置能力失败: {exc}")
+        if raise_on_unknown:
+            raise IFMIBCapabilityResolutionError("Unable to resolve IF-MIB capability from database or manifest") from exc
         return False
 
 
@@ -78,11 +207,17 @@ def is_interface_filter_capable_plugin(plugin: Any) -> bool:
     return _is_network_device_snmp_plugin(plugin)
 
 
+def resolve_interface_filter_capability_for_migration(plugin: Any) -> bool:
+    """Resolve migration scope without converting unknown capability to unsupported."""
+    return _is_network_device_snmp_plugin(plugin, raise_on_unknown=True)
+
+
 def is_ifmib_capable_plugin_data(plugin_data: dict[str, Any]) -> bool:
     """Metadata-file adapter for the importer, with the same capability contract."""
     collect_type = str(plugin_data.get("collect_type") or "")
     return (
         str(plugin_data.get("type") or "") == NETWORK_DEVICE_TYPE_ID
+        and str(plugin_data.get("name") or "") in CORE_IFMIB_OBJECT_NAMES
         and (not collect_type or collect_type.startswith("snmp"))
     )
 

--- a/server/apps/monitor/utils/snmp_interface_filters.py
+++ b/server/apps/monitor/utils/snmp_interface_filters.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from copy import deepcopy
 
 from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.monitor.constants.snmp_interface import (
@@ -13,6 +14,8 @@ from apps.monitor.constants.snmp_interface import (
 )
 
 _IFTYPE_LABELED_RE = re.compile(r"^(\d+)\s+-\s+.+$")
+_INTERFACE_FILTER_KEYS = ("tagpass", "tagdrop", "tagexclude")
+_SNMP_INPUT_PAYLOAD_KEYS = frozenset({"field", "table", *_INTERFACE_FILTER_KEYS})
 
 _MSG_IFTYPE_MUTEX = {
     "zh": "排除与仅采集的接口类型不能同时配置，请先清空其中一侧",
@@ -21,6 +24,10 @@ _MSG_IFTYPE_MUTEX = {
 _MSG_IFDESCR_MUTEX = {
     "zh": "排除与仅采集的接口名称不能同时配置，请先清空其中一侧",
     "en": "Excluded and included interface names cannot be set together. Clear one side first",
+}
+_MSG_IFTYPE_INVALID = {
+    "zh": "ifType 只能填写数字或“数字 - 名称”格式，非法值：{values}",
+    "en": "ifType accepts only numbers or 'number - name'; invalid values: {values}",
 }
 
 
@@ -65,6 +72,17 @@ def normalize_iftype_list(value) -> list[str]:
     return values
 
 
+def _assert_valid_iftype_input(value) -> None:
+    invalid = [
+        item
+        for item in normalize_filter_list(value)
+        if not item.isdigit() and _IFTYPE_LABELED_RE.match(item) is None
+    ]
+    if invalid:
+        message = _mutex_message(_MSG_IFTYPE_INVALID).format(values=", ".join(invalid))
+        raise ValidationAppException(message)
+
+
 def _prune_table_key(config: dict, table_name: str, key: str, values: list[str]) -> None:
     table = config.get(table_name)
     if values:
@@ -103,8 +121,10 @@ def assert_snmp_interface_filter_mutex_from_values(values: dict | None) -> None:
     """从创建/编辑表单字段校验黑白名单互斥；顺带规范化 ifType 为数字。"""
     values = values or {}
     if FIELD_IFTYPE_INCLUDE in values:
+        _assert_valid_iftype_input(values.get(FIELD_IFTYPE_INCLUDE))
         values[FIELD_IFTYPE_INCLUDE] = normalize_iftype_list(values.get(FIELD_IFTYPE_INCLUDE))
     if FIELD_IFTYPE_EXCLUDE in values:
+        _assert_valid_iftype_input(values.get(FIELD_IFTYPE_EXCLUDE))
         values[FIELD_IFTYPE_EXCLUDE] = normalize_iftype_list(values.get(FIELD_IFTYPE_EXCLUDE))
     assert_snmp_interface_filter_mutex(
         iftype_include=values.get(FIELD_IFTYPE_INCLUDE),
@@ -155,4 +175,108 @@ def normalize_snmp_interface_filter_config(content: dict | None, form_values: di
 
     if "tagexclude" not in config:
         config["tagexclude"] = ["ifType"]
+    return sync_snmp_interface_split_inputs(content)
+
+
+def _iter_snmp_input_configs(content: dict) -> list[dict]:
+    document = content.get("_toml_document") if isinstance(content, dict) else None
+    if isinstance(document, dict):
+        inputs = document.get("inputs")
+        snmp_inputs = inputs.get("snmp") if isinstance(inputs, dict) else None
+        if isinstance(snmp_inputs, list):
+            return [item for item in snmp_inputs if isinstance(item, dict)]
+        if isinstance(snmp_inputs, dict):
+            return [snmp_inputs]
+    config = content.get("config") if isinstance(content, dict) else None
+    return [config] if isinstance(config, dict) else []
+
+
+def _public_ifmib_snmp_inputs(content: dict) -> list[dict]:
+    from apps.monitor.utils.snmp_interface_template import is_public_ifmib_table
+
+    owners = []
+    for snmp_input in _iter_snmp_input_configs(content):
+        tables = snmp_input.get("table")
+        if not isinstance(tables, list):
+            continue
+        if any(isinstance(table, dict) and is_public_ifmib_table(table) for table in tables):
+            owners.append(snmp_input)
+    return owners
+
+
+def _select_interface_filter_owner(owners: list[dict]) -> dict:
+    return max(
+        owners,
+        key=lambda snmp_input: (
+            any(key in snmp_input for key in ("tagpass", "tagdrop")),
+            "tagexclude" in snmp_input,
+        ),
+    )
+
+
+def expose_snmp_interface_filters_for_edit(content: dict | None) -> dict | None:
+    """表单只绑定 content.config；把承载公共 IF-MIB 的 snmp input 上的过滤投影回去显。"""
+    if not isinstance(content, dict):
+        return content
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return content
+    owners = _public_ifmib_snmp_inputs(content)
+    if not owners:
+        return content
+    owner = _select_interface_filter_owner(owners)
+    if owner is config:
+        return content
+    for key in _INTERFACE_FILTER_KEYS:
+        if key in owner:
+            config[key] = deepcopy(owner[key])
+        else:
+            config.pop(key, None)
+    return content
+
+
+def sync_snmp_interface_split_inputs(content: dict | None) -> dict | None:
+    """tagpass 隔离后过滤真正落在 snmp[1]；把表单对 config 的修改写回接口 input，并同步 agents 等连接参数。
+
+    ConfigFormat.json_to_toml 始终用 content.config 覆盖 snmp[0]。前端编辑会浅拷贝
+    config，使其不再是 document 里的同一对象；若公共表在 snmp[0]，必须把过滤留在
+    config 上，否则写回会丢掉刚同步到 owner 的 tagpass/tagdrop。
+    """
+    if not isinstance(content, dict):
+        return content
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return content
+    snmp_inputs = _iter_snmp_input_configs(content)
+    owners = _public_ifmib_snmp_inputs(content)
+    if len(snmp_inputs) <= 1 or not owners:
+        return content
+
+    owner = _select_interface_filter_owner(owners)
+    for key in _INTERFACE_FILTER_KEYS:
+        if key in config:
+            owner[key] = deepcopy(config[key])
+        else:
+            owner.pop(key, None)
+
+    shared = {key: deepcopy(value) for key, value in config.items() if key not in _SNMP_INPUT_PAYLOAD_KEYS}
+    for snmp_input in snmp_inputs:
+        for key, value in shared.items():
+            snmp_input[key] = deepcopy(value)
+        if snmp_input is owner:
+            continue
+        for key in _INTERFACE_FILTER_KEYS:
+            snmp_input.pop(key, None)
+
+    first = snmp_inputs[0]
+    if owner is first:
+        # snmp[0] 即过滤承载方：config 必须带上过滤，供 json_to_toml 写回。
+        for key in _INTERFACE_FILTER_KEYS:
+            if key in owner:
+                config[key] = deepcopy(owner[key])
+            else:
+                config.pop(key, None)
+    else:
+        for key in _INTERFACE_FILTER_KEYS:
+            config.pop(key, None)
     return content

--- a/server/apps/monitor/utils/snmp_interface_template.py
+++ b/server/apps/monitor/utils/snmp_interface_template.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import re
-import tomllib
 from copy import deepcopy
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
+
+import toml
+import tomllib
 
 from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.monitor.constants.snmp_interface import (
@@ -26,6 +29,55 @@ FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
 
 IFMIB_MARKER_BEGIN = "# ---- BK-Lite core IF-MIB collection (begin) ----"
 IFMIB_MARKER_END = "# ---- BK-Lite core IF-MIB collection (end) ----"
+COMMON_IFMIB_TABLE_PATH = Path(__file__).resolve().parents[1] / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
+PUBLIC_IFMIB_TABLE_OIDS = frozenset(
+    {
+        "1.3.6.1.2.1.2.2",
+        "1.3.6.1.2.1.31.1.1",
+        "IF-MIB::ifTable",
+        "IF-MIB::ifXTable",
+    }
+)
+PUBLIC_IFDESCR_OIDS = frozenset({"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.1", "IF-MIB::ifDescr"})
+
+
+def has_managed_ifmib_section(raw_content: str | None) -> bool:
+    """渲染后的 child 是否包含公共 IF-MIB 管理区间（含 enable_ifmib=false 的空区间）。"""
+    text = raw_content or ""
+    return IFMIB_MARKER_BEGIN in text and IFMIB_MARKER_END in text
+
+
+@lru_cache(maxsize=1)
+def _load_common_ifmib_table() -> dict[str, Any]:
+    document = tomllib.loads(COMMON_IFMIB_TABLE_PATH.read_text(encoding="utf-8"))
+    snmp_inputs = document.get("inputs", {}).get("snmp", [])
+    if isinstance(snmp_inputs, dict):
+        snmp_inputs = [snmp_inputs]
+    for snmp_input in snmp_inputs:
+        for table in snmp_input.get("table", []):
+            if isinstance(table, dict) and table.get("name") == "interface":
+                return table
+    raise ValueError(f"通用 IF-MIB 模板缺少 interface 表: {COMMON_IFMIB_TABLE_PATH}")
+
+
+def get_common_ifmib_table() -> dict[str, Any]:
+    """返回公共 IF-MIB 表副本，供模板导入与存量配置回填共享。"""
+    return deepcopy(_load_common_ifmib_table())
+
+
+def is_public_ifmib_table(table: dict[str, Any]) -> bool:
+    """只按标准表/字段 OID 识别公共 IF-MIB，名称本身不构成身份。"""
+    table_oid = table.get("oid")
+    if table_oid in PUBLIC_IFMIB_TABLE_OIDS:
+        return True
+    if table_oid not in (None, "") or table.get("name") != "interface":
+        return False
+    fields = table.get("field")
+    return isinstance(fields, list) and any(
+        isinstance(field, dict) and field.get("name") == "ifDescr" and field.get("oid") in PUBLIC_IFDESCR_OIDS
+        for field in fields
+    )
+
 
 FILTER_JINJA_BLOCK = f"""\
 {{% if enable_ifmib | default(true) %}}
@@ -163,12 +215,10 @@ _UI_FILTER_FIELDS: list[dict[str, Any]] = [
         "advanced": True,
         "section": "interface_filter",
         "default_value": [],
-        "description": (
-            "留空表示不限制类型。非空时只保留所选 ifType；与排除列表互斥。填写后本配置中的非接口指标"
-            "将不再采集，一般建议优先使用排除黑名单。"
-        ),
+        "description": ("留空表示不限制类型。非空时只保留所选 ifType；与排除列表互斥。"
+                        "过滤仅作用于公共接口指标，厂商 CPU、内存和硬件健康指标仍会采集。"),
         "description_en": ("Leave empty for no type restriction. Mutually exclusive with exclude list. Non-empty keeps only "
-                           "matching interface metrics; non-interface metrics from this config will not be collected."),
+                           "matching interface metrics; vendor CPU, memory, and hardware-health metrics remain collected."),
         "options": IFTYPE_OPTIONS,
         "widget_props": {
             "mode": "tags",
@@ -284,20 +334,15 @@ FILTER_BLOCK_RE = re.compile(
 TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
 SNMP_INPUT_RE = re.compile(r"^\s*\[\[inputs\.snmp\]\]", re.MULTILINE)
 
-# 所有网络设备共用这一个 IF-MIB 模板；它仅声明 ifDescr tag，Telegraf walk 完整接口表。
-COMMON_IFMIB_TEMPLATE_PATH = (
-    Path(__file__).resolve().parents[1] / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
-)
-
 
 def get_common_ifmib_table_block() -> str:
     """从唯一通用 IF-MIB 模板读取接口表，供厂商单 child 配置复用。"""
     try:
-        interface_table = COMMON_IFMIB_TEMPLATE_PATH.read_text(encoding="utf-8").strip()
+        interface_table = COMMON_IFMIB_TABLE_PATH.read_text(encoding="utf-8").strip()
     except OSError as exc:
-        raise RuntimeError(f"无法读取通用 IF-MIB 模板: {COMMON_IFMIB_TEMPLATE_PATH}") from exc
+        raise RuntimeError(f"无法读取通用 IF-MIB 模板: {COMMON_IFMIB_TABLE_PATH}") from exc
     if not IFMIB_HINT_RE.search(interface_table):
-        raise RuntimeError(f"通用 IF-MIB 模板缺少接口表: {COMMON_IFMIB_TEMPLATE_PATH}")
+        raise RuntimeError(f"通用 IF-MIB 模板缺少接口表: {COMMON_IFMIB_TABLE_PATH}")
     return interface_table
 
 
@@ -339,9 +384,25 @@ def has_interface_collection(template_content: str) -> bool:
 def _strip_ifmib_tables(template_content: str) -> str:
     """删除各厂商复制的 IF-MIB table，绝不删除私有 OID table。"""
 
+    def get_header_value(table_text: str, key: str) -> str | None:
+        header = table_text.split("[[inputs.snmp.table.field]]", 1)[0]
+        match = re.search(rf'^\s*{re.escape(key)}\s*=\s*"([^"]+)"\s*$', header, re.MULTILINE)
+        return match.group(1) if match else None
+
+    def is_public_table_block(table_text: str) -> bool:
+        table_oid = get_header_value(table_text, "oid")
+        if table_oid in PUBLIC_IFMIB_TABLE_OIDS:
+            return True
+        if table_oid not in (None, "") or get_header_value(table_text, "name") != "interface":
+            return False
+        return any(
+            re.search(rf'^\s*oid\s*=\s*"{re.escape(ifdescr_oid)}"\s*$', table_text, re.MULTILINE)
+            for ifdescr_oid in PUBLIC_IFDESCR_OIDS
+        )
+
     def strip_table(table_match: re.Match[str]) -> str:
         table_text = table_match.group(0)
-        return "" if IFMIB_HINT_RE.search(table_text) else table_text
+        return "" if is_public_table_block(table_text) else table_text
 
     text = TABLE_BLOCK_RE.sub(strip_table, template_content)
     text = re.sub(
@@ -387,7 +448,7 @@ def validate_rendered_core_network_ifmib(template_content: str, context: dict[st
         message = "SNMP IF-MIB 配置冲突：最终 TOML 无法解析，请检查重复的接口表或 tagpass/tagdrop 段"
         raise ValidationAppException(f"{message}：{exc}") from exc
 
-    interface_tables = [table for table in _get_snmp_input_tables(config) if table.get("name") == "interface"]
+    interface_tables = [table for table in _get_snmp_input_tables(config) if is_public_ifmib_table(table)]
     enabled = context.get("enable_ifmib", True) is not False
     if enabled:
         if len(interface_tables) != 1:
@@ -409,10 +470,54 @@ def validate_rendered_core_network_ifmib(template_content: str, context: dict[st
     if interface_tables:
         raise ValidationAppException("SNMP IF-MIB 配置冲突：关闭标准接口监控后仍渲染了接口表")
 
-    for table in _get_snmp_input_tables(config):
-        fields = table.get("field")
-        if isinstance(fields, list) and any(field.get("name") == "ifType" for field in fields if isinstance(field, dict)):
-            raise ValidationAppException("SNMP IF-MIB 配置冲突：关闭标准接口监控后仍渲染了 ifType 过滤标签")
+
+def isolate_snmp_interface_tagpass(template_content: str, context: dict[str, Any]) -> str:
+    """白名单仅作用于公共接口 input，避免丢弃没有接口标签的厂商指标。"""
+    if not should_manage_core_network_ifmib(context) or context.get("enable_ifmib", True) is False:
+        return template_content
+
+    document = toml.loads(template_content)
+    snmp_inputs = document.get("inputs", {}).get("snmp", [])
+    for index, snmp_input in enumerate(snmp_inputs):
+        if not isinstance(snmp_input, dict) or not isinstance(snmp_input.get("tagpass"), dict):
+            continue
+        tables = snmp_input.get("table")
+        if not isinstance(tables, list):
+            continue
+        interface_tables = [table for table in tables if isinstance(table, dict) and is_public_ifmib_table(table)]
+        if not interface_tables:
+            continue
+
+        input_payload_keys = {"field", "table", "tagexclude", "tagpass", "tagdrop"}
+        interface_input = {key: deepcopy(value) for key, value in snmp_input.items() if key not in input_payload_keys}
+        source_fields = [deepcopy(field) for field in snmp_input.get("field", []) if isinstance(field, dict) and field.get("is_tag") is True]
+        if source_fields:
+            interface_input["field"] = source_fields
+        interface_input["table"] = interface_tables
+        for filter_key in ("tagexclude", "tagpass", "tagdrop"):
+            if filter_key in snmp_input:
+                interface_input[filter_key] = deepcopy(snmp_input.pop(filter_key))
+
+        remaining_tables = [table for table in tables if table not in interface_tables]
+        source_payload_fields = snmp_input.get("field")
+        has_non_tag_fields = isinstance(source_payload_fields, list) and any(
+            not isinstance(field, dict) or field.get("is_tag") is not True
+            for field in source_payload_fields
+        )
+        if remaining_tables:
+            snmp_input["table"] = remaining_tables
+        else:
+            snmp_input.pop("table", None)
+
+        if remaining_tables or has_non_tag_fields:
+            snmp_inputs.insert(index + 1, interface_input)
+        else:
+            # 原 input 仅承载公共接口表（以及已复制的 tag 字段）时直接替换，
+            # 避免生成一个没有任何采集载荷的额外 inputs.snmp。
+            snmp_inputs[index] = interface_input
+        rendered = toml.dumps(document)
+        return rendered.replace("[inputs]\n", "")
+    return template_content
 
 
 def should_inject_snmp_interface_filters(plugin: Any, content: dict | None = None) -> bool:

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -14,7 +14,12 @@ from apps.monitor.models import MonitorPlugin
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
-from apps.monitor.utils.snmp_ifmib_capability import IFMIB_ZH_DISPLAY_TEXTS
+from apps.monitor.utils.snmp_ifmib_capability import (
+    COMMON_IFMIB_METRIC_NAMES,
+    IFMIB_ZH_DISPLAY_TEXTS,
+    get_ifmib_metric_names_matching_keyword,
+    is_ifmib_capable_plugin,
+)
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 
 
@@ -88,7 +93,7 @@ def get_snmp_base_plugin(request, monitor_object_id):
         or plugin.collect_type == "snmp"
         or not str(plugin.collect_type or "").startswith("snmp_")
         or plugin.template_type != "builtin"
-        or not plugin.monitor_object.filter(type_id="Network Device").exists()
+        or not is_ifmib_capable_plugin(plugin)
     ):
         return None
     return (
@@ -114,7 +119,7 @@ def apply_inherited_group_filters(queryset, query_params):
     return queryset
 
 
-def apply_inherited_metric_filters(queryset, query_params):
+def apply_inherited_metric_filters(queryset, query_params, locale=""):
     """Apply the same catalog filters to inherited IF-MIB metrics without the vendor plugin constraint."""
     metric_id = parse_optional_positive_id(query_params.get("id"), "id")
     if metric_id:
@@ -130,10 +135,12 @@ def apply_inherited_metric_filters(queryset, query_params):
         queryset = queryset.filter(name__in=[value for value in names.split(",") if value])
     keyword = str(query_params.get("keyword") or "").strip()
     if keyword:
+        localized_names = get_ifmib_metric_names_matching_keyword(keyword, locale)
         queryset = queryset.filter(
             Q(name__icontains=keyword)
             | Q(display_name__icontains=keyword)
             | Q(description__icontains=keyword)
+            | Q(name__in=localized_names)
         )
     is_ifmib = query_params.get("is_ifmib")
     if is_ifmib is not None and str(is_ifmib).strip() != "":
@@ -239,17 +246,13 @@ class MetricGroupViewSet(viewsets.ModelViewSet):
         vendor_groups = self.filter_queryset(self.get_queryset()).order_by()
         base_plugin = get_snmp_base_plugin(request, monitor_object_id)
         if base_plugin is not None:
-            vendor_group_names = MetricGroup.objects.filter(
-                monitor_object_id=monitor_object_id,
-                monitor_plugin_id=request.query_params.get("monitor_plugin_id"),
-            )
             base_groups = MetricGroup.objects.filter(
                 monitor_object_id=monitor_object_id,
                 monitor_plugin=base_plugin,
             ).order_by()
             base_groups = apply_inherited_group_filters(base_groups, request.query_params)
             queryset = vendor_groups.union(
-                base_groups.exclude(name__in=Subquery(vendor_group_names.values("name")))
+                base_groups.exclude(name__in=Subquery(vendor_groups.values("name")))
             ).order_by("sort_order", "id")
         else:
             queryset = vendor_groups.order_by("sort_order", "id")
@@ -323,20 +326,40 @@ class MetricViewSet(viewsets.ModelViewSet):
         monitor_object_id = get_optional_query_param_id(request, "monitor_object_id")
         vendor_metrics = self.filter_queryset(Metric.objects.all()).order_by()
         base_plugin = get_snmp_base_plugin(request, monitor_object_id)
-        if str(request.query_params.get("include_ifmib", "true")).lower() == "false":
+        include_ifmib = str(request.query_params.get("include_ifmib", "true")).lower() != "false"
+        if base_plugin is not None:
+            # 仅在 base 已提供对应公共指标时，才剥掉厂商未标记的同名脏数据，
+            # 避免升级窗口里 base 尚未导入时目录出现空洞。关闭 IF-MIB 时仍需全部隐藏。
+            stale_ifmib_names = (
+                COMMON_IFMIB_METRIC_NAMES
+                if not include_ifmib
+                else set(
+                    Metric.objects.filter(
+                        monitor_object_id=monitor_object_id,
+                        monitor_plugin=base_plugin,
+                        name__in=COMMON_IFMIB_METRIC_NAMES,
+                    ).values_list("name", flat=True)
+                )
+            )
+            if stale_ifmib_names:
+                vendor_metrics = vendor_metrics.exclude(
+                    name__in=stale_ifmib_names,
+                    is_ifmib=False,
+                )
+        if not include_ifmib:
             base_plugin = None
         if base_plugin is not None:
-            vendor_metric_names = Metric.objects.filter(
-                monitor_object_id=monitor_object_id,
-                monitor_plugin_id=request.query_params.get("monitor_plugin_id"),
-            )
             base_metrics = Metric.objects.filter(
                 monitor_object_id=monitor_object_id,
                 monitor_plugin=base_plugin,
             ).order_by()
-            base_metrics = apply_inherited_metric_filters(base_metrics, request.query_params)
+            base_metrics = apply_inherited_metric_filters(
+                base_metrics,
+                request.query_params,
+                request.user.locale,
+            )
             queryset = vendor_metrics.union(
-                base_metrics.exclude(name__in=Subquery(vendor_metric_names.values("name")))
+                base_metrics.exclude(name__in=Subquery(vendor_metrics.values("name")))
             ).order_by("sort_order", "id")
         else:
             queryset = vendor_metrics.order_by("sort_order", "id")

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -435,6 +435,20 @@ class NatsService:
 
         child_config.save()
 
+    @transaction.atomic
+    def compare_and_swap_child_config_content(self, id, expected_content, content):
+        """锁内比较并更新子配置，冲突时返回 False 且不覆盖当前内容。"""
+        if not content:
+            raise BaseAppException("Content must be provided for compare-and-swap update.")
+        child_config = ChildConfig.objects.select_for_update().filter(id=id).first()
+        if not child_config:
+            raise BaseAppException("Child config not found.")
+        if child_config.content != expected_content:
+            return False
+        child_config.content = content
+        child_config.save(update_fields=["content", "updated_at"])
+        return True
+
     def update_config_content(self, id, content, env_config=None):
         """更新配置内容"""
 
@@ -675,6 +689,15 @@ def update_child_config_content(data: dict):
     content = data.get("content")
     env_config = data.get("env_config")
     NatsService().update_child_config_content(id, content, env_config)
+
+
+def compare_and_swap_child_config_content(data: dict):
+    """同进程运维命令专用：仅当内容仍等于读取快照时更新实例子配置。"""
+    return NatsService().compare_and_swap_child_config_content(
+        data.get("id"),
+        data.get("expected_content"),
+        data.get("content"),
+    )
 
 
 @nats_client.register

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -6,6 +6,7 @@ from apps.rpc.base import RpcClient, AppClient
 class NodeMgmt(object):
     def __init__(self, is_local_client=False):
         is_local_client = os.getenv("IS_LOCAL_RPC", "0") == "1" or is_local_client
+        self.is_local_client = is_local_client
 
         self.permission_client = AppClient("apps.node_mgmt.nats.node.permission") if is_local_client else RpcClient()
         self.client = AppClient("apps.node_mgmt.nats.node") if is_local_client else RpcClient()
@@ -150,6 +151,15 @@ class NodeMgmt(object):
             {"id": id, "content": content, "env_config": env_config},
         )
         return return_data
+
+    def compare_and_swap_child_config_content_local(self, id, expected_content, content):
+        """同进程运维专用：仅当子配置内容仍等于读取快照时更新。"""
+        if not self.is_local_client:
+            raise RuntimeError("compare-and-swap child config requires local AppClient")
+        return self.client.run(
+            "compare_and_swap_child_config_content",
+            {"id": id, "expected_content": expected_content, "content": content},
+        )
 
     def update_config_content(self, id, content, env_config=None):
         """

--- a/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/asset/updateConfig.tsx
@@ -22,6 +22,7 @@ import { getIfmibSnapshotEnabled } from '../list/detail/configure/ifmibDeploymen
 
 interface PluginFormField {
   name?: string;
+  default_value?: unknown;
 }
 
 interface PluginConfig {
@@ -201,7 +202,13 @@ const UpdateConfig = forwardRef<ModalRef, ModalProps>(({ onSuccess }, ref) => {
                 name="basic"
                 layout="vertical"
                 onValuesChange={(changed, all) => {
-                  const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(changed);
+                  const defaultIfTypeExclude = currentConfig?.form_fields?.find(
+                    (field) => field.name === 'iftype_exclude'
+                  )?.default_value;
+                  const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(
+                    changed,
+                    defaultIfTypeExclude
+                  );
                   const nextValues = Object.keys(interfaceFilterModePatch).length
                     ? { ...all, ...interfaceFilterModePatch }
                     : all;

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -983,7 +983,13 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       layout="vertical"
       onValuesChange={(changed, all) => {
         clearCollectDetectState();
-        const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(changed);
+        const defaultIfTypeExclude = currentConfig?.form_fields?.find(
+          (field: { name?: string }) => field.name === 'iftype_exclude'
+        )?.default_value;
+        const interfaceFilterModePatch = getSnmpInterfaceFilterModePatch(
+          changed,
+          defaultIfTypeExclude
+        );
         const nextValues = Object.keys(interfaceFilterModePatch).length
           ? { ...all, ...interfaceFilterModePatch }
           : all;

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/ifmibDeploymentState.ts
@@ -23,18 +23,49 @@ export const getIfmibDeploymentPatch = (
   return { enable_ifmib: enableIfmibFromUrl };
 };
 
-const hasInterfaceTable = (tables: unknown): boolean => (
+const PUBLIC_IFMIB_TABLE_OIDS = new Set([
+  '1.3.6.1.2.1.2.2',
+  '1.3.6.1.2.1.31.1.1',
+  'IF-MIB::ifTable',
+  'IF-MIB::ifXTable'
+]);
+
+const PUBLIC_IFDESCR_OIDS = new Set([
+  '1.3.6.1.2.1.2.2.1.2',
+  '1.3.6.1.2.1.31.1.1.1.1',
+  'IF-MIB::ifDescr'
+]);
+
+const isPublicIfmibTable = (table: Record<string, unknown>): boolean => {
+  const tableOid = table.oid;
+  if (typeof tableOid === 'string' && PUBLIC_IFMIB_TABLE_OIDS.has(tableOid)) {
+    return true;
+  }
+  if ((tableOid != null && tableOid !== '') || table.name !== 'interface') {
+    return false;
+  }
+  const fields = table.field;
+  return Array.isArray(fields) && fields.some((field) => (
+    typeof field === 'object'
+    && field !== null
+    && (field as Record<string, unknown>).name === 'ifDescr'
+    && typeof (field as Record<string, unknown>).oid === 'string'
+    && PUBLIC_IFDESCR_OIDS.has((field as Record<string, unknown>).oid as string)
+  ));
+};
+
+const hasPublicIfmibTable = (tables: unknown): boolean => (
   Array.isArray(tables)
   && tables.some((table) => (
     typeof table === 'object'
     && table !== null
-    && (table as Record<string, unknown>).name === 'interface'
+    && isPublicIfmibTable(table as Record<string, unknown>)
   ))
 );
 
 const snmpInputHasInterfaceTable = (input: unknown): boolean => {
   if (typeof input !== 'object' || input === null) return false;
-  return hasInterfaceTable((input as Record<string, unknown>).table);
+  return hasPublicIfmibTable((input as Record<string, unknown>).table);
 };
 
 /**

--- a/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
+++ b/web/src/app/monitor/hooks/integration/snmpInterfaceFilterMode.ts
@@ -34,7 +34,8 @@ export const resolveSnmpInterfaceFilterMode = (values: {
 };
 
 export const getSnmpInterfaceFilterModePatch = (
-  changedValues: Record<string, unknown>
+  changedValues: Record<string, unknown>,
+  defaultIfTypeExclude: unknown = DEFAULT_SNMP_IFTYPE_EXCLUDE
 ): Record<string, unknown> => {
   const mode = changedValues.interface_filter_mode as SnmpInterfaceFilterMode | undefined;
   if (!mode) return {};
@@ -51,7 +52,9 @@ export const getSnmpInterfaceFilterModePatch = (
   );
   // 切回“排除部分”时恢复产品默认的虚拟接口排除，避免策略名称与实际规则不一致。
   if (mode === 'exclude') {
-    patch.iftype_exclude = DEFAULT_SNMP_IFTYPE_EXCLUDE;
+    patch.iftype_exclude = Array.isArray(defaultIfTypeExclude)
+      ? defaultIfTypeExclude.map((value) => String(value).trim()).filter(Boolean)
+      : DEFAULT_SNMP_IFTYPE_EXCLUDE;
   }
   return patch;
 };


### PR DESCRIPTION
## 变更说明

- 逐文件校验 policy.json；遗留格式、格式错误、重复定义及未导入对象或插件仅记录日志后跳过。
- 本轮存在跳过项时，停止 builtin 策略模板的差集删除，避免坏文件导致历史模板被清空；正常模板仍会创建和更新。

## 验证

- apps/monitor/tests/test_policy_migrate.py -q：2 passed。
- 使用 dev/local/server.env 执行 manage.py plugin_init：386 个插件成功导入；33 个问题策略告警跳过；923 个内置策略模板持久化。

## 范围

仅提交 policy_migrate.py 和 policy.py。回归测试文件及工作区其他本地改动未提交。