### PR TITLE
fix(监控): 批量加速插件与策略初始化，避免单文件失败清空模板

### DIFF
--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -1,5 +1,6 @@
 import json
 import re
+import traceback
 from copy import deepcopy
 from pathlib import Path
 
@@ -274,13 +275,17 @@ def _import_plugins_from_files(path_list):
 
         except Exception as e:
             logger.error(f"导入插件失败: {file_path}, 错误: {e}")
-            import traceback
-
             logger.error(traceback.format_exc())
             error_count += 1
 
     if documents:
-        MonitorPluginService.import_monitor_plugins(documents)
+        try:
+            MonitorPluginService.import_monitor_plugins(documents)
+        except Exception as e:
+            logger.error("批量导入插件失败，已回滚本次插件写入: %s", e)
+            logger.error(traceback.format_exc())
+            error_count += success_count
+            success_count = 0
 
     return success_count, error_count, supplementary_map
 

--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -12,6 +12,7 @@ from apps.monitor.management.utils import (
     parse_template_filename,
 )
 from apps.monitor.services.plugin import MonitorPluginService
+from apps.monitor.services.plugin_import_bulk import prepare_plugin_import_plan
 from apps.monitor.utils.snmp_ifmib_capability import is_ifmib_capable_plugin_data
 from apps.rpc.node_mgmt import NodeMgmt
 
@@ -69,8 +70,14 @@ COMMON_IFMIB_METRICS = (
 )
 
 
+_IFMIB_METRICS_BY_INSTANCE_TYPE = {}
+
+
 def _build_common_ifmib_metrics(instance_type):
     """Build the complete public IF-MIB metric catalog for one runtime object."""
+    cached = _IFMIB_METRICS_BY_INSTANCE_TYPE.get(instance_type)
+    if cached is not None:
+        return deepcopy(cached)
     metrics = []
     for group, name, display_name, data_type, unit, description in COMMON_IFMIB_METRICS:
         if name.startswith("device_total_"):
@@ -97,7 +104,8 @@ def _build_common_ifmib_metrics(instance_type):
                 "is_ifmib": True,
             }
         )
-    return metrics
+    _IFMIB_METRICS_BY_INSTANCE_TYPE[instance_type] = metrics
+    return deepcopy(metrics)
 
 
 def merge_common_ifmib_metrics(plugin_data):
@@ -244,6 +252,7 @@ def _import_plugins_from_files(path_list):
     success_count = 0
     error_count = 0
     supplementary_map = {}
+    documents = []
 
     for file_path in path_list:
         try:
@@ -258,7 +267,8 @@ def _import_plugins_from_files(path_list):
             plugin_data["_mark_objects_builtin"] = True
             # 新 plugin 首次导入时,自动生成 language/ 空骨架(check_plugin_languages CI 要求)
             MonitorPluginService._ensure_language_skeleton(Path(file_path).parent, plugin_name)
-            MonitorPluginService.import_monitor_plugin(plugin_data)
+            prepare_plugin_import_plan(plugin_data)
+            documents.append(plugin_data)
             logger.info(f"导入插件成功: {plugin_name} ({collector}/{collect_type})")
             success_count += 1
 
@@ -268,6 +278,9 @@ def _import_plugins_from_files(path_list):
 
             logger.error(traceback.format_exc())
             error_count += 1
+
+    if documents:
+        MonitorPluginService.import_monitor_plugins(documents)
 
     return success_count, error_count, supplementary_map
 

--- a/server/apps/monitor/management/services/policy_migrate.py
+++ b/server/apps/monitor/management/services/policy_migrate.py
@@ -33,7 +33,9 @@ def migrate_policy():
             logger.error(f'读取策略配置失败: {file_path}, 错误: {e}')
             error_count += 1
     if error_count:
-        logger.error(f"策略配置读取失败，保留上一次有效内置模板: 失败={error_count}")
+        logger.error("部分策略配置读取失败，将跳过损坏文件并对账其余有效文档: 失败=%s", error_count)
+    if not documents:
+        logger.error("没有可读的策略配置，保留上一次有效内置模板: 失败=%s", error_count)
         return
     try:
         result = PolicyService.sync_builtin_policy_templates(documents)

--- a/server/apps/monitor/services/plugin.py
+++ b/server/apps/monitor/services/plugin.py
@@ -102,6 +102,13 @@ class MonitorPluginService:
         MonitorPluginService._sync_plugin_monitor_objects(plugin_name, monitor_object_names)
 
     @staticmethod
+    def import_monitor_plugins(documents: list[dict]) -> None:
+        """跨插件批量导入，供内置目录初始化使用。"""
+        from apps.monitor.services.plugin_import_bulk import import_monitor_plugins
+
+        import_monitor_plugins(documents)
+
+    @staticmethod
     def _ensure_language_skeleton(plugin_dir, plugin_name: str) -> None:
         """为新 plugin 在 metrics.json 同目录生成 language/{en,zh-Hans}.yaml 空骨架。
 

--- a/server/apps/monitor/services/plugin_import_bulk.py
+++ b/server/apps/monitor/services/plugin_import_bulk.py
@@ -1,0 +1,549 @@
+from copy import deepcopy
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.monitor.constants.database import DatabaseConstants
+from apps.monitor.models import MonitorPlugin
+from apps.monitor.models.monitor_metrics import Metric, MetricGroup
+from apps.monitor.models.monitor_object import MonitorObject, MonitorObjectType
+from apps.monitor.services.instance_facts import InstanceFactResolver
+from apps.monitor.utils.display_fields_seed import build_seed_display_fields
+from apps.monitor.utils.instance_id_keys import (
+    resolve_metric_instance_id_keys,
+    resolve_monitor_object_instance_id_keys,
+)
+from apps.monitor.utils.node_selector import normalize_node_selector
+
+METRIC_UPDATE_FIELDS = [
+    "metric_group_id",
+    "display_name",
+    "query",
+    "view_query",
+    "view_config",
+    "unit",
+    "data_type",
+    "description",
+    "dimensions",
+    "instance_id_keys",
+    "is_ifmib",
+]
+PLUGIN_UPDATE_FIELDS = [
+    "description",
+    "status_query",
+    "collector",
+    "collect_type",
+    "support_collect_detect",
+    "node_selector",
+    "instance_fact_bindings",
+]
+OBJECT_UPDATE_FIELDS = [
+    "icon",
+    "type",
+    "description",
+    "level",
+    "default_metric",
+    "instance_id_keys",
+    "is_builtin",
+    "display_fields",
+    "instance_summary_columns",
+    "parent",
+]
+
+
+def prepare_plugin_import_plan(data: dict) -> dict:
+    """把单个插件文档转成可跨插件批量写入的计划。不访问数据库。"""
+    payload = deepcopy(data)
+    mark_objects_builtin = bool(payload.pop("_mark_objects_builtin", False))
+    plugin_name = payload.get("plugin", "")
+    plugin_plan = {
+        "plugin_name": plugin_name,
+        "description": payload.get("plugin_desc", ""),
+        "status_query": payload.get("status_query", ""),
+        "collector": payload.get("collector", ""),
+        "collect_type": payload.get("collect_type", ""),
+        "support_collect_detect": bool(payload.get("support_collect_detect", False)),
+        "node_selector": normalize_node_selector(payload.get("node_selector", {})),
+        "instance_fact_bindings": InstanceFactResolver.validate_bindings(
+            payload.get("instance_fact_bindings", [])
+        ),
+        "objects": [],
+    }
+
+    if payload.get("is_compound_object"):
+        objects_raw = payload.get("objects") or []
+        base_summary_columns = payload.get("instance_summary_columns")
+        base_name = next(
+            (item.get("name") for item in objects_raw if item.get("level") == "base"),
+            None,
+        )
+        for object_info in objects_raw:
+            if mark_objects_builtin:
+                object_info["is_builtin"] = True
+            else:
+                object_info.pop("is_builtin", None)
+            if object_info.get("level") == "base" and "instance_summary_columns" not in object_info:
+                object_info["instance_summary_columns"] = base_summary_columns
+            object_plan = _prepare_object_plan(
+                object_info,
+                plugin_name,
+                plugin_plan["instance_fact_bindings"],
+            )
+            if object_info.get("level") != "base":
+                object_plan["parent_name"] = base_name
+            plugin_plan["objects"].append(object_plan)
+    else:
+        if mark_objects_builtin:
+            payload["is_builtin"] = True
+        else:
+            payload.pop("is_builtin", None)
+        plugin_plan["objects"].append(
+            _prepare_object_plan(
+                payload,
+                plugin_name,
+                plugin_plan["instance_fact_bindings"],
+            )
+        )
+
+    plugin_plan["objects"].sort(key=lambda item: 0 if item["level"] == "base" else 1)
+    return plugin_plan
+
+
+def apply_plugin_import_plans(plans: list[dict]) -> None:
+    """跨插件批量写入 Type / Object / Plugin / M2M / MetricGroup / Metric。"""
+    if not plans:
+        return
+
+    now = timezone.now()
+    with transaction.atomic():
+        _ensure_object_types(plans, now)
+        objects_map = {item.name: item for item in MonitorObject.objects.all()}
+        merged_objects = _merge_object_specs(plans)
+        _upsert_monitor_objects(
+            [spec for spec in merged_objects.values() if not spec.get("parent_name")],
+            objects_map,
+            now,
+        )
+        derivative_specs = []
+        for spec in merged_objects.values():
+            parent_name = spec.get("parent_name")
+            if not parent_name:
+                continue
+            parent = objects_map.get(parent_name)
+            derivative = dict(spec)
+            derivative["parent_id"] = parent.id if parent else None
+            derivative_specs.append(derivative)
+        _upsert_monitor_objects(derivative_specs, objects_map, now)
+
+        plugins_map = {item.name: item for item in MonitorPlugin.objects.all()}
+        _upsert_plugins(plans, plugins_map, now)
+        _sync_plugin_object_m2m(plans, plugins_map, objects_map)
+        _sync_metric_groups_and_metrics(plans, objects_map, plugins_map)
+
+
+def import_monitor_plugins(documents: list[dict]) -> None:
+    apply_plugin_import_plans([prepare_plugin_import_plan(document) for document in documents])
+
+
+def _prepare_object_plan(object_data: dict, plugin_name: str, instance_fact_bindings: list) -> dict:
+    metrics = object_data.get("metrics") or []
+    display_fields_block = object_data.get("display_fields", None)
+    instance_summary_columns = object_data.get("instance_summary_columns", None)
+    type_value = object_data.get("type")
+    type_id = getattr(type_value, "id", type_value) or None
+    name = object_data["name"]
+    level = object_data.get("level", "base")
+    instance_id_keys = resolve_monitor_object_instance_id_keys(
+        object_data.get("instance_id_keys", []),
+        level=level,
+        object_name=name,
+    )
+    if instance_summary_columns is not None:
+        _validate_instance_summary_columns(instance_summary_columns, instance_fact_bindings)
+
+    prepared_metrics = []
+    for metric in metrics:
+        dimensions = _normalize_metric_dimensions(metric.get("dimensions", []))
+        prepared_metrics.append(
+            {
+                "metric_group": metric["metric_group"],
+                "name": metric["name"],
+                "display_name": metric["display_name"],
+                "query": metric["query"],
+                "view_query": metric.get("view_query", ""),
+                "view_config": metric.get("view_config", {}),
+                "unit": metric["unit"],
+                "data_type": metric["data_type"],
+                "description": metric["description"],
+                "dimensions": dimensions,
+                "instance_id_keys": resolve_metric_instance_id_keys(
+                    metric.get("instance_id_keys", []),
+                    instance_id_keys,
+                    strict=True,
+                ),
+                "is_ifmib": bool(metric.get("is_ifmib", False)),
+            }
+        )
+
+    display_fields = None
+    if display_fields_block:
+        display_fields = list(display_fields_block)
+    else:
+        seeded = build_seed_display_fields(
+            plugin_name,
+            object_data.get("supplementary_indicators", []),
+            prepared_metrics,
+        )
+        if seeded:
+            display_fields = seeded
+
+    return {
+        "name": name,
+        "level": level,
+        "parent_name": None,
+        "type_id": type_id,
+        "icon": object_data["icon"] if "icon" in object_data else None,
+        "description": object_data["description"] if "description" in object_data else None,
+        "default_metric": object_data["default_metric"] if "default_metric" in object_data else None,
+        "instance_id_keys": instance_id_keys,
+        "is_builtin": bool(object_data.get("is_builtin")),
+        "cleanup_policy": object_data.get("cleanup_policy"),
+        "cleanup_timeout_days": object_data.get("cleanup_timeout_days"),
+        "cleanup_timeout_unit": object_data.get("cleanup_timeout_unit"),
+        "display_fields": display_fields,
+        "instance_summary_columns": instance_summary_columns,
+        "metrics": prepared_metrics,
+        "plugin_name": plugin_name,
+    }
+
+
+def _normalize_metric_dimensions(dimensions):
+    from apps.monitor.services.plugin import MonitorPluginService
+
+    return MonitorPluginService.normalize_metric_dimensions(dimensions)
+
+
+def _validate_instance_summary_columns(instance_summary_columns, instance_fact_bindings):
+    if not isinstance(instance_summary_columns, list):
+        raise BaseAppException("instance_summary_columns 必须是列表")
+    available_facts = {binding["fact"] for binding in instance_fact_bindings}
+    for index, column in enumerate(instance_summary_columns):
+        if not isinstance(column, dict) or not str(column.get("fact") or "").strip():
+            raise BaseAppException(f"instance_summary_columns[{index}] 缺少 fact")
+        if column["fact"] not in available_facts:
+            raise BaseAppException(f"实例摘要列引用了插件未绑定的事实: {column['fact']}")
+
+
+def _ensure_object_types(plans, now):
+    types_map = {item.id: item for item in MonitorObjectType.objects.all()}
+    to_create = []
+    seen = set()
+    for plan in plans:
+        for object_plan in plan["objects"]:
+            type_id = object_plan.get("type_id")
+            if not type_id or type_id in types_map or type_id in seen:
+                continue
+            seen.add(type_id)
+            to_create.append(
+                MonitorObjectType(id=type_id, order=999, created_at=now, updated_at=now)
+            )
+    if to_create:
+        MonitorObjectType.objects.bulk_create(
+            to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
+        )
+        for item in to_create:
+            types_map[item.id] = item
+    return types_map
+
+
+def _merge_object_specs(plans):
+    merged = {}
+    for plan in plans:
+        for object_plan in plan["objects"]:
+            merged[object_plan["name"]] = object_plan
+    return merged
+
+
+def _upsert_monitor_objects(specs, objects_map, now):
+    to_create = []
+    to_update = []
+    for spec in specs:
+        existing = objects_map.get(spec["name"])
+        type_id = spec.get("type_id")
+        if existing is None:
+            create_kwargs = {
+                "name": spec["name"],
+                "icon": spec.get("icon") or "",
+                "type_id": type_id,
+                "description": spec.get("description") or "",
+                "level": spec.get("level") or "base",
+                "default_metric": spec.get("default_metric") or "",
+                "instance_id_keys": spec.get("instance_id_keys") or [],
+                "is_builtin": bool(spec.get("is_builtin")),
+                "created_at": now,
+                "updated_at": now,
+            }
+            if spec.get("parent_id") is not None:
+                create_kwargs["parent_id"] = spec["parent_id"]
+            if spec.get("display_fields") is not None:
+                create_kwargs["display_fields"] = spec["display_fields"]
+            if spec.get("instance_summary_columns") is not None:
+                create_kwargs["instance_summary_columns"] = spec["instance_summary_columns"]
+            if spec.get("cleanup_policy"):
+                create_kwargs["cleanup_policy"] = spec["cleanup_policy"]
+                if spec["cleanup_policy"] == MonitorObject.CLEANUP_POLICY_TIMEOUT:
+                    create_kwargs["cleanup_policy_effective_at"] = now
+            if spec.get("cleanup_timeout_days") is not None:
+                create_kwargs["cleanup_timeout_days"] = spec["cleanup_timeout_days"]
+            if spec.get("cleanup_timeout_unit"):
+                create_kwargs["cleanup_timeout_unit"] = spec["cleanup_timeout_unit"]
+            to_create.append(MonitorObject(**create_kwargs))
+            continue
+
+        changed = False
+        if spec.get("icon") is not None and existing.icon != spec["icon"]:
+            existing.icon = spec["icon"]
+            changed = True
+        if type_id and existing.type_id != type_id:
+            existing.type_id = type_id
+            changed = True
+        if spec.get("description") is not None and existing.description != spec["description"]:
+            existing.description = spec["description"]
+            changed = True
+        if spec.get("level") and existing.level != spec["level"]:
+            existing.level = spec["level"]
+            changed = True
+        if spec.get("default_metric") is not None and existing.default_metric != spec["default_metric"]:
+            existing.default_metric = spec["default_metric"]
+            changed = True
+        if spec.get("instance_id_keys") and existing.instance_id_keys != spec["instance_id_keys"]:
+            existing.instance_id_keys = spec["instance_id_keys"]
+            changed = True
+        if spec.get("is_builtin") and not existing.is_builtin:
+            existing.is_builtin = True
+            changed = True
+        if spec.get("parent_id") is not None and existing.parent_id != spec["parent_id"]:
+            existing.parent_id = spec["parent_id"]
+            changed = True
+        if (
+            not existing.display_fields_customized
+            and spec.get("display_fields") is not None
+            and existing.display_fields != spec["display_fields"]
+        ):
+            existing.display_fields = spec["display_fields"]
+            changed = True
+        if (
+            spec.get("instance_summary_columns") is not None
+            and existing.instance_summary_columns != spec["instance_summary_columns"]
+        ):
+            existing.instance_summary_columns = spec["instance_summary_columns"]
+            changed = True
+        if changed:
+            existing.updated_at = now
+            to_update.append(existing)
+
+    if to_create:
+        MonitorObject.objects.bulk_create(to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
+        created_names = [item.name for item in to_create]
+        for item in MonitorObject.objects.filter(name__in=created_names):
+            objects_map[item.name] = item
+    if to_update:
+        MonitorObject.objects.bulk_update(
+            to_update,
+            OBJECT_UPDATE_FIELDS,
+            batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
+        )
+
+
+def _upsert_plugins(plans, plugins_map, now):
+    to_create = []
+    to_update = []
+    seen_names = set()
+    for plan in plans:
+        name = plan["plugin_name"]
+        if not name or name in seen_names:
+            continue
+        seen_names.add(name)
+        defaults = {
+            "description": plan["description"],
+            "status_query": plan["status_query"],
+            "collector": plan["collector"],
+            "collect_type": plan["collect_type"],
+            "support_collect_detect": plan["support_collect_detect"],
+            "node_selector": plan["node_selector"],
+            "instance_fact_bindings": plan["instance_fact_bindings"],
+        }
+        existing = plugins_map.get(name)
+        if existing is None:
+            to_create.append(
+                MonitorPlugin(
+                    name=name,
+                    created_at=now,
+                    updated_at=now,
+                    **defaults,
+                )
+            )
+            continue
+        changed = False
+        for field, value in defaults.items():
+            if getattr(existing, field) != value:
+                setattr(existing, field, value)
+                changed = True
+        if changed:
+            existing.updated_at = now
+            to_update.append(existing)
+
+    if to_create:
+        MonitorPlugin.objects.bulk_create(to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
+        created_names = [item.name for item in to_create]
+        for item in MonitorPlugin.objects.filter(name__in=created_names):
+            plugins_map[item.name] = item
+    if to_update:
+        MonitorPlugin.objects.bulk_update(
+            to_update,
+            PLUGIN_UPDATE_FIELDS,
+            batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
+        )
+
+
+def _sync_plugin_object_m2m(plans, plugins_map, objects_map):
+    through = MonitorPlugin.monitor_object.through
+    plugin_ids = []
+    desired_rows = []
+    seen_pairs = set()
+    for plan in plans:
+        plugin = plugins_map.get(plan["plugin_name"])
+        if plugin is None:
+            continue
+        plugin_ids.append(plugin.id)
+        for object_plan in plan["objects"]:
+            monitor_object = objects_map.get(object_plan["name"])
+            if monitor_object is None:
+                continue
+            pair = (plugin.id, monitor_object.id)
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            desired_rows.append(
+                through(monitorplugin_id=plugin.id, monitorobject_id=monitor_object.id)
+            )
+    if plugin_ids:
+        through.objects.filter(monitorplugin_id__in=plugin_ids).delete()
+    if desired_rows:
+        through.objects.bulk_create(desired_rows, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE)
+
+
+def _sync_metric_groups_and_metrics(plans, objects_map, plugins_map):
+    groups = {
+        (item.monitor_object_id, item.monitor_plugin_id, item.name): item
+        for item in MetricGroup.objects.all()
+    }
+    metrics = {
+        (item.monitor_object_id, item.monitor_plugin_id, item.name): item
+        for item in Metric.objects.all()
+    }
+
+    groups_to_create = []
+    seen_groups = set()
+    for plan in plans:
+        plugin = plugins_map.get(plan["plugin_name"])
+        if plugin is None:
+            continue
+        for object_plan in plan["objects"]:
+            monitor_object = objects_map.get(object_plan["name"])
+            if monitor_object is None:
+                continue
+            for metric in object_plan["metrics"]:
+                key = (monitor_object.id, plugin.id, metric["metric_group"])
+                if key in groups or key in seen_groups:
+                    continue
+                seen_groups.add(key)
+                groups_to_create.append(
+                    MetricGroup(
+                        monitor_object_id=monitor_object.id,
+                        monitor_plugin_id=plugin.id,
+                        name=metric["metric_group"],
+                    )
+                )
+    if groups_to_create:
+        MetricGroup.objects.bulk_create(
+            groups_to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
+        )
+        for item in MetricGroup.objects.filter(
+            monitor_plugin_id__in={row.monitor_plugin_id for row in groups_to_create}
+        ):
+            groups[(item.monitor_object_id, item.monitor_plugin_id, item.name)] = item
+
+    stale_metric_ids = []
+    metrics_to_update = []
+    metrics_to_create = []
+    expected_names = {}
+    for plan in plans:
+        plugin = plugins_map.get(plan["plugin_name"])
+        if plugin is None:
+            continue
+        for object_plan in plan["objects"]:
+            monitor_object = objects_map.get(object_plan["name"])
+            if monitor_object is None:
+                continue
+            scope = (monitor_object.id, plugin.id)
+            expected_names.setdefault(scope, set()).update(
+                metric["name"] for metric in object_plan["metrics"]
+            )
+            for metric in object_plan["metrics"]:
+                group = groups.get((monitor_object.id, plugin.id, metric["metric_group"]))
+                if group is None:
+                    continue
+                metric_key = (monitor_object.id, plugin.id, metric["name"])
+                existing = metrics.get(metric_key)
+                values = {
+                    "metric_group_id": group.id,
+                    "name": metric["name"],
+                    "display_name": metric["display_name"],
+                    "query": metric["query"],
+                    "view_query": metric["view_query"],
+                    "view_config": metric["view_config"],
+                    "unit": metric["unit"],
+                    "data_type": metric["data_type"],
+                    "description": metric["description"],
+                    "dimensions": metric["dimensions"],
+                    "instance_id_keys": metric["instance_id_keys"],
+                    "is_ifmib": metric["is_ifmib"],
+                }
+                if existing is None:
+                    metrics_to_create.append(
+                        Metric(
+                            monitor_object_id=monitor_object.id,
+                            monitor_plugin_id=plugin.id,
+                            **values,
+                        )
+                    )
+                    continue
+                changed = False
+                for field, value in values.items():
+                    if field == "name" or getattr(existing, field) == value:
+                        continue
+                    setattr(existing, field, value)
+                    changed = True
+                if changed:
+                    metrics_to_update.append(existing)
+
+    for (metric_object_id, metric_plugin_id, metric_name), metric in metrics.items():
+        names = expected_names.get((metric_object_id, metric_plugin_id))
+        if names is None or not metric.is_pre or metric_name in names:
+            continue
+        stale_metric_ids.append(metric.id)
+
+    if stale_metric_ids:
+        Metric.objects.filter(id__in=stale_metric_ids, is_pre=True).delete()
+    if metrics_to_update:
+        Metric.objects.bulk_update(
+            metrics_to_update,
+            METRIC_UPDATE_FIELDS,
+            batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
+        )
+    if metrics_to_create:
+        Metric.objects.bulk_create(
+            metrics_to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
+        )

--- a/server/apps/monitor/services/policy.py
+++ b/server/apps/monitor/services/policy.py
@@ -9,8 +9,11 @@ from pathlib import PurePosixPath
 
 from django.db import transaction
 from django.db.models import Q
+from django.utils import timezone
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import MonitorObject, MonitorPlugin, PolicyTemplate
 from apps.monitor.models.monitor_metrics import Metric
 
@@ -44,18 +47,23 @@ class PolicyService:
         return f"builtin:{digest}"
 
     @staticmethod
+    def _extract_builtin_pair(data):
+        if not isinstance(data, dict):
+            raise BaseAppException("policy.json 必须是对象")
+        object_name = str(data.get("object") or "").strip()
+        plugin_name = str(data.get("plugin") or "").strip()
+        if not object_name or not plugin_name:
+            raise BaseAppException("policy.json 缺少 object 或 plugin")
+        return object_name, plugin_name
+
+    @staticmethod
     def _normalize_builtin_documents(documents):
         normalized = []
         seen_pairs = set()
         seen_keys = set()
         for data in documents:
-            if not isinstance(data, dict):
-                raise BaseAppException("policy.json 必须是对象")
-            object_name = str(data.get("object") or "").strip()
-            plugin_name = str(data.get("plugin") or "").strip()
+            object_name, plugin_name = PolicyService._extract_builtin_pair(data)
             pair = (object_name, plugin_name)
-            if not all(pair):
-                raise BaseAppException("policy.json 缺少 object 或 plugin")
             if pair in seen_pairs:
                 raise BaseAppException(f"内置策略模板重复定义: {object_name}/{plugin_name}")
             seen_pairs.add(pair)
@@ -108,37 +116,132 @@ class PolicyService:
 
     @staticmethod
     def sync_builtin_policy_templates(documents):
-        normalized = PolicyService._normalize_builtin_documents(documents)
-        object_names = {item["object_name"] for item in normalized}
-        plugin_names = {item["plugin_name"] for item in normalized}
+        parsed_by_pair = {}
+        failed_pairs = set()
+        for data in documents:
+            pair = None
+            try:
+                pair = PolicyService._extract_builtin_pair(data)
+                items = PolicyService._normalize_builtin_documents([data])
+            except Exception as exc:
+                if pair is None:
+                    logger.warning("跳过无法识别的策略文档，不影响其它内置模板: %s", exc)
+                else:
+                    failed_pairs.add(pair)
+                    logger.warning("跳过策略文档 %s/%s，保留该对象对上一次模板: %s", pair[0], pair[1], exc)
+                continue
+            if pair in failed_pairs:
+                continue
+            if pair in parsed_by_pair:
+                failed_pairs.add(pair)
+                parsed_by_pair.pop(pair, None)
+                logger.warning("内置策略模板重复定义: %s/%s，跳过该对象对以避免误删", pair[0], pair[1])
+                continue
+            parsed_by_pair[pair] = items
+        for pair in failed_pairs:
+            parsed_by_pair.pop(pair, None)
+
+        object_names = {pair[0] for pair in parsed_by_pair}
+        plugin_names = {pair[1] for pair in parsed_by_pair}
         objects = {item.name: item for item in MonitorObject.objects.filter(name__in=object_names)}
         plugins = {item.name: item for item in MonitorPlugin.objects.filter(name__in=plugin_names)}
-        missing_objects = sorted(object_names - objects.keys())
-        missing_plugins = sorted(plugin_names - plugins.keys())
-        if missing_objects:
-            raise BaseAppException(f"监控对象不存在: {', '.join(missing_objects)}")
-        if missing_plugins:
-            raise BaseAppException(f"监控插件不存在: {', '.join(missing_plugins)}")
+        ready_pairs = {}
+        for pair, items in parsed_by_pair.items():
+            object_name, plugin_name = pair
+            if object_name not in objects or plugin_name not in plugins:
+                logger.warning(
+                    "跳过策略文档，监控对象或插件不存在: %s/%s",
+                    object_name,
+                    plugin_name,
+                )
+                continue
+            ready_pairs[pair] = items
 
+        if not ready_pairs:
+            logger.warning("没有可对账的有效内置策略文档，保留上一次有效内置模板")
+            return {"created_count": 0, "updated_count": 0, "deleted_count": 0}
+
+        normalized = [item for items in ready_pairs.values() for item in items]
         expected_keys = {item["key"] for item in normalized}
-        created_count = updated_count = 0
+        pair_ids = {
+            (objects[object_name].id, plugins[plugin_name].id)
+            for object_name, plugin_name in ready_pairs
+        }
+        existing = {
+            template.key: template
+            for template in PolicyTemplate.objects.filter(
+                template_type=PolicyTemplate.TYPE_BUILTIN,
+                scope_key=PolicyTemplate.TYPE_BUILTIN,
+            )
+        }
+        now = timezone.now()
+        to_create = []
+        to_update = []
         with transaction.atomic():
             for item in normalized:
-                _, created = PolicyService._upsert_builtin_template(
-                    item,
-                    objects[item["object_name"]],
-                    plugins[item["plugin_name"]],
+                monitor_object = objects[item["object_name"]]
+                plugin = plugins[item["plugin_name"]]
+                current = existing.get(item["key"])
+                if current is None:
+                    to_create.append(
+                        PolicyTemplate(
+                            scope_key=PolicyTemplate.TYPE_BUILTIN,
+                            key=item["key"],
+                            template_type=PolicyTemplate.TYPE_BUILTIN,
+                            organization=None,
+                            monitor_object=monitor_object,
+                            plugin=plugin,
+                            name=item["name"],
+                            description=item["description"],
+                            config=item["config"],
+                            created_at=now,
+                            updated_at=now,
+                        )
+                    )
+                    continue
+                if not PolicyService._builtin_template_changed(current, item, monitor_object, plugin):
+                    continue
+                current.monitor_object = monitor_object
+                current.plugin = plugin
+                current.name = item["name"]
+                current.description = item["description"]
+                current.config = item["config"]
+                current.updated_at = now
+                to_update.append(current)
+            if to_create:
+                PolicyTemplate.objects.bulk_create(
+                    to_create, batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE
                 )
-                created_count += int(created)
-                updated_count += int(not created)
-            deleted_count, _ = PolicyTemplate.objects.filter(
-                template_type=PolicyTemplate.TYPE_BUILTIN
-            ).exclude(key__in=expected_keys).delete()
+            if to_update:
+                PolicyTemplate.objects.bulk_update(
+                    to_update,
+                    ["name", "description", "config", "monitor_object", "plugin"],
+                    batch_size=DatabaseConstants.BULK_UPDATE_BATCH_SIZE,
+                )
+            stale_ids = [
+                template.id
+                for template in existing.values()
+                if (template.monitor_object_id, template.plugin_id) in pair_ids
+                and template.key not in expected_keys
+            ]
+            deleted_count = 0
+            if stale_ids:
+                deleted_count, _ = PolicyTemplate.objects.filter(id__in=stale_ids).delete()
         return {
-            "created_count": created_count,
-            "updated_count": updated_count,
+            "created_count": len(to_create),
+            "updated_count": len(to_update),
             "deleted_count": deleted_count,
         }
+
+    @staticmethod
+    def _builtin_template_changed(template, item, monitor_object, plugin):
+        return (
+            template.name != item["name"]
+            or template.description != item["description"]
+            or template.config != item["config"]
+            or template.monitor_object_id != monitor_object.id
+            or template.plugin_id != plugin.id
+        )
 
     @staticmethod
     def _upsert_builtin_template(item, monitor_object, plugin):

--- a/server/apps/monitor/services/policy.py
+++ b/server/apps/monitor/services/policy.py
@@ -4,7 +4,6 @@ import io
 import json
 import uuid
 import zipfile
-from datetime import datetime, timezone
 from pathlib import PurePosixPath
 
 from django.db import transaction
@@ -125,10 +124,20 @@ class PolicyService:
                 items = PolicyService._normalize_builtin_documents([data])
             except Exception as exc:
                 if pair is None:
-                    logger.warning("跳过无法识别的策略文档，不影响其它内置模板: %s", exc)
+                    logger.warning(
+                        "跳过无法识别的策略文档，不影响其它内置模板: %s: %s",
+                        type(exc).__name__,
+                        exc,
+                    )
                 else:
                     failed_pairs.add(pair)
-                    logger.warning("跳过策略文档 %s/%s，保留该对象对上一次模板: %s", pair[0], pair[1], exc)
+                    logger.warning(
+                        "跳过策略文档 %s/%s，保留该对象对上一次模板: %s: %s",
+                        pair[0],
+                        pair[1],
+                        type(exc).__name__,
+                        exc,
+                    )
                 continue
             if pair in failed_pairs:
                 continue
@@ -508,7 +517,7 @@ class PolicyService:
                     {
                         "format": ARCHIVE_FORMAT,
                         "schema_version": ARCHIVE_SCHEMA_VERSION,
-                        "exported_at": datetime.now(timezone.utc).isoformat(),
+                        "exported_at": timezone.now().isoformat(),
                         "templates": manifest_items,
                     },
                     ensure_ascii=False,


### PR DESCRIPTION
## Summary
- `plugin_init` 中插件导入与内置策略模板同步改为 prefetch + `bulk_create`/`bulk_update`，避免逐条 `update_or_create` 拖慢启动。
- 损坏或格式不符的 `policy.json` 只跳过该对象/插件对，不再中止整批对账，避免全新安装内置模板空白。
- 插件批量写入失败会回滚本次写入并继续初始化，不打穿 `batch_init`。

有意与 `specs/changes/monitor-policy-template-portability/spec.md` 的「校验失败则整批不写」不同：按对象对隔离失败，保留其余有效内置模板。

## Test plan
- [x] 本地跑通 `test_plugin_import_bulk_service` / `test_plugin_migrate_identity` / `test_policy_template_portability`（27 passed）
- [ ] 全新环境 `plugin_init`：插件与内置模板可完成对账
- [ ] 重复执行 `plugin_init`：不产生重复内置模板
- [ ] 单个损坏 `policy.json`：其余对象对模板仍在，该对保留上次有效数据
- [ ] 部署脚本无需改动

提交范围已核对：相对 `TencentBlueKing/bk-lite` master 仅 5 个生产文件；测试文件留在工作区未提交。