### PR TITLE
fix(日志): 对齐分析页侧栏与时间控件样式

### DIFF
--- a/web/src/app/log/(pages)/analysis/dashBoard/index.tsx
+++ b/web/src/app/log/(pages)/analysis/dashBoard/index.tsx
@@ -523,6 +523,7 @@ const Dashboard = forwardRef<DashboardRef, DashboardProps>(
               <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
                 <div className="flex flex-none items-center">
                   <TimeSelector
+                    appearance="toolbar"
                     className="flex-none"
                     ref={timeSelectorRef}
                     key="time-selector"

--- a/web/src/app/log/(pages)/analysis/page.tsx
+++ b/web/src/app/log/(pages)/analysis/page.tsx
@@ -8,12 +8,12 @@ import React, {
   useCallback
 } from 'react';
 import Dashboard, { DashboardRef } from './dashBoard';
-import { LeftOutlined, RightOutlined } from '@ant-design/icons';
-import { Button, Input, Spin } from 'antd';
+import { Input, Spin } from 'antd';
 import { useBuildInDashBoards } from '../../hooks/analysis';
 import useApiClient from '@/utils/request';
 import useLogApi from '@/app/log/api/integration';
 import { useCollectTypeInfo } from '@/app/log/hooks/integration/common/getCollectTypeConfig';
+import ResizableSidebar from '@/components/resizable-sidebar';
 import { TreeItem } from '@/app/log/types';
 import { ObjectItem } from '@/app/log/types/event';
 
@@ -42,7 +42,6 @@ const Analysis: React.FC = () => {
   const { isLoading } = useApiClient();
   const { getCollectTypes, getDisplayCategoryEnum } = useLogApi();
   const { getIcon } = useCollectTypeInfo();
-  const [collapsed, setCollapsed] = useState(false);
   const dashboardRef = useRef<DashboardRef>(null);
   const [dashboardId, setDashboardId] = useState<string>('');
   const [dashboardCollectTypeIdMap, setDashboardCollectTypeIdMap] = useState<
@@ -195,49 +194,39 @@ const Analysis: React.FC = () => {
 
   return (
     <div className="flex w-full h-[calc(100vh-90px)] relative rounded-lg">
-      <div
-        className={`h-full relative transition-all duration-300 ${
-          collapsed ? 'w-0 min-w-0' : 'w-[160px] min-w-[160px]'
-        }`}
-        style={{
-          width: collapsed ? 0 : 160,
-          minWidth: collapsed ? 0 : 160,
-          maxWidth: collapsed ? 0 : 160,
-          flexShrink: 0
-        }}
+      <ResizableSidebar
+        storageKey="log.analysis.sidebar.width"
+        collapseStorageKey="log.analysis.sidebarCollapsed"
+        defaultWidth={160}
+        minWidth={140}
+        maxWidth={320}
       >
-        {!collapsed && (
-          <div
-            className="h-full flex flex-col bg-[var(--color-bg-1)] overflow-hidden"
-            style={{ width: 160, height: 'calc(100vh - 90px)' }}
-          >
-            {/* 搜索框 */}
-            <div className="px-2 pt-4 pb-2 flex-shrink-0">
-              <Search
-                placeholder="搜索..."
-                value={searchValue}
-                onChange={(e) => setSearchValue(e.target.value)}
-                allowClear
-              />
-            </div>
-            {/* 扁平图标列表 */}
-            <div className="flex-1 overflow-y-auto overflow-x-hidden px-1 pb-2">
-              <Spin spinning={treeLoading}>
-                {flatList
-                  .filter((item) =>
-                    searchValue
-                      ? item.title
-                        .toLowerCase()
-                        .includes(searchValue.toLowerCase())
-                      : true
-                  )
-                  .map((item) => {
-                    const isSelected = item.key === dashboardId;
-                    return (
-                      <div
-                        key={item.key}
-                        onClick={() => handleNodeSelect(item.key)}
-                        className={`
+        <div className="flex h-full flex-col overflow-hidden bg-[var(--color-bg-1)]">
+          <div className="flex-shrink-0 px-2 pb-2 pt-4">
+            <Search
+              placeholder="搜索..."
+              value={searchValue}
+              onChange={(e) => setSearchValue(e.target.value)}
+              allowClear
+            />
+          </div>
+          <div className="flex-1 overflow-x-hidden overflow-y-auto px-1 pb-2">
+            <Spin spinning={treeLoading}>
+              {flatList
+                .filter((item) =>
+                  searchValue
+                    ? item.title
+                      .toLowerCase()
+                      .includes(searchValue.toLowerCase())
+                    : true
+                )
+                .map((item) => {
+                  const isSelected = item.key === dashboardId;
+                  return (
+                    <div
+                      key={item.key}
+                      onClick={() => handleNodeSelect(item.key)}
+                      className={`
                           flex items-center gap-2 px-2 py-2 rounded-lg cursor-pointer
                           transition-colors duration-150 mb-0.5
                           ${
@@ -246,49 +235,37 @@ const Analysis: React.FC = () => {
                               : 'text-[var(--color-text-1)] hover:bg-[var(--color-fill-1)]'
                           }
                         `}
+                    >
+                      <span
+                        className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md"
+                        style={{ backgroundColor: 'var(--color-fill-2)' }}
                       >
-                        <span
-                          className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md"
-                          style={{ backgroundColor: 'var(--color-fill-2)' }}
-                        >
-                          <img
-                            src={`/assets/icons/${item.icon}.svg`}
-                            alt={item.title}
-                            className="flex-shrink-0"
-                            style={{ width: 14, height: 14 }}
-                            onError={(e) => {
-                              (e.target as HTMLImageElement).src =
-                                '/assets/icons/cc-default_默认.svg';
-                            }}
-                          />
-                        </span>
-                        <span
-                          className="text-xs leading-tight break-words min-w-0"
-                          style={{ wordBreak: 'break-all' }}
-                        >
-                          {item.title}
-                        </span>
-                      </div>
-                    );
-                  })}
-              </Spin>
-            </div>
+                        <img
+                          src={`/assets/icons/${item.icon}.svg`}
+                          alt={item.title}
+                          className="flex-shrink-0"
+                          style={{ width: 14, height: 14 }}
+                          onError={(e) => {
+                            (e.target as HTMLImageElement).src =
+                              '/assets/icons/cc-default_默认.svg';
+                          }}
+                        />
+                      </span>
+                      <span
+                        className="min-w-0 break-words text-xs leading-tight"
+                        style={{ wordBreak: 'break-all' }}
+                      >
+                        {item.title}
+                      </span>
+                    </div>
+                  );
+                })}
+            </Spin>
           </div>
-        )}
-        <Button
-          type="text"
-          onClick={() => setCollapsed(!collapsed)}
-          className={`absolute z-10 w-6 h-6 top-4 p-0 border border-[var(--color-border-3)] bg-[var(--color-bg-1)] flex items-center justify-center cursor-pointer rounded-full transition-all duration-300 ${
-            collapsed
-              ? 'left-0 border-l-0 rounded-tl-none rounded-bl-none'
-              : 'left-[100%] -translate-x-1/2'
-          }`}
-        >
-          {collapsed ? <RightOutlined /> : <LeftOutlined />}
-        </Button>
-      </div>
+        </div>
+      </ResizableSidebar>
       <div
-        className="h-full flex-1 flex border-l border-[var(--color-border-1)]"
+        className="flex h-full flex-1 border-l border-[var(--color-border-1)]"
         style={{ minWidth: 0 }}
       >
         <Dashboard

--- a/web/src/app/monitor/components/monitor-dashboard-widgets/dashboard-instance-card.tsx
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/dashboard-instance-card.tsx
@@ -80,6 +80,7 @@ export function DashboardInstanceCard({
         {timeSelectorProps ? (
           <div className={styles.toolbarTimeSelector}>
             <TimeSelector
+              appearance="toolbar"
               defaultValue={timeSelectorProps.timeDefaultValue}
               customFrequencyList={
                 timeSelectorProps.frequencyList ?? DEFAULT_REFRESH_FREQUENCY_LIST

--- a/web/src/app/monitor/components/monitor-dashboard-widgets/dashboard-page-header.tsx
+++ b/web/src/app/monitor/components/monitor-dashboard-widgets/dashboard-page-header.tsx
@@ -72,6 +72,7 @@ export function DashboardPageHeader({
           {showTimeSelector ? (
             <div className={styles.toolbarTimeSelector}>
               <TimeSelector
+                appearance="toolbar"
                 defaultValue={timeDefaultValue}
                 customFrequencyList={frequencyList}
                 onChange={onTimeChange}

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-instance-card.tsx
@@ -100,6 +100,7 @@ export function DashboardInstanceCard({
         {timeSelectorProps ? (
           <div className={styles.toolbarTimeSelector}>
             <TimeSelector
+              appearance="toolbar"
               defaultValue={timeSelectorProps.timeDefaultValue}
               customFrequencyList={timeSelectorProps.frequencyList ?? DEFAULT_REFRESH_FREQUENCY_LIST}
               onChange={timeSelectorProps.onTimeChange}

--- a/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
+++ b/web/src/app/monitor/dashboards/shared/widgets/dashboard-page-header.tsx
@@ -79,8 +79,9 @@ export function DashboardPageHeader({
           onChange={(value) => onDisplayModeChange(value as 'dashboard' | 'metrics')}
         />
         {showTimeSelector ? (
-          <div className={styles.toolbarTimeSelector}>
+            <div className={styles.toolbarTimeSelector}>
             <TimeSelector
+              appearance="toolbar"
               defaultValue={timeDefaultValue}
               customFrequencyList={frequencyList}
               onChange={onTimeChange}

--- a/web/src/components/time-selector/index.module.scss
+++ b/web/src/components/time-selector/index.module.scss
@@ -1,5 +1,6 @@
 .timeSelector {
     display: flex;
+    align-items: center;
     .customSlect {
         position: relative;
         width: 100%;
@@ -51,6 +52,140 @@
     }
 }
 
+// 仪表盘工具栏：与监控仪表盘一致的紧凑时间选择 + 合并刷新组。
+.toolbar {
+    flex-shrink: 0;
+    min-width: 0;
+
+    .customSlect {
+        width: 220px;
+        overflow: visible;
+        transition: width 0.15s ease;
+
+        :global(.ant-select),
+        :global(.ant-picker) {
+            width: 100% !important;
+        }
+
+        :global(.ant-select-selector),
+        :global(.ant-picker) {
+            min-height: 32px !important;
+            height: 32px !important;
+            border: 1px solid var(--color-border) !important;
+            border-radius: 8px !important;
+            background: var(--color-bg) !important;
+            box-shadow: none !important;
+        }
+
+        :global(.ant-picker-focused) {
+            border-color: var(--color-primary) !important;
+        }
+
+        :global(.ant-picker-input > input) {
+            font-size: 12px;
+        }
+
+        :global(.ant-select-selection-item),
+        :global(.ant-select-selection-placeholder) {
+            color: var(--color-text-2) !important;
+            font-size: 13px;
+            font-weight: 500;
+            line-height: 30px !important;
+        }
+
+        :global(.ant-picker-suffix) {
+            display: none !important;
+        }
+    }
+
+    &.customActive .customSlect,
+    &.pickerVisible .customSlect {
+        width: 340px;
+    }
+
+    &.pickerVisible .customSlect :global(.ant-picker) {
+        min-height: 32px !important;
+        height: 32px !important;
+        border: 1px solid var(--color-border) !important;
+        border-radius: 8px !important;
+        background: var(--color-bg) !important;
+        box-shadow: none !important;
+    }
+
+    &.pickerVisible .customSlect :global(.ant-picker-focused) {
+        border-color: var(--color-primary) !important;
+    }
+
+    .refreshBox {
+        margin-left: 8px !important;
+        display: inline-flex;
+        align-items: center;
+        height: 32px;
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        background: var(--color-bg);
+        overflow: hidden;
+
+        .refreshBtn {
+            height: 100% !important;
+            border: none !important;
+            border-right: 1px solid var(--color-border) !important;
+            border-radius: 0 !important;
+            background: transparent !important;
+            box-shadow: none !important;
+            color: var(--color-text-3) !important;
+            padding: 0 10px !important;
+
+            &:hover {
+                color: var(--color-primary) !important;
+                background: var(--color-fill-1) !important;
+            }
+        }
+
+        .frequence {
+            width: 96px !important;
+
+            :global(.ant-select-selector) {
+                min-height: 30px !important;
+                height: 30px !important;
+                border: none !important;
+                border-radius: 0 !important;
+                background: transparent !important;
+                box-shadow: none !important;
+            }
+
+            :global(.ant-select-selection-item),
+            :global(.ant-select-selection-placeholder) {
+                color: var(--color-text-2) !important;
+                font-size: 13px;
+                font-weight: 500;
+                line-height: 30px !important;
+            }
+        }
+    }
+}
+
+:global(html.dark) .toolbar {
+    .customSlect :global(.ant-select-selector),
+    .refreshBox {
+        background: var(--color-bg) !important;
+        border-color: var(--color-border) !important;
+    }
+
+    .refreshBox {
+        :global(.ant-btn),
+        :global(.ant-select-selector) {
+            background: transparent !important;
+            color: var(--color-text-2) !important;
+        }
+
+        :global(.ant-btn) {
+            border: none !important;
+            border-right: 1px solid var(--color-border) !important;
+        }
+    }
+}
+
 .timeSelector .customSlect :global(.ant-select-arrow) {
     visibility: hidden;
 }
@@ -61,6 +196,10 @@
 
 .timeSelector .refreshBox .frequence :global(.ant-select-selector) {
     border-radius: 0 6px 6px 0;
+}
+
+.timeSelector.toolbar .refreshBox .frequence :global(.ant-select-selector) {
+    border-radius: 0;
 }
 
 // 供仪表盘等外层识别「已选自定义区间」并加宽展示。

--- a/web/src/components/time-selector/index.tsx
+++ b/web/src/components/time-selector/index.tsx
@@ -21,6 +21,8 @@ interface TimeSelectorProps {
   format?: string; //rangePicker组件属性，格式化
   onlyRefresh?: boolean; // 仅显示刷新按钮
   onlyTimeSelect?: boolean; // 仅显示时间组合组件
+  /** 仪表盘工具栏外观：时间选择器更紧凑，刷新与自动刷新合并为单组边框 */
+  appearance?: 'default' | 'toolbar';
   customFrequencyList?: ListItem[];
   customTimeRangeList?: ListItem[];
   clearable?: boolean; // 组件的值是否能为空
@@ -37,6 +39,7 @@ const TimeSelector = forwardRef((props: TimeSelectorProps, ref) => {
     format = 'YYYY-MM-DD HH:mm:ss',
     onlyRefresh = false,
     onlyTimeSelect = false,
+    appearance = 'default',
     clearable = false,
     className,
     defaultValue = {
@@ -267,17 +270,22 @@ const TimeSelector = forwardRef((props: TimeSelectorProps, ref) => {
     onChange?.(rangeTime, numericValue);
   };
 
+  const isToolbar = appearance === 'toolbar';
+  const timeFieldWidthClass = isToolbar ? 'w-full' : 'w-[350px]';
+
   return (
     <div
       className={`${timeSelectorStyle.timeSelector} ${
-        selectValue === 0 ? timeSelectorStyle.customActive : ''
-      } ${pickerVisible ? timeSelectorStyle.pickerVisible : ''} ${className || ''}`}
+        isToolbar ? timeSelectorStyle.toolbar : ''
+      } ${selectValue === 0 ? timeSelectorStyle.customActive : ''} ${
+        pickerVisible ? timeSelectorStyle.pickerVisible : ''
+      } ${className || ''}`}
     >
       {!onlyRefresh && (
         <div className={timeSelectorStyle.customSlect} ref={selectRef}>
           <Select
             allowClear={clearable}
-            className={`w-[350px] ${timeSelectorStyle.frequence} ${className || ''}`}
+            className={`${timeFieldWidthClass} ${timeSelectorStyle.frequence}`}
             value={selectValue}
             options={customTimeRangeList || TIME_RANGE_LIST}
             open={dropdownOpen}
@@ -285,7 +293,7 @@ const TimeSelector = forwardRef((props: TimeSelectorProps, ref) => {
             onOpenChange={handleDropdownVisibleChange}
           />
           <RangePicker
-            className={`w-[350px] ${timeSelectorStyle.rangePicker} ${className || ''}`}
+            className={`${timeFieldWidthClass} ${timeSelectorStyle.rangePicker}`}
             popupClassName={timeSelectorStyle.rangePickerDropdown}
             open={rangePickerOpen}
             showTime={showTime}

--- a/web/src/stories/time-selector.stories.tsx
+++ b/web/src/stories/time-selector.stories.tsx
@@ -25,6 +25,22 @@ export const Default: Story = {
   },
 };
 
+export const Toolbar: Story = {
+  args: {
+    appearance: 'toolbar',
+    defaultValue: {
+      selectValue: 15,
+      rangePickerVaule: null,
+    },
+    onFrequenceChange: (frequency: number) => {
+      console.log('Frequency changed:', frequency);
+    },
+    onRefresh: () => {
+      console.log('Refresh clicked');
+    },
+  },
+};
+
 export const OnlyTimeSelect: Story = {
   args: {
     defaultValue: {


### PR DESCRIPTION
## Summary
- 日志分析左侧栏改用共享 `ResizableSidebar`，收起按钮与监控一致
- 共享 `TimeSelector` 新增 `appearance="toolbar"`，日志分析与监控仪表盘共用紧凑时间选择 + 合并刷新组样式
- 补充 TimeSelector `Toolbar` Storybook 契约

## Test plan
- [ ] 打开 `/log/analysis`，确认侧栏收起按钮为垂直居中圆形样式，与监控仪表盘一致
- [ ] 确认时间选择 / 刷新 / 自动刷新为合并边框组，与监控一致
- [ ] 侧栏可拖拽调宽，收起状态刷新后仍保持
- [ ] 抽查一个监控仪表盘，时间控件外观无回退

## Review notes
- 已排除测试文件与无关图标，未纳入本次提交
- IF-MIB 相关提交仍在 `codex/fix-ifmib-filter-jinja-idempotence`，不在本 PR