### PR TITLE
perf: 合并移动端 AI 流式文本刷新

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -67,6 +67,7 @@
     "eslint": "^8.57.1",
     "eslint-config-next": "15.5.3",
     "husky": "^9.1.7",
+    "jsdom": "27.0.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      jsdom:
+        specifier: 27.0.0
+        version: 27.0.0
       tailwindcss:
         specifier: ^4
         version: 4.1.14
@@ -164,6 +167,15 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
@@ -171,6 +183,42 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -1015,6 +1063,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ahooks@3.9.5:
     resolution: {integrity: sha512-TrjXie49Q8HuHKTa84Fm9A+famMDAG1+7a9S9Gq6RQ0h90Jgqmiq3CkObuRjWT/C4d6nRZCw35Y2k2fmybb5eA==}
     engines: {node: '>=18'}
@@ -1115,6 +1167,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -1186,11 +1241,23 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1273,6 +1340,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   es-abstract@1.24.0:
@@ -1580,10 +1651,26 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1696,6 +1783,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1759,6 +1849,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@27.0.0:
+    resolution: {integrity: sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1879,6 +1978,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -1893,6 +1996,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
@@ -2045,6 +2151,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2404,6 +2513,10 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
 
@@ -2432,6 +2545,9 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2449,6 +2565,13 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2587,6 +2710,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.1.14:
     resolution: {integrity: sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==}
 
@@ -2609,12 +2735,27 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
   toggle-selection@1.0.6:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2685,6 +2826,31 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2712,6 +2878,25 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
@@ -2810,9 +2995,51 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
   '@babel/runtime@7.28.4': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.5.0':
     dependencies:
@@ -3575,6 +3802,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ahooks@3.9.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.28.6
@@ -3777,6 +4006,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -3846,9 +4079,26 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.5.2
+
   csstype@3.1.3: {}
 
   damerau-levenshtein@1.0.8: {}
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3929,6 +4179,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.0:
     dependencies:
@@ -4041,8 +4293,8 @@ snapshots:
       '@typescript-eslint/parser': 8.46.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -4061,7 +4313,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4072,22 +4324,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4098,7 +4350,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -4400,7 +4652,29 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -4519,6 +4793,8 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -4582,6 +4858,33 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.0.0:
+    dependencies:
+      '@asamuzakjp/dom-selector': 6.8.1
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   json-buffer@3.0.1: {}
 
@@ -4680,6 +4983,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
@@ -4698,6 +5003,8 @@ snapshots:
       uc.micro: 2.1.0
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
@@ -4858,6 +5165,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -5308,6 +5619,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-from-string@2.0.2: {}
+
   resize-observer-polyfill@1.5.1: {}
 
   resolve-from@4.0.0: {}
@@ -5331,6 +5644,8 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  rrweb-cssom@0.8.0: {}
 
   run-parallel@1.2.0:
     dependencies:
@@ -5356,6 +5671,12 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5545,6 +5866,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.1.14: {}
 
   tapable@2.3.0: {}
@@ -5566,11 +5889,25 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toggle-selection@1.0.6: {}
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.1.0(typescript@5.9.3):
     dependencies:
@@ -5673,6 +6010,25 @@ snapshots:
 
   uuid@8.3.2: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+
   which-boxed-primitive@1.1.1:
     dependencies:
       is-bigint: 1.1.0
@@ -5721,6 +6077,12 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@4.0.0: {}
 

--- a/mobile/scripts/mobile-conversation-flow-test.mjs
+++ b/mobile/scripts/mobile-conversation-flow-test.mjs
@@ -773,6 +773,7 @@ test('AI 流未收到 RUN_FINISHED 时保留部分内容并标记中断', async 
     assert.equal(response?.status, 'interrupted');
     assert.equal(response?.streamError, '响应中断，请重试');
     assert.equal(response?.contentParts?.[0]?.content, 'partial answer');
+    assert.equal(manager.getMessageMarkdown('session-1', response?.id), 'partial answer');
     assert.match(messageList, /isAIMessage\s*=[^;]*msg\.status === 'interrupted'/);
     assert.match(messageList, /showActions\s*=\s*isAIMessage/);
   } finally {
@@ -806,6 +807,201 @@ test('AI 流收到 RUN_FINISHED 后标记正常结束', async () => {
     assert.equal(response?.status, 'ended');
     assert.equal(response?.streamError, undefined);
     assert.equal(response?.contentParts?.[0]?.content, 'complete answer');
+  } finally {
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态保持纯文本', async () => {
+  const messageList = await readProjectFile('src/app/conversation/components/message-list.tsx');
+  let releaseStream;
+  let markContentReady;
+  const contentReady = new Promise((resolve) => {
+    markContentReady = resolve;
+  });
+  const continueStream = new Promise((resolve) => {
+    releaseStream = resolve;
+  });
+  const deltas = ['<img src=x onerror=alert(1)>', '\n```ts\n', ...Array(100).fill('const value = 1;\n'), '```'];
+  const fullText = deltas.join('');
+  const { ConversationManager } = await loadConversationManager(async function* () {
+    yield { type: 'RUN_STARTED', timestamp: 1 };
+    yield { type: 'TEXT_MESSAGE_START' };
+    for (const delta of deltas) {
+      yield { type: 'TEXT_MESSAGE_CONTENT', delta };
+    }
+    markContentReady();
+    await continueStream;
+    yield { type: 'TEXT_MESSAGE_END' };
+    yield { type: 'RUN_FINISHED' };
+  });
+  const manager = new ConversationManager();
+  const renderedInputs = [];
+  let notifications = 0;
+  let markStreamingFlush;
+  const streamingFlush = new Promise((resolve) => {
+    markStreamingFlush = resolve;
+  });
+  const unsubscribe = manager.subscribe(() => {
+    notifications += 1;
+    const content = manager.getSessionState('session-long-stream')?.messages[0]?.contentParts?.[0]?.content;
+    if (content === fullText) {
+      markStreamingFlush();
+    }
+  });
+
+  try {
+    const responsePromise = manager.startAIResponse(
+      'session-long-stream',
+      9,
+      'mobile-node',
+      'question',
+      (text) => {
+        renderedInputs.push(text);
+        return `rendered:${text}`;
+      },
+      '响应中断，请重试',
+      false,
+    );
+    await contentReady;
+    await streamingFlush;
+
+    const streamingPart = manager.getSessionState('session-long-stream')?.messages[0]?.contentParts?.[0];
+    assert.equal(renderedInputs.length, 0);
+    assert.equal(streamingPart?.content, fullText);
+    assert.equal(typeof streamingPart?.content, 'string');
+    assert.equal(streamingPart?.isStreamingText, true);
+    assert.ok(notifications <= 6, `expected batched stream updates, received ${notifications}`);
+    assert.match(messageList, /part\.isStreamingText[\s\S]*whitespace-pre-wrap[\s\S]*\{part\.content\}/);
+    assert.doesNotMatch(messageList, /dangerouslySetInnerHTML/);
+
+    releaseStream();
+    await responsePromise;
+
+    const finalPart = manager.getSessionState('session-long-stream')?.messages[0]?.contentParts?.[0];
+    assert.deepEqual(renderedInputs, [fullText]);
+    assert.equal(finalPart?.content, `rendered:${fullText}`);
+    assert.equal(finalPart?.isStreamingText, false);
+  } finally {
+    unsubscribe();
+    releaseStream?.();
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('AI 文本段完成后发生流错误不会把最终 Markdown 退回纯文本', async () => {
+  const { ConversationManager } = await loadConversationManager(async function* () {
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: '**completed**' };
+    yield { type: 'TEXT_MESSAGE_END' };
+    throw new Error('stream failed after text end');
+  });
+  const manager = new ConversationManager();
+  const renderedInputs = [];
+  const originalConsoleError = console.error;
+
+  try {
+    console.error = () => {};
+    await manager.startAIResponse(
+      'session-ended-before-error',
+      9,
+      'mobile-node',
+      'question',
+      (text) => {
+        renderedInputs.push(text);
+        return `rendered:${text}`;
+      },
+      '响应中断，请重试',
+      false,
+    );
+
+    const response = manager.getSessionState('session-ended-before-error')?.messages[0];
+    assert.equal(response?.status, 'interrupted');
+    assert.deepEqual(renderedInputs, ['**completed**']);
+    assert.equal(response?.contentParts?.[0]?.content, 'rendered:**completed**');
+    assert.equal(response?.contentParts?.[0]?.isStreamingText, false);
+  } finally {
+    console.error = originalConsoleError;
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('AI 文本段开始但首个内容未到达时保持加载状态', { timeout: 5000 }, async () => {
+  let markStarted;
+  let releaseContent;
+  const started = new Promise((resolve) => {
+    markStarted = resolve;
+  });
+  const continueStream = new Promise((resolve) => {
+    releaseContent = resolve;
+  });
+  const { ConversationManager } = await loadConversationManager(async function* () {
+    yield { type: 'TEXT_MESSAGE_START' };
+    markStarted();
+    await continueStream;
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'ready' };
+    yield { type: 'TEXT_MESSAGE_END' };
+    yield { type: 'RUN_FINISHED' };
+  });
+  const manager = new ConversationManager();
+
+  try {
+    const responsePromise = manager.startAIResponse(
+      'session-waiting-content',
+      9,
+      'mobile-node',
+      'question',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+    await started;
+    assert.equal(manager.getSessionState('session-waiting-content')?.messages[0]?.status, 'loading');
+
+    releaseContent();
+    await responsePromise;
+  } finally {
+    releaseContent?.();
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('主动取消 AI 流后保留已接收的部分原文供复制', { timeout: 5000 }, async () => {
+  let markContentReady;
+  const contentReady = new Promise((resolve) => {
+    markContentReady = resolve;
+  });
+  const { ConversationManager } = await loadConversationManager(async function* (
+    _bot,
+    _nodeId,
+    _message,
+    _sessionId,
+    options,
+  ) {
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'partial **copy**' };
+    markContentReady();
+    await new Promise((resolve) => options.signal.addEventListener('abort', resolve, { once: true }));
+  });
+  const manager = new ConversationManager();
+
+  try {
+    const responsePromise = manager.startAIResponse(
+      'session-copy-after-cancel',
+      9,
+      'mobile-node',
+      'question',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+    await contentReady;
+    manager.abortStream('session-copy-after-cancel');
+    await responsePromise;
+
+    const response = manager.getSessionState('session-copy-after-cancel')?.messages[0];
+    assert.equal(response?.contentParts?.[0]?.content, 'partial **copy**');
+    assert.equal(manager.getMessageMarkdown('session-copy-after-cancel', response?.id), 'partial **copy**');
   } finally {
     delete globalThis.__conversationAiChatStream;
   }

--- a/mobile/scripts/mobile-conversation-flow-test.mjs
+++ b/mobile/scripts/mobile-conversation-flow-test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import { readFile, readdir } from 'node:fs/promises';
 import test from 'node:test';
+import createDOMPurify from 'dompurify';
+import { JSDOM } from 'jsdom';
+import MarkdownIt from 'markdown-it';
 import ts from 'typescript';
 
 const projectRoot = new URL('../', import.meta.url);
@@ -29,6 +32,39 @@ async function loadConversationManager(aiChatStream) {
     const aiChatStream = (...args) => globalThis.__conversationAiChatStream(...args);
     ${managerDeclaration.getText(sourceFile)}
     export { ConversationManager };
+  `;
+  const compiled = ts.transpileModule(moduleSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+    },
+  }).outputText;
+
+  return import(`data:text/javascript;base64,${Buffer.from(compiled).toString('base64')}#${Math.random()}`);
+}
+
+async function loadSanitizeMarkdownHtml(domPurify) {
+  const source = await readProjectFile('src/app/conversation/page.tsx');
+  const sourceFile = ts.createSourceFile(
+    'page.tsx',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const declaration = sourceFile.statements.find(
+    (statement) => ts.isVariableStatement(statement)
+      && statement.declarationList.declarations.some(
+        (item) => ts.isIdentifier(item.name) && item.name.text === 'sanitizeMarkdownHtml',
+      ),
+  );
+  assert.ok(declaration, 'sanitizeMarkdownHtml declaration must exist');
+
+  globalThis.__conversationDOMPurify = domPurify;
+  const moduleSource = `
+    const DOMPurify = globalThis.__conversationDOMPurify;
+    ${declaration.getText(sourceFile)}
+    export { sanitizeMarkdownHtml };
   `;
   const compiled = ts.transpileModule(moduleSource, {
     compilerOptions: {
@@ -822,8 +858,27 @@ test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态�
   const continueStream = new Promise((resolve) => {
     releaseStream = resolve;
   });
-  const deltas = ['<img src=x onerror=alert(1)>', '\n```ts\n', ...Array(100).fill('const value = 1;\n'), '```'];
+  const deltas = [
+    '<img src=x onerror=alert(1)>',
+    '\n\n| na',
+    'me | value |\n| ---',
+    ' | --- |\n| item | **ok** |',
+    '\n\n```ts\n',
+    ...Array(100).fill('const value = 1;\n'),
+    '```',
+  ];
   const fullText = deltas.join('');
+  const dom = new JSDOM('');
+  const domPurify = createDOMPurify(dom.window);
+  const { sanitizeMarkdownHtml } = await loadSanitizeMarkdownHtml(domPurify);
+  const md = new MarkdownIt({ html: true, linkify: true, typographer: true, breaks: true });
+  const React = await import('react');
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const renderProductionMarkdown = (text) => React.createElement('div', {
+    className: 'markdown-body',
+    dangerouslySetInnerHTML: { __html: sanitizeMarkdownHtml(md.render(text)) },
+  });
+  const oldFinalMarkup = renderToStaticMarkup(renderProductionMarkdown(fullText));
   const { ConversationManager } = await loadConversationManager(async function* () {
     yield { type: 'RUN_STARTED', timestamp: 1 };
     yield { type: 'TEXT_MESSAGE_START' };
@@ -858,7 +913,7 @@ test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态�
       'question',
       (text) => {
         renderedInputs.push(text);
-        return `rendered:${text}`;
+        return renderProductionMarkdown(text);
       },
       '响应中断，请重试',
       false,
@@ -874,8 +929,6 @@ test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态�
     assert.ok(notifications <= 6, `expected batched stream updates, received ${notifications}`);
     assert.match(messageList, /part\.isStreamingText[\s\S]*whitespace-pre-wrap[\s\S]*\{part\.content\}/);
     assert.doesNotMatch(messageList, /dangerouslySetInnerHTML/);
-    const React = await import('react');
-    const { renderToStaticMarkup } = await import('react-dom/server');
     const streamingHtml = renderToStaticMarkup(React.createElement('span', null, streamingPart.content));
     assert.match(streamingHtml, /&lt;img src=x onerror=alert\(1\)&gt;/);
     assert.doesNotMatch(streamingHtml, /<img/);
@@ -885,11 +938,18 @@ test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态�
 
     const finalPart = manager.getSessionState('session-long-stream')?.messages[0]?.contentParts?.[0];
     assert.deepEqual(renderedInputs, [fullText]);
-    assert.equal(finalPart?.content, `rendered:${fullText}`);
+    const finalMarkup = renderToStaticMarkup(finalPart?.content);
+    assert.equal(finalMarkup, oldFinalMarkup);
+    assert.match(finalMarkup, /<table>/);
+    assert.match(finalMarkup, /<pre><code class="language-ts">/);
+    assert.match(finalMarkup, /<img src="x">/);
+    assert.doesNotMatch(finalMarkup, /onerror|<script/i);
     assert.equal(finalPart?.isStreamingText, false);
   } finally {
     unsubscribe();
     releaseStream?.();
+    dom.window.close();
+    delete globalThis.__conversationDOMPurify;
     delete globalThis.__conversationAiChatStream;
   }
 });

--- a/mobile/scripts/mobile-conversation-flow-test.mjs
+++ b/mobile/scripts/mobile-conversation-flow-test.mjs
@@ -1059,6 +1059,8 @@ test('文本、工具和自定义组件按流事件顺序渲染', async () => {
 });
 
 test('同会话重连后旧 timer 和回调不会覆盖新回答', { timeout: 5000 }, async () => {
+  const originalDateNow = Date.now;
+  Date.now = () => 1730000000000;
   let markOldContentReady;
   const oldContentReady = new Promise((resolve) => {
     markOldContentReady = resolve;
@@ -1110,6 +1112,7 @@ test('同会话重连后旧 timer 和回调不会覆盖新回答', { timeout: 50
 
     const messages = manager.getSessionState('session-reconnect')?.messages;
     assert.equal(messages?.length, 2);
+    assert.notEqual(messages?.[0]?.id, messages?.[1]?.id);
     assert.equal(messages?.[0]?.status, 'interrupted');
     assert.equal(messages?.[0]?.contentParts?.[0]?.content, 'old');
     assert.equal(messages?.[1]?.status, 'ended');
@@ -1120,7 +1123,53 @@ test('同会话重连后旧 timer 和回调不会覆盖新回答', { timeout: 50
     await new Promise((resolve) => setTimeout(resolve, 30));
     assert.equal(notifications, notificationsAfterCompletion);
   } finally {
+    Date.now = originalDateNow;
     unsubscribe();
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('登出后旧流取消收尾不会写入新账号同 ID 会话', { timeout: 5000 }, async () => {
+  let markOldContentReady;
+  const oldContentReady = new Promise((resolve) => {
+    markOldContentReady = resolve;
+  });
+  const { ConversationManager } = await loadConversationManager(async function* (
+    _bot,
+    _nodeId,
+    _message,
+    _sessionId,
+    options,
+  ) {
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'old-account-secret' };
+    markOldContentReady();
+    await new Promise((resolve) => options.signal.addEventListener('abort', resolve, { once: true }));
+  });
+  const manager = new ConversationManager();
+
+  try {
+    const oldResponse = manager.startAIResponse(
+      'shared-session-id',
+      9,
+      'mobile-node',
+      'old',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+    await oldContentReady;
+
+    manager.clearAll();
+    manager.initSession('shared-session-id');
+    await oldResponse;
+
+    const newScopeState = manager.getSessionState('shared-session-id');
+    assert.deepEqual(newScopeState?.messages, []);
+    assert.equal(newScopeState?.messageMarkdown.size, 0);
+    assert.equal(manager.isSessionRunning('shared-session-id'), false);
+  } finally {
+    manager.clearAll();
     delete globalThis.__conversationAiChatStream;
   }
 });

--- a/mobile/scripts/mobile-conversation-flow-test.mjs
+++ b/mobile/scripts/mobile-conversation-flow-test.mjs
@@ -874,6 +874,11 @@ test('AI 长流只在文本段结束时渲染完整 Markdown，流式中间态�
     assert.ok(notifications <= 6, `expected batched stream updates, received ${notifications}`);
     assert.match(messageList, /part\.isStreamingText[\s\S]*whitespace-pre-wrap[\s\S]*\{part\.content\}/);
     assert.doesNotMatch(messageList, /dangerouslySetInnerHTML/);
+    const React = await import('react');
+    const { renderToStaticMarkup } = await import('react-dom/server');
+    const streamingHtml = renderToStaticMarkup(React.createElement('span', null, streamingPart.content));
+    assert.match(streamingHtml, /&lt;img src=x onerror=alert\(1\)&gt;/);
+    assert.doesNotMatch(streamingHtml, /<img/);
 
     releaseStream();
     await responsePromise;
@@ -1000,9 +1005,122 @@ test('主动取消 AI 流后保留已接收的部分原文供复制', { timeout:
     await responsePromise;
 
     const response = manager.getSessionState('session-copy-after-cancel')?.messages[0];
+    assert.equal(response?.status, 'interrupted');
+    assert.equal(response?.streamError, undefined);
     assert.equal(response?.contentParts?.[0]?.content, 'partial **copy**');
     assert.equal(manager.getMessageMarkdown('session-copy-after-cancel', response?.id), 'partial **copy**');
+    assert.equal(manager.isSessionRunning('session-copy-after-cancel'), false);
   } finally {
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('文本、工具和自定义组件按流事件顺序渲染', async () => {
+  const { ConversationManager } = await loadConversationManager(async function* () {
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'before' };
+    yield { type: 'TOOL_CALL_START', toolCallId: 'tool-1', toolCallName: 'inspect' };
+    yield { type: 'TOOL_CALL_ARGS', toolCallId: 'tool-1', delta: '{"id":1}' };
+    yield { type: 'TOOL_CALL_RESULT', toolCallId: 'tool-1', content: 'done' };
+    yield { type: 'CUSTOM', name: 'render_component', value: { component: 'Card', props: { id: 1 } } };
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'after' };
+    yield { type: 'TEXT_MESSAGE_END' };
+    yield { type: 'RUN_FINISHED' };
+  });
+  const manager = new ConversationManager();
+
+  try {
+    await manager.startAIResponse(
+      'session-event-order',
+      9,
+      'mobile-node',
+      'question',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+
+    const parts = manager.getSessionState('session-event-order')?.messages[0]?.contentParts;
+    assert.deepEqual(parts?.map((part) => part.type), ['text', 'tool_call', 'component', 'text']);
+    assert.equal(parts?.[0]?.content, 'rendered:before');
+    assert.deepEqual(parts?.[1]?.toolCall, {
+      id: 'tool-1',
+      name: 'inspect',
+      args: '{"id":1}',
+      result: 'done',
+      status: 'completed',
+    });
+    assert.deepEqual(parts?.[2]?.component, { name: 'Card', props: { id: 1 } });
+    assert.equal(parts?.[3]?.content, 'rendered:after');
+  } finally {
+    delete globalThis.__conversationAiChatStream;
+  }
+});
+
+test('同会话重连后旧 timer 和回调不会覆盖新回答', { timeout: 5000 }, async () => {
+  let markOldContentReady;
+  const oldContentReady = new Promise((resolve) => {
+    markOldContentReady = resolve;
+  });
+  const { ConversationManager } = await loadConversationManager(async function* (
+    _bot,
+    _nodeId,
+    message,
+    _sessionId,
+    options,
+  ) {
+    yield { type: 'TEXT_MESSAGE_START' };
+    yield { type: 'TEXT_MESSAGE_CONTENT', delta: message };
+    if (message === 'old') {
+      markOldContentReady();
+      await new Promise((resolve) => options.signal.addEventListener('abort', resolve, { once: true }));
+      return;
+    }
+    yield { type: 'TEXT_MESSAGE_END' };
+    yield { type: 'RUN_FINISHED' };
+  });
+  const manager = new ConversationManager();
+  let notifications = 0;
+  const unsubscribe = manager.subscribe(() => {
+    notifications += 1;
+  });
+
+  try {
+    const oldResponse = manager.startAIResponse(
+      'session-reconnect',
+      9,
+      'mobile-node',
+      'old',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+    await oldContentReady;
+    const newResponse = manager.startAIResponse(
+      'session-reconnect',
+      9,
+      'mobile-node',
+      'new',
+      (text) => `rendered:${text}`,
+      '响应中断，请重试',
+      false,
+    );
+    await Promise.all([oldResponse, newResponse]);
+
+    const messages = manager.getSessionState('session-reconnect')?.messages;
+    assert.equal(messages?.length, 2);
+    assert.equal(messages?.[0]?.status, 'interrupted');
+    assert.equal(messages?.[0]?.contentParts?.[0]?.content, 'old');
+    assert.equal(messages?.[1]?.status, 'ended');
+    assert.equal(messages?.[1]?.contentParts?.[0]?.content, 'rendered:new');
+    assert.equal(manager.isSessionRunning('session-reconnect'), false);
+
+    const notificationsAfterCompletion = notifications;
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(notifications, notificationsAfterCompletion);
+  } finally {
+    unsubscribe();
     delete globalThis.__conversationAiChatStream;
   }
 });

--- a/mobile/src/app/conversation/components/message-list.tsx
+++ b/mobile/src/app/conversation/components/message-list.tsx
@@ -145,6 +145,13 @@ export const MessageList: React.FC<MessageListProps> = ({
                                     if (!part.content) {
                                         return null;
                                     }
+                                    if (part.isStreamingText) {
+                                        return (
+                                            <span key={`text-${idx}`} className="whitespace-pre-wrap break-words">
+                                                {part.content}
+                                            </span>
+                                        );
+                                    }
                                     return <React.Fragment key={`text-${idx}`}>{part.content}</React.Fragment>;
                                 } else if (part.type === 'tool_call' && part.toolCall) {
                                     // 渲染工具调用

--- a/mobile/src/context/conversation.tsx
+++ b/mobile/src/context/conversation.tsx
@@ -39,6 +39,7 @@ type RenderMarkdownFn = (text: string) => React.ReactNode;
  * - 超过最大数量时自动清理最老的非活跃会话
  */
 class ConversationManager {
+    private readonly STREAM_TEXT_FLUSH_INTERVAL_MS = 16;
     private sessions: Map<string, SessionState> = new Map();
     private streamControllers: Map<string, StreamController> = new Map();
     private listeners: Set<() => void> = new Set();
@@ -474,7 +475,80 @@ class ConversationManager {
         let currentTextSegmentIndex = 0;
         let messageAccumulated = '';
         let totalMessageAccumulated = '';
+        let textSegmentFinalized = true;
+        let pendingTextFlush: ReturnType<typeof setTimeout> | undefined;
         const toolArgsAccumulated: Record<string, string> = {};
+
+        const updateTextSegment = (content: React.ReactNode, isStreamingText: boolean): void => {
+            this.updateMessages(sessionId, (prev) =>
+                prev.map((msg) => {
+                    if (msg.id !== aiMsgId) {
+                        return msg;
+                    }
+
+                    const parts = msg.contentParts || [];
+                    const existingTextPartIndex = parts.findIndex(p =>
+                        p.type === 'text' && p.segmentIndex === currentTextSegmentIndex
+                    );
+                    const textPart = {
+                        type: 'text' as const,
+                        content,
+                        segmentIndex: currentTextSegmentIndex,
+                        isStreamingText,
+                    };
+
+                    if (existingTextPartIndex >= 0) {
+                        const updatedParts = [...parts];
+                        updatedParts[existingTextPartIndex] = textPart;
+                        return {
+                            ...msg,
+                            status: content ? 'success' : msg.status,
+                            contentParts: updatedParts,
+                        };
+                    }
+
+                    return {
+                        ...msg,
+                        status: content ? 'success' : msg.status,
+                        contentParts: [...parts, textPart],
+                    };
+                })
+            );
+        };
+
+        const flushTextSegment = (renderFinal: boolean): void => {
+            if (pendingTextFlush !== undefined) {
+                clearTimeout(pendingTextFlush);
+                pendingTextFlush = undefined;
+            }
+            if (!messageAccumulated) {
+                return;
+            }
+            updateTextSegment(
+                renderFinal ? renderMarkdown(messageAccumulated) : messageAccumulated,
+                !renderFinal,
+            );
+            textSegmentFinalized = renderFinal;
+        };
+
+        const scheduleTextFlush = (): void => {
+            if (pendingTextFlush !== undefined) {
+                return;
+            }
+            pendingTextFlush = setTimeout(() => {
+                pendingTextFlush = undefined;
+                if (!signal.aborted && !textSegmentFinalized) {
+                    updateTextSegment(messageAccumulated, true);
+                }
+            }, this.STREAM_TEXT_FLUSH_INTERVAL_MS);
+        };
+
+        const preservePartialText = (): void => {
+            if (!textSegmentFinalized) {
+                flushTextSegment(false);
+            }
+            this.setMessageMarkdown(sessionId, aiMsgId, totalMessageAccumulated);
+        };
 
         try {
             const eventStream = aiChatStream(bot, nodeId, userMessage, sessionId, { signal });
@@ -482,6 +556,7 @@ class ConversationManager {
             for await (const event of eventStream) {
                 // 检查是否已取消
                 if (signal.aborted) {
+                    preservePartialText();
                     return;
                 }
 
@@ -626,55 +701,26 @@ class ConversationManager {
                         break;
 
                     case 'TEXT_MESSAGE_START':
+                        if (!textSegmentFinalized) {
+                            flushTextSegment(true);
+                        }
                         messageAccumulated = '';
                         currentTextSegmentIndex++;
+                        textSegmentFinalized = false;
+                        // 先占位以保持文本、工具和组件事件的到达顺序；空内容不会实际渲染。
+                        updateTextSegment('', true);
                         break;
 
                     case 'TEXT_MESSAGE_CONTENT':
                         const textDelta = event.delta || event.msg || '';
                         messageAccumulated += textDelta;
                         totalMessageAccumulated += textDelta;
-
-                        const renderedContent = renderMarkdown(messageAccumulated);
-
-                        this.updateMessages(sessionId, (prev) =>
-                            prev.map((msg) => {
-                                if (msg.id === aiMsgId) {
-                                    const parts = msg.contentParts || [];
-                                    const existingTextPartIndex = parts.findIndex(p =>
-                                        p.type === 'text' && p.segmentIndex === currentTextSegmentIndex
-                                    );
-
-                                    if (existingTextPartIndex >= 0) {
-                                        const updatedParts = [...parts];
-                                        updatedParts[existingTextPartIndex] = {
-                                            type: 'text' as const,
-                                            content: renderedContent,
-                                            segmentIndex: currentTextSegmentIndex
-                                        };
-                                        return {
-                                            ...msg,
-                                            status: 'success',
-                                            contentParts: updatedParts
-                                        };
-                                    } else {
-                                        return {
-                                            ...msg,
-                                            status: 'success',
-                                            contentParts: [...parts, {
-                                                type: 'text' as const,
-                                                content: renderedContent,
-                                                segmentIndex: currentTextSegmentIndex
-                                            }]
-                                        };
-                                    }
-                                }
-                                return msg;
-                            })
-                        );
+                        textSegmentFinalized = false;
+                        scheduleTextFlush();
                         break;
 
                     case 'TEXT_MESSAGE_END':
+                        flushTextSegment(true);
                         break;
 
                     case 'CUSTOM':
@@ -701,6 +747,9 @@ class ConversationManager {
                         break;
 
                     case 'RUN_FINISHED':
+                        if (!textSegmentFinalized) {
+                            flushTextSegment(true);
+                        }
                         this.setMessageMarkdown(sessionId, aiMsgId, totalMessageAccumulated);
                         this.updateMessages(sessionId, (prev) =>
                             prev.map((msg) => {
@@ -718,13 +767,17 @@ class ConversationManager {
                 }
             }
 
-            if (!signal.aborted) {
-                throw new Error('AI response stream ended before RUN_FINISHED');
-            }
-        } catch (error) {
-            if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+            if (signal.aborted) {
+                preservePartialText();
                 return;
             }
+            throw new Error('AI response stream ended before RUN_FINISHED');
+        } catch (error) {
+            if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
+                preservePartialText();
+                return;
+            }
+            preservePartialText();
             console.error('API 事件流处理错误:', error);
             this.setAIRunning(sessionId, false);
 
@@ -754,6 +807,10 @@ class ConversationManager {
                     ];
                 }
             });
+        } finally {
+            if (pendingTextFlush !== undefined) {
+                clearTimeout(pendingTextFlush);
+            }
         }
     }
 }

--- a/mobile/src/context/conversation.tsx
+++ b/mobile/src/context/conversation.tsx
@@ -40,6 +40,8 @@ type RenderMarkdownFn = (text: string) => React.ReactNode;
  */
 class ConversationManager {
     private readonly STREAM_TEXT_FLUSH_INTERVAL_MS = 16;
+    private messageIdSequence = 0;
+    private scopeGeneration = 0;
     private sessions: Map<string, SessionState> = new Map();
     private streamControllers: Map<string, StreamController> = new Map();
     private listeners: Set<() => void> = new Set();
@@ -320,6 +322,7 @@ class ConversationManager {
      * 清理当前账号的全部会话状态，用于登出、401 与账号切换。
      */
     clearAll(): void {
+        this.scopeGeneration++;
         this.streamControllers.forEach((controller) => controller.abort());
         this.streamControllers.clear();
         this.sessions.clear();
@@ -387,13 +390,15 @@ class ConversationManager {
     ): Promise<void> {
         // 初始化会话
         this.initSession(sessionId);
+        const responseScopeGeneration = this.scopeGeneration;
 
         // 先结束旧流，再标记新流运行，避免旧流取消状态覆盖同会话的新请求。
         this.abortStream(sessionId);
 
         const userMessageTimestamp = Date.now();
-        const userMsgId = `user-${userMessageTimestamp}`;
-        const aiMsgId = `ai-${userMessageTimestamp}`;
+        const messageIdSuffix = `${userMessageTimestamp}-${this.messageIdSequence++}`;
+        const userMsgId = `user-${messageIdSuffix}`;
+        const aiMsgId = `ai-${messageIdSuffix}`;
 
         // 添加用户消息和 AI loading 消息
         this.setAIRunning(sessionId, true);
@@ -451,6 +456,7 @@ class ConversationManager {
                 renderMarkdown,
                 errorMessage,
                 abortController.signal,
+                responseScopeGeneration,
             );
         } finally {
             // 仅允许当前流收尾，避免旧流结束时覆盖同一会话的新请求状态。
@@ -473,6 +479,7 @@ class ConversationManager {
         renderMarkdown: RenderMarkdownFn,
         errorMessage: string,
         signal: AbortSignal,
+        responseScopeGeneration: number,
     ): Promise<void> {
         let thinkingAccumulated = '';
         let currentTextSegmentIndex = 0;
@@ -554,6 +561,10 @@ class ConversationManager {
         };
 
         const preserveCancelledText = (): void => {
+            // 登出、401 或账号切换已清空原作用域时，旧流不得写回同 ID 的新会话。
+            if (responseScopeGeneration !== this.scopeGeneration) {
+                return;
+            }
             preservePartialText();
             this.updateMessages(sessionId, (prev) =>
                 prev.map((msg) =>

--- a/mobile/src/context/conversation.tsx
+++ b/mobile/src/context/conversation.tsx
@@ -336,6 +336,7 @@ class ConversationManager {
         if (controller) {
             controller.abort();
             this.streamControllers.delete(sessionId);
+            this.setAIRunning(sessionId, false);
         }
     }
 
@@ -387,6 +388,9 @@ class ConversationManager {
         // 初始化会话
         this.initSession(sessionId);
 
+        // 先结束旧流，再标记新流运行，避免旧流取消状态覆盖同会话的新请求。
+        this.abortStream(sessionId);
+
         const userMessageTimestamp = Date.now();
         const userMsgId = `user-${userMessageTimestamp}`;
         const aiMsgId = `ai-${userMessageTimestamp}`;
@@ -431,7 +435,6 @@ class ConversationManager {
         }
 
         // 同一会话只保留一条活跃流，并将取消传递到底层请求。
-        this.abortStream(sessionId);
         const abortController = new AbortController();
         const controller: StreamController = {
             abort: () => abortController.abort(),
@@ -550,13 +553,24 @@ class ConversationManager {
             this.setMessageMarkdown(sessionId, aiMsgId, totalMessageAccumulated);
         };
 
+        const preserveCancelledText = (): void => {
+            preservePartialText();
+            this.updateMessages(sessionId, (prev) =>
+                prev.map((msg) =>
+                    msg.id === aiMsgId
+                        ? { ...msg, status: 'interrupted' as const }
+                        : msg
+                )
+            );
+        };
+
         try {
             const eventStream = aiChatStream(bot, nodeId, userMessage, sessionId, { signal });
 
             for await (const event of eventStream) {
                 // 检查是否已取消
                 if (signal.aborted) {
-                    preservePartialText();
+                    preserveCancelledText();
                     return;
                 }
 
@@ -768,13 +782,13 @@ class ConversationManager {
             }
 
             if (signal.aborted) {
-                preservePartialText();
+                preserveCancelledText();
                 return;
             }
             throw new Error('AI response stream ended before RUN_FINISHED');
         } catch (error) {
             if (signal.aborted || (error instanceof Error && error.name === 'AbortError')) {
-                preservePartialText();
+                preserveCancelledText();
                 return;
             }
             preservePartialText();

--- a/mobile/src/types/conversation.ts
+++ b/mobile/src/types/conversation.ts
@@ -33,6 +33,7 @@ export interface ContentPart {
   }; // 组件配置
   toolCall?: ToolCall; // 工具调用信息
   segmentIndex?: number; // 分段索引
+  isStreamingText?: boolean; // 流式纯文本中间态；结束后替换为完整 Markdown 渲染结果
 }
 
 export interface Message {


### PR DESCRIPTION
## 问题

Mobile AI 流此前每收到一个文本 delta，都会重新解析和净化从段首到当前的完整 Markdown，并立即更新整条消息。固定小分片下，累计解析量随回答长度呈二次增长。

## 怎么修的

- delta 只追加原始文本，流式刷新按 16ms 合并，不再逐片调用 MarkdownIt 与 DOMPurify。
- 中间态用 React 文本节点显示并保留换行，由 React 自动转义；不引入未净化 HTML。
- `TEXT_MESSAGE_END` 或 `RUN_FINISHED` 才对完整文本段执行一次既有 Markdown 渲染与净化。
- 文本段开始时保留空占位，维持文本、工具调用和自定义组件的事件顺序；首个内容到达前仍保持 loading。
- 正常结束、提前断流、主动取消和异常统一清理 timer，并保存部分原文供复制。

## 复杂度变化

- Markdown 解析：从每个 delta 重算完整前缀，降为每个文本段一次完整解析。
- 状态刷新：从每个 delta 一次，降为每 16ms 至多一次。
- 103 个连续 delta 的回归测试中，Markdown 渲染调用从旧实现的 103 次降为 1 次。

## 验证

- AI 流关联专项：8 passed，覆盖长流、跨 chunk 代码块、纯文本转义、最终渲染、提前断流、主动取消、复制原文、文本段结束后异常及 loading 状态。
- Mobile 会话完整套件：45 passed；唯一失败为仓库既有底部导航 CSS 基线，与本次改动无关。
- Mobile 平台壳：10 passed。
- Tauri 流专项：7 passed。
- Mobile 监控与资产专项：36 passed。
- ESLint、TypeScript、diff-check：通过。

## 三轨门禁

- Standards：PASS
- Spec：PASS
- Runtime Contract：PASS

Closes #4624
