### PR TITLE
bugfix: 优化日志在线聚合复杂度

### DIFF
--- a/algorithms/classify_log_server/classify_log_server/serving/service.py
+++ b/algorithms/classify_log_server/classify_log_server/serving/service.py
@@ -134,20 +134,17 @@ class MLService:
             
             # 统计基本信息
             total_logs = len(data)
-            matched_logs = len(result_df[result_df['cluster_id'] != -1])
-            
-            # 统计每个模板的出现次数
-            cluster_counts = result_df['cluster_id'].value_counts().to_dict()
+            unknown_mask = result_df["cluster_id"] == -1
+            matched_logs = int((~unknown_mask).sum())
             
             # 构建模板分组
             template_groups = []
-            for cluster_id, count in cluster_counts.items():
-                if cluster_id == -1:
-                    continue  # 未知日志单独处理
-                
-                # 获取该模板的所有日志索引
-                mask = result_df['cluster_id'] == cluster_id
-                indices = result_df[mask].index.tolist()
+            matched_groups = result_df.loc[~unknown_mask].groupby(
+                "cluster_id", sort=False
+            )
+            for cluster_id, group in matched_groups:
+                count = len(group)
+                indices = group.index.tolist()
                 
                 # 采样代表性日志
                 sample_size = min(req_config.max_samples, count)
@@ -155,7 +152,7 @@ class MLService:
                 sample_logs = [data[i] for i in sample_indices]
                 
                 # 获取模板字符串
-                template_str = result_df[mask]['template'].iloc[0]
+                template_str = group["template"].iloc[0]
                 
                 template_groups.append(TemplateGroup(
                     cluster_id=int(cluster_id),
@@ -173,7 +170,6 @@ class MLService:
                 template_groups.sort(key=lambda x: x.cluster_id)
             
             # 处理未知日志
-            unknown_mask = result_df['cluster_id'] == -1
             unknown_logs = []
             if unknown_mask.any():
                 unknown_indices = result_df[unknown_mask].index.tolist()
@@ -265,4 +261,3 @@ class MLService:
             "model_source": self.config.source,
             "model_version": getattr(self.model, "version", "unknown"),
         }
-

--- a/algorithms/classify_log_server/tests/test_predict_validation.py
+++ b/algorithms/classify_log_server/tests/test_predict_validation.py
@@ -86,8 +86,9 @@ def _setup_stubs():
     prom_mod.Histogram = lambda *a, **k: _Counter()
     prom_mod.Gauge = lambda *a, **k: _Counter()
 
-    # ---- pandas 桩（仅用于类型，实际路径不走 predict 推理逻辑）----
-    _install("pandas")
+    # ---- pandas 桩（仅在依赖不可用时兜底，避免污染同进程聚合测试）----
+    if importlib.util.find_spec("pandas") is None:
+        _install("pandas")
 
     # ---- 服务内部子模块桩 ----
     serving_base = "classify_log_server.serving"

--- a/algorithms/classify_log_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_log_server/tests/test_schema_and_predict.py
@@ -316,7 +316,7 @@ class TestMLServicePredict:
         ]
         mock_model = self._make_mock_model(data, [0, 1], ["User login *", "DB timeout *"])
         svc = self._make_service(mock_model)
-        response = await svc.predict(data)
+        response = await svc.predict(LogClusterRequest(data=data))
         assert response.summary.total_logs == 2
 
     @pytest.mark.asyncio
@@ -329,7 +329,7 @@ class TestMLServicePredict:
         # 第二条日志 cluster_id=-1（未匹配）
         mock_model = self._make_mock_model(data, [0, -1], ["User login *", None])
         svc = self._make_service(mock_model)
-        response = await svc.predict(data)
+        response = await svc.predict(LogClusterRequest(data=data))
         assert 0.0 <= response.summary.coverage_rate <= 1.0
 
     @pytest.mark.asyncio
@@ -348,7 +348,7 @@ class TestMLServicePredict:
             data, [0, 1, -1], ["User login *", "DB timeout *", None]
         )
         svc = self._make_service(mock_model)
-        response = await svc.predict(data)
+        response = await svc.predict(LogClusterRequest(data=data))
         assert (
             response.summary.matched_logs + response.summary.unknown_logs
             == response.summary.total_logs
@@ -360,5 +360,115 @@ class TestMLServicePredict:
         data = ["User login failed from IP 1.2.3.4"]
         mock_model = self._make_mock_model(data, [0], ["User login *"])
         svc = self._make_service(mock_model)
-        response = await svc.predict(data)
+        response = await svc.predict(LogClusterRequest(data=data))
         assert response.details is None
+
+    @pytest.mark.asyncio
+    async def test_predict_aggregates_high_cardinality_without_per_cluster_rescan(self):
+        """高基数聚合不应为每个 cluster 重建整列相等比较。"""
+        import pandas as pd
+
+        cluster_count = 64
+        data = [f"log-{index}" for index in range(cluster_count)]
+        mock_model = self._make_mock_model(
+            data,
+            list(range(cluster_count)),
+            [f"template-{index}" for index in range(cluster_count)],
+        )
+        svc = self._make_service(mock_model)
+        original_eq = pd.Series.__eq__
+        cluster_comparisons = []
+
+        def count_cluster_comparisons(series, other):
+            if series.name == "cluster_id":
+                cluster_comparisons.append(other)
+            return original_eq(series, other)
+
+        with patch.object(pd.Series, "__eq__", count_cluster_comparisons):
+            response = await svc.predict(LogClusterRequest(data=data))
+
+        assert len(response.template_groups) == cluster_count
+        assert len(cluster_comparisons) <= 1
+
+    @pytest.mark.asyncio
+    async def test_predict_grouping_preserves_response_contract(self):
+        """一次分组仍保留计数、原始顺序、样本、未知项与稳定排序语义。"""
+        data = ["c2-first", "unknown", "c1-first", "c2-second", "c1-second"]
+        mock_model = self._make_mock_model(
+            data,
+            [2, -1, 1, 2, 1],
+            ["template-2", None, "template-1", "template-2", "template-1"],
+        )
+        svc = self._make_service(mock_model)
+        request = LogClusterRequest(
+            data=data,
+            config=LogClusterConfig(max_samples=1, sort_by="count"),
+        )
+
+        response = await svc.predict(request)
+
+        assert [group.model_dump() for group in response.template_groups] == [
+            {
+                "cluster_id": 2,
+                "template": "template-2",
+                "count": 2,
+                "percentage": 40.0,
+                "log_indices": [0, 3],
+                "sample_logs": ["c2-first"],
+            },
+            {
+                "cluster_id": 1,
+                "template": "template-1",
+                "count": 2,
+                "percentage": 40.0,
+                "log_indices": [2, 4],
+                "sample_logs": ["c1-first"],
+            },
+        ]
+        assert response.unknown_logs == [
+            {"index": 1, "log": "unknown", "reason": "no_matching_template"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_predict_grouping_preserves_duplicate_dataframe_indices(self):
+        """分组后的 log_indices 与样本仍按模型 DataFrame 的原始索引工作。"""
+        import pandas as pd
+
+        data = ["first", "second", "third"]
+        mock_model = MagicMock()
+        mock_model.predict.return_value = pd.DataFrame(
+            {
+                "log": data,
+                "cluster_id": [7, 7, -1],
+                "template": ["template-7", "template-7", None],
+            },
+            index=[1, 1, 2],
+        )
+        svc = self._make_service(mock_model)
+
+        response = await svc.predict(LogClusterRequest(data=data))
+
+        assert response.template_groups[0].log_indices == [1, 1]
+        assert response.template_groups[0].sample_logs == ["second", "second"]
+        assert response.unknown_logs == [
+            {"index": 2, "log": "third", "reason": "no_matching_template"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_predict_grouping_sorts_non_contiguous_cluster_ids(self):
+        """cluster_id 排序仍按数值升序处理非连续 ID。"""
+        data = ["cluster-10", "cluster-2", "cluster-10"]
+        mock_model = self._make_mock_model(
+            data,
+            [10, 2, 10],
+            ["template-10", "template-2", "template-10"],
+        )
+        svc = self._make_service(mock_model)
+        request = LogClusterRequest(
+            data=data,
+            config=LogClusterConfig(sort_by="cluster_id"),
+        )
+
+        response = await svc.predict(request)
+
+        assert [group.cluster_id for group in response.template_groups] == [2, 10]


### PR DESCRIPTION
## 问题

在线日志聚类聚合本应只遍历一次模型结果，但旧实现先统计 cluster，再为每个 cluster 重建整列 mask 并切片。当合法请求包含大量唯一模板时，聚合会从线性路径退化为 `O(C·N)`，挤占在线推理 worker。

## 根因

聚合边界由 cluster 驱动整表查询，而不是由结果表一次分组。计数、索引和模板分别从重复切片中提取，使 cluster 数接近日志数时产生平方级比较与临时 DataFrame。

## 怎么修的

- 只构造一次未知日志 mask，并复用它计算匹配数与未知项。
- 对匹配结果执行一次 `groupby("cluster_id", sort=False)`，直接从每组读取索引、首模板和样本。
- 保留既有最终排序，因此 count 相同时仍按 cluster 首次出现顺序稳定排列，`cluster_id` 模式仍按数值升序。
- 修正聚合测试使用 `LogClusterRequest` 的公开入口，并避免输入校验测试在 pandas 已安装时注入全局空存根。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MLService.predict\nserving/service.py"]
    end

    P["model.predict\n生成结果 DataFrame"]

    subgraph A["聚合层"]
        A1["一次 unknown mask"]
        A2["一次稳定 groupby"]
        A3["组内读取索引/模板/样本"]
    end

    R["LogClusterResponseV2\n稳定排序并返回"]

    T1 --> P --> A1 --> A2 --> A3 --> R
```

## 影响范围

仅修改 `classify_log_server` 在线聚合内部实现，不改变请求 schema、响应字段、模型调用或部署配置。复杂度由 `O(C·N)` 收敛为分组 `O(N)` 加最终排序 `O(C log C)`。

兼容语义覆盖：count、percentage、原始索引顺序、每组前 N 条样本、未知日志、非连续 cluster ID、重复 DataFrame 索引，以及两种排序模式。

## 验证

- `tests/test_schema_and_predict.py` 与 `tests/test_predict_validation.py`：34 passed。
- `classify_log_server` 模块全量：47 passed。
- 可红契约：64 个唯一 cluster 在旧实现产生 65 次整列相等比较，修复后为 1 次；回退实现时测试会失败。
- 10000 条、10000 个唯一 cluster 的公开 `MLService.predict(LogClusterRequest(...))` 路径完成约 0.20 秒，计数与分组完整。

## 三轨门禁

- Standards：PASS，未发现仓库规范违反或阻塞代码味道。
- Spec：PASS，复杂度目标和全部输出兼容要求均已实现。
- Runtime Contract：PASS，专项、全量、可红复现和 10000 条上限场景均通过。

关联 Issue #4617。
