### PR TITLE
fix(监控): 对齐策略模版卡片内置标签

### DIFF
--- a/web/src/app/monitor/(pages)/event/template/index.module.scss
+++ b/web/src/app/monitor/(pages)/event/template/index.module.scss
@@ -194,17 +194,38 @@
     white-space: nowrap;
 }
 
+.cardMeta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 8px;
+    min-height: 22px;
+
+    :global(.ant-tag) {
+        margin-inline-end: 0;
+    }
+}
+
 .cardTag {
     max-width: 100%;
-    margin-top: 8px;
+    margin: 0;
     border: 0;
     border-radius: 4px;
     color: #005cff;
     background: #e8f1ff;
     font-size: 12px;
     font-weight: 600;
+    line-height: 20px;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.cardTypeTag {
+    margin: 0;
+    flex-shrink: 0;
+    font-size: 12px;
+    line-height: 20px;
 }
 
 .cardDescription {

--- a/web/src/app/monitor/(pages)/event/template/page.tsx
+++ b/web/src/app/monitor/(pages)/event/template/page.tsx
@@ -304,12 +304,17 @@ const Template: React.FC = () => {
           <div className={templateStyle.cardTitle} title={item.name || '--'}>
             {item.name || '--'}
           </div>
-          <Tag className={templateStyle.cardTag}>
-            {item.template_group || item.plugin_display_name || item.plugin_name || '--'}
-          </Tag>
-          <Tag color={item.template_type === 'custom' ? 'blue' : 'default'}>
-            {item.template_type === 'custom' ? '自定义' : '内置'}
-          </Tag>
+          <div className={templateStyle.cardMeta}>
+            <Tag className={templateStyle.cardTag}>
+              {item.template_group || item.plugin_display_name || item.plugin_name || '--'}
+            </Tag>
+            <Tag
+              className={templateStyle.cardTypeTag}
+              color={item.template_type === 'custom' ? 'blue' : 'default'}
+            >
+              {item.template_type === 'custom' ? '自定义' : '内置'}
+            </Tag>
+          </div>
           <div className={templateStyle.cardDescription} title={item.description || '--'}>
             {item.description || '--'}
           </div>


### PR DESCRIPTION
## Summary
- 策略模版卡片中「分组」与「内置/自定义」标签原先作为并列 Ant Design Tag，因默认边距与 baseline 对齐导致上下错位
- 将两个标签包入同一 flex 行（`cardMeta`），统一 `align-items: center`、行高与边距

## Test plan
- [ ] 打开事件 → 模板 → Host，确认每张卡片上「Host (Host)」与「内置」垂直居中对齐
- [ ] 切换到含自定义模版的对象，确认「自定义」标签同样对齐
- [ ] 缩小卡片宽度使标签换行时，两行标签仍各自水平对齐