### PR TITLE
fix(监控): 仪表盘查询默认关闭自动换算并修正 Etcd/Pod 展示单位

### DIFF
--- a/web/src/app/monitor/dashboards/objects/etcd/config.ts
+++ b/web/src/app/monitor/dashboards/objects/etcd/config.ts
@@ -61,18 +61,18 @@ export const ETCD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       name: 'etcd_wal_fsync_p99',
       display_name: 'WAL fsync P99',
       description: 'WAL 刷盘延迟 P99。',
-      unit: 's',
+      unit: 'ms',
       query:
-        'histogram_quantile(0.99, sum(rate((label_replace({__name__=~"etcd_disk_wal_fsync_duration_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "etcd_disk_wal_fsync_duration_seconds_(.+)"))[5m:]) or label_replace(rate(etcd_disk_wal_fsync_duration_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (instance_id, le))',
+        '1000 * histogram_quantile(0.99, sum(rate((label_replace({__name__=~"etcd_disk_wal_fsync_duration_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "etcd_disk_wal_fsync_duration_seconds_(.+)"))[5m:]) or label_replace(rate(etcd_disk_wal_fsync_duration_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (instance_id, le))',
       color: '#722ed1'
     },
     {
       name: 'etcd_backend_commit_p99',
       display_name: 'Backend commit P99',
       description: '后端 commit 延迟 P99。',
-      unit: 's',
+      unit: 'ms',
       query:
-        'histogram_quantile(0.99, sum(rate((label_replace({__name__=~"etcd_disk_backend_commit_duration_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "etcd_disk_backend_commit_duration_seconds_(.+)"))[5m:]) or label_replace(rate(etcd_disk_backend_commit_duration_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (instance_id, le))',
+        '1000 * histogram_quantile(0.99, sum(rate((label_replace({__name__=~"etcd_disk_backend_commit_duration_seconds_[0-9.]+", __$labels__}, "le", "$1", "__name__", "etcd_disk_backend_commit_duration_seconds_(.+)"))[5m:]) or label_replace(rate(etcd_disk_backend_commit_duration_seconds_count{__$labels__}[5m]), "le", "+Inf", "__name__", ".*")) by (instance_id, le))',
       color: '#8a5cff'
     },
     {
@@ -230,7 +230,7 @@ export const ETCD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
     {
       title: 'WAL fsync P99',
       metric: 'etcd_wal_fsync_p99',
-      unit: 's',
+      unit: 'ms',
       color: '#722ed1',
       icon: 'clock',
       compare: true,
@@ -253,8 +253,8 @@ export const ETCD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
         { label: 'Backend', detail: '后端 commit P99。' }
       ],
       series: [
-        { metric: 'etcd_wal_fsync_p99', label: 'WAL fsync P99', color: '#722ed1', unit: 's' },
-        { metric: 'etcd_backend_commit_p99', label: 'Backend commit P99', color: '#8a5cff', unit: 's' }
+        { metric: 'etcd_wal_fsync_p99', label: 'WAL fsync P99', color: '#722ed1', unit: 'ms' },
+        { metric: 'etcd_backend_commit_p99', label: 'Backend commit P99', color: '#8a5cff', unit: 'ms' }
       ]
     },
     {

--- a/web/src/app/monitor/dashboards/objects/k3s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k3s-pod/config.ts
@@ -73,7 +73,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       name: 'pod_io_reads_rate',
       display_name: '磁盘读 IOPS',
       description: 'Pod 每秒磁盘读操作次数。',
-      unit: 'counts',
+      unit: 'cps',
       query:
         'sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_reads_total{instance_type="k3s",__$labels__}[__$window__]) )',
       color: '#9254de',
@@ -83,7 +83,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       name: 'pod_io_writes_rate',
       display_name: '磁盘写 IOPS',
       description: 'Pod 每秒磁盘写操作次数。',
-      unit: 'counts',
+      unit: 'cps',
       query:
         'sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_writes_total{instance_type="k3s",__$labels__}[__$window__]) )',
       color: '#f5a623',
@@ -156,8 +156,8 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '磁盘 I/O',
       subtitle: '读 · 写 IOPS',
       rows: [
-        { label: '读 IOPS', metric: 'pod_io_reads_rate', unit: 'counts' },
-        { label: '写 IOPS', metric: 'pod_io_writes_rate', unit: 'counts' }
+        { label: '读 IOPS', metric: 'pod_io_reads_rate', unit: 'cps' },
+        { label: '写 IOPS', metric: 'pod_io_writes_rate', unit: 'cps' }
       ]
     }
   ]

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
@@ -72,7 +72,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       name: 'pod_io_reads_rate',
       display_name: '磁盘读 IOPS',
       description: 'Pod 每秒磁盘读操作次数。',
-      unit: 'counts',
+      unit: 'cps',
       query:
         'sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_reads_total{instance_type="k8s",__$labels__}[__$window__]) )',
       color: '#9254de',
@@ -82,7 +82,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       name: 'pod_io_writes_rate',
       display_name: '磁盘写 IOPS',
       description: 'Pod 每秒磁盘写操作次数。',
-      unit: 'counts',
+      unit: 'cps',
       query:
         'sum by (instance_id,pod,device) ( rate(prometheus_remote_write_container_fs_writes_total{instance_type="k8s",__$labels__}[__$window__]) )',
       color: '#f5a623',
@@ -155,8 +155,8 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       title: '磁盘 I/O',
       subtitle: '读 · 写 IOPS',
       rows: [
-        { label: '读 IOPS', metric: 'pod_io_reads_rate', unit: 'counts' },
-        { label: '写 IOPS', metric: 'pod_io_writes_rate', unit: 'counts' }
+        { label: '读 IOPS', metric: 'pod_io_reads_rate', unit: 'cps' },
+        { label: '写 IOPS', metric: 'pod_io_writes_rate', unit: 'cps' }
       ]
     }
   ]

--- a/web/src/app/monitor/dashboards/shared/utils/search-params.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/search-params.ts
@@ -22,9 +22,12 @@ export const buildSearchParams = (
   const recentTimeRange = getRecentTimeRange(timeValues);
   const startTime = recentTimeRange.at(0);
   const endTime = recentTimeRange.at(1);
+  // 仪表盘按声明单位由前端 formatMetricValue。省略 autoConvertUnit 且未传 rawValueMetrics 时默认 false，
+  // 避免服务端先缩成 hour/GiB 再按原单位展示。显式 true 仍可用于会读响应 data.unit 的调用方。
+  // 传入 rawValueMetrics 时：命中白名单的 query 关闭自动换算，其余仍为 true。
   const resolvedAutoConvert = autoConvertUnit !== undefined
     ? autoConvertUnit
-    : rawValueMetrics ? !Array.from(rawValueMetrics).some((m) => query.includes(m)) : true;
+    : rawValueMetrics ? !Array.from(rawValueMetrics).some((m) => query.includes(m)) : false;
   const params: SearchParams = {
     query: query
       .replace(/__\$labels__/g, labels)


### PR DESCRIPTION
## Summary
- 仪表盘 `buildSearchParams` 在省略 `autoConvertUnit` 且未传 `rawValueMetrics` 时默认 `false`，避免服务端先把秒/字节缩成 hour/GiB，前端再按声明单位二次展示。搜索页走独立的 `buildSearchQueryParams`，不设该字段，后端仍默认自动换算。
- Etcd WAL/Backend P99 查询乘 1000，声明单位改为 `ms`，避免典型 1–20ms 被 `formatTimeValue` 显示成 `0s`。
- K8s/K3s Pod 磁盘 IOPS 单位从 `counts` 改为 `cps`，与 `rate(...)` 语义一致。

## Test plan
- [x] `tsx scripts/monitor-promql-window-test.ts` 通过
- [x] 漏传第 7 参 → `auto_convert_unit: false`；显式 `true` 仍为 true；`rawValueMetrics` 命中/未命中分支保持原语义
- [x] `formatMetricValue(2,'ms')` → `2ms`；`0.002s` 仍为 `0s`（未改全局时间换算）；`12.5 cps` → `12.50/s`
- [ ] Etcd 专业盘 WAL/Backend P99 卡片与曲线显示毫秒级数值
- [ ] K8s/K3s Pod 磁盘 I/O 行显示每秒次数

## Review notes
对抗式审查后仅修正了 `search-params.ts` 注释（搜索页不走此 helper；`rawValueMetrics` 分支行为写清楚）。未改 Node IOPS、未改全局 `formatTimeValue`。

已检查提交范围：仅上述 4 个文件；未跟踪 SVG 图标未纳入。