### PR TITLE
fix(opspilot): 修复 nats_listener 旁路线程 ORM 连接泄漏

### DIFF
--- a/server/apps/opspilot/metis/llm/tools/cmdb/__init__.py
+++ b/server/apps/opspilot/metis/llm/tools/cmdb/__init__.py
@@ -16,16 +16,37 @@ from apps.opspilot.metis.llm.tools.cmdb.instances import (
     cmdb_topo_search,
     cmdb_update_instance,
 )
-from apps.opspilot.metis.llm.tools.cmdb.models import (
+from apps.opspilot.metis.llm.tools.cmdb.models import cmdb_get_model_info, cmdb_list_model_attrs, cmdb_list_models
+from apps.opspilot.metis.llm.tools.cmdb.search import cmdb_fulltext_search, cmdb_fulltext_search_by_model, cmdb_fulltext_search_stats
+from apps.opspilot.utils.db_cleanup import wrap_langchain_tool
+
+# LangGraph 异步 ToolNode 会把同步 @tool 丢进默认 executor；该线程上的 Django
+# ORM 连接不在 nats_listener SensitiveThread 清理范围内，必须在工具出口关闭。
+_CMDB_TOOLS = (
+    cmdb_list_models,
     cmdb_get_model_info,
     cmdb_list_model_attrs,
-    cmdb_list_models,
-)
-from apps.opspilot.metis.llm.tools.cmdb.search import (
+    cmdb_search_instances,
+    cmdb_get_instance,
+    cmdb_create_instance,
+    cmdb_update_instance,
+    cmdb_batch_update_instances,
+    cmdb_delete_instance,
+    cmdb_batch_delete_instances,
+    cmdb_topo_search,
+    cmdb_topo_expand,
+    cmdb_list_model_associations,
+    cmdb_list_instance_associations,
+    cmdb_list_associated_instances,
+    cmdb_create_instance_association,
+    cmdb_delete_instance_association,
     cmdb_fulltext_search,
-    cmdb_fulltext_search_by_model,
     cmdb_fulltext_search_stats,
+    cmdb_fulltext_search_by_model,
 )
+for _tool in _CMDB_TOOLS:
+    wrap_langchain_tool(_tool)
+del _tool, _CMDB_TOOLS
 
 CONSTRUCTOR_PARAMS = [
     {

--- a/server/apps/opspilot/services/chat_service.py
+++ b/server/apps/opspilot/services/chat_service.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import os
 import re
+import threading
 import uuid
 from typing import Any, Dict, Tuple
 
@@ -225,37 +226,64 @@ class ChatService:
                 raise RuntimeError("当前 Celery worker 使用 eventlet 池，不支持异步执行，请改用 --pool threads 或 solo")
 
             # 调用 agent 的 execute 方法（非流式同步执行）
-            # 在独立线程中创建全新事件循环来执行异步代码，避免与 ASGI 主事件循环交互导致死锁
+            # 在独立 daemon 线程中创建全新事件循环来执行异步代码，避免与 ASGI
+            # 主事件循环交互导致死锁；超时后调用方立即返回，后台线程结束时
+            # 仍会清理本线程 Django 连接（CONN_MAX_AGE=0 下避免 idle 驻留）。
+            from django.db import close_old_connections
+
+            timed_out_holder = {"value": False}
+            worker_result: Dict[str, Any] = {}
+            worker_done = threading.Event()
+
             def _run_in_new_loop():
                 loop = asyncio.new_event_loop()
                 asyncio.set_event_loop(loop)
+                close_old_connections()
                 try:
                     return loop.run_until_complete(graph.execute(request))
                 finally:
-                    # 清理所有待处理的异步资源（如 httpx 连接池）
                     try:
-                        _cancel_all_tasks(loop)
-                        loop.run_until_complete(loop.shutdown_asyncgens())
-                        loop.run_until_complete(loop.shutdown_default_executor())
+                        if not loop.is_closed() and not timed_out_holder["value"]:
+                            _cancel_all_tasks(loop)
+                            loop.run_until_complete(loop.shutdown_asyncgens())
+                            loop.run_until_complete(loop.shutdown_default_executor())
+                        elif not loop.is_closed():
+                            # 超时路径：不 wait 默认 executor；旁路 ORM 连接由
+                            # run_with_db_cleanup / 工具包装负责。
+                            executor = getattr(loop, "_default_executor", None)
+                            if executor is not None:
+                                executor.shutdown(wait=False, cancel_futures=True)
+                                loop._default_executor = None
                     except Exception:
                         pass
-                    loop.close()
+                    try:
+                        if not loop.is_closed():
+                            loop.close()
+                    except Exception:
+                        pass
+                    close_old_connections()
+
+            def _worker():
+                try:
+                    worker_result["response"] = _run_in_new_loop()
+                except BaseException as exc:  # noqa: BLE001 — 原样传回调用方
+                    worker_result["error"] = exc
+                finally:
+                    worker_done.set()
 
             # 整轮 agent 执行预算（含多轮 LLM + 工具调用），独立于单次 LLM 调用超时
             _agent_timeout = _resolve_agent_execute_timeout()
-            pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-            timed_out = False
-            try:
-                future = pool.submit(_run_in_new_loop)
-                response = future.result(timeout=_agent_timeout)
-            except concurrent.futures.TimeoutError:
-                timed_out = True
-                # Python 无法强制终止已运行的线程；先尽力取消尚未启动的任务，
-                # 再让工作流立即收敛到失败，不能在 shutdown(wait=True) 中继续阻塞。
-                future.cancel()
-                raise
-            finally:
-                pool.shutdown(wait=not timed_out, cancel_futures=timed_out)
+            worker = threading.Thread(target=_worker, name="opspilot-invoke-chat", daemon=True)
+            worker.start()
+            if not worker_done.wait(timeout=_agent_timeout):
+                timed_out_holder["value"] = True
+                # Python 无法强制终止已运行的线程；调用方立即返回。
+                # daemon 线程在进程退出时不阻塞；若进程仍存活，线程结束时会
+                # 走 _run_in_new_loop.finally 清理本线程 DB 连接。
+                raise concurrent.futures.TimeoutError()
+            if "error" in worker_result:
+                raise worker_result["error"]
+            response = worker_result["response"]
 
             # 构建返回结果
             result = {

--- a/server/apps/opspilot/services/skill_package/runtime.py
+++ b/server/apps/opspilot/services/skill_package/runtime.py
@@ -171,7 +171,13 @@ def hydrate_skill_packages(skill_packages: Any) -> list[dict[str, Any]]:
 
     try:
         # 同步 ORM 查询,调用方须在 sync 上下文(用 ThreadPoolExecutor 包一层)。
-        stored_list = list(SkillPackage.objects.filter(id__in=ids, is_enabled=True))
+        # 该线程可能是 asyncio/LangGraph 旁路线程，必须在本线程清理连接。
+        from apps.opspilot.utils.db_cleanup import run_with_db_cleanup
+
+        def _load_packages():
+            return list(SkillPackage.objects.filter(id__in=ids, is_enabled=True))
+
+        stored_list = run_with_db_cleanup(_load_packages)
         # key 统一转 str:LangGraph configurable 跨节点序列化会把 int id 转 str,
         # 后续 stored_packages.get(item.get("id")) 也用 str 查,保持一致。
         stored_packages = {str(item.id): item for item in stored_list}

--- a/server/apps/opspilot/tests/test_chat_service_llm_timeout.py
+++ b/server/apps/opspilot/tests/test_chat_service_llm_timeout.py
@@ -63,14 +63,14 @@ class TestChatServiceFutureTimeout:
 
     def test_future_result_has_timeout(self, chat_service_src):
         """
-        future.result() 必须携带 timeout 参数。
+        整轮 agent 执行必须有超时预算（worker_done.wait(timeout=...)）。
 
-        revert 修复（还原为 `future.result()`）后，此测试应失败。
+        revert 修复（去掉 timeout）后，此测试应失败。
         """
-        match = re.search(r"future\.result\s*\(([^)]*)\)", chat_service_src)
-        assert match, "chat_service.py 中未找到 future.result() 调用"
+        match = re.search(r"worker_done\.wait\s*\(([^)]*)\)", chat_service_src)
+        assert match, "chat_service.py 中未找到 worker_done.wait() 调用"
         args = match.group(1).strip()
-        assert "timeout" in args, f"future.result() 缺少 timeout 参数，当前参数为：({args})。" "没有 timeout 参数时，LLM 卡死会导致 worker 线程永久阻塞（Issue #3718）。"
+        assert "timeout" in args, f"worker_done.wait() 缺少 timeout 参数，当前参数为：({args})。" "没有 timeout 参数时，LLM 卡死会导致调用方永久阻塞（Issue #3718）。"
 
     def test_llm_invoke_timeout_env_var_referenced(self, chat_service_src):
         """
@@ -112,7 +112,9 @@ class TestChatServiceFutureTimeout:
 
         class BlockingGraph:
             async def execute(self, _request):
-                time.sleep(2)
+                # 略长于 AGENT_EXECUTE_TIMEOUT=1，确保触发超时；
+                # 不宜过长，避免后台 daemon 线程拖慢测试进程收尾。
+                time.sleep(1.2)
                 return SimpleNamespace(
                     message="late response",
                     total_tokens=0,
@@ -146,6 +148,12 @@ class TestChatServiceFutureTimeout:
         assert result["success"] is False
         assert result["error_type"] == "TimeoutError"
         assert elapsed < 1.5, f"超时返回仍等待了后台线程: {elapsed:.3f}s"
+
+    def test_timeout_path_cleans_db_connections_in_worker(self, chat_service_src):
+        """worker finally 必须 close_old_connections；超时使用 daemon 线程避免阻塞退出。"""
+        assert "close_old_connections" in chat_service_src
+        assert "timed_out_holder" in chat_service_src
+        assert "daemon=True" in chat_service_src
 
 
 class TestLLMClientFactoryTimeout:

--- a/server/apps/opspilot/tests/test_db_cleanup_service.py
+++ b/server/apps/opspilot/tests/test_db_cleanup_service.py
@@ -1,0 +1,52 @@
+"""旁路线程 Django 连接清理（Issue #4710）。"""
+
+from unittest.mock import MagicMock, patch
+
+from apps.opspilot.utils.db_cleanup import run_with_db_cleanup, with_db_cleanup, wrap_langchain_tool
+
+
+class TestRunWithDbCleanup:
+    def test_closes_connections_before_and_after_success(self):
+        with patch("apps.opspilot.utils.db_cleanup.close_old_connections") as close:
+            result = run_with_db_cleanup(lambda: 42)
+        assert result == 42
+        assert close.call_count == 2
+
+    def test_closes_connections_after_exception(self):
+        with patch("apps.opspilot.utils.db_cleanup.close_old_connections") as close:
+            try:
+                run_with_db_cleanup(lambda: (_ for _ in ()).throw(ValueError("boom")))
+            except ValueError:
+                pass
+        assert close.call_count == 2
+
+    def test_decorator_wraps_function(self):
+        @with_db_cleanup
+        def add(a, b):
+            return a + b
+
+        with patch("apps.opspilot.utils.db_cleanup.close_old_connections") as close:
+            assert add(1, 2) == 3
+        assert close.call_count == 2
+
+    def test_wrap_langchain_tool_replaces_func(self):
+        calls = []
+
+        def original(*, x):
+            calls.append(x)
+            return {"ok": True}
+
+        tool = MagicMock()
+        tool.func = original
+
+        wrap_langchain_tool(tool)
+
+        with patch("apps.opspilot.utils.db_cleanup.close_old_connections") as close:
+            assert tool.func(x=1) == {"ok": True}
+        assert calls == [1]
+        assert close.call_count == 2
+        # 幂等：再次包装不叠多层
+        first_wrapped = tool.func
+        wrap_langchain_tool(tool)
+        assert tool.func is first_wrapped
+        assert getattr(tool.func, "_db_cleanup_wrapped", False) is True

--- a/server/apps/opspilot/utils/chat_flow_utils/engine/node_runner.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/engine/node_runner.py
@@ -280,13 +280,26 @@ class NodeRunnerMixin:
         results = {}
         timeout_per_node = remaining_timeout / len(node_ids)
 
+        from apps.opspilot.utils.db_cleanup import run_with_db_cleanup
+
+        def _run_parallel_branch(node_id: str):
+            # 并行分支在独立线程访问 ORM；必须在该线程清理连接，
+            # 外层 database_sync_to_async 的 close_old_connections 清不到这里。
+            return run_with_db_cleanup(
+                self._execute_node_recursive,
+                node_id,
+                input_data,
+                set(),
+                timeout_per_node,
+            )
+
         with ThreadPoolExecutor(max_workers=min(len(node_ids), self.max_parallel_nodes)) as executor:
             # 提交任务
             futures = {}
             for node_id in node_ids:
                 if self._check_interrupt_requested():
                     break
-                future = executor.submit(self._execute_node_recursive, node_id, input_data, set(), timeout_per_node)  # 每个并行分支使用独立的访问集合
+                future = executor.submit(_run_parallel_branch, node_id)  # 每个并行分支使用独立的访问集合
                 futures[future] = node_id
 
             # 收集结果

--- a/server/apps/opspilot/utils/db_cleanup.py
+++ b/server/apps/opspilot/utils/db_cleanup.py
@@ -1,0 +1,52 @@
+"""Django ORM 旁路线程连接清理。
+
+``close_old_connections`` 只作用于调用它的线程（connections 为 thread-local）。
+在 ThreadPoolExecutor / ``sync_to_async(thread_sensitive=False)`` /
+asyncio 默认 executor 里访问 ORM 时，必须在**真正建连的那个线程**上清理，
+否则 idle 连接会永久驻留，最终打满 PostgreSQL ``max_connections``。
+"""
+
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, TypeVar
+
+from django.db import close_old_connections
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def run_with_db_cleanup(func: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
+    """在当前线程执行 func，前后关闭过期/不可用的 Django DB 连接。"""
+    close_old_connections()
+    try:
+        return func(*args, **kwargs)
+    finally:
+        close_old_connections()
+
+
+def with_db_cleanup(func: F) -> F:
+    """装饰器：保证被装饰函数无论成功失败都会清理本线程 Django 连接。"""
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        return run_with_db_cleanup(func, *args, **kwargs)
+
+    return wrapper  # type: ignore[return-value]
+
+
+def wrap_langchain_tool(tool: Any) -> Any:
+    """包装 LangChain StructuredTool 的同步 ``func``，使每次工具调用后清理连接。"""
+    original = getattr(tool, "func", None)
+    # 用 ``is True``：MagicMock 等对任意属性返回真值对象，不能直接当 bool 用。
+    if original is None or getattr(original, "_db_cleanup_wrapped", False) is True:
+        return tool
+
+    wrapped = with_db_cleanup(original)
+    wrapped._db_cleanup_wrapped = True  # type: ignore[attr-defined]
+    try:
+        tool.func = wrapped
+    except Exception:
+        # 部分 StructuredTool 实现可能禁止直接赋值，退化为不影响调用方
+        pass
+    return tool

--- a/server/apps/opspilot/utils/execution_interrupt.py
+++ b/server/apps/opspilot/utils/execution_interrupt.py
@@ -33,23 +33,32 @@ def _check_interrupt_in_database(execution_id: str) -> bool:
 
     仅在缓存未命中时调用，避免频繁数据库访问。
     使用 exists() 优化查询性能。
-    """
-    # 延迟导入避免循环依赖
-    from apps.opspilot.enum import WorkFlowTaskStatus
-    from apps.opspilot.models import WorkFlowTaskResult
 
-    try:
-        return WorkFlowTaskResult.objects.filter(
-            execution_id=execution_id,
-            status=WorkFlowTaskStatus.INTERRUPTED,
-        ).exists()
-    except Exception as e:
-        logger.warning(
-            "Failed to check interrupt status in database: execution_id=%s, error=%s",
-            execution_id,
-            str(e),
-        )
-        return False
+    本函数可能经 ``sync_to_async(thread_sensitive=False)`` 跑在 asyncio 默认
+    executor 线程上，必须在本线程清理连接，外层 SensitiveThread 的
+    ``close_old_connections`` 清不到这里。
+    """
+    from apps.opspilot.utils.db_cleanup import run_with_db_cleanup
+
+    def _query() -> bool:
+        # 延迟导入避免循环依赖
+        from apps.opspilot.enum import WorkFlowTaskStatus
+        from apps.opspilot.models import WorkFlowTaskResult
+
+        try:
+            return WorkFlowTaskResult.objects.filter(
+                execution_id=execution_id,
+                status=WorkFlowTaskStatus.INTERRUPTED,
+            ).exists()
+        except Exception as e:
+            logger.warning(
+                "Failed to check interrupt status in database: execution_id=%s, error=%s",
+                execution_id,
+                str(e),
+            )
+            return False
+
+    return run_with_db_cleanup(_query)
 
 
 async def _check_interrupt_in_database_async(execution_id: str) -> bool:
@@ -59,6 +68,7 @@ async def _check_interrupt_in_database_async(execution_id: str) -> bool:
     使用 sync_to_async 包装同步 ORM 调用，安全地在异步上下文中执行。
     注意：使用 thread_sensitive=False 避免在 LangGraph 异步节点中触发
     "You cannot submit onto CurrentThreadExecutor from its own thread" 错误。
+    ORM 清理由 ``_check_interrupt_in_database`` 内部的 ``run_with_db_cleanup`` 负责。
     """
     return await sync_to_async(_check_interrupt_in_database, thread_sensitive=False)(execution_id)
 


### PR DESCRIPTION
## Summary
- 修复 #4710：
ats_listener 经 OpsPilot 工作流旁路线程访问 Django ORM 后连接未清理，idle 连接单调累积直至耗尽 PostgreSQL max_connections
- 新增 un_with_db_cleanup / 工具包装，覆盖并行节点、interrupt DB 回查、skill hydrate、CMDB tools；invoke_chat 超时改为 daemon 线程并在 worker inally 清理连接
- 补充单元测试；本地方式一压测 40 轮 	rigger_workflow_by_nats，idle 始终为 3、冷却后不堆积

## Test plan
- [x] pytest：	est_db_cleanup_service / 	est_chat_service_llm_timeout / interrupt 相关用例通过
- [x] 方式 B：裸 ThreadPool ORM idle +N，un_with_db_cleanup 后 +0
- [x] 方式 A：本地 NATS + 
ats_listener，40 轮工作流，pg_stat_activity idle 基线不变
- [ ] CI 绿灯后人工 review，**请勿自动合并**

Fixes #4710