### PR TITLE
fix: 修复进程监控 Telegraf 配置兼容性

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/host/process/procstat.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/host/process/procstat.child.toml.j2
@@ -3,7 +3,7 @@
     pattern = "{{ pattern }}"
     pid_finder = "native"
     pid_tag = false
-    process_name_tag = false
+    process_name = "{{ process_name }}"
     interval = "{{ interval }}s"
     [inputs.procstat.tags]
         instance_id = "{{ instance_id }}"


### PR DESCRIPTION
## 变更说明

- 将进程监控 `inputs.procstat` 模板中的 `process_name_tag = false` 替换为 `process_name = "{{ process_name }}"`。
- 保留页面配置的进程别名作为 `process_name` 指标维度，不改变现有查询与实例身份契约。

## 根因

BK-Lite 当前 Fusion Collector 发布镜像内实际使用 Telegraf 1.34.4。该版本的 `inputs.procstat` 不支持 `process_name_tag`，加载下发配置时会报未使用字段并拒绝启动；其内置配置契约支持 `process_name` 作为进程名称覆盖项。

## 影响

修复后，从页面下发的进程监控配置可以被当前 Telegraf 正常加载，同时 `procstat` 与 `procstat_lookup` 指标继续使用页面填写的进程别名。

## 验证

- 固定 BK-Lite Fusion Collector 镜像摘要：`sha256:57b12e342a3096be02f6e6eb8597281eae2ed381fe1a3500d4e875167fe421f0`。
- 镜像内 `/opt/fusion-collectors/bin/telegraf --version`：Telegraf 1.34.4。
- 原配置加载退出码 1，复现 `fields ["process_name_tag"] ... does not exist in this version`。
- 修复后的真实模板加载退出码 0，`procstat` 和 `procstat_lookup` 均输出 `process_name=configured-alias`。
- Standards / Spec 双轴审查：均为 0 findings。
- `git diff --check`：通过。

## 范围检查

- 相对目标分支仅 1 个生产模板文件、1 行替换。
- 未提交测试文件、设计文档、本地配置、日志、缓存、生成文件或其他工作区改动。
