### PR TITLE
feat(monitor): 对齐阿里云，腾讯云基础对象展示为腾讯云

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/language/en.yaml
@@ -5,8 +5,8 @@ Tencent Cloud:
     users to gain deep insights into resource status, precisely pinpoint anomalies,
     and efficiently accomplish operational management and cost optimization.
 monitor_object:
-  TCP: TCP
-  CVM: Cloud Virtual Machine
+  TCP: Tencent Cloud
+  CVM: Cloud Server CVM
 monitor_object_type:
   Tencent Cloud: Tencent Cloud
 monitor_object_metric_group:

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/language/zh-Hans.yaml
@@ -2,8 +2,8 @@ Tencent Cloud:
   name: 腾讯云
   desc: 实时采集腾讯云各类监控指标数据，涵盖计算资源、网络性能、存储使用等维度，助力用户深入了解资源状态，精准定位异常，高效完成运维管理与成本优化。
 monitor_object:
-  TCP: TCP
-  CVM: 云服务器
+  TCP: 腾讯云
+  CVM: 云服务器 CVM
 monitor_object_type:
   Tencent Cloud: 腾讯云
 monitor_object_metric_group:

--- a/web/src/app/monitor/dashboards/metadata.ts
+++ b/web/src/app/monitor/dashboards/metadata.ts
@@ -64,8 +64,18 @@ export const PROFESSIONAL_DASHBOARD_METADATA: ProfessionalDashboardMetaItem[] = 
 /** @deprecated 使用 PROFESSIONAL_DASHBOARD_METADATA；保留别名兼容旧引用。 */
 export const PROFESSIONAL_DASHBOARDS = PROFESSIONAL_DASHBOARD_METADATA;
 
-const getDashboardCandidates = (item: ProfessionalDashboardMetaItem) =>
-  [item.key, ...(item.aliases || []), item.objectName, item.objectDisplayName]
+/** URL / 路由查找：含 dashboard key。 */
+const getDashboardRouteCandidates = (item: ProfessionalDashboardMetaItem) =>
+  [item.key, ...(item.aliases || []), item.objectName]
+    .filter(Boolean)
+    .map((value) => normalizeDashboardKey(value));
+
+/**
+ * 监控对象查找：只用 objectName + aliases。
+ * 不含 dashboard key 与泛化展示名，避免腾讯云 slug `TCP` 误绑 TCP 端口盘。
+ */
+export const getDashboardObjectMatchKeys = (item: ProfessionalDashboardMetaItem) =>
+  [item.objectName, ...(item.aliases || [])]
     .filter(Boolean)
     .map((value) => normalizeDashboardKey(value));
 
@@ -75,7 +85,7 @@ export const findProfessionalDashboardMeta = (
 ) => {
   const objectCandidates = [objectName, objectDisplayName].map((value) => normalizeDashboardKey(value));
   return PROFESSIONAL_DASHBOARD_METADATA.find((item) => {
-    const candidates = getDashboardCandidates(item);
+    const candidates = getDashboardObjectMatchKeys(item);
     return objectCandidates.some((candidate) => candidate && candidates.includes(candidate));
   });
 };
@@ -84,7 +94,7 @@ export const findProfessionalDashboardMetaByKey = (objectKey?: string | null) =>
   const normalizedKey = normalizeDashboardKey(objectKey);
   if (!normalizedKey) return undefined;
   return PROFESSIONAL_DASHBOARD_METADATA.find((item) =>
-    getDashboardCandidates(item).includes(normalizedKey)
+    getDashboardRouteCandidates(item).includes(normalizedKey)
   );
 };
 
@@ -120,7 +130,7 @@ export const getProfessionalDashboardUrl = (
 export const getProfessionalDashboardPermissionPath = (url?: string | null) => {
   const normalizedUrl = String(url || '').replace(/\/$/, '').toLowerCase();
   const matched = PROFESSIONAL_DASHBOARD_METADATA.find((item) => {
-    return getDashboardCandidates(item).some((candidate) => {
+    return getDashboardRouteCandidates(item).some((candidate) => {
       const dashboardPath = `/monitor/view/dashboard/${candidate}`;
       return normalizedUrl === dashboardPath || normalizedUrl.startsWith(`${dashboardPath}/`);
     });

--- a/web/src/app/monitor/dashboards/registry.ts
+++ b/web/src/app/monitor/dashboards/registry.ts
@@ -8,6 +8,7 @@ export {
   PROFESSIONAL_DASHBOARDS,
   findProfessionalDashboardMeta,
   findProfessionalDashboardMetaByKey,
+  getDashboardObjectMatchKeys,
   getProfessionalDashboardKey,
   getProfessionalObjectDisplayName,
   getProfessionalDashboardUrl,

--- a/web/src/app/monitor/dashboards/shared/utils/use-resolve-object-id.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/use-resolve-object-id.ts
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import useMonitorApi from '@/app/monitor/api';
-import { findProfessionalDashboardMetaByKey } from '../../metadata';
+import { findProfessionalDashboardMetaByKey, getDashboardObjectMatchKeys } from '../../metadata';
 import { normalizeDashboardKey } from './index';
 import { buildInstanceDisplayName, encodeInstanceIdValuesParam } from './instance';
 
@@ -50,9 +50,7 @@ export function useResolveObjectId(objectKey: string) {
     if (!monitorObjId) {
       const registryItem = findProfessionalDashboardMetaByKey(objectKey);
       if (!registryItem) return;
-      const registryCandidates = [registryItem.key, ...(registryItem.aliases || []), registryItem.objectName, registryItem.objectDisplayName]
-        .filter(Boolean)
-        .map((value) => normalizeDashboardKey(value));
+      const registryCandidates = getDashboardObjectMatchKeys(registryItem);
 
       resolving.current = true;
 


### PR DESCRIPTION
## Summary
- 腾讯云基础对象展示名由 `TCP` 改为与阿里云一致的「腾讯云」，CVM 改为「云服务器 CVM」；内部 slug 仍为 `TCP`。
- 专业仪表盘对象匹配只使用 `objectName` + `aliases`，避免腾讯云 slug `TCP` 误绑 TCP 端口拨测盘。
- 拨测 `TCPPort` 展示名保持 `TCP`。

## Test plan
- [ ] 集成树：腾讯云 → 腾讯云（仅基础对象）
- [ ] 视图树：腾讯云 → 腾讯云、云服务器 CVM
- [ ] 拨测/网络：仍为 TCP
- [ ] 打开 `/monitor/view/dashboard/tcp` 绑到 `TCPPort`，不是腾讯云 `TCP`