### PR TITLE
fix(监控): 修复 IF-MIB 模板前导空白渲染

### DIFF
--- a/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
+++ b/server/apps/monitor/management/commands/patch_snmp_interface_filters.py
@@ -22,6 +22,7 @@ from apps.monitor.utils.snmp_interface_template import (
     PUBLIC_IFMIB_TABLE_OIDS,
     get_common_ifmib_table,
     has_managed_ifmib_section,
+    is_ambiguous_ifmib_table,
     is_public_ifmib_table,
 )
 from apps.rpc.node_mgmt import NodeMgmt
@@ -335,13 +336,7 @@ def patch_child_content_dict(content: dict, overwrite_default: bool = False) -> 
     for config in snmp_configs:
         _validate_snmp_filter_structure(config)
         tables = _snmp_tables(config)
-        public_tables = [table for table in tables if is_public_ifmib_table(table)]
-        if any(
-            table.get("name") == common_table.get("name")
-            and table.get("oid") in (None, "")
-            and table not in public_tables
-            for table in tables
-        ):
+        if any(is_ambiguous_ifmib_table(table) and table.get("name") == common_table.get("name") for table in tables):
             raise ValueError("ambiguous interface table: public IF-MIB identity cannot be proven")
 
     public_owners = [config for config in snmp_configs if _public_tables_in_config(config)]

--- a/server/apps/monitor/utils/snmp_interface_template.py
+++ b/server/apps/monitor/utils/snmp_interface_template.py
@@ -29,6 +29,17 @@ FILTER_MARKER_END = "# ---- BK-Lite SNMP interface dimension filters (end) ----"
 
 IFMIB_MARKER_BEGIN = "# ---- BK-Lite core IF-MIB collection (begin) ----"
 IFMIB_MARKER_END = "# ---- BK-Lite core IF-MIB collection (end) ----"
+
+
+def _marker_line_pattern(marker: str) -> re.Pattern[str]:
+    """只匹配独占一行的 BK-Lite 保留标记。"""
+    return re.compile(rf"^[ \t]*{re.escape(marker)}[ \t]*(?:\r?\n|\Z)", re.MULTILINE)
+
+
+IFMIB_MARKER_BEGIN_LINE_RE = _marker_line_pattern(IFMIB_MARKER_BEGIN)
+IFMIB_MARKER_END_LINE_RE = _marker_line_pattern(IFMIB_MARKER_END)
+FILTER_MARKER_BEGIN_LINE_RE = _marker_line_pattern(FILTER_MARKER_BEGIN)
+FILTER_MARKER_END_LINE_RE = _marker_line_pattern(FILTER_MARKER_END)
 # 编辑走 toml↔dict 会丢掉注释标记；用该旗标在写回时恢复关闭态，避免对账误回填。
 BK_IFMIB_CLOSED_FLAG = "_bk_ifmib_closed"
 COMMON_IFMIB_TABLE_PATH = Path(__file__).resolve().parents[1] / "support-files/plugins/Telegraf/snmp/_common/ifmib.table.toml"
@@ -45,8 +56,7 @@ PUBLIC_IFDESCR_OIDS = frozenset({"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.1"
 
 def has_managed_ifmib_section(raw_content: str | None) -> bool:
     """渲染后的 child 是否包含公共 IF-MIB 管理区间（含 enable_ifmib=false 的空区间）。"""
-    text = raw_content or ""
-    return IFMIB_MARKER_BEGIN in text and IFMIB_MARKER_END in text
+    return _has_canonical_ifmib_marker_section(raw_content or "")
 
 
 def _iter_content_snmp_inputs(content: dict) -> list[dict]:
@@ -94,6 +104,7 @@ def preserve_closed_ifmib_markers(toml_text: str | None, content: dict | None) -
         return text
     if has_managed_ifmib_section(text):
         return text
+    text = _remove_ifmib_marker_lines(text)
     return f"{IFMIB_MARKER_BEGIN}\n{IFMIB_MARKER_END}\n{text}"
 
 
@@ -126,6 +137,16 @@ def is_public_ifmib_table(table: dict[str, Any]) -> bool:
     return isinstance(fields, list) and any(
         isinstance(field, dict) and field.get("name") == "ifDescr" and field.get("oid") in PUBLIC_IFDESCR_OIDS
         for field in fields
+    )
+
+
+def is_ambiguous_ifmib_table(table: dict[str, Any]) -> bool:
+    """识别既无法证明为公共 IF-MIB、也没有私有 OID 身份的 interface 表。"""
+    if is_public_ifmib_table(table) or table.get("name") != "interface" or table.get("oid") not in (None, ""):
+        return False
+    fields = table.get("field")
+    return not isinstance(fields, list) or not any(
+        isinstance(field, dict) and field.get("oid") not in (None, "") for field in fields
     )
 
 
@@ -371,7 +392,7 @@ IFMIB_HINT_RE = re.compile(
 )
 TABLE_BLOCK_RE = re.compile(
     r"^[ \t]*\[\[inputs\.snmp\.table\]\][^\n]*\n.*?"
-    r"(?=^[ \t]*\[\[(?!inputs\.snmp\.table\.field\]\])|\Z)",
+    r"(?=^[ \t]*(?:\[(?!\[)|\[\[(?!inputs\.snmp\.table\.field\]\]))|\Z)",
     re.MULTILINE | re.DOTALL,
 )
 FIELD_BLOCK_RE = re.compile(
@@ -379,13 +400,170 @@ FIELD_BLOCK_RE = re.compile(
     re.MULTILINE | re.DOTALL,
 )
 PROCESSORS_RE = re.compile(r"^\[\[processors\.", re.MULTILINE)
-FILTER_BLOCK_RE = re.compile(
-    re.escape(FILTER_MARKER_BEGIN) + r".*?" + re.escape(FILTER_MARKER_END) + r"\n?",
-    re.DOTALL,
+FILTER_TABLE_BLOCK_RE = re.compile(
+    r"^[ \t]*\[inputs\.snmp\.(?:tagpass|tagdrop)\][^\n]*\n.*?(?=^[ \t]*\[|\Z)",
+    re.MULTILINE | re.DOTALL,
 )
 TAGEXCLUDE_IFTYPE_RE = re.compile(r'^\s*tagexclude\s*=\s*\["ifType"\]\s*\n', re.MULTILINE)
 INPUT_TAGEXCLUDE_KEY_RE = re.compile(r"^[ \t]*tagexclude\s*=", re.MULTILINE)
-SNMP_INPUT_RE = re.compile(r"^\s*\[\[inputs\.snmp\]\]", re.MULTILINE)
+SNMP_INPUT_RE = re.compile(r"^[ \t]*\[\[inputs\.snmp\]\]", re.MULTILINE)
+
+
+def _toml_non_string_view(text: str) -> str:
+    """屏蔽 TOML 字符串，同时保留注释、原始位置与换行。"""
+    chars = list(text)
+    index = 0
+    quote = ""
+    multiline = False
+    while index < len(text):
+        if quote:
+            delimiter = quote * (3 if multiline else 1)
+            if text.startswith(delimiter, index):
+                delimiter_length = len(delimiter)
+                if multiline:
+                    while index + delimiter_length < len(text) and text[index + delimiter_length] == quote:
+                        delimiter_length += 1
+                for offset in range(delimiter_length):
+                    chars[index + offset] = " "
+                index += delimiter_length
+                quote = ""
+                multiline = False
+                continue
+            if quote == '"' and text[index] == "\\":
+                chars[index] = " "
+                index += 1
+                if index < len(text):
+                    if text[index] not in "\r\n":
+                        chars[index] = " "
+                    index += 1
+                continue
+            if text[index] not in "\r\n":
+                chars[index] = " "
+            index += 1
+            continue
+
+        if text[index] == "#":
+            while index < len(text) and text[index] not in "\r\n":
+                index += 1
+            continue
+        if text[index] in {'"', "'"}:
+            quote = text[index]
+            multiline = text.startswith(quote * 3, index)
+            delimiter_length = 3 if multiline else 1
+            for offset in range(delimiter_length):
+                chars[index + offset] = " "
+            index += delimiter_length
+            continue
+        index += 1
+    return "".join(chars)
+
+
+def _toml_structural_view(text: str) -> str:
+    """屏蔽 TOML 字符串和注释，同时保留原始位置与换行。"""
+    chars = list(_toml_non_string_view(text))
+    index = 0
+    while index < len(chars):
+        if chars[index] == "#":
+            while index < len(chars) and chars[index] not in "\r\n":
+                chars[index] = " "
+                index += 1
+            continue
+        index += 1
+    return "".join(chars)
+
+
+def _non_string_spans(pattern: re.Pattern[str], text: str) -> list[tuple[int, int]]:
+    return [match.span() for match in pattern.finditer(_toml_non_string_view(text))]
+
+
+def _structural_spans(pattern: re.Pattern[str], text: str) -> list[tuple[int, int]]:
+    return [match.span() for match in pattern.finditer(_toml_structural_view(text))]
+
+
+def _first_structural_raw_match(pattern: re.Pattern[str], text: str) -> re.Match[str] | None:
+    structural = _toml_structural_view(text)
+    return next((match for match in pattern.finditer(text) if structural[match.start() : match.end()].strip()), None)
+
+
+def _replace_structural_blocks(
+    pattern: re.Pattern[str],
+    text: str,
+    replace: Any,
+) -> str:
+    return _replace_spans(text, _structural_spans(pattern, text), replace)
+
+
+def _replace_spans(
+    text: str,
+    spans: list[tuple[int, int]],
+    replace: Any,
+) -> str:
+    if not spans:
+        return text
+    chunks: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        chunks.append(text[cursor:start])
+        chunks.append(replace(text[start:end]))
+        cursor = end
+    chunks.append(text[cursor:])
+    return "".join(chunks)
+
+
+def _marker_tokens(
+    text: str,
+    begin_pattern: re.Pattern[str],
+    end_pattern: re.Pattern[str],
+) -> list[tuple[str, int, int]]:
+    """在字符串外提取精确 marker 行，返回保持原始 offset 的有序 token。"""
+    view = _toml_non_string_view(text)
+    tokens = [
+        ("begin", *match.span())
+        for match in begin_pattern.finditer(text)
+        if view[match.start() : match.end()] == match.group(0)
+    ]
+    tokens.extend(
+        ("end", *match.span())
+        for match in end_pattern.finditer(text)
+        if view[match.start() : match.end()] == match.group(0)
+    )
+    return sorted(tokens, key=lambda token: token[1])
+
+
+def _merge_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _remove_marker_lines(
+    text: str,
+    begin_pattern: re.Pattern[str],
+    end_pattern: re.Pattern[str],
+) -> str:
+    spans = [(start, end) for _, start, end in _marker_tokens(text, begin_pattern, end_pattern)]
+    return _replace_spans(text, spans, lambda _: "")
+
+
+def _strip_owned_marker_sections(
+    text: str,
+    begin_pattern: re.Pattern[str],
+    end_pattern: re.Pattern[str],
+    owns_payload: Any,
+) -> str:
+    """删除可证明归属的相邻 marker 块；畸形序列只删 marker 行，绝不跨区吞业务内容。"""
+    tokens = _marker_tokens(text, begin_pattern, end_pattern)
+    owned_spans = [
+        (left[1], right[2])
+        for left, right in zip(tokens, tokens[1:])
+        if left[0] == "begin" and right[0] == "end" and owns_payload(text[left[2] : right[1]])
+    ]
+    marker_spans = [(start, end) for _, start, end in tokens]
+    return _replace_spans(text, _merge_spans([*owned_spans, *marker_spans]), lambda _: "")
 
 
 def get_common_ifmib_table_block() -> str:
@@ -431,43 +609,122 @@ def get_ui_advanced_panel() -> dict[str, Any]:
 
 
 def has_interface_collection(template_content: str) -> bool:
-    return bool(INTERFACE_HINT_RE.search(template_content or ""))
+    return _first_structural_raw_match(INTERFACE_HINT_RE, template_content or "") is not None
 
 
 def _table_block_header_value(table_text: str, key: str) -> str | None:
-    header = table_text.split("[[inputs.snmp.table.field]]", 1)[0]
-    match = re.search(rf'^\s*{re.escape(key)}\s*=\s*"([^"]+)"\s*$', header, re.MULTILINE)
+    fields = _structural_spans(FIELD_BLOCK_RE, table_text)
+    header = table_text[: fields[0][0]] if fields else table_text
+    pattern = re.compile(rf'^\s*{re.escape(key)}\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
+    match = _first_structural_raw_match(pattern, header)
     return match.group(1) if match else None
 
 
 def is_public_ifmib_table_block(table_text: str) -> bool:
     """渲染文本层面的公共表判定，与 is_public_ifmib_table 的 OID 口径保持一致。"""
+    try:
+        tables = _get_snmp_input_tables(tomllib.loads(f"[[inputs.snmp]]\n{table_text}"))
+    except tomllib.TOMLDecodeError:
+        tables = []
+    if len(tables) == 1:
+        return is_public_ifmib_table(tables[0])
+
     table_oid = _table_block_header_value(table_text, "oid")
     if table_oid in PUBLIC_IFMIB_TABLE_OIDS:
         return True
     if table_oid not in (None, "") or _table_block_header_value(table_text, "name") != "interface":
         return False
     return any(
-        re.search(rf'^\s*oid\s*=\s*"{re.escape(ifdescr_oid)}"\s*$', table_text, re.MULTILINE)
+        _first_structural_raw_match(
+            re.compile(rf'^\s*oid\s*=\s*"{re.escape(ifdescr_oid)}"\s*$', re.MULTILINE),
+            table_text,
+        )
         for ifdescr_oid in PUBLIC_IFDESCR_OIDS
     )
+
+
+def _strip_ifmib_jinja_wrapper(payload: str) -> str | None:
+    """剥离本模块生成的 IF-MIB 外层 Jinja；其他 Jinja 形态不视为模块所有。"""
+    normalized = payload.replace("\r\n", "\n").strip()
+    opening = "{% if enable_ifmib | default(true) %}"
+    closing = "{% endif %}"
+    if not normalized.startswith(f"{opening}\n") or not normalized.endswith(f"\n{closing}"):
+        return None
+    return normalized[len(opening) : -len(closing)].strip()
+
+
+def _is_owned_ifmib_payload(payload: str) -> bool:
+    """只认空关闭块或只含一张公共表的 BK-Lite 管理内容。"""
+    candidate = payload.strip()
+    if not candidate:
+        return True
+    without_wrapper = _strip_ifmib_jinja_wrapper(payload)
+    if without_wrapper is not None:
+        candidate = without_wrapper
+    elif "{%" in candidate or "{{" in candidate:
+        return False
+
+    try:
+        document = tomllib.loads(f"[[inputs.snmp]]\n{candidate}\n")
+    except tomllib.TOMLDecodeError:
+        return False
+    snmp_inputs = document.get("inputs", {}).get("snmp", [])
+    if not isinstance(snmp_inputs, list) or len(snmp_inputs) != 1:
+        return False
+    snmp_input = snmp_inputs[0]
+    if not isinstance(snmp_input, dict) or set(snmp_input) != {"table"}:
+        return False
+    tables = snmp_input.get("table")
+    return isinstance(tables, list) and len(tables) == 1 and is_public_ifmib_table(tables[0])
+
+
+def _has_canonical_ifmib_marker_section(text: str) -> bool:
+    tokens = _marker_tokens(text, IFMIB_MARKER_BEGIN_LINE_RE, IFMIB_MARKER_END_LINE_RE)
+    return (
+        len(tokens) == 2
+        and tokens[0][0] == "begin"
+        and tokens[1][0] == "end"
+        and _is_owned_ifmib_payload(text[tokens[0][2] : tokens[1][1]])
+    )
+
+
+def _remove_ifmib_marker_lines(text: str) -> str:
+    return _remove_marker_lines(text, IFMIB_MARKER_BEGIN_LINE_RE, IFMIB_MARKER_END_LINE_RE)
 
 
 def _strip_ifmib_tables(template_content: str) -> str:
     """删除各厂商复制的 IF-MIB table，绝不删除私有 OID table。"""
 
-    def strip_table(table_match: re.Match[str]) -> str:
-        table_text = table_match.group(0)
+    def strip_table(table_text: str) -> str:
         return "" if is_public_ifmib_table_block(table_text) else table_text
 
-    text = TABLE_BLOCK_RE.sub(strip_table, template_content)
-    text = re.sub(
-        re.escape(IFMIB_MARKER_BEGIN) + r".*?" + re.escape(IFMIB_MARKER_END) + r"\n?",
-        "",
-        text,
-        flags=re.DOTALL,
-    )
-    return re.sub(r"\n{3,}", "\n\n", text)
+    tokens = _marker_tokens(template_content, IFMIB_MARKER_BEGIN_LINE_RE, IFMIB_MARKER_END_LINE_RE)
+    owned_spans = [
+        (left[1], right[2])
+        for left, right in zip(tokens, tokens[1:])
+        if left[0] == "begin"
+        and right[0] == "end"
+        and _is_owned_ifmib_payload(template_content[left[2] : right[1]])
+    ]
+    if len(tokens) == 2 and len(owned_spans) == 1:
+        start, end = owned_spans[0]
+        # 该块由 ensure_core_network_ifmib_jinja 以一个空行作为边界追加；删除旧块时
+        # 一并吞掉紧邻两侧的整行空白，再由追加路径重建固定边界，避免重复渲染累积。
+        leading = re.search(r"(?:^|\r?\n)(?:[ \t]*\r?\n)*\Z", template_content[:start])
+        trailing = re.match(r"(?:[ \t]*\r?\n)*", template_content[end:])
+        leading_newline_length = 2 if leading.group(0).startswith("\r\n") else int(leading.group(0).startswith("\n"))
+        start = leading.start() + leading_newline_length
+        end += trailing.end()
+        text = _replace_spans(template_content, [(start, end)], lambda _: "")
+    else:
+        text = _strip_owned_marker_sections(
+            template_content,
+            IFMIB_MARKER_BEGIN_LINE_RE,
+            IFMIB_MARKER_END_LINE_RE,
+            _is_owned_ifmib_payload,
+        )
+    text = _replace_structural_blocks(TABLE_BLOCK_RE, text, strip_table)
+    return text
 
 
 def should_manage_core_network_ifmib(context: dict[str, Any]) -> bool:
@@ -511,27 +768,28 @@ def ensure_public_ifmib_input_tagexclude(
             return template_content
 
     text = template_content or ""
-    headers = list(SNMP_INPUT_RE.finditer(text))
+    headers = _structural_spans(SNMP_INPUT_RE, text)
     if not headers:
         return text
 
     insert_positions: list[tuple[int, str]] = []
-    for index, header in enumerate(headers):
-        segment_end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
-        segment = text[header.start() : segment_end]
-        if not any(is_public_ifmib_table_block(match.group(0)) for match in TABLE_BLOCK_RE.finditer(segment)):
+    for index, (header_start, _) in enumerate(headers):
+        segment_end = headers[index + 1][0] if index + 1 < len(headers) else len(text)
+        segment = text[header_start:segment_end]
+        if not any(is_public_ifmib_table_block(segment[start:end]) for start, end in _structural_spans(TABLE_BLOCK_RE, segment)):
             continue
         header_line_end = segment.find("\n")
         if header_line_end == -1:
             continue
         body = segment[header_line_end + 1 :]
-        first_section = re.search(r"^[ \t]*\[", body, re.MULTILINE)
-        input_level = body[: first_section.start()] if first_section else body
-        if INPUT_TAGEXCLUDE_KEY_RE.search(input_level):
+        section_spans = _structural_spans(re.compile(r"^[ \t]*\[", re.MULTILINE), body)
+        input_level = body[: section_spans[0][0]] if section_spans else body
+        if _structural_spans(INPUT_TAGEXCLUDE_KEY_RE, input_level):
             continue
         indent_match = re.search(r"^([ \t]+)\S", input_level, re.MULTILINE)
         indent = indent_match.group(1) if indent_match else "    "
-        insert_positions.append((header.start() + header_line_end + 1, f'{indent}tagexclude = ["ifType"]\n'))
+        newline = "\r\n" if segment[: header_line_end + 1].endswith("\r\n") else "\n"
+        insert_positions.append((header_start + header_line_end + 1, f'{indent}tagexclude = ["ifType"]{newline}'))
 
     if not insert_positions:
         return text
@@ -542,7 +800,7 @@ def ensure_public_ifmib_input_tagexclude(
 
 def validate_rendered_core_network_ifmib(template_content: str, context: dict[str, Any]) -> None:
     """在下发前校验最终 SNMP TOML，拒绝公共 IF-MIB 与厂商配置的结构冲突。"""
-    if not should_manage_core_network_ifmib(context) or not SNMP_INPUT_RE.search(template_content):
+    if not should_manage_core_network_ifmib(context) or not _structural_spans(SNMP_INPUT_RE, template_content):
         return
 
     try:
@@ -554,8 +812,14 @@ def validate_rendered_core_network_ifmib(template_content: str, context: dict[st
     snmp_inputs = config.get("inputs", {}).get("snmp", []) if isinstance(config.get("inputs"), dict) else []
     if isinstance(snmp_inputs, dict):
         snmp_inputs = [snmp_inputs]
-    interface_tables = [table for table in _get_snmp_input_tables(config) if is_public_ifmib_table(table)]
+    tables = _get_snmp_input_tables(config)
     enabled = context.get("enable_ifmib", True) is not False
+    if any(is_ambiguous_ifmib_table(table) for table in tables):
+        raise ValidationAppException(
+            "SNMP IF-MIB 配置冲突：存在无 OID 的 interface 表，公共 IF-MIB 身份无法证明"
+        )
+
+    interface_tables = [table for table in tables if is_public_ifmib_table(table)]
     if enabled:
         if len(interface_tables) != 1:
             raise ValidationAppException(
@@ -604,23 +868,66 @@ def restore_managed_ifmib_markers(template_content: str) -> str:
     text = template_content or ""
     if has_managed_ifmib_section(text):
         return text
-    headers = list(SNMP_INPUT_RE.finditer(text))
+    headers = _structural_spans(SNMP_INPUT_RE, text)
     wraps: list[tuple[int, int]] = []
-    for index, header in enumerate(headers):
-        segment_end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
-        segment = text[header.start() : segment_end]
+    for index, (header_start, _) in enumerate(headers):
+        segment_end = headers[index + 1][0] if index + 1 < len(headers) else len(text)
+        segment = text[header_start:segment_end]
         public_blocks = [
-            match
-            for match in TABLE_BLOCK_RE.finditer(segment)
-            if is_public_ifmib_table_block(match.group(0))
+            span
+            for span in _structural_spans(TABLE_BLOCK_RE, segment)
+            if is_public_ifmib_table_block(segment[span[0] : span[1]])
         ]
         if not public_blocks:
             continue
-        wraps.append((header.start() + public_blocks[0].start(), header.start() + public_blocks[-1].end()))
+        wraps.append((header_start + public_blocks[0][0], header_start + public_blocks[-1][1]))
     for start, end in reversed(wraps):
         chunk = text[start:end].strip("\n")
         text = f"{text[:start]}{IFMIB_MARKER_BEGIN}\n{chunk}\n{IFMIB_MARKER_END}\n{text[end:]}"
     return text
+
+
+def _restore_managed_filter_markers_after_roundtrip(
+    template_content: str,
+    *,
+    managed_filter_provenance: dict[str, dict[str, list[str]]] | None,
+    owner_index: int,
+) -> str:
+    """仅为往返前可证明受管的接口过滤恢复注释标记。"""
+    text = template_content or ""
+    if not managed_filter_provenance or _has_canonical_filter_marker_section(text):
+        return text
+
+    headers = _structural_spans(SNMP_INPUT_RE, text)
+    if owner_index >= len(headers):
+        return text
+    header_start = headers[owner_index][0]
+    segment_end = headers[owner_index + 1][0] if owner_index + 1 < len(headers) else len(text)
+    segment = text[header_start:segment_end]
+    if sum(
+        is_public_ifmib_table_block(candidate[start:end])
+        for input_index, (input_start, _) in enumerate(headers)
+        for candidate in [text[input_start : headers[input_index + 1][0] if input_index + 1 < len(headers) else len(text)]]
+        for start, end in _structural_spans(TABLE_BLOCK_RE, candidate)
+    ) != 1:
+        return text
+    matched: dict[str, tuple[int, int]] = {}
+    for start, end in _structural_spans(FILTER_TABLE_BLOCK_RE, segment):
+        filters = _parse_owned_filter_payload(segment[start:end])
+        if not filters or len(filters) != 1:
+            continue
+        kind, values = next(iter(filters.items()))
+        if managed_filter_provenance.get(kind) == values:
+            matched[kind] = (header_start + start, header_start + end)
+    if set(matched) != set(managed_filter_provenance):
+        return text
+
+    start = min(span[0] for span in matched.values())
+    end = max(span[1] for span in matched.values())
+    chunk = text[start:end].strip("\n")
+    if _parse_owned_filter_payload(chunk) != managed_filter_provenance:
+        return text
+    return f"{text[:start]}{FILTER_MARKER_BEGIN}\n{chunk}\n{FILTER_MARKER_END}\n{text[end:]}"
 
 
 def isolate_snmp_interface_tagpass(
@@ -639,6 +946,7 @@ def isolate_snmp_interface_tagpass(
         if not should_manage_core_network_ifmib(context) or context.get("enable_ifmib", True) is False:
             return template_content
 
+    managed_filter_source = _canonical_managed_filter_provenance(template_content)
     document = toml.loads(template_content)
     snmp_inputs = document.get("inputs", {}).get("snmp", [])
     if isinstance(snmp_inputs, dict):
@@ -679,13 +987,23 @@ def isolate_snmp_interface_tagpass(
 
         if remaining_tables or has_non_tag_fields:
             snmp_inputs.insert(index + 1, interface_input)
+            owner_index = index + 1
         else:
             # 原 input 仅承载公共接口表（以及已复制的 tag 字段）时直接替换，
             # 避免生成一个没有任何采集载荷的额外 inputs.snmp。
             snmp_inputs[index] = interface_input
+            owner_index = index
         rendered = toml.dumps(document).replace("[inputs]\n", "")
         # toml.dumps 会丢掉注释；管理区间标记必须写回，否则对账无法识别关闭态。
-        return restore_managed_ifmib_markers(rendered)
+        rendered = restore_managed_ifmib_markers(rendered)
+        managed_filter_provenance = None
+        if managed_filter_source is not None and managed_filter_source[0] == index:
+            managed_filter_provenance = managed_filter_source[1]
+        return _restore_managed_filter_markers_after_roundtrip(
+            rendered,
+            managed_filter_provenance=managed_filter_provenance,
+            owner_index=owner_index,
+        )
     return template_content
 
 
@@ -701,37 +1019,117 @@ def needs_snmp_interface_filter_jinja(template_content: str) -> bool:
     return has_interface_collection(text) or FILTER_MARKER_BEGIN in text
 
 
+def _parse_owned_filter_payload(payload: str) -> dict[str, dict[str, list[str]]] | None:
+    """解析只含接口 tagpass/tagdrop 的模块负载；其他键不宣称归属。"""
+    normalized = payload.replace("\r\n", "\n").strip()
+    if not normalized:
+        return {}
+
+    if "{%" in normalized or "{{" in normalized:
+        return None
+
+    try:
+        document = tomllib.loads(normalized)
+    except tomllib.TOMLDecodeError:
+        return None
+    inputs = document.get("inputs")
+    if set(document) != {"inputs"} or not isinstance(inputs, dict):
+        return None
+    snmp = inputs.get("snmp")
+    if set(inputs) != {"snmp"} or not isinstance(snmp, dict):
+        return None
+    if not snmp or not set(snmp).issubset({"tagpass", "tagdrop"}):
+        return None
+    for filters in snmp.values():
+        if not isinstance(filters, dict) or not filters or not set(filters).issubset({"ifType", "ifDescr"}):
+            return None
+        if any(
+            not isinstance(values, list) or not all(isinstance(value, str) for value in values)
+            for values in filters.values()
+        ):
+            return None
+    return deepcopy(snmp)
+
+
+def _is_owned_filter_payload(payload: str) -> bool:
+    """只删除本模块生成的过滤 Jinja 或只含接口 tagpass/tagdrop 的渲染结果。"""
+    normalized = payload.replace("\r\n", "\n").strip()
+
+    generated_tokens = _marker_tokens(
+        FILTER_JINJA_BLOCK,
+        FILTER_MARKER_BEGIN_LINE_RE,
+        FILTER_MARKER_END_LINE_RE,
+    )
+    generated_payload = FILTER_JINJA_BLOCK[generated_tokens[0][2] : generated_tokens[1][1]]
+    if normalized == generated_payload.replace("\r\n", "\n").strip():
+        return True
+    return _parse_owned_filter_payload(payload) is not None
+
+
+def _canonical_managed_filter_provenance(
+    text: str,
+) -> tuple[int, dict[str, dict[str, list[str]]]] | None:
+    """返回唯一规范 FILTER 区间的源 input 索引与逐类精确负载。"""
+    tokens = _marker_tokens(text, FILTER_MARKER_BEGIN_LINE_RE, FILTER_MARKER_END_LINE_RE)
+    if len(tokens) != 2 or tokens[0][0] != "begin" or tokens[1][0] != "end":
+        return None
+    filters = _parse_owned_filter_payload(text[tokens[0][2] : tokens[1][1]])
+    if not filters:
+        return None
+    headers = _structural_spans(SNMP_INPUT_RE, text)
+    owner_indexes = [index for index, (start, _) in enumerate(headers) if start < tokens[0][1]]
+    if not owner_indexes:
+        return None
+    owner_index = owner_indexes[-1]
+    next_header = headers[owner_index + 1][0] if owner_index + 1 < len(headers) else len(text)
+    if tokens[1][2] > next_header:
+        return None
+    return owner_index, filters
+
+
+def _has_canonical_filter_marker_section(text: str) -> bool:
+    return _canonical_managed_filter_provenance(text) is not None
+
+
 def ensure_iftype_tag_fields(template_content: str) -> str:
     """幂等：在每个 ifDescr 采集字段后注入 ifType tag，供 tagpass/tagdrop 使用。"""
     if not has_interface_collection(template_content):
         return template_content
 
-    def ensure_table(table_match: re.Match[str]) -> str:
-        table_text = table_match.group(0)
-        fields = list(FIELD_BLOCK_RE.finditer(table_text))
+    def ensure_table(table_text: str) -> str:
+        fields = _structural_spans(FIELD_BLOCK_RE, table_text)
         ifdescr = next(
-            (field for field in fields if re.search(r'^\s*name\s*=\s*"ifDescr"\s*$', field.group(0), re.MULTILINE)),
+            (
+                field
+                for field in fields
+                if _first_structural_raw_match(
+                    re.compile(r'^\s*name\s*=\s*"ifDescr"\s*$', re.MULTILINE),
+                    table_text[field[0] : field[1]],
+                )
+            ),
             None,
         )
         if ifdescr is None:
             return table_text
         if any(
-            re.search(r'^\s*name\s*=\s*"ifType"\s*$', field.group(0), re.MULTILINE)
-            or re.search(
-                rf'^\s*oid\s*=\s*"{re.escape(IFTYPE_OID)}"\s*$',
-                field.group(0),
-                re.MULTILINE,
+            _first_structural_raw_match(
+                re.compile(r'^\s*name\s*=\s*"ifType"\s*$', re.MULTILINE),
+                table_text[field[0] : field[1]],
+            )
+            or _first_structural_raw_match(
+                re.compile(rf'^\s*oid\s*=\s*"{re.escape(IFTYPE_OID)}"\s*$', re.MULTILINE),
+                table_text[field[0] : field[1]],
             )
             for field in fields
         ):
             return table_text
-        insert_at = ifdescr.end()
+        insert_at = ifdescr[1]
         before = table_text[:insert_at].rstrip("\n")
         after = table_text[insert_at:].lstrip("\n")
         injected = f"{before}\n{IFTYPE_FIELD_BLOCK.rstrip()}"
         return f"{injected}\n{after}" if after else f"{injected}\n"
 
-    return TABLE_BLOCK_RE.sub(ensure_table, template_content)
+    return _replace_structural_blocks(TABLE_BLOCK_RE, template_content, ensure_table)
 
 
 def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
@@ -741,13 +1139,17 @@ def ensure_snmp_interface_filter_jinja(template_content: str) -> str:
 
     # 核心网络模板的公共 IF-MIB 条件块已在同一块内声明 ifType；再次用
     # 正则插入会跨越 Jinja endif，把字段遗留在关闭块之外。
-    text = template_content if IFMIB_MARKER_BEGIN in template_content else ensure_iftype_tag_fields(template_content)
-    text = FILTER_BLOCK_RE.sub("", text)
-    text = TAGEXCLUDE_IFTYPE_RE.sub("", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = template_content if has_managed_ifmib_section(template_content) else ensure_iftype_tag_fields(template_content)
+    text = _strip_owned_marker_sections(
+        text,
+        FILTER_MARKER_BEGIN_LINE_RE,
+        FILTER_MARKER_END_LINE_RE,
+        _is_owned_filter_payload,
+    )
+    text = _replace_structural_blocks(TAGEXCLUDE_IFTYPE_RE, text, lambda _: "")
 
-    processors = PROCESSORS_RE.search(text)
-    insert_at = processors.start() if processors else len(text)
+    processors = _structural_spans(PROCESSORS_RE, text)
+    insert_at = processors[0][0] if processors else len(text)
     before = text[:insert_at].rstrip("\n")
     after = text[insert_at:].lstrip("\n")
     block = FILTER_JINJA_BLOCK.strip("\n")


### PR DESCRIPTION
## Summary
- harden IF-MIB/FILTER marker ownership so malformed or string/comment marker text cannot delete vendor-private SNMP content
- preserve private interface tables with explicit field OIDs while fail-closing oidless ambiguous interface tables consistently in render and backfill paths
- restore managed FILTER markers after TOML roundtrip only when source input/index and exact payload provenance match
- make direct FILTER Jinja injection idempotent by removing the generated outer enable_ifmib wrapper together with its managed marker block

## Validation
- python3 -m py_compile server/apps/monitor/utils/snmp_interface_template.py server/apps/monitor/management/commands/patch_snmp_interface_filters.py
- git diff --check && git diff --cached --check
- cd server && set -a && source ../dev/local/server.env && set +a && UV_CACHE_DIR=/Users/fanzhongming/workspace/Weops/.uv-cache uv run pytest -q --no-cov apps/monitor/tests/test_snmp_ifmib_filter_capability_pure.py apps/monitor/tests/test_patch_snmp_interface_filters_pure.py apps/monitor/tests/test_plugin_controller.py — 69 passed
- cd server && set -a && source ../dev/local/server.env && set +a && UV_CACHE_DIR=/Users/fanzhongming/workspace/Weops/.uv-cache uv run python manage.py patch_snmp_interface_filters --dry-run --continue-on-item-error — no IF-MIB-capable SNMP child configs found
- cd web && pnpm test:monitor-config-contract — passed
- cd web && pnpm test:monitor-network-device-cloud-region-fill — passed
- adversarial property/fuzzer review on frozen blobs: no PR-blocking confirmed finding after direct helper idempotence was fixed

## Scope check
- Committed files only: server/apps/monitor/utils/snmp_interface_template.py; server/apps/monitor/management/commands/patch_snmp_interface_filters.py
- Local regression tests and unrelated MinIO WIP are intentionally not included in this PR.