### PR TITLE
feat: 支持 MinIO 多版本指标监控

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/UI.json
@@ -9,6 +9,99 @@
   "instance_id": "{{cloud_region}}_{{host}}_{{port}}",
   "form_fields": [
     {
+      "name": "metrics_api_version",
+      "label": "指标 API 版本",
+      "type": "select",
+      "required": true,
+      "default_value": "v3",
+      "description": "选择 MinIO Prometheus 指标接口版本",
+      "guide_short": "RELEASE.2024-05-28 及之后推荐 v3；更早版本选择 v2。",
+      "guide_short_en": "Use v3 for RELEASE.2024-05-28 and later; select v2 for older releases.",
+      "options": [
+        {"label": "v3（2024-05-28 及之后）", "label_en": "v3 (2024-05-28 and later)", "value": "v3"},
+        {"label": "v2（兼容模式）", "label_en": "v2 (compatibility)", "value": "v2"}
+      ],
+      "label_en": "Metrics API Version"
+    },
+    {
+      "name": "scheme",
+      "label": "协议",
+      "type": "select",
+      "required": true,
+      "default_value": "https",
+      "description": "MinIO API 使用的 HTTP 协议",
+      "guide_short": "生产环境使用 HTTPS；HTTP 仅适用于隔离可信网络。",
+      "guide_short_en": "Use HTTPS in production. HTTP is only appropriate for isolated trusted networks.",
+      "options": [{"label": "HTTPS", "value": "https"}, {"label": "HTTP", "value": "http"}],
+      "transform_on_edit": {
+        "origin_path": "child.content.config.urls[0]",
+        "to_form": {"regex": "^(https?)://"},
+        "to_api": {}
+      },
+      "label_en": "Protocol"
+    },
+    {
+      "name": "auth_type",
+      "label": "认证方式",
+      "type": "select",
+      "required": true,
+      "default_value": "bearer",
+      "description": "MinIO Prometheus 指标端点认证方式",
+      "guide_short": "默认使用 Bearer Token；仅服务端显式配置 public 时选择公开访问。",
+      "guide_short_en": "Use a bearer token by default. Select Public only when the server explicitly enables it.",
+      "options": [
+        {"label": "Bearer Token", "value": "bearer"},
+        {"label": "公开访问", "label_en": "Public", "value": "public"}
+      ],
+      "label_en": "Authentication"
+    },
+    {
+      "name": "ENV_BEARER_TOKEN",
+      "label": "Bearer Token",
+      "type": "password",
+      "required": true,
+      "encrypted": true,
+      "dependency": {"field": "auth_type", "value": "bearer"},
+      "description": "由 mc admin prometheus generate 生成的指标抓取令牌；v3 使用 --api-version v3",
+      "guide_short": "v3 使用 mc admin prometheus generate ALIAS --api-version v3；仅填写 Token，不添加 Bearer 前缀。",
+      "guide_short_en": "For v3, run mc admin prometheus generate ALIAS --api-version v3. Enter only the token without the Bearer prefix.",
+      "widget_props": {"placeholder": "Bearer Token"},
+      "transform_on_edit": {"origin_path": "child.env_config.BEARER_TOKEN__{{config_id}}", "to_api": {}},
+      "label_en": "Bearer Token"
+    },
+    {
+      "name": "metric_extensions",
+      "label": "扩展指标",
+      "type": "select",
+      "required": false,
+      "default_value": [],
+      "description": "支持多选；选择后将在核心指标之外额外采集对应功能指标",
+      "guide_short": "扩展指标支持多选。默认不采集扩展指标；只有选中的分组才会在核心指标之外额外采集。请仅选择实际使用的功能，以控制采集开销和时序基数。",
+      "guide_short_en": "You can select multiple extensions. No extension metrics are collected by default; only selected groups are collected in addition to core metrics. Select only features in use to control scrape cost and cardinality.",
+      "options": [
+        {"label": "Bucket 使用量", "label_en": "Bucket Usage", "value": "bucket"},
+        {"label": "复制", "label_en": "Replication", "value": "replication"},
+        {"label": "生命周期与扫描", "label_en": "Lifecycle and Scanner", "value": "lifecycle"},
+        {"label": "审计与通知", "label_en": "Audit and Notification", "value": "integrations"},
+        {"label": "IAM 与 KMS", "label_en": "IAM and KMS", "value": "security"}
+      ],
+      "widget_props": {"mode": "multiple", "placeholder": "请选择额外指标（可多选）", "placeholder_en": "Select additional metrics (multiple)"},
+      "label_en": "Metric Extensions"
+    },
+    {
+      "name": "insecure_skip_verify",
+      "label": "跳过证书校验",
+      "type": "switch",
+      "required": false,
+      "default_value": false,
+      "description": "是否跳过 HTTPS 证书链和主机名校验",
+      "guide_short": "仅临时排障时开启；生产环境保持关闭。",
+      "guide_short_en": "Enable only for temporary troubleshooting. Keep it disabled in production.",
+      "widget_props": {},
+      "transform_on_edit": {"origin_path": "child.content.config.insecure_skip_verify", "to_api": {}},
+      "label_en": "Skip Certificate Verification"
+    },
+    {
       "name": "host",
       "label": "主机",
       "type": "input",
@@ -16,8 +109,8 @@
       "visible_in": "edit",
       "editable": false,
       "description": "与设备进行通信的主机",
-      "guide_short": "填写 MinIO API 的 IP 地址或域名，不包含协议、端口或路径；当前模板固定使用 HTTP 访问三个 v2 指标端点。",
-      "guide_short_en": "Enter the MinIO API IP address or hostname without a scheme, port, or path. The current template uses HTTP for three fixed v2 metrics endpoints.",
+      "guide_short": "填写 MinIO API 的 IP 地址或域名，不包含协议、端口或路径。",
+      "guide_short_en": "Enter the MinIO API IP address or hostname without a scheme, port, or path.",
       "widget_props": {
         "placeholder": "主机地址"
       },
@@ -37,8 +130,8 @@
       "visible_in": "edit",
       "editable": false,
       "description": "与设备进行通信的端口",
-      "guide_short": "填写 MinIO API 的实际服务端口；采集节点必须能通过该端口访问固定的 cluster、bucket 和 resource 指标端点。",
-      "guide_short_en": "Enter the actual MinIO API service port. The collector node must reach the fixed cluster, bucket, and resource metrics endpoints through this port.",
+      "guide_short": "填写 MinIO API 实际服务端口，不要填写 Console 管理端口。",
+      "guide_short_en": "Enter the MinIO API service port, not the Console administration port.",
       "widget_props": {
         "min": 1,
         "precision": 0,
@@ -60,8 +153,8 @@
       "required": true,
       "default_value": 60,
       "description": "监控数据的采集时间间隔（单位：秒）",
-      "guide_short": "Telegraf 拉取 MinIO 三个固定指标端点的周期，单位秒，默认 60。",
-      "guide_short_en": "Telegraf interval for pulling the three fixed MinIO metrics endpoints, in seconds; the default is 60.",
+      "guide_short": "Telegraf 拉取 MinIO 指标端点的周期，单位秒，默认 60。",
+      "guide_short_en": "Telegraf interval for pulling MinIO metrics endpoints, in seconds; the default is 60.",
       "widget_props": {
         "min": 1,
         "precision": 0,

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
@@ -1,71 +1,113 @@
-# MinIO Monitoring Guide
+# MinIO Multi-version Monitoring Guide
 
-This capability uses Telegraf `inputs.prometheus` to access three fixed MinIO Prometheus v2 endpoints: cluster, bucket, and resource.
+This capability uses Telegraf's Prometheus collector to scrape official MinIO Metrics v2/v3, covering cluster health, capacity, request traffic, and node resources.
+
+## Version Selection
+
+| MinIO release | Selection | Notes |
+| --- | --- | --- |
+| Before `RELEASE.2021-01-30` | Unsupported | Legacy Metrics v1 is out of scope. |
+| `RELEASE.2021-01-30` through `RELEASE.2024-05-27` | v2 | Uses compatibility endpoints. |
+| `RELEASE.2024-05-28` and later | v3 (recommended) | Uses the complete set of core Metrics v3 groups. |
+
+Metrics v3 first appeared in `RELEASE.2024-03-15`, but the early interface was still evolving, so this integration uses `RELEASE.2024-05-28` as its complete-core baseline. Current MinIO source still registers both v2 and v3; there is no “supported only through 2024-07-15” upper limit.
+
+Existing instances without the new fields continue as `v2 + HTTP + public` with the original cluster, bucket, and resource endpoints. New instances default to `v3 + HTTPS + Bearer Token`.
 
 ## Prerequisites
 
-- The collector node can reach the MinIO API host and port over HTTP.
-- All three fixed endpoints allow anonymous reads: `/minio/v2/metrics/cluster`, `/minio/v2/metrics/bucket`, and `/minio/v2/metrics/resource`.
-- The current page has only host, port, and interval fields. The template sends no username, password, or Bearer Token and does not generate HTTPS URLs.
-- If the MinIO endpoints require authentication or force HTTPS, the current configuration cannot integrate them directly. Restrict anonymous metrics access at the network boundary.
-
-## Setup Steps
-
-1. From the actual collector node, validate all three fixed metrics endpoints.
-2. Set the interval (default `60` seconds).
-3. In the monitored objects table, select the node and enter only the MinIO API host and port, without a scheme or path.
-4. Enter the instance name and optional group, save, and wait for at least one collection interval.
-
-## Pre-checks
-
-The commands below use an example address. `--fail` preserves `4xx/5xx` failures:
+- Enter the MinIO **API port**, not the Console administration port. API and Console commonly use `9000` and `9001`, respectively, but your deployment is authoritative.
+- Use HTTPS in production and make the server certificate chain trusted by the collector node. Skip-certificate-verification is only for temporary diagnosis.
+- Bearer Token is the default authentication mode. Do not enter an Access Key, Secret Key, username/password, or the `Bearer ` prefix.
+- Create a dedicated identity with only `admin:Prometheus`, then generate a token using the corresponding `mc` alias. Explicitly select v3; with current `mc`, omitting `--api-version` generates a v2 scrape configuration:
 
 ```bash
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/cluster"
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/bucket"
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/resource"
+mc admin prometheus generate ALIAS --api-version v3
 ```
 
-All three commands must succeed, and they must be run from the actual collector node's network.
+If `mc` does not recognize `--api-version`, update `mc` first. Older `mc admin prometheus generate ALIAS` still produces a Bearer token, but its generated scrape configuration targets v2; before using that token, validate the v3 endpoint selected on this page with the command below.
 
-## Field Reference
+The token is injected through a collector environment variable and is not written into the Telegraf TOML body. Select Public only when the server explicitly sets `MINIO_PROMETHEUS_AUTH_TYPE=public`; never expose anonymous metrics directly to the public Internet.
 
-| Field | Required | Description |
+## Core and Extension Metrics
+
+- v2 core endpoints: `/minio/v2/metrics/cluster` and `/minio/v2/metrics/resource`.
+- Earlier than `RELEASE.2023-10-07T15-07-38Z`, v2 does not yet expose `/minio/v2/metrics/resource`. Telegraf reports 404 for that URL while continuing to collect the metrics available from the cluster endpoint. If persistent 404 logs are unacceptable, upgrade MinIO before enabling this integration. BK-Lite does not remove endpoints or fall back at runtime.
+- v3 core endpoints: `/api/requests`, `/cluster/health`, `/cluster/erasure-set`, `/cluster/usage/objects`, `/system/cpu`, `/system/memory`, `/system/drive`, `/system/process`, and `/system/network/internode`, all under `/minio/metrics/v3`.
+- Bucket extension: the v2 bucket endpoint or v3 `/cluster/usage/buckets`. The first release does not page through every `/bucket/.../<bucket>` detail endpoint.
+- Replication, lifecycle, audit/notification, and IAM/KMS are opt-in. KMS metrics come from the v2 cluster endpoint; the current official v3 groups expose IAM without a separate KMS endpoint.
+
+The template uses `namepass` to write only selected core and extension families and excludes the TTFB histogram to control cardinality. Every series includes `minio_metrics_version=v2|v3`.
+
+## Minimum Metric Versions
+
+Each metric's Description field shows its full minimum MinIO release. The table below summarizes the registered metric families. On an older release, an endpoint may respond successfully while a particular metric is still absent. The recommended complete-core baseline remains `RELEASE.2024-05-28T17-19-04Z` for v3; selected extensions must also meet their later minimums below.
+
+| API | Registered metrics | Minimum MinIO release |
 | --- | --- | --- |
-| Host | Yes | MinIO API IP address or hostname, without `http://`, a port, or a path. |
-| Port | Yes | Actual MinIO API port. |
-| Interval | Yes | Collection interval in seconds; default `60`. |
-| Node | Yes | Collector node that can reach all three fixed endpoints. |
-| Instance Name | Yes | Display name in the platform. |
-| Group | No | Optional instance group. |
+| v2 | Cluster capacity, online/offline drives and nodes, S3 traffic | `RELEASE.2021-01-30T00-20-58Z` |
+| v2 | Waiting S3 requests | `RELEASE.2021-02-23T20-05-01Z` |
+| v2 | Process uptime | `RELEASE.2021-03-26T00-00-41Z` |
+| v2 | Rejected S3 authentication | `RELEASE.2021-04-18T19-26-29Z` |
+| v2 | Process CPU and resident memory | `RELEASE.2021-05-11T23-27-41Z` |
+| v2 | Scanner objects scanned | `RELEASE.2021-12-18T04-42-33Z` |
+| v2 | Current incoming S3 requests | `RELEASE.2022-02-12T00-51-25Z` |
+| v2 | S3 5xx errors | `RELEASE.2022-06-10T16-59-15Z` |
+| v2 | KMS internal request failures | `RELEASE.2022-07-13T23-29-44Z` |
+| v2 | Cluster health status | `RELEASE.2023-08-04T17-40-21Z` |
+| v2 | Resource CPU and drive I/O/utilization | `RELEASE.2023-10-07T15-07-38Z` |
+| v2 | Resource memory-used percentage | `RELEASE.2023-12-07T04-16-00Z` |
+| v2 | Erasure-set online drives | `RELEASE.2023-12-23T07-19-11Z` |
+| v2 | Erasure-set health status | `RELEASE.2024-01-28T22-35-53Z` |
+| v3 | API requests, cluster health/capacity, erasure sets, object usage, internode network | `RELEASE.2024-03-15T01-07-19Z` |
+| v3 | System memory and drives | `RELEASE.2024-04-18T19-09-19Z` |
+| v3 | System CPU, process, and notification errors | `RELEASE.2024-04-28T17-53-50Z` |
+| v3 | IAM synchronization failures | `RELEASE.2024-05-07T06-41-25Z` |
+| v3 | Scanner and Audit | `RELEASE.2024-05-27T19-17-46Z` |
+| v3 | ILM | `RELEASE.2024-06-06T09-36-42Z` |
+| v3 | Bucket usage after the endpoint fix used by this integration | `RELEASE.2024-07-15T19-02-30Z` |
+| v3 | Recent replication backlog | `RELEASE.2024-08-03T04-33-23Z` |
 
-## Post-setup Verification
+## Setup
 
-After saving and waiting for one interval, confirm that these metrics are queryable in the platform:
+1. Validate the selected version, scheme, and authentication mode from the actual collector node.
+2. For a new instance, explicitly confirm the metrics API version, scheme, and authentication mode.
+3. Enter the API host and port. Do not include a scheme, port, or path in Host.
+4. Enable only required extensions, save, and wait at least one collection interval.
 
-- `minio_cluster_health_status_gauge`
-- `minio_cluster_capacity_usable_free_bytes_gauge`
-- `minio_cluster_drive_online_total_gauge`
-- `minio_node_cpu_avg_idle_gauge`
+Bearer v3 example:
+
+```bash
+export MINIO_METRICS_TOKEN='Token from mc admin prometheus generate output'
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer ${MINIO_METRICS_TOKEN}" \
+  "https://minio.example.com:9000/minio/metrics/v3/cluster/health"
+```
+
+Public v2 example:
+
+```bash
+curl --fail --silent --show-error \
+  "http://minio.example.com:9000/minio/v2/metrics/cluster"
+```
+
+Do not print real tokens in shell history, platform logs, or tickets. In production, do not use `curl -k` instead of installing the correct CA trust.
+
+## Fields
+
+| Field | Description |
+| --- | --- |
+| Metrics API Version | Defaults to v3 for new instances; select v2 for older releases. |
+| Scheme | Defaults to HTTPS. HTTP is only for isolated trusted networks. |
+| Authentication | Defaults to Bearer; Public must match an explicit server setting. |
+| Bearer Token | Encrypted field shown only for Bearer and injected through the environment. |
+| Metric Extensions | Multi-select and disabled by default; only selected groups are collected in addition to core metrics. |
+| Skip Certificate Verification | Disabled by default and intended only for temporary diagnosis. |
+| Host and Port | The MinIO API address, not the Console address. |
 
 ## Troubleshooting
 
-### The endpoint returns `401` or `403`
-
-- The current template has no authentication fields. Allow anonymous reads from the collector node.
-- Do not embed credentials or a token in the Host field.
-
-### The endpoint returns `404`
-
-- Confirm that the configured port is the MinIO API port, not the Console port.
-- The paths are fixed to the three Prometheus v2 endpoints; the legacy path is not supported.
-
-### HTTP or TLS fails
-
-- The current template generates HTTP URLs only. An HTTPS-only target cannot be integrated directly.
-- Check routing, firewalls, and security groups between the collector node and the MinIO API port.
-
-### Only some data is present
-
-- Validate the cluster, bucket, and resource endpoints separately. A failure on any endpoint removes its corresponding data.
-- Some series may be absent when there are no buckets or related activity.
+- `401/403`: the token is missing, wrong, expired, or lacks `admin:Prometheus`; or Public does not match server configuration.
+- `404`: the selected version path is wrong, or the Console port was entered. This integration does not perform runtime fallback.
+- TLS failure: check the certificate chain, hostname, and the collector node's system CA; do not leave verification disabled.
+- Partial metrics: verify that the corresponding extension is enabled and the MinIO feature has emitted data. MinIO omits metrics with no value.

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/en.md
@@ -32,10 +32,11 @@ The token is injected through a collector environment variable and is not writte
 ## Core and Extension Metrics
 
 - v2 core endpoints: `/minio/v2/metrics/cluster` and `/minio/v2/metrics/resource`.
+- v2 `minio_node_scanner_*` is part of the resource core `namepass` and does not require the Lifecycle and Scanner extension; v3 scanner/ILM endpoints still require that extension.
 - Earlier than `RELEASE.2023-10-07T15-07-38Z`, v2 does not yet expose `/minio/v2/metrics/resource`. Telegraf reports 404 for that URL while continuing to collect the metrics available from the cluster endpoint. If persistent 404 logs are unacceptable, upgrade MinIO before enabling this integration. BK-Lite does not remove endpoints or fall back at runtime.
 - v3 core endpoints: `/api/requests`, `/cluster/health`, `/cluster/erasure-set`, `/cluster/usage/objects`, `/system/cpu`, `/system/memory`, `/system/drive`, `/system/process`, and `/system/network/internode`, all under `/minio/metrics/v3`.
 - Bucket extension: the v2 bucket endpoint or v3 `/cluster/usage/buckets`. The first release does not page through every `/bucket/.../<bucket>` detail endpoint.
-- Replication, lifecycle, audit/notification, and IAM/KMS are opt-in. KMS metrics come from the v2 cluster endpoint; the current official v3 groups expose IAM without a separate KMS endpoint.
+- Replication, lifecycle, audit/notification, and IAM/KMS are opt-in. The registered KMS metric comes from the v2 cluster endpoint; the v3 security extension currently scrapes `/cluster/iam` only. Official MinIO also exposes `/minio/metrics/v3/kms` (`minio_kms_*`), which this capability does not collect in the first release.
 
 The template uses `namepass` to write only selected core and extension families and excludes the TTFB histogram to control cardinality. Every series includes `minio_metrics_version=v2|v3`.
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
@@ -1,71 +1,113 @@
-# MinIO 监控接入指南
+# MinIO 多版本监控接入指南
 
-本能力通过 Telegraf `inputs.prometheus` 固定访问 MinIO Prometheus v2 的 cluster、bucket 和 resource 三个端点。
+本能力通过 Telegraf Prometheus 采集器抓取 MinIO 官方 Metrics v2/v3 指标，覆盖集群健康、容量、请求流量和节点资源等监控场景。
+
+## 版本选择
+
+| MinIO 版本 | 页面选择 | 说明 |
+| --- | --- | --- |
+| `RELEASE.2021-01-30` 之前 | 不支持 | legacy Metrics v1 不在本能力范围内。 |
+| `RELEASE.2021-01-30` 至 `RELEASE.2024-05-27` | v2 | 使用兼容端点。 |
+| `RELEASE.2024-05-28` 及之后 | v3（推荐） | 使用分组明确的 Metrics v3 核心端点。 |
+
+Metrics v3 最早出现于 `RELEASE.2024-03-15`，但早期接口仍在演进，因此本能力以 `RELEASE.2024-05-28` 作为完整核心能力起点。较新的 MinIO 同时保留 v2/v3，不存在“仅支持 2024-07-15 及之前版本”的上限。
+
+旧实例缺少新增字段时继续按 `v2 + HTTP + public` 运行，并保留原来的 cluster、bucket、resource 三端点；新建实例默认 `v3 + HTTPS + Bearer Token`。
 
 ## 前置要求
 
-- 采集节点能够通过 HTTP 访问 MinIO API 主机和端口。
-- 三个固定端点均允许匿名读取：`/minio/v2/metrics/cluster`、`/minio/v2/metrics/bucket`、`/minio/v2/metrics/resource`。
-- 当前页面只有主机、端口和间隔字段；模板不会发送用户名、密码或 Bearer Token，也不会生成 HTTPS URL。
-- 若 MinIO 端点要求认证或强制 HTTPS，当前配置无法直接接入。开放匿名指标时应通过网络边界限制来源。
+- 填写 MinIO **API 端口**，不是 Console 管理端口。默认部署中 API 常为 `9000`、Console 常为 `9001`，但以实际部署为准。
+- 生产环境使用 HTTPS，并确保采集节点信任服务端证书链。`跳过证书校验` 只用于临时排障。
+- 默认鉴权使用 Bearer Token。不要填写 Access Key、Secret Key、用户名密码或 `Bearer ` 前缀。
+- 建议创建只授予 `admin:Prometheus` 的专用访问身份，再使用该身份对应的 `mc` alias 生成 Token。v3 必须显式指定 API 版本；省略 `--api-version` 时，当前 `mc` 生成的是 v2 抓取配置：
+
+```bash
+mc admin prometheus generate ALIAS --api-version v3
+```
+
+如果 `mc` 提示不支持 `--api-version`，请先升级 `mc`。旧版 `mc admin prometheus generate ALIAS` 仍可生成 Bearer Token，但输出的是 v2 抓取配置；使用该 Token 前，应按下文命令直接验证页面所选的 v3 端点。
+
+Token 通过采集器环境变量注入，不写入 Telegraf TOML 正文。只有服务端显式设置 `MINIO_PROMETHEUS_AUTH_TYPE=public` 时才选择“公开访问”；不要把匿名指标端点直接暴露到公网。
+
+## 核心与扩展指标
+
+- v2 核心端点：`/minio/v2/metrics/cluster`、`/minio/v2/metrics/resource`。
+- 早于 `RELEASE.2023-10-07T15-07-38Z` 的 v2 版本尚未提供 `/minio/v2/metrics/resource`；Telegraf 会对该 URL 报 404，但仍可从 cluster 端点采集当时已有的指标。若不能接受持续的 404 日志，请先升级 MinIO 再启用本接入。BK-Lite 不会在运行期自动删除端点或回退版本。
+- v3 核心端点：`/api/requests`、`/cluster/health`、`/cluster/erasure-set`、`/cluster/usage/objects`、`/system/cpu`、`/system/memory`、`/system/drive`、`/system/process`、`/system/network/internode`，均位于 `/minio/metrics/v3` 下。
+- Bucket 扩展：v2 bucket 端点或 v3 `/cluster/usage/buckets`。首版不自动分页枚举每个 Bucket 的 `/bucket/.../<bucket>` 明细。
+- 复制、生命周期、审计通知、IAM/KMS 为按需扩展。KMS 指标来自 v2 cluster 端点；当前 v3 官方分组提供 IAM 而没有独立 KMS 端点。
+
+模板用 `namepass` 只写入所选核心及扩展指标族，并排除 TTFB histogram，以控制时序基数。每条时序都带有 `minio_metrics_version=v2|v3` 标签。
+
+## 指标最低版本
+
+指标详情的“描述”会逐项显示完整的最低 MinIO release。下表按本能力登记的指标族汇总；低于对应版本时，即使端点本身可访问，该项指标也可能不存在。v3 核心建议仍以 `RELEASE.2024-05-28T17-19-04Z` 及之后版本使用；扩展指标应另外满足下表版本。
+
+| API | 本能力登记的指标 | 最低 MinIO release |
+| --- | --- | --- |
+| v2 | 集群容量、在线/离线磁盘、在线/离线节点、S3 收发流量 | `RELEASE.2021-01-30T00-20-58Z` |
+| v2 | S3 等待请求 | `RELEASE.2021-02-23T20-05-01Z` |
+| v2 | 进程运行时间 | `RELEASE.2021-03-26T00-00-41Z` |
+| v2 | S3 鉴权拒绝 | `RELEASE.2021-04-18T19-26-29Z` |
+| v2 | 进程 CPU、进程常驻内存 | `RELEASE.2021-05-11T23-27-41Z` |
+| v2 | Scanner 对象扫描 | `RELEASE.2021-12-18T04-42-33Z` |
+| v2 | S3 当前传入请求 | `RELEASE.2022-02-12T00-51-25Z` |
+| v2 | S3 5xx 错误 | `RELEASE.2022-06-10T16-59-15Z` |
+| v2 | KMS 请求内部失败 | `RELEASE.2022-07-13T23-29-44Z` |
+| v2 | 集群健康状态 | `RELEASE.2023-08-04T17-40-21Z` |
+| v2 | Resource CPU、磁盘 I/O/利用率 | `RELEASE.2023-10-07T15-07-38Z` |
+| v2 | Resource 内存使用率 | `RELEASE.2023-12-07T04-16-00Z` |
+| v2 | 纠删组在线磁盘 | `RELEASE.2023-12-23T07-19-11Z` |
+| v2 | 纠删组健康状态 | `RELEASE.2024-01-28T22-35-53Z` |
+| v3 | API 请求、集群健康/容量、纠删组、对象使用量、节点间网络 | `RELEASE.2024-03-15T01-07-19Z` |
+| v3 | 系统内存、磁盘 | `RELEASE.2024-04-18T19-09-19Z` |
+| v3 | 系统 CPU、进程、通知错误 | `RELEASE.2024-04-28T17-53-50Z` |
+| v3 | IAM 同步失败 | `RELEASE.2024-05-07T06-41-25Z` |
+| v3 | Scanner、Audit | `RELEASE.2024-05-27T19-17-46Z` |
+| v3 | ILM | `RELEASE.2024-06-06T09-36-42Z` |
+| v3 | Bucket 使用量（本能力使用的端点修复后） | `RELEASE.2024-07-15T19-02-30Z` |
+| v3 | 复制最近积压 | `RELEASE.2024-08-03T04-33-23Z` |
 
 ## 接入步骤
 
-1. 从实际采集节点验证三个固定指标端点。
-2. 在接入页面设置采集间隔（默认 `60` 秒）。
-3. 在监控对象表格中选择节点，只填写 MinIO API 主机和端口，不要包含协议或路径。
-4. 填写实例名称和可选分组，保存后等待至少一个采集周期。
+1. 在实际采集节点验证所选版本、协议和认证方式。
+2. 新建实例时显式确认指标 API 版本、协议和认证方式。
+3. 填写 API 主机和端口；主机字段不要包含协议、端口或路径。
+4. 按需开启扩展指标，保存后等待至少一个采集周期。
 
-## 接入前校验
-
-以下命令使用示例地址；`--fail` 会保留 `4xx/5xx` 失败状态：
+Bearer v3 示例：
 
 ```bash
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/cluster"
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/bucket"
-curl --fail --silent --show-error --output /dev/null "http://minio.example.com:9000/minio/v2/metrics/resource"
+export MINIO_METRICS_TOKEN='从 mc admin prometheus generate 输出中取得的 Token'
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer ${MINIO_METRICS_TOKEN}" \
+  "https://minio.example.com:9000/minio/metrics/v3/cluster/health"
 ```
 
-三个命令都应成功。必须从实际采集节点所在网络验证。
+public v2 示例：
 
-## 页面字段说明
+```bash
+curl --fail --silent --show-error \
+  "http://minio.example.com:9000/minio/v2/metrics/cluster"
+```
 
-| 页面字段 | 是否必填 | 说明 |
-| --- | --- | --- |
-| 主机 | 是 | MinIO API 的 IP 或域名，不包含 `http://`、端口或路径。 |
-| 端口 | 是 | MinIO API 实际端口。 |
-| 间隔 | 是 | 采集周期，单位秒，默认 `60`。 |
-| 节点 | 是 | 能够访问三个固定端点的采集节点。 |
-| 实例名称 | 是 | 平台内展示的实例名称。 |
-| 组 | 否 | 实例所属分组。 |
+不要在 shell 历史、平台日志或工单中打印真实 Token。生产环境不要用 `curl -k` 代替正确的证书信任配置。
 
-## 接入后验证
+## 页面字段
 
-保存并等待一个采集周期后，在平台确认以下指标可查询：
+| 字段 | 说明 |
+| --- | --- |
+| 指标 API 版本 | 新建默认 v3；旧版本选择 v2。 |
+| 协议 | 新建默认 HTTPS。HTTP 仅用于隔离可信网络。 |
+| 认证方式 | 新建默认 Bearer；public 仅匹配服务端显式匿名配置。 |
+| Bearer Token | 加密字段，仅 Bearer 模式显示，经环境变量注入。 |
+| 扩展指标 | 支持多选且默认关闭；只有选中的分组会在核心指标之外额外采集。 |
+| 跳过证书校验 | 默认关闭，仅用于临时排障。 |
+| 主机、端口 | MinIO API 地址，不是 Console 地址。 |
 
-- `minio_cluster_health_status_gauge`
-- `minio_cluster_capacity_usable_free_bytes_gauge`
-- `minio_cluster_drive_online_total_gauge`
-- `minio_node_cpu_avg_idle_gauge`
+## 故障定位
 
-## 常见问题
-
-### 返回 `401` 或 `403`
-
-- 当前模板不支持任何认证字段；确认指标端点允许采集节点匿名读取。
-- 不要在主机字段中拼接凭据或 Token。
-
-### 返回 `404`
-
-- 确认填写的是 MinIO API 端口，而不是 Console 端口。
-- 当前路径固定为 Prometheus v2 三个端点，不支持旧路径。
-
-### HTTP 或 TLS 失败
-
-- 当前模板只生成 HTTP URL；强制 HTTPS 的目标不能直接接入。
-- 检查采集节点到 MinIO API 端口的路由、防火墙和安全组。
-
-### 只有部分数据
-
-- 分别验证 cluster、bucket 和 resource 端点；任一端点失败都会缺少对应数据。
-- 没有 Bucket 或相关活动时，部分序列可能暂时不存在。
+- `401/403`：Token 缺失、错误、过期或缺少 `admin:Prometheus`；public 模式与服务端设置不一致。
+- `404`：通常是版本路径选错，或误填 Console 端口。本能力不在运行期自动回退。
+- TLS 失败：检查证书链、主机名和采集节点系统 CA；不要长期启用跳过校验。
+- 只有部分指标：确认对应扩展已开启，且 MinIO 功能实际启用并产生数据；MinIO 会省略无值指标。

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/guide/zh-Hans.md
@@ -32,10 +32,11 @@ Token 通过采集器环境变量注入，不写入 Telegraf TOML 正文。只�
 ## 核心与扩展指标
 
 - v2 核心端点：`/minio/v2/metrics/cluster`、`/minio/v2/metrics/resource`。
+- v2 的 `minio_node_scanner_*` 属于 resource 核心 `namepass`，不依赖「生命周期与扫描」扩展；v3 的 scanner/ILM 端点仍需显式开启该扩展。
 - 早于 `RELEASE.2023-10-07T15-07-38Z` 的 v2 版本尚未提供 `/minio/v2/metrics/resource`；Telegraf 会对该 URL 报 404，但仍可从 cluster 端点采集当时已有的指标。若不能接受持续的 404 日志，请先升级 MinIO 再启用本接入。BK-Lite 不会在运行期自动删除端点或回退版本。
 - v3 核心端点：`/api/requests`、`/cluster/health`、`/cluster/erasure-set`、`/cluster/usage/objects`、`/system/cpu`、`/system/memory`、`/system/drive`、`/system/process`、`/system/network/internode`，均位于 `/minio/metrics/v3` 下。
 - Bucket 扩展：v2 bucket 端点或 v3 `/cluster/usage/buckets`。首版不自动分页枚举每个 Bucket 的 `/bucket/.../<bucket>` 明细。
-- 复制、生命周期、审计通知、IAM/KMS 为按需扩展。KMS 指标来自 v2 cluster 端点；当前 v3 官方分组提供 IAM 而没有独立 KMS 端点。
+- 复制、生命周期、审计通知、IAM/KMS 为按需扩展。KMS 登记指标来自 v2 cluster 端点；v3 扩展当前只采集 `/cluster/iam`。官方另有 `/minio/metrics/v3/kms`（`minio_kms_*`），本能力首版不采集。
 
 模板用 `namepass` 只写入所选核心及扩展指标族，并排除 TTFB histogram，以控制时序基数。每条时序都带有 `minio_metrics_version=v2|v3` 标签。
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/language/en.yaml
@@ -11,106 +11,177 @@ monitor_object_metric:
   Minio:
     minio_cluster_capacity_usable_total_bytes_gauge:
       name: Cluster Usable Total Capacity
-      desc: Total usable logical storage capacity after erasure coding, reflecting
-        storage resource scale after redundancy
+      desc: Total usable logical storage capacity after erasure coding, reflecting storage resource scale after redundancy Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_cluster_capacity_usable_free_bytes_gauge:
       name: Cluster Usable Free Capacity
-      desc: Available logical storage capacity of the cluster, used for monitoring
-        usage and predicting storage needs
+      desc: Available logical storage capacity of the cluster, used for monitoring usage and predicting storage needs Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_cluster_drive_online_total_gauge:
       name: Online Drives Count
-      desc: Number of currently online and available storage drives, indicating storage
-        hardware availability
+      desc: Number of currently online and available storage drives, indicating storage hardware availability Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_cluster_nodes_online_total_gauge:
       name: Online Nodes Count
-      desc: Number of currently online server nodes, affecting cluster processing
-        capacity and fault tolerance
+      desc: Number of currently online server nodes, affecting cluster processing capacity and fault tolerance Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_cluster_health_status_gauge:
       name: Cluster Health Status
-      desc: Overall cluster health status, 1 indicates healthy, 0 indicates unhealthy,
-        providing quick overview of cluster status
+      desc: Overall cluster health status, 1 indicates healthy, 0 indicates unhealthy, providing quick overview of cluster status Available from MinIO RELEASE.2023-08-04T17-40-21Z onward (Metrics v2).
     minio_cluster_health_erasure_set_status_gauge:
       name: Erasure Set Status
-      desc: Erasure set status (1=healthy), indicating data redundancy set health
-        and directly affecting data security
+      desc: Erasure set status (1=healthy), indicating data redundancy set health and directly affecting data security Available from MinIO RELEASE.2024-01-28T22-35-53Z onward (Metrics v2).
     minio_cluster_health_erasure_set_online_drives_gauge:
       name: Erasure Set Online Drives
-      desc: Number of online drives in erasure set, affecting data availability and
-        redundancy, ensuring redundancy strategy effectiveness
+      desc: Number of online drives in erasure set, affecting data availability and redundancy, ensuring redundancy strategy effectiveness Available from MinIO RELEASE.2023-12-23T07-19-11Z onward (Metrics v2).
     minio_node_cpu_avg_load1_gauge:
       name: Node 1-minute Average Load
-      desc: Average system load over last 1 minute, indicating short-term CPU pressure
-        and performance stress
+      desc: Average system load over last 1 minute, indicating short-term CPU pressure and performance stress Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).
     minio_node_cpu_avg_idle_gauge:
       name: Node CPU Idle Rate
-      desc: Percentage of CPU idle time, indicating CPU utilization, low idle rate
-        may indicate CPU bottleneck
+      desc: Percentage of CPU idle time, indicating CPU utilization, low idle rate may indicate CPU bottleneck Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).
     minio_node_mem_used_perc_gauge:
       name: Node Memory Usage Rate
-      desc: Percentage of memory used, indicating memory pressure, high usage may
-        cause performance degradation
+      desc: Percentage of memory used, indicating memory pressure, high usage may cause performance degradation Available from MinIO RELEASE.2023-12-07T04-16-00Z onward (Metrics v2).
     minio_node_drive_perc_util_gauge:
       name: Drive Utilization Rate
-      desc: Utilization percentage of single drive, reflecting storage space usage,
-        important for capacity planning
+      desc: Utilization percentage of single drive, reflecting storage space usage, important for capacity planning Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).
     minio_node_drive_reads_per_sec_gauge:
       name: Drive Reads Per Second
-      desc: Number of read operations per second on single drive, reflecting read
-        performance and workload
+      desc: Number of read operations per second on single drive, reflecting read performance and workload Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).
     minio_node_drive_writes_per_sec_gauge:
       name: Drive Writes Per Second
-      desc: Number of write operations per second on single drive, reflecting write
-        performance and workload
-    minio_node_if_rx_bytes_gauge:
-      name: Network Interface Receive Bytes
-      desc: Received data bytes on network interface, reflecting network inflow, monitoring
-        bandwidth usage
-    minio_node_if_tx_bytes_gauge:
-      name: Network Interface Transmit Bytes
-      desc: Transmitted data bytes on network interface, reflecting network outflow,
-        monitoring bandwidth usage
+      desc: Number of write operations per second on single drive, reflecting write performance and workload Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).
     minio_node_process_uptime_seconds_gauge:
       name: Process Uptime
-      desc: Seconds MinIO process has been running, indicating stability, long uptime
-        indicates stability, frequent restarts may indicate issues
+      desc: Seconds MinIO process has been running, indicating stability, long uptime indicates stability, frequent restarts may indicate issues Available from MinIO RELEASE.2021-03-26T00-00-41Z onward (Metrics v2).
     minio_node_process_cpu_total_seconds_counter_rate:
       name: Process CPU Usage Rate
-      desc: CPU time consumed per second by MinIO process, reflecting real-time CPU
-        resource consumption
+      desc: CPU time consumed per second by MinIO process, reflecting real-time CPU resource consumption Available from MinIO RELEASE.2021-05-11T23-27-41Z onward (Metrics v2).
     minio_node_process_resident_memory_bytes_gauge:
       name: Process Resident Memory
-      desc: Resident memory size occupied by MinIO process, reflecting memory usage,
-        monitoring memory leaks
-    minio_node_go_routine_total_gauge:
-      name: Go Routines Total
-      desc: Current number of Go routines in MinIO process, reflecting concurrency
-        capacity, abnormal increase may indicate issues
+      desc: Resident memory size occupied by MinIO process, reflecting memory usage, monitoring memory leaks Available from MinIO RELEASE.2021-05-11T23-27-41Z onward (Metrics v2).
     minio_s3_requests_incoming_total_gauge:
       name: Current Incoming S3 Requests
-      desc: Number of incoming S3 API requests currently being processed, reflecting
-        current S3 service load
+      desc: Number of incoming S3 API requests currently being processed, reflecting current S3 service load Available from MinIO RELEASE.2022-02-12T00-51-25Z onward (Metrics v2).
     minio_s3_requests_waiting_total_gauge:
       name: Waiting S3 Requests
-      desc: Number of S3 API requests currently waiting for processing, reflecting
-        S3 service queue backlog
+      desc: Number of S3 API requests currently waiting for processing, reflecting S3 service queue backlog Available from MinIO RELEASE.2021-02-23T20-05-01Z onward (Metrics v2).
     minio_s3_traffic_received_bytes_counter_rate:
       name: S3 Received Traffic Rate
-      desc: Data traffic received per second by S3 service, reflecting upload rate
-        and network inflow bandwidth usage
+      desc: Data traffic received per second by S3 service, reflecting upload rate and network inflow bandwidth usage Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_s3_traffic_sent_bytes_counter_rate:
       name: S3 Sent Traffic Rate
-      desc: Data traffic sent per second by S3 service, reflecting download rate and
-        network outflow bandwidth usage
+      desc: Data traffic sent per second by S3 service, reflecting download rate and network outflow bandwidth usage Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
     minio_s3_requests_rejected_auth_total_counter_rate:
       name: Auth Rejected S3 Requests Rate
-      desc: Number of S3 requests rejected per second due to authentication failure,
-        reflecting authentication failure frequency and security status
+      desc: Number of S3 requests rejected per second due to authentication failure, reflecting authentication failure frequency and security status Available from MinIO RELEASE.2021-04-18T19-26-29Z onward (Metrics v2).
     minio_node_scanner_objects_scanned_counter_rate:
       name: Objects Scan Rate
-      desc: Number of objects scanned per second by scanner, reflecting efficiency
-        of storage system internal maintenance activities
+      desc: Number of objects scanned per second by scanner, reflecting efficiency of storage system internal maintenance activities Available from MinIO RELEASE.2021-12-18T04-42-33Z onward (Metrics v2).
+    minio_cluster_drive_offline_total_gauge:
+      name: V2 Offline Drives
+      desc: Offline drives reported by the Metrics v2 cluster endpoint. Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
+    minio_cluster_nodes_offline_total_gauge:
+      name: V2 Offline Nodes
+      desc: Offline nodes reported by the Metrics v2 cluster endpoint. Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).
+    minio_s3_requests_5xx_errors_total_counter_rate:
+      name: V2 S3 5xx Error Rate
+      desc: Per-second rate of S3 server errors reported by Metrics v2. Available from MinIO RELEASE.2022-06-10T16-59-15Z onward (Metrics v2).
+    minio_cluster_erasure_set_overall_health_gauge:
+      name: V3 Overall Erasure Health
+      desc: Overall erasure-set health where 1 is healthy and 0 is unhealthy. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_erasure_set_online_drives_count_gauge:
+      name: V3 Erasure Set Online Drives
+      desc: Online drives in each Metrics v3 erasure set. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_capacity_usable_total_bytes_gauge:
+      name: V3 Usable Total Capacity
+      desc: Total usable cluster capacity reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_capacity_usable_free_bytes_gauge:
+      name: V3 Usable Free Capacity
+      desc: Free usable cluster capacity reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_drives_online_count_gauge:
+      name: V3 Online Drives
+      desc: Online cluster drives reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_drives_offline_count_gauge:
+      name: V3 Offline Drives
+      desc: Offline cluster drives reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_nodes_online_count_gauge:
+      name: V3 Online Nodes
+      desc: Online cluster nodes reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_health_nodes_offline_count_gauge:
+      name: V3 Offline Nodes
+      desc: Offline cluster nodes reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_usage_objects_total_bytes_gauge:
+      name: V3 Stored Object Bytes
+      desc: Total bytes consumed by objects according to Metrics v3 usage data. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_usage_objects_count_gauge:
+      name: V3 Object Count
+      desc: Total objects according to Metrics v3 usage data. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_incoming_total_gauge:
+      name: V3 Incoming API Requests
+      desc: Current incoming S3 API requests reported by Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_waiting_total_gauge:
+      name: V3 Waiting API Requests
+      desc: Current S3 API requests waiting in the server queue. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_5xx_errors_total_counter_rate:
+      name: V3 API 5xx Error Rate
+      desc: Per-second rate of API requests returning server errors. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_rejected_auth_total_counter_rate:
+      name: V3 API Authentication Rejection Rate
+      desc: Per-second rate of API requests rejected because authentication failed. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_traffic_received_bytes_counter_rate:
+      name: V3 API Received Traffic Rate
+      desc: Per-second API request bytes received through Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_api_requests_traffic_sent_bytes_counter_rate:
+      name: V3 API Sent Traffic Rate
+      desc: Per-second API response bytes sent through Metrics v3. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_system_cpu_avg_idle_gauge:
+      name: V3 System CPU Idle Percentage
+      desc: Average CPU idle percentage reported by Metrics v3. Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).
+    minio_system_memory_used_perc_gauge:
+      name: V3 Memory Usage Percentage
+      desc: Node memory usage percentage reported by Metrics v3. Available from MinIO RELEASE.2024-04-18T19-09-19Z onward (Metrics v3).
+    minio_system_drive_perc_util_gauge:
+      name: V3 Drive Utilization Percentage
+      desc: Per-drive utilization percentage reported by Metrics v3. Available from MinIO RELEASE.2024-04-18T19-09-19Z onward (Metrics v3).
+    minio_system_process_uptime_seconds_gauge:
+      name: V3 Process Uptime
+      desc: MinIO server process uptime reported by Metrics v3. Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).
+    minio_system_process_cpu_total_seconds_counter_rate:
+      name: V3 Process CPU Usage Rate
+      desc: Per-second process CPU time consumed according to Metrics v3. Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).
+    minio_system_network_internode_errors_total_counter_rate:
+      name: V3 Internode Error Rate
+      desc: Per-second rate of failed internode calls. Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).
+    minio_cluster_usage_buckets_total_bytes_gauge:
+      name: V3 Bucket Used Bytes
+      desc: Bytes consumed by each bucket from the high-level bucket usage endpoint. Available from MinIO RELEASE.2024-07-15T19-02-30Z onward (Metrics v3).
+    minio_replication_recent_backlog_count_gauge:
+      name: V3 Recent Replication Backlog
+      desc: Objects observed in the cluster replication backlog during the last five minutes. Available from MinIO RELEASE.2024-08-03T04-33-23Z onward (Metrics v3).
+    minio_ilm_expiry_pending_tasks_gauge:
+      name: V3 Pending ILM Expiry Tasks
+      desc: Pending lifecycle expiry tasks in the MinIO ILM queue. Available from MinIO RELEASE.2024-06-06T09-36-42Z onward (Metrics v3).
+    minio_scanner_objects_scanned_counter_rate:
+      name: V3 Scanner Object Rate
+      desc: Per-second rate of objects scanned by the Metrics v3 scanner. Available from MinIO RELEASE.2024-05-27T19-17-46Z onward (Metrics v3).
+    minio_audit_failed_messages_counter_rate:
+      name: V3 Audit Delivery Failure Rate
+      desc: Per-second rate of audit messages that failed delivery. Available from MinIO RELEASE.2024-05-27T19-17-46Z onward (Metrics v3).
+    minio_notification_events_errors_total_counter_rate:
+      name: V3 Notification Delivery Error Rate
+      desc: Per-second rate of notification events that failed delivery. Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).
+    minio_cluster_iam_sync_failures_counter_rate:
+      name: V3 IAM Sync Failure Rate
+      desc: Per-second rate of failed IAM synchronization operations. Available from MinIO RELEASE.2024-05-07T06-41-25Z onward (Metrics v3).
+    minio_cluster_kms_request_failure_counter_rate:
+      name: V2 KMS Internal Failure Rate
+      desc: Per-second rate of KMS requests that failed with an internal server error. Available from MinIO RELEASE.2022-07-13T23-29-44Z onward (Metrics v2).
 monitor_object_metric_group:
   Minio:
     Cluster Monitoring: Cluster Monitoring
     Resource Monitoring: Resource Monitoring
     S3 Service Monitoring: S3 Service Monitoring
+    Cluster Health and Erasure: Cluster Health and Erasure
+    Capacity and Object Usage: Capacity and Object Usage
+    Node Drive and Process Resources: Node Drive and Process Resources
+    S3 API Requests: S3 API Requests
+    Bucket Replication and Lifecycle: Bucket Replication and Lifecycle
+    External Integrations and Security: External Integrations and Security

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/language/zh-Hans.yaml
@@ -9,81 +9,177 @@ monitor_object_metric:
   Minio:
     minio_cluster_capacity_usable_total_bytes_gauge:
       name: 集群可用总容量
-      desc: 集群经过纠删码计算后的可用逻辑存储总容量，反映了考虑冗余后的存储资源规模
+      desc: 集群经过纠删码计算后的可用逻辑存储总容量，反映了考虑冗余后的存储资源规模 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_cluster_capacity_usable_free_bytes_gauge:
       name: 集群可用空闲容量
-      desc: 集群可用逻辑存储的空闲容量，用于监控存储使用情况和预测存储需求
+      desc: 集群可用逻辑存储的空闲容量，用于监控存储使用情况和预测存储需求 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_cluster_drive_online_total_gauge:
       name: 在线驱动器数
-      desc: 集群中当前在线可用的存储驱动器数量，反映存储硬件的可用性状态
+      desc: 集群中当前在线可用的存储驱动器数量，反映存储硬件的可用性状态 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_cluster_nodes_online_total_gauge:
       name: 在线节点数
-      desc: 集群中当前在线可用的节点服务器数量，影响集群处理能力和容错能力
+      desc: 集群中当前在线可用的节点服务器数量，影响集群处理能力和容错能力 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_cluster_health_status_gauge:
       name: 集群健康状态
-      desc: 集群整体健康状态，1表示健康，0表示不健康，提供集群运行状况快速概览
+      desc: 集群整体健康状态，1表示健康，0表示不健康，提供集群运行状况快速概览 自 MinIO RELEASE.2023-08-04T17-40-21Z 起可采集（Metrics v2）。
     minio_cluster_health_erasure_set_status_gauge:
       name: 擦除集状态
-      desc: 擦除集的状态（1=正常），反映数据冗余集的健康状况，直接影响数据安全性
+      desc: 擦除集的状态（1=正常），反映数据冗余集的健康状况，直接影响数据安全性 自 MinIO RELEASE.2024-01-28T22-35-53Z 起可采集（Metrics v2）。
     minio_cluster_health_erasure_set_online_drives_gauge:
       name: 擦除集在线驱动器数
-      desc: 擦除集中在线驱动器的数量，影响数据可用性和冗余度，确保冗余策略有效性
+      desc: 擦除集中在线驱动器的数量，影响数据可用性和冗余度，确保冗余策略有效性 自 MinIO RELEASE.2023-12-23T07-19-11Z 起可采集（Metrics v2）。
     minio_node_cpu_avg_load1_gauge:
       name: 节点1分钟平均负载
-      desc: 节点过去1分钟的平均系统负载，反映短期CPU压力，评估短期性能压力
+      desc: 节点过去1分钟的平均系统负载，反映短期CPU压力，评估短期性能压力 自 MinIO RELEASE.2023-10-07T15-07-38Z 起可采集（Metrics v2）。
     minio_node_cpu_avg_idle_gauge:
       name: 节点CPU空闲率
-      desc: 节点CPU的空闲时间百分比，反映CPU利用率，低空闲率可能表示CPU瓶颈
+      desc: 节点CPU的空闲时间百分比，反映CPU利用率，低空闲率可能表示CPU瓶颈 自 MinIO RELEASE.2023-10-07T15-07-38Z 起可采集（Metrics v2）。
     minio_node_mem_used_perc_gauge:
       name: 节点内存使用率
-      desc: 节点内存使用百分比，反映内存压力，过高使用率可能导致性能下降
+      desc: 节点内存使用百分比，反映内存压力，过高使用率可能导致性能下降 自 MinIO RELEASE.2023-12-07T04-16-00Z 起可采集（Metrics v2）。
     minio_node_drive_perc_util_gauge:
       name: 驱动器使用率
-      desc: 单个驱动器的使用百分比，反映存储设备空间使用情况，对容量规划重要
+      desc: 单个驱动器的使用百分比，反映存储设备空间使用情况，对容量规划重要 自 MinIO RELEASE.2023-10-07T15-07-38Z 起可采集（Metrics v2）。
     minio_node_drive_reads_per_sec_gauge:
       name: 驱动器每秒读取次数
-      desc: 单个驱动器每秒读取操作次数，反映存储设备读取性能和工作负载
+      desc: 单个驱动器每秒读取操作次数，反映存储设备读取性能和工作负载 自 MinIO RELEASE.2023-10-07T15-07-38Z 起可采集（Metrics v2）。
     minio_node_drive_writes_per_sec_gauge:
       name: 驱动器每秒写入次数
-      desc: 单个驱动器每秒写入操作次数，反映存储设备写入性能和工作负载
-    minio_node_if_rx_bytes_gauge:
-      name: 网络接口接收字节数
-      desc: 网络接口接收的数据字节数，反映网络流入流量，监控网络带宽使用
-    minio_node_if_tx_bytes_gauge:
-      name: 网络接口发送字节数
-      desc: 网络接口发送的数据字节数，反映网络流出流量，监控网络带宽使用
+      desc: 单个驱动器每秒写入操作次数，反映存储设备写入性能和工作负载 自 MinIO RELEASE.2023-10-07T15-07-38Z 起可采集（Metrics v2）。
     minio_node_process_uptime_seconds_gauge:
       name: 进程运行时间
-      desc: MinIO进程运行秒数，反映进程稳定性，长时间运行表示稳定，频繁重启可能有问题
+      desc: MinIO进程运行秒数，反映进程稳定性，长时间运行表示稳定，频繁重启可能有问题 自 MinIO RELEASE.2021-03-26T00-00-41Z 起可采集（Metrics v2）。
     minio_node_process_cpu_total_seconds_counter_rate:
       name: 进程CPU使用速率
-      desc: MinIO进程每秒消耗的CPU时间，反映MinIO服务对CPU资源的实时消耗
+      desc: MinIO进程每秒消耗的CPU时间，反映MinIO服务对CPU资源的实时消耗 自 MinIO RELEASE.2021-05-11T23-27-41Z 起可采集（Metrics v2）。
     minio_node_process_resident_memory_bytes_gauge:
       name: 进程常驻内存
-      desc: MinIO进程占用的常驻内存大小，反映进程内存使用情况，监控内存泄漏
-    minio_node_go_routine_total_gauge:
-      name: Go协程总数
-      desc: MinIO进程中当前的Go协程数量，反映并发处理能力，异常增加可能表示问题
+      desc: MinIO进程占用的常驻内存大小，反映进程内存使用情况，监控内存泄漏 自 MinIO RELEASE.2021-05-11T23-27-41Z 起可采集（Metrics v2）。
     minio_s3_requests_incoming_total_gauge:
       name: 当前传入S3请求数
-      desc: 当前正在处理的传入S3 API请求数量，反映当前S3服务负载
+      desc: 当前正在处理的传入S3 API请求数量，反映当前S3服务负载 自 MinIO RELEASE.2022-02-12T00-51-25Z 起可采集（Metrics v2）。
     minio_s3_requests_waiting_total_gauge:
       name: 等待中S3请求数
-      desc: 当前等待处理的S3 API请求数量，反映S3服务处理队列积压情况
+      desc: 当前等待处理的S3 API请求数量，反映S3服务处理队列积压情况 自 MinIO RELEASE.2021-02-23T20-05-01Z 起可采集（Metrics v2）。
     minio_s3_traffic_received_bytes_counter_rate:
       name: S3接收流量速率
-      desc: S3服务每秒接收的数据流量，反映数据上传速率和网络流入带宽使用
+      desc: S3服务每秒接收的数据流量，反映数据上传速率和网络流入带宽使用 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_s3_traffic_sent_bytes_counter_rate:
       name: S3发送流量速率
-      desc: S3服务每秒发送的数据流量，反映数据下载速率和网络流出带宽使用
+      desc: S3服务每秒发送的数据流量，反映数据下载速率和网络流出带宽使用 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
     minio_s3_requests_rejected_auth_total_counter_rate:
       name: 认证拒绝S3请求速率
-      desc: 因认证失败而被拒绝的S3请求每秒数量，反映认证失败频率和安全状况
+      desc: 因认证失败而被拒绝的S3请求每秒数量，反映认证失败频率和安全状况 自 MinIO RELEASE.2021-04-18T19-26-29Z 起可采集（Metrics v2）。
     minio_node_scanner_objects_scanned_counter_rate:
       name: 对象扫描速率
-      desc: 扫描器每秒扫描的对象数量，反映存储系统内部维护活动的效率
+      desc: 扫描器每秒扫描的对象数量，反映存储系统内部维护活动的效率 自 MinIO RELEASE.2021-12-18T04-42-33Z 起可采集（Metrics v2）。
+    minio_cluster_drive_offline_total_gauge:
+      name: V2 离线磁盘数
+      desc: Metrics v2 集群端点报告的离线磁盘数量。 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
+    minio_cluster_nodes_offline_total_gauge:
+      name: V2 离线节点数
+      desc: Metrics v2 集群端点报告的离线节点数量。 自 MinIO RELEASE.2021-01-30T00-20-58Z 起可采集（Metrics v2）。
+    minio_s3_requests_5xx_errors_total_counter_rate:
+      name: V2 S3 5xx 错误速率
+      desc: Metrics v2 报告的每秒 S3 服务端错误数。 自 MinIO RELEASE.2022-06-10T16-59-15Z 起可采集（Metrics v2）。
+    minio_cluster_erasure_set_overall_health_gauge:
+      name: V3 纠删组整体健康
+      desc: 纠删组整体健康状态，1 为健康，0 为不健康。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_erasure_set_online_drives_count_gauge:
+      name: V3 纠删组在线磁盘数
+      desc: Metrics v3 各纠删组中的在线磁盘数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_capacity_usable_total_bytes_gauge:
+      name: V3 集群可用总容量
+      desc: Metrics v3 报告的集群可用总容量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_capacity_usable_free_bytes_gauge:
+      name: V3 集群可用空闲容量
+      desc: Metrics v3 报告的集群可用空闲容量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_drives_online_count_gauge:
+      name: V3 在线磁盘数
+      desc: Metrics v3 报告的集群在线磁盘数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_drives_offline_count_gauge:
+      name: V3 离线磁盘数
+      desc: Metrics v3 报告的集群离线磁盘数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_nodes_online_count_gauge:
+      name: V3 在线节点数
+      desc: Metrics v3 报告的集群在线节点数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_health_nodes_offline_count_gauge:
+      name: V3 离线节点数
+      desc: Metrics v3 报告的集群离线节点数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_usage_objects_total_bytes_gauge:
+      name: V3 对象占用字节数
+      desc: Metrics v3 使用量数据中的对象总占用字节数。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_usage_objects_count_gauge:
+      name: V3 对象总数
+      desc: Metrics v3 使用量数据中的对象总数。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_incoming_total_gauge:
+      name: V3 当前传入 API 请求数
+      desc: Metrics v3 报告的当前传入 S3 API 请求数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_waiting_total_gauge:
+      name: V3 等待中 API 请求数
+      desc: 当前在服务端队列中等待的 S3 API 请求数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_5xx_errors_total_counter_rate:
+      name: V3 API 5xx 错误速率
+      desc: 每秒返回服务端错误的 API 请求数。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_rejected_auth_total_counter_rate:
+      name: V3 API 鉴权拒绝速率
+      desc: 因鉴权失败而被拒绝的 API 请求每秒速率。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_traffic_received_bytes_counter_rate:
+      name: V3 API 接收流量速率
+      desc: Metrics v3 API 每秒接收的请求字节数。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_api_requests_traffic_sent_bytes_counter_rate:
+      name: V3 API 发送流量速率
+      desc: Metrics v3 API 每秒发送的响应字节数。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_system_cpu_avg_idle_gauge:
+      name: V3 系统 CPU 空闲率
+      desc: Metrics v3 报告的平均 CPU 空闲百分比。 自 MinIO RELEASE.2024-04-28T17-53-50Z 起可采集（Metrics v3）。
+    minio_system_memory_used_perc_gauge:
+      name: V3 内存使用率
+      desc: Metrics v3 报告的节点内存使用百分比。 自 MinIO RELEASE.2024-04-18T19-09-19Z 起可采集（Metrics v3）。
+    minio_system_drive_perc_util_gauge:
+      name: V3 磁盘利用率
+      desc: Metrics v3 报告的单磁盘利用百分比。 自 MinIO RELEASE.2024-04-18T19-09-19Z 起可采集（Metrics v3）。
+    minio_system_process_uptime_seconds_gauge:
+      name: V3 进程运行时间
+      desc: Metrics v3 报告的 MinIO 服务进程运行秒数。 自 MinIO RELEASE.2024-04-28T17-53-50Z 起可采集（Metrics v3）。
+    minio_system_process_cpu_total_seconds_counter_rate:
+      name: V3 进程 CPU 使用速率
+      desc: Metrics v3 进程每秒消耗的 CPU 时间。 自 MinIO RELEASE.2024-04-28T17-53-50Z 起可采集（Metrics v3）。
+    minio_system_network_internode_errors_total_counter_rate:
+      name: V3 节点间调用错误速率
+      desc: 节点间调用每秒失败数量。 自 MinIO RELEASE.2024-03-15T01-07-19Z 起可采集（Metrics v3）。
+    minio_cluster_usage_buckets_total_bytes_gauge:
+      name: V3 Bucket 已用字节数
+      desc: 高层 Bucket 使用量端点报告的各 Bucket 占用字节数。 自 MinIO RELEASE.2024-07-15T19-02-30Z 起可采集（Metrics v3）。
+    minio_replication_recent_backlog_count_gauge:
+      name: V3 近期复制积压对象数
+      desc: 最近五分钟在集群复制积压中观察到的对象数量。 自 MinIO RELEASE.2024-08-03T04-33-23Z 起可采集（Metrics v3）。
+    minio_ilm_expiry_pending_tasks_gauge:
+      name: V3 待处理 ILM 过期任务数
+      desc: MinIO 生命周期过期队列中等待处理的任务数。 自 MinIO RELEASE.2024-06-06T09-36-42Z 起可采集（Metrics v3）。
+    minio_scanner_objects_scanned_counter_rate:
+      name: V3 对象扫描速率
+      desc: Metrics v3 扫描器每秒扫描的对象数。 自 MinIO RELEASE.2024-05-27T19-17-46Z 起可采集（Metrics v3）。
+    minio_audit_failed_messages_counter_rate:
+      name: V3 审计消息投递失败速率
+      desc: 审计消息每秒投递失败数量。 自 MinIO RELEASE.2024-05-27T19-17-46Z 起可采集（Metrics v3）。
+    minio_notification_events_errors_total_counter_rate:
+      name: V3 通知事件投递错误速率
+      desc: 通知事件每秒投递失败数量。 自 MinIO RELEASE.2024-04-28T17-53-50Z 起可采集（Metrics v3）。
+    minio_cluster_iam_sync_failures_counter_rate:
+      name: V3 IAM 同步失败速率
+      desc: IAM 同步操作每秒失败数量。 自 MinIO RELEASE.2024-05-07T06-41-25Z 起可采集（Metrics v3）。
+    minio_cluster_kms_request_failure_counter_rate:
+      name: V2 KMS 内部失败速率
+      desc: KMS 请求因服务端内部错误失败的每秒速率。 自 MinIO RELEASE.2022-07-13T23-29-44Z 起可采集（Metrics v2）。
 monitor_object_metric_group:
   Minio:
     Cluster Monitoring: 集群监控
     Resource Monitoring: 资源监控
     S3 Service Monitoring: S3服务监控
+    Cluster Health and Erasure: 集群健康与纠删冗余
+    Capacity and Object Usage: 容量与对象使用量
+    Node Drive and Process Resources: 节点磁盘与进程资源
+    S3 API Requests: S3 API 请求
+    Bucket Replication and Lifecycle: Bucket复制与生命周期
+    External Integrations and Security: 外部集成与安全

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/metrics.json
@@ -10,8 +10,13 @@
   "description": "",
   "default_metric": "any({instance_type='minio'}) by (instance_id)",
   "instance_id_keys": ["instance_id"],
-  "supplementary_indicators": ["minio_cluster_capacity_usable_free_bytes_gauge", "minio_cluster_drive_online_total_gauge", "minio_cluster_health_status_gauge"],
-  "display_fields": [{"name": "集群健康状态", "sort_order": 0, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_health_status_gauge"}]}, {"name": "可用空闲容量", "sort_order": 1, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_capacity_usable_free_bytes_gauge"}]}, {"name": "在线驱动器数", "sort_order": 2, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_drive_online_total_gauge"}]}, {"name": "S3接收流量速率", "sort_order": 3, "metrics": [{"plugin": "Minio", "metric": "minio_s3_traffic_received_bytes_counter_rate"}]}],
+  "supplementary_indicators": ["minio_cluster_erasure_set_overall_health_gauge", "minio_cluster_health_status_gauge", "minio_cluster_health_capacity_usable_free_bytes_gauge", "minio_cluster_capacity_usable_free_bytes_gauge", "minio_cluster_health_drives_online_count_gauge", "minio_cluster_drive_online_total_gauge"],
+  "display_fields": [
+    {"name": "集群健康状态", "sort_order": 0, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_erasure_set_overall_health_gauge"}, {"plugin": "Minio", "metric": "minio_cluster_health_status_gauge"}]},
+    {"name": "可用空闲容量", "sort_order": 1, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_health_capacity_usable_free_bytes_gauge"}, {"plugin": "Minio", "metric": "minio_cluster_capacity_usable_free_bytes_gauge"}]},
+    {"name": "在线驱动器数", "sort_order": 2, "metrics": [{"plugin": "Minio", "metric": "minio_cluster_health_drives_online_count_gauge"}, {"plugin": "Minio", "metric": "minio_cluster_drive_online_total_gauge"}]},
+    {"name": "S3接收流量速率", "sort_order": 3, "metrics": [{"plugin": "Minio", "metric": "minio_api_requests_traffic_received_bytes_counter_rate"}, {"plugin": "Minio", "metric": "minio_s3_traffic_received_bytes_counter_rate"}]}
+  ],
   "metrics": [
     {
       "metric_group": "Cluster Monitoring",
@@ -21,7 +26,7 @@
       "data_type": "Number",
       "unit": "bytes",
       "dimensions": [],
-      "description": "Total usable logical storage capacity after erasure coding, reflecting storage resource scale after redundancy",
+      "description": "Total usable logical storage capacity after erasure coding, reflecting storage resource scale after redundancy Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "minio_cluster_capacity_usable_total_bytes_gauge{__$labels__}"
     },
     {
@@ -32,7 +37,7 @@
       "data_type": "Number",
       "unit": "bytes",
       "dimensions": [],
-      "description": "Available logical storage capacity of the cluster, used for monitoring usage and predicting storage needs",
+      "description": "Available logical storage capacity of the cluster, used for monitoring usage and predicting storage needs Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "minio_cluster_capacity_usable_free_bytes_gauge{__$labels__}"
     },
     {
@@ -43,7 +48,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of currently online and available storage drives, indicating storage hardware availability",
+      "description": "Number of currently online and available storage drives, indicating storage hardware availability Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "minio_cluster_drive_online_total_gauge{__$labels__}"
     },
     {
@@ -54,7 +59,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of currently online server nodes, affecting cluster processing capacity and fault tolerance",
+      "description": "Number of currently online server nodes, affecting cluster processing capacity and fault tolerance Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "minio_cluster_nodes_online_total_gauge{__$labels__}"
     },
     {
@@ -65,7 +70,7 @@
       "data_type": "Enum",
       "unit": "[{\"name\":\"不健康\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"健康\",\"id\":1,\"color\":\"#1ac44a\"}]",
       "dimensions": [],
-      "description": "Overall cluster health status, 1 indicates healthy, 0 indicates unhealthy, providing quick overview of cluster status",
+      "description": "Overall cluster health status, 1 indicates healthy, 0 indicates unhealthy, providing quick overview of cluster status Available from MinIO RELEASE.2023-08-04T17-40-21Z onward (Metrics v2).",
       "query": "minio_cluster_health_status_gauge{__$labels__}"
     },
     {
@@ -76,7 +81,7 @@
       "data_type": "Enum",
       "unit": "[{\"name\":\"不正常\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"正常\",\"id\":1,\"color\":\"#1ac44a\"}]",
       "dimensions": [],
-      "description": "Erasure set status (1=healthy), indicating data redundancy set health and directly affecting data security",
+      "description": "Erasure set status (1=healthy), indicating data redundancy set health and directly affecting data security Available from MinIO RELEASE.2024-01-28T22-35-53Z onward (Metrics v2).",
       "query": "minio_cluster_health_erasure_set_status_gauge{__$labels__}"
     },
     {
@@ -87,7 +92,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of online drives in erasure set, affecting data availability and redundancy, ensuring redundancy strategy effectiveness",
+      "description": "Number of online drives in erasure set, affecting data availability and redundancy, ensuring redundancy strategy effectiveness Available from MinIO RELEASE.2023-12-23T07-19-11Z onward (Metrics v2).",
       "query": "minio_cluster_health_erasure_set_online_drives_gauge{__$labels__}"
     },
     {
@@ -98,7 +103,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Average system load over last 1 minute, indicating short-term CPU pressure and performance stress",
+      "description": "Average system load over last 1 minute, indicating short-term CPU pressure and performance stress Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).",
       "query": "minio_node_cpu_avg_load1_gauge{__$labels__}"
     },
     {
@@ -109,7 +114,7 @@
       "data_type": "Number",
       "unit": "percent",
       "dimensions": [],
-      "description": "Percentage of CPU idle time, indicating CPU utilization, low idle rate may indicate CPU bottleneck",
+      "description": "Percentage of CPU idle time, indicating CPU utilization, low idle rate may indicate CPU bottleneck Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).",
       "query": "minio_node_cpu_avg_idle_gauge{__$labels__}"
     },
     {
@@ -120,7 +125,7 @@
       "data_type": "Number",
       "unit": "percent",
       "dimensions": [],
-      "description": "Percentage of memory used, indicating memory pressure, high usage may cause performance degradation",
+      "description": "Percentage of memory used, indicating memory pressure, high usage may cause performance degradation Available from MinIO RELEASE.2023-12-07T04-16-00Z onward (Metrics v2).",
       "query": "minio_node_mem_used_perc_gauge{__$labels__}"
     },
     {
@@ -131,7 +136,7 @@
       "data_type": "Number",
       "unit": "percent",
       "dimensions": [],
-      "description": "Utilization percentage of single drive, reflecting storage space usage, important for capacity planning",
+      "description": "Utilization percentage of single drive, reflecting storage space usage, important for capacity planning Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).",
       "query": "minio_node_drive_perc_util_gauge{__$labels__}"
     },
     {
@@ -142,7 +147,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of read operations per second on single drive, reflecting read performance and workload",
+      "description": "Number of read operations per second on single drive, reflecting read performance and workload Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).",
       "query": "minio_node_drive_reads_per_sec_gauge{__$labels__}"
     },
     {
@@ -153,30 +158,8 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of write operations per second on single drive, reflecting write performance and workload",
+      "description": "Number of write operations per second on single drive, reflecting write performance and workload Available from MinIO RELEASE.2023-10-07T15-07-38Z onward (Metrics v2).",
       "query": "minio_node_drive_writes_per_sec_gauge{__$labels__}"
-    },
-    {
-      "metric_group": "Resource Monitoring",
-      "name": "minio_node_if_rx_bytes_gauge",
-      "display_name": "Network Interface Receive Bytes",
-      "instance_id_keys": ["instance_id"],
-      "data_type": "Number",
-      "unit": "bytes",
-      "dimensions": [],
-      "description": "Received data bytes on network interface, reflecting network inflow, monitoring bandwidth usage",
-      "query": "minio_node_if_rx_bytes_gauge{__$labels__}"
-    },
-    {
-      "metric_group": "Resource Monitoring",
-      "name": "minio_node_if_tx_bytes_gauge",
-      "display_name": "Network Interface Transmit Bytes",
-      "instance_id_keys": ["instance_id"],
-      "data_type": "Number",
-      "unit": "bytes",
-      "dimensions": [],
-      "description": "Transmitted data bytes on network interface, reflecting network outflow, monitoring bandwidth usage",
-      "query": "minio_node_if_tx_bytes_gauge{__$labels__}"
     },
     {
       "metric_group": "Resource Monitoring",
@@ -186,7 +169,7 @@
       "data_type": "Number",
       "unit": "s",
       "dimensions": [],
-      "description": "Seconds MinIO process has been running, indicating stability, long uptime indicates stability, frequent restarts may indicate issues",
+      "description": "Seconds MinIO process has been running, indicating stability, long uptime indicates stability, frequent restarts may indicate issues Available from MinIO RELEASE.2021-03-26T00-00-41Z onward (Metrics v2).",
       "query": "minio_node_process_uptime_seconds_gauge{__$labels__}"
     },
     {
@@ -197,7 +180,7 @@
       "data_type": "Number",
       "unit": "cps",
       "dimensions": [],
-      "description": "CPU time consumed per second by MinIO process, reflecting real-time CPU resource consumption",
+      "description": "CPU time consumed per second by MinIO process, reflecting real-time CPU resource consumption Available from MinIO RELEASE.2021-05-11T23-27-41Z onward (Metrics v2).",
       "query": "rate(minio_node_process_cpu_total_seconds_counter[5m])"
     },
     {
@@ -208,19 +191,8 @@
       "data_type": "Number",
       "unit": "bytes",
       "dimensions": [],
-      "description": "Resident memory size occupied by MinIO process, reflecting memory usage, monitoring memory leaks",
+      "description": "Resident memory size occupied by MinIO process, reflecting memory usage, monitoring memory leaks Available from MinIO RELEASE.2021-05-11T23-27-41Z onward (Metrics v2).",
       "query": "minio_node_process_resident_memory_bytes_gauge{__$labels__}"
-    },
-    {
-      "metric_group": "Resource Monitoring",
-      "name": "minio_node_go_routine_total_gauge",
-      "display_name": "Go Routines Total",
-      "instance_id_keys": ["instance_id"],
-      "data_type": "Number",
-      "unit": "counts",
-      "dimensions": [],
-      "description": "Current number of Go routines in MinIO process, reflecting concurrency capacity, abnormal increase may indicate issues",
-      "query": "minio_node_go_routine_total_gauge{__$labels__}"
     },
     {
       "metric_group": "S3 Service Monitoring",
@@ -230,7 +202,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of incoming S3 API requests currently being processed, reflecting current S3 service load",
+      "description": "Number of incoming S3 API requests currently being processed, reflecting current S3 service load Available from MinIO RELEASE.2022-02-12T00-51-25Z onward (Metrics v2).",
       "query": "minio_s3_requests_incoming_total_gauge{__$labels__}"
     },
     {
@@ -241,7 +213,7 @@
       "data_type": "Number",
       "unit": "counts",
       "dimensions": [],
-      "description": "Number of S3 API requests currently waiting for processing, reflecting S3 service queue backlog",
+      "description": "Number of S3 API requests currently waiting for processing, reflecting S3 service queue backlog Available from MinIO RELEASE.2021-02-23T20-05-01Z onward (Metrics v2).",
       "query": "minio_s3_requests_waiting_total_gauge{__$labels__}"
     },
     {
@@ -252,7 +224,7 @@
       "data_type": "Number",
       "unit": "byteps",
       "dimensions": [],
-      "description": "Data traffic received per second by S3 service, reflecting upload rate and network inflow bandwidth usage",
+      "description": "Data traffic received per second by S3 service, reflecting upload rate and network inflow bandwidth usage Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "rate(minio_s3_traffic_received_bytes_counter{__$labels__}[5m])"
     },
     {
@@ -263,7 +235,7 @@
       "data_type": "Number",
       "unit": "byteps",
       "dimensions": [],
-      "description": "Data traffic sent per second by S3 service, reflecting download rate and network outflow bandwidth usage",
+      "description": "Data traffic sent per second by S3 service, reflecting download rate and network outflow bandwidth usage Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
       "query": "rate(minio_s3_traffic_sent_bytes_counter{__$labels__}[5m])"
     },
     {
@@ -274,7 +246,7 @@
       "data_type": "Number",
       "unit": "cps",
       "dimensions": [],
-      "description": "Number of S3 requests rejected per second due to authentication failure, reflecting authentication failure frequency and security status",
+      "description": "Number of S3 requests rejected per second due to authentication failure, reflecting authentication failure frequency and security status Available from MinIO RELEASE.2021-04-18T19-26-29Z onward (Metrics v2).",
       "query": "rate(minio_s3_requests_rejected_auth_total_counter{__$labels__}[5m])"
     },
     {
@@ -285,8 +257,371 @@
       "data_type": "Number",
       "unit": "cps",
       "dimensions": [],
-      "description": "Number of objects scanned per second by scanner, reflecting efficiency of storage system internal maintenance activities",
+      "description": "Number of objects scanned per second by scanner, reflecting efficiency of storage system internal maintenance activities Available from MinIO RELEASE.2021-12-18T04-42-33Z onward (Metrics v2).",
       "query": "rate(minio_node_scanner_objects_scanned_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_drive_offline_total_gauge",
+      "display_name": "V2 Offline Drives",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of offline drives reported by the MinIO Metrics v2 cluster endpoint Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
+      "query": "minio_cluster_drive_offline_total_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_nodes_offline_total_gauge",
+      "display_name": "V2 Offline Nodes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of offline nodes reported by the MinIO Metrics v2 cluster endpoint Available from MinIO RELEASE.2021-01-30T00-20-58Z onward (Metrics v2).",
+      "query": "minio_cluster_nodes_offline_total_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_s3_requests_5xx_errors_total_counter_rate",
+      "display_name": "V2 S3 5xx Error Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of S3 requests returning server errors through Metrics v2 Available from MinIO RELEASE.2022-06-10T16-59-15Z onward (Metrics v2).",
+      "query": "rate(minio_s3_requests_5xx_errors_total_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_erasure_set_overall_health_gauge",
+      "display_name": "V3 Overall Erasure Health",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Enum",
+      "unit": "[{\"name\":\"不健康\",\"id\":0,\"color\":\"#ff4d4f\"},{\"name\":\"健康\",\"id\":1,\"color\":\"#1ac44a\"}]",
+      "dimensions": [],
+      "description": "Overall erasure-set health from the Metrics v3 cluster erasure-set endpoint Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_erasure_set_overall_health_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_erasure_set_online_drives_count_gauge",
+      "display_name": "V3 Erasure Set Online Drives",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": ["pool_id", "set_id"],
+      "description": "Online drives in each Metrics v3 erasure set Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_erasure_set_online_drives_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_capacity_usable_total_bytes_gauge",
+      "display_name": "V3 Usable Total Capacity",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [],
+      "description": "Total usable cluster capacity reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_capacity_usable_total_bytes_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_capacity_usable_free_bytes_gauge",
+      "display_name": "V3 Usable Free Capacity",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [],
+      "description": "Free usable cluster capacity reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_capacity_usable_free_bytes_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_drives_online_count_gauge",
+      "display_name": "V3 Online Drives",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of online cluster drives reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_drives_online_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_drives_offline_count_gauge",
+      "display_name": "V3 Offline Drives",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of offline cluster drives reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_drives_offline_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_nodes_online_count_gauge",
+      "display_name": "V3 Online Nodes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of online cluster nodes reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_nodes_online_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Cluster Health and Erasure",
+      "name": "minio_cluster_health_nodes_offline_count_gauge",
+      "display_name": "V3 Offline Nodes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Number of offline cluster nodes reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_health_nodes_offline_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Capacity and Object Usage",
+      "name": "minio_cluster_usage_objects_total_bytes_gauge",
+      "display_name": "V3 Stored Object Bytes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": [],
+      "description": "Total bytes consumed by objects according to Metrics v3 usage data Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_usage_objects_total_bytes_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Capacity and Object Usage",
+      "name": "minio_cluster_usage_objects_count_gauge",
+      "display_name": "V3 Object Count",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Total number of objects according to Metrics v3 usage data Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_cluster_usage_objects_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_incoming_total_gauge",
+      "display_name": "V3 Incoming API Requests",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Current incoming S3 API requests reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_api_requests_incoming_total_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_waiting_total_gauge",
+      "display_name": "V3 Waiting API Requests",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Current S3 API requests waiting in the server queue Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "minio_api_requests_waiting_total_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_5xx_errors_total_counter_rate",
+      "display_name": "V3 API 5xx Error Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of API requests returning server errors through Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "rate(minio_api_requests_5xx_errors_total_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_rejected_auth_total_counter_rate",
+      "display_name": "V3 API Authentication Rejection Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of API requests rejected because authentication failed Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "rate(minio_api_requests_rejected_auth_total_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_traffic_received_bytes_counter_rate",
+      "display_name": "V3 API Received Traffic Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [],
+      "description": "Per-second API request bytes received through Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "rate(minio_api_requests_traffic_received_bytes_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "S3 API Requests",
+      "name": "minio_api_requests_traffic_sent_bytes_counter_rate",
+      "display_name": "V3 API Sent Traffic Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "byteps",
+      "dimensions": [],
+      "description": "Per-second API response bytes sent through Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "rate(minio_api_requests_traffic_sent_bytes_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_cpu_avg_idle_gauge",
+      "display_name": "V3 System CPU Idle Percentage",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "description": "Average CPU idle percentage reported by Metrics v3 Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).",
+      "query": "minio_system_cpu_avg_idle_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_memory_used_perc_gauge",
+      "display_name": "V3 Memory Usage Percentage",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "description": "Node memory usage percentage reported by Metrics v3 Available from MinIO RELEASE.2024-04-18T19-09-19Z onward (Metrics v3).",
+      "query": "minio_system_memory_used_perc_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_drive_perc_util_gauge",
+      "display_name": "V3 Drive Utilization Percentage",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [],
+      "description": "Per-drive utilization percentage reported by Metrics v3 Available from MinIO RELEASE.2024-04-18T19-09-19Z onward (Metrics v3).",
+      "query": "minio_system_drive_perc_util_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_process_uptime_seconds_gauge",
+      "display_name": "V3 Process Uptime",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "s",
+      "dimensions": [],
+      "description": "MinIO server process uptime reported by Metrics v3 Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).",
+      "query": "minio_system_process_uptime_seconds_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_process_cpu_total_seconds_counter_rate",
+      "display_name": "V3 Process CPU Usage Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second process CPU time consumed according to Metrics v3 Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).",
+      "query": "rate(minio_system_process_cpu_total_seconds_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Node Drive and Process Resources",
+      "name": "minio_system_network_internode_errors_total_counter_rate",
+      "display_name": "V3 Internode Error Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of failed internode calls reported by Metrics v3 Available from MinIO RELEASE.2024-03-15T01-07-19Z onward (Metrics v3).",
+      "query": "rate(minio_system_network_internode_errors_total_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "Bucket Replication and Lifecycle",
+      "name": "minio_cluster_usage_buckets_total_bytes_gauge",
+      "display_name": "V3 Bucket Used Bytes",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "bytes",
+      "dimensions": ["bucket"],
+      "description": "Bytes consumed by each bucket from the high-level v3 bucket usage endpoint Available from MinIO RELEASE.2024-07-15T19-02-30Z onward (Metrics v3).",
+      "query": "minio_cluster_usage_buckets_total_bytes_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Bucket Replication and Lifecycle",
+      "name": "minio_replication_recent_backlog_count_gauge",
+      "display_name": "V3 Recent Replication Backlog",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Objects observed in the cluster replication backlog during the last five minutes Available from MinIO RELEASE.2024-08-03T04-33-23Z onward (Metrics v3).",
+      "query": "minio_replication_recent_backlog_count_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Bucket Replication and Lifecycle",
+      "name": "minio_ilm_expiry_pending_tasks_gauge",
+      "display_name": "V3 Pending ILM Expiry Tasks",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "counts",
+      "dimensions": [],
+      "description": "Pending lifecycle expiry tasks in the MinIO ILM queue Available from MinIO RELEASE.2024-06-06T09-36-42Z onward (Metrics v3).",
+      "query": "minio_ilm_expiry_pending_tasks_gauge{__$labels__}"
+    },
+    {
+      "metric_group": "Bucket Replication and Lifecycle",
+      "name": "minio_scanner_objects_scanned_counter_rate",
+      "display_name": "V3 Scanner Object Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of objects scanned by the Metrics v3 scanner Available from MinIO RELEASE.2024-05-27T19-17-46Z onward (Metrics v3).",
+      "query": "rate(minio_scanner_objects_scanned_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "External Integrations and Security",
+      "name": "minio_audit_failed_messages_counter_rate",
+      "display_name": "V3 Audit Delivery Failure Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": ["target_id"],
+      "description": "Per-second rate of audit messages that failed delivery Available from MinIO RELEASE.2024-05-27T19-17-46Z onward (Metrics v3).",
+      "query": "rate(minio_audit_failed_messages_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "External Integrations and Security",
+      "name": "minio_notification_events_errors_total_counter_rate",
+      "display_name": "V3 Notification Delivery Error Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of notification events that failed delivery Available from MinIO RELEASE.2024-04-28T17-53-50Z onward (Metrics v3).",
+      "query": "rate(minio_notification_events_errors_total_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "External Integrations and Security",
+      "name": "minio_cluster_iam_sync_failures_counter_rate",
+      "display_name": "V3 IAM Sync Failure Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of failed IAM synchronization operations Available from MinIO RELEASE.2024-05-07T06-41-25Z onward (Metrics v3).",
+      "query": "rate(minio_cluster_iam_sync_failures_counter{__$labels__}[5m])"
+    },
+    {
+      "metric_group": "External Integrations and Security",
+      "name": "minio_cluster_kms_request_failure_counter_rate",
+      "display_name": "V2 KMS Internal Failure Rate",
+      "instance_id_keys": ["instance_id"],
+      "data_type": "Number",
+      "unit": "cps",
+      "dimensions": [],
+      "description": "Per-second rate of KMS requests that failed with an internal server error in Metrics v2 Available from MinIO RELEASE.2022-07-13T23-29-44Z onward (Metrics v2).",
+      "query": "rate(minio_cluster_kms_request_failure_counter{__$labels__}[5m])"
     }
   ]
 }

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/minio.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/minio.child.toml.j2
@@ -1,15 +1,112 @@
+{% set _minio_metrics_version = metrics_api_version | default("v2", true) %}
+{% set _minio_scheme = scheme | default("http", true) %}
+{% set _minio_auth_type = auth_type | default("public", true) %}
+{% set _minio_extensions = metric_extensions | default(["bucket"]) %}
 [[inputs.prometheus]]
     startup_error_behavior = "retry"
     urls = [
-        "http://{{ host }}:{{ port }}/minio/v2/metrics/cluster",
-        "http://{{ host }}:{{ port }}/minio/v2/metrics/bucket",
-        "http://{{ host }}:{{ port }}/minio/v2/metrics/resource",
+{% if _minio_metrics_version == "v3" %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/api/requests",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/cluster/health",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/cluster/erasure-set",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/cluster/usage/objects",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/system/cpu",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/system/memory",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/system/drive",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/system/process",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/system/network/internode",
+{% if "bucket" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/cluster/usage/buckets",
+{% endif %}
+{% if "replication" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/replication",
+{% endif %}
+{% if "lifecycle" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/ilm",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/scanner",
+{% endif %}
+{% if "integrations" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/audit",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/notification",
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/logger/webhook",
+{% endif %}
+{% if "security" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/metrics/v3/cluster/iam",
+{% endif %}
+{% else %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/v2/metrics/cluster",
+{% if "bucket" in _minio_extensions or "replication" in _minio_extensions %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/v2/metrics/bucket",
+{% endif %}
+        "{{ _minio_scheme }}://{{ host }}:{{ port }}/minio/v2/metrics/resource",
+{% endif %}
     ]
     interval = "{{ interval }}s"
     timeout = "{{ interval }}s"
     response_timeout = "{{ interval }}s"
+    insecure_skip_verify = {{ insecure_skip_verify | default(false, true) | lower }}
+{% if _minio_auth_type == "bearer" %}
+    bearer_token_string = "${BEARER_TOKEN__{{ config_id }}}"
+{% endif %}
+    namepass = [
+{% if _minio_metrics_version == "v3" %}
+        "minio_cluster_health_*",
+        "minio_cluster_erasure_set_*",
+        "minio_cluster_usage_objects_*",
+        "minio_api_requests_*",
+        "minio_system_cpu_*",
+        "minio_system_memory_*",
+        "minio_system_drive_*",
+        "minio_system_process_*",
+        "minio_system_network_internode_*",
+{% else %}
+        "minio_cluster_capacity_*",
+        "minio_cluster_drive_*",
+        "minio_cluster_nodes_*",
+        "minio_cluster_health_*",
+        "minio_s3_requests_*",
+        "minio_s3_traffic_*",
+        "minio_node_cpu_*",
+        "minio_node_mem_*",
+        "minio_node_drive_*",
+        "minio_node_process_*",
+        "minio_node_file_descriptor_*",
+        "minio_inter_node_traffic_*",
+{% endif %}
+{% if "bucket" in _minio_extensions %}
+        "minio_bucket_*",
+        "minio_cluster_usage_buckets_*",
+{% endif %}
+{% if "replication" in _minio_extensions %}
+        "minio_*replication*",
+{% endif %}
+{% if "lifecycle" in _minio_extensions %}
+        "minio_*ilm*",
+        "minio_*scanner*",
+        "minio_*heal*",
+{% endif %}
+{% if "integrations" in _minio_extensions %}
+        "minio_audit_*",
+        "minio_cluster_audit_*",
+        "minio_cluster_notify_*",
+        "minio_cluster_webhook_*",
+        "minio_notify_*",
+        "minio_notification_*",
+        "minio_logger_webhook_*",
+{% endif %}
+{% if "security" in _minio_extensions %}
+        "minio_cluster_iam_*",
+        "minio_cluster_kms_*",
+{% endif %}
+    ]
+    namedrop = ["*_ttfb_seconds_distribution*"]
     [inputs.prometheus.tags]
         instance_id = "{{ instance_id }}"
         instance_type = "{{ instance_type }}"
         collect_type = "bkpull"
         config_type = "minio"
+        minio_metrics_version = "{{ _minio_metrics_version }}"
+        minio_auth_type = "{{ _minio_auth_type }}"
+{% if _minio_extensions %}
+        minio_metric_extensions = "{{ _minio_extensions | join(',') }}"
+{% endif %}

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/minio.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/minio.child.toml.j2
@@ -72,6 +72,7 @@
         "minio_node_process_*",
         "minio_node_file_descriptor_*",
         "minio_inter_node_traffic_*",
+        "minio_node_scanner_*",
 {% endif %}
 {% if "bucket" in _minio_extensions %}
         "minio_bucket_*",

--- a/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/policy.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/bkpull/minio/policy.json
@@ -3,119 +3,112 @@
   "plugin": "Minio",
   "templates": [
     {
-      "name": "MinIO 集群健康状态异常",
-      "alert_name": "MinIO ${resource_name} 集群不健康",
-      "description": "检测集群健康状态（health_status），非1表示集群异常，需立即检查节点和网络状态。",
+      "name": "MinIO v2 集群健康异常",
+      "alert_name": "MinIO ${resource_name} v2 集群不健康",
+      "description": "Metrics v2 集群健康状态非 1，请检查节点、磁盘和网络。",
       "metric_name": "minio_cluster_health_status_gauge",
       "algorithm": "last_over_time",
-      "threshold": [
-        {
-          "level": "critical",
-          "value": 1,
-          "method": "!="
-        }
-      ],
-      "group_algorithm": "avg"
+      "threshold": [{"level": "critical", "value": 1, "method": "!="}],
+      "group_algorithm": "min"
     },
     {
-      "name": "MinIO 节点离线率过高",
-      "alert_name": "MinIO ${resource_name} 节点大量离线",
-      "description": "检测离线节点占比（nodes_offline_rate），过高可能影响数据可用性和写入quorum。",
-      "metric_name": "minio_cluster_nodes_offline_rate",
+      "name": "MinIO v3 纠删集整体健康异常",
+      "alert_name": "MinIO ${resource_name} v3 纠删集不健康",
+      "description": "Metrics v3 纠删集整体健康状态非 1，集群冗余或可写能力可能受损。",
+      "metric_name": "minio_cluster_erasure_set_overall_health_gauge",
       "algorithm": "last_over_time",
-      "threshold": [
-        {
-          "level": "critical",
-          "value": 50,
-          "method": ">="
-        },
-        {
-          "level": "error",
-          "value": 30,
-          "method": ">="
-        },
-        {
-          "level": "warning",
-          "value": 10,
-          "method": ">="
-        }
-      ],
-      "group_algorithm": "avg"
+      "threshold": [{"level": "critical", "value": 1, "method": "!="}],
+      "group_algorithm": "min"
     },
     {
-      "name": "MinIO 磁盘离线率过高",
-      "alert_name": "MinIO ${resource_name} 磁盘大量离线",
-      "description": "监控离线磁盘占比（drive_offline_rate），过高可能导致数据丢失风险。",
-      "metric_name": "minio_cluster_drive_offline_rate",
+      "name": "MinIO v2 节点离线",
+      "alert_name": "MinIO ${resource_name} 存在离线节点",
+      "description": "Metrics v2 报告至少一个 MinIO 节点离线。",
+      "metric_name": "minio_cluster_nodes_offline_total_gauge",
       "algorithm": "last_over_time",
-      "threshold": [
-        {
-          "level": "critical",
-          "value": 30,
-          "method": ">="
-        },
-        {
-          "level": "error",
-          "value": 20,
-          "method": ">="
-        },
-        {
-          "level": "warning",
-          "value": 10,
-          "method": ">="
-        }
-      ],
-      "group_algorithm": "avg"
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}],
+      "group_algorithm": "max"
     },
     {
-      "name": "MinIO 磁盘利用率过高",
-      "alert_name": "MinIO ${resource_name} 磁盘过载",
-      "description": "监控磁盘使用率（drive_perc_util），持续过高可能导致IO性能下降。",
-      "metric_name": "minio_node_drive_perc_util_gauge",
-      "algorithm": "avg_over_time",
-      "threshold": [
-        {
-          "level": "critical",
-          "value": 90,
-          "method": ">="
-        },
-        {
-          "level": "error",
-          "value": 80,
-          "method": ">="
-        },
-        {
-          "level": "warning",
-          "value": 70,
-          "method": ">="
-        }
-      ],
-      "group_algorithm": "avg"
+      "name": "MinIO v3 节点离线",
+      "alert_name": "MinIO ${resource_name} 存在离线节点",
+      "description": "Metrics v3 报告至少一个 MinIO 节点离线。",
+      "metric_name": "minio_cluster_health_nodes_offline_count_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}],
+      "group_algorithm": "max"
     },
     {
-      "name": "MinIO 请求排队数过多",
-      "alert_name": "MinIO ${resource_name} 请求积压严重",
-      "description": "检测等待处理的S3请求数（requests_waiting_total），积压过多表明服务过载。",
+      "name": "MinIO v2 磁盘离线",
+      "alert_name": "MinIO ${resource_name} 存在离线磁盘",
+      "description": "Metrics v2 报告至少一个集群磁盘离线。",
+      "metric_name": "minio_cluster_drive_offline_total_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "MinIO v3 磁盘离线",
+      "alert_name": "MinIO ${resource_name} 存在离线磁盘",
+      "description": "Metrics v3 报告至少一个集群磁盘离线。",
+      "metric_name": "minio_cluster_health_drives_offline_count_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}],
+      "group_algorithm": "max"
+    },
+    {
+      "name": "MinIO v2 可用容量不足",
+      "alert_name": "MinIO ${resource_name} 可用容量不足",
+      "description": "Metrics v2 集群可用空闲容量低于 10 GiB，请及时扩容或清理。",
+      "metric_name": "minio_cluster_capacity_usable_free_bytes_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 10737418240, "method": "<="}],
+      "group_algorithm": "min"
+    },
+    {
+      "name": "MinIO v3 可用容量不足",
+      "alert_name": "MinIO ${resource_name} 可用容量不足",
+      "description": "Metrics v3 集群可用空闲容量低于 10 GiB，请及时扩容或清理。",
+      "metric_name": "minio_cluster_health_capacity_usable_free_bytes_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 10737418240, "method": "<="}],
+      "group_algorithm": "min"
+    },
+    {
+      "name": "MinIO v2 请求积压",
+      "alert_name": "MinIO ${resource_name} S3 请求积压",
+      "description": "Metrics v2 等待处理的 S3 请求持续增加，服务可能过载。",
       "metric_name": "minio_s3_requests_waiting_total_gauge",
       "algorithm": "last_over_time",
-      "threshold": [
-        {
-          "level": "critical",
-          "value": 100,
-          "method": ">="
-        },
-        {
-          "level": "error",
-          "value": 50,
-          "method": ">="
-        },
-        {
-          "level": "warning",
-          "value": 20,
-          "method": ">="
-        }
-      ],
-      "group_algorithm": "avg"
+      "threshold": [{"level": "critical", "value": 100, "method": ">="}, {"level": "warning", "value": 20, "method": ">="}],
+      "group_algorithm": "sum"
+    },
+    {
+      "name": "MinIO v3 请求积压",
+      "alert_name": "MinIO ${resource_name} API 请求积压",
+      "description": "Metrics v3 等待处理的 API 请求持续增加，服务可能过载。",
+      "metric_name": "minio_api_requests_waiting_total_gauge",
+      "algorithm": "last_over_time",
+      "threshold": [{"level": "critical", "value": 100, "method": ">="}, {"level": "warning", "value": 20, "method": ">="}],
+      "group_algorithm": "sum"
+    },
+    {
+      "name": "MinIO v2 S3 5xx 错误",
+      "alert_name": "MinIO ${resource_name} S3 服务端错误",
+      "description": "Metrics v2 S3 5xx 错误速率大于零。",
+      "metric_name": "minio_s3_requests_5xx_errors_total_counter_rate",
+      "algorithm": "avg_over_time",
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}, {"level": "warning", "value": 0, "method": ">"}],
+      "group_algorithm": "sum"
+    },
+    {
+      "name": "MinIO v3 API 5xx 错误",
+      "alert_name": "MinIO ${resource_name} API 服务端错误",
+      "description": "Metrics v3 API 5xx 错误速率大于零。",
+      "metric_name": "minio_api_requests_5xx_errors_total_counter_rate",
+      "algorithm": "avg_over_time",
+      "threshold": [{"level": "critical", "value": 1, "method": ">="}, {"level": "warning", "value": 0, "method": ">"}],
+      "group_algorithm": "sum"
     }
   ]
 }

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -20,6 +20,7 @@ from apps.rpc.node_mgmt import NodeMgmt
 
 _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "default",
+    "join",
     "lower",
     "urlencode",
     "replace",
@@ -64,6 +65,8 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "ip_version",
     "jmx_url",
     "logical_instance_value",
+    "metric_extensions",
+    "metrics_api_version",
     "metrics_modules",
     "monitor_plugin_id",
     "namespace",
@@ -93,6 +96,7 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
     "send",
     "server",
     "server_url",
+    "scheme",
     "sslmode",
     "storage_instance_key",
     "timeout",

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
@@ -381,7 +381,9 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
               </Descriptions.Item>
               <Descriptions.Item label={t('common.description')}>
                 <div className="whitespace-pre-wrap break-words">
-                  {groupForm.description || '--'}
+                  {groupForm.display_description ||
+                    groupForm.description ||
+                    '--'}
                 </div>
               </Descriptions.Item>
             </Descriptions>

--- a/web/src/app/monitor/dashboards/objects/minio/config.ts
+++ b/web/src/app/monitor/dashboards/objects/minio/config.ts
@@ -12,7 +12,7 @@ const ERASURE_STATUS_ENUM = {
 
 /**
  * MinIO 专业盘：对象存储集群健康 + 可用容量 + 纠删组冗余 + S3 服务。
- * 当前 metrics.json 无站点复制指标；纠删组健康作为冗余代理，不虚构 replication 卡片。
+ * Metrics v3 查询在前，Metrics v2 通过 PromQL `or` 回退；两侧均使用真实指标名。
  */
 export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'minio',
@@ -28,7 +28,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '集群健康状态',
       description: '集群整体健康：1 健康、0 不健康。',
       unit: 'none',
-      query: 'max by (instance_id) (minio_cluster_health_status_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_cluster_erasure_set_overall_health_gauge{__$labels__}) or max by (instance_id) (minio_cluster_health_status_gauge{__$labels__})',
       color: '#27c274'
     },
     {
@@ -36,7 +37,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '纠删组状态',
       description: '纠删组（Erasure Set）健康状态。',
       unit: 'none',
-      query: 'min(minio_cluster_health_erasure_set_status_gauge{__$labels__}) by (instance_id)',
+      query:
+        'min by (instance_id) (minio_cluster_erasure_set_overall_health_gauge{__$labels__}) or min by (instance_id) (minio_cluster_health_erasure_set_status_gauge{__$labels__})',
       color: '#2f6bff'
     },
     {
@@ -44,7 +46,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '可用空闲容量',
       description: '集群可用逻辑空闲容量。',
       unit: 'bytes',
-      query: 'max by (instance_id) (minio_cluster_capacity_usable_free_bytes_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_cluster_health_capacity_usable_free_bytes_gauge{__$labels__}) or max by (instance_id) (minio_cluster_capacity_usable_free_bytes_gauge{__$labels__})',
       color: '#13c2c2'
     },
     {
@@ -52,7 +55,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '可用总容量',
       description: '纠删编码后的可用逻辑总容量。',
       unit: 'bytes',
-      query: 'max by (instance_id) (minio_cluster_capacity_usable_total_bytes_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_cluster_health_capacity_usable_total_bytes_gauge{__$labels__}) or max by (instance_id) (minio_cluster_capacity_usable_total_bytes_gauge{__$labels__})',
       color: '#2f6bff'
     },
     {
@@ -61,7 +65,7 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '已用可用容量占总可用容量的比例。',
       unit: 'percent',
       query:
-        'clamp_min(100 * (1 - minio_cluster_capacity_usable_free_bytes_gauge{__$labels__} / clamp_min(minio_cluster_capacity_usable_total_bytes_gauge{__$labels__}, 1)), 0)',
+        'clamp_min(100 * (1 - minio_cluster_health_capacity_usable_free_bytes_gauge{__$labels__} / clamp_min(minio_cluster_health_capacity_usable_total_bytes_gauge{__$labels__}, 1)), 0) or clamp_min(100 * (1 - minio_cluster_capacity_usable_free_bytes_gauge{__$labels__} / clamp_min(minio_cluster_capacity_usable_total_bytes_gauge{__$labels__}, 1)), 0)',
       color: '#ff8a1f'
     },
     {
@@ -69,7 +73,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '在线驱动器数',
       description: '当前在线可用存储驱动器数量。',
       unit: 'counts',
-      query: 'max by (instance_id) (minio_cluster_drive_online_total_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_cluster_health_drives_online_count_gauge{__$labels__}) or max by (instance_id) (minio_cluster_drive_online_total_gauge{__$labels__})',
       color: '#27c274'
     },
     {
@@ -77,7 +82,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '在线节点数',
       description: '当前在线服务器节点数。',
       unit: 'counts',
-      query: 'max by (instance_id) (minio_cluster_nodes_online_total_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_cluster_health_nodes_online_count_gauge{__$labels__}) or max by (instance_id) (minio_cluster_nodes_online_total_gauge{__$labels__})',
       color: '#597ef7'
     },
     {
@@ -85,7 +91,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '纠删组在线盘',
       description: '纠删组内在线驱动器数。',
       unit: 'counts',
-      query: 'min by (instance_id) (minio_cluster_health_erasure_set_online_drives_gauge{__$labels__})',
+      query:
+        'min by (instance_id) (minio_cluster_erasure_set_online_drives_count_gauge{__$labels__}) or min by (instance_id) (minio_cluster_health_erasure_set_online_drives_gauge{__$labels__})',
       color: '#8a5cff'
     },
     {
@@ -93,7 +100,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: 'S3 接收流量',
       description: 'S3 接收字节速率。',
       unit: 'byteps',
-      query: 'sum by (instance_id) (rate(minio_s3_traffic_received_bytes_counter{__$labels__}[__$window__]))',
+      query:
+        'sum by (instance_id) (rate(minio_api_requests_traffic_received_bytes_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_traffic_received_bytes_counter{__$labels__}[__$window__]))',
       color: '#2f6bff'
     },
     {
@@ -101,7 +109,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: 'S3 发送流量',
       description: 'S3 发送字节速率。',
       unit: 'byteps',
-      query: 'sum by (instance_id) (rate(minio_s3_traffic_sent_bytes_counter{__$labels__}[__$window__]))',
+      query:
+        'sum by (instance_id) (rate(minio_api_requests_traffic_sent_bytes_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_traffic_sent_bytes_counter{__$labels__}[__$window__]))',
       color: '#13c2c2'
     },
     {
@@ -109,7 +118,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '进行中的 S3 请求',
       description: '当前正在处理的入向 S3 请求数。',
       unit: 'counts',
-      query: 'sum by (instance_id) (minio_s3_requests_incoming_total_gauge{__$labels__})',
+      query:
+        'sum by (instance_id) (minio_api_requests_incoming_total_gauge{__$labels__}) or sum by (instance_id) (minio_s3_requests_incoming_total_gauge{__$labels__})',
       color: '#27c274'
     },
     {
@@ -117,7 +127,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '等待中的 S3 请求',
       description: '当前等待处理的 S3 请求数。',
       unit: 'counts',
-      query: 'sum by (instance_id) (minio_s3_requests_waiting_total_gauge{__$labels__})',
+      query:
+        'sum by (instance_id) (minio_api_requests_waiting_total_gauge{__$labels__}) or sum by (instance_id) (minio_s3_requests_waiting_total_gauge{__$labels__})',
       color: '#ff8a1f'
     },
     {
@@ -126,7 +137,16 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       description: '因认证失败被拒绝的 S3 请求速率。',
       unit: 'cps',
       query:
-        'sum by (instance_id) (rate(minio_s3_requests_rejected_auth_total_counter{__$labels__}[__$window__]))',
+        'sum by (instance_id) (rate(minio_api_requests_rejected_auth_total_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_requests_rejected_auth_total_counter{__$labels__}[__$window__]))',
+      color: '#ff4d4f'
+    },
+    {
+      name: 'minio_5xx_error_rate',
+      display_name: '5xx 错误速率',
+      description: '服务端错误请求速率，v3 优先并回退到 v2。',
+      unit: 'cps',
+      query:
+        'sum by (instance_id) (rate(minio_api_requests_5xx_errors_total_counter{__$labels__}[__$window__])) or sum by (instance_id) (rate(minio_s3_requests_5xx_errors_total_counter{__$labels__}[__$window__]))',
       color: '#ff4d4f'
     },
     {
@@ -134,7 +154,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '节点内存使用率',
       description: '节点内存使用率（取最大值以覆盖压力最高节点）。',
       unit: 'percent',
-      query: 'max by (instance_id) (minio_node_mem_used_perc_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_system_memory_used_perc_gauge{__$labels__}) or max by (instance_id) (minio_node_mem_used_perc_gauge{__$labels__})',
       color: '#8a5cff'
     },
     {
@@ -142,7 +163,8 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: '驱动器使用率峰值',
       description: '单盘使用率峰值。',
       unit: 'percent',
-      query: 'max by (instance_id) (minio_node_drive_perc_util_gauge{__$labels__})',
+      query:
+        'max by (instance_id) (minio_system_drive_perc_util_gauge{__$labels__}) or max by (instance_id) (minio_node_drive_perc_util_gauge{__$labels__})',
       color: '#ff8a1f'
     }
   ],
@@ -238,7 +260,7 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       guide: [
         {
           label: '冗余',
-          detail: '当前插件无站点复制指标；用在线盘/节点与纠删组在线盘观察冗余与成员健康。'
+          detail: '用在线盘、节点与纠删组在线盘观察集群冗余和成员健康。'
         }
       ],
       series: [
@@ -277,6 +299,13 @@ export const MINIO_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       series: [
         { metric: 'minio_s3_auth_reject_rate', label: '鉴权拒绝', color: '#ff4d4f', unit: 'cps' }
       ]
+    },
+    {
+      title: '服务端错误',
+      subtitle: 'S3/API 5xx 错误速率',
+      metric: 'minio_5xx_error_rate',
+      guide: [{ label: '5xx 错误', detail: '服务端内部错误速率，持续大于零需检查 MinIO 日志与节点健康。' }],
+      series: [{ metric: 'minio_5xx_error_rate', label: '5xx 错误', color: '#ff4d4f', unit: 'cps' }]
     }
   ],
   statusPanels: [],

--- a/web/src/app/monitor/hooks/integration/minio-config.ts
+++ b/web/src/app/monitor/hooks/integration/minio-config.ts
@@ -1,0 +1,187 @@
+interface MinioEditForm {
+  metrics_api_version?: 'v2' | 'v3';
+  scheme?: 'http' | 'https';
+  auth_type?: 'public' | 'bearer';
+  metric_extensions?: string[];
+  insecure_skip_verify?: boolean;
+}
+
+type MinioMetricsVersion = 'v2' | 'v3';
+type MinioAuthType = 'public' | 'bearer';
+
+interface MinioPrometheusConfig {
+  urls?: string[];
+  namepass?: string[];
+  namedrop?: string[];
+  bearer_token_string?: string;
+  insecure_skip_verify?: boolean;
+  tags?: Record<string, unknown>;
+}
+
+interface MinioChildConfig {
+  id?: string | number;
+  env_config?: Record<string, string>;
+  content?: { config?: MinioPrometheusConfig };
+}
+
+interface MinioPluginConfig {
+  child?: MinioChildConfig;
+}
+
+const V3_CORE_PATHS = [
+  'api/requests',
+  'cluster/health',
+  'cluster/erasure-set',
+  'cluster/usage/objects',
+  'system/cpu',
+  'system/memory',
+  'system/drive',
+  'system/process',
+  'system/network/internode'
+];
+
+const CORE_NAMEPASS = {
+  v2: [
+    'minio_cluster_capacity_*', 'minio_cluster_drive_*', 'minio_cluster_nodes_*',
+    'minio_cluster_health_*', 'minio_s3_requests_*', 'minio_s3_traffic_*',
+    'minio_node_cpu_*', 'minio_node_mem_*', 'minio_node_drive_*',
+    'minio_node_process_*', 'minio_node_file_descriptor_*',
+    'minio_inter_node_traffic_*'
+  ],
+  v3: [
+    'minio_cluster_health_*', 'minio_cluster_erasure_set_*',
+    'minio_cluster_usage_objects_*', 'minio_api_requests_*',
+    'minio_system_cpu_*', 'minio_system_memory_*', 'minio_system_drive_*',
+    'minio_system_process_*', 'minio_system_network_internode_*'
+  ]
+};
+
+const EXTENSION_NAMEPASS: Record<string, string[]> = {
+  bucket: ['minio_bucket_*', 'minio_cluster_usage_buckets_*'],
+  replication: ['minio_*replication*'],
+  lifecycle: ['minio_*ilm*', 'minio_*scanner*', 'minio_*heal*'],
+  integrations: [
+    'minio_audit_*', 'minio_cluster_audit_*', 'minio_cluster_notify_*',
+    'minio_cluster_webhook_*', 'minio_notify_*', 'minio_notification_*',
+    'minio_logger_webhook_*'
+  ],
+  security: ['minio_cluster_iam_*', 'minio_cluster_kms_*']
+};
+
+function isMetricsVersion(value: unknown): value is MinioMetricsVersion {
+  return value === 'v2' || value === 'v3';
+}
+
+function isAuthType(value: unknown): value is MinioAuthType {
+  return value === 'public' || value === 'bearer';
+}
+
+function inferExtensions(config: MinioPrometheusConfig, version: MinioMetricsVersion): string[] {
+  const saved = config?.tags?.minio_metric_extensions;
+  if (typeof saved === 'string') {
+    return saved.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+  const urls = config.urls?.filter((url): url is string => typeof url === 'string') ?? [];
+  return version === 'v2' && urls.some((url) => url.includes('/v2/metrics/bucket'))
+    ? ['bucket']
+    : [];
+}
+
+export function getMinioEditCompatibilityValues(original: MinioPluginConfig): Pick<
+  MinioEditForm,
+  'metrics_api_version' | 'auth_type' | 'metric_extensions'
+> {
+  const config = original.child?.content?.config ?? {};
+  const firstUrl = config.urls?.[0];
+  const savedVersion = config.tags?.minio_metrics_version;
+  const inferredVersion = typeof firstUrl === 'string' && firstUrl.includes('/metrics/v3/') ? 'v3' : 'v2';
+  const version = isMetricsVersion(savedVersion) ? savedVersion : inferredVersion;
+  const savedAuth = config.tags?.minio_auth_type;
+  const auth = isAuthType(savedAuth) ? savedAuth : config.bearer_token_string ? 'bearer' : 'public';
+  return {
+    metrics_api_version: version,
+    auth_type: auth,
+    metric_extensions: inferExtensions(config, version)
+  };
+}
+
+/** Rebuild every coupled MinIO field when an existing rendered config is edited. */
+export function applyMinioEditConfig(
+  result: MinioPluginConfig,
+  original: MinioPluginConfig,
+  form: MinioEditForm
+): MinioPluginConfig {
+  const originalConfig = original.child?.content?.config ?? {};
+  const targetChild = result.child;
+  const targetConfig = targetChild?.content?.config;
+  const firstUrl = originalConfig.urls?.[0];
+  if (!targetChild || !targetConfig || typeof firstUrl !== 'string') return result;
+
+  let endpoint: URL;
+  try {
+    endpoint = new URL(firstUrl);
+  } catch {
+    return result;
+  }
+  const currentVersion = firstUrl.includes('/metrics/v3/') ? 'v3' : 'v2';
+  const savedVersion = originalConfig.tags?.minio_metrics_version;
+  const version = form.metrics_api_version ?? (isMetricsVersion(savedVersion) ? savedVersion : currentVersion);
+  const scheme = form.scheme ?? (endpoint.protocol === 'https:' ? 'https' : 'http');
+  const savedAuth = originalConfig.tags?.minio_auth_type;
+  const auth = form.auth_type ?? (isAuthType(savedAuth)
+    ? savedAuth
+    : originalConfig.bearer_token_string ? 'bearer' : 'public');
+  const extensions = form.metric_extensions ?? inferExtensions(originalConfig, version);
+  const base = `${scheme}://${endpoint.host}`;
+
+  if (version === 'v3') {
+    targetConfig.urls = V3_CORE_PATHS.map((path) => `${base}/minio/metrics/v3/${path}`);
+    if (extensions.includes('bucket')) targetConfig.urls.push(`${base}/minio/metrics/v3/cluster/usage/buckets`);
+    if (extensions.includes('replication')) targetConfig.urls.push(`${base}/minio/metrics/v3/replication`);
+    if (extensions.includes('lifecycle')) {
+      targetConfig.urls.push(`${base}/minio/metrics/v3/ilm`, `${base}/minio/metrics/v3/scanner`);
+    }
+    if (extensions.includes('integrations')) {
+      targetConfig.urls.push(
+        `${base}/minio/metrics/v3/audit`,
+        `${base}/minio/metrics/v3/notification`,
+        `${base}/minio/metrics/v3/logger/webhook`
+      );
+    }
+    if (extensions.includes('security')) targetConfig.urls.push(`${base}/minio/metrics/v3/cluster/iam`);
+  } else {
+    targetConfig.urls = [`${base}/minio/v2/metrics/cluster`];
+    if (extensions.includes('bucket') || extensions.includes('replication')) {
+      targetConfig.urls.push(`${base}/minio/v2/metrics/bucket`);
+    }
+    targetConfig.urls.push(`${base}/minio/v2/metrics/resource`);
+  }
+
+  targetConfig.namepass = [
+    ...CORE_NAMEPASS[version],
+    ...extensions.flatMap((extension) => EXTENSION_NAMEPASS[extension] || [])
+  ];
+  targetConfig.namedrop = ['*_ttfb_seconds_distribution*'];
+  targetConfig.insecure_skip_verify = form.insecure_skip_verify ?? originalConfig.insecure_skip_verify ?? false;
+  targetConfig.tags = {
+    ...(targetConfig.tags || {}),
+    minio_metrics_version: version,
+    minio_auth_type: auth
+  };
+  if (extensions.length > 0) {
+    targetConfig.tags.minio_metric_extensions = extensions.join(',');
+  } else {
+    delete targetConfig.tags.minio_metric_extensions;
+  }
+
+  const configId = String(targetChild.id || '').toUpperCase();
+  const tokenKey = `BEARER_TOKEN__${configId}`;
+  targetChild.env_config = { ...(targetChild.env_config || {}) };
+  if (auth === 'bearer') {
+    targetConfig.bearer_token_string = `\${${tokenKey}}`;
+  } else {
+    delete targetConfig.bearer_token_string;
+    delete targetChild.env_config[tokenKey];
+  }
+  return result;
+}

--- a/web/src/app/monitor/hooks/integration/minio-config.ts
+++ b/web/src/app/monitor/hooks/integration/minio-config.ts
@@ -46,7 +46,7 @@ const CORE_NAMEPASS = {
     'minio_cluster_health_*', 'minio_s3_requests_*', 'minio_s3_traffic_*',
     'minio_node_cpu_*', 'minio_node_mem_*', 'minio_node_drive_*',
     'minio_node_process_*', 'minio_node_file_descriptor_*',
-    'minio_inter_node_traffic_*'
+    'minio_inter_node_traffic_*', 'minio_node_scanner_*'
   ],
   v3: [
     'minio_cluster_health_*', 'minio_cluster_erasure_set_*',

--- a/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
+++ b/web/src/app/monitor/hooks/integration/usePluginFromJson.tsx
@@ -7,6 +7,7 @@ import {
   splitWebsiteRequestUrl,
   validateWebsiteRequestHeaders
 } from './http-request-config';
+import { applyMinioEditConfig, getMinioEditCompatibilityValues } from './minio-config';
 import { resolveSnmpInterfaceFilterMode } from './snmpInterfaceFilterMode';
 import useIntegrationApi from '@/app/monitor/api/integration';
 import useApiClient from '@/utils/request';
@@ -416,6 +417,9 @@ export const usePluginFromJson = () => {
             if (formFields?.some((field: any) => field?.name === 'interface_filter_mode')) {
               formValues.interface_filter_mode = resolveSnmpInterfaceFilterMode(formValues);
             }
+            if (config.instance_type === 'minio') {
+              Object.assign(formValues, getMinioEditCompatibilityValues(apiData));
+            }
             if (config.instance_type === 'web') {
               const requestUrl = apiData?.child?.content?.config?.urls?.[0];
               if (requestUrl) {
@@ -696,6 +700,9 @@ export const usePluginFromJson = () => {
                 delete childEnvConfig[passwordEnvKey];
                 delete childEnvConfig[bearerEnvKey];
               }
+            }
+            if (config.instance_type === 'minio') {
+              applyMinioEditConfig(result, configForm, filledFormData);
             }
             // 如果有 base，统一同步 child.env_config 到 base.env_config
             if (result.base && result.child?.env_config) {

--- a/web/src/app/monitor/types/integration.ts
+++ b/web/src/app/monitor/types/integration.ts
@@ -46,6 +46,7 @@ export interface MetricInfo {
   data_type?: string;
   unit?: string;
   description?: string;
+  display_description?: string;
   dimensions?: string[];
   is_ifmib?: boolean;
 }


### PR DESCRIPTION
## 变更说明

- 基于 Telegraf `inputs.prometheus` 支持 MinIO Metrics v2/v3，新增 HTTPS、Bearer Token、TLS 校验与可多选扩展指标配置
- 新建默认 v3 + HTTPS + Bearer；旧配置兼容回显并保持 v2 + HTTP + public 三端点，可显式取消 Bucket 扩展
- 补齐 v2/v3 指标目录、最低支持版本、双语指南、仪表盘与告警策略，并通过 `namepass` 控制实际写入指标族
- Token 仅通过采集器环境变量注入，不写入 Telegraf TOML 或日志
- 复审后删除被 MinIO 专用兼容逻辑覆盖的通用编辑转换、无效防御分支、未登记的隐藏采集，以及无法通过 `namepass` 的悬空指标登记

## 验证

- MinIO 配置/指标合同：22 passed（v2/v3 × HTTP/HTTPS × public/bearer × core/extended，并验证每个登记指标至少能通过一种受支持 `namepass`）
- 独立模板渲染矩阵：16 passed
- 前端 MinIO 编辑合同：passed（legacy v2/public/bucket 回显、三端点保持、显式清空、畸形 URL）
- MinIO 相关 ESLint：passed
- JSON/YAML 与指标合同：passed（55 metrics、12 policies）
- `git diff --check`：passed

## 基线说明

- server 全量 `make test` 在收集 20,481 项时因 enterprise apps 未注册产生 449 个任务外 collection errors
- web 全量 `pnpm lint` 有 39 个任务外 APM/CMDB 等既有错误；本次文件定向 ESLint 通过

## 提交范围

已检查暂存 diff、相对 `tencent-upstream/master` 的完整 diff 和未跟踪文件。PR 仅包含 14 个 MinIO 必需生产文件及共用渲染/编辑链路改动，并保持单一 commit。两份本地测试、handoff 与本地依赖链接均未提交。