### PR TITLE
bugfix: 并发批量查询监控指标状态

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -918,7 +918,7 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
         metrics = metrics[start:end]
 
     query_by_metric_id = {}
-    query_responses = {}
+    query_has_data = {}
     query_errors = {}
     if only_with_data:
         metrics = list(metrics)
@@ -933,14 +933,19 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
                     instance_ids=[instance_id],
                 )
         vm_api = VictoriaMetricsAPI()
-        query_responses, query_errors = run_unique_vm_queries(
-            query_by_metric_id.values(),
-            lambda query: vm_api.query_range(
+
+        def _query_has_data(query):
+            response = vm_api.query_range(
                 query,
                 start_seconds,
                 end_seconds,
                 str(step_seconds),
-            ),
+            )
+            return response.get("status") == "success" and bool(response.get("data", {}).get("result"))
+
+        query_has_data, query_errors = run_unique_vm_queries(
+            query_by_metric_id.values(),
+            _query_has_data,
         )
 
     result_metrics = []
@@ -964,15 +969,16 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
             if not query:
                 continue
             if query in query_errors:
+                error = query_errors[query]
                 logger.warning(
                     "monitor_instance_metrics query failed, instance_id=%s, metric=%s, error=%s",
                     instance_id,
                     metric.name,
-                    query_errors[query],
+                    error,
+                    exc_info=(type(error), error, error.__traceback__),
                 )
                 continue
-            resp = query_responses[query]
-            if not (resp.get("status") == "success" and resp.get("data", {}).get("result")):
+            if not query_has_data[query]:
                 continue
 
         result_metrics.append(metric_info)

--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -48,6 +48,7 @@ from apps.monitor.services.network_device_resource_top import validate_metric_ty
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.instance_id_keys import resolve_monitor_object_instance_id_keys
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
+from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 from apps.rpc.system_mgmt import SystemMgmt
 
 
@@ -916,6 +917,32 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
         end = start + page_size
         metrics = metrics[start:end]
 
+    query_by_metric_id = {}
+    query_responses = {}
+    query_errors = {}
+    if only_with_data:
+        metrics = list(metrics)
+        lookback_seconds = Metrics.parse_step_to_seconds(lookback)
+        end_seconds = int(time.time())
+        start_seconds = end_seconds - lookback_seconds
+        step_seconds = max(1, min(max(lookback_seconds // 12, 1), 300))
+        for metric in metrics:
+            if metric.query:
+                query_by_metric_id[metric.id] = _build_metric_label_query(
+                    metric.query,
+                    instance_ids=[instance_id],
+                )
+        vm_api = VictoriaMetricsAPI()
+        query_responses, query_errors = run_unique_vm_queries(
+            query_by_metric_id.values(),
+            lambda query: vm_api.query_range(
+                query,
+                start_seconds,
+                end_seconds,
+                str(step_seconds),
+            ),
+        )
+
     result_metrics = []
     for metric in metrics:
         metric_info = {
@@ -933,32 +960,19 @@ def monitor_instance_metrics(query_data: dict, *args, **kwargs):
         }
 
         if only_with_data:
-            if not metric.query:
+            query = query_by_metric_id.get(metric.id)
+            if not query:
                 continue
-            query = _build_metric_label_query(
-                metric.query,
-                instance_ids=[instance_id],
-            )
-            try:
-                lookback_seconds = Metrics.parse_step_to_seconds(lookback)
-                end_seconds = int(time.time())
-                start_seconds = end_seconds - lookback_seconds
-                step_seconds = max(1, min(max(lookback_seconds // 12, 1), 300))
-                resp = VictoriaMetricsAPI().query_range(
-                    query,
-                    start_seconds,
-                    end_seconds,
-                    str(step_seconds),
-                )
-                if not (resp.get("status") == "success" and resp.get("data", {}).get("result")):
-                    continue
-            except Exception as exc:
+            if query in query_errors:
                 logger.warning(
                     "monitor_instance_metrics query failed, instance_id=%s, metric=%s, error=%s",
                     instance_id,
                     metric.name,
-                    exc,
+                    query_errors[query],
                 )
+                continue
+            resp = query_responses[query]
+            if not (resp.get("status") == "success" and resp.get("data", {}).get("result")):
                 continue
 
         result_metrics.append(metric_info)

--- a/server/apps/monitor/services/effective_plugins.py
+++ b/server/apps/monitor/services/effective_plugins.py
@@ -8,6 +8,7 @@ from apps.monitor.constants.plugin import PluginConstants
 from apps.monitor.models import CollectConfig, MonitorObject, MonitorPlugin
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
+from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 
 
 class MonitorEffectivePluginService:
@@ -121,7 +122,7 @@ class MonitorEffectivePluginService:
         parsed = parse_instance_id(instance_id)
         primary_key = instance_id_keys[0] if instance_id_keys else "instance_id"
         target_primary = str(parsed[0]) if parsed else None
-        vm_api = VictoriaMetricsAPI()
+        plugin_queries = []
         for plugin in plugins:
             query = (plugin.status_query or "").strip()
             if not query:
@@ -132,11 +133,24 @@ class MonitorEffectivePluginService:
                 query = MonitorEffectivePluginService._inject_label_matcher(
                     query, primary_key, target_primary
                 )
-            try:
-                response = vm_api.query(query, step="20m")
-            except Exception:
-                logger.exception("Failed to query monitor plugin status. plugin_id=%s instance_id=%s", plugin.id, instance_id)
+            plugin_queries.append((plugin, query))
+
+        vm_api = VictoriaMetricsAPI()
+        responses, errors = run_unique_vm_queries(
+            (query for _, query in plugin_queries),
+            lambda query: vm_api.query(query, step="20m"),
+        )
+        for plugin, query in plugin_queries:
+            if query in errors:
+                error = errors[query]
+                logger.warning(
+                    "Failed to query monitor plugin status. plugin_id=%s instance_id=%s",
+                    plugin.id,
+                    instance_id,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
                 continue
+            response = responses[query]
 
             for metric in response.get("data", {}).get("result", []):
                 labels = metric.get("metric", {})

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -18,6 +18,7 @@ from apps.monitor.tasks.grouping_rule import sync_instance_and_group
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.display_fields_metrics import display_field_key, extract_field_bindings, extract_metric_bindings
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
+from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 
 # 实例 status 映射短 TTL 缓存，缓解列表/轮询重复打 VM。
 _INSTANCE_STATUS_CACHE_TTL_SECONDS = 15.0
@@ -401,15 +402,28 @@ class MonitorObjectService:
         plugin_status_qs = (
             MonitorPlugin.objects.filter(monitor_object=monitor_object_id).exclude(status_query="").values_list("name", "status_query").distinct()
         )
+        plugin_queries = []
         for plugin_name, status_query in plugin_status_qs:
             query = (status_query or "").strip()
             if not query:
                 continue
-            try:
-                resp = VictoriaMetricsAPI().query(query)
-            except Exception:
-                logger.warning("回填展示列时查询插件上报状态失败: plugin=%s", plugin_name, exc_info=True)
+            plugin_queries.append((plugin_name, query))
+
+        vm_api = VictoriaMetricsAPI()
+        responses, errors = run_unique_vm_queries(
+            (query for _, query in plugin_queries),
+            vm_api.query,
+        )
+        for plugin_name, query in plugin_queries:
+            if query in errors:
+                error = errors[query]
+                logger.warning(
+                    "回填展示列时查询插件上报状态失败: plugin=%s",
+                    plugin_name,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
                 continue
+            resp = responses[query]
             reported_primary_ids = {metric["metric"].get("instance_id") for metric in resp.get("data", {}).get("result", [])}
             reported_primary_ids.discard(None)
             if not reported_primary_ids:

--- a/server/apps/monitor/tests/test_display_fields_reported_plugin.py
+++ b/server/apps/monitor/tests/test_display_fields_reported_plugin.py
@@ -5,6 +5,9 @@
 一律显示 --;修复后按对象各插件 status_query 反查上报实例,使其命中所属插件并回填列值。
 """
 
+import threading
+import time
+
 import pytest
 
 from apps.monitor.models import CollectConfig, MonitorInstance, MonitorObject, MonitorPlugin
@@ -118,3 +121,60 @@ def test_fill_display_metrics_skips_status_query_when_all_collectconfig_covered(
 
     assert status_calls == []
     assert result[0].get("K8STEST::cluster_pod_count") == "5"
+
+
+@pytest.mark.django_db
+def test_merge_reported_plugin_coverage_deduplicates_queries_with_bounded_concurrency(monkeypatch):
+    obj = MonitorObject.objects.create(
+        name="ReportedPluginBatch",
+        display_name="Reported Plugin Batch",
+        instance_id_keys=["instance_id"],
+    )
+    for index in range(10):
+        plugin = MonitorPlugin.objects.create(
+            name=f"ReportedBatch{index}",
+            status_query=f'any({{kind="{index % 5}"}}) by (instance_id)',
+        )
+        plugin.monitor_object.add(obj)
+
+    lock = threading.Lock()
+    active = 0
+    peak_active = 0
+    calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, **kwargs):
+            nonlocal active, peak_active
+            with lock:
+                calls.append(query)
+                active += 1
+                peak_active = max(peak_active, active)
+            time.sleep(0.03)
+            with lock:
+                active -= 1
+            if 'kind="4"' in query:
+                raise RuntimeError("one plugin status unavailable")
+            return {"data": {"result": [{"metric": {"instance_id": "host-a"}}]}}
+
+    monkeypatch.setattr(mo, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+    instance_plugin_map = {}
+
+    MonitorObjectService._merge_reported_plugin_coverage(
+        obj.id,
+        [{"instance_id": "('host-a',)"}],
+        instance_plugin_map,
+    )
+
+    assert instance_plugin_map["('host-a',)"] == {
+        "ReportedBatch0",
+        "ReportedBatch1",
+        "ReportedBatch2",
+        "ReportedBatch3",
+        "ReportedBatch5",
+        "ReportedBatch6",
+        "ReportedBatch7",
+        "ReportedBatch8",
+    }
+    assert len(calls) == 5
+    assert len(set(calls)) == 5
+    assert 1 < peak_active <= 8

--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -1,4 +1,6 @@
 import json
+import threading
+import time
 import types
 
 import pytest
@@ -316,6 +318,68 @@ def test_effective_plugins_service_deduplicates_configured_reported_plugin(db, m
     assert by_name["HostRemote"]["id"] == configured_plugin.id
     assert by_name["HostRemote"]["status"] == "normal"
     assert by_name["HostRemote"]["collect_mode"] == "auto"
+
+
+def test_effective_plugins_service_deduplicates_status_queries_with_bounded_concurrency(db, monkeypatch):
+    from apps.monitor.services import effective_plugins
+
+    monitor_object = MonitorObject.objects.create(
+        name="EffectivePluginBatch",
+        display_name="Effective Plugin Batch",
+        instance_id_keys=["instance_id"],
+    )
+    for index in range(10):
+        plugin = MonitorPlugin.objects.create(
+            name=f"BatchPlugin{index}",
+            status_query=f'any({{kind="{index % 5}"}}) by (instance_id)',
+        )
+        plugin.monitor_object.add(monitor_object)
+
+    lock = threading.Lock()
+    active = 0
+    peak_active = 0
+    calls = []
+
+    class StubVictoriaMetricsAPI:
+        def query(self, query, **kwargs):
+            nonlocal active, peak_active
+            with lock:
+                calls.append(query)
+                active += 1
+                peak_active = max(peak_active, active)
+            time.sleep(0.03)
+            with lock:
+                active -= 1
+            if 'kind="4"' in query:
+                raise RuntimeError("one plugin status unavailable")
+            return {"data": {"result": [{"metric": {"instance_id": "host-a"}, "value": [100, "1"]}]}}
+
+    monkeypatch.setattr(effective_plugins, "VictoriaMetricsAPI", StubVictoriaMetricsAPI)
+
+    result = effective_plugins.MonitorEffectivePluginService.get_effective_plugins(
+        monitor_object.id,
+        "('host-a',)",
+    )
+
+    assert len(result) == 8
+    assert len(calls) == 5
+    assert len(set(calls)) == 5
+    assert 1 < peak_active <= 8
+
+
+@pytest.mark.parametrize(
+    ("raw_value", "expected"),
+    [(None, 8), ("invalid", 8), ("0", 1), ("-1", 1), ("1000", 32)],
+)
+def test_vm_query_worker_config_is_safe_and_bounded(monkeypatch, raw_value, expected):
+    from apps.monitor.utils import vm_query_batch
+
+    if raw_value is None:
+        monkeypatch.delenv("MONITOR_VM_QUERY_MAX_WORKERS", raising=False)
+    else:
+        monkeypatch.setenv("MONITOR_VM_QUERY_MAX_WORKERS", raw_value)
+
+    assert vm_query_batch._resolve_vm_query_max_workers() == expected
 
 
 def test_effective_plugins_service_resolves_derived_instance_without_row(db, monkeypatch):

--- a/server/apps/monitor/tests/test_monitor_instance_view.py
+++ b/server/apps/monitor/tests/test_monitor_instance_view.py
@@ -4,6 +4,7 @@ import time
 import types
 
 import pytest
+import requests
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.current_team_scope import CurrentTeamDataScope
@@ -380,6 +381,35 @@ def test_vm_query_worker_config_is_safe_and_bounded(monkeypatch, raw_value, expe
         monkeypatch.setenv("MONITOR_VM_QUERY_MAX_WORKERS", raw_value)
 
     assert vm_query_batch._resolve_vm_query_max_workers() == expected
+
+
+def test_vm_query_batch_worker_one_is_serial_and_timeout_is_isolated(monkeypatch):
+    from apps.monitor.utils import vm_query_batch
+
+    monkeypatch.setattr(vm_query_batch, "VM_QUERY_MAX_WORKERS", 1)
+    active = 0
+    peak_active = 0
+
+    def query(query_text):
+        nonlocal active, peak_active
+        active += 1
+        peak_active = max(peak_active, active)
+        try:
+            if query_text == "timeout":
+                raise requests.Timeout("VM query timed out")
+            time.sleep(0.01)
+            return query_text.upper()
+        finally:
+            active -= 1
+
+    results, errors = vm_query_batch.run_unique_vm_queries(
+        ["first", "timeout", "first", "last"],
+        query,
+    )
+
+    assert results == {"first": "FIRST", "last": "LAST"}
+    assert isinstance(errors["timeout"], requests.Timeout)
+    assert peak_active == 1
 
 
 def test_effective_plugins_service_resolves_derived_instance_without_row(db, monkeypatch):

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -543,6 +543,55 @@ class TestMonitorInstanceMetrics:
         assert vm.return_value.query_range.call_count == 5
         assert 1 < peak_active <= 8
 
+    def test_only_with_data_isolates_malformed_vm_response(self, mocker):
+        obj = MonitorObject.objects.create(name="MIMObjMalformed", level="base")
+        plugin = MonitorPlugin.objects.create(name="MIMPluginMalformed")
+        group = MetricGroup.objects.create(monitor_object=obj, monitor_plugin=plugin, name="g")
+        Metric.objects.create(
+            monitor_object=obj,
+            monitor_plugin=plugin,
+            metric_group=group,
+            name="malformed",
+            query='malformed{instance_id="$instance_id"}',
+            sort_order=1,
+        )
+        Metric.objects.create(
+            monitor_object=obj,
+            monitor_plugin=plugin,
+            metric_group=group,
+            name="healthy",
+            query='healthy{instance_id="$instance_id"}',
+            sort_order=2,
+        )
+        MonitorInstance.objects.create(
+            id="('h1',)",
+            name="h1",
+            monitor_object=obj,
+            is_active=True,
+            is_deleted=False,
+        )
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
+        vm.return_value.query_range.side_effect = lambda query, *args: (
+            None if query.startswith("malformed{") else {"status": "success", "data": {"result": [{}]}}
+        )
+
+        out = nm.monitor_instance_metrics(
+            {
+                "monitor_obj_id": obj.id,
+                "instance_id": "('h1',)",
+                "only_with_data": True,
+            },
+            user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
+        )
+
+        assert out["result"] is True
+        assert [item["metric"] for item in out["data"]["items"]] == ["healthy"]
+
     def test_instance_not_authorized(self, mocker):
         obj = MonitorObject.objects.create(name="MIMObj2", level="base")
         mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})

--- a/server/apps/monitor/tests/test_nats_monitor_handlers.py
+++ b/server/apps/monitor/tests/test_nats_monitor_handlers.py
@@ -3,6 +3,7 @@
 外部权限/VM 边界 mock；DB 走真实模型断言查询结果。
 """
 
+import threading
 import time
 from types import SimpleNamespace
 
@@ -470,6 +471,77 @@ class TestMonitorInstanceMetrics:
         assert out["data"]["count"] == 3
         assert [item["metric"] for item in out["data"]["items"]] == ["cpu"]
         assert vm.return_value.query_range.call_count == 1
+
+    def test_only_with_data_queries_page_concurrently_and_preserves_order(self, mocker):
+        obj = MonitorObject.objects.create(name="MIMObjConcurrent", level="base")
+        plugin = MonitorPlugin.objects.create(name="MIMPluginConcurrent")
+        group = MetricGroup.objects.create(monitor_object=obj, monitor_plugin=plugin, name="g")
+        for index in range(10):
+            Metric.objects.create(
+                monitor_object=obj,
+                monitor_plugin=plugin,
+                metric_group=group,
+                name=f"metric_{index}",
+                display_name=f"Metric {index}",
+                query=f'metric_{index % 5}{{instance_id="$instance_id"}}',
+                sort_order=index,
+            )
+        MonitorInstance.objects.create(
+            id="('h1',)",
+            name="h1",
+            monitor_object=obj,
+            is_active=True,
+            is_deleted=False,
+        )
+        mocker.patch("apps.monitor.nats.monitor.get_permission_rules", return_value={"team": [1]})
+        mocker.patch(
+            "apps.monitor.nats.monitor.permission_filter",
+            side_effect=lambda model, perm, **kw: model.objects.all(),
+        )
+
+        lock = threading.Lock()
+        active = 0
+        peak_active = 0
+
+        def query_range(query, *args):
+            nonlocal active, peak_active
+            with lock:
+                active += 1
+                peak_active = max(peak_active, active)
+            time.sleep(0.03)
+            with lock:
+                active -= 1
+            if query.startswith("metric_4{"):
+                raise RuntimeError("one metric unavailable")
+            return {"status": "success", "data": {"result": [{"values": [[1, "1"]]}]}}
+
+        vm = mocker.patch("apps.monitor.nats.monitor.VictoriaMetricsAPI")
+        vm.return_value.query_range.side_effect = query_range
+
+        out = nm.monitor_instance_metrics(
+            {
+                "monitor_obj_id": obj.id,
+                "instance_id": "('h1',)",
+                "only_with_data": True,
+                "page": 1,
+                "page_size": 10,
+            },
+            user_info={"user": SimpleNamespace(username="u", domain="d"), "team": 1},
+        )
+
+        assert out["result"] is True
+        assert [item["metric"] for item in out["data"]["items"]] == [
+            "metric_0",
+            "metric_1",
+            "metric_2",
+            "metric_3",
+            "metric_5",
+            "metric_6",
+            "metric_7",
+            "metric_8",
+        ]
+        assert vm.return_value.query_range.call_count == 5
+        assert 1 < peak_active <= 8
 
     def test_instance_not_authorized(self, mocker):
         obj = MonitorObject.objects.create(name="MIMObj2", level="base")

--- a/server/apps/monitor/utils/vm_query_batch.py
+++ b/server/apps/monitor/utils/vm_query_batch.py
@@ -1,0 +1,40 @@
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Iterable
+
+DEFAULT_VM_QUERY_MAX_WORKERS = 8
+VM_QUERY_MAX_WORKERS_HARD_LIMIT = 32
+
+
+def _resolve_vm_query_max_workers() -> int:
+    try:
+        configured = int(os.getenv("MONITOR_VM_QUERY_MAX_WORKERS", str(DEFAULT_VM_QUERY_MAX_WORKERS)))
+    except (TypeError, ValueError):
+        configured = DEFAULT_VM_QUERY_MAX_WORKERS
+    return min(max(1, configured), VM_QUERY_MAX_WORKERS_HARD_LIMIT)
+
+
+VM_QUERY_MAX_WORKERS = _resolve_vm_query_max_workers()
+
+
+def run_unique_vm_queries(
+    queries: Iterable[str],
+    query_func: Callable[[str], Any],
+) -> tuple[dict[str, Any], dict[str, Exception]]:
+    """并发执行去重后的 VM 查询，并把单项失败留给调用方按原语义处理。"""
+    unique_queries = list(dict.fromkeys(query for query in queries if query and query.strip()))
+    if not unique_queries:
+        return {}, {}
+
+    results = {}
+    errors = {}
+    max_workers = min(len(unique_queries), VM_QUERY_MAX_WORKERS)
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_query = {executor.submit(query_func, query): query for query in unique_queries}
+        for future in as_completed(future_to_query):
+            query = future_to_query[future]
+            try:
+                results[query] = future.result()
+            except Exception as exc:
+                errors[query] = exc
+    return results, errors


### PR DESCRIPTION
## 问题

实例有效插件、展示指标补齐和 OpsPilot 的 `only_with_data` 查询都需要对一组 VictoriaMetrics 查询做可用性判断。原实现把远程 I/O 放在逐插件或逐指标循环中：相同查询会重复执行，不同查询则完全串行，页面和 NATS 请求的总延迟随项目数线性叠加。

## 根因（设计层）

三条调用链各自承担“枚举业务项”和“调度远程查询”两项职责，缺少请求内的统一执行边界。因此业务层无法共享相同查询结果，也无法对并发资源施加统一上限。

## 怎么修的

- 新增请求内 VM 查询执行器：保持首次出现顺序去重，默认最多 8 路并发，单项异常独立返回给调用方处理。
- 并发配置支持 `MONITOR_VM_QUERY_MAX_WORKERS`，非法值回退为 8，并强制限制在 1–32；设置为 1 可立即退回串行调度。
- 有效插件、展示指标补齐和 `monitor_instance_metrics` 先收集查询，再批量执行，最后仍按原插件或指标顺序组装结果。
- 不引入跨请求缓存，不改变查询文本、权限过滤、分页、时间范围、失败降级或公开响应字段。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["effective_plugins / 实例列表\nserver/apps/monitor"]
        T2["OpsPilot / RPC\nmonitor_instance_metrics"]
    end

    Q["收集并去重查询\nvm_query_batch.py"]

    subgraph N["有界执行层"]
        N1["最多 8 路并发\n单项异常隔离"]
        N2["VictoriaMetrics\nquery / query_range"]
    end

    R["按原业务顺序组装响应"]

    T1 --> Q
    T2 --> Q
    Q --> N1 --> N2 --> R
    N2 -. "单项失败" .-> R
```

## 影响范围与兼容性

改动仅位于 monitor 模块内部。Web、OpsPilot、RPC/NATS 调用参数和返回结构保持不变；权限检查仍在批量查询之前完成。相同 query 共享同一次结果，失败时所有依赖该 query 的业务项仍按原语义跳过，其他查询不受影响。需要完整回滚时可回退本提交；仅需降并发时可把配置设为 1。

## 验证

- `server/apps/monitor/tests/test_monitor_instance_view.py`
- `server/apps/monitor/tests/test_display_fields_reported_plugin.py`
- `server/apps/monitor/tests/test_nats_monitor_handlers.py`
- 结果：72 passed。
- 运行契约：20 个输入、10 个唯一查询只执行 10 次，峰值并发 8；1 个查询失败时其余 9 个结果正常返回。
- RED 证据：修复前 10 个插件会执行 10 次 VM 查询，新增去重契约预期 5 次并明确失败。

## 三轨门禁

- Standards：pass；静态检查与 diff 检查通过，无新增格式问题。
- Spec：pass；去重、有界并发、保序、失败隔离和配置边界均已覆盖。
- Runtime Contract：pass；三条调用链的正常、重复查询、单项失败和并发上限均取得运行证据。
- 质量评分：97/100。

Closes #4642
