### PR TITLE
fix: 规范 RPC 异常国际化边界

### DIFF
--- a/server/apps/rpc/ansible.py
+++ b/server/apps/rpc/ansible.py
@@ -1,6 +1,7 @@
 import uuid
 
 from apps.rpc.base import RpcClient
+from apps.rpc.exceptions import RpcPlaybookSourceError, RpcTargetSourceError
 
 
 class AnsibleRpcClient(RpcClient):
@@ -100,7 +101,7 @@ class AnsibleExecutor(object):
         """
         if not inventory and not inventory_content:
             if not host_credentials:
-                raise ValueError("inventory or inventory_content or host_credentials is required")
+                raise RpcTargetSourceError
 
         request_data = {
             "inventory": inventory,
@@ -182,10 +183,10 @@ class AnsibleExecutor(object):
         )
         """
         if not playbook_path and not playbook_content and not file_distribution:
-            raise ValueError("playbook_path or playbook_content is required")
+            raise RpcPlaybookSourceError
         if not inventory and not inventory_content:
             if not host_credentials:
-                raise ValueError("inventory or inventory_content or host_credentials is required")
+                raise RpcTargetSourceError
 
         request_data = {
             "playbook_path": playbook_path,

--- a/server/apps/rpc/base.py
+++ b/server/apps/rpc/base.py
@@ -4,6 +4,8 @@ import os
 from django.conf import settings
 
 import nats_client
+from apps.core.logger import logger
+from apps.rpc.exceptions import RpcMethodNotFoundError, RpcTimeoutError
 
 DEFAULT_REQUEST_TIMEOUT = 60
 
@@ -19,24 +21,27 @@ class RpcClient(object):
     def run(self, method_name, *args, **kwargs):
         timeout = kwargs.get("_timeout")
         effective_timeout = timeout if timeout is not None else getattr(settings, "NATS_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)
-        try:
-            request_coro = nats_client.request(self.namespace, method_name, *args, **kwargs)
-            if effective_timeout and effective_timeout > 0:
-                request_coro = asyncio.wait_for(request_coro, timeout=effective_timeout)
-            return asyncio.run(request_coro)
-        except TimeoutError:
-            raise TimeoutError(f"RPC request timeout: namespace={self.namespace}, method={method_name}, timeout={effective_timeout}s")
+        return self._request_with_timeout(nats_client.request, method_name, effective_timeout, *args, **kwargs)
 
     def request(self, method_name, **kwargs):
         timeout = kwargs.get("_timeout")
         effective_timeout = timeout if timeout is not None else getattr(settings, "NATS_REQUEST_TIMEOUT", DEFAULT_REQUEST_TIMEOUT)
+        return self._request_with_timeout(nats_client.nat_request, method_name, effective_timeout, **kwargs)
+
+    def _request_with_timeout(self, request_func, method_name, effective_timeout, *args, **kwargs):
         try:
-            request_coro = nats_client.nat_request(self.namespace, method_name, **kwargs)
+            request_coro = request_func(self.namespace, method_name, *args, **kwargs)
             if effective_timeout and effective_timeout > 0:
                 request_coro = asyncio.wait_for(request_coro, timeout=effective_timeout)
             return asyncio.run(request_coro)
-        except TimeoutError:
-            raise TimeoutError(f"RPC request timeout: namespace={self.namespace}, method={method_name}, timeout={effective_timeout}s")
+        except TimeoutError as exc:
+            logger.warning(
+                "RPC request timeout: namespace=%s, method=%s, timeout=%ss",
+                self.namespace,
+                method_name,
+                effective_timeout,
+            )
+            raise RpcTimeoutError(self.namespace, method_name, effective_timeout) from exc
 
 
 class AppClient(object):
@@ -47,7 +52,8 @@ class AppClient(object):
         m = __import__(self.path, globals(), locals(), ["*"])
         method = getattr(m, method_name, None)
         if not method:
-            raise ValueError(f"Method {method_name} not found in {self.path}")
+            logger.warning("RPC method not found: path=%s, method=%s", self.path, method_name)
+            raise RpcMethodNotFoundError(self.path, method_name)
         return method(*args, **kwargs)
 
 

--- a/server/apps/rpc/exceptions.py
+++ b/server/apps/rpc/exceptions.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+
+class RpcError(Exception):
+    """RPC 层结构化异常契约，不携带面向客户的自然语言。"""
+
+    code = "rpc.error"
+
+    def _init_rpc_error(self, *, params: dict[str, Any] | None = None) -> None:
+        self.params = params or {}
+
+
+class RpcValidationError(ValueError, RpcError):
+    """RPC 参数校验失败，保留 ``ValueError`` 兼容性。"""
+
+    code = "rpc.validation_error"
+
+    def __init__(self, *, params: dict[str, Any] | None = None) -> None:
+        self._init_rpc_error(params=params)
+        super().__init__(self.code)
+
+
+class RpcTargetSourceError(RpcValidationError):
+    code = "rpc.invalid_target_source"
+
+
+class RpcPlaybookSourceError(RpcValidationError):
+    code = "rpc.invalid_playbook_source"
+
+
+class RpcTimeoutError(TimeoutError, RpcError):
+    """RPC 请求超时；客户文案与内部调用上下文分离。"""
+
+    code = "rpc.request_timeout"
+
+    def __init__(self, namespace: str, method_name: str, timeout) -> None:
+        self._init_rpc_error()
+        self.namespace = namespace
+        self.method_name = method_name
+        self.timeout = timeout
+        super().__init__(self.code)
+
+
+class RpcMethodNotFoundError(ValueError, RpcError):
+    """本地 RPC 映射缺失；模块路径只供日志诊断。"""
+
+    code = "rpc.method_not_found"
+
+    def __init__(self, path: str, method_name: str) -> None:
+        self._init_rpc_error()
+        self.path = path
+        self.method_name = method_name
+        super().__init__(self.code)
+
+
+class RpcLocalClientRequiredError(RuntimeError, RpcError):
+    """某项 RPC 能力仅允许通过同进程客户端调用。"""
+
+    code = "rpc.local_client_required"
+
+    def __init__(self, operation: str) -> None:
+        self._init_rpc_error()
+        self.operation = operation
+        super().__init__(self.code)

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -1,6 +1,8 @@
 import os
 
+from apps.core.logger import logger
 from apps.rpc.base import AppClient, RpcClient
+from apps.rpc.exceptions import RpcLocalClientRequiredError
 
 
 class NodeMgmt(object):
@@ -163,7 +165,8 @@ class NodeMgmt(object):
     def compare_and_swap_child_config_content_local(self, id, expected_content, content):
         """同进程运维专用：仅当子配置内容仍等于读取快照时更新。"""
         if not self.is_local_client:
-            raise RuntimeError("compare-and-swap child config requires local AppClient")
+            logger.warning("RPC local client required: operation=compare_and_swap_child_config_content")
+            raise RpcLocalClientRequiredError("compare_and_swap_child_config_content")
         return self.client.run(
             "compare_and_swap_child_config_content",
             {"id": id, "expected_content": expected_content, "content": content},

--- a/server/apps/rpc/tests/test_ansible_executor.py
+++ b/server/apps/rpc/tests/test_ansible_executor.py
@@ -46,8 +46,12 @@ def test_rpc_client_subclass_namespace():
 
 
 def test_adhoc_缺少所有目标源抛错(ex):
-    with pytest.raises(ValueError, match="inventory or inventory_content or host_credentials is required"):
+    with pytest.raises(ValueError) as exc_info:
         ex.adhoc()
+
+    assert str(exc_info.value) == "rpc.invalid_target_source"
+    assert exc_info.value.code == "rpc.invalid_target_source"
+    assert exc_info.value.params == {}
 
 
 def test_adhoc_仅host_credentials也可执行(ex):
@@ -101,13 +105,20 @@ def test_adhoc_可选字段仅在传入时加入(ex):
 
 
 def test_playbook_缺少playbook源抛错(ex):
-    with pytest.raises(ValueError, match="playbook_path or playbook_content is required"):
+    with pytest.raises(ValueError) as exc_info:
         ex.playbook(inventory="localhost,")
+
+    assert str(exc_info.value) == "rpc.invalid_playbook_source"
+    assert exc_info.value.code == "rpc.invalid_playbook_source"
+    assert exc_info.value.params == {}
 
 
 def test_playbook_缺少目标源抛错(ex):
-    with pytest.raises(ValueError, match="inventory or inventory_content or host_credentials is required"):
+    with pytest.raises(ValueError) as exc_info:
         ex.playbook(playbook_content="- hosts: all")
+
+    assert str(exc_info.value) == "rpc.invalid_target_source"
+    assert exc_info.value.code == "rpc.invalid_target_source"
 
 
 def test_playbook_file_distribution满足playbook源校验(ex):

--- a/server/apps/rpc/tests/test_base.py
+++ b/server/apps/rpc/tests/test_base.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 import pytest
 
-from apps.rpc.base import AppClient, DEFAULT_REQUEST_TIMEOUT, RpcClient
+from apps.rpc.base import AppClient, RpcClient
 
 pytestmark = pytest.mark.unit
 
@@ -41,8 +41,12 @@ class TestAppClientDispatch:
 
     def test_函数不存在抛_valueerror(self):
         client = AppClient("math")
-        with pytest.raises(ValueError, match="not found"):
+        with pytest.raises(ValueError) as exc_info:
             client.run("no_such_function")
+
+        assert str(exc_info.value) == "rpc.method_not_found"
+        assert exc_info.value.code == "rpc.method_not_found"
+        assert exc_info.value.params == {}
 
 
 class TestRpcClientRequestTimeout:
@@ -50,8 +54,10 @@ class TestRpcClientRequestTimeout:
 
     def _make_mock_coro(self, return_value):
         """返回一个可以被 asyncio.run / asyncio.wait_for 使用的真实协程。"""
+
         async def _coro(*args, **kwargs):
             return return_value
+
         return _coro
 
     def test_request_使用_wait_for_包裹_nat_request(self):
@@ -59,9 +65,9 @@ class TestRpcClientRequestTimeout:
         client = RpcClient(namespace="test_ns")
         expected = {"result": True, "data": {}}
 
-        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
-             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
-             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, mock.patch(
+            "apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for
+        ) as mock_wait_for, mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
             mock_nc.nat_request = self._make_mock_coro(expected)
             client.request("some_method", key="val")
 
@@ -72,10 +78,9 @@ class TestRpcClientRequestTimeout:
         client = RpcClient(namespace="test_ns")
         expected = {"result": True, "data": {}}
 
-        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
-             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
-             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run), \
-             mock.patch("apps.rpc.base.settings") as mock_settings:
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, mock.patch(
+            "apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for
+        ) as mock_wait_for, mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run), mock.patch("apps.rpc.base.settings") as mock_settings:
             mock_settings.NATS_REQUEST_TIMEOUT = 30
             mock_nc.nat_request = self._make_mock_coro(expected)
             client.request("some_method")
@@ -88,9 +93,9 @@ class TestRpcClientRequestTimeout:
         client = RpcClient(namespace="test_ns")
         expected = {"result": True, "data": {}}
 
-        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
-             mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as mock_wait_for, \
-             mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, mock.patch(
+            "apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for
+        ) as mock_wait_for, mock.patch("apps.rpc.base.asyncio.run", wraps=asyncio.run):
             mock_nc.nat_request = self._make_mock_coro(expected)
             client.request("some_method", _timeout=15)
 
@@ -104,8 +109,7 @@ class TestRpcClientRequestTimeout:
         async def _never_return(*args, **kwargs):
             await asyncio.sleep(9999)
 
-        with mock.patch("apps.rpc.base.nats_client") as mock_nc, \
-             mock.patch("apps.rpc.base.settings") as mock_settings:
+        with mock.patch("apps.rpc.base.nats_client") as mock_nc, mock.patch("apps.rpc.base.settings") as mock_settings:
             mock_settings.NATS_REQUEST_TIMEOUT = 0.01
             mock_nc.nat_request = _never_return
             with pytest.raises(TimeoutError):

--- a/server/apps/rpc/tests/test_base_extra.py
+++ b/server/apps/rpc/tests/test_base_extra.py
@@ -7,18 +7,13 @@
 - BaseOperationAnaRpc 按 server/namespace 构造内部 client。
 不触达真实 NATS。
 """
-import pydantic.root_model  # noqa
-
 import asyncio
 from unittest import mock
 
+import pydantic.root_model  # noqa
 import pytest
 
-from apps.rpc.base import (
-    BaseOperationAnaRpc,
-    OperationAnalysisRpc,
-    RpcClient,
-)
+from apps.rpc.base import AppClient, BaseOperationAnaRpc, OperationAnalysisRpc, RpcClient
 
 pytestmark = pytest.mark.unit
 
@@ -26,6 +21,7 @@ pytestmark = pytest.mark.unit
 def _coro(return_value):
     async def _c(*args, **kwargs):
         return return_value
+
     return _c
 
 
@@ -46,9 +42,7 @@ class TestRpcClientRun:
 
     def test_run_尊重显式_timeout(self):
         client = RpcClient(namespace="ns")
-        with mock.patch("apps.rpc.base.nats_client") as m, mock.patch(
-            "apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for
-        ) as wait_for:
+        with mock.patch("apps.rpc.base.nats_client") as m, mock.patch("apps.rpc.base.asyncio.wait_for", wraps=asyncio.wait_for) as wait_for:
             m.request.side_effect = _coro({"ok": 1})
             client.run("do", _timeout=12)
         assert wait_for.call_args.kwargs.get("timeout") == 12 or wait_for.call_args.args[1] == 12
@@ -61,8 +55,29 @@ class TestRpcClientRun:
 
         with mock.patch("apps.rpc.base.nats_client") as m:
             m.request.side_effect = _slow
-            with pytest.raises(TimeoutError, match="RPC request timeout"):
+            with pytest.raises(TimeoutError) as exc_info:
                 client.run("do", _timeout=0.01)
+
+        assert str(exc_info.value) == "rpc.request_timeout"
+        assert exc_info.value.code == "rpc.request_timeout"
+        assert exc_info.value.params == {}
+        assert exc_info.value.namespace == "ns"
+        assert exc_info.value.method_name == "do"
+        assert exc_info.value.timeout == 0.01
+
+    def test_request_超时不暴露英文内部细节(self):
+        client = RpcClient(namespace="ns")
+
+        async def _slow(*a, **k):
+            await asyncio.sleep(5)
+
+        with mock.patch("apps.rpc.base.nats_client") as m:
+            m.nat_request.side_effect = _slow
+            with pytest.raises(TimeoutError) as exc_info:
+                client.request("query", _timeout=0.01)
+
+        assert str(exc_info.value) == "rpc.request_timeout"
+        assert exc_info.value.code == "rpc.request_timeout"
 
 
 class TestOperationAnalysisRpc:
@@ -122,3 +137,17 @@ class TestBaseOperationAnaRpc:
         base = BaseOperationAnaRpc()
         assert isinstance(base.client, OperationAnalysisRpc)
         assert base.client.server == ""
+
+
+class TestAppClient:
+    def test_方法不存在时只返回稳定错误码(self):
+        client = AppClient("apps.rpc.base")
+
+        with pytest.raises(ValueError) as exc_info:
+            client.run("missing_method")
+
+        assert str(exc_info.value) == "rpc.method_not_found"
+        assert exc_info.value.code == "rpc.method_not_found"
+        assert exc_info.value.params == {}
+        assert exc_info.value.method_name == "missing_method"
+        assert exc_info.value.path == "apps.rpc.base"

--- a/server/apps/rpc/tests/test_node_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_node_mgmt_forwarding.py
@@ -197,3 +197,13 @@ def test_env_变量强制本地模式(monkeypatch):
     monkeypatch.setenv("IS_LOCAL_RPC", "1")
     n = NodeMgmt(is_local_client=False)
     assert n.client.path == "apps.node_mgmt.nats.node"
+
+
+def test_compare_and_swap_非本地调用返回稳定错误码(node):
+    with pytest.raises(RuntimeError) as exc_info:
+        node.compare_and_swap_child_config_content_local(1, "old", "new")
+
+    assert str(exc_info.value) == "rpc.local_client_required"
+    assert exc_info.value.code == "rpc.local_client_required"
+    assert exc_info.value.params == {}
+    assert exc_info.value.operation == "compare_and_swap_child_config_content"


### PR DESCRIPTION
## 背景

RPC 层部分异常直接包含英文自然语言文案，调用方可能将其原样返回给客户。这会导致用户文案无法由上层根据 locale 统一处理，同时可能暴露 namespace、method 和模块路径等内部实现信息。

## 修改内容

- 新增 RPC 结构化异常契约，统一使用稳定的 `code` 和 `params`
- 将 Ansible 目标源和 Playbook 源校验改为结构化异常
- 修正 Playbook 来源校验，使 `file_distribution` 与真实参数契约一致
- 将 `RpcClient.run/request` 的超时异常统一为 `rpc.request_timeout`
- 将 AppClient 方法缺失统一为 `rpc.method_not_found`
- 将 Node CAS 的本地客户端限制统一为 `rpc.local_client_required`
- 技术上下文仅保存在异常属性和安全日志中，不再放入异常字符串

## 兼容性与影响

- 保留 `ValueError`、`TimeoutError`、`RuntimeError` 类型兼容性
- `str(error)` 从英文技术文案调整为稳定错误码，上层可基于 `code + params` 做 locale 映射
- 不修改 NATS 协议、数据库模型、迁移、部署配置或具体客户文案
- 已基于最新 `master` 重放并解决 `node_mgmt` 冲突

## 验证

- 4 个直接关联测试文件：64 passed
- 完整 `apps/rpc/tests`：322 passed
- 触及模块定向覆盖率：99%
- Black、isort、flake8、compileall、`git diff --check`：通过

