### PR TITLE
bugfix: 云区域部署模板未给 stargazer 注入 NATS_INSTANCE_ID，导致探活 no responders

### DIFF
--- a/agents/webhookd/infra/proxy/docker-compose.yaml
+++ b/agents/webhookd/infra/proxy/docker-compose.yaml
@@ -139,7 +139,10 @@ services:
 
   stargazer:
     image: ${DOCKER_IMAGE_STARGAZER}
+    restart: always
     environment:
+      # server 按 {zone_name}_stargazer 探活，缺少该变量会回落为 default_stargazer 导致 no responders
+      NATS_INSTANCE_ID: ${ZONE_NAME}
       NATS_URLS: tls://${NATS_ADMIN_USERNAME}:${NATS_ADMIN_PASSWORD}@nats:4222
       UV_OFFLINE: True
       NATS_TLS_ENABLED: true

--- a/agents/webhookd/infra/tests/test_proxy_certificate_san.py
+++ b/agents/webhookd/infra/tests/test_proxy_certificate_san.py
@@ -8,9 +8,9 @@ import tarfile
 from pathlib import Path
 
 import pytest
+import yaml
 from cryptography import x509
 from cryptography.x509.oid import ExtensionOID
-
 
 PROXY_SCRIPT = Path(__file__).resolve().parents[1] / "proxy.sh"
 
@@ -95,15 +95,9 @@ def test_proxy_certificate_contains_typed_san_and_valid_nats_route(
     certificate_authority,
 ):
     with _generate_proxy_archive(proxy_address, certificate_authority) as archive:
-        certificate = x509.load_pem_x509_certificate(
-            archive.extractfile("./conf/certs/proxy.crt").read()
-        )
-        san = certificate.extensions.get_extension_for_oid(
-            ExtensionOID.SUBJECT_ALTERNATIVE_NAME
-        ).value
-        nats_config = archive.extractfile(
-            "./conf/nats/nats.conf"
-        ).read().decode()
+        certificate = x509.load_pem_x509_certificate(archive.extractfile("./conf/certs/proxy.crt").read())
+        san = certificate.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_ALTERNATIVE_NAME).value
+        nats_config = archive.extractfile("./conf/nats/nats.conf").read().decode()
         compose_config = archive.extractfile("./docker-compose.yaml").read().decode()
         generated_env = archive.extractfile("./.env").read().decode()
         regional_config = archive.extractfile("./conf/apm/regional.yaml").read().decode()
@@ -111,10 +105,7 @@ def test_proxy_certificate_contains_typed_san_and_valid_nats_route(
     if expected_dns:
         assert expected_dns in san.get_values_for_type(x509.DNSName)
     if expected_ip:
-        assert expected_ip in {
-            str(address)
-            for address in san.get_values_for_type(x509.IPAddress)
-        }
+        assert expected_ip in {str(address) for address in san.get_values_for_type(x509.IPAddress)}
     assert f'url: "tls://{proxy_address}:4222"' in nats_config
     assert 'publish = ["apm.traces.2"]' in nats_config
     assert 'subscribe = ["_INBOX.>"]' in nats_config
@@ -122,3 +113,23 @@ def test_proxy_certificate_contains_typed_san_and_valid_nats_route(
     assert "APM_NATS_USERNAME=apm_region_2" in generated_env
     assert "APM_NATS_PASSWORD=apm-password" in generated_env
     assert "trace_guard:" in regional_config
+
+
+def test_proxy_compose_injects_zone_instance_id_for_region_services(
+    certificate_authority,
+):
+    with _generate_proxy_archive("10.0.0.8", certificate_authority) as archive:
+        compose_config = yaml.safe_load(archive.extractfile("./docker-compose.yaml").read().decode())
+        generated_env = archive.extractfile("./.env").read().decode()
+
+    assert "ZONE_NAME=proxy-test" in generated_env
+
+    services = compose_config["services"]
+    stargazer = services["stargazer"]
+    nats_executor = services["nats-executor"]
+
+    # server 端按 {zone_name}_stargazer / {zone_name} 探活，两个服务都必须拿到 ZONE_NAME
+    assert stargazer["environment"]["NATS_INSTANCE_ID"] == "${ZONE_NAME}"
+    assert "NATS_INSTANCE_ID=${ZONE_NAME}" in nats_executor["environment"]
+
+    assert stargazer["restart"] == "always"


### PR DESCRIPTION
## 问题

自建云区域通过部署脚本安装代理机组件后，stargazer 在 server 页面始终显示"未部署/异常"，健康检查报 `nats: no responders available for request`。

## 根因

代理机 compose 模板 `agents/webhookd/infra/proxy/docker-compose.yaml` 中：

- `nats-executor` 有 `NATS_INSTANCE_ID=${ZONE_NAME}` ✅
- `stargazer` 的 environment 缺少该变量 ❌

stargazer 启动时（`agents/stargazer/server.py`）读不到 `NATS_INSTANCE_ID` 便回落为默认值 `default`，以 `default_stargazer` 注册 NATS 主题；而 server 侧探活按 `{zone_name}_stargazer` 请求（`RegionService.get_region_service_instance_id`），主题永远对不上，所有走该模板部署的自建云区域全部命中。

`ZONE_NAME` 本身已由 server → webhookd `/infra/proxy` → `env.template` 一路正确写入代理机 `.env`，仅 compose 未转交给 stargazer 容器。已在实际环境验证：补上该变量重启后探活立即恢复 `status: ok`。

## 修改

- `docker-compose.yaml`：stargazer 补上 `NATS_INSTANCE_ID: ${ZONE_NAME}`；补上缺失的 `restart: always`（模板中唯一没有重启策略的业务容器，宿主机重启后不会自动拉起）
- 新增契约测试 `test_proxy_compose_injects_zone_instance_id_for_region_services`：从 proxy.sh 实际产物中解包校验两个区域服务的实例 ID 注入与 stargazer 重启策略

## 测试

```
pytest agents/webhookd/infra/tests/test_proxy_certificate_san.py -q
4 passed
```

## 存量环境修复指引

已部署的云区域不受本 PR 自动修复，需在代理机 stargazer 的 compose 配置补上 `NATS_INSTANCE_ID=<云区域名>` 后 `docker compose up -d stargazer`，或重新生成部署脚本重跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)