### PR TITLE
fix(mobile): 略加强监控实例表数值列字重

### DIFF
--- a/mobile/src/features/monitor/monitor.module.css
+++ b/mobile/src/features/monitor/monitor.module.css
@@ -319,6 +319,10 @@
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
+.instanceRow .colRight {
+  font-size: var(--font-size-secondary);
+  font-weight: 500;
+}
 /* 与 Web Ant Tag 上报状态列一致：正常 success，失联 default 灰底。 */
 .statusCell {
   min-width: 0;


### PR DESCRIPTION
上报时间等列保持 secondary 字号，用 500 字重减轻过细观感。