### PR TITLE
fix(监控): 全面修复 SNMP 多行健康指标查询聚合

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/metrics.json
@@ -67,8 +67,8 @@
       "unit": "[{\"name\":\"powered\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"unpowered\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "PSU description"
+          "name": "psu",
+          "description": "Power supply"
         }
       ],
       "instance_id_keys": [
@@ -85,8 +85,8 @@
       "unit": "[{\"name\":\"present\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"absent\",\"id\":2,\"color\":\"#d9d9d9\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "PSU description"
+          "name": "psu",
+          "description": "Power supply"
         }
       ],
       "instance_id_keys": [

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='router', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -73,7 +73,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/metrics.json
@@ -91,7 +91,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
@@ -104,7 +104,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "device_memory_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/metrics.json
@@ -35,7 +35,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
@@ -48,7 +48,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_free",
-      "query": "device_memory_free{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Free",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/metrics.json
@@ -47,7 +47,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/metrics.json
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
@@ -47,7 +47,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "device_memory_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -47,7 +47,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
@@ -60,7 +60,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
@@ -73,7 +73,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/metrics.json
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "device_memory_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -47,7 +47,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
@@ -60,7 +60,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
@@ -73,7 +73,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/metrics.json
@@ -34,16 +34,11 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_free",
-      "query": "device_memory_free{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [
-        {
-          "name": "descr",
-          "description": "Memory bank"
-        }
-      ],
+      "dimensions": [],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -52,16 +47,11 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [
-        {
-          "name": "descr",
-          "description": "Memory bank"
-        }
-      ],
+      "dimensions": [],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/metrics.json
@@ -37,7 +37,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
@@ -50,7 +50,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/metrics.json
@@ -37,7 +37,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__} * 1024",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 1024",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
@@ -50,7 +50,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__} * 1024",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) * 1024",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/metrics.json
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
@@ -47,7 +47,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "device_memory_usage{instance_type='switch', __$labels__}",
+      "query": "max(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -73,7 +73,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/metrics.json
@@ -73,7 +73,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
@@ -86,7 +86,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
@@ -99,7 +99,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/metrics.json
@@ -86,7 +86,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "device_fan_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
@@ -99,7 +99,7 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "device_psu_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/metrics.json
@@ -41,7 +41,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__} * 1024",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 1024",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
@@ -54,7 +54,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__} * 1024",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) * 1024",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/metrics.json
@@ -36,7 +36,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "device_memory_total{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
@@ -49,7 +49,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "device_memory_used{instance_type='switch', __$labels__}",
+      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/metrics.json
@@ -21,7 +21,7 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
@@ -34,7 +34,7 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "device_memory_usage{instance_type='switch', __$labels__}",
+      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/metrics.json
@@ -117,16 +117,11 @@
     {
       "metric_group": "Fan",
       "name": "device_fan_ac_state",
-      "query": "device_fan_ac_state{instance_type='switch', __$labels__}",
+      "query": "max(device_fan_ac_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Fan AC Power State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [
-        {
-          "name": "descr",
-          "description": "Fan description"
-        }
-      ],
+      "dimensions": [],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -135,16 +130,11 @@
     {
       "metric_group": "Power",
       "name": "device_psu_ac_dc_state",
-      "query": "device_psu_ac_dc_state{instance_type='switch', __$labels__}",
+      "query": "max(device_psu_ac_dc_state{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "PSU AC/DC State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [
-        {
-          "name": "descr",
-          "description": "PSU description"
-        }
-      ],
+      "dimensions": [],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/metrics.json
@@ -33,7 +33,7 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
+      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/metrics.json
@@ -47,7 +47,7 @@
     {
       "metric_group": "Fan",
       "name": "device_fan_fan1_state",
-      "query": "device_fan_fan1_state{instance_type='transmission', __$labels__}",
+      "query": "max(device_fan_fan1_state{instance_type='transmission', __$labels__}) by (instance_id)",
       "display_name": "Fan 1 State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",


### PR DESCRIPTION
## Summary
- 全面扫描 Telegraf SNMP 插件：对「多行表采 + 未声明维度 + query 未聚合」的健康指标（CPU/内存/温度/风扇/电源等）在 `metrics.json` 按实例做 `avg`/`max`/`sum`
- **华为交换机 CPU/内存**在上游已具备 `descr` 采集标签，保留多维度（不做聚合）
- 修正 Extreme 内存、Wi-Tek 风扇/电源等「声明了 descr 维度但 toml 无对应 `is_tag`」的契约错误；Benu 电源维度名与标签对齐为 `psu`
- **未改** Telegraf `*.child.toml.j2` 采集模板（华为多维除外，其采集本已有 descr），避免 tagpass/维度类采集回归

## 聚合策略
- 实体表大量为 0（如 Juniper）：`max`
- 多核/多模块有效值：`avg`
- 内存 used/free/total 分行：`sum`
- 温度 / 风扇 / 电源状态：`max`

## Test plan
- [ ] 核对 PR 仅含 `metrics.json` 与必要契约测试，无无关 WIP
- [ ] 华为：CPU/内存按 `descr` 多实体展示
- [ ] Cisco/MikroTik 等：CPU 为实例级均值
- [ ] D-Link/Dell Force/Netgear：温度与风扇/电源为实例级 max
- [ ] Extreme 内存 used/free 无悬空 descr 维度
- [ ] 告警策略仍可基于对应指标触发

## 提交范围检查
- 基于 `tencent-upstream/master`
- 工作区其他 WIP 未纳入