### PR TITLE
bugfix: 取消 Tauri 非流式原生请求

### DIFF
--- a/mobile/scripts/mobile-tauri-stream-test.mjs
+++ b/mobile/scripts/mobile-tauri-stream-test.mjs
@@ -59,21 +59,28 @@ test.afterEach(() => {
   delete globalThis.window;
 });
 
-test('Tauri fetch rejects responses that arrive after the request is aborted', async () => {
+test('Tauri fetch cancels an active native request and rejects without waiting for its response', { timeout: 1000 }, async () => {
   class MockChannel {
     onmessage = () => {};
   }
 
   let resolveInvoke;
-  let invokeCalls = 0;
+  let acknowledgeRegistration;
+  const invokeCalls = [];
   const invokePending = new Promise((resolve) => {
     resolveInvoke = resolve;
   });
   globalThis.window = { __TAURI_INTERNALS__: {} };
   globalThis.__loadTauriCore = async () => ({
     Channel: MockChannel,
-    invoke: async () => {
-      invokeCalls += 1;
+    invoke: async (command, args) => {
+      invokeCalls.push({ command, args });
+      if (command === 'cancel_request') {
+        return undefined;
+      }
+      assert.equal(command, 'api_proxy');
+      assert.ok(args.onRegistered instanceof MockChannel);
+      acknowledgeRegistration = () => args.onRegistered.onmessage(true);
       return invokePending;
     },
   });
@@ -85,18 +92,111 @@ test('Tauri fetch rejects responses that arrive after the request is aborted', a
     tauriApiFetch('https://bklite.example.com/api/profile', { signal: alreadyAborted.signal }),
     { name: 'AbortError' },
   );
-  assert.equal(invokeCalls, 0);
+  assert.equal(invokeCalls.length, 0);
 
   const controller = new AbortController();
   const request = tauriApiFetch('https://bklite.example.com/api/profile', {
     signal: controller.signal,
   });
+  const rejection = assert.rejects(request, { name: 'AbortError' });
   await new Promise((resolve) => setTimeout(resolve, 0));
   controller.abort();
-  resolveInvoke({ status: 200, headers: {}, body: '{"ok":true}' });
 
-  await assert.rejects(request, { name: 'AbortError' });
-  assert.equal(invokeCalls, 1);
+  assert.deepEqual(
+    invokeCalls.map(({ command }) => command),
+    ['api_proxy'],
+  );
+  acknowledgeRegistration();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  await rejection;
+  assert.deepEqual(
+    invokeCalls.map(({ command }) => command),
+    ['api_proxy', 'cancel_request'],
+  );
+  assert.equal(typeof invokeCalls[0].args.request.requestId, 'string');
+  assert.equal(invokeCalls[1].args.requestId, invokeCalls[0].args.request.requestId);
+
+  resolveInvoke({ status: 200, headers: {}, body: '{"ok":true}' });
+});
+
+test('Tauri fetch without an AbortSignal keeps the legacy request contract', async () => {
+  class MockChannel {
+    onmessage = () => {};
+  }
+
+  let nativeRequest;
+  globalThis.window = { __TAURI_INTERNALS__: {} };
+  globalThis.__loadTauriCore = async () => ({
+    Channel: MockChannel,
+    invoke: async (command, args) => {
+      assert.equal(command, 'api_proxy');
+      nativeRequest = args.request;
+      return { status: 200, headers: {}, body: '{"ok":true}' };
+    },
+  });
+
+  const { tauriApiFetch } = await loadTauriApiProxy();
+  const response = await tauriApiFetch('https://bklite.example.com/api/profile');
+
+  assert.equal(await response.text(), '{"ok":true}');
+  assert.equal('requestId' in nativeRequest, false);
+});
+
+test('Tauri fetch with an AbortSignal preserves a normally completed response', async () => {
+  class MockChannel {
+    onmessage = () => {};
+  }
+
+  const commands = [];
+  globalThis.window = { __TAURI_INTERNALS__: {} };
+  globalThis.__loadTauriCore = async () => ({
+    Channel: MockChannel,
+    invoke: async (command, args) => {
+      commands.push(command);
+      assert.equal(command, 'api_proxy');
+      args.onRegistered.onmessage(true);
+      return { status: 200, headers: { 'content-type': 'application/json' }, body: '{"ok":true}' };
+    },
+  });
+
+  const { tauriApiFetch } = await loadTauriApiProxy();
+  const response = await tauriApiFetch('https://bklite.example.com/api/profile', {
+    signal: new AbortController().signal,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(await response.text(), '{"ok":true}');
+  assert.deepEqual(commands, ['api_proxy']);
+});
+
+test('Tauri fetch keeps the legacy native proxy error shape for signalled requests', async () => {
+  class MockChannel {
+    onmessage = () => {};
+  }
+
+  globalThis.window = { __TAURI_INTERNALS__: {} };
+  globalThis.__loadTauriCore = async () => ({
+    Channel: MockChannel,
+    invoke: async (command, args) => {
+      assert.equal(command, 'api_proxy');
+      args.onRegistered?.onmessage(true);
+      throw { message: 'HTTP request failed: connection reset', status: 502 };
+    },
+  });
+
+  const { tauriApiFetch } = await loadTauriApiProxy();
+  const { tauriApiProxy } = await loadTauriApiProxy();
+  const legacyError = await tauriApiProxy({
+    url: 'https://bklite.example.com/api/profile',
+    method: 'GET',
+  }).catch((error) => error);
+  const signalError = await tauriApiFetch('https://bklite.example.com/api/profile', {
+    signal: new AbortController().signal,
+  }).catch((error) => error);
+
+  assert.equal(signalError.name, legacyError.name);
+  assert.equal(signalError.message, legacyError.message);
 });
 
 test('Tauri stream receives events emitted before the start command returns', async () => {

--- a/mobile/scripts/mobile-tauri-stream-test.mjs
+++ b/mobile/scripts/mobile-tauri-stream-test.mjs
@@ -78,7 +78,7 @@ test('Tauri fetch cancels an active native request and rejects without waiting f
       if (command === 'cancel_request') {
         return undefined;
       }
-      assert.equal(command, 'api_proxy');
+      assert.equal(command, 'api_proxy_cancellable');
       assert.ok(args.onRegistered instanceof MockChannel);
       acknowledgeRegistration = () => args.onRegistered.onmessage(true);
       return invokePending;
@@ -104,7 +104,7 @@ test('Tauri fetch cancels an active native request and rejects without waiting f
 
   assert.deepEqual(
     invokeCalls.map(({ command }) => command),
-    ['api_proxy'],
+    ['api_proxy_cancellable'],
   );
   acknowledgeRegistration();
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -112,7 +112,7 @@ test('Tauri fetch cancels an active native request and rejects without waiting f
   await rejection;
   assert.deepEqual(
     invokeCalls.map(({ command }) => command),
-    ['api_proxy', 'cancel_request'],
+    ['api_proxy_cancellable', 'cancel_request'],
   );
   assert.equal(typeof invokeCalls[0].args.request.requestId, 'string');
   assert.equal(invokeCalls[1].args.requestId, invokeCalls[0].args.request.requestId);
@@ -154,7 +154,7 @@ test('Tauri fetch with an AbortSignal preserves a normally completed response', 
     Channel: MockChannel,
     invoke: async (command, args) => {
       commands.push(command);
-      assert.equal(command, 'api_proxy');
+      assert.equal(command, 'api_proxy_cancellable');
       args.onRegistered.onmessage(true);
       return { status: 200, headers: { 'content-type': 'application/json' }, body: '{"ok":true}' };
     },
@@ -167,7 +167,7 @@ test('Tauri fetch with an AbortSignal preserves a normally completed response', 
 
   assert.equal(response.status, 200);
   assert.equal(await response.text(), '{"ok":true}');
-  assert.deepEqual(commands, ['api_proxy']);
+  assert.deepEqual(commands, ['api_proxy_cancellable']);
 });
 
 test('Tauri fetch keeps the legacy native proxy error shape for signalled requests', async () => {
@@ -175,11 +175,12 @@ test('Tauri fetch keeps the legacy native proxy error shape for signalled reques
     onmessage = () => {};
   }
 
+  const commands = [];
   globalThis.window = { __TAURI_INTERNALS__: {} };
   globalThis.__loadTauriCore = async () => ({
     Channel: MockChannel,
     invoke: async (command, args) => {
-      assert.equal(command, 'api_proxy');
+      commands.push(command);
       args.onRegistered?.onmessage(true);
       throw { message: 'HTTP request failed: connection reset', status: 502 };
     },
@@ -197,6 +198,7 @@ test('Tauri fetch keeps the legacy native proxy error shape for signalled reques
 
   assert.equal(signalError.name, legacyError.name);
   assert.equal(signalError.message, legacyError.message);
+  assert.deepEqual(commands, ['api_proxy', 'api_proxy_cancellable']);
 });
 
 test('Tauri stream receives events emitted before the start command returns', async () => {

--- a/mobile/scripts/mobile-tauri-stream-test.mjs
+++ b/mobile/scripts/mobile-tauri-stream-test.mjs
@@ -161,13 +161,45 @@ test('Tauri fetch with an AbortSignal preserves a normally completed response', 
   });
 
   const { tauriApiFetch } = await loadTauriApiProxy();
+  const controller = new AbortController();
   const response = await tauriApiFetch('https://bklite.example.com/api/profile', {
-    signal: new AbortController().signal,
+    signal: controller.signal,
   });
 
   assert.equal(response.status, 200);
   assert.equal(await response.text(), '{"ok":true}');
+  controller.abort();
+  await new Promise((resolve) => setTimeout(resolve, 0));
   assert.deepEqual(commands, ['api_proxy_cancellable']);
+});
+
+test('Tauri fetch with an AbortSignal preserves a 401 response contract', async () => {
+  class MockChannel {
+    onmessage = () => {};
+  }
+
+  globalThis.window = { __TAURI_INTERNALS__: {} };
+  globalThis.__loadTauriCore = async () => ({
+    Channel: MockChannel,
+    invoke: async (command, args) => {
+      assert.equal(command, 'api_proxy_cancellable');
+      args.onRegistered.onmessage(true);
+      return {
+        status: 401,
+        headers: { 'x-tauri-proxied': 'true' },
+        body: '{"detail":"unauthorized"}',
+      };
+    },
+  });
+
+  const { tauriApiFetch } = await loadTauriApiProxy();
+  const response = await tauriApiFetch('https://bklite.example.com/api/profile', {
+    signal: new AbortController().signal,
+  });
+
+  assert.equal(response.status, 401);
+  assert.equal(response.headers.get('x-tauri-proxied'), 'true');
+  assert.equal(await response.text(), '{"detail":"unauthorized"}');
 });
 
 test('Tauri fetch keeps the legacy native proxy error shape for signalled requests', async () => {

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -9,6 +9,15 @@ use tokio::sync::oneshot;
 /// 每个活跃 SSE 流的取消发送端，keyed by stream_id
 pub struct StreamRegistry(pub Mutex<HashMap<String, oneshot::Sender<()>>>);
 
+/// 每个活跃非流式请求的取消发送端，keyed by request_id。
+#[derive(Default)]
+pub struct RequestRegistry(Mutex<HashMap<String, RequestCancellation>>);
+
+struct RequestCancellation {
+    owner_id: uuid::Uuid,
+    sender: oneshot::Sender<()>,
+}
+
 #[derive(Default)]
 struct Utf8ChunkDecoder {
     pending: Vec<u8>,
@@ -173,6 +182,8 @@ pub struct ApiRequest {
     pub method: String,
     pub headers: Option<HashMap<String, String>>,
     pub body: Option<String>,
+    #[serde(default)]
+    pub request_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -196,8 +207,7 @@ pub struct ApiError {
     pub status: Option<u16>,
 }
 
-#[command]
-pub async fn api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError> {
+async fn execute_api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError> {
     // URL 白名单校验：防止注入脚本通过 IPC 发起任意域的 SSRF 请求
     if !is_allowed_host(&request.url) {
         log::warn!("[Tauri-API] 拒绝非白名单 URL: {}", request.url);
@@ -340,6 +350,74 @@ pub async fn api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError> {
 }
 
 #[command]
+pub async fn api_proxy(
+    registry: State<'_, RequestRegistry>,
+    request: ApiRequest,
+    on_registered: Option<Channel<bool>>,
+) -> Result<ApiResponse, ApiError> {
+    execute_registered_api_proxy(&registry, request, on_registered).await
+}
+
+async fn execute_registered_api_proxy(
+    registry: &RequestRegistry,
+    request: ApiRequest,
+    on_registered: Option<Channel<bool>>,
+) -> Result<ApiResponse, ApiError> {
+    let Some(request_id) = request.request_id.clone() else {
+        return execute_api_proxy(request).await;
+    };
+    if request_id.is_empty()
+        || request_id.len() > 128
+        || !request_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(ApiError {
+            message: "Invalid request ID".to_string(),
+            status: None,
+        });
+    }
+
+    let owner_id = uuid::Uuid::new_v4();
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    {
+        let mut active_requests = registry.0.lock().unwrap_or_else(|error| error.into_inner());
+        if active_requests.contains_key(&request_id) {
+            return Err(ApiError {
+                message: "Duplicate active request ID".to_string(),
+                status: None,
+            });
+        }
+        active_requests.insert(
+            request_id.clone(),
+            RequestCancellation {
+                owner_id,
+                sender: cancel_tx,
+            },
+        );
+    }
+    if let Some(on_registered) = on_registered {
+        if let Err(error) = on_registered.send(true) {
+            remove_registered_request_if_owned(registry, &request_id, owner_id);
+            return Err(ApiError {
+                message: format!("Failed to acknowledge request registration: {error}"),
+                status: None,
+            });
+        }
+    }
+
+    let result = tokio::select! {
+        result = execute_api_proxy(request) => result,
+        _ = cancel_rx => Err(ApiError {
+            message: "Request cancelled".to_string(),
+            status: None,
+        }),
+    };
+    remove_registered_request_if_owned(registry, &request_id, owner_id);
+    result
+}
+
+#[command]
 pub async fn simple_api_proxy(
     url: String,
     method: String,
@@ -351,9 +429,10 @@ pub async fn simple_api_proxy(
         method,
         headers,
         body,
+        request_id: None,
     };
 
-    match api_proxy(request).await {
+    match execute_api_proxy(request).await {
         Ok(response) => Ok(response.body),
         Err(error) => Err(error.message),
     }
@@ -642,6 +721,50 @@ pub async fn cancel_stream(
     Ok(())
 }
 
+/// 幂等取消一个正在进行的非流式请求。
+#[command]
+pub async fn cancel_request(
+    registry: State<'_, RequestRegistry>,
+    request_id: String,
+) -> Result<(), String> {
+    if cancel_registered_request(&registry, &request_id) {
+        log::info!(
+            "🛑 [cancel_request] Cancelled request: {}",
+            &request_id[..8.min(request_id.len())]
+        );
+    }
+    Ok(())
+}
+
+fn cancel_registered_request(registry: &RequestRegistry, request_id: &str) -> bool {
+    let cancellation = registry
+        .0
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(request_id);
+    match cancellation {
+        Some(cancellation) => {
+            let _ = cancellation.sender.send(());
+            true
+        }
+        None => false,
+    }
+}
+
+fn remove_registered_request_if_owned(
+    registry: &RequestRegistry,
+    request_id: &str,
+    owner_id: uuid::Uuid,
+) {
+    let mut active_requests = registry.0.lock().unwrap_or_else(|error| error.into_inner());
+    if active_requests
+        .get(request_id)
+        .is_some_and(|cancellation| cancellation.owner_id == owner_id)
+    {
+        active_requests.remove(request_id);
+    }
+}
+
 fn cancel_registered_stream(registry: &StreamRegistry, stream_id: &str) -> bool {
     let sender = registry
         .0
@@ -660,15 +783,18 @@ fn cancel_registered_stream(registry: &StreamRegistry, stream_id: &str) -> bool 
 #[cfg(test)]
 mod tests {
     use super::{
-        build_http_client, cancel_registered_stream, is_allowed_host_with_allowlist,
-        redact_headers_for_log, StreamEvent, StreamRegistry, Utf8ChunkDecoder,
+        build_http_client, cancel_registered_request, cancel_registered_stream,
+        execute_registered_api_proxy, is_allowed_host_with_allowlist,
+        remove_registered_request_if_owned, ApiRequest, RequestCancellation, RequestRegistry,
+        StreamEvent, StreamRegistry, Utf8ChunkDecoder,
     };
     use std::{
         collections::HashMap,
         io::{Read, Write},
         net::TcpListener,
-        sync::Mutex,
+        sync::{mpsc, Mutex},
         thread,
+        time::Duration,
     };
     use tokio::sync::oneshot;
 
@@ -737,6 +863,157 @@ mod tests {
         assert!(!cancel_registered_stream(&registry, "stream-finished"));
         assert!(!cancel_registered_stream(&registry, "stream-finished"));
         assert!(registry.0.lock().expect("lock stream registry").is_empty());
+    }
+
+    #[test]
+    fn test_request_cleanup_only_removes_the_registration_owned_by_that_execution() {
+        let registry = RequestRegistry::default();
+        let owner_id = uuid::Uuid::new_v4();
+        let replacement_owner_id = uuid::Uuid::new_v4();
+        let (cancel_tx, mut cancel_rx) = oneshot::channel();
+        registry
+            .0
+            .lock()
+            .expect("lock request registry")
+            .insert(
+                "request-reused".to_string(),
+                RequestCancellation {
+                    owner_id: replacement_owner_id,
+                    sender: cancel_tx,
+                },
+            );
+
+        remove_registered_request_if_owned(&registry, "request-reused", owner_id);
+
+        assert!(cancel_registered_request(&registry, "request-reused"));
+        cancel_rx
+            .try_recv()
+            .expect("replacement registration remains cancellable");
+        assert!(!cancel_registered_request(&registry, "request-reused"));
+    }
+
+    #[tokio::test]
+    async fn test_registered_api_request_rejects_unsafe_request_ids_without_registering() {
+        let registry = RequestRegistry::default();
+        let request = ApiRequest {
+            url: "http://127.0.0.1:1/unused".to_string(),
+            method: "GET".to_string(),
+            headers: None,
+            body: None,
+            request_id: Some("你你你".to_string()),
+        };
+
+        let error = execute_registered_api_proxy(&registry, request, None)
+            .await
+            .expect_err("unsafe request ID is rejected");
+
+        assert_eq!(error.message, "Invalid request ID");
+        assert!(registry.0.lock().expect("lock request registry").is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_registered_api_request_cancellation_stops_waiting_for_the_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind cancellation test server");
+        let address = listener.local_addr().expect("read cancellation test address");
+        let (request_received_tx, request_received_rx) = mpsc::channel();
+        let (release_server_tx, release_server_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept cancellation test request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            request_received_tx
+                .send(())
+                .expect("signal request received by server");
+            release_server_rx.recv().expect("release cancellation test server");
+        });
+        let registry = RequestRegistry::default();
+        let request_id = "request-cancellable".to_string();
+        let request = ApiRequest {
+            url: format!("http://{address}/slow"),
+            method: "GET".to_string(),
+            headers: None,
+            body: None,
+            request_id: Some(request_id.clone()),
+        };
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async {
+                let (result, ()) = tokio::join!(
+                    execute_registered_api_proxy(&registry, request, None),
+                    async {
+                tokio::task::spawn_blocking(move || {
+                    request_received_rx
+                        .recv_timeout(Duration::from_secs(5))
+                        .expect("request reaches server before cancellation")
+                })
+                .await
+                .expect("join request receipt waiter");
+                assert!(cancel_registered_request(&registry, &request_id));
+                    }
+                );
+                result
+            },
+        )
+        .await
+        .expect("cancellation completes without waiting for the server");
+
+        assert_eq!(result.expect_err("request is cancelled").message, "Request cancelled");
+        assert!(registry.0.lock().expect("lock request registry").is_empty());
+        release_server_tx.send(()).expect("release cancellation test server");
+        server.join().expect("join cancellation test server");
+    }
+
+    #[tokio::test]
+    async fn test_registered_api_request_cancellation_stops_reading_the_response_body() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind body cancellation server");
+        let address = listener.local_addr().expect("read body cancellation server address");
+        let (headers_sent_tx, headers_sent_rx) = mpsc::channel();
+        let (release_body_tx, release_body_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept body cancellation request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\n")
+                .expect("write response headers");
+            headers_sent_tx.send(()).expect("signal response headers sent");
+            release_body_rx.recv().expect("release body cancellation server");
+        });
+        let registry = RequestRegistry::default();
+        let request_id = "request-body-cancellable".to_string();
+        let request = ApiRequest {
+            url: format!("http://{address}/slow-body"),
+            method: "GET".to_string(),
+            headers: None,
+            body: None,
+            request_id: Some(request_id.clone()),
+        };
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            async {
+                let (result, ()) = tokio::join!(
+                    execute_registered_api_proxy(&registry, request, None),
+                    async {
+                tokio::task::spawn_blocking(move || {
+                    headers_sent_rx
+                        .recv_timeout(Duration::from_secs(5))
+                        .expect("response headers arrive before body cancellation")
+                })
+                .await
+                .expect("join response header waiter");
+                assert!(cancel_registered_request(&registry, &request_id));
+                    }
+                );
+                result
+            },
+        )
+        .await
+        .expect("body cancellation completes without waiting for the server");
+
+        assert_eq!(result.expect_err("body read is cancelled").message, "Request cancelled");
+        assert!(registry.0.lock().expect("lock request registry").is_empty());
+        release_body_tx.send(()).expect("release body cancellation server");
+        server.join().expect("join body cancellation server");
     }
 
     // --- 未配置白名单（默认只放行 localhost/127.0.0.1）---

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -353,9 +353,17 @@ async fn execute_api_proxy(request: ApiRequest) -> Result<ApiResponse, ApiError>
 pub async fn api_proxy(
     registry: State<'_, RequestRegistry>,
     request: ApiRequest,
-    on_registered: Option<Channel<bool>>,
 ) -> Result<ApiResponse, ApiError> {
-    execute_registered_api_proxy(&registry, request, on_registered).await
+    execute_registered_api_proxy(&registry, request, None).await
+}
+
+#[command]
+pub async fn api_proxy_cancellable(
+    registry: State<'_, RequestRegistry>,
+    request: ApiRequest,
+    on_registered: Channel<bool>,
+) -> Result<ApiResponse, ApiError> {
+    execute_registered_api_proxy(&registry, request, Some(on_registered)).await
 }
 
 async fn execute_registered_api_proxy(
@@ -785,8 +793,8 @@ mod tests {
     use super::{
         build_http_client, cancel_registered_request, cancel_registered_stream,
         execute_registered_api_proxy, is_allowed_host_with_allowlist,
-        remove_registered_request_if_owned, ApiRequest, RequestCancellation, RequestRegistry,
-        StreamEvent, StreamRegistry, Utf8ChunkDecoder,
+        redact_headers_for_log, remove_registered_request_if_owned, ApiRequest,
+        RequestCancellation, RequestRegistry, StreamEvent, StreamRegistry, Utf8ChunkDecoder,
     };
     use std::{
         collections::HashMap,

--- a/mobile/src-tauri/src/api_proxy.rs
+++ b/mobile/src-tauri/src/api_proxy.rs
@@ -182,7 +182,7 @@ pub struct ApiRequest {
     pub method: String,
     pub headers: Option<HashMap<String, String>>,
     pub body: Option<String>,
-    #[serde(default)]
+    #[serde(default, rename = "requestId", alias = "request_id")]
     pub request_id: Option<String>,
 }
 
@@ -806,6 +806,20 @@ mod tests {
     };
     use tokio::sync::oneshot;
 
+    fn spawn_one_shot_http_server(response: &'static str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind one-shot test server");
+        let address = listener.local_addr().expect("read one-shot test address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept one-shot test request");
+            let mut buffer = [0_u8; 1024];
+            let _ = stream.read(&mut buffer);
+            stream
+                .write_all(response.as_bytes())
+                .expect("write one-shot test response");
+        });
+        (format!("http://{address}/test"), server)
+    }
+
     #[test]
     fn test_utf8_chunk_decoder_preserves_code_points_split_across_network_chunks() {
         let bytes = "data: {\"text\":\"你好\"}\n".as_bytes();
@@ -917,6 +931,77 @@ mod tests {
 
         assert_eq!(error.message, "Invalid request ID");
         assert!(registry.0.lock().expect("lock request registry").is_empty());
+    }
+
+    #[test]
+    fn test_api_request_accepts_camel_case_and_legacy_snake_case_request_ids() {
+        for (field, request_id) in [
+            ("requestId", "request-camel"),
+            ("request_id", "request-snake"),
+        ] {
+            let mut value = serde_json::json!({
+                "url": "http://127.0.0.1:1/unused",
+                "method": "GET"
+            });
+            value[field] = serde_json::json!(request_id);
+
+            let request: ApiRequest = serde_json::from_value(value).expect("deserialize request");
+
+            assert_eq!(request.request_id.as_deref(), Some(request_id));
+        }
+    }
+
+    #[tokio::test]
+    async fn test_registered_api_request_completion_cleans_before_late_cancel() {
+        let (url, server) = spawn_one_shot_http_server(
+            "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        );
+        let registry = RequestRegistry::default();
+        let request_id = "request-completed";
+        let response = execute_registered_api_proxy(
+            &registry,
+            ApiRequest {
+                url,
+                method: "GET".to_string(),
+                headers: None,
+                body: None,
+                request_id: Some(request_id.to_string()),
+            },
+            None,
+        )
+        .await
+        .expect("complete registered request");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, "ok");
+        assert!(!cancel_registered_request(&registry, request_id));
+        server.join().expect("join one-shot test server");
+    }
+
+    #[tokio::test]
+    async fn test_registered_api_request_preserves_unauthorized_response_and_cleans_up() {
+        let (url, server) = spawn_one_shot_http_server(
+            "HTTP/1.1 401 Unauthorized\r\nContent-Length: 12\r\nConnection: close\r\n\r\nunauthorized",
+        );
+        let registry = RequestRegistry::default();
+        let response = execute_registered_api_proxy(
+            &registry,
+            ApiRequest {
+                url,
+                method: "GET".to_string(),
+                headers: None,
+                body: None,
+                request_id: Some("request-401".to_string()),
+            },
+            None,
+        )
+        .await
+        .expect("return unauthorized response");
+
+        assert_eq!(response.status, 401);
+        assert_eq!(response.body, "unauthorized");
+        assert!(registry.0.lock().expect("lock request registry").is_empty());
+        server.join().expect("join one-shot test server");
     }
 
     #[tokio::test]

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -2,8 +2,8 @@ mod api_proxy;
 mod secure_credentials;
 
 use api_proxy::{
-    api_proxy, api_stream_proxy, cancel_request, cancel_stream, simple_api_proxy, RequestRegistry,
-    StreamRegistry,
+    api_proxy, api_proxy_cancellable, api_stream_proxy, cancel_request, cancel_stream,
+    simple_api_proxy, RequestRegistry, StreamRegistry,
 };
 #[cfg(target_os = "android")]
 use secure_credentials::init_android_secure_credentials;
@@ -96,6 +96,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             api_proxy,
+            api_proxy_cancellable,
             simple_api_proxy,
             api_stream_proxy,
             cancel_stream,

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -1,7 +1,10 @@
 mod api_proxy;
 mod secure_credentials;
 
-use api_proxy::{api_proxy, api_stream_proxy, cancel_stream, simple_api_proxy, StreamRegistry};
+use api_proxy::{
+    api_proxy, api_stream_proxy, cancel_request, cancel_stream, simple_api_proxy, RequestRegistry,
+    StreamRegistry,
+};
 #[cfg(target_os = "android")]
 use secure_credentials::init_android_secure_credentials;
 use secure_credentials::{secure_credential_get, secure_credential_remove, secure_credential_set};
@@ -89,12 +92,14 @@ pub fn run() {
 
     builder
         .manage(StreamRegistry(Mutex::new(HashMap::new())))
+        .manage(RequestRegistry::default())
         .plugin(tauri_plugin_store::Builder::new().build())
         .invoke_handler(tauri::generate_handler![
             api_proxy,
             simple_api_proxy,
             api_stream_proxy,
             cancel_stream,
+            cancel_request,
             secure_credential_set,
             secure_credential_get,
             secure_credential_remove,

--- a/mobile/src/utils/tauriApiProxy.ts
+++ b/mobile/src/utils/tauriApiProxy.ts
@@ -76,12 +76,7 @@ async function getTauriCore() {
 
 async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
   const { invoke } = await getTauriCore();
-  try {
-    return await invoke<T>(cmd, args);
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new Error(`Tauri invoke failed: ${errorMessage}`);
-  }
+  return normalizeInvokeError(invoke<T>(cmd, args));
 }
 
 async function normalizeInvokeError<T>(operation: Promise<T>): Promise<T> {
@@ -118,9 +113,9 @@ async function invokeCancellableApiProxy(
       nativeRequest,
       new Promise<never>((_, reject) => {
         abort = () => {
-          void registered.then(() => invoke('cancel_request', { requestId })).catch((error: unknown) => {
-              console.warn('[TauriAPI] Failed to cancel native request:', error);
-            });
+          void registered
+            .then(() => invoke('cancel_request', { requestId }))
+            .catch(() => undefined);
           reject(new DOMException('The operation was aborted', 'AbortError'));
         };
         signal.addEventListener('abort', abort, { once: true });
@@ -129,11 +124,6 @@ async function invokeCancellableApiProxy(
         }
       }),
     ]);
-  } catch (error) {
-    if (!(error instanceof DOMException && error.name === 'AbortError')) {
-      console.error('[TauriAPI] Request failed:', error);
-    }
-    throw error;
   } finally {
     if (abort) {
       signal.removeEventListener('abort', abort);

--- a/mobile/src/utils/tauriApiProxy.ts
+++ b/mobile/src/utils/tauriApiProxy.ts
@@ -110,7 +110,7 @@ async function invokeCancellableApiProxy(
   const onRegistered = new Channel<boolean>();
   onRegistered.onmessage = () => markRegistered?.();
   const nativeRequest = normalizeInvokeError(
-    invoke<ApiResponse>('api_proxy', { request, onRegistered })
+    invoke<ApiResponse>('api_proxy_cancellable', { request, onRegistered })
   );
   let abort: (() => void) | undefined;
   try {

--- a/mobile/src/utils/tauriApiProxy.ts
+++ b/mobile/src/utils/tauriApiProxy.ts
@@ -11,6 +11,7 @@ export interface ApiRequest {
   method: string;
   headers?: Record<string, string>;
   body?: string;
+  requestId?: string;
 }
 
 export interface ApiResponse {
@@ -29,6 +30,13 @@ export interface CurrentTeamResolution {
   source: 'cookie' | 'stored-login-info' | 'missing';
 }
 
+let requestSequence = 0;
+
+function createNativeRequestId(): string {
+  requestSequence = (requestSequence + 1) % Number.MAX_SAFE_INTEGER;
+  return `request-${Date.now()}-${requestSequence}`;
+}
+
 type NativeStreamEvent =
   | { event: 'chunk'; data: string }
   | { event: 'end' }
@@ -45,7 +53,7 @@ export class TauriStreamError extends Error {
  * 安全地调用 Tauri invoke
  * Tauri 2.x 使用 __TAURI_INTERNALS__ 作为主要标识
  */
-async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+async function getTauriCore() {
   // 检查 Tauri 运行时是否可用
   if (typeof window === 'undefined') {
     throw new Error('Tauri is not available: window is undefined');
@@ -56,18 +64,80 @@ async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promi
     throw new Error('Tauri is not available: __TAURI_INTERNALS__ not found');
   }
 
+  // 动态导入 Tauri API
+  const { Channel, invoke } = await import('@tauri-apps/api/core');
+
+  if (typeof invoke !== 'function') {
+    throw new Error('Tauri invoke is not a function');
+  }
+
+  return { Channel, invoke };
+}
+
+async function safeInvoke<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
+  const { invoke } = await getTauriCore();
   try {
-    // 动态导入 Tauri API
-    const { invoke } = await import('@tauri-apps/api/core');
-
-    if (typeof invoke !== 'function') {
-      throw new Error('Tauri invoke is not a function');
-    }
-
     return await invoke<T>(cmd, args);
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Tauri invoke failed: ${errorMessage}`);
+  }
+}
+
+async function normalizeInvokeError<T>(operation: Promise<T>): Promise<T> {
+  try {
+    return await operation;
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    throw new Error(`Tauri invoke failed: ${errorMessage}`);
+  }
+}
+
+async function invokeCancellableApiProxy(
+  request: ApiRequest,
+  signal: AbortSignal,
+  requestId: string
+): Promise<ApiResponse> {
+  const { Channel, invoke } = await getTauriCore();
+  if (signal.aborted) {
+    throw new DOMException('The operation was aborted', 'AbortError');
+  }
+
+  let markRegistered: (() => void) | undefined;
+  const registered = new Promise<void>((resolve) => {
+    markRegistered = resolve;
+  });
+  const onRegistered = new Channel<boolean>();
+  onRegistered.onmessage = () => markRegistered?.();
+  const nativeRequest = normalizeInvokeError(
+    invoke<ApiResponse>('api_proxy', { request, onRegistered })
+  );
+  let abort: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      nativeRequest,
+      new Promise<never>((_, reject) => {
+        abort = () => {
+          void registered.then(() => invoke('cancel_request', { requestId })).catch((error: unknown) => {
+              console.warn('[TauriAPI] Failed to cancel native request:', error);
+            });
+          reject(new DOMException('The operation was aborted', 'AbortError'));
+        };
+        signal.addEventListener('abort', abort, { once: true });
+        if (signal.aborted) {
+          abort();
+        }
+      }),
+    ]);
+  } catch (error) {
+    if (!(error instanceof DOMException && error.name === 'AbortError')) {
+      console.error('[TauriAPI] Request failed:', error);
+    }
+    throw error;
+  } finally {
+    if (abort) {
+      signal.removeEventListener('abort', abort);
+    }
   }
 }
 
@@ -174,14 +244,18 @@ export async function tauriApiFetch(
     }
   }
 
-  const response = await tauriApiProxy({
+  const requestId = options.signal ? createNativeRequestId() : undefined;
+  const request = {
     url,
     method,
     headers,
     body,
-  });
+    ...(requestId ? { requestId } : {}),
+  };
+  const response = options.signal && requestId
+    ? await invokeCancellableApiProxy(request, options.signal, requestId)
+    : await tauriApiProxy(request);
 
-  // 原生非流式请求暂不支持中途取消，但取消后的响应不得再进入业务状态。
   if (options.signal?.aborted) {
     throw new DOMException('The operation was aborted', 'AbortError');
   }


### PR DESCRIPTION
## 问题

Mobile 的 `AbortSignal` 应同时终止 JavaScript 等待和 Tauri 原生 HTTP 工作；此前非流式请求只丢弃晚到结果，Rust 仍会继续发送、等待并读取完整响应。

## 根因（设计层）

非流式 IPC 契约没有请求标识和取消通道，且前端无法确认 Rust 何时完成注册。若直接增加取消命令，还会出现取消先于注册到达、请求继续执行的竞态。

## 怎么修的

- 仅为带 `AbortSignal` 的请求生成可选 `requestId`，旧调用仍使用原 IPC 形状。
- Rust 为非流式请求维护独立注册表，用 `tokio::select!` 同时覆盖发送和响应体读取。
- 通过请求级 Channel 确认注册完成；abort 可立即结束 JavaScript Promise，原生取消在确认后可靠送达。
- 完成、异常和取消统一按注册所有权清理；重复取消幂等，重复或非法请求 ID 明确拒绝。
- signal 与旧调用共用错误标准化，保持既有错误形状和文本。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["AbortController / tauriApiFetch\ntauriApiProxy.ts"]
    end
    subgraph N["原生请求层"]
        N1["api_proxy_cancellable 注册 requestId\napi_proxy.rs"]
        N2["HTTP send + body read\nexecute_api_proxy"]
    end
    subgraph C["取消与清理层"]
        C1["cancel_request\nRequestRegistry"]
        C2["按 owner 清理注册"]
    end
    T1 --> N1 --> N2
    T1 -. "abort" .-> C1
    C1 -. "取消 future" .-> N2
    N2 --> C2
```

## 影响范围

只影响 Mobile Tauri 非流式代理。无 `AbortSignal` 的请求不携带 `requestId`，状态码、响应头、401 处理和错误文本保持不变；流式请求继续使用既有 `cancel_stream`。

## 验证

- `mobile-tauri-stream-test.mjs`：10 passed，覆盖调用前取消、注册竞态、正常完成、错误兼容、重复取消及既有 401/流式语义。
- PR CI 在 macOS 上完成 Rust 编译，Rust 单测 19 passed；覆盖发送中取消、响应体读取中取消、注册所有权、非法 ID 和幂等清理场景。
- Mobile 平台壳专项：10 passed。
- Mobile 监控与资产专项：36 passed。
- ESLint、TypeScript、diff-check：通过。
- 全量 Node 基线仍有与本次无关的底部导航样式契约失败，本 PR 未改对应 CSS。

## 三轨门禁

- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS（JavaScript 专项 10 passed；PR CI Rust 19 passed）

Closes #4623
