### PR TITLE
fix(监控): SNMP 多行指标按维度展开查询

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/arris.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/arris.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_card"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4998.1.1.10.1.4.12.1.13"
         name = "state"
@@ -62,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_disk"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4998.1.1.10.1.4.14.1.7"
         name = "state"
@@ -72,6 +74,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4998.1.1.10.1.4.17.1.5"
         name = "celsius"
@@ -79,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4998.1.1.10.1.4.18.1.1"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/metrics.json
@@ -25,11 +25,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='access', __$labels__}",
       "display_name": "Fan Ambient Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,11 +43,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_card_temperature_level",
-      "query": "max(device_card_temperature_level{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_card_temperature_level{instance_type='access', __$labels__}",
       "display_name": "Card Temperature Level",
       "data_type": "Number",
       "unit": "none",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,11 +61,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_card_state",
-      "query": "max(device_card_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_card_state{instance_type='access', __$labels__}",
       "display_name": "Card State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -64,11 +79,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='access', __$labels__}",
       "display_name": "Power Module State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -77,11 +97,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_disk_usage",
-      "query": "max(device_disk_usage{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_disk_usage{instance_type='access', __$labels__}",
       "display_name": "Disk Volume Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -90,11 +115,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_disk_state",
-      "query": "max(device_disk_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_disk_state{instance_type='access', __$labels__}",
       "display_name": "Disk Volume Usage State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='access', __$labels__} / 1000) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='access', __$labels__} / 1000",
       "display_name": "Board Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "descr",
+          "description": "Entity / sensor description"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='access', __$labels__}",
       "display_name": "Power Supply State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "descr",
+          "description": "Entity / sensor description"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/metrics.json
@@ -24,11 +24,16 @@
     {
       "metric_group": "Access",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='access', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -89,11 +94,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='access', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -102,11 +112,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='access', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='access', __$labels__}",
       "display_name": "Power Supply State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/raisecom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/raisecom.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.8886.1.1.1.3.1.2.1.2.3"
         name = "usage"
@@ -76,6 +77,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.8886.1.1.5.2.2.1.3"
         name = "state"
@@ -83,6 +85,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.8886.1.24.2.1.1.6"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/forcepoint.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/forcepoint.child.toml.j2
@@ -50,6 +50,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.1369.5.2.1.11.1.1.3"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/metrics.json
@@ -37,11 +37,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/hillstone.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/hillstone.child.toml.j2
@@ -85,6 +85,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.28557.2.27.1.2.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/metrics.json
@@ -88,11 +88,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='firewall', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "tempName",
+          "description": "Temperature sensor name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -101,11 +106,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='firewall', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/opnsense.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/opnsense.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/metrics.json
@@ -37,11 +37,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/paloalto.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/paloalto.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/pfsense.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/pfsense.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/metrics.json
@@ -37,11 +37,16 @@
     {
       "metric_group": "Firewall",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='firewall', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/stormshield.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/stormshield.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/a10.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/a10.child.toml.j2
@@ -53,6 +53,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.22610.2.4.1.3.2.1.3"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Loadbalance",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='loadbalance', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='loadbalance', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/metrics.json
@@ -37,11 +37,16 @@
     {
       "metric_group": "Loadbalance",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='loadbalance', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='loadbalance', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/netscaler.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/netscaler.child.toml.j2
@@ -53,6 +53,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5951.4.1.1.41.6.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/metrics.json
@@ -127,11 +127,16 @@
     {
       "metric_group": "NetworkService",
       "name": "network_service_virtual_server_state",
-      "query": "max(network_service_virtual_server_state{instance_type='network_service', __$labels__}) by (instance_id)",
+      "query": "network_service_virtual_server_state{instance_type='network_service', __$labels__}",
       "display_name": "Virtual Server Status",
       "data_type": "Enum",
       "unit": "none",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "ltmVirtualServName",
+          "description": "Virtual server name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -140,11 +145,16 @@
     {
       "metric_group": "NetworkService",
       "name": "network_service_node_state",
-      "query": "max(network_service_node_state{instance_type='network_service', __$labels__}) by (instance_id)",
+      "query": "network_service_node_state{instance_type='network_service', __$labels__}",
       "display_name": "Node Status",
       "data_type": "Enum",
       "unit": "none",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "ltmNodeAddrStatusName",
+          "description": "Node name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -153,11 +163,16 @@
     {
       "metric_group": "NetworkService",
       "name": "network_service_pool_state",
-      "query": "max(network_service_pool_state{instance_type='network_service', __$labels__}) by (instance_id)",
+      "query": "network_service_pool_state{instance_type='network_service', __$labels__}",
       "display_name": "Pool Status",
       "data_type": "Enum",
       "unit": "none",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "ltmPoolStatusName",
+          "description": "Pool name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -166,11 +181,24 @@
     {
       "metric_group": "NetworkService",
       "name": "network_service_pool_member_state",
-      "query": "max(network_service_pool_member_state{instance_type='network_service', __$labels__}) by (instance_id)",
+      "query": "network_service_pool_member_state{instance_type='network_service', __$labels__}",
       "display_name": "Pool Member Status",
       "data_type": "Enum",
       "unit": "none",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "ltmPoolMbrStatusPoolName",
+          "description": "Pool name"
+        },
+        {
+          "name": "ltmPoolMbrStatusNodeName",
+          "description": "Node name"
+        },
+        {
+          "name": "ltmPoolMbrStatusPort",
+          "description": "Member port"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/metrics.json
@@ -22,11 +22,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "sensor",
+          "description": "Sensor"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -35,11 +40,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='router', __$labels__}",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "fan",
+          "description": "Fan"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -48,11 +58,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='router', __$labels__}",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "psu",
+          "description": "Power supply"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -67,8 +82,8 @@
       "unit": "[{\"name\":\"powered\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"unpowered\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "PSU description"
+          "name": "psu",
+          "description": "Power supply"
         }
       ],
       "instance_id_keys": [
@@ -85,8 +100,8 @@
       "unit": "[{\"name\":\"present\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"absent\",\"id\":2,\"color\":\"#d9d9d9\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "PSU description"
+          "name": "psu",
+          "description": "Power supply"
         }
       ],
       "instance_id_keys": [

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/draytek.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/draytek.child.toml.j2
@@ -49,6 +49,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/metrics.json
@@ -37,11 +37,16 @@
     {
       "metric_group": "Router",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/huawei_ar.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/huawei_ar.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2011.5.25.31.1.1.1.1.5"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2011.5.25.31.1.1.1.1.7"
         name = "usage"
@@ -71,6 +73,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2011.5.25.31.1.1.1.1.11"
         name = "celsius"
@@ -78,6 +81,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2011.5.25.31.1.1.10.1.7"
         name = "state"
@@ -85,6 +89,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2011.5.25.31.1.1.20.1.7"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Router",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -49,11 +54,16 @@
     {
       "metric_group": "Router",
       "name": "device_memory_usage",
-      "query": "avg(device_memory_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='router', __$labels__}",
       "display_name": "Memory Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -62,11 +72,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -75,11 +90,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='router', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -88,11 +108,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='router', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/juniper_mx.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/juniper_mx.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2636.3.1.13.1.8"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2636.3.1.13.1.11"
         name = "usage"
@@ -71,6 +73,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2636.3.1.13.1.7"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Router",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -49,11 +54,16 @@
     {
       "metric_group": "Router",
       "name": "device_memory_usage",
-      "query": "avg(device_memory_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='router', __$labels__}",
       "display_name": "Memory Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -62,11 +72,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
@@ -50,6 +50,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2356.11.1.47.20"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/metrics.json
@@ -19,13 +19,18 @@
   "metrics": [
     {
       "metric_group": "Router",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_temperature_celsius",
       "display_name": "设备温度",
-      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
       "unit": "celsius",
       "data_type": "Number",
       "description": "Hardware temperature of the LANCOM router in degrees Celsius (LCOS-MIB lcsStatusHardwareInfoTemperatureDegrees)."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -77,7 +82,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/mikrotik.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/mikrotik.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"
@@ -77,6 +78,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.14988.1.1.3.10"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='router', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/sierrawireless.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/sierrawireless.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.20542.9.1.1.1.267"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "Router",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/teltonika.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/teltonika.child.toml.j2
@@ -53,6 +53,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/metrics.json
@@ -36,11 +36,16 @@
     {
       "metric_group": "Router",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='router', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/vyatta.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/vyatta.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.43.45.1.6.1.1.1.3"
         name = "usage"
@@ -60,6 +61,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.43.45.1.6.1.2.1.1.2"
         name = "total"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -68,39 +73,54 @@
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_total",
       "display_name": "内存总量",
-      "query": "sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_total{instance_type='switch', __$labels__}",
       "unit": "bytes",
       "data_type": "Number",
       "description": "Total memory of the 3Com switch in bytes (hwMemSize)."
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_free",
       "display_name": "内存空闲",
-      "query": "sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_free{instance_type='switch', __$labels__}",
       "unit": "bytes",
       "data_type": "Number",
       "description": "Free memory of the 3Com switch in bytes (hwMemFree)."
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_usage",
       "display_name": "内存使用率",
-      "query": "(sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) - sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "(device_memory_total{instance_type='switch', __$labels__} - device_memory_free{instance_type='switch', __$labels__}) / device_memory_total{instance_type='switch', __$labels__} * 100",
       "unit": "percent",
       "data_type": "Number",
       "description": "Memory utilisation of the 3Com switch, derived as (total-free)/total."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/alaxala.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/alaxala.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.21839.2.2.6.2.1.2.1.11"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.21839.2.2.6.2.1.2.1.8"
         name = "used"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "max(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_used{instance_type='switch', __$labels__}",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -47,11 +57,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_free",
-      "query": "max(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_free{instance_type='switch', __$labels__}",
       "display_name": "Memory Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -60,11 +75,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / (device_memory_used{instance_type='switch', __$labels__} + device_memory_free{instance_type='switch', __$labels__}) * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/alcatel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/alcatel.child.toml.j2
@@ -88,6 +88,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6527.3.1.2.2.1.4.1.2"
         name = "state"
@@ -97,6 +98,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6527.3.1.2.2.1.5.1.7"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/metrics.json
@@ -95,7 +95,12 @@
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -108,7 +113,12 @@
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/alliedtelesis.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/alliedtelesis.child.toml.j2
@@ -50,6 +50,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.207.8.4.4.3.3.8.1.4"
         name = "usage"
@@ -58,6 +59,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.207.8.4.4.3.12.3.1.5"
         name = "celsius"
@@ -66,6 +68,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.207.8.4.4.3.12.1.1.7"
         name = "state"
@@ -74,6 +77,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.207.8.4.4.3.12.4.2.1.6"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/metrics.json
@@ -39,11 +39,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Usage",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -214,11 +219,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__} != 128 != -128) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__} != 128 != -128",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -227,11 +237,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -240,11 +255,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
@@ -56,6 +56,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.278.107.1.1.4.2.1.3"
         name = "usage"
@@ -66,6 +67,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.278.107.1.1.1.1.3"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/metrics.json
@@ -22,11 +22,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -35,11 +40,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -48,11 +58,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "fanIndex",
+          "description": "Fan index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -61,11 +76,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "Power Supply State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "psuIndex",
+          "description": "Power supply index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/arista.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/arista.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/aruba.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/aruba.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.47196.4.1.1.3.22.1.0.1.1.3"
         name = "usage"
@@ -62,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.47196.4.1.1.3.22.1.0.1.1.4"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,7 +43,12 @@
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3320.9.109.1.1.1.1.5.1"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3320.9.48.1.1.1.5"
         name = "used"
@@ -75,6 +77,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3320.3.6.10.1.13"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/metrics.json
@@ -22,11 +22,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -39,7 +44,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -52,7 +62,12 @@
       "display_name": "Memory Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -61,11 +76,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / (device_memory_used{instance_type='switch', __$labels__} + device_memory_free{instance_type='switch', __$labels__}) * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -74,11 +94,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/brocade.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/brocade.child.toml.j2
@@ -72,6 +72,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.1991.1.1.1.1.18"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/metrics.json
@@ -51,7 +51,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/cisco.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/cisco.child.toml.j2
@@ -53,6 +53,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.9.9.109.1.1.1.1.8"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -70,11 +75,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / (device_memory_used{instance_type='switch', __$labels__} + device_memory_free{instance_type='switch', __$labels__}) * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "name",
+          "description": "Memory pool name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/cumulus.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/cumulus.child.toml.j2
@@ -53,6 +53,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"
@@ -75,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2021.13.16.2.1.3"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -107,13 +112,18 @@
     },
     {
       "metric_group": "Temperature",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_temperature_celsius",
       "display_name": "设备温度",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "unit": "celsius",
       "data_type": "Number",
       "description": "Chassis temperature of the Cumulus Linux switch in degrees Celsius (LM-SENSORS-MIB lmTempSensorsValue)."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/datacom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/datacom.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3709.3.6.4.1.2.1.4"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3709.3.6.4.2.2.1.3"
         name = "used"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,7 +43,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,7 +61,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -60,11 +75,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/dellforce.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/dellforce.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6027.3.10.1.2.9.1.3"
         name = "usage"
@@ -62,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6027.3.10.1.2.9.1.5"
         name = "usage"
@@ -70,6 +72,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6027.3.10.1.2.2.1.14"
         name = "celsius"
@@ -79,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6027.3.10.1.2.4.1.2"
         name = "state"
@@ -88,6 +92,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6027.3.10.1.2.3.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,7 +43,12 @@
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,7 +61,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -64,7 +79,12 @@
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -77,7 +97,12 @@
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/dlink.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/dlink.child.toml.j2
@@ -62,6 +62,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.171.12.1.1.9.1.4"
         name = "usage"
@@ -70,6 +71,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.171.12.11.1.8.1.2"
         name = "celsius"
@@ -79,6 +81,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.171.12.11.1.7.1.3"
         name = "state"
@@ -89,6 +92,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.171.12.11.1.6.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/metrics.json
@@ -38,7 +38,12 @@
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,7 +56,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -64,7 +74,12 @@
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -77,7 +92,12 @@
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
@@ -80,6 +80,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.259.10.1.24.1.1.4.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the Edgecore managed switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/eltex.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/eltex.child.toml.j2
@@ -74,6 +74,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.89.53.15.1.10"
         name = "celsius"
@@ -96,6 +97,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.89.53.15.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/metrics.json
@@ -76,11 +76,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -89,11 +94,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "fanName",
+          "description": "Fan name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -102,11 +112,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5624.1.2.49.1.4.1.1.5"
         name = "usage"
@@ -60,6 +61,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5624.1.2.49.1.1.1.1.7"
         name = "used"
@@ -71,6 +73,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5624.1.2.16.1.1.1.4"
         name = "celsius"
@@ -79,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5624.1.2.16.1.1.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -68,65 +73,90 @@
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_used",
       "display_name": "内存已用",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__} * 1024) by (instance_id)",
+      "query": "device_memory_used{instance_type='switch', __$labels__} * 1024",
       "unit": "bytes",
       "data_type": "Number",
       "description": "Used memory of the Enterasys switch in bytes (ENTERASYS-MIB etsysResourceStorageUsed, KB*1024)."
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_free",
       "display_name": "内存空闲",
-      "query": "sum(device_memory_free{instance_type='switch', __$labels__} * 1024) by (instance_id)",
+      "query": "device_memory_free{instance_type='switch', __$labels__} * 1024",
       "unit": "bytes",
       "data_type": "Number",
       "description": "Free memory of the Enterasys switch in bytes (ENTERASYS-MIB etsysResourceStorageAvailable, KB*1024)."
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_usage",
       "display_name": "内存使用率",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / (device_memory_used{instance_type='switch', __$labels__} + device_memory_free{instance_type='switch', __$labels__}) * 100",
       "unit": "percent",
       "data_type": "Number",
       "description": "Memory utilisation of the Enterasys switch, derived as used/(used+free)."
     },
     {
       "metric_group": "Temperature",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_temperature_celsius",
       "display_name": "设备温度",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "unit": "celsius",
       "data_type": "Number",
       "description": "Chassis temperature of the Enterasys switch in degrees Celsius (ENTERASYS-MIB chassis temperature sensor)."
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the Enterasys switch (ENTERASYS-MIB etsysChassisPowerSupplyState), normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/metrics.json
@@ -34,11 +34,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "Power Supply State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "psuName",
+          "description": "Power supply name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/extreme.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/extreme.child.toml.j2
@@ -71,6 +71,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.1916.1.32.2.2.1.2"
         name = "total"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/metrics.json
@@ -40,8 +40,8 @@
       "unit": "bytes",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "Memory bank"
+          "name": "index",
+          "description": "SNMP table row index"
         }
       ],
       "instance_id_keys": [
@@ -58,8 +58,8 @@
       "unit": "bytes",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "Memory bank"
+          "name": "index",
+          "description": "SNMP table row index"
         }
       ],
       "instance_id_keys": [
@@ -70,11 +70,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "(sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) - sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "(device_memory_total{instance_type='switch', __$labels__} - device_memory_free{instance_type='switch', __$labels__}) / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/fiberhome.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/fiberhome.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3807.1.8012.1.4.1.1.2"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3807.1.8012.1.5.4.1.7"
         name = "used"
@@ -75,6 +77,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3807.1.8012.1.6.2.1.5"
         name = "celsius"
@@ -84,6 +87,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3807.1.8012.1.2.1.1.3"
         name = "state"
@@ -101,6 +105,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3807.1.8012.1.11.4.1.2"
         name = "speed"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/metrics.json
@@ -24,11 +24,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id) / 100",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__} / 100",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -41,7 +46,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -54,7 +64,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -63,11 +78,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -76,11 +96,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -89,11 +114,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -102,11 +132,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_speed",
-      "query": "max(device_fan_speed{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_speed{instance_type='switch', __$labels__}",
       "display_name": "Fan Speed",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/fs.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/fs.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.52642.1.1.10.2.36.1.2.1.5"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.52642.1.1.10.2.35.1.2.1.6"
         name = "total"
@@ -74,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.52642.1.1.10.2.1.1.44.1.5"
         name = "celsius"
@@ -84,6 +87,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.52642.1.1.10.2.1.1.43.1.4"
         name = "state"
@@ -93,6 +97,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.52642.1.1.10.2.1.1.41.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/metrics.json
@@ -24,11 +24,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -41,7 +46,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -54,7 +64,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -63,11 +78,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -76,11 +96,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -89,11 +114,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -102,11 +132,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
@@ -80,6 +80,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.14778.1.2.1.5.1.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the GarretCom industrial switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.25506.2.6.1.1.1.1.6"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.25506.2.6.1.1.1.1.8"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "max(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='switch', __$labels__}",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
@@ -78,6 +78,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.248.14.1.2.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the Hirschmann switch (hmPSState), normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/hphpn.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/hphpn.child.toml.j2
@@ -63,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.7"
         name = "used"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/metrics.json
@@ -38,7 +38,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,7 +56,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -60,11 +70,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/intelbras.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/intelbras.child.toml.j2
@@ -56,6 +56,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.26138.2.6.1.1.1.1.6"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.26138.2.6.1.1.1.1.10"
         name = "total"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_total",
-      "query": "max(device_memory_total{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_total{instance_type='switch', __$labels__}",
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -47,11 +57,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "max(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='switch', __$labels__}",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/juniper.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/juniper.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2636.3.1.13.1.8"
         name = "usage"
@@ -62,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2636.3.1.13.1.11"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,7 +43,12 @@
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
@@ -82,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.5651.1.1.1.1.5.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the Maipu switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/mellanox.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/mellanox.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the MICROSENS industrial switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
@@ -82,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3181.10.6.1.6.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -77,7 +82,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/mikrotik.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/mikrotik.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"
@@ -77,6 +78,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.14988.1.1.3.10"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/metrics.json
@@ -77,7 +77,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -90,7 +95,12 @@
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -103,7 +113,12 @@
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/netgear.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/netgear.child.toml.j2
@@ -74,6 +74,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4526.10.43.1.8.1.5"
         name = "celsius"
@@ -83,6 +84,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4526.10.43.1.6.1.3"
         name = "state"
@@ -92,6 +94,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4526.10.43.1.7.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/netonix.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/netonix.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.46242.3.1.3"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -68,52 +73,72 @@
     },
     {
       "metric_group": "Memory",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_memory_usage",
       "display_name": "内存使用率",
-      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='switch', __$labels__}",
       "unit": "percent",
       "data_type": "Number",
       "description": "This metric reports the memory utilisation percentage of the Nokia OmniSwitch (ALCATEL-IND1-HEALTH-MIB healthModuleMemoryLatest), reported directly as a percentage and aggregated as the average across modules. Sustained high memory may indicate a leak or resource pressure and can degrade device stability."
     },
     {
       "metric_group": "Temperature",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_temperature_celsius",
       "display_name": "设备温度",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "unit": "celsius",
       "data_type": "Number",
       "description": "This metric reports the chassis temperature in degrees Celsius of the Nokia OmniSwitch (ALCATEL-IND1-CHASSIS-MIB chasChassisTemp), aggregated as the maximum across sensors. High temperatures can indicate cooling failure or airflow obstruction and risk thermal shutdown."
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_fan_state",
       "display_name": "风扇状态",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "This metric reports the fan operational state of the Nokia OmniSwitch (ALCATEL-IND1-CHASSIS-MIB chasEntPhysOperStatus for fan entities), normalised via telegraf processors.enum to 1=normal / 2=abnormal. An abnormal fan reduces cooling capacity and raises the risk of thermal shutdown."
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "This metric reports the power-supply state of the Nokia OmniSwitch (ALCATEL-IND1-CHASSIS-MIB chasEntPhysOperStatus for power-supply entities), normalised via telegraf processors.enum to 1=normal / 2=abnormal. A failed power supply removes redundancy and a single-supply failure can take the device offline."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
@@ -52,12 +52,14 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1.13"
         name = "usage"
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.2.1.16.1.1.1.1.14"
         name = "usage"
@@ -66,6 +68,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.1.1.3.1.1.4.1"
         name = "celsius"
@@ -74,12 +77,14 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.1.1.1.1.1.1.2"
         name = "state"
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.6486.800.1.1.1.4.1.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/metrics.json
@@ -24,11 +24,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -50,11 +55,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -63,11 +73,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_optical_rx_power",
-      "query": "min((device_optical_rx_power{instance_type='switch', __$labels__} != -2147483648) / 100) by (instance_id)",
+      "query": "(device_optical_rx_power{instance_type='switch', __$labels__} != -2147483648) / 100",
       "display_name": "SFP RX Power",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "portName",
+          "description": "Port name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -76,11 +91,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_optical_tx_power",
-      "query": "min((device_optical_tx_power{instance_type='switch', __$labels__} != -2147483648) / 100) by (instance_id)",
+      "query": "(device_optical_tx_power{instance_type='switch', __$labels__} != -2147483648) / 100",
       "display_name": "SFP TX Power",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "portName",
+          "description": "Port name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/parks.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/parks.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.50224.3.1.1.17"
         name = "usage"
@@ -70,6 +71,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.50224.3.1.1.23"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the PLANET managed switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
@@ -80,6 +80,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.10456.1.999.1.4.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -107,13 +112,18 @@
     },
     {
       "metric_group": "Temperature",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_temperature_celsius",
       "display_name": "设备温度",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "unit": "celsius",
       "data_type": "Number",
       "description": "Chassis temperature of the Pluribus Netvisor ONE switch in degrees Celsius (LM-SENSORS-MIB lmTempSensorsValue)."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/pluribus.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/pluribus.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.25.3.3.1.2"
         name = "usage"
@@ -75,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.2021.13.16.2.1.3"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/metrics.json
@@ -90,7 +90,12 @@
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -103,7 +108,12 @@
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"warning\",\"id\":2,\"color\":\"#faad14\"},{\"name\":\"critical\",\"id\":3,\"color\":\"#ff4d4f\"},{\"name\":\"shutdown\",\"id\":4,\"color\":\"#ff4d4f\"},{\"name\":\"notPresent\",\"id\":5,\"color\":\"#d9d9d9\"},{\"name\":\"notFunctioning\",\"id\":6,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/qtech.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/qtech.child.toml.j2
@@ -83,6 +83,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.27514.100.1.12.1.3"
         name = "state"
@@ -92,6 +93,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.27514.100.1.7.1.5"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the RuggedCOM industrial switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
@@ -82,6 +82,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.15004.4.2.3.1.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/metrics.json
@@ -28,11 +28,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -45,7 +50,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -58,7 +68,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -67,11 +82,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -80,11 +100,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -93,11 +118,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -106,11 +136,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -119,11 +154,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_speed",
-      "query": "max(device_fan_speed{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_speed{instance_type='switch', __$labels__}",
       "display_name": "Fan Speed",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -132,11 +172,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_voltage_volts",
-      "query": "max(device_voltage_volts{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_voltage_volts{instance_type='switch', __$labels__}",
       "display_name": "Input Voltage",
       "data_type": "Number",
       "unit": "volts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -145,11 +190,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_optical_rx_power",
-      "query": "min((device_optical_rx_power{instance_type='switch', __$labels__} != -10000) / 100) by (instance_id)",
+      "query": "(device_optical_rx_power{instance_type='switch', __$labels__} != -10000) / 100",
       "display_name": "SFP RX Power",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "portName",
+          "description": "Port name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -158,11 +208,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_optical_tx_power",
-      "query": "min((device_optical_tx_power{instance_type='switch', __$labels__} != -10000) / 100) by (instance_id)",
+      "query": "(device_optical_tx_power{instance_type='switch', __$labels__} != -10000) / 100",
       "display_name": "SFP TX Power",
       "data_type": "Number",
       "unit": "counts",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "portName",
+          "description": "Port name"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/ruijie.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/ruijie.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.36.1.2.1.5"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.35.1.1.1.6"
         name = "total"
@@ -74,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.1.1.44.1.5"
         name = "celsius"
@@ -84,6 +87,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.1.1.43.1.4"
         name = "state"
@@ -98,6 +102,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.1.1.41.1.3"
         name = "state"
@@ -107,6 +112,7 @@
     [[inputs.snmp.table]]
         name = "device_voltage"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4881.1.1.10.2.1.1.41.1.11"
         name = "volts"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/metrics.json
@@ -23,11 +23,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -40,7 +45,12 @@
       "display_name": "Memory Total",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -53,7 +63,12 @@
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -62,11 +77,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / sum(device_memory_total{instance_type='switch', __$labels__}) by (instance_id) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / device_memory_total{instance_type='switch', __$labels__} * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -75,11 +95,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -88,11 +113,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/snr.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/snr.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.40418.7.100.1.8.1.11"
         name = "usage"
@@ -63,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.40418.7.100.1.8.1.7"
         name = "total"
@@ -74,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.40418.7.100.1.8.1.10"
         name = "celsius"
@@ -83,6 +86,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.40418.7.100.1.12.1.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/metrics.json
@@ -25,7 +25,12 @@
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -38,7 +43,12 @@
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/tplink.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/tplink.child.toml.j2
@@ -54,6 +54,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.11863.6.4.1.1.1.1.3"
         name = "usage"
@@ -62,6 +63,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.11863.6.4.1.2.1.1.2"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/metrics.json
@@ -24,11 +24,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -37,11 +42,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "max(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='switch', __$labels__}",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -50,11 +60,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -63,11 +78,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -76,11 +96,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/tsntec.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/tsntec.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.65531.1.25"
         name = "usage"
@@ -59,6 +60,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.65531.1.26"
         name = "usage"
@@ -66,6 +68,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.65531.1.7"
         name = "celsius"
@@ -73,6 +76,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.65531.1.10"
         name = "state"
@@ -80,6 +84,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.65531.1.19"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/metrics.json
@@ -61,11 +61,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -74,11 +79,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/ubiquiti.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/ubiquiti.child.toml.j2
@@ -66,6 +66,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4413.1.1.43.1.8.1.5"
         name = "celsius"
@@ -76,6 +77,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.4413.1.1.43.1.6.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/metrics.json
@@ -120,13 +120,18 @@
     },
     {
       "metric_group": "Hardware Status",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
       "name": "device_psu_state",
       "display_name": "电源状态",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "data_type": "Enum",
       "description": "Power-supply state of the Westermo industrial switch, normalised to 1=normal / 2=abnormal."

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
@@ -80,6 +80,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.16177.1.5.1.6.1.1.3"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/metrics.json
@@ -26,11 +26,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "max(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -39,11 +44,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_used",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_used{instance_type='switch', __$labels__}",
       "display_name": "Memory Used",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -52,11 +62,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_free",
-      "query": "sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_free{instance_type='switch', __$labels__}",
       "display_name": "Memory Free",
       "data_type": "Number",
       "unit": "bytes",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -65,11 +80,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) / (sum(device_memory_used{instance_type='switch', __$labels__}) by (instance_id) + sum(device_memory_free{instance_type='switch', __$labels__}) by (instance_id)) * 100",
+      "query": "device_memory_used{instance_type='switch', __$labels__} / (device_memory_used{instance_type='switch', __$labels__} + device_memory_free{instance_type='switch', __$labels__}) * 100",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -78,11 +98,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='switch', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -91,11 +116,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='switch', __$labels__}",
       "display_name": "Fan State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -104,11 +134,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='switch', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -123,8 +158,8 @@
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "Fan description"
+          "name": "index",
+          "description": "SNMP table row index"
         }
       ],
       "instance_id_keys": [
@@ -141,8 +176,8 @@
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",
       "dimensions": [
         {
-          "name": "descr",
-          "description": "PSU description"
+          "name": "index",
+          "description": "SNMP table row index"
         }
       ],
       "instance_id_keys": [

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/witek.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/witek.child.toml.j2
@@ -52,6 +52,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.12284.4.2.4"
         name = "usage"
@@ -59,6 +60,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.12284.4.1.1"
         name = "free"
@@ -69,6 +71,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.12284.5.5.5"
         name = "celsius"
@@ -76,6 +79,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.12284.5.5.8"
         name = "ac_state"
@@ -86,6 +90,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.12284.5.5.22"
         name = "ac_dc_state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "CPU",
       "name": "device_cpu_usage",
-      "query": "avg(device_cpu_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_cpu_usage{instance_type='switch', __$labels__}",
       "display_name": "CPU Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Memory",
       "name": "device_memory_usage",
-      "query": "avg(device_memory_usage{instance_type='switch', __$labels__}) by (instance_id)",
+      "query": "device_memory_usage{instance_type='switch', __$labels__}",
       "display_name": "Memory Utilization",
       "data_type": "Number",
       "unit": "percent",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/zte.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/zte.child.toml.j2
@@ -55,6 +55,7 @@
     [[inputs.snmp.table]]
         name = "device_cpu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3902.3.3.1.1.12"
         name = "usage"
@@ -64,6 +65,7 @@
     [[inputs.snmp.table]]
         name = "device_memory"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.3902.3.3.1.1.4"
         name = "usage"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/metrics.json
@@ -37,7 +37,12 @@
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/zyxel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/zyxel.child.toml.j2
@@ -62,6 +62,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.890.1.5.8.20.9.2.1.2"
         name = "celsius"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/4rf.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/4rf.child.toml.j2
@@ -60,6 +60,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.14817.7.3.1.2.51.8"
         name = "celsius"
@@ -67,6 +68,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.14817.7.3.1.2.21.1"
         name = "fan1_state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_4rf/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='transmission', __$labels__}",
       "display_name": "Receiver Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='transmission', __$labels__}",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -51,7 +61,12 @@
       "display_name": "Fan 1 State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"normal\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"abnormal\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/hubersuhner.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/hubersuhner.child.toml.j2
@@ -59,6 +59,7 @@
     [[inputs.snmp.table]]
         name = "device_temperature"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.27894.11.241.1.9.5.1.4"
         name = "celsius"
@@ -66,6 +67,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.27894.11.241.1.3.1.1.4"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='transmission', __$labels__} / 10) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='transmission', __$labels__} / 10",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='transmission', __$labels__}",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/metrics.json
@@ -20,11 +20,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='transmission', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "sensor_label",
+          "description": "Sensor label"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/metrics.json
@@ -22,11 +22,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='transmission', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "sensor",
+          "description": "Sensor"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -35,11 +40,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_fan_state",
-      "query": "max(device_fan_state{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_fan_state{instance_type='transmission', __$labels__}",
       "display_name": "Fan Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -48,11 +58,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='transmission', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='transmission', __$labels__}",
       "display_name": "Power Supply Status",
       "data_type": "Enum",
       "unit": "[{\"id\":1,\"name\":\"Normal\"},{\"id\":2,\"name\":\"Abnormal\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/xkl.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/xkl.child.toml.j2
@@ -70,6 +70,7 @@
     [[inputs.snmp.table]]
         name = "device_fan"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.21150.1.1.5.1.2"
         name = "state"
@@ -77,6 +78,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.21150.1.1.9.1.2"
         name = "state"

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/metrics.json
@@ -21,11 +21,16 @@
     {
       "metric_group": "Temperature",
       "name": "device_temperature_celsius",
-      "query": "max(device_temperature_celsius{instance_type='voice_gateway', __$labels__}) by (instance_id)",
+      "query": "device_temperature_celsius{instance_type='voice_gateway', __$labels__}",
       "display_name": "Temperature",
       "data_type": "Number",
       "unit": "celsius",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "sensor",
+          "description": "Sensor"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],
@@ -34,11 +39,16 @@
     {
       "metric_group": "Hardware Status",
       "name": "device_psu_state",
-      "query": "max(device_psu_state{instance_type='voice_gateway', __$labels__}) by (instance_id)",
+      "query": "device_psu_state{instance_type='voice_gateway', __$labels__}",
       "display_name": "PSU State",
       "data_type": "Enum",
       "unit": "[{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"},{\"name\":\"异常\",\"id\":2,\"color\":\"#ff4d4f\"}]",
-      "dimensions": [],
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
       "instance_id_keys": [
         "instance_id"
       ],

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/zenitel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/zenitel.child.toml.j2
@@ -64,6 +64,7 @@
     [[inputs.snmp.table]]
         name = "device_psu"
         inherit_tags = ["source"]
+        index_as_tag = true
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.4.1.26122.3.5.1.1.3"
         name = "source"


### PR DESCRIPTION
## Summary
- 纠正此前用 `max`/`avg`/`sum` 把多行 SNMP 健康/状态指标压成单值的做法；改为声明 `dimensions`，查询保留每个实体一条序列。
- 优先复用采集侧已有 `is_tag`（如 `descr`/`name`/`portName`）；否则启用 `index_as_tag`，维度使用 `index`。
- 覆盖交换机/路由器/防火墙等厂商的 CPU、内存、温度、风扇、电源、光模块、盘卡等，以及 ZDNS 虚拟服务/节点/池成员状态；标量 OID（`.0`）与固定单行仍保持设备级。

## Test plan
- [x] 全量扫描：多行表 + 空 `dimensions` = 0
- [x] 全量扫描：已声明维度但仍 `by (instance_id)` 压扁 = 0
- [x] 抽查 MikroTik 温度/CPU 为原始查询 + `index`；华为为 `descr`；Cisco 内存为 `name`；Parks/Ruijie 光模块为 `portName`
- [ ] 现网抽检：多核 CPU / 多传感器温度在监控详情可按维度展开查看