### PR TITLE
fix(监控): 防止 insecure_skip_verify 空串渲染非法 TOML

### DIFF
--- a/server/apps/monitor/services/website_config.py
+++ b/server/apps/monitor/services/website_config.py
@@ -54,30 +54,40 @@ def normalize_website_request_config(config: dict) -> dict:
     if auth_type == "bearer":
         _require_value(normalized.get("ENV_BEARER_TOKEN"), "Bearer Token")
     normalized["auth_type"] = auth_type
+    # 前端可选开关缺省时可能被补成 ""；空串会让 Jinja default(false) 渲出非法 TOML。
+    normalized["insecure_skip_verify"] = _coerce_bool(normalized.get("insecure_skip_verify"), False)
     return normalized
 
 
 def validate_rendered_website_config(config: dict, env_config: dict | None = None) -> None:
     """Validate the TOML-shaped config used by the edit API."""
     env_config = env_config or {}
-    urls = config.get("urls") or []
+    # 编辑接口 content 通常是 ConfigFormat 形态 {plugin, config}；兼容扁平 config。
+    target = (
+        config["config"]
+        if isinstance(config.get("config"), dict) and config.get("plugin") is not None
+        else config
+    )
+    urls = target.get("urls") or []
     if not isinstance(urls, list) or len(urls) != 1:
         raise ValueError("网站拨测必须配置一个 URL")
     parts = urlsplit(str(urls[0] or ""))
     if parts.scheme not in {"http", "https"} or not parts.netloc or parts.fragment:
         raise ValueError("URL 必须是有效的 HTTP 或 HTTPS 地址，且不能包含 fragment")
 
-    method = str(config.get("method") or "GET").upper()
+    method = str(target.get("method") or "GET").upper()
     if method not in SUPPORTED_METHODS:
         raise ValueError("请求方式仅支持 GET、HEAD 或 POST")
-    if method != "POST" and config.get("body") not in (None, ""):
+    if method != "POST" and target.get("body") not in (None, ""):
         raise ValueError("仅 POST 请求允许填写请求体")
-    _validate_optional_int(config.get("response_status_code"), "期望状态码", MIN_HTTP_STATUS_CODE, MAX_HTTP_STATUS_CODE)
-    timeout = config.get("response_timeout")
+    _validate_optional_int(target.get("response_status_code"), "期望状态码", MIN_HTTP_STATUS_CODE, MAX_HTTP_STATUS_CODE)
+    timeout = target.get("response_timeout")
     if isinstance(timeout, str) and timeout.endswith("s"):
         timeout = timeout[:-1]
     _validate_optional_int(timeout, "请求超时", MIN_TIMEOUT_SECONDS, MAX_TIMEOUT_SECONDS)
-    headers = config.get("headers") or {}
+    # 空串/缺省统一成 bool，避免 toml.dumps 写出 insecure_skip_verify = ""。
+    target["insecure_skip_verify"] = _coerce_bool(target.get("insecure_skip_verify"), False)
+    headers = target.get("headers") or {}
     if not isinstance(headers, dict):
         raise ValueError("请求头必须是键值列表")
     authorization_values = [value for key, value in headers.items() if str(key).lower() == "authorization"]
@@ -90,8 +100,8 @@ def validate_rendered_website_config(config: dict, env_config: dict | None = Non
         if str(key).lower() != "authorization"
     ]
     _normalize_headers(non_authorization_headers)
-    username = config.get("username")
-    password = config.get("password")
+    username = target.get("username")
+    password = target.get("password")
     if username or password:
         _require_value(username, "Basic Auth 用户名")
         password_env_key = _extract_env_reference(password, "PASSWORD")
@@ -103,6 +113,24 @@ def validate_rendered_website_config(config: dict, env_config: dict | None = Non
             raise ValueError("Authorization 请求头请使用认证配置")
         if env_config.get(bearer_env_key) in (None, ""):
             raise ValueError("Bearer Token 不能为空")
+
+
+def _coerce_bool(value, default=False):
+    """Normalize optional TLS/switch values before Telegraf TOML render/edit."""
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        raise ValueError("跳过证书校验必须是布尔值")
+    raise ValueError("跳过证书校验必须是布尔值")
 
 
 def _normalize_entries(entries, field_name):

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/etcd/etcd.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/etcd/etcd.child.toml.j2
@@ -15,7 +15,7 @@
     {% if tls_key %}
     tls_key = "{{ tls_key }}"
     {% endif %}
-    insecure_skip_verify = {{ insecure_skip_verify | default(false) | lower }}
+    insecure_skip_verify = {{ insecure_skip_verify | default(false, true) | lower }}
     [inputs.prometheus.tags]
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/database/influxdb/influxdb.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/database/influxdb/influxdb.child.toml.j2
@@ -16,7 +16,7 @@
     {% if tls_key %}
     tls_key = "{{ tls_key }}"
     {% endif %}
-    insecure_skip_verify = {{ insecure_skip_verify | default(false) | lower }}
+    insecure_skip_verify = {{ insecure_skip_verify | default(false, true) | lower }}
     [inputs.influxdb.tags]
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type }}"

--- a/server/apps/monitor/support-files/plugins/Telegraf/web/web/http_response.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/web/web/http_response.child.toml.j2
@@ -2,7 +2,7 @@
     startup_error_behavior = "retry"
     urls = ["{{ request_url | default(url, true) }}"]
     interval = "{{ interval }}s"
-    insecure_skip_verify = {{ insecure_skip_verify | default(false) | lower }}
+    insecure_skip_verify = {{ insecure_skip_verify | default(false, true) | lower }}
     {% if request_method %}
     method = "{{ request_method }}"
     {% endif %}

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -13,11 +13,15 @@ import useApiClient from '@/utils/request';
 import { useTranslation } from '@/utils/i18n';
 
 /**
- * 兜底：把 formFields 中非必填且用户未填的字段补成空串。
+ * 兜底：把 formFields 中非必填且用户未填的字段补齐。
  * 原因：前端表单只回填用户实际改过的字段，未改的 key 不会出现在 formData 里。
  * 但后端 Jinja2 模板（child.toml.j2）用 `{{ 字段名 }}` 渲染时，未定义的 key 会抛
- * UndefinedError,触发 "渲染采集模板失败"。非必填字段以空串提交,模板侧
- * `{% if send %}{% endif %}` 会跳过该行,既保留可选语义又避免渲染失败。
+ * UndefinedError,触发 "渲染采集模板失败"。
+ *
+ * 文本类可选字段补空串，配合模板 `{% if send %}{% endif %}` 跳过该行。
+ * 布尔开关（或带 default_value 的字段）绝不能补空串：Jinja
+ * `{{ x | default(false) }}` 对已定义的空串不会兜底，会渲出
+ * `insecure_skip_verify = ` 这类非法 TOML，拖垮同机 Telegraf。
  *
  * 导出供单元测试使用。
  */
@@ -29,9 +33,16 @@ export const fillOptionalFormFields = (
   const result = { ...formData };
   formFields.forEach((field: any) => {
     if (field.required === true) return;
-    if (result[field.name] === undefined) {
-      result[field.name] = '';
+    if (result[field.name] !== undefined) return;
+    if (Object.prototype.hasOwnProperty.call(field, 'default_value')) {
+      result[field.name] = field.default_value;
+      return;
     }
+    if (field.type === 'switch') {
+      result[field.name] = false;
+      return;
+    }
+    result[field.name] = '';
   });
   return result;
 };
@@ -654,6 +665,11 @@ export const usePluginFromJson = () => {
               } else {
                 childConfig.follow_redirects = filledFormData.follow_redirects;
               }
+              // 布尔开关：空串/缺省一律写成 false，避免 toml.dumps 产出
+              // insecure_skip_verify = "" 拖垮同机 Telegraf。
+              childConfig.insecure_skip_verify =
+                filledFormData.insecure_skip_verify === true ||
+                filledFormData.insecure_skip_verify === 'true';
               if (filledFormData.auth_type === 'basic') {
                 delete result.child.content.config.bearer_token;
                 delete result.child.content.config.headers.Authorization;


### PR DESCRIPTION
## Summary
- 网站拨测等可选 TLS 开关在提交时可能被补成空串，Jinja `default(false)` 无法兜底，会渲染出 `insecure_skip_verify = ` 非法 TOML，可能导致同机 Telegraf 整进程失败。
- 前端 `fillOptionalFormFields`：带 `default_value` 或 `switch` 时补布尔默认值，不再补 `''`；编辑路径显式写入布尔。
- 模板改为 `default(false, true)`（website / etcd / influxdb）；后端 normalize/validate 将空串/缺省强制收成布尔。

## Test plan
- [ ] 自动接入网站拨测：不展开高级配置直接提交，检查节点 Telegraf child 配置含 `insecure_skip_verify = false`（无空值）
- [ ] 编辑已有网站拨测实例并保存，确认 TOML 中仍为合法布尔
- [ ] 同节点上主机/Redis/PostgreSQL 等任务在新增网站拨测后仍可采集

## Scope check
- 已核对暂存与相对 `master` 的 diff：仅 5 个生产文件，未提交测试文件、无关图标、`plugin_controller` 等本地改动。