### PR TITLE
bugfix: 拒绝 HostCollector 错配其他主机输出

### DIFF
--- a/agents/stargazer/tasks/collectors/host_collector.py
+++ b/agents/stargazer/tasks/collectors/host_collector.py
@@ -443,7 +443,6 @@ class HostCollector(BaseCollector):
             return task_result
         if isinstance(task_result, list):
             expected_host = self.params.get("host")
-            fallback_stdout = ""
             for host_data in task_result:
                 if not isinstance(host_data, dict):
                     continue
@@ -451,14 +450,12 @@ class HostCollector(BaseCollector):
                 host_key = host_data.get("host", "")
                 if stdout and host_key == expected_host:
                     return stdout
-                if stdout and not fallback_stdout:
-                    fallback_stdout = stdout
                 if not stdout:
                     logger.warning(
                         f"[Host Collector] No stdout for host_key={host_key}, "
                         f"status={host_data.get('status')}, stderr={host_data.get('stderr', '')[:200]}"
                     )
-            return fallback_stdout
+            raise RuntimeError(f"Host collection result missing expected host {expected_host}")
         if isinstance(task_result, dict):
             hosts_result = task_result.get("contacted", task_result)
             for host_key, host_data in hosts_result.items():

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -770,6 +770,26 @@ class TestHostCollectorExtractStdout:
         with pytest.raises(RuntimeError, match="missing expected host 10.0.0.1"):
             self.collector._extract_stdout(result)
 
+    def test_list_uses_expected_host_among_multiple_hosts(self):
+        result = {
+            "result": [
+                {"host": "10.0.0.2", "stdout": '{"cpu": {}}'},
+                {"host": "10.0.0.1", "stdout": '{"mem": {}}'},
+            ]
+        }
+
+        assert self.collector._extract_stdout(result) == '{"mem": {}}'
+
+    def test_list_with_empty_expected_host_stdout_raises(self):
+        result = {
+            "result": [
+                {"host": "10.0.0.1", "status": "success", "stdout": ""},
+            ]
+        }
+
+        with pytest.raises(RuntimeError, match="missing expected host 10.0.0.1"):
+            self.collector._extract_stdout(result)
+
     def test_empty_result(self):
         result = {"result": {}}
         # 空 dict 应返回 JSON 序列化

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -756,8 +756,9 @@ class TestHostCollectorExtractStdout:
         }
         assert self.collector._extract_stdout(result) == '{"mem": {}}'
 
-    def test_list_without_expected_host_raises(self):
+    def test_process_result_without_expected_host_raises(self):
         result = {
+            "success": True,
             "result": [
                 {
                     "host": "10.0.0.2",
@@ -768,27 +769,32 @@ class TestHostCollectorExtractStdout:
         }
 
         with pytest.raises(RuntimeError, match="missing expected host 10.0.0.1"):
-            self.collector._extract_stdout(result)
+            self.collector.process_adhoc_result(result)
 
-    def test_list_uses_expected_host_among_multiple_hosts(self):
+    def test_process_result_uses_expected_host_among_multiple_hosts(self):
         result = {
+            "success": True,
             "result": [
                 {"host": "10.0.0.2", "stdout": '{"cpu": {}}'},
                 {"host": "10.0.0.1", "stdout": '{"mem": {}}'},
             ]
         }
 
-        assert self.collector._extract_stdout(result) == '{"mem": {}}'
+        metrics = self.collector.process_adhoc_result(result)
 
-    def test_list_with_empty_expected_host_stdout_raises(self):
+        assert "host_mem_total_bytes" in metrics
+        assert "host_cpu_usage_percent" not in metrics
+
+    def test_process_result_with_empty_expected_host_stdout_raises(self):
         result = {
+            "success": True,
             "result": [
                 {"host": "10.0.0.1", "status": "success", "stdout": ""},
             ]
         }
 
         with pytest.raises(RuntimeError, match="missing expected host 10.0.0.1"):
-            self.collector._extract_stdout(result)
+            self.collector.process_adhoc_result(result)
 
     def test_empty_result(self):
         result = {"result": {}}

--- a/agents/stargazer/tests/test_host_collector.py
+++ b/agents/stargazer/tests/test_host_collector.py
@@ -756,6 +756,20 @@ class TestHostCollectorExtractStdout:
         }
         assert self.collector._extract_stdout(result) == '{"mem": {}}'
 
+    def test_list_without_expected_host_raises(self):
+        result = {
+            "result": [
+                {
+                    "host": "10.0.0.2",
+                    "status": "success",
+                    "stdout": '{"cpu": {"usage_percent": 91}}',
+                }
+            ]
+        }
+
+        with pytest.raises(RuntimeError, match="missing expected host 10.0.0.1"):
+            self.collector._extract_stdout(result)
+
     def test_empty_result(self):
         result = {"result": {}}
         # 空 dict 应返回 JSON 序列化


### PR DESCRIPTION
## 问题

HostCollector 处理 Ansible 的 per-host 列表回调时，本应只消费当前目标主机的 stdout；但目标主机缺失时，旧逻辑会退回列表中首个非空 stdout，可能把其他主机的指标发布到当前实例。

## 根因（设计层）

列表解析把“输出是否非空”当成了可接受条件，没有把 stdout 的主机身份与 `expected_host` 绑定。这样一来，异常或错配回调仍能越过解析边界进入指标转换，既有的 callback 失败指标链也无法感知这类数据身份错误。

## 怎么修的

- 列表结果继续优先返回与 `expected_host` 精确匹配的非空 stdout。
- 遍历结束仍未命中目标主机时，抛出包含目标 host 的 `RuntimeError`，复用现有 error metric、`processing_failed` 和 `delivery_failed` 路径。
- 新增错 host 回归用例，确保修复回退后测试会重新失败。

## 影响范围与兼容性

- 仅修改 Stargazer 内部回调结果解析，不改 NATS subject、RPC 参数、回调载荷字段、持久化结构或配置。
- 正常单主机列表、合法 JSON、带 warning 的 JSON 容错保持不变。
- 当前 Ansible executor 的合法 per-host 列表项始终携带 host；仓库内未发现依赖“错 host fallback”的调用方、配置或测试。
- 回滚方式为 revert 本 PR 单一提交，无数据迁移。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["submit_host_remote_collection\nadapter.py"]
        T2["ansible_adhoc\nansible_rpc.py"]
    end

    subgraph N["核心处理层"]
        N1["per-host callback\nansible-executor"]
        N2["process_adhoc_result\nhost_collector.py"]
        N3["_extract_stdout\nhost_collector.py"]
    end

    subgraph C["失败处理层"]
        C1["error metrics\nhost_remote_handler.py"]
        C2["processing_failed\ncallback state"]
    end

    T1 --> T2 --> N1 --> N2 --> N3
    N3 -. "目标 host 缺失" .-> C1 --> C2
```

## 验证

- `agents/stargazer/tests/test_host_collector.py`：72 passed。
- 运行契约矩阵：错 host 拒绝、正常列表、非法 JSON、warning 污染 JSON、callback 失败链，共 5 passed。
- TDD：新增用例在修复前以 `DID NOT RAISE RuntimeError` 失败，修复后通过。
- Black 变更区、flake8 增量、`git diff --check` 与 Python 编译检查通过。
- Stargazer 的 `make lint` 在当前环境因未提供 `pre-commit` 未启动；已用仓库内对应格式与静态规则完成增量核验，未新增 finding。

## 三轨门禁

- Standards：pass
- Spec：pass
- Runtime Contract：pass
- G6：96 / 100（SCORE_PASS）

Closes #4004
