### PR TITLE
fix(webhookd): Proxy 安装包第三方镜像对齐主部署版本(redis 7.4.10 / nats 2.12.12 / traefik 3.6.24)

### DIFF
--- a/agents/webhookd/infra/proxy/env.template
+++ b/agents/webhookd/infra/proxy/env.template
@@ -1,10 +1,10 @@
 # 容器镜像
-DOCKER_IMAGE_NATS=bk-lite.tencentcloudcr.com/bklite/library/nats:2.10.25
+DOCKER_IMAGE_NATS=bk-lite.tencentcloudcr.com/bklite/library/nats:2.12.12
 DOCKER_IMAGE_NATS_EXECUTOR=bk-lite.tencentcloudcr.com/bklite/bklite/nats-executor:latest
 DOCKER_IMAGE_STARGAZER=bk-lite.tencentcloudcr.com/bklite/bklite/stargazer:latest
-DOCKER_IMAGE_TRAEFIK=bk-lite.tencentcloudcr.com/bklite/library/traefik:3.6.2
+DOCKER_IMAGE_TRAEFIK=bk-lite.tencentcloudcr.com/bklite/library/traefik:3.6.24
 DOCKER_IMAGE_FUSION_COLLECTOR=bk-lite.tencentcloudcr.com/bklite/bklite/fusion-collector:latest
-DOCKER_IMAGE_REDIS=bk-lite.tencentcloudcr.com/bklite/library/redis:5.0.14
+DOCKER_IMAGE_REDIS=bk-lite.tencentcloudcr.com/bklite/library/redis:7.4.10
 DOCKER_IMAGE_NATS_BOX=bk-lite.tencentcloudcr.com/bklite/natsio/nats-box:latest
 DOCKER_IMAGE_APM_COLLECTOR=bk-lite.tencentcloudcr.com/bklite/bklite/apm-otel-collector:0.153.0-bklite.1
 DOCKER_IMAGE_APM_QUEUE_INIT=bk-lite.tencentcloudcr.com/bklite/library/busybox:1.37.0


### PR DESCRIPTION
## 问题

Proxy 现场反馈:`stargazer:latest` 连接 Redis 时固定发送 `HELLO 3`,配套的 `redis:5.0.14` 返回 `unknown command HELLO`,Sanic worker 启动失败,Proxy 安装主阻塞。详见 #4729。

## 根因

主部署脚本(bklite-website `deploy/docker-compose/bootstrap.sh`)已于 2026-07-29 将第三方基础镜像升级至安全版本,但 `agents/webhookd/infra/proxy/env.template` 未同步,三个第三方组件全部停留在升级前的旧版本。`proxy.sh` 生成安装包时镜像地址为硬编码文本原样带出,所有新装 Proxy 均受影响。

`stargazer:latest` 镜像构建未锁依赖,已漂移到 redis-py 8.x(默认 RESP3,建连发 HELLO 且无 RESP2 回退);中心侧 Redis 7.4.10 支持 HELLO 正常,Proxy 侧 Redis 5.0.14 不支持,因此仅 Proxy 现场爆发。

## 变更

`agents/webhookd/infra/proxy/env.template` 三个第三方镜像对齐主部署:

| 组件 | 变更前 | 变更后(=主部署) |
|---|---|---|
| redis | 5.0.14 | 7.4.10 |
| nats | 2.10.25 | 2.12.12 |
| traefik | 3.6.2 | 3.6.24 |

## 验证

- `docker manifest inspect` 确认三个新 tag 均已存在于 `bk-lite.tencentcloudcr.com/bklite/library/`(主部署 7-29 起在用);
- Proxy 的 `nats.conf.template` 仅含 jetstream/leafnodes/tls/authorization 标准配置,NATS 2.12 兼容,且与中心侧 NATS 版本一致;
- `docker-compose.yaml` 中 Redis 仅用 `--requirepass` 与 `redis-cli ping` 健康检查,Redis 7 行为不变;Redis 7 可直接加载 Redis 5 的 RDB,存量 Proxy 升级可保留数据卷。

## 后续(不在本 PR 范围)

- stargazer `build_redis_client()` 显式 `protocol=2` / 支持 `REDIS_PROTOCOL`,及镜像构建锁定依赖(防 `latest` 再次随上游破坏性变更漂移);
- Proxy 模板镜像清单与主部署清单建立同步机制。

Fixes #4729

🤖 Generated with [Claude Code](https://claude.com/claude-code)
