### PR TITLE
feat(monitor): 复合对象指标切换改为图标胶囊并隐藏空分组

### DIFF
--- a/server/apps/monitor/constants/monitor_object.py
+++ b/server/apps/monitor/constants/monitor_object.py
@@ -32,6 +32,18 @@ class MonitorObjConstants:
         {"name_list": ["Docker", "Docker Container"], "type": "Container Management"},
         {"name_list": ["Cluster", "Pod", "Node"], "type": "K8S"},
         {"name_list": ["vCenter", "ESXI", "VM", "DataStorage"], "type": "VMWare"},
+        {
+            "name_list": [
+                "SangforSCP",
+                "SangforSCPHost",
+                "SangforSCPVM",
+                "CNware",
+                "CNwareHost",
+                "CNwareVM",
+            ],
+            "type": "Cloud",
+        },
         {"name_list": ["TCP", "CVM"], "type": "Tencent Cloud"},
+        {"name_list": ["Aliyun"], "type": "Aliyun Cloud"},
         {"name_list": ["JVM", "SNMP Trap"], "type": "Other"},
     ]

--- a/server/apps/monitor/language/en.yaml
+++ b/server/apps/monitor/language/en.yaml
@@ -8,7 +8,9 @@ monitor_object_type:
   Container Management: Container Management
   K8S: K8S
   VMWare: VMware
+  Cloud: Cloud
   Tencent Cloud: Tencent Cloud
+  Aliyun Cloud: Aliyun Cloud
   Other: Other
 
 # Fallback display name when plugin i18n is missing: show TCP, not TCPPort

--- a/server/apps/monitor/language/zh-Hans.yaml
+++ b/server/apps/monitor/language/zh-Hans.yaml
@@ -8,7 +8,9 @@ monitor_object_type:
   Container Management: 容器管理
   K8S: K8S
   VMWare: VMware
+  Cloud: 云
   Tencent Cloud: 腾讯云
+  Aliyun Cloud: 阿里云
   Other: 其他
 
 # 对象展示名兜底：插件语言未合并时仍显示「TCP」而非技术名 TCPPort

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/index.module.scss
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/index.module.scss
@@ -7,3 +7,102 @@
         overflow-y: auto;
     }
 }
+
+/* 复合对象切换：图标胶囊 + 描边选中态 */
+.objectSegmented {
+    margin-bottom: 20px;
+    width: 100%;
+    height: auto !important;
+    padding: 4px !important;
+    border-radius: 8px !important;
+    border: 1px solid var(--color-border);
+    background: var(--color-fill-1) !important;
+
+    :global(.ant-segmented-group) {
+        flex-wrap: wrap;
+        gap: 4px;
+        row-gap: 4px;
+    }
+
+    :global(.ant-segmented-item) {
+        min-height: 32px;
+        line-height: 32px;
+        border-radius: 6px !important;
+        color: var(--color-text-3);
+        font-size: 13px;
+        font-weight: 400;
+        margin: 0;
+        cursor: pointer;
+    }
+
+    :global(.ant-segmented-item:hover:not(.ant-segmented-item-selected)) {
+        color: var(--color-text-2);
+        background: var(--color-fill-2);
+    }
+
+    :global(.ant-segmented-item-selected) {
+        color: var(--color-primary) !important;
+        font-weight: 600;
+        background: var(--color-bg) !important;
+        box-shadow: inset 0 0 0 1px var(--color-primary);
+    }
+
+    :global(.ant-segmented-item-label) {
+        display: flex;
+        align-items: center;
+        padding: 0 10px;
+        min-height: 32px;
+        line-height: 32px;
+    }
+
+    :global(.ant-segmented-thumb) {
+        border-radius: 6px !important;
+        background: var(--color-bg) !important;
+        box-shadow: inset 0 0 0 1px var(--color-primary);
+    }
+}
+
+.objectChip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 220px;
+    min-height: 32px;
+}
+
+.objectChipName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.objectChipMark {
+    flex-shrink: 0;
+    font-size: 10px;
+    line-height: 16px;
+    padding: 0 4px;
+    border-radius: 3px;
+    color: var(--color-text-3);
+    background: var(--color-fill-2);
+}
+
+:global(.ant-segmented-item-selected) .objectChipMark {
+    color: var(--color-primary);
+    background: var(--color-fill-1);
+}
+
+:global(html.dark) .objectSegmented {
+    background: var(--color-fill-1) !important;
+    border-color: var(--color-border);
+
+    :global(.ant-segmented-item) {
+        color: var(--color-text-3);
+    }
+
+    :global(.ant-segmented-item-selected),
+    :global(.ant-segmented-thumb) {
+        color: var(--color-primary) !important;
+        background: var(--color-bg) !important;
+        box-shadow: inset 0 0 0 1px var(--color-primary);
+    }
+}

--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -21,7 +21,6 @@ import CustomTable from '@/components/custom-table';
 import {
   ColumnItem,
   ModalRef,
-  IntegrationItem,
   ObjectItem,
   MetricItem
 } from '@/app/monitor/types';
@@ -29,6 +28,7 @@ import { MetricListItem, DimensionItem } from '@/app/monitor/types/integration';
 import Collapse from '@/components/collapse';
 import GroupModal from './groupModal';
 import MetricModal from './metricModal';
+import ObjectIcon from '@/app/monitor/components/objectIcon';
 import { useSearchParams } from 'next/navigation';
 import Permission from '@/components/permission';
 import {
@@ -37,6 +37,32 @@ import {
 } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
 import { buildIfmibMetricView, getDefaultMetricGroupOpenState } from './ifmibMetricView';
+
+type ObjectTabOption = {
+  label: React.ReactNode;
+  value: string;
+  title?: string;
+};
+
+const ObjectTabLabel = ({
+  icon,
+  name,
+  isBase,
+  baseLabel
+}: {
+  icon?: string;
+  name: string;
+  isBase: boolean;
+  baseLabel: string;
+}) => (
+  <span className={metricStyle.objectChip}>
+    <ObjectIcon icon={icon} size={16} />
+    <span className={metricStyle.objectChipName}>{name}</span>
+    {isBase ? (
+      <span className={metricStyle.objectChipMark}>{baseLabel}</span>
+    ) : null}
+  </span>
+);
 
 const Configure = () => {
   const { isLoading } = useApiClient();
@@ -69,7 +95,7 @@ const Configure = () => {
   // 保留接口返回的真实分组供指标编辑使用。
   const [apiGroupList, setApiGroupList] = useState<MetricListItem[]>([]);
   const [activeTab, setActiveTab] = useState<string>('');
-  const [items, setItems] = useState<IntegrationItem[]>([]);
+  const [items, setItems] = useState<ObjectTabOption[]>([]);
   const [draggingItemId, setDraggingItemId] = useState<string | null>(null);
   const [dragOverTargetId, setDragOverTargetId] = useState<string | null>(null);
   const [confirmLoading, setConfirmLoading] = useState(false);
@@ -201,11 +227,22 @@ const Configure = () => {
         const _items = data
           .filter((item: ObjectItem) => item.type === objectType)
           .sort((a: ObjectItem, b: ObjectItem) => a.id - b.id)
-          .map((item: ObjectItem) => ({
-            label: item.display_name,
-            value: item.id
-          }));
-        _objId = _items[0]?.value;
+          .map((item: ObjectItem) => {
+            const name = item.display_name || item.name;
+            return {
+              label: (
+                <ObjectTabLabel
+                  icon={item.icon}
+                  name={name}
+                  isBase={item.level === 'base'}
+                  baseLabel={t('monitor.integrations.baseObject')}
+                />
+              ),
+              value: String(item.id),
+              title: name
+            };
+          });
+        _objId = _items[0]?.value || '';
         setItems(_items);
       } else {
         setShowTabs(false);
@@ -378,11 +415,12 @@ const Configure = () => {
     getInitData(activeTab, true);
   };
 
-  const onTabChange = (val: string) => {
+  const onTabChange = (val: string | number) => {
+    const next = String(val);
     setMetricData([]);
-    setActiveTab(val);
+    setActiveTab(next);
     setMetricPage(1);
-    getInitData(val, false, 1);
+    getInitData(next, false, 1);
   };
 
   const onMetricPageChange = (page: number) => {
@@ -507,7 +545,7 @@ const Configure = () => {
     <div className={metricStyle.metric}>
       {showTabs && (
         <Segmented
-          className="mb-[20px] custom-tabs"
+          className={metricStyle.objectSegmented}
           value={activeTab}
           options={items}
           onChange={onTabChange}

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -542,6 +542,7 @@
       "originalValue": "Original Value",
       "metricTitle": "The following monitoring indicators are supported by this collector",
       "searchMetricPlaceholder": "Please enter the metric name",
+      "baseObject": "Base",
       "step1": "Step1",
       "portDes": "Configured SNMP port number, typically using port 161 for communication with the device.",
       "access": "Access",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -542,6 +542,7 @@
       "originalValue": "原始值",
       "metricTitle": "此收集器支持以下监控指标",
       "searchMetricPlaceholder": "请输入指标名称",
+      "baseObject": "基础",
       "step1": "步骤1",
       "portDes": "配置SNMP端口号，通常使用161端口与设备进行通信。",
       "access": "接入",


### PR DESCRIPTION
## Summary
- 集成指标页的复合对象切换改为图标胶囊，基础对象带「基础 / Base」标记。
- 首装默认顺序补齐 Cloud（深信服 / CNware）和 Aliyun Cloud；只作用于 `order=999`，不锁定侧栏拖拽。

## Test plan
- [ ] 打开 vCenter / 阿里云等复合对象的集成 → 指标页，对象切换为图标胶囊，基础对象有标记
- [ ] 新环境侧栏能看到「云」「阿里云」类型文案；已拖拽过的顺序不被覆盖

已检查提交范围：2 个 commit；未包含 K3S、空分组过滤、已合并的腾讯云展示对齐（#4754）；未加入未跟踪图标。