### PR TITLE
fix(opspilot): 修复附件下载链接与 Qwen system 消息顺序

### DIFF
--- a/server/apps/opspilot/metis/llm/agent/__init__.py
+++ b/server/apps/opspilot/metis/llm/agent/__init__.py
@@ -1,10 +1,11 @@
-from apps.opspilot.metis.llm.agent.deep_agent import (
-    DeepAgentGraph,
-    DeepAgentNode,
-    DeepAgentRequest,
-    DeepAgentResponse,
-    DeepAgentState,
-)
+"""DeepAgent 包入口。
+
+子模块（如 ``tool_execution_planner``）必须能在不导入 ``deep_agent`` 的情况下加载。
+否则 ``node → tool_runtime → agent.tool_execution_planner → agent.__init__ → deep_agent → node``
+会在「先 import node」时形成循环导入，单测按文件收集会失败。
+"""
+
+from typing import Any
 
 __all__ = [
     "DeepAgentGraph",
@@ -13,3 +14,13 @@ __all__ = [
     "DeepAgentState",
     "DeepAgentNode",
 ]
+
+_DEEP_AGENT_EXPORTS = frozenset(__all__)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEEP_AGENT_EXPORTS:
+        from apps.opspilot.metis.llm.agent import deep_agent as _deep_agent
+
+        return getattr(_deep_agent, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/server/apps/opspilot/metis/llm/chain/lc_patches.py
+++ b/server/apps/opspilot/metis/llm/chain/lc_patches.py
@@ -21,6 +21,7 @@ import langchain_openai.chat_models.base as _lc_openai_base
 import openai
 from langchain_core.messages import AIMessage, AIMessageChunk
 from langchain_openai.chat_models.base import BaseChatOpenAI as _BaseChatOpenAI
+from langchain_openai.chat_models.base import ChatOpenAI as _ChatOpenAI
 from langchain_openai.chat_models.base import _convert_delta_to_message_chunk as _original_convert_delta_to_message_chunk
 from langchain_openai.chat_models.base import _convert_dict_to_message as _original_convert_dict_to_message
 from langchain_openai.chat_models.base import _convert_message_to_dict as _original_convert_message_to_dict
@@ -159,3 +160,88 @@ def _patched_convert_message_to_dict(message, *args, **kwargs):
 
 
 _lc_openai_base._convert_message_to_dict = _patched_convert_message_to_dict
+
+
+# --- Patch 5: merge system messages to the front of the OpenAI payload --------
+#
+# Qwen / MiniMax compatible gateways reject any system message that is not
+# messages[0] ("System message must be at the beginning."). DeepAgent prepends
+# its own system_prompt while the graph already inserted a SystemMessage, and
+# some tool loops inject extra SystemMessage mid-conversation. Merge them.
+
+
+def _payload_message_text(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and item.get("text"):
+                parts.append(str(item.get("text") or ""))
+        return "\n".join(part for part in parts if part)
+    return str(content)
+
+
+def merge_openai_payload_system_messages(messages: list) -> list:
+    """Keep a single system/developer message at index 0; leave other roles in order."""
+    if not messages:
+        return messages
+
+    system_indexes = [
+        index
+        for index, message in enumerate(messages)
+        if isinstance(message, dict) and str(message.get("role") or "").lower() in {"system", "developer"}
+    ]
+    if not system_indexes or system_indexes == [0]:
+        return messages
+
+    system_parts = []
+    rest = []
+    first_system = None
+    for message in messages:
+        if isinstance(message, dict) and str(message.get("role") or "").lower() in {"system", "developer"}:
+            if first_system is None:
+                first_system = dict(message)
+            text = _payload_message_text(message.get("content"))
+            if text:
+                system_parts.append(text)
+            continue
+        rest.append(message)
+
+    merged = dict(first_system or {"role": "system", "content": ""})
+    merged["content"] = "\n\n".join(system_parts)
+    return [merged] + rest
+
+
+def _install_system_message_payload_patch(cls) -> None:
+    """Merge system/developer messages after the class builds the OpenAI payload.
+
+    ChatOpenAI overrides ``_get_request_payload`` and calls ``super()``, then
+    may rewrite ``system`` → ``developer`` for o-series models. Patching only
+    BaseChatOpenAI still works via super(), but patching ChatOpenAI itself
+    makes the merge the last step on the class LLMClientFactory actually uses.
+    """
+    original = cls._get_request_payload
+    if getattr(original, "_opspilot_system_merge", False):
+        return
+
+    def _patched(self, *args, **kwargs):
+        payload = original(self, *args, **kwargs)
+        messages = payload.get("messages") if isinstance(payload, dict) else None
+        if isinstance(messages, list):
+            payload["messages"] = merge_openai_payload_system_messages(messages)
+        return payload
+
+    _patched._opspilot_system_merge = True
+    cls._get_request_payload = _patched
+
+
+_install_system_message_payload_patch(_BaseChatOpenAI)
+if _ChatOpenAI is not _BaseChatOpenAI:
+    _install_system_message_payload_patch(_ChatOpenAI)
+
+_patched_get_request_payload = _BaseChatOpenAI._get_request_payload

--- a/server/apps/opspilot/metis/llm/chain/node.py
+++ b/server/apps/opspilot/metis/llm/chain/node.py
@@ -59,6 +59,8 @@ from apps.opspilot.metis.llm.chain.lc_patches import (  # noqa: E402,F401
     _patched_convert_dict_to_message,
     _patched_convert_message_to_dict,
     _patched_create_chat_result,
+    _patched_get_request_payload,
+    merge_openai_payload_system_messages,
 )
 from apps.opspilot.metis.llm.common.llm_client_factory import LLMClientFactory
 from apps.opspilot.metis.llm.common.structured_output_parser import StructuredOutputParser
@@ -144,6 +146,15 @@ def normalize_messages_for_llm(messages: List[Any]) -> List[Any]:
         return [merged_system] + non_system_messages
     else:
         return non_system_messages
+
+
+def without_system_messages(messages: List[Any]) -> List[Any]:
+    """Drop SystemMessage so DeepAgent 的 system_prompt 成为唯一 system。
+
+    图前置节点已写入 SystemMessage；create_deep_agent(system_prompt=...) 会再注入一条，
+    部分网关会因此返回 400 “System message must be at the beginning.”
+    """
+    return [message for message in (messages or []) if not isinstance(message, SystemMessage)]
 
 
 class BasicNode:
@@ -3058,7 +3069,8 @@ class ToolsNodes(BasicNode):
                     },
                 }
                 try:
-                    result = await deep_agent.ainvoke({"messages": original_messages}, config=deep_config)
+                    deep_input_messages = without_system_messages(original_messages)
+                    result = await deep_agent.ainvoke({"messages": deep_input_messages}, config=deep_config)
                 except Exception as _await_exc:
                     try:
                         err_prompt = (
@@ -3092,7 +3104,7 @@ class ToolsNodes(BasicNode):
                 final_messages = result.get("messages", [])
                 if not final_messages:
                     return {"messages": [AIMessage(content="DeepAgent 未返回任何消息")]}
-                new_messages = final_messages[len(original_messages) :]
+                new_messages = final_messages[len(deep_input_messages) :]
                 if not new_messages:
                     return {"messages": [AIMessage(content="DeepAgent 未产生新的响应")]}
                 try:
@@ -3319,7 +3331,7 @@ class ToolsNodes(BasicNode):
                 else:
                     header = "【步骤摘要】以下为已完成步骤摘要，请仅基于摘要与用户问题继续，不要重复已完成步骤。\n"
                 summary = _internal_message(header + ("\n".join(summary_lines) if summary_lines else "无"))
-                return {"messages": list(original_messages) + [summary]}
+                return {"messages": without_system_messages(original_messages) + [summary]}
 
             def _step_summary(messages: List[BaseMessage]) -> str:
                 for message in reversed(messages):
@@ -3366,7 +3378,7 @@ class ToolsNodes(BasicNode):
             try:
                 completed_steps: List[CompletedExecutionStep] = []
                 pending_steps = list(plan.steps)
-                agent_state: Dict[str, Any] = {"messages": original_messages}
+                agent_state: Dict[str, Any] = {"messages": without_system_messages(original_messages)}
                 replan_count = 0
                 total_steps = len(plan.steps)
 

--- a/server/apps/opspilot/metis/llm/tools/attachment/generate_attachment.py
+++ b/server/apps/opspilot/metis/llm/tools/attachment/generate_attachment.py
@@ -26,8 +26,9 @@ def generate_attachment_file(
     save, or export any file, document, report, or attachment — regardless of file format.**
 
     Do NOT output file content as plain text in your response. Always use this tool so the
-    user receives a downloadable link. After calling this tool, briefly summarize what was
-    generated and present the returned download URL to the user.
+    user receives a downloadable file. After calling this tool, briefly summarize what was
+    generated. Do NOT paste the download URL, file:// links, /api/proxy paths, or placeholder
+    tokens such as "加密token" into the chat or the file body; the UI renders the download button.
 
     When to call this tool:
     - User says "generate a report / create a file / export data / save as PDF" etc.

--- a/server/apps/opspilot/services/chat_service.py
+++ b/server/apps/opspilot/services/chat_service.py
@@ -505,7 +505,9 @@ class ChatService:
                 "* 如果任务目标涉及生成、创建、导出任何文件、报告、月报或文档，"
                 "必须调用 generate_attachment_file 工具把完整内容写入可下载文件"
                 "（如 .md），绝对不允许将文件全文以纯文字/Markdown 直接渲染在对话中。\n"
-                "* 工具调用成功后，仅输出简短摘要与工具返回的下载链接，不要重复输出完整内容。\n"
+                "* 工具调用成功后，仅输出简短摘要，不要重复输出完整内容。\n"
+                "* 不要在回复或附件正文中粘贴下载 URL、file:// 链接、/api/proxy 路径或「加密token」占位符；"
+                "下载入口由界面提供。\n"
                 "* 以上规则覆盖所有其他'直接输出'类指令。"
             )
             chat_kwargs["system_message_prompt"] = chat_kwargs.get("system_message_prompt", "") + attachment_override

--- a/server/apps/opspilot/tests/test_chain_nodes_public_contracts.py
+++ b/server/apps/opspilot/tests/test_chain_nodes_public_contracts.py
@@ -82,6 +82,66 @@ def test_normalize_messages_empty_input():
     assert node.normalize_messages_for_llm([]) == []
 
 
+def test_without_system_messages_drops_graph_system_for_deepagent():
+    from apps.opspilot.metis.llm.chain.node import without_system_messages
+
+    kept = without_system_messages(
+        [
+            SystemMessage(content="图前置"),
+            HumanMessage(content="写月报"),
+            AIMessage(content="好的"),
+        ]
+    )
+    assert [type(message) for message in kept] == [HumanMessage, AIMessage]
+
+
+def test_merge_openai_payload_system_messages_moves_mid_conversation_system_to_front():
+    from apps.opspilot.metis.llm.chain.lc_patches import merge_openai_payload_system_messages
+
+    leading = [
+        {"role": "system", "content": "only"},
+        {"role": "user", "content": "hi"},
+    ]
+    assert merge_openai_payload_system_messages(leading) is leading
+
+    merged = merge_openai_payload_system_messages(
+        [
+            {"role": "system", "content": "graph-system"},
+            {"role": "user", "content": "生成附件"},
+            {"role": "assistant", "content": "开始"},
+            {"role": "system", "content": "deepagent-system"},
+        ]
+    )
+    assert merged[0]["role"] == "system"
+    assert "graph-system" in merged[0]["content"]
+    assert "deepagent-system" in merged[0]["content"]
+    assert [item["role"] for item in merged[1:]] == ["user", "assistant"]
+    assert sum(1 for item in merged if item.get("role") == "system") == 1
+
+
+def test_chatopenai_request_payload_merges_mid_conversation_system():
+    """ChatOpenAI 覆盖了 Base._get_request_payload；补丁必须打在实际发请求的类上。"""
+    from langchain_openai import ChatOpenAI
+
+    import apps.opspilot.metis.llm.chain.lc_patches  # noqa: F401
+
+    llm = ChatOpenAI(model="qwen-plus", api_key="test-key", base_url="http://127.0.0.1")
+    payload = llm._get_request_payload(
+        [
+            SystemMessage(content="graph-system"),
+            HumanMessage(content="生成附件"),
+            AIMessage(content="开始"),
+            SystemMessage(content="deepagent-system"),
+        ]
+    )
+    messages = payload["messages"]
+    assert messages[0]["role"] in {"system", "developer"}
+    assert "graph-system" in messages[0]["content"]
+    assert "deepagent-system" in messages[0]["content"]
+    assert [item["role"] for item in messages[1:]] == ["user", "assistant"]
+    assert sum(1 for item in messages if item.get("role") in {"system", "developer"}) == 1
+
+
 def test_prompt_suggestion_and_history_nodes_build_valid_message_sequence():
     request = SimpleNamespace(
         system_message_prompt="Follow operations policy.",

--- a/web/scripts/opspilot-download-url-security-test.ts
+++ b/web/scripts/opspilot-download-url-security-test.ts
@@ -1,5 +1,12 @@
 import assert from 'node:assert/strict';
-import { normalizeSafeDownloadUrl } from '../src/app/opspilot/components/custom-chat-sse/downloadUrl';
+import {
+  isRenderableReportDownload,
+  looksLikeAttachmentDownloadUrl,
+  looksLikeFakeDownloadHref,
+  normalizeSafeDownloadUrl,
+  rewriteAttachmentDownloadMentions,
+  toAbsoluteDownloadHref,
+} from '../src/app/opspilot/components/custom-chat-sse/downloadUrl';
 
 const currentOrigin = 'https://console.example.com';
 
@@ -37,5 +44,86 @@ assert.equal(normalizeSafeDownloadUrl('report.docx', { currentOrigin }), '');
 assert.equal(normalizeSafeDownloadUrl('https://user:pass@console.example.com/report.docx', { currentOrigin }), '');
 assert.equal(normalizeSafeDownloadUrl('/api/proxy/opspilot/down\nload/token/', { currentOrigin }), '');
 assert.equal(normalizeSafeDownloadUrl('\\evil.example.com\\report.docx', { currentOrigin }), '');
+
+const signedUrl = '/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/signed-real-token/';
+const screenshotMarkdown = [
+  '请点击以下链接获取月报附件：',
+  '[/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/加密token]',
+  '(file:///api/proxy/opspilot/bot_mgmt/workflow_attachment/download/加密token/)',
+].join('\n');
+const rewritten = rewriteAttachmentDownloadMentions(
+  screenshotMarkdown,
+  [
+    {
+      download_id: 'attachment_1',
+      filename: 'K8s_集群运维月报_2026-08.md',
+      mime_type: 'text/markdown',
+      file_url: signedUrl,
+      received_at: 1,
+    },
+  ],
+  { currentOrigin },
+);
+
+assert.equal(rewritten.includes('加密token'), false);
+assert.equal(rewritten.includes('file:///'), false);
+assert.equal(rewritten.includes('/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/加密token'), false);
+assert.match(
+  rewritten,
+  /<a href="\/api\/proxy\/opspilot\/bot_mgmt\/workflow_attachment\/download\/signed-real-token\/" download="K8s_集群运维月报_2026-08\.md">下载 K8s_集群运维月报_2026-08\.md<\/a>/,
+);
+assert.equal(
+  looksLikeAttachmentDownloadUrl('file:///api/proxy/opspilot/bot_mgmt/workflow_attachment/download/加密token/'),
+  true,
+);
+assert.equal(
+  isRenderableReportDownload({
+    download_id: 'url-only',
+    filename: 'report.md',
+    mime_type: 'text/markdown',
+    file_url: signedUrl,
+    received_at: 1,
+  }),
+  true,
+);
+assert.equal(
+  isRenderableReportDownload({
+    download_id: 'unsafe',
+    filename: 'report.md',
+    mime_type: 'text/markdown',
+    file_url: 'javascript:alert(1)',
+    received_at: 1,
+  }),
+  false,
+);
+
+const strippedWithoutDownload = rewriteAttachmentDownloadMentions(screenshotMarkdown, [], { currentOrigin });
+assert.equal(strippedWithoutDownload.includes('加密token'), false);
+assert.equal(strippedWithoutDownload.includes('file:///'), false);
+assert.match(strippedWithoutDownload, /附件可在对话中下载/);
+
+const rcaMarkdown = '[下载 RCA 报告](地址: http://api-lite-inner-test-833-2025-x.example/{token})';
+const rcaRewritten = rewriteAttachmentDownloadMentions(
+  rcaMarkdown,
+  [
+    {
+      download_id: 'attachment_rca',
+      filename: 'api-lite-inner-test-RCA-2025-08-13.md',
+      mime_type: 'text/markdown',
+      file_url: signedUrl,
+      received_at: 1,
+    },
+  ],
+  { currentOrigin },
+);
+assert.equal(rcaRewritten.includes('地址:'), false);
+assert.equal(rcaRewritten.includes('{token}'), false);
+assert.equal(rcaRewritten.includes('api-lite-inner-test-833-2025-x.example'), false);
+assert.match(rcaRewritten, /^<a href="\/api\/proxy\/opspilot\/bot_mgmt\/workflow_attachment\/download\/signed-real-token\/"/);
+assert.equal(looksLikeFakeDownloadHref('地址: http://api-lite-inner-test.example/{token}'), true);
+assert.equal(
+  toAbsoluteDownloadHref(signedUrl, { currentOrigin }),
+  'https://console.example.com/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/signed-real-token/',
+);
 
 console.log('opspilot download URL security tests passed');

--- a/web/src/app/opspilot/components/custom-chat-sse/ReportDownloadCard.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/ReportDownloadCard.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from 'react';
 import { Tag } from 'antd';
 import { DownloadOutlined, FileWordOutlined } from '@ant-design/icons';
 import { ReportFileDownload } from '@/app/opspilot/types/global';
-import { normalizeSafeDownloadUrl } from './downloadUrl';
+import { normalizeSafeDownloadUrl, toAbsoluteDownloadHref } from './downloadUrl';
 
 interface ReportDownloadCardProps {
   download: ReportFileDownload;
@@ -16,8 +16,8 @@ const ReportDownloadCard: React.FC<ReportDownloadCardProps> = ({ download }) => 
   const handleDownload = useCallback(() => {
     if (normalizedFileUrl) {
       const link = document.createElement('a');
-      link.href = normalizedFileUrl;
-      link.download = download.filename;
+      link.setAttribute('href', toAbsoluteDownloadHref(download.file_url) || normalizedFileUrl);
+      link.setAttribute('download', download.filename);
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);

--- a/web/src/app/opspilot/components/custom-chat-sse/downloadUrl.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/downloadUrl.ts
@@ -105,6 +105,145 @@ export const normalizeSafeDownloadUrl = (
   return '';
 };
 
+const ATTACHMENT_DOWNLOAD_HREF_PATTERN =
+  '(?:file:\\/\\/)?(?:https?:\\/\\/[^\\s/]+)?\\/api\\/(?:proxy|v1)\\/opspilot\\/bot_mgmt\\/workflow_attachment\\/download\\/[^\\s)\\]>\'"]+';
+
+const MARKDOWN_LINK_RE = /\[[^\]]*\]\s*\(\s*[^)]+\)/g;
+const HTML_ANCHOR_RE = /<a\b([^>]*)>([\s\S]*?)<\/a>/gi;
+
+const attachmentDownloadMentionRe = () =>
+  new RegExp(
+    `(?:\\[[^\\]]*\\]\\s*\\(\\s*${ATTACHMENT_DOWNLOAD_HREF_PATTERN}\\s*\\)|${ATTACHMENT_DOWNLOAD_HREF_PATTERN})`,
+    'gi',
+  );
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+export const looksLikeAttachmentDownloadUrl = (value?: string): boolean => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  return new RegExp(`^(?:${ATTACHMENT_DOWNLOAD_HREF_PATTERN})\\/?$`, 'i').test(trimmed);
+};
+
+export const looksLikeFakeDownloadHref = (value?: string): boolean => {
+  const trimmed = value?.trim() || '';
+  if (!trimmed) {
+    return true;
+  }
+  if (/地址\s*[:：]/.test(trimmed)) {
+    return true;
+  }
+  if (/\{token\}|加密token/i.test(trimmed)) {
+    return true;
+  }
+  if (/^file:/i.test(trimmed)) {
+    return true;
+  }
+  if (/\/api\/v1\/file-view/i.test(trimmed)) {
+    return true;
+  }
+  return false;
+};
+
+export const isRenderableReportDownload = (download?: ReportFileDownload): boolean => {
+  if (!download) {
+    return false;
+  }
+  if (download.content_base64) {
+    return true;
+  }
+  return Boolean(normalizeSafeDownloadUrl(download.file_url));
+};
+
+export const toAbsoluteDownloadHref = (
+  url?: string,
+  options?: NormalizeDownloadUrlOptions,
+): string => {
+  const safeUrl = normalizeSafeDownloadUrl(url, options);
+  if (!safeUrl) {
+    return '';
+  }
+  if (!safeUrl.startsWith('/') || safeUrl.startsWith('//')) {
+    return safeUrl;
+  }
+  const origin = normalizeOrigin(options?.currentOrigin || getCurrentOrigin());
+  return origin ? `${origin}${safeUrl}` : safeUrl;
+};
+
+const resolveLinkableDownloads = (
+  downloads?: ReportFileDownload[],
+  options?: NormalizeDownloadUrlOptions,
+) => {
+  return (downloads || [])
+    .map(download => ({
+      download,
+      safeUrl: normalizeSafeDownloadUrl(download.file_url, options),
+    }))
+    .filter(item => item.safeUrl);
+};
+
+const buildFriendlyDownloadAnchor = (
+  downloads?: ReportFileDownload[],
+  options?: NormalizeDownloadUrlOptions,
+): string => {
+  const linkableDownloads = resolveLinkableDownloads(downloads, options);
+  if (linkableDownloads.length === 0) {
+    return '附件可在对话中下载';
+  }
+  return linkableDownloads
+    .map(({ download, safeUrl }) => (
+      `<a href="${escapeHtml(safeUrl)}" download="${escapeHtml(download.filename)}">下载 ${escapeHtml(download.filename)}</a>`
+    ))
+    .join(' ');
+};
+
+const shouldRewriteMarkdownLink = (text: string, href: string): boolean => {
+  return /下载/.test(text) || looksLikeFakeDownloadHref(href) || looksLikeAttachmentDownloadUrl(href);
+};
+
+const rewriteBareAttachmentUrls = (markdown: string, replacement: string): string => {
+  return markdown.replace(attachmentDownloadMentionRe(), (match, offset, source) => {
+    const start = typeof offset === 'number' ? offset : 0;
+    const before = String(source).slice(Math.max(0, start - 6), start);
+    if (before.endsWith('href="') || before.endsWith("href='")) {
+      return match;
+    }
+    return replacement;
+  });
+};
+
+export const rewriteAttachmentDownloadMentions = (
+  markdown: string,
+  downloads?: ReportFileDownload[],
+  options?: NormalizeDownloadUrlOptions,
+): string => {
+  if (!markdown) {
+    return markdown;
+  }
+
+  const replacement = buildFriendlyDownloadAnchor(downloads, options);
+  const withMarkdownLinks = markdown.replace(MARKDOWN_LINK_RE, (match) => {
+    const parsed = match.match(/^\[([^\]]*)\]\s*\(\s*([^)]+)\)/);
+    if (!parsed) {
+      return match;
+    }
+    return shouldRewriteMarkdownLink(parsed[1], parsed[2]) ? replacement : match;
+  });
+  const withHtmlAnchors = withMarkdownLinks.replace(HTML_ANCHOR_RE, (full, attrs, text) => {
+    const href = String(attrs).match(/href\s*=\s*["']([^"']*)["']/i)?.[1] || '';
+    const plainText = String(text).replace(/<[^>]+>/g, '');
+    return shouldRewriteMarkdownLink(plainText, href) ? replacement : full;
+  });
+  return rewriteBareAttachmentUrls(withHtmlAnchors, replacement);
+};
+
 export const hydrateGeneratedFileLinks = (
   html: string,
   downloads?: ReportFileDownload[]
@@ -113,19 +252,14 @@ export const hydrateGeneratedFileLinks = (
     return html;
   }
 
-  const linkableDownloads = downloads
-    .map(download => ({
-      download,
-      safeUrl: normalizeSafeDownloadUrl(download.file_url),
-    }))
-    .filter(item => item.safeUrl);
+  const linkableDownloads = resolveLinkableDownloads(downloads);
   if (linkableDownloads.length === 0 || !html.includes('<a')) {
     return html;
   }
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(html, 'text/html');
-  const anchors = Array.from(doc.querySelectorAll('a:not([href])'));
+  const anchors = Array.from(doc.querySelectorAll('a'));
   if (anchors.length === 0) {
     return html;
   }
@@ -133,6 +267,22 @@ export const hydrateGeneratedFileLinks = (
   const normalizeText = (value: string) => value.replace(/^下载/, '').replace(/\.[^.]+$/, '').trim().toLowerCase();
 
   anchors.forEach(anchor => {
+    const href = anchor.getAttribute('href') || '';
+    const safeHref = normalizeSafeDownloadUrl(href);
+    const textLooksLikeDownload = /下载/.test(anchor.textContent || '');
+    const needsRewrite = !href || looksLikeFakeDownloadHref(href) || !safeHref;
+    if (!needsRewrite && !looksLikeAttachmentDownloadUrl(anchor.textContent || '')) {
+      return;
+    }
+    if (
+      needsRewrite
+      && !textLooksLikeDownload
+      && !looksLikeFakeDownloadHref(href)
+      && !looksLikeAttachmentDownloadUrl(href)
+    ) {
+      return;
+    }
+
     const anchorText = normalizeText(anchor.textContent || '');
     const matchedDownload = linkableDownloads.length === 1
       ? linkableDownloads[0]
@@ -146,8 +296,16 @@ export const hydrateGeneratedFileLinks = (
     }
 
     anchor.setAttribute('href', matchedDownload.safeUrl);
-    anchor.setAttribute('target', '_blank');
+    anchor.setAttribute('download', matchedDownload.download.filename);
     anchor.setAttribute('rel', 'noopener noreferrer');
+    if (
+      !href
+      || looksLikeFakeDownloadHref(href)
+      || looksLikeAttachmentDownloadUrl(href)
+      || looksLikeAttachmentDownloadUrl(anchor.textContent || '')
+    ) {
+      anchor.textContent = `下载 ${matchedDownload.download.filename}`;
+    }
   });
 
   return doc.body.innerHTML;

--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -24,7 +24,7 @@ import ConfigAnalysisReportCard from './ConfigAnalysisReportCard';
 import ReportDownloadCard from './ReportDownloadCard';
 import RepairCommandsCard from './RepairCommandsCard';
 import SkillView from './SkillView';
-import { hydrateGeneratedFileLinks } from './downloadUrl';
+import { hydrateGeneratedFileLinks, isRenderableReportDownload, rewriteAttachmentDownloadMentions } from './downloadUrl';
 import {CustomChatMessage} from '@/app/opspilot/types/global';
 import {useSession} from 'next-auth/react';
 import {useAuth} from '@/context/auth';
@@ -613,11 +613,12 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
   const renderContent = (msg: CustomChatMessage) => {
     const { content, images, browserStepsHistory, thinking, isThinking, approvalRequests, userChoiceRequests, configDiffReports, configAnalysisReports, reportFileDownloads, repairCommands, agentStepProgress, skillViews, plannedExecutionSteps, toolCalls, isStreamingTools } = msg;
     const visibleReportFileDownloads = Array.isArray(reportFileDownloads)
-      ? reportFileDownloads.filter(download => Boolean(download.content_base64))
+      ? reportFileDownloads.filter(isRenderableReportDownload)
       : [];
 
     let replacedContent = parseReferenceLinks(content || '');
     replacedContent = parseSuggestionLinks(replacedContent);
+    replacedContent = rewriteAttachmentDownloadMentions(replacedContent, reportFileDownloads);
 
     // Split content at placeholder markers and render components inline
     const renderContentWithInlineComponents = () => {

--- a/web/src/stories/report-download-card.stories.tsx
+++ b/web/src/stories/report-download-card.stories.tsx
@@ -40,3 +40,15 @@ export const PdfReport: Story = {
     },
   },
 };
+
+export const SignedUrlAttachment: Story = {
+  args: {
+    download: {
+      download_id: 'download-3',
+      filename: 'K8s_集群运维月报_2026-08.md',
+      mime_type: 'text/markdown',
+      file_url: '/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/signed-real-token/',
+      received_at: Date.now(),
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- 生成附件时 DeepAgent 会叠两条 system 消息，Qwen/兼容网关返回 400 `System message must be at the beginning`；请求前合并为单条 system，并去掉图前置 SystemMessage 避免重复。
- 对话里的下载链接被模型写成 `地址: http://...{token}` / `file://` 等相对路径，浏览器会拼到当前路由后面；改为使用站点根路径签名地址 `/api/proxy/opspilot/bot_mgmt/workflow_attachment/download/<token>/`，并以文件名展示可点击下载。
- 有 `file_url` 时也渲染下载卡片，不再只认 `content_base64`。

## Test plan
- [x] `pytest`：`test_without_system_messages_drops_graph_system_for_deepagent`、`test_merge_openai_payload_system_messages_moves_mid_conversation_system_to_front`、`test_chatopenai_request_payload_merges_mid_conversation_system`
- [x] `pnpm exec tsx scripts/opspilot-download-url-security-test.ts`
- [x] 对话生成附件后可点击下载，地址为 `/api/proxy/opspilot/.../download/<真实签名>/`，不再出现 `{token}` / `地址:` / 当前路由拼接

Made with [Cursor](https://cursor.com)