### PR TITLE
fix(监控): 仪表盘跳过补点假 0 并避免单位双重换算

### DIFF
--- a/web/src/app/monitor/(pages)/view/detail/overview.tsx
+++ b/web/src/app/monitor/(pages)/view/detail/overview.tsx
@@ -143,7 +143,9 @@ const Overview: React.FC<ViewDetailProps> = ({
           { keys: item.instance_id_keys || [], values: idValues }
         ])
       ),
-      source_unit: item.unit || ''
+      source_unit: item.unit || '',
+      // 概览卡按指标声明单位格式化，禁止服务端自动换算（否则 ms/bytes/counts 被缩放过后再按原单位展示）。
+      auto_convert_unit: false
     };
     // Overview 指标卡与详情指标 Tab 共用 card budget，避免大基数全量打满。
     params.query_budget = 'card';

--- a/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/docker/dashboard.tsx
@@ -81,7 +81,7 @@ export default function DockerDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>性能趋势</div>
           <FlexiblePanelSection styles={styles}>

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/dashboard.tsx
@@ -80,7 +80,9 @@ export default function ElasticsearchDashboardPage() {
     }
     let active = true;
     runWithConcurrency(ES_TOP_NODE_QUERIES, TOP_NODE_CONCURRENCY, async (q) =>
-      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, undefined, currentInstanceInterval))
+      // autoConvert=false:禁用服务端单位自动换算,否则会与前端 formatMetricValue 双重换算
+      //(如 bytes 被后端先缩成 GiB,前端再按 bytes 缩放)。见 postgresql / host 同因。
+      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
         .then((res: any) => [q.key, topNodeBars(res, q.unit, q.color)] as const)
         .catch(() => [q.key, [] as BarItem[]] as const)
     ).then((entries) => {

--- a/web/src/app/monitor/dashboards/objects/elasticsearch/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/elasticsearch/parse.ts
@@ -1,43 +1,9 @@
-import { formatMetricValue } from '../../shared/utils';
+import { topLabelBars } from '../../shared/utils';
 import type { BarItem } from '../../shared/widgets';
 
-interface RawSeries {
-  metric?: Record<string, string>;
-  values?: Array<[number, string | number]>;
-}
-
 /**
- * 把「按 node_name 聚合 + topk/bottomk」查询的原始结果(result.data.result 多序列)
- * 解析成按值降序的 BarList items:每序列取最新值、取 node_name label、按值排序。
- * topk/bottomk 已在查询层限制条数;此处仅排序 + 格式化,数据缺失时返回空数组(空态)。
+ * 按 node_name 的 topk/bottomk 结果 → BarList。
+ * 走共享 topLabelBars：会丢掉 fill_missing_points 补的 null（Number(null)===0）。
  */
-export const topNodeBars = (raw: any, unit: string, color: string): BarItem[] => {
-  const series: RawSeries[] = raw?.data?.result || [];
-  const rows = series
-    .map((s) => {
-      // 仅用真实的 node_name 标签;缺失或空串说明该数据没有按节点维度,
-      // 不再伪造「未知节点」(否则会把实例级聚合值误展示成某个节点的排行)。
-      const label = (s.metric?.node_name || '').trim();
-      const nums = (s.values || [])
-        .map(([, v]) => Number(v))
-        .filter((n) => Number.isFinite(n));
-      const value = nums.length ? nums[nums.length - 1] : 0;
-      return { label, value };
-    })
-    .filter((r) => r.label && Number.isFinite(r.value))
-    .sort((a, b) => b.value - a.value);
-
-  const peak = rows.length ? Math.max(...rows.map((r) => r.value)) : 0;
-  const max = peak > 0 ? peak : 1;
-
-  return rows.map((r) => {
-    const fmt = formatMetricValue(r.value, unit as Parameters<typeof formatMetricValue>[1]);
-    return {
-      label: r.label,
-      value: r.value,
-      display: `${fmt.value}${fmt.unit || ''}`,
-      color,
-      max
-    };
-  });
-};
+export const topNodeBars = (raw: any, unit: string, color: string): BarItem[] =>
+  topLabelBars(raw, unit, color, ['node_name']);

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/dashboard.tsx
@@ -102,14 +102,6 @@ const sumSeries = (arrs: ChartData[][]): ChartData[] => {
   return Array.from(byTime.values()).sort((a, b) => Number(a.time) - Number(b.time));
 };
 
-// 字节类指标(内存)需禁用服务端单位自动换算:服务端会把 bytes 缩放成 GiB,
-// 前端 bytesDisplay 会再格式化一次,不禁用则双重换算导致数值小约 1e9 倍。
-const RAW_VALUE_METRICS = new Set([
-  'prometheus_remote_write_container_memory_working_set_bytes',
-  'prometheus_remote_write_kube_node_status_allocatable',
-  'prometheus_remote_write_kube_pod_container_resource_requests'
-]);
-
 export default function K3sClusterDashboardPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -209,7 +201,8 @@ export default function K3sClusterDashboardPage() {
     runWithConcurrency(keys, QUERY_CONCURRENCY, async (key) => {
       const q = QUERIES[key];
       try {
-        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, RAW_VALUE_METRICS, undefined, currentInstanceInterval));
+        // 前端按声明单位(bytes/counts/percent)格式化，必须关掉服务端自动换算。
+        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, undefined, false, currentInstanceInterval));
         return [key, result] as const;
       } catch {
         return [key, null] as const;

--- a/web/src/app/monitor/dashboards/objects/k3s-cluster/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-cluster/parse.ts
@@ -1,20 +1,14 @@
 import { HEALTH_GREEN, HEALTH_AMBER, HEALTH_RED, SATURATION_WARN, SATURATION_CRIT } from './queries';
-import { formatMetricValue } from '../../shared/utils';
+import { formatMetricValue, latestFiniteValue } from '../../shared/utils';
 import { TOP_N } from './queries';
 
-type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string]> }> } } | null;
-
-const lastValue = (values?: Array<[number, string]>): number => {
-  if (!values || values.length === 0) return 0;
-  const v = Number(values[values.length - 1][1]);
-  return Number.isFinite(v) ? v : 0;
-};
+type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string | number | null]> }> } } | null;
 
 /** 取单序列结果的最新标量(无数据 → 0)。 */
 export const latestScalar = (result: QueryResult): number => {
   const series = result?.data?.result;
   if (!series || series.length === 0) return 0;
-  return lastValue(series[0].values);
+  return latestFiniteValue(series[0].values);
 };
 
 /**
@@ -31,7 +25,7 @@ export const seriesLatestByLabel = (
   return series
     .map((s) => {
       const picked = candidates.map((l) => s.metric?.[l]).find((v) => v !== undefined && v !== '');
-      return { label: String(picked ?? ''), value: lastValue(s.values) };
+      return { label: String(picked ?? ''), value: latestFiniteValue(s.values) };
     })
     .filter((item) => item.label !== '');
 };

--- a/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k3s-node/dashboard.tsx
@@ -46,7 +46,7 @@ export default function K3sNodeDashboardPage() {
     if (idValues.length === 0) return;
     let active = true;
     const tv: TimeValuesProps = dashboard.timeValues;
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, undefined, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
       .then((r) => { if (active) setTopPodCpuRaw(r); })
       .catch(() => { if (active) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k3s-cluster 同因)。

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/dashboard.tsx
@@ -102,14 +102,6 @@ const sumSeries = (arrs: ChartData[][]): ChartData[] => {
   return Array.from(byTime.values()).sort((a, b) => Number(a.time) - Number(b.time));
 };
 
-// 字节类指标(内存)需禁用服务端单位自动换算:服务端会把 bytes 缩放成 GiB,
-// 前端 bytesDisplay 会再格式化一次,不禁用则双重换算导致数值小约 1e9 倍。
-const RAW_VALUE_METRICS = new Set([
-  'prometheus_remote_write_container_memory_working_set_bytes',
-  'prometheus_remote_write_kube_node_status_allocatable',
-  'prometheus_remote_write_kube_pod_container_resource_requests'
-]);
-
 export default function K8sClusterDashboardPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -209,7 +201,8 @@ export default function K8sClusterDashboardPage() {
     runWithConcurrency(keys, QUERY_CONCURRENCY, async (key) => {
       const q = QUERIES[key];
       try {
-        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, RAW_VALUE_METRICS, undefined, currentInstanceInterval));
+        // 前端按声明单位(bytes/counts/percent)格式化，必须关掉服务端自动换算。
+        const result = await getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, tv, undefined, false, currentInstanceInterval));
         return [key, result] as const;
       } catch {
         return [key, null] as const;

--- a/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-cluster/parse.ts
@@ -1,20 +1,14 @@
 import { HEALTH_GREEN, HEALTH_AMBER, HEALTH_RED, SATURATION_WARN, SATURATION_CRIT } from './queries';
-import { formatMetricValue } from '../../shared/utils';
+import { formatMetricValue, latestFiniteValue } from '../../shared/utils';
 import { TOP_N } from './queries';
 
-type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string]> }> } } | null;
-
-const lastValue = (values?: Array<[number, string]>): number => {
-  if (!values || values.length === 0) return 0;
-  const v = Number(values[values.length - 1][1]);
-  return Number.isFinite(v) ? v : 0;
-};
+type QueryResult = { data?: { result?: Array<{ metric?: Record<string, string>; values?: Array<[number, string | number | null]> }> } } | null;
 
 /** 取单序列结果的最新标量(无数据 → 0)。 */
 export const latestScalar = (result: QueryResult): number => {
   const series = result?.data?.result;
   if (!series || series.length === 0) return 0;
-  return lastValue(series[0].values);
+  return latestFiniteValue(series[0].values);
 };
 
 /**
@@ -31,7 +25,7 @@ export const seriesLatestByLabel = (
   return series
     .map((s) => {
       const picked = candidates.map((l) => s.metric?.[l]).find((v) => v !== undefined && v !== '');
-      return { label: String(picked ?? ''), value: lastValue(s.values) };
+      return { label: String(picked ?? ''), value: latestFiniteValue(s.values) };
     })
     .filter((item) => item.label !== '');
 };

--- a/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/k8s-node/dashboard.tsx
@@ -46,7 +46,7 @@ export default function K8sNodeDashboardPage() {
     if (idValues.length === 0) return;
     let active = true;
     const tv: TimeValuesProps = dashboard.timeValues;
-    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, undefined, dashboard.currentInstanceInterval))
+    getInstanceQuery(buildSearchParams(NODE_TOP_POD_CPU, 'none', idValues, instanceIdKeys, tv, undefined, false, dashboard.currentInstanceInterval))
       .then((r) => { if (active) setTopPodCpuRaw(r); })
       .catch(() => { if (active) setTopPodCpuRaw(null); });
     // 内存为字节类指标:禁用服务端单位自动换算,否则与前端 bytesDisplay 双重换算(见 k8s-cluster 同因)。

--- a/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
+++ b/web/src/app/monitor/dashboards/objects/kafka/lag-risk-table.tsx
@@ -66,7 +66,7 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
     const load = async () => {
       // instant Top 10 在时间窗终点求值（buildSearchParams.time=end），与趋势 range 对齐；负 Lag 不参与排行。
       const lag = await getInstanceInstantQuery(buildSearchParams(
-        KAFKA_LAG_TOP_QUERY, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues,
+        KAFKA_LAG_TOP_QUERY, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false,
       )).catch(() => null);
       if (!active) return;
       const topRows = parseKafkaLagRiskRows({ lag } as KafkaLagRiskResult);
@@ -83,9 +83,9 @@ export function KafkaLagRiskTable({ dashboard, styles }: KafkaLagRiskTableProps)
       const oldestQuery = buildKafkaTopNExactQuery('kafka_topic_partition_oldest_offset_gauge', dimensions, false);
       const historyQuery = buildKafkaTopNExactQuery('kafka_consumergroup_lag_gauge', trendDimensions, true);
       setHistoryLoading(true);
-      const currentOffsetPromise = getInstanceInstantQuery(buildSearchParams(currentQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues)).catch(() => null);
-      const oldestOffsetPromise = getInstanceInstantQuery(buildSearchParams(oldestQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues)).catch(() => null);
-      const historyPromise = getInstanceQuery(buildSearchParams(historyQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, undefined, dashboard.currentInstanceInterval)).catch(() => null);
+      const currentOffsetPromise = getInstanceInstantQuery(buildSearchParams(currentQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false)).catch(() => null);
+      const oldestOffsetPromise = getInstanceInstantQuery(buildSearchParams(oldestQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false)).catch(() => null);
+      const historyPromise = getInstanceQuery(buildSearchParams(historyQuery, 'counts', dashboard.idValues, instanceIdKeys, dashboard.timeValues, undefined, false, dashboard.currentInstanceInterval)).catch(() => null);
       const [currentOffset, oldestOffset] = await Promise.all([
         currentOffsetPromise,
         oldestOffsetPromise,

--- a/web/src/app/monitor/dashboards/objects/kafka/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/kafka/parse.ts
@@ -18,13 +18,14 @@ export interface KafkaLagRiskRow {
 }
 
 const latestValue = (series: RawSeries): number | null => {
-  if (series.value) {
-    const value = Number(series.value[1]);
-    return Number.isFinite(value) ? value : null;
-  }
-  const values = series.values || [];
-  for (let index = values.length - 1; index >= 0; index -= 1) {
-    const value = Number(values[index][1]);
+  const points: Array<[number, string | number | null | undefined]> = series.value
+    ? [series.value]
+    : (series.values || []);
+  for (let index = points.length - 1; index >= 0; index -= 1) {
+    const raw = points[index][1];
+    // fill_missing_points 补的 null：Number(null)===0，必须跳过占位点。
+    if (raw === null || raw === undefined || raw === '') continue;
+    const value = Number(raw);
     if (Number.isFinite(value)) return value;
   }
   return null;

--- a/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mongodb/dashboard.tsx
@@ -297,7 +297,7 @@ export default function MongoDashboardPage() {
             compareMetrics,
             METRIC_QUERY_CONCURRENCY,
             async (metric) =>
-              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, undefined, currentInstanceInterval))
+              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval))
                 .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
                 .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
           )

--- a/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mssql/dashboard.tsx
@@ -23,8 +23,8 @@ import { MSSQL_TOP_DB_QUERIES } from './queries';
 import { topDbBars } from './parse';
 import styles from './index.module.scss';
 
-// 数据库类对象首行统一带「运行时长」(放首位);KpiSection 上限 6 列(含采集状态卡)即最多 5 张 KPI,
-// 故用运行时长替换信息密度较低的「信号等待占比」(其语义仍由「等待时间趋势」图保留)。
+// 数据库类对象首行统一带「运行时长」(放首位);采集状态 + 5 张 KPI = 6 列一行。
+// 用运行时长替换信息密度较低的「信号等待占比」(其语义仍由「等待时间趋势」图保留)。
 const SUMMARY_TITLES = ['运行时长', '读延迟', '批量请求速率', '缓存命中率', '卷可用空间'];
 const PRIMARY_CHART_TITLES = ['等待时间趋势', '请求耗时趋势', '读写延迟'];
 // 一线排障：阻塞/内存授予与编译/死锁紧挨主趋势，单独成节避免挤进 CPU/吞吐。
@@ -64,7 +64,9 @@ export default function MssqlDashboardPage() {
     }
     let active = true;
     runWithConcurrency(MSSQL_TOP_DB_QUERIES, TOP_DB_CONCURRENCY, async (q) =>
-      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, undefined, currentInstanceInterval))
+      // autoConvert=false:禁用服务端单位自动换算,否则会与前端 formatMetricValue 双重换算
+      //(如 ms 被后端先换成 hour,前端再按 ms 格式化,量级错乱)。见 postgresql 同因。
+      getInstanceQuery(buildSearchParams(q.query, q.unit, idValues, instanceIdKeys, timeValues, undefined, false, currentInstanceInterval))
         .then((res: any) => [q.key, topDbBars(res, q.unit, q.color)] as const)
         .catch(() => [q.key, [] as BarItem[]] as const)
     ).then((entries) => {
@@ -86,7 +88,7 @@ export default function MssqlDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>性能与等待趋势</div>
           <TrendSection charts={primaryCharts} onXRangeChange={dashboard.onXRangeChange} loading={dashboard.loading} styles={styles} />

--- a/web/src/app/monitor/dashboards/objects/mssql/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/mssql/parse.ts
@@ -1,44 +1,10 @@
-import { formatMetricValue } from '../../shared/utils';
+import { topLabelBars } from '../../shared/utils';
 import type { BarItem } from '../../shared/widgets';
 
-interface RawSeries {
-  metric?: Record<string, string>;
-  values?: Array<[number, string | number]>;
-}
-
 /**
- * 把「按 database 聚合 + topk」查询的原始结果(result.data.result 多序列)
- * 解析成按值降序的 BarList items:每序列取最新值、取 database label、按值排序。
- * topk 已在查询层限制条数;此处仅排序 + 格式化,数据缺失时返回空数组(空态)。
+ * 按 database_name 的 topk 结果 → BarList。
+ * 走共享 topLabelBars：会丢掉 fill_missing_points 补的 null（Number(null)===0），
+ * 避免「取最后一个点」拿到占位 0 导致整列显示 0ms。
  */
-export const topDbBars = (raw: any, unit: string, color: string): BarItem[] => {
-  const series: RawSeries[] = raw?.data?.result || [];
-  const rows = series
-    .map((s) => {
-      // 仅用真实的 database_name 标签(Telegraf sqlserver 输出的库维度即此名);
-      // 缺失或空串说明该数据没有按库维度,不再伪造「未知库」
-      //(否则会把实例级聚合值误展示成某个库的排行)。
-      const label = (s.metric?.database_name || '').trim();
-      const nums = (s.values || [])
-        .map(([, v]) => Number(v))
-        .filter((n) => Number.isFinite(n));
-      const value = nums.length ? nums[nums.length - 1] : 0;
-      return { label, value };
-    })
-    .filter((r) => r.label && Number.isFinite(r.value))
-    .sort((a, b) => b.value - a.value);
-
-  const peak = rows.length ? Math.max(...rows.map((r) => r.value)) : 0;
-  const max = peak > 0 ? peak : 1;
-
-  return rows.map((r) => {
-    const fmt = formatMetricValue(r.value, unit as Parameters<typeof formatMetricValue>[1]);
-    return {
-      label: r.label,
-      value: r.value,
-      display: `${fmt.value}${fmt.unit || ''}`,
-      color,
-      max
-    };
-  });
-};
+export const topDbBars = (raw: any, unit: string, color: string): BarItem[] =>
+  topLabelBars(raw, unit, color, ['database_name']);

--- a/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/mysql/dashboard.tsx
@@ -69,18 +69,6 @@ interface MysqlInstanceOption {
 }
 
 const MYSQL_REFRESH_FREQUENCY_LIST = DEFAULT_REFRESH_FREQUENCY_LIST;
-const RAW_VALUE_METRICS = new Set([
-  'mysql_uptime',
-  'mysql_innodb_buffer_pool_pages_total',
-  'mysql_innodb_buffer_pool_pages_free',
-  'mysql_innodb_buffer_pool_pages_dirty',
-  // 字节速率(byteps)与字节配置项(bytes):禁用服务端自动换算,避免与前端双重换算
-  'mysql_bytes_received',
-  'mysql_bytes_sent',
-  'mysql_variables_innodb_buffer_pool_size',
-  'mysql_variables_tmp_table_size',
-  'mysql_variables_max_heap_table_size'
-]);
 const METRIC_QUERY_CONCURRENCY = 4;
 const MYSQL_METRIC_GROUPS = [
   {
@@ -395,7 +383,7 @@ export default function MysqlDashboardPage() {
       metrics,
       METRIC_QUERY_CONCURRENCY,
       async (metric) =>
-        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, RAW_VALUE_METRICS, undefined, currentInstanceInterval))
+        getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, targetTimeValues, undefined, false, currentInstanceInterval))
           .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
           .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
     );
@@ -419,7 +407,7 @@ export default function MysqlDashboardPage() {
         );
         const summaryResultsPromise = loadMetricGroup(MYSQL_METRIC_GROUPS[0].names, frozenTimeValues);
 
-        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, RAW_VALUE_METRICS, undefined, currentInstanceInterval))
+        const collectionStatusPromise: Promise<MetricSeries> = getInstanceQuery(buildSearchParams(MYSQL_COLLECTION_STATUS_QUERY, 'counts', idValues, instanceIdKeys, frozenTimeValues, undefined, false, currentInstanceInterval))
           .then((result) =>
             toMetricSeries(
               {
@@ -456,7 +444,7 @@ export default function MysqlDashboardPage() {
             compareMetrics,
             METRIC_QUERY_CONCURRENCY,
             async (metric) =>
-              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, RAW_VALUE_METRICS, undefined, currentInstanceInterval))
+              getInstanceQuery(buildSearchParams(metric.query, metric.unit, idValues, instanceIdKeys, previousTimeValues, undefined, false, currentInstanceInterval))
                 .then((result) => [metric.name, toMetricSeries(metric, result, instanceId, resolvedInstanceName, idValues, instanceIdKeys)] as const)
                 .catch(() => [metric.name, { ...metric, viewData: [], loadState: 'error' as const }] as const)
           )

--- a/web/src/app/monitor/dashboards/objects/postgresql/parse.ts
+++ b/web/src/app/monitor/dashboards/objects/postgresql/parse.ts
@@ -1,46 +1,9 @@
-import { formatMetricValue } from '../../shared/utils';
+import { topLabelBars } from '../../shared/utils';
 import type { BarItem } from '../../shared/widgets';
 
-interface RawSeries {
-  metric?: Record<string, string>;
-  values?: Array<[number, string | number]>;
-}
-
 /**
- * 把「按 db 聚合 + topk」查询的原始结果(result.data.result 多序列)
- * 解析成按值降序的 BarList items:每序列取最新值、取 db label、按值排序。
- * topk 已在查询层限制条数;此处仅排序 + 格式化,数据缺失时返回空数组(空态)。
+ * 按 db/datname 的 topk 结果 → BarList。
+ * 走共享 topLabelBars：会丢掉 fill_missing_points 补的 null（Number(null)===0）。
  */
-export const topDbBars = (raw: any, unit: string, color: string): BarItem[] => {
-  const series: RawSeries[] = raw?.data?.result || [];
-  const rows = series
-    .map((s) => {
-      // 仅用真实的 db/datname 标签;缺失或空串说明该数据没有按库维度,
-      // 不再伪造「未知库」(否则会把实例级聚合值误展示成某个库的排行)。
-      const label = (s.metric?.db || s.metric?.datname || '').trim();
-      // 后端 fill_missing_points 会把 [最后采样点, end] 之间补成 null;因 Number(null)===0,
-      // 必须先剔除这些占位点,否则「取最后一个点」会拿到补出来的 0,导致整列显示 0。
-      const nums = (s.values || [])
-        .filter(([, v]) => v !== null && v !== undefined && v !== '')
-        .map(([, v]) => Number(v))
-        .filter((n) => Number.isFinite(n));
-      const value = nums.length ? nums[nums.length - 1] : 0;
-      return { label, value };
-    })
-    .filter((r) => r.label && Number.isFinite(r.value))
-    .sort((a, b) => b.value - a.value);
-
-  const peak = rows.length ? Math.max(...rows.map((r) => r.value)) : 0;
-  const max = peak > 0 ? peak : 1;
-
-  return rows.map((r) => {
-    const fmt = formatMetricValue(r.value, unit as Parameters<typeof formatMetricValue>[1]);
-    return {
-      label: r.label,
-      value: r.value,
-      display: `${fmt.value}${fmt.unit || ''}`,
-      color,
-      max
-    };
-  });
-};
+export const topDbBars = (raw: any, unit: string, color: string): BarItem[] =>
+  topLabelBars(raw, unit, color, ['db', 'datname']);

--- a/web/src/app/monitor/dashboards/objects/tomcat/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/tomcat/dashboard.tsx
@@ -39,7 +39,7 @@ export default function TomcatDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           <div className={styles.sectionLabel}>性能趋势</div>
           <FlexiblePanelSection styles={styles}>

--- a/web/src/app/monitor/dashboards/objects/zookeeper/dashboard.tsx
+++ b/web/src/app/monitor/dashboards/objects/zookeeper/dashboard.tsx
@@ -43,7 +43,7 @@ export default function ZookeeperDashboardPage() {
       dashboardContent={
         <>
           <div className={styles.sectionLabel}>健康概览</div>
-          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={5} styles={styles} />
+          <KpiSection dashboard={dashboard} summaryCards={summaryCards} kpiCols={6} styles={styles} />
 
           {/* Row 1: packet rate (span6) + latency (span6) = 12 */}
           <div className={styles.sectionLabel}>性能趋势</div>

--- a/web/src/app/monitor/dashboards/shared/utils/top-bars.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/top-bars.ts
@@ -1,10 +1,28 @@
 import { formatMetricValue } from './format';
 import type { BarItem } from '../widgets';
 
+type SeriesPoint = [number, string | number | null | undefined];
+
 interface RawSeries {
   metric?: Record<string, string>;
-  values?: Array<[number, string | number]>;
+  values?: SeriesPoint[];
 }
+
+/**
+ * 取序列最后一个有限值。
+ * 后端 fill_missing_points 会把 [最后采样点, end] 之间补成 null；
+ * Number(null)===0 且 isFinite(0)，直接取最后一个点会把整列显示成 0。
+ */
+export const latestFiniteValue = (values?: SeriesPoint[]): number => {
+  if (!values?.length) return 0;
+  for (let i = values.length - 1; i >= 0; i -= 1) {
+    const raw = values[i]?.[1];
+    if (raw === null || raw === undefined || raw === '') continue;
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+};
 
 /**
  * 把「按维度 topk」查询结果解析为 BarList。
@@ -20,11 +38,7 @@ export const topLabelBars = (
   const rows = series
     .map((s) => {
       const label = labelKeys.map((k) => (s.metric?.[k] || '').trim()).find(Boolean) || '';
-      const nums = (s.values || [])
-        .filter(([, v]) => v !== null && v !== undefined && v !== '')
-        .map(([, v]) => Number(v))
-        .filter((n) => Number.isFinite(n));
-      const value = nums.length ? nums[nums.length - 1] : 0;
+      const value = latestFiniteValue(s.values);
       return { label, value };
     })
     .filter((r) => r.label && Number.isFinite(r.value))


### PR DESCRIPTION
## Summary
- `query_range` 窗尾 `fill_missing_points` 补的 `null` 会被 `Number(null)===0` 当成真实 0；Top/KPI 改为取最后一个有限值（`latestFiniteValue` / `topLabelBars`）。
- 仪表盘与实例概览按声明单位由前端格式化时关闭 `auto_convert_unit`，避免 ms/bytes/counts 被服务端先缩放后再按原单位展示。
- 健康概览 5 张 KPI + 采集状态应对齐 `kpiCols={6}`（MSSQL / Docker / Tomcat / Zookeeper），避免掉到第二行。

## Test plan
- [ ] MSSQL / ES / PG Top 条在窗尾有补点时不再整列 0；搜索页（保留 autoConvert）仍按响应 `data.unit` 展示。
- [ ] MySQL / K8s / K3s / Kafka / MongoDB / 实例概览数值量级与声明单位一致，无 hour/GiB 双重换算。
- [ ] MSSQL / Docker / Tomcat / Zookeeper 健康概览宽屏一行 6 卡。

## Review notes
- 已检查提交范围：仅 20 个 `web/src/app/monitor/` 文件；未跟踪的 SVG 图标、测试文件均未纳入。
- 无 `specs/changes` 规格；对照会话中的假 0、双重换算、健康概览一行三项验收。