### PR TITLE
fix(监控): 集成指标页改为默认折叠并支持全部展开

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/ifmibMetricView.ts
@@ -8,9 +8,9 @@ const IFMIB_DEVICE_TOTAL_METRICS = new Set([
 
 export const isIfmibMetric = (metric: MetricItem) => metric.is_ifmib === true;
 
-/** 默认只展开第一个可见分组，避免 IF-MIB 归并后首屏过长。 */
+/** 进入指标页时默认全部折叠，由用户按组展开或一键全部展开。 */
 export const getDefaultMetricGroupOpenState = (groups: MetricListItem[]) => (
-  new Map(groups.map((group, index) => [group.id, index === 0]))
+  new Map(groups.map((group) => [group.id, false]))
 );
 
 const IFMIB_METRIC_GROUPS = [

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -75,8 +75,6 @@ const Configure = () => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const [groupConfirmLoading, setGroupConfirmLoading] = useState(false);
   const [showTabs, setShowTabs] = useState<boolean>(false);
-  const metricTableRef = useRef<HTMLDivElement>(null);
-  const manuallyClosedGroupIds = useRef<Set<string>>(new Set());
   const metricCatalogAbortRef = useRef<AbortController | null>(null);
   const canReorderCatalog = metricCount <= 100 && !searchText.trim();
 
@@ -264,7 +262,6 @@ const Configure = () => {
 
     if (!preserveState) {
       setSearchText('');
-      manuallyClosedGroupIds.current.clear();
     }
     try {
       // 厂商指标按页分页；IF-MIB 固定约十余条，单独拉全量后置底归并，避免拆页。
@@ -312,8 +309,8 @@ const Configure = () => {
       const groupData = metricView.map((group) => ({
         ...group,
         isOpen: currentOpenState
-          ? (currentOpenState.get(group.id) ?? defaultOpenState.get(group.id))
-          : defaultOpenState.get(group.id)
+          ? (currentOpenState.get(group.id) ?? defaultOpenState.get(group.id) ?? false)
+          : (defaultOpenState.get(group.id) ?? false)
       }));
       setMetrics(groupData.flatMap((group) => group.child));
       setMetricData(groupData);
@@ -487,11 +484,6 @@ const Configure = () => {
   };
 
   const onToggle = (id: string, isOpen: boolean) => {
-    if (isOpen) {
-      manuallyClosedGroupIds.current.delete(id);
-    } else {
-      manuallyClosedGroupIds.current.add(id);
-    }
     setMetricData((prev) =>
       prev.map((item) => (item.id === id ? { ...item, isOpen } : item))
     );
@@ -500,30 +492,15 @@ const Configure = () => {
     );
   };
 
-  const autoExpandVisibleGroups = () => {
-    const container = metricTableRef.current;
-    if (!container || searchText.trim()) return;
-    const containerRect = container.getBoundingClientRect();
-    const visibleGroupIds = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-metric-group-id]')
-    )
-      .filter((element) => {
-        const rect = element.getBoundingClientRect();
-        return rect.top < containerRect.bottom && rect.bottom > containerRect.top;
-      })
-      .map((element) => element.dataset.metricGroupId)
-      .filter((id): id is string => Boolean(id));
+  const allGroupsExpanded =
+    filteredMetricData.length > 0 &&
+    filteredMetricData.every((group) => group.isOpen);
 
-    if (!visibleGroupIds.length) return;
-    const shouldOpen = new Set(
-      visibleGroupIds.filter((id) => !manuallyClosedGroupIds.current.has(id))
-    );
-    if (!shouldOpen.size) return;
-    const openVisibleGroups = (groups: MetricListItem[]) => groups.map((group) => (
-      shouldOpen.has(group.id) && !group.isOpen ? { ...group, isOpen: true } : group
-    ));
-    setMetricData(openVisibleGroups);
-    setFilteredMetricData(openVisibleGroups);
+  const setAllGroupsOpen = (isOpen: boolean) => {
+    const next = (groups: MetricListItem[]) =>
+      groups.map((group) => ({ ...group, isOpen }));
+    setMetricData(next);
+    setFilteredMetricData(next);
   };
 
   return (
@@ -550,6 +527,15 @@ const Configure = () => {
           onClear={onTxtClear}
         />
         <div>
+          <Button
+            className="mr-[8px]"
+            disabled={!filteredMetricData.length}
+            onClick={() => setAllGroupsOpen(!allGroupsExpanded)}
+          >
+            {allGroupsExpanded
+              ? t('common.collapseAll')
+              : t('common.expandAll')}
+          </Button>
           <Permission requiredPermissions={['Add Group']} className="mr-[8px]">
             <Button type="primary" onClick={() => openGroupModal('add')}>
               {t('monitor.integrations.addGroup')}
@@ -564,8 +550,6 @@ const Configure = () => {
       </div>
       <Spin spinning={loading}>
         <div
-          ref={metricTableRef}
-          onScroll={autoExpandVisibleGroups}
           className={metricStyle.metricTable}
           style={{
             height: showTabs ? 'calc(100vh - 396px)' : 'calc(100vh - 346px)'


### PR DESCRIPTION
## Summary
- 去掉集成指标页滚动时自动展开分组的逻辑。
- 进入页面时全部分组默认折叠，工具栏增加「全部展开 / 全部折叠」切换按钮。
- 单个分组仍可独立展开或收起。

## Test plan
- [ ] 打开集成指标页，确认所有分组默认折叠，按钮文案为「全部展开」。
- [ ] 点击「全部展开」后所有分组打开，按钮变为「全部折叠」。
- [ ] 滚动列表时分组不会自动展开。
- [ ] 单个分组仍可独立开关；无分组时按钮禁用。