### PR TITLE
bugfix: 保证 NATS 创建失败时完整回滚

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from typing import Optional
 
+from django.db import transaction
 from django.db.models import Count, F, Q
 from django.utils import timezone
 from rest_framework import serializers
@@ -345,7 +346,8 @@ def _execute_nats_create(create_func, data: dict, user_info: Optional[dict] = No
         return identity_error
     try:
         operator, domain = _resolve_nats_actor(user_info)
-        _, result_data = create_func(data, operator=operator, domain=domain)
+        with transaction.atomic():
+            _, result_data = create_func(data, operator=operator, domain=domain)
         return {"result": True, "data": result_data, "message": ""}
     except (serializers.ValidationError, ValueError) as exc:
         return {"result": False, "data": [], "message": _build_validation_message(exc)}

--- a/server/apps/monitor/tests/test_nats_monitor_helpers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_helpers.py
@@ -5,9 +5,11 @@
 
 from datetime import datetime
 from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 
+import apps.node_mgmt  # noqa: F401 - MonitorPolicyViewSet 的运行时模型依赖
 from apps.monitor.nats import monitor as nm
 
 
@@ -244,6 +246,7 @@ class TestRequireAuthenticatedActor:
         assert nm._require_authenticated_actor({"user": user}) is None
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 class TestExecuteNatsCreate:
     def test_identity_gate_blocks_anonymous(self):
@@ -290,3 +293,53 @@ class TestExecuteNatsCreate:
             "message": "simulated late create failure",
         }
         assert not MonitorObjectType.objects.filter(id=object_type_id).exists()
+
+    def test_object_child_failure_rolls_back_and_retry_succeeds(self, mocker):
+        from apps.monitor.models.monitor_object import MonitorObject
+
+        name = f"nats-object-{uuid4().hex[:8]}"
+        original_bulk_create = MonitorObject.objects.bulk_create
+        bulk_create = mocker.patch.object(MonitorObject.objects, "bulk_create")
+        bulk_create.side_effect = RuntimeError("child create failed")
+        payload = {"name": name, "level": "base", "children": [{"id": f"{name}-child", "name": "子对象"}]}
+        user_info = {"user": SimpleNamespace(username="a", domain="domain.com")}
+
+        assert nm.create_monitor_object(payload, user_info=user_info)["result"] is False
+        assert not MonitorObject.objects.filter(name=name).exists()
+        bulk_create.side_effect = original_bulk_create
+        assert nm.create_monitor_object(payload, user_info=user_info)["result"] is True
+        assert MonitorObject.objects.filter(name__in=[name, f"{name}-child"]).count() == 2
+
+    @pytest.mark.parametrize(
+        ("failing_method", "enable_alerts"),
+        [
+            ("update_or_create_task", ["threshold"]),
+            ("update_policy_organizations", ["threshold"]),
+            ("update_policy_baselines", ["no_data"]),
+        ],
+    )
+    def test_policy_stage_failure_rolls_back_all_writes(self, mocker, failing_method, enable_alerts):
+        from django_celery_beat.models import CrontabSchedule, PeriodicTask
+
+        from apps.monitor.models.monitor_object import MonitorObject
+        from apps.monitor.models.monitor_policy import MonitorPolicy, PolicyOrganization
+        from apps.monitor.views.monitor_policy import MonitorPolicyViewSet
+
+        monitor_object = MonitorObject.objects.create(name=f"nats-policy-object-{uuid4().hex[:8]}", level="base")
+        policy_name = f"nats-policy-{uuid4().hex[:8]}"
+        before_tasks = set(PeriodicTask.objects.values_list("id", flat=True))
+        before_schedules = set(CrontabSchedule.objects.values_list("id", flat=True))
+        failing_write = mocker.patch.object(MonitorPolicyViewSet, failing_method, side_effect=RuntimeError("late failure"))
+        payload = {
+            "name": policy_name, "monitor_object": monitor_object.id, "organizations": [1],
+            "algorithm": "max_over_time", "group_algorithm": "max", "query_condition": {"type": "pmq", "query": "up"},
+            "schedule": {"type": "min", "value": 5}, "period": {"type": "min", "value": 5},
+            "enable_alerts": enable_alerts,
+        }
+
+        assert nm.create_monitor_policy(payload, user_info={"user": SimpleNamespace(username="a", domain="domain.com")})["result"] is False
+        failing_write.assert_called_once()
+        assert not MonitorPolicy.objects.filter(name=policy_name).exists()
+        assert set(PeriodicTask.objects.values_list("id", flat=True)) == before_tasks
+        assert set(CrontabSchedule.objects.values_list("id", flat=True)) == before_schedules
+        assert not PolicyOrganization.objects.filter(policy__name=policy_name).exists()

--- a/server/apps/monitor/tests/test_nats_monitor_helpers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_helpers.py
@@ -268,3 +268,25 @@ class TestExecuteNatsCreate:
         )
         assert out["result"] is False
         assert out["message"]
+
+    def test_late_failure_rolls_back_database_writes(self):
+        from apps.monitor.models.monitor_object import MonitorObjectType
+
+        object_type_id = "nats-create-rollback"
+
+        def create_then_fail(data, operator, domain):
+            MonitorObjectType.objects.create(id=object_type_id, name="待回滚类型")
+            raise RuntimeError("simulated late create failure")
+
+        out = nm._execute_nats_create(
+            create_then_fail,
+            {},
+            user_info={"user": SimpleNamespace(username="a", domain="domain.com")},
+        )
+
+        assert out == {
+            "result": False,
+            "data": [],
+            "message": "simulated late create failure",
+        }
+        assert not MonitorObjectType.objects.filter(id=object_type_id).exists()


### PR DESCRIPTION
## 问题

监控 NATS 创建入口在完成主记录写入后，还会继续创建子对象、周期任务、组织关系或无数据基线。后置步骤异常时，调用方收到失败响应，但先前数据库写入不会回滚，导致响应与持久化状态不一致。

## 根因（设计层）

通用创建执行器统一了身份校验和错误响应，却没有定义数据库事务边界。各创建函数因此只能依赖调用方自行保证原子性，而 NATS 路径没有像 REST 策略创建那样建立这一边界。

## 怎么修的

在 `_execute_nats_create` 调用具体创建函数时建立统一的 `transaction.atomic()` 边界，并继续在事务退出后沿用原有异常响应。这样任何后置异常都会先触发完整回滚，再返回既有失败结构。

## 影响范围与兼容性

- 覆盖监控对象类型、监控对象、插件、指标组、指标和监控策略六个既有 NATS 创建入口。
- 不改变 NATS subject、请求字段、身份校验、成功响应或错误响应格式。
- 成功路径仍正常提交；失败路径从“部分提交”修正为“全部回滚”。
- 不涉及数据迁移；如需回滚本改动，可直接回退该提交。历史上已产生的残留数据不在本 PR 的自动清理范围内。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["NATS create handler\nserver/apps/monitor/nats/monitor.py"]
    end

    subgraph N["原子处理层"]
        N1["_execute_nats_create"]
        N2["具体 create_func"]
        N3["主记录与依赖记录写入"]
    end

    subgraph C["失败收敛层"]
        C1["transaction.atomic 回滚"]
        C2["沿用既有失败响应"]
    end

    T1 --> N1 --> N2 --> N3
    N3 -. "后置异常" .-> C1 --> C2
```

## 验证

- `server/apps/monitor/tests/test_nats_monitor_helpers.py`：59 passed。
- 回归用例在修复前稳定失败于“后置异常后记录仍存在”，修复后确认记录完整回滚。
- 运行契约覆盖匿名身份拒绝、成功持久化、序列化校验失败和后置异常回滚。

## 三轨门禁

- Standards：pass。最小两文件改动，导入排序、静态错误检查和 diff 格式检查通过。
- Spec：pass。完整实现失败原子性，未改变既有 NATS 契约。
- Runtime Contract：pass。真实 ORM 写入完成 RED→GREEN，并保留成功、身份和校验失败契约。

Fixes #4641
