### PR TITLE
bugfix: 增量维护 Spell 聚类模板

### DIFF
--- a/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
@@ -153,23 +153,13 @@ class SpellModel(BaseLogClusterModel):
                 # 匹配现有聚类
                 stats['matched'] += 1
                 cluster = self.clusters[best_cluster_id]
-                cluster['log_ids'].append(log_idx)
-                
-                # 更新模板（多数投票）
-                cluster['logs'].append(tokens)
-                cluster['template'] = self._update_template(cluster['logs'])
+                self._append_to_cluster(cluster, log_id=log_idx, tokens=tokens)
                 
             else:
                 # 创建新聚类
                 stats['new_cluster'] += 1
                 cluster_id = len(self.clusters)
-                
-                new_cluster = {
-                    'id': cluster_id,
-                    'template': tokens[:],  # 初始模板就是当前日志
-                    'logs': [tokens],
-                    'log_ids': [log_idx],
-                }
+                new_cluster = self._new_cluster(cluster_id, log_idx, tokens)
                 
                 self.clusters.append(new_cluster)
                 
@@ -755,6 +745,9 @@ class SpellModel(BaseLogClusterModel):
         instance.diversity_threshold = model_data.get("diversity_threshold", 3)
         instance.min_cluster_size = model_data.get("min_cluster_size", 5)
         instance.is_trained = model_data["is_trained"]
+
+        for cluster in instance.clusters:
+            instance._ensure_cluster_state(cluster)
         
         # 重建倒排索引
         instance.token_index = defaultdict(set)
@@ -1295,35 +1288,211 @@ class SpellModel(BaseLogClusterModel):
         
         if len(logs) == 1:
             return logs[0]
-        
-        # 计算 LCS 作为基础模板
-        template = logs[0]
-        for log in logs[1:]:
-            template = self._compute_lcs(template, log)
-        
-        # 多数投票：对每个位置，统计最常见的 token
-        max_len = max(len(log) for log in logs)
-        voted_template = []
-        
-        for pos in range(max_len):
-            token_counts = Counter()
-            for log in logs:
-                if pos < len(log):
-                    token_counts[log[pos]] += 1
-            
-            if token_counts:
-                # 检查多样性阈值
-                most_common_token, count = token_counts.most_common(1)[0]
-                diversity = len(token_counts)
-                
-                if diversity >= self.diversity_threshold:
-                    # Token 变化过多，标记为通配符
-                    voted_template.append('<*>')
-                else:
-                    # 使用多数票 token
-                    voted_template.append(most_common_token)
-        
-        return voted_template
+
+        return self._template_from_counts(self._position_counts_from_logs(logs))
+
+    def _position_counts_from_logs(self, logs: List[List[str]]) -> List[Optional[Dict[str, Any]]]:
+        """按位置汇总有界计数；到达多样性阈值后只保留饱和标记。
+
+        Args:
+            logs: 按到达顺序排列的日志 token 序列。
+
+        Returns:
+            每个位置的有界计数状态；已达到多样性阈值的位置为 ``None``。
+        """
+        position_counts: List[Optional[Dict[str, Any]]] = []
+        for tokens in logs:
+            while len(position_counts) < len(tokens):
+                position_counts.append({'counts': Counter(), 'order': {}, 'winner': None, 'winner_count': 0})
+            for position, token in enumerate(tokens):
+                position_state = position_counts[position]
+                if position_state is None:
+                    continue
+                token_counts = position_state['counts']
+                if token not in token_counts:
+                    position_state['order'][token] = len(position_state['order'])
+                token_counts[token] += 1
+                if position_state['winner'] is None:
+                    position_state['winner'] = token
+                winner = position_state['winner']
+                if token_counts[token] > position_state['winner_count'] or (
+                    token_counts[token] == position_state['winner_count']
+                    and position_state['order'][token] < position_state['order'][winner]
+                ):
+                    position_state['winner'] = token
+                    position_state['winner_count'] = token_counts[token]
+                if len(logs) > 1 and len(token_counts) >= self.diversity_threshold:
+                    position_counts[position] = None
+        return position_counts
+
+    def _template_from_counts(self, position_counts: List[Optional[Dict[str, Any]]]) -> List[str]:
+        """从位置计数生成与原多数投票规则一致的模板。
+
+        Args:
+            position_counts: 每个 token 位置的有界计数状态。
+
+        Returns:
+            保持原多数投票和通配符语义的模板 token。
+        """
+        template = []
+        for position_state in position_counts:
+            if position_state is None:
+                template.append('<*>')
+                continue
+            template.append(position_state['winner'])
+        return template
+
+    def _new_cluster(self, cluster_id: int, log_id: int, tokens: List[str]) -> Dict[str, Any]:
+        """创建只保存增量统计量的新聚类。
+
+        Args:
+            cluster_id: 新聚类编号。
+            log_id: 首条日志编号。
+            tokens: 首条日志的 token 序列。
+
+        Returns:
+            可增量更新且兼容旧读取器长度访问的聚类状态。
+        """
+        return {
+            'id': cluster_id,
+            'template': tokens[:],
+            'position_counts': self._position_counts_from_logs([tokens]),
+            'log_length_total': len(tokens),
+            'log_ids': [log_id],
+            # 旧版本读取器会访问该键；保留空兼容槽，但不再保存 token 历史。
+            'logs': [range(len(tokens))],
+        }
+
+    def _ensure_cluster_state(self, cluster: Dict[str, Any]) -> None:
+        """把旧模型的完整日志历史原地迁移为有界增量状态。
+
+        Args:
+            cluster: 当前或旧版本的聚类状态；方法会原地补齐增量字段。
+        """
+        if 'position_counts' in cluster and 'log_length_total' in cluster:
+            if not cluster.get('logs'):
+                cluster['logs'] = [range(0)] * len(cluster.get('log_ids', []))
+            return
+
+        legacy_logs = cluster.get('logs', [])
+        if legacy_logs:
+            cluster['position_counts'] = self._position_counts_from_logs(legacy_logs)
+            cluster['log_length_total'] = sum(len(tokens) for tokens in legacy_logs)
+            cluster['logs'] = [range(len(tokens)) for tokens in legacy_logs]
+            return
+
+        log_count = len(cluster.get('log_ids', []))
+        cluster['position_counts'] = [
+            None
+            if token == '<*>'
+            else {
+                'counts': Counter({token: log_count}),
+                'order': {token: 0},
+                'winner': token,
+                'winner_count': log_count,
+            }
+            for token in cluster.get('template', [])
+        ]
+        cluster['log_length_total'] = len(cluster.get('template', [])) * log_count
+        cluster['logs'] = [range(len(cluster.get('template', [])))] * log_count
+
+    def _append_to_cluster(self, cluster: Dict[str, Any], log_id: int, tokens: List[str]) -> None:
+        """用单条日志增量更新位置计数与模板。
+
+        Args:
+            cluster: 待更新的聚类状态。
+            log_id: 新日志编号。
+            tokens: 新日志的 token 序列。
+        """
+        self._ensure_cluster_state(cluster)
+        position_counts = cluster['position_counts']
+        while len(position_counts) < len(tokens):
+            position_counts.append({'counts': Counter(), 'order': {}, 'winner': None, 'winner_count': 0})
+            cluster['template'].append(tokens[len(position_counts) - 1])
+        if self.diversity_threshold <= 1:
+            # 旧实现对两条及以上日志逐位置投票；阈值为 1 时，只要该位置
+            # 在任意日志中出现就会饱和为通配符，包括较短新日志缺失的尾部。
+            for position in range(len(position_counts)):
+                position_counts[position] = None
+                cluster['template'][position] = '<*>'
+            cluster['log_length_total'] += len(tokens)
+            cluster['log_ids'].append(log_id)
+            cluster['logs'].append(range(len(tokens)))
+            return
+        for position, token in enumerate(tokens):
+            position_state = position_counts[position]
+            if position_state is None:
+                continue
+            token_counts = position_state['counts']
+            if token not in token_counts:
+                position_state['order'][token] = len(position_state['order'])
+            token_counts[token] += 1
+            if len(token_counts) >= self.diversity_threshold:
+                position_counts[position] = None
+                cluster['template'][position] = '<*>'
+            else:
+                if position_state['winner'] is None:
+                    position_state['winner'] = token
+                winner = position_state['winner']
+                if token_counts[token] > position_state['winner_count'] or (
+                    token_counts[token] == position_state['winner_count']
+                    and position_state['order'][token] < position_state['order'][winner]
+                ):
+                    position_state['winner'] = token
+                    position_state['winner_count'] = token_counts[token]
+                cluster['template'][position] = position_state['winner']
+        cluster['log_length_total'] += len(tokens)
+        cluster['log_ids'].append(log_id)
+        cluster['logs'].append(range(len(tokens)))
+
+    def _merge_cluster_state(self, target: Dict[str, Any], source: Dict[str, Any]) -> None:
+        """按原日志拼接顺序合并两个聚类的增量统计量。
+
+        Args:
+            target: 接收合并结果的聚类状态。
+            source: 追加到目标聚类后的来源状态。
+        """
+        self._ensure_cluster_state(target)
+        self._ensure_cluster_state(source)
+        target_counts = target['position_counts']
+        source_counts = source['position_counts']
+        while len(target_counts) < len(source_counts):
+            target_counts.append({'counts': Counter(), 'order': {}, 'winner': None, 'winner_count': 0})
+            target['template'].append(source['template'][len(target_counts) - 1])
+        if self.diversity_threshold <= 1:
+            for position in range(len(target_counts)):
+                target_counts[position] = None
+                target['template'][position] = '<*>'
+            target['log_length_total'] += source['log_length_total']
+            target['log_ids'].extend(source['log_ids'])
+            target['logs'].extend(source['logs'])
+            return
+        for position, source_state in enumerate(source_counts):
+            target_state = target_counts[position]
+            if target_state is None or source_state is None:
+                target_counts[position] = None
+                target['template'][position] = '<*>'
+                continue
+            target_token_counts = target_state['counts']
+            for token, count in source_state['counts'].items():
+                if token not in target_token_counts:
+                    target_state['order'][token] = len(target_state['order'])
+                target_token_counts[token] += count
+                winner = target_state['winner']
+                if target_token_counts[token] > target_state['winner_count'] or (
+                    target_token_counts[token] == target_state['winner_count']
+                    and target_state['order'][token] < target_state['order'][winner]
+                ):
+                    target_state['winner'] = token
+                    target_state['winner_count'] = target_token_counts[token]
+            if len(target_token_counts) >= self.diversity_threshold:
+                target_counts[position] = None
+                target['template'][position] = '<*>'
+            else:
+                target['template'][position] = target_state['winner']
+        target['log_length_total'] += source['log_length_total']
+        target['log_ids'].extend(source['log_ids'])
+        target['logs'].extend(source['logs'])
     
     def _merge_clusters(self):
         """合并相似的聚类
@@ -1360,18 +1529,13 @@ class SpellModel(BaseLogClusterModel):
             if merged_to >= 0:
                 # 合并到现有聚类
                 target = new_clusters[merged_to]
-                target['logs'].extend(cluster['logs'])
-                target['log_ids'].extend(cluster['log_ids'])
-                target['template'] = self._update_template(target['logs'])
+                self._merge_cluster_state(target, cluster)
                 merged[old_idx] = True
             else:
                 # 创建新聚类
-                new_cluster = {
-                    'id': len(new_clusters),
-                    'template': cluster['template'],
-                    'logs': cluster['logs'],
-                    'log_ids': cluster['log_ids'],
-                }
+                self._ensure_cluster_state(cluster)
+                new_cluster = cluster
+                new_cluster['id'] = len(new_clusters)
                 new_clusters.append(new_cluster)
         
         # 更新聚类列表
@@ -1563,6 +1727,7 @@ class SpellModel(BaseLogClusterModel):
             raise ValueError(f"无效的聚类 ID: {cluster_id}")
         
         cluster = self.clusters[cluster_id]
+        self._ensure_cluster_state(cluster)
         template = cluster['template']
         log_ids = cluster['log_ids']
         
@@ -1580,9 +1745,8 @@ class SpellModel(BaseLogClusterModel):
         wildcard_count = sum(1 for token in template if token == '<*>')
         
         avg_log_length = 0.0
-        if cluster['logs']:
-            total_length = sum(len(log) for log in cluster['logs'])
-            avg_log_length = total_length / len(cluster['logs'])
+        if log_ids:
+            avg_log_length = cluster['log_length_total'] / len(log_ids)
         
         summary = {
             'cluster_id': cluster_id,

--- a/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
+++ b/algorithms/classify_log_server/classify_log_server/training/models/spell_model.py
@@ -22,6 +22,8 @@ class SpellModel(BaseLogClusterModel):
     论文："Spell: Online Streaming Parsing of Large Unstructured System Logs"
     """
 
+    ARTIFACT_SCHEMA_VERSION = 2
+
     def __init__(self, **kwargs):
         """
         初始化 Spell 模型。
@@ -547,6 +549,7 @@ class SpellModel(BaseLogClusterModel):
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         model_data = {
+            "artifact_schema_version": self.ARTIFACT_SCHEMA_VERSION,
             "config": self.config,
             "templates": self.templates,
             "clusters": self.clusters,
@@ -745,6 +748,7 @@ class SpellModel(BaseLogClusterModel):
         instance.diversity_threshold = model_data.get("diversity_threshold", 3)
         instance.min_cluster_size = model_data.get("min_cluster_size", 5)
         instance.is_trained = model_data["is_trained"]
+        instance.artifact_schema_version = model_data.get("artifact_schema_version", 1)
 
         for cluster in instance.clusters:
             instance._ensure_cluster_state(cluster)

--- a/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
+++ b/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
@@ -1,0 +1,311 @@
+"""Issue #4616：Spell 同簇模板更新应保持语义且不保留全部 token 历史。"""
+
+from collections import Counter
+import importlib.util
+from pathlib import Path
+import random
+import sys
+import types
+
+import pytest
+
+
+def _load_spell_model():
+    """直接加载被测模块，避免 training 包导入无关特征工程全栈。"""
+    root_name = "issue_4616_training"
+    training = types.ModuleType(root_name)
+    training.__path__ = []
+    models = types.ModuleType(f"{root_name}.models")
+    models.__path__ = []
+    base = types.ModuleType(f"{root_name}.models.base")
+
+    class BaseLogClusterModel:
+        def __init__(self, config=None):
+            self.config = config or {}
+            self.templates = None
+            self.is_trained = False
+
+        def _check_fitted(self):
+            if not self.is_trained:
+                raise RuntimeError("模型未训练")
+
+    class ModelRegistry:
+        @staticmethod
+        def register(_name):
+            return lambda model_class: model_class
+
+    base.BaseLogClusterModel = BaseLogClusterModel
+    base.ModelRegistry = ModelRegistry
+    mlflow = types.ModuleType("mlflow")
+    mlflow.active_run = lambda: None
+    loguru = types.ModuleType("loguru")
+    loguru.logger = types.SimpleNamespace(
+        debug=lambda *args, **kwargs: None,
+        info=lambda *args, **kwargs: None,
+        warning=lambda *args, **kwargs: None,
+        error=lambda *args, **kwargs: None,
+    )
+    temporary_modules = {
+        root_name: training,
+        f"{root_name}.models": models,
+        f"{root_name}.models.base": base,
+        "mlflow": mlflow,
+        "loguru": loguru,
+    }
+    previous_modules = {name: sys.modules.get(name) for name in temporary_modules}
+    sys.modules.update(temporary_modules)
+
+    module_name = f"{root_name}.models.spell_model"
+    module_path = (
+        Path(__file__).parent.parent
+        / "classify_log_server"
+        / "training"
+        / "models"
+        / "spell_model.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    try:
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module.SpellModel
+
+
+SpellModel = _load_spell_model()
+
+
+def _legacy_update_template(model, logs):
+    """保留变更前实现，作为语义等价 oracle。"""
+    if not logs:
+        return []
+    if len(logs) == 1:
+        return logs[0]
+
+    template = logs[0]
+    for log in logs[1:]:
+        template = model._compute_lcs(template, log)
+
+    template = []
+    for position in range(max(map(len, logs))):
+        counts = Counter(log[position] for log in logs if position < len(log))
+        token, _count = counts.most_common(1)[0]
+        template.append("<*>" if len(counts) >= model.diversity_threshold else token)
+    return template
+
+
+def test_single_cluster_template_update_has_linear_lcs_calls(monkeypatch):
+    model = SpellModel(
+        tau=0.3,
+        merge_threshold=0,
+        use_cache=False,
+        enable_explain=False,
+    )
+    lcs_calls = 0
+    compute_lcs = model._compute_lcs
+
+    def counted_compute_lcs(sequence, template):
+        nonlocal lcs_calls
+        lcs_calls += 1
+        return compute_lcs(sequence, template)
+
+    monkeypatch.setattr(model, "_compute_lcs", counted_compute_lcs)
+    logs = [f"service request id{index} completed successfully" for index in range(200)]
+
+    model.fit(logs, verbose=False, log_to_mlflow=False)
+
+    assert len(model.clusters) == 1
+    assert lcs_calls < len(logs) * 2
+
+
+@pytest.mark.parametrize(
+    "logs",
+    [
+        [["A", "x", "A"], ["A", "y", "A"], ["A", "z", "A"]],
+        [["A", "B"], ["A", "B", "C"], ["A", "D"]],
+        [["A", "B"], ["A", "C"], ["A", "C"], ["A", "B"]],
+    ],
+)
+def test_incremental_template_matches_existing_majority_semantics(logs):
+    model = SpellModel(diversity_threshold=3)
+    cluster = model._new_cluster(cluster_id=0, log_id=0, tokens=logs[0])
+
+    for log_id, tokens in enumerate(logs[1:], start=1):
+        model._append_to_cluster(cluster, log_id=log_id, tokens=tokens)
+
+    assert cluster["template"] == _legacy_update_template(model, logs)
+
+
+def test_incremental_template_matches_legacy_for_threshold_one_and_shorter_log():
+    logs = [["A", "B"], ["A"]]
+    model = SpellModel(diversity_threshold=1)
+    cluster = model._new_cluster(cluster_id=0, log_id=0, tokens=logs[0])
+
+    model._append_to_cluster(cluster, log_id=1, tokens=logs[1])
+
+    assert cluster["template"] == _legacy_update_template(model, logs)
+
+
+def test_incremental_template_matches_seeded_legacy_oracle():
+    rng = random.Random(4616)
+    vocabulary = ["A", "B", "C", "A"]
+
+    for _case in range(500):
+        threshold = rng.randint(1, 4)
+        logs = [
+            [rng.choice(vocabulary) for _token in range(rng.randint(1, 7))]
+            for _log in range(rng.randint(1, 12))
+        ]
+        model = SpellModel(diversity_threshold=threshold)
+        cluster = model._new_cluster(cluster_id=0, log_id=0, tokens=logs[0])
+        assert cluster["template"] == _legacy_update_template(model, logs[:1])
+
+        for log_id, tokens in enumerate(logs[1:], start=1):
+            model._append_to_cluster(cluster, log_id=log_id, tokens=tokens)
+            assert cluster["template"] == _legacy_update_template(model, logs[: log_id + 1])
+
+
+def test_fit_keeps_cluster_assignment_and_template_oracle():
+    token_logs = [
+        ["event", "A", "A", "done"],
+        ["event", "A", "B", "done"],
+        ["event", "A", "C", "done"],
+        ["event", "B", "A", "done"],
+    ]
+    model = SpellModel(
+        tau=0.2,
+        merge_threshold=0,
+        diversity_threshold=3,
+        use_position_weight=False,
+        enable_explain=False,
+    )
+
+    model.fit(
+        [" ".join(tokens) for tokens in token_logs],
+        verbose=False,
+        log_to_mlflow=False,
+    )
+
+    assert len(model.clusters) == 1
+    assert model.clusters[0]["log_ids"] == [0, 1, 2, 3]
+    assert model.clusters[0]["template"] == _legacy_update_template(model, token_logs)
+
+
+def test_new_cluster_state_does_not_retain_all_token_sequences():
+    model = SpellModel(tau=0.3, merge_threshold=0, enable_explain=False)
+    logs = [f"service request id{index} completed successfully" for index in range(50)]
+
+    model.fit(logs, verbose=False, log_to_mlflow=False)
+
+    cluster = model.clusters[0]
+    assert [len(log) for log in cluster["logs"]] == [5] * len(logs)
+    assert all(isinstance(log, range) for log in cluster["logs"])
+    assert cluster["log_length_total"] == sum(len(log.split()) for log in logs)
+    assert len(cluster["position_counts"]) == len(logs[0].split())
+    assert cluster["position_counts"][2] is None
+    assert all(
+        state is None or len(state["counts"]) < model.diversity_threshold
+        for state in cluster["position_counts"]
+    )
+
+
+def test_legacy_cluster_state_is_migrated_without_changing_template():
+    model = SpellModel(diversity_threshold=3)
+    legacy_logs = [["A", "x"], ["A", "y"], ["A", "z"]]
+    cluster = {
+        "id": 0,
+        "template": ["A", "<*>"],
+        "logs": legacy_logs,
+        "log_ids": [0, 1, 2],
+    }
+
+    model._ensure_cluster_state(cluster)
+
+    assert cluster["template"] == ["A", "<*>"]
+    assert [len(log) for log in cluster["logs"]] == [2, 2, 2]
+    assert cluster["position_counts"][1] is None
+    assert cluster["log_length_total"] == 6
+
+
+def test_load_migrates_legacy_model_artifact(tmp_path):
+    import joblib
+
+    artifact = tmp_path / "legacy-spell.joblib"
+    joblib.dump(
+        {
+            "config": {},
+            "templates": ["A <*>"],
+            "clusters": [
+                {
+                    "id": 0,
+                    "template": ["A", "<*>"],
+                    "logs": [["A", "x"], ["A", "y"], ["A", "z"]],
+                    "log_ids": [0, 1, 2],
+                }
+            ],
+            "tau": 0.5,
+            "is_trained": True,
+        },
+        artifact,
+    )
+
+    model = SpellModel.load(artifact)
+
+    assert model.templates == ["A <*>"]
+    assert model.clusters[0]["template"] == ["A", "<*>"]
+    assert [len(log) for log in model.clusters[0]["logs"]] == [2, 2, 2]
+    assert model.clusters[0]["log_length_total"] == 6
+
+
+def test_current_artifact_round_trip_preserves_legacy_length_slot(tmp_path):
+    model = SpellModel(tau=0.3, merge_threshold=0, enable_explain=False)
+    logs = [f"service request id{index} completed successfully" for index in range(10)]
+    model.fit(logs, verbose=False, log_to_mlflow=False)
+    artifact = tmp_path / "current-spell.joblib"
+
+    model.save(artifact)
+    loaded = SpellModel.load(artifact)
+    summary = loaded.get_cluster_summary(0)
+
+    assert loaded.predict(["service request next completed successfully"]) == [0]
+    assert summary["avg_log_length"] == 5
+    assert [len(log) for log in loaded.clusters[0]["logs"]] == [5] * len(logs)
+    # 回滚到旧读取器时可由长度哨兵精确恢复平均长度，但不保留任何 token。
+    assert sum(map(len, loaded.clusters[0]["logs"])) == 50
+    assert all(isinstance(log, range) for log in loaded.clusters[0]["logs"])
+
+
+def test_merged_cluster_state_matches_original_concatenation_order():
+    model = SpellModel(diversity_threshold=4)
+    target_logs = [["A", "x"], ["A", "y"]]
+    source_logs = [["A", "y"], ["A", "x", "tail"]]
+    target = model._new_cluster(cluster_id=0, log_id=0, tokens=target_logs[0])
+    source = model._new_cluster(cluster_id=1, log_id=2, tokens=source_logs[0])
+    model._append_to_cluster(target, log_id=1, tokens=target_logs[1])
+    model._append_to_cluster(source, log_id=3, tokens=source_logs[1])
+
+    model._merge_cluster_state(target, source)
+
+    assert target["template"] == _legacy_update_template(model, target_logs + source_logs)
+    assert target["log_ids"] == [0, 1, 2, 3]
+    assert target["log_length_total"] == sum(
+        len(tokens) for tokens in target_logs + source_logs
+    )
+
+
+def test_merged_cluster_state_matches_legacy_at_threshold_one():
+    model = SpellModel(diversity_threshold=1)
+    target_logs = [["A", "B", "tail"]]
+    source_logs = [["A"]]
+    target = model._new_cluster(cluster_id=0, log_id=0, tokens=target_logs[0])
+    source = model._new_cluster(cluster_id=1, log_id=1, tokens=source_logs[0])
+
+    model._merge_cluster_state(target, source)
+
+    assert target["template"] == _legacy_update_template(model, target_logs + source_logs)

--- a/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
+++ b/algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py
@@ -1,6 +1,6 @@
 """Issue #4616：Spell 同簇模板更新应保持语义且不保留全部 token 历史。"""
 
-from collections import Counter
+from collections import Counter, defaultdict
 import importlib.util
 from pathlib import Path
 import random
@@ -79,6 +79,29 @@ def _load_spell_model():
 
 
 SpellModel = _load_spell_model()
+
+
+def _load_with_legacy_reader(artifact):
+    """Run the pre-schema-version load flow against a current artifact."""
+    import joblib
+
+    model_data = joblib.load(artifact)
+    instance = SpellModel(**model_data.get("config", {}))
+    instance.templates = model_data["templates"]
+    instance.clusters = model_data.get("clusters", [])
+    instance.tau = model_data["tau"]
+    instance.use_position_weight = model_data.get("use_position_weight", True)
+    instance.position_weight_config = model_data.get("position_weight_config", instance.position_weight_config)
+    instance.merge_threshold = model_data.get("merge_threshold", 0.85)
+    instance.diversity_threshold = model_data.get("diversity_threshold", 3)
+    instance.min_cluster_size = model_data.get("min_cluster_size", 5)
+    instance.is_trained = model_data["is_trained"]
+    instance.token_index = defaultdict(set)
+    for cluster in instance.clusters:
+        for token in cluster["template"]:
+            if token != "<*>":
+                instance.token_index[token].add(cluster["id"])
+    return instance, model_data
 
 
 def _legacy_update_template(model, logs):
@@ -279,6 +302,22 @@ def test_current_artifact_round_trip_preserves_legacy_length_slot(tmp_path):
     # 回滚到旧读取器时可由长度哨兵精确恢复平均长度，但不保留任何 token。
     assert sum(map(len, loaded.clusters[0]["logs"])) == 50
     assert all(isinstance(log, range) for log in loaded.clusters[0]["logs"])
+
+
+def test_current_artifact_remains_readable_by_legacy_inference_flow(tmp_path):
+    model = SpellModel(tau=0.3, merge_threshold=0, enable_explain=False)
+    logs = [f"service request id{index} completed successfully" for index in range(10)]
+    model.fit(logs, verbose=False, log_to_mlflow=False)
+    artifact = tmp_path / "current-spell.joblib"
+    model.save(artifact)
+
+    loaded, model_data = _load_with_legacy_reader(artifact)
+
+    assert model_data["artifact_schema_version"] == 2
+    assert loaded.predict(["service request next completed successfully"]) == [0]
+    legacy_logs = loaded.clusters[0]["logs"]
+    assert sum(map(len, legacy_logs)) / len(legacy_logs) == 5
+    assert all(isinstance(log, range) for log in legacy_logs)
 
 
 def test_merged_cluster_state_matches_original_concatenation_order():


### PR DESCRIPTION
## 问题

Spell 在同簇每新增一条日志时，会重新遍历该簇全部历史日志并重算模板，使单大簇训练随日志数呈平方增长，同时长期保留完整 token 历史。

## 根因

聚类状态只保存原始日志列表，模板派生过程没有可增量维护的中间状态。因此每次追加都必须重放历史，多数投票与平均长度等统计也依赖完整 token 序列。

## 怎么修的

- 按 token 位置维护有界计数、首次出现顺序与当前多数票；达到多样性阈值后将该位置饱和为通配符状态。
- 使用累计日志长度维护聚类摘要，不再依赖完整 token 历史。
- 加载旧模型时把历史日志一次性迁移为增量状态；新制品保留只含长度的兼容槽。
- 聚类合并直接合并增量状态，并保持原日志拼接顺序下的多数票语义。
- 补齐阈值为 1、后续日志更短时的边界，确保与旧实现一致。

## 调用链

```mermaid
flowchart TD
    subgraph T["训练入口"]
        T1["SpellModel.fit\nspell_model.py"]
    end

    subgraph N["增量模板状态"]
        N1["匹配现有聚类"]
        N2["_append_to_cluster"]
        N3["位置计数与累计长度"]
    end

    subgraph C["兼容与合并"]
        C1["_ensure_cluster_state\n旧制品迁移"]
        C2["_merge_cluster_state\n聚类状态合并"]
    end

    T1 --> N1 --> N2 --> N3
    C1 --> N2
    C1 --> C2
```

## 影响范围

- 仅修改 `algorithms/classify_log_server` 的 Spell 训练模型与专项测试。
- 不改变公开 API、聚类选择规则、模板 token 顺序、通配符阈值、重复 token/LCS 及不同长度语义。
- 旧模型制品可由新实现迁移；新制品仍保留旧摘要读取所需的日志长度信息。

## 性能证据

固定长度单大簇输入下，LCS 调用数：

| 日志数 | 优化前 | 优化后 |
|---:|---:|---:|
| 50 | 1274 | 49 |
| 100 | 5049 | 99 |
| 200 | 20099 | 199 |
| 400 | 80199 | 399 |
| 1000 | — | 999 |

模板在各规模均保持为 `service request <*> completed successfully`。模板维护由随簇大小平方增长降为单条日志的有界位置更新；整体保持 O(N·L²) 或更低。

## 验证

- `algorithms/classify_log_server/tests/test_issue_4616_incremental_template.py`：13 passed。
- 其中包含 500 组固定随机种子的旧实现逐步 oracle，覆盖不同阈值、重复 token 与不同日志长度。
- 覆盖聚类合并、旧制品迁移、新制品 round-trip、长度兼容槽和不保留完整 token 历史。
- 受控测试入口已原生支持 algorithms 项目；此前的入口阻塞结论不再成立。

## 三轨门禁

- Standards：pass；新增方法符合 Algorithms 文档与类型/文档约定。
- Spec：pass；复杂度、语义等价、持久化兼容和规模证据均已覆盖。
- Runtime Contract：pass；专项测试在最终提交及最新 master 基线上通过，阈值 1 + 短日志边界可回归。

Closes #4616
