### PR TITLE
bugfix: 修复 k8s 日志采集器 reduce 分组失效导致的日志丢失

### DIFF
--- a/agents/webhookd/bk-lite-log-collector.yaml
+++ b/agents/webhookd/bk-lite-log-collector.yaml
@@ -136,12 +136,20 @@ data:
       kubernetes_logs:
         type: kubernetes_logs
         self_node_name: "${VECTOR_NODE_NAME}"
+        # 注意：这些值是「事件字段路径」，默认是 kubernetes.xxx。
+        # 下面把它们改写到了事件根级，因此下游引用必须用 .pod_name 而不是
+        # .kubernetes.pod_name（reduce 的 group_by 尤其容易踩错，见 multiline_merge）。
         pod_annotation_fields:
           container_image: "container_image"
-          container_name: "container_name" 
+          container_name: "container_name"
           pod_name: "pod_name"
           pod_namespace: "pod_namespace"
           pod_node_name: "pod_node_name"
+          # 抑制 pod annotations：kubectl.kubernetes.io/last-applied-configuration
+          # 这类注解可达几百 KB，且会随每一条日志重复发送，是撑爆 NATS
+          # max_payload（默认 1MB）的主要体积来源。pod_labels 体积小且有检索
+          # 价值（按 app/version 过滤），保留在 .kubernetes.pod_labels。
+          pod_annotations: ""
         namespace_annotation_fields:
           namespace_labels: "namespace_labels"
         node_annotation_fields:
@@ -160,15 +168,33 @@ data:
         type: reduce
         inputs:
           - kubernetes_logs
+        # 必须与 pod_annotation_fields 里配置的实际路径一致。这些字段被改写到了
+        # 事件根级，写成 kubernetes.xxx 会全部取到 null，导致整个节点上所有容器的
+        # 日志被合并进同一个分组。
         group_by:
-          - kubernetes.pod_name
-          - kubernetes.container_name
-          - kubernetes.pod_namespace
+          - pod_name
+          - container_name
+          - pod_namespace
         merge_strategies:
           message: concat_newline
-        # 匹配常见的日志开始模式：支持 Log4j、uWSGI、Traefik 等
-        starts_when: match(string!(.message), r'(?i)^(\d{4}-\d{2}-\d{2}[\sT]\d{2}:\d{2}:\d{2}|\d{2}/\w{3}/\d{4}\s+\d{2}:\d{2}:\d{2}|\w{3}\s+\d{1,2},\s+\d{4}|\[[^\]]*\d{2}:\d{2}:\d{2}[^\]]*\]|time="[^"]*").*?(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)|^(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)[\s\[\(:>-]|^\[pid:\s*\d+\||^\*{3}\s+\w+|^spawned\s+uWSGI')
+        # 判定「新日志的第一行」。这里采用反向判定：默认每一行都是一条新日志，
+        # 只有明显属于上一条日志的续行才合并——缩进行（Java/Python/Node/Go 堆栈）、
+        # Java 的 Caused by/Suppressed/... N more、Python 异常链、Go 的 goroutine 帧、
+        # PHP 的 Stack trace:/#N 栈帧、pretty-print JSON/YAML 的收尾括号。
+        # 反向判定的关键收益是未知日志格式退化为「不合并」而不是「无限合并」：
+        # 正向匹配一旦覆盖不到某种格式（纯 JSON、access log、klog 等），该容器的日志
+        # 会一直 concat 下去，单条事件最终超过 NATS max_payload（默认 1MB）被整条丢弃。
+        # 注意 $$ 是 Vector 配置里 $ 的转义写法。裸 $ 会被当成环境变量引用，
+        # 导致启动时报 "Missing environment variable in config" 并 CrashLoop。
+        starts_when: |-
+          !match(string!(.message), r'(?i)^(\s|at\s+[\w.<]|caused by:|suppressed:|\.{3}\s+\d+\s+more|goroutine\s+\d+\s+\[|during handling of the above|the above exception was|#\d+\s|stack trace:\s*$$|[}\]],?\s*$$)')
+        # expire_after_ms 是「收到最后一条事件之后的静默时长」，不是分组存活上限。
+        # 默认 30s 对持续输出日志的容器等同于永不过期，必须显式收紧。
+        expire_after_ms: 2000
         flush_period_ms: 1000
+        # 行数硬边界。续行判定万一被某种日志格式绕过（例如某个容器持续输出全缩进
+        # 的行），仅靠 expire_after_ms 仍然拦不住——只要它一直有输出就永远不静默。
+        max_events: 500
 
       parse_and_enrich:
         type: remap
@@ -188,10 +214,12 @@ data:
           }
           
           # 提取重要的Kubernetes元数据
-          .k8s_pod_name = .kubernetes.pod_name
-          .k8s_namespace = .kubernetes.pod_namespace
-          .k8s_container_name = .kubernetes.container_name
-          .k8s_node_name = .kubernetes.pod_node_name
+          # 源字段被 pod_annotation_fields 改写到了事件根级，取值必须用根级路径；
+          # 这里保留 k8s_* 一套命名以兼容已入库的历史数据和检索字段契约。
+          .k8s_pod_name = .pod_name
+          .k8s_namespace = .pod_namespace
+          .k8s_container_name = .container_name
+          .k8s_node_name = .pod_node_name
           
           # 保持原始消息
           .log_message = .message

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
@@ -146,12 +146,20 @@ data:
       kubernetes_logs:
         type: kubernetes_logs
         self_node_name: "${VECTOR_NODE_NAME}"
+        # 注意：这些值是「事件字段路径」，默认是 kubernetes.xxx。
+        # 下面把它们改写到了事件根级，因此下游引用必须用 .pod_name 而不是
+        # .kubernetes.pod_name（reduce 的 group_by 尤其容易踩错，见 multiline_merge）。
         pod_annotation_fields:
           container_image: "container_image"
-          container_name: "container_name" 
+          container_name: "container_name"
           pod_name: "pod_name"
           pod_namespace: "pod_namespace"
           pod_node_name: "pod_node_name"
+          # 抑制 pod annotations：kubectl.kubernetes.io/last-applied-configuration
+          # 这类注解可达几百 KB，且会随每一条日志重复发送，是撑爆 NATS
+          # max_payload（默认 1MB）的主要体积来源。pod_labels 体积小且有检索
+          # 价值（按 app/version 过滤），保留在 .kubernetes.pod_labels。
+          pod_annotations: ""
         namespace_annotation_fields:
           namespace_labels: "namespace_labels"
         node_annotation_fields:
@@ -170,15 +178,33 @@ data:
         type: reduce
         inputs:
           - kubernetes_logs
+        # 必须与 pod_annotation_fields 里配置的实际路径一致。这些字段被改写到了
+        # 事件根级，写成 kubernetes.xxx 会全部取到 null，导致整个节点上所有容器的
+        # 日志被合并进同一个分组。
         group_by:
-          - kubernetes.pod_name
-          - kubernetes.container_name
-          - kubernetes.pod_namespace
+          - pod_name
+          - container_name
+          - pod_namespace
         merge_strategies:
           message: concat_newline
-        # 匹配常见的日志开始模式：支持 Log4j、uWSGI、Traefik 等
-        starts_when: match(string!(.message), r'(?i)^(\d{4}-\d{2}-\d{2}[\sT]\d{2}:\d{2}:\d{2}|\d{2}/\w{3}/\d{4}\s+\d{2}:\d{2}:\d{2}|\w{3}\s+\d{1,2},\s+\d{4}|\[[^\]]*\d{2}:\d{2}:\d{2}[^\]]*\]|time="[^"]*").*?(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)|^(ERROR|WARN|WARNING|INFO|DEBUG|TRACE|FATAL|SEVERE)[\s\[\(:>-]|^\[pid:\s*\d+\||^\*{3}\s+\w+|^spawned\s+uWSGI')
+        # 判定「新日志的第一行」。这里采用反向判定：默认每一行都是一条新日志，
+        # 只有明显属于上一条日志的续行才合并——缩进行（Java/Python/Node/Go 堆栈）、
+        # Java 的 Caused by/Suppressed/... N more、Python 异常链、Go 的 goroutine 帧、
+        # PHP 的 Stack trace:/#N 栈帧、pretty-print JSON/YAML 的收尾括号。
+        # 反向判定的关键收益是未知日志格式退化为「不合并」而不是「无限合并」：
+        # 正向匹配一旦覆盖不到某种格式（纯 JSON、access log、klog 等），该容器的日志
+        # 会一直 concat 下去，单条事件最终超过 NATS max_payload（默认 1MB）被整条丢弃。
+        # 注意 $$ 是 Vector 配置里 $ 的转义写法。裸 $ 会被当成环境变量引用，
+        # 导致启动时报 "Missing environment variable in config" 并 CrashLoop。
+        starts_when: |-
+          !match(string!(.message), r'(?i)^(\s|at\s+[\w.<]|caused by:|suppressed:|\.{3}\s+\d+\s+more|goroutine\s+\d+\s+\[|during handling of the above|the above exception was|#\d+\s|stack trace:\s*$$|[}\]],?\s*$$)')
+        # expire_after_ms 是「收到最后一条事件之后的静默时长」，不是分组存活上限。
+        # 默认 30s 对持续输出日志的容器等同于永不过期，必须显式收紧。
+        expire_after_ms: 2000
         flush_period_ms: 1000
+        # 行数硬边界。续行判定万一被某种日志格式绕过（例如某个容器持续输出全缩进
+        # 的行），仅靠 expire_after_ms 仍然拦不住——只要它一直有输出就永远不静默。
+        max_events: 500
 
       parse_and_enrich:
         type: remap
@@ -197,10 +223,12 @@ data:
           }
           
           # 提取重要的Kubernetes元数据
-          .k8s_pod_name = .kubernetes.pod_name
-          .k8s_namespace = .kubernetes.pod_namespace
-          .k8s_container_name = .kubernetes.container_name
-          .k8s_node_name = .kubernetes.pod_node_name
+          # 源字段被 pod_annotation_fields 改写到了事件根级，取值必须用根级路径；
+          # 这里保留 k8s_* 一套命名以兼容已入库的历史数据和检索字段契约。
+          .k8s_pod_name = .pod_name
+          .k8s_namespace = .pod_namespace
+          .k8s_container_name = .container_name
+          .k8s_node_name = .pod_node_name
           
           # 保持原始消息
           .log_message = .message


### PR DESCRIPTION
## 问题

修复 #4517。k8s 日志采集插件安装后，采集器持续报 `server error: nats: maximum payload violation`，部分 namespace 下的 pod 日志无法上报，且报错信息里看不出是哪个 namespace 的哪个 pod。

## 根因

`kubernetes_logs` 的 `pod_annotation_fields` 把 `pod_name` / `pod_namespace` / `container_name` 改写到了事件**根级**（这些配置项的值是"事件字段路径"，默认为 `kubernetes.xxx`），但下游两处仍按默认路径取值：

- `multiline_merge` 的 `group_by` 写的是 `kubernetes.pod_name` 等三个键 —— 实测 100% 取到 null
- `parse_and_enrich` 的 `.k8s_pod_name = .kubernetes.pod_name` 等四行 —— 同样全为 null

三个分组键全为 null 意味着 reduce 退化成**整个节点一个分组**，全部容器的日志被 `concat_newline` 拼进同一条事件。叠加两个默认值——`expire_after_ms` 默认 30s 是"最后一条事件之后的静默时长"（持续输出日志的容器永远不静默）、`max_events` 默认无上限——事件会一直增长直到超过 NATS `max_payload`（默认 1MB）被整条拒收。

`starts_when` 的正向枚举正则加剧了这一点：它要求"时间戳 + 级别词"同时出现，实测 klog、celery、nginx access log、PostgreSQL（级别是 `LOG`，不在枚举里）、Elasticsearch JSON 等常见格式全部匹配不上，于是既不作为新起点也不断开。

`k8s_namespace` / `k8s_pod_name` 恒为 null，正是 issue 中"看不出来是哪个 namespace 下的 pod"的原因。

## 改动

1. **`group_by` 与 remap 取值改用实际的根级路径**（核心修复）
2. **`starts_when` 改为反向判定**：默认每行都是新日志，仅明确的续行才合并（缩进行、Java `Caused by`/`... N more`、Python 异常链、Go `goroutine`、PHP `Stack trace:`/`#N` 栈帧、JSON/YAML 收尾括号）。关键收益是未知格式退化为"不合并"而非"无限合并"
3. **补充边界**：`expire_after_ms: 2000`、`max_events: 500`
4. **抑制 `pod_annotations`**：`last-applied-configuration` 这类注解可达几百 KB 且随每条日志重复发送；`pod_labels` 体积小、有检索价值，保留

> 正则中的 `$$` 是 Vector 配置里 `$` 的转义写法。裸 `$` 会被当作环境变量引用，导致 `Missing environment variable in config` 并 CrashLoop —— 这个坑在验证过程中实际踩到过，已在注释中标注。

## 验证

在 demo TKE 集群上部署新旧两份配置**同节点同时运行**做对照（sink 改为 console/blackhole，不写 NATS，不影响演示数据），验证后资源已全部清理。

| 指标 | 改动前 | 改动后 |
|---|---|---|
| `>1MB` 事件数 | **27**（最大 62MB） | **0** |
| 一条事件混入的 pod 数 | 最多 6 个，跨 namespace | **100% 单 pod** |
| `k8s_namespace` / `k8s_pod_name` | 全部 null | **全部有值** |
| source 读入行数 | 550,357 | **550,358**（无丢失） |
| payload max | 5,086,928 | 8,625 |

**多行合并兼容性**（12 种语言/框架格式实测）：Java 裸异常、Node.js、.NET、Ruby、多行 SQL、PHP、pretty-print JSON 完整合并；各类单行日志正确拆分；Java 带 logger 前缀、Python traceback 堆栈主体完整；Go panic 帧行与 Rust panic 仍会拆开（顶格续行，加规则的误伤风险大于收益）。

配置已用真实 vector 二进制 `vector validate` 确认可加载。

## 已知影响与取舍

- **NATS 消息数增加约 8.7 倍**（实测 62,560 → 543,992）。总字节数按 p50 推算增加 4~7 倍——每条事件各带一份 k8s 元数据，事件数上升则元数据开销同比上升。修复前那 8.8 行/事件是错误粘连，1.0 行/事件才是单行日志的正确形态。**上线前建议确认 NATS 与消费端的消息速率余量**。
- **理论上限未完全封死**：`32KB/行 × 500 行 × 2（log_message 副本）≈ 32MB`，需要"连续 500 行全缩进且平均行长 >1KB"才会触发，实测平均行长 138~326 字符，余量 120 倍。若需绝对保证，可在 `.log_message = .message` 之前加一行 `slice!` 截断。
- **按 pod annotations 检索的能力移除**（`pod_labels` 保留）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
