### PR TITLE
docs(algorithms): 修正图片分类请求示例

### DIFF
--- a/algorithms/classify_image_classification_server/README.md
+++ b/algorithms/classify_image_classification_server/README.md
@@ -60,12 +60,16 @@ export MODEL_SOURCE=dummy
 ```json
 {
     "images": [
-        "iVBORw0KGgo...",  // 纯base64
-        "data:image/jpeg;base64,/9j/4AAQ..."  // Data URI
+        "iVBORw0KGgo...",
+        "data:image/jpeg;base64,/9j/4AAQ..."
     ],
-    "top_k": 5  // 可选，默认5
+    "config": {
+        "top_k": 5
+    }
 }
 ```
+
+`config` 可选；未提供时，`top_k` 默认为 5。
 
 **响应格式**:
 ```json
@@ -86,6 +90,12 @@ export MODEL_SOURCE=dummy
         "source": "local",
         "batch_size": 1,
         "total_time_ms": 45.3,
+        "decode_time_ms": 15.2,
+        "predict_time_ms": 25.0,
+        "postprocess_time_ms": 5.1,
+        "avg_time_per_image_ms": 25.0,
+        "success_count": 1,
+        "failure_count": 0,
         "success_rate": 1.0
     },
     "success": true
@@ -106,7 +116,7 @@ with open("image.jpg", "rb") as f:
 # 调用API
 response = requests.post(
     "http://localhost:3000/predict",
-    json={"images": [img_b64], "top_k": 5}
+    json={"images": [img_b64], "config": {"top_k": 5}}
 )
 
 result = response.json()["results"][0]
@@ -130,7 +140,7 @@ for img_path in Path("images/").glob("*.jpg"):
 # 批量调用
 response = requests.post(
     "http://localhost:3000/predict",
-    json={"images": images, "top_k": 3}
+    json={"images": images, "config": {"top_k": 3}}
 )
 
 # 处理结果
@@ -141,10 +151,6 @@ for idx, result in enumerate(response.json()["results"]):
     else:
         print(f"Image {idx} failed: {result['error']}")
 ```
-
-## 迁移指南
-
-从v1.x迁移到v2.0？请查看 [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md)
 
 ## License
 

--- a/algorithms/classify_image_classification_server/tests/test_issue_4620_readme_contract.py
+++ b/algorithms/classify_image_classification_server/tests/test_issue_4620_readme_contract.py
@@ -1,0 +1,75 @@
+"""Issue #4620：README 的可复制示例必须遵循真实预测 API 契约。"""
+
+import ast
+import json
+import re
+from pathlib import Path
+
+from classify_image_classification_server.serving.schemas import PredictResponse
+
+
+MODULE_ROOT = Path(__file__).parents[1]
+README_PATH = MODULE_ROOT / "README.md"
+
+
+def _readme() -> str:
+    return README_PATH.read_text(encoding="utf-8")
+
+
+def test_readme_json_request_uses_nested_predict_config():
+    request_section = _readme().split("**请求格式**:", maxsplit=1)[1]
+    json_example = re.search(
+        r"```json\s*(.*?)\s*```", request_section, flags=re.DOTALL
+    )
+
+    assert json_example is not None
+    payload = json.loads(json_example.group(1))
+    assert set(payload) == {"images", "config"}
+    assert payload["config"] == {"top_k": 5}
+
+
+def test_readme_json_response_matches_public_response_schema():
+    json_examples = re.findall(
+        r"```json\s*(.*?)\s*```", _readme(), flags=re.DOTALL
+    )
+
+    response = json.loads(json_examples[1])
+    PredictResponse.model_validate(response)
+
+
+def test_readme_python_clients_use_nested_predict_config():
+    python_examples = re.findall(
+        r"```python\s*(.*?)\s*```", _readme(), flags=re.DOTALL
+    )
+
+    request_payloads = []
+    for example in python_examples:
+        tree = ast.parse(example)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr != "post":
+                continue
+            json_keyword = next(
+                keyword for keyword in node.keywords if keyword.arg == "json"
+            )
+            request_payloads.append(json_keyword.value)
+
+    assert len(request_payloads) == 2
+    for payload in request_payloads:
+        assert isinstance(payload, ast.Dict)
+        top_level_keys = [ast.literal_eval(key) for key in payload.keys]
+        assert top_level_keys == ["images", "config"]
+
+        config = payload.values[1]
+        assert isinstance(config, ast.Dict)
+        assert [ast.literal_eval(key) for key in config.keys] == ["top_k"]
+
+
+def test_readme_local_links_resolve_to_existing_files():
+    local_links = re.findall(r"\[[^]]+\]\((?!https?://)([^)#]+)", _readme())
+
+    for link in local_links:
+        assert (MODULE_ROOT / link).exists(), f"README 链接不存在: {link}"


### PR DESCRIPTION
## 变更说明

关闭 #4620。

图片分类 README 的请求示例此前把 `top_k` 放在 JSON 顶层，与真实 API 的 `config.top_k` 契约不一致；请求 JSON 还包含标准 JSON 不支持的行内注释，迁移指南链接指向不存在的文件。

本次修复：

- 将请求 JSON 和两处 Python 示例统一为 `config.top_k`；
- 将请求与响应代码块修正为可直接解析、符合真实 Pydantic Schema 的 JSON；
- 补齐响应 metadata 的必填字段；
- 删除失效迁移文档链接；
- 增加 README 契约测试，防止示例再次漂移。

```mermaid
flowchart LR
    A["开发者复制 README 示例"] --> B["images + config.top_k"]
    B --> C["PredictConfig"]
    C --> D["图片分类预测"]
    D --> E["PredictResponse 合法响应"]
```

## 验证

- 文档契约测试：4 passed；
- 模块完整测试：17 passed；
- 请求示例可由标准 `json` 解析并构造真实 `PredictRequest`；
- 响应示例通过真实 `PredictResponse.model_validate`；
- 两个 Python 示例均可由 AST 解析且请求层级正确；
- README 本地链接全部有效；
- `git diff --check` 通过。

## 三轨复审

- Standards：PASS，0 findings；
- Spec：首轮发现响应 metadata 缺少 6 个必填字段，原任务内修复后终审 PASS；
- Runtime Contract：PASS，0 blockers；
- 综合评分：96/100，满足 R1 自动 PR 发布门槛。

## 风险与回滚

仅修改公开文档和契约测试，不改变运行时 API。若需回滚，可直接回退本提交。
