### PR TITLE
fix(algorithms): 透传目标检测数量上限

### DIFF
--- a/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
+++ b/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
@@ -266,6 +266,7 @@ class MLService:
                 "images": valid_images,
                 "conf": request.config.conf_threshold,
                 "iou": request.config.iou_threshold,
+                "max_det": request.config.max_detections,
             }
 
             # 调用模型预测（返回格式见 YOLOWrapper）

--- a/algorithms/classify_object_detection_server/classify_object_detection_server/training/models/yolo_wrapper.py
+++ b/algorithms/classify_object_detection_server/classify_object_detection_server/training/models/yolo_wrapper.py
@@ -59,15 +59,22 @@ class YOLODetectionWrapper(mlflow.pyfunc.PythonModel):
             conf = model_input.get("conf", 0.25)
             iou = model_input.get("iou", 0.45)
             imgsz = model_input.get("imgsz", 640)
+            max_det = model_input.get("max_det", 300)
         else:
             images = model_input
             conf = 0.25
             iou = 0.45
             imgsz = 640
+            max_det = 300
 
         # 执行预测
         results = self.model.predict(
-            images, conf=conf, iou=iou, imgsz=imgsz, verbose=False
+            images,
+            conf=conf,
+            iou=iou,
+            imgsz=imgsz,
+            max_det=max_det,
+            verbose=False,
         )
 
         # 格式化输出

--- a/algorithms/classify_object_detection_server/tests/test_issue_4619_max_detections.py
+++ b/algorithms/classify_object_detection_server/tests/test_issue_4619_max_detections.py
@@ -1,0 +1,125 @@
+"""Issue #4619：公开 max_detections 契约必须到达 YOLO NMS。"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from classify_object_detection_server.serving.service import MLService
+from classify_object_detection_server.training.models.yolo_wrapper import (
+    YOLODetectionWrapper,
+)
+
+
+EMPTY_PREDICTION = {
+    "boxes": [],
+    "classes": [],
+    "confidences": [],
+    "labels": [],
+    "count": 0,
+}
+
+
+def make_service():
+    service = object.__new__(MLService.inner)
+    service.config = SimpleNamespace(
+        source="dummy",
+        model_path=None,
+        mlflow_model_uri=None,
+    )
+    service.model = MagicMock()
+    service.model.predict.return_value = [EMPTY_PREDICTION]
+    service._decode_base64_image = MagicMock(
+        return_value=Image.new("RGB", (2, 2))
+    )
+    return service
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_detections", [1, 300, 301, 1_000])
+async def test_service_passes_max_detections_to_model(max_detections):
+    service = make_service()
+
+    response = await service.predict(
+        ["A" * 100],
+        {
+            "conf_threshold": 0.25,
+            "iou_threshold": 0.45,
+            "max_detections": max_detections,
+        },
+    )
+
+    assert response.success is True
+    service.model.predict.assert_called_once_with(
+        {
+            "images": [service._decode_base64_image.return_value],
+            "conf": 0.25,
+            "iou": 0.45,
+            "max_det": max_detections,
+        }
+    )
+
+
+@pytest.mark.parametrize("max_det", [1, 300, 301, 1_000])
+def test_wrapper_passes_max_det_to_ultralytics(max_det):
+    wrapper = YOLODetectionWrapper()
+    wrapper.model = MagicMock()
+    wrapper.model.predict.return_value = [SimpleNamespace(boxes=None)]
+    wrapper.class_names = []
+    images = [object()]
+
+    predictions = wrapper.predict(
+        None,
+        {
+            "images": images,
+            "conf": 0.25,
+            "iou": 0.45,
+            "imgsz": 640,
+            "max_det": max_det,
+        },
+    )
+
+    assert predictions == [EMPTY_PREDICTION]
+    wrapper.model.predict.assert_called_once_with(
+        images,
+        conf=0.25,
+        iou=0.45,
+        imgsz=640,
+        max_det=max_det,
+        verbose=False,
+    )
+
+
+def test_wrapper_preserves_default_max_detections_for_legacy_input():
+    wrapper = YOLODetectionWrapper()
+    wrapper.model = MagicMock()
+    wrapper.model.predict.return_value = [SimpleNamespace(boxes=None)]
+    wrapper.class_names = []
+
+    wrapper.predict(None, {"images": [object()]})
+
+    assert wrapper.model.predict.call_args.kwargs["max_det"] == 300
+
+
+@pytest.mark.asyncio
+async def test_service_keeps_response_slice_as_defense_in_depth():
+    service = make_service()
+    detection_count = 305
+    service.model.predict.return_value = [
+        {
+            "boxes": [[0.1, 0.1, 0.2, 0.2]] * detection_count,
+            "classes": [0] * detection_count,
+            "confidences": [0.9] * detection_count,
+            "labels": ["object"] * detection_count,
+            "count": detection_count,
+        }
+    ]
+
+    response = await service.predict(
+        ["A" * 100], {"max_detections": 301}
+    )
+
+    assert response.success is True
+    assert len(response.results[0].detections) == 301
+    assert response.metadata.total_detections == 301

--- a/algorithms/classify_object_detection_server/tests/test_issue_4619_max_detections.py
+++ b/algorithms/classify_object_detection_server/tests/test_issue_4619_max_detections.py
@@ -61,6 +61,34 @@ async def test_service_passes_max_detections_to_model(max_detections):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_detections", [0, 1_001])
+async def test_service_rejects_invalid_max_detections(max_detections):
+    service = make_service()
+
+    response = await service.predict(
+        ["A" * 100], {"max_detections": max_detections}
+    )
+
+    assert response.success is False
+    assert response.error.code == "E1000"
+    service.model.predict.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_service_preserves_model_error_contract():
+    service = make_service()
+    service.model.predict.side_effect = RuntimeError("model unavailable")
+
+    response = await service.predict(
+        ["A" * 100], {"max_detections": 301}
+    )
+
+    assert response.success is False
+    assert response.error.code == "E2001"
+    assert response.metadata.total_detections == 0
+
+
 @pytest.mark.parametrize("max_det", [1, 300, 301, 1_000])
 def test_wrapper_passes_max_det_to_ultralytics(max_det):
     wrapper = YOLODetectionWrapper()
@@ -103,9 +131,10 @@ def test_wrapper_preserves_default_max_detections_for_legacy_input():
 
 
 @pytest.mark.asyncio
-async def test_service_keeps_response_slice_as_defense_in_depth():
+@pytest.mark.parametrize("max_detections", [1, 300, 301, 1_000])
+async def test_service_keeps_response_slice_as_defense_in_depth(max_detections):
     service = make_service()
-    detection_count = 305
+    detection_count = max_detections + 4
     service.model.predict.return_value = [
         {
             "boxes": [[0.1, 0.1, 0.2, 0.2]] * detection_count,
@@ -117,9 +146,10 @@ async def test_service_keeps_response_slice_as_defense_in_depth():
     ]
 
     response = await service.predict(
-        ["A" * 100], {"max_detections": 301}
+        ["A" * 100], {"max_detections": max_detections}
     )
 
     assert response.success is True
-    assert len(response.results[0].detections) == 301
-    assert response.metadata.total_detections == 301
+    assert len(response.results[0].detections) == max_detections
+    assert response.metadata.total_detections == max_detections
+    assert len(response.model_dump()["results"][0]["detections"]) == max_detections


### PR DESCRIPTION
## 变更说明

关闭 #4619。

目标检测接口虽然公开允许 `max_detections=1..1000`，但该值此前没有进入 YOLO 的 NMS 参数，Ultralytics 仍使用默认 `max_det=300`，因此 301–1000 的合法配置无法生效。

本次修复：

- 将请求中的 `max_detections` 作为 `max_det` 传入模型包装层；
- 将 `max_det` 继续传给 Ultralytics `model.predict`；
- 旧包装层调用未提供参数时保持默认 300；
- 保留响应层切片作为防御性边界。

```mermaid
flowchart LR
    A["PredictRequest.max_detections"] --> B["MLService model_input.max_det"]
    B --> C["YOLODetectionWrapper.predict"]
    C --> D["Ultralytics model.predict max_det"]
    D --> E["响应层按请求上限防御性截断"]
```

## 验证

- 模块完整测试：20 passed；
- 边界 1、300、301、1000 均完成 service 与 wrapper 两层透传；
- 旧调用未传参数时仍使用 300；
- 模型返回 305 条、请求 301 时响应及 metadata 均为 301；
- Ultralytics 8.4.3 使用本地 YOLO 配置实际执行 `predict(max_det=301)` 成功；
- 非法 0/1001、模型异常和响应序列化契约保持正常；
- `git diff --check` 通过。

## 三轨复审

- Standards：PASS，0 findings；
- Spec：PASS，0 findings；
- Runtime Contract：PASS，0 blockers；
- 综合评分：96/100，满足 R1 自动 PR 发布门槛。

## 风险与回滚

风险较低：仅补齐既有配置的透传，不改变公开 schema。若需回滚，可直接回退本提交，旧的 300 条默认行为仍由上游依赖恢复。
