### PR TITLE
fix(node_mgmt): 限制 Sidecar 心跳字段所有权

### DIFF
--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -36,21 +36,6 @@ class Sidecar:
     CONVERGE_DEBOUNCE_SECONDS = 5
     CPU_ARCHITECTURE_TAG = "cpu_architecture"
     INSTALL_TASK_NODE_TAG = "install_task_node"
-    CLIENT_REPORTED_NODE_FIELDS = frozenset(
-        {
-            "ip",
-            "operating_system",
-            "cpu_architecture",
-            "architecture",
-            "collector_configuration_directory",
-            "metrics",
-            "status",
-            "tags",
-            "log_file_list",
-            "install_method",
-            "node_type",
-        }
-    )
     SERVER_OWNED_NODE_FIELDS = frozenset(
         {
             "id",
@@ -68,6 +53,20 @@ class Sidecar:
             "updated_by_domain",
         }
     )
+    CLIENT_REPORTED_NODE_FIELD_TYPES = {
+        "ip": str,
+        "operating_system": str,
+        "cpu_architecture": str,
+        "architecture": str,
+        "collector_configuration_directory": str,
+        "metrics": dict,
+        "status": dict,
+        "tags": list,
+        "log_file_list": list,
+        "install_method": str,
+        "node_type": str,
+    }
+    CLIENT_REPORTED_NODE_FIELDS = frozenset(CLIENT_REPORTED_NODE_FIELD_TYPES)
     BASE_CONFIG_HEADER = "# ---- BK-Lite collector base configuration (shared by all monitoring templates) ----\n"
     INSTANCE_CONFIG_HEADER = "# ---- BK-Lite instance collection configurations (per monitoring template) ----\n"
 
@@ -420,6 +419,14 @@ class Sidecar:
         """Keep heartbeat input within fields owned by the Sidecar client."""
         if not isinstance(node_details, dict):
             raise ValidationAppException("node_details must be an object")
+        invalid_fields = [
+            field
+            for field, value in node_details.items()
+            if field in Sidecar.CLIENT_REPORTED_NODE_FIELD_TYPES
+            and not isinstance(value, Sidecar.CLIENT_REPORTED_NODE_FIELD_TYPES[field])
+        ]
+        if invalid_fields or any(not isinstance(tag, str) for tag in node_details.get("tags", [])):
+            raise ValidationAppException("node_details contains invalid field values")
         dropped_fields = set(node_details) - Sidecar.CLIENT_REPORTED_NODE_FIELDS
         if dropped_fields:
             server_fields = sorted(dropped_fields & Sidecar.SERVER_OWNED_NODE_FIELDS)
@@ -503,6 +510,9 @@ class Sidecar:
             response["ETag"] = cached_etag
             return response
 
+        if not node_details.get("operating_system"):
+            raise ValidationAppException("node_details.operating_system is required")
+
         # 从请求体中获取数据
         request_data = dict(
             id=node_id,
@@ -539,7 +549,10 @@ class Sidecar:
         # 补充云区域关联
         clouds = tags_data.get(ControllerConstants.CLOUD_TAG, [])
         if clouds and not node:
-            request_data.update(cloud_region_id=int(clouds[0]))
+            try:
+                request_data.update(cloud_region_id=int(clouds[0]))
+            except (TypeError, ValueError) as exc:
+                raise ValidationAppException("node_details.tags contains an invalid zone") from exc
 
         # 补充安装方法
         install_methods = tags_data.get(ControllerConstants.INSTALL_METHOD_TAG, [])

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -35,6 +35,38 @@ class Sidecar:
     CONVERGE_DEBOUNCE_SECONDS = 5
     CPU_ARCHITECTURE_TAG = "cpu_architecture"
     INSTALL_TASK_NODE_TAG = "install_task_node"
+    CLIENT_REPORTED_NODE_FIELDS = frozenset(
+        {
+            "ip",
+            "operating_system",
+            "cpu_architecture",
+            "architecture",
+            "collector_configuration_directory",
+            "metrics",
+            "status",
+            "tags",
+            "log_file_list",
+            "install_method",
+            "node_type",
+        }
+    )
+    SERVER_OWNED_NODE_FIELDS = frozenset(
+        {
+            "id",
+            "name",
+            "cloud_region",
+            "cloud_region_id",
+            "cmdb_id",
+            "monitor_id",
+            "push_status",
+            "created_at",
+            "updated_at",
+            "created_by",
+            "updated_by",
+            "domain",
+            "updated_by_domain",
+        }
+    )
     BASE_CONFIG_HEADER = "# ---- BK-Lite collector base configuration (shared by all monitoring templates) ----\n"
     INSTANCE_CONFIG_HEADER = "# ---- BK-Lite instance collection configurations (per monitoring template) ----\n"
 
@@ -383,6 +415,21 @@ class Sidecar:
         return updates, request_data.get("ip", "")
 
     @staticmethod
+    def _filter_reported_node_details(node_id: str, node_details: dict) -> dict:
+        """Keep heartbeat input within fields owned by the Sidecar client."""
+        dropped_fields = set(node_details) - Sidecar.CLIENT_REPORTED_NODE_FIELDS
+        if dropped_fields:
+            server_fields = sorted(dropped_fields & Sidecar.SERVER_OWNED_NODE_FIELDS)
+            unknown_field_count = len(dropped_fields - Sidecar.SERVER_OWNED_NODE_FIELDS)
+            logger.warning(
+                "Ignored non-client fields in Sidecar heartbeat node_id=%s server_fields=%s unknown_field_count=%d",
+                node_id,
+                ",".join(server_fields),
+                unknown_field_count,
+            )
+        return {key: value for key, value in node_details.items() if key in Sidecar.CLIENT_REPORTED_NODE_FIELDS}
+
+    @staticmethod
     def _default_collector_priority(collector_cpu_architecture: str, node_cpu_architecture: str) -> int:
         collector_arch = normalize_cpu_architecture(collector_cpu_architecture)
         node_arch = normalize_cpu_architecture(node_cpu_architecture)
@@ -433,6 +480,8 @@ class Sidecar:
     def update_node_client(request, node_id):
         """更新sidecar客户端信息"""
 
+        node_details = Sidecar._filter_reported_node_details(node_id, request.data.get("node_details", {}))
+
         # 获取客户端发送的ETag
         if_none_match = request.headers.get("If-None-Match")
         if if_none_match:
@@ -443,7 +492,6 @@ class Sidecar:
 
         # 如果缓存的ETag存在且与客户端的相同，则返回304 Not Modified
         if cached_etag and cached_etag == if_none_match:
-            node_details = request.data.get("node_details", {})
             updates, node_ip = Sidecar._cached_heartbeat_updates(node_id, node_details)
             Node.objects.filter(id=node_id).update(**updates)
             Sidecar.trigger_converge_tasks_if_needed(node_id, node_ip, updates["status"])
@@ -456,7 +504,7 @@ class Sidecar:
         request_data = dict(
             id=node_id,
             name=request.data.get("node_name", ""),
-            **request.data.get("node_details", {}),
+            **node_details,
         )
 
         # 操作系统转小写
@@ -487,7 +535,7 @@ class Sidecar:
 
         # 补充云区域关联
         clouds = tags_data.get(ControllerConstants.CLOUD_TAG, [])
-        if clouds:
+        if clouds and not node:
             request_data.update(cloud_region_id=int(clouds[0]))
 
         # 补充安装方法

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -8,10 +8,11 @@ from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import Q
 from django.http import HttpResponse
-from apps.core.utils.safe_template import build_sandboxed_env
 
+from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.core.logger import node_logger as logger
 from apps.core.utils.crypto.aes_crypto import AESCryptor
+from apps.core.utils.safe_template import build_sandboxed_env
 from apps.node_mgmt.constants.collector import CollectorConstants
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.database import DatabaseConstants
@@ -417,6 +418,8 @@ class Sidecar:
     @staticmethod
     def _filter_reported_node_details(node_id: str, node_details: dict) -> dict:
         """Keep heartbeat input within fields owned by the Sidecar client."""
+        if not isinstance(node_details, dict):
+            raise ValidationAppException("node_details must be an object")
         dropped_fields = set(node_details) - Sidecar.CLIENT_REPORTED_NODE_FIELDS
         if dropped_fields:
             server_fields = sorted(dropped_fields & Sidecar.SERVER_OWNED_NODE_FIELDS)

--- a/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
@@ -213,3 +213,18 @@ def test_first_sidecar_heartbeat_keeps_zone_registration_compatibility(monkeypat
 def test_sidecar_heartbeat_rejects_non_object_node_details(node_details):
     with pytest.raises(ValidationAppException, match="node_details must be an object"):
         Sidecar.update_node_client(_heartbeat_request("invalid", node_details), "issue-4644-invalid")
+
+
+@pytest.mark.parametrize(
+    ("node_details", "message"),
+    [
+        ({"ip": "10.0.0.1"}, "node_details.operating_system is required"),
+        ({"operating_system": 1}, "node_details contains invalid field values"),
+        ({"operating_system": "Linux", "tags": "zone:1"}, "node_details contains invalid field values"),
+        ({"operating_system": "Linux", "tags": [1]}, "node_details contains invalid field values"),
+        ({"operating_system": "Linux", "tags": ["zone:not-an-id"]}, "node_details.tags contains an invalid zone"),
+    ],
+)
+def test_sidecar_heartbeat_rejects_invalid_client_field_values(node_details, message):
+    with pytest.raises(ValidationAppException, match=message):
+        Sidecar.update_node_client(_heartbeat_request("invalid", node_details), "issue-4644-invalid")

--- a/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
@@ -1,0 +1,210 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from apps.node_mgmt.constants.controller import ControllerConstants
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.models import CloudRegion, Node
+from apps.node_mgmt.services.sidecar import Sidecar
+
+
+def _heartbeat_request(node_name, node_details):
+    return SimpleNamespace(headers={}, META={}, data={"node_name": node_name, "node_details": node_details})
+
+
+def _node_details(region_id, **overrides):
+    details = {
+        "ip": "10.0.0.20",
+        "operating_system": "Linux",
+        "cpu_architecture": NodeConstants.X86_64_ARCH,
+        "collector_configuration_directory": "/opt/fusion-collectors/generated",
+        "metrics": {"cpu": 30},
+        "status": {"status": 0},
+        "tags": [
+            f"zone:{region_id}",
+            f"{ControllerConstants.INSTALL_METHOD_TAG}:{ControllerConstants.MANUAL}",
+            f"{ControllerConstants.NODE_TYPE_TAG}:{ControllerConstants.NODE_TYPE_CONTAINER}",
+        ],
+        "log_file_list": ["/var/log/app.log"],
+    }
+    details.update(overrides)
+    return details
+
+
+@pytest.mark.django_db
+def test_existing_sidecar_heartbeat_preserves_server_owned_fields(monkeypatch, caplog):
+    original_region = CloudRegion.objects.create(name="issue-4644-original")
+    reported_region = CloudRegion.objects.create(name="issue-4644-reported")
+    node = Node.objects.create(
+        id="issue-4644-existing",
+        name="server-owned-name",
+        ip="10.0.0.10",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/etc/collector",
+        metrics={},
+        status={},
+        tags=[],
+        log_file_list=[],
+        cloud_region=original_region,
+        cmdb_id="cmdb-server",
+        monitor_id="monitor-server",
+        push_status={"cmdb": {"state": "ok"}},
+        created_by="server-admin",
+        updated_by="server-admin",
+    )
+    monkeypatch.setattr(Sidecar, "trigger_converge_tasks_if_needed", lambda *args, **kwargs: None)
+    caplog.set_level(logging.WARNING)
+
+    request = _heartbeat_request(
+        "untrusted-name",
+        _node_details(
+            reported_region.id,
+            cloud_region_id=reported_region.id,
+            cmdb_id="cmdb-untrusted",
+            monitor_id="monitor-untrusted",
+            push_status={"monitor": {"state": "done"}},
+            created_by="untrusted-creator",
+            updated_by="untrusted-updater",
+        ),
+    )
+
+    response = Sidecar.update_node_client(request, node.id)
+
+    node.refresh_from_db()
+    assert response.status_code == 202
+    assert node.name == "server-owned-name"
+    assert node.cloud_region_id == original_region.id
+    assert node.cmdb_id == "cmdb-server"
+    assert node.monitor_id == "monitor-server"
+    assert node.push_status == {"cmdb": {"state": "ok"}}
+    assert node.created_by == "server-admin"
+    assert node.updated_by == "server-admin"
+    assert node.ip == "10.0.0.20"
+    assert node.operating_system == NodeConstants.LINUX_OS
+    assert node.collector_configuration_directory == "/opt/fusion-collectors/generated"
+    assert node.metrics == {"cpu": 30}
+    assert node.status == {"status": 0}
+    assert node.tags == [
+        f"zone:{reported_region.id}",
+        f"{ControllerConstants.INSTALL_METHOD_TAG}:{ControllerConstants.MANUAL}",
+        f"{ControllerConstants.NODE_TYPE_TAG}:{ControllerConstants.NODE_TYPE_CONTAINER}",
+    ]
+    assert node.log_file_list == ["/var/log/app.log"]
+    assert node.install_method == ControllerConstants.MANUAL
+    assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER
+    assert "cmdb_id" in caplog.text
+    assert "cmdb-untrusted" not in caplog.text
+
+
+@pytest.mark.django_db
+def test_cached_heartbeat_ignores_server_owned_and_unknown_fields(monkeypatch, caplog):
+    region = CloudRegion.objects.create(name="issue-4644-cached")
+    node = Node.objects.create(
+        id="issue-4644-cached",
+        name="cached-sidecar",
+        ip="10.0.0.10",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=region,
+        cmdb_id="cmdb-server",
+    )
+    monkeypatch.setattr("apps.node_mgmt.services.sidecar.cache.get", lambda _key: "cached-etag")
+    monkeypatch.setattr(Sidecar, "trigger_converge_tasks_if_needed", lambda *args, **kwargs: None)
+    caplog.set_level(logging.WARNING)
+
+    request = _heartbeat_request(
+        node.name,
+        {
+            "ip": "10.0.0.10",
+            "operating_system": "Linux",
+            "status": {"status": 1},
+            "id": "untrusted-node-id",
+            "name": "untrusted-node-name",
+            "cmdb_id": "cmdb-untrusted",
+            "kernel_version": "6.6.0",
+            "forged\nwarning secret-token": "ignored",
+            "x" * 10_000: "ignored",
+        },
+    )
+    request.headers = {"If-None-Match": '"cached-etag"'}
+
+    response = Sidecar.update_node_client(request, node.id)
+
+    node.refresh_from_db()
+    assert response.status_code == 304
+    assert node.cmdb_id == "cmdb-server"
+    assert node.status == {"status": 1}
+    assert "server_fields=cmdb_id,id,name" in caplog.text
+    assert "unknown_field_count=3" in caplog.text
+    assert "cmdb-untrusted" not in caplog.text
+    assert "untrusted-node-id" not in caplog.text
+    assert "untrusted-node-name" not in caplog.text
+    assert "forged" not in caplog.text
+    assert "secret-token" not in caplog.text
+    assert "x" * 100 not in caplog.text
+
+
+@pytest.mark.django_db
+def test_existing_heartbeat_keeps_direct_client_runtime_fields(monkeypatch):
+    region = CloudRegion.objects.create(name="issue-4644-direct-runtime-fields")
+    node = Node.objects.create(
+        id="issue-4644-direct-runtime-fields",
+        name="direct-runtime-fields",
+        ip="10.0.0.10",
+        operating_system=NodeConstants.LINUX_OS,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=region,
+    )
+    monkeypatch.setattr(Sidecar, "trigger_converge_tasks_if_needed", lambda *args, **kwargs: None)
+
+    response = Sidecar.update_node_client(
+        _heartbeat_request(
+            node.name,
+            _node_details(
+                region.id,
+                tags=[],
+                install_method=ControllerConstants.MANUAL,
+                node_type=ControllerConstants.NODE_TYPE_CONTAINER,
+            ),
+        ),
+        node.id,
+    )
+
+    node.refresh_from_db()
+    assert response.status_code == 202
+    assert node.install_method == ControllerConstants.MANUAL
+    assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER
+
+
+@pytest.mark.django_db
+def test_first_sidecar_heartbeat_keeps_zone_registration_compatibility(monkeypatch):
+    region = CloudRegion.objects.create(name="issue-4644-registration")
+    monkeypatch.setattr(Sidecar, "create_default_config", lambda *args, **kwargs: None)
+    monkeypatch.setattr(Sidecar, "trigger_converge_tasks_if_needed", lambda *args, **kwargs: None)
+
+    response = Sidecar.update_node_client(
+        _heartbeat_request(
+            "new-sidecar",
+            _node_details(
+                region.id,
+                cmdb_id="cmdb-untrusted",
+                monitor_id="monitor-untrusted",
+                push_status={"cmdb": {"state": "done"}},
+                created_by="untrusted-creator",
+            ),
+        ),
+        "issue-4644-new",
+    )
+
+    node = Node.objects.get(id="issue-4644-new")
+    assert response.status_code == 202
+    assert node.name == "new-sidecar"
+    assert node.cloud_region_id == region.id
+    assert node.cmdb_id == ""
+    assert node.monitor_id == ""
+    assert node.push_status == {}
+    assert node.created_by == ""
+    assert node.install_method == ControllerConstants.MANUAL
+    assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER

--- a/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py
@@ -3,10 +3,13 @@ from types import SimpleNamespace
 
 import pytest
 
+from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models import CloudRegion, Node
 from apps.node_mgmt.services.sidecar import Sidecar
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 def _heartbeat_request(node_name, node_details):
@@ -32,7 +35,6 @@ def _node_details(region_id, **overrides):
     return details
 
 
-@pytest.mark.django_db
 def test_existing_sidecar_heartbeat_preserves_server_owned_fields(monkeypatch, caplog):
     original_region = CloudRegion.objects.create(name="issue-4644-original")
     reported_region = CloudRegion.objects.create(name="issue-4644-reported")
@@ -98,7 +100,6 @@ def test_existing_sidecar_heartbeat_preserves_server_owned_fields(monkeypatch, c
     assert "cmdb-untrusted" not in caplog.text
 
 
-@pytest.mark.django_db
 def test_cached_heartbeat_ignores_server_owned_and_unknown_fields(monkeypatch, caplog):
     region = CloudRegion.objects.create(name="issue-4644-cached")
     node = Node.objects.create(
@@ -146,7 +147,6 @@ def test_cached_heartbeat_ignores_server_owned_and_unknown_fields(monkeypatch, c
     assert "x" * 100 not in caplog.text
 
 
-@pytest.mark.django_db
 def test_existing_heartbeat_keeps_direct_client_runtime_fields(monkeypatch):
     region = CloudRegion.objects.create(name="issue-4644-direct-runtime-fields")
     node = Node.objects.create(
@@ -178,7 +178,6 @@ def test_existing_heartbeat_keeps_direct_client_runtime_fields(monkeypatch):
     assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER
 
 
-@pytest.mark.django_db
 def test_first_sidecar_heartbeat_keeps_zone_registration_compatibility(monkeypatch):
     region = CloudRegion.objects.create(name="issue-4644-registration")
     monkeypatch.setattr(Sidecar, "create_default_config", lambda *args, **kwargs: None)
@@ -208,3 +207,9 @@ def test_first_sidecar_heartbeat_keeps_zone_registration_compatibility(monkeypat
     assert node.created_by == ""
     assert node.install_method == ControllerConstants.MANUAL
     assert node.node_type == ControllerConstants.NODE_TYPE_CONTAINER
+
+
+@pytest.mark.parametrize("node_details", [None, [], "invalid"])
+def test_sidecar_heartbeat_rejects_non_object_node_details(node_details):
+    with pytest.raises(ValidationAppException, match="node_details must be an object"):
+        Sidecar.update_node_client(_heartbeat_request("invalid", node_details), "issue-4644-invalid")


### PR DESCRIPTION
## 问题

Sidecar 心跳把客户端提交的 `node_details` 直接交给 Node 模型更新，导致已有节点的云区域以及 CMDB、监控、推送状态等服务端字段可能被客户端覆盖。

## 根因与修复

根因是心跳协议字段与 Node 模型字段共用同一字典，但没有显式划分客户端和服务端字段所有权。

- 为心跳协议建立客户端可写字段白名单，未知字段及服务端字段在进入缓存与数据库更新分支前统一过滤。
- 已有节点不再根据客户端 `zone` 改写云区域；首次注册仍保留 `zone` 建立云区域的兼容行为。
- 丢弃字段的审计日志只记录受控服务端字段名和未知字段数量，不记录客户端提交的未知键名或字段值。
- 保留 IP、操作系统、架构、采集目录、运行指标、状态、标签、日志列表、安装方式和节点类型等现有心跳行为。

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Sidecar.update_node_client<br/>services/sidecar.py"]
    end
    subgraph N["核心处理层"]
        N1["客户端字段白名单"]
        N2["缓存心跳或 Node 更新"]
    end
    subgraph A["审计层"]
        A1["受控服务端字段名<br/>未知字段数量"]
    end
    T1 --> N1 --> N2
    N1 -. "丢弃非客户端字段" .-> A1
```

## 兼容性与风险

- 仅收紧 Sidecar 心跳对 Node 服务端事实源的写入范围，不改变认证、接口响应或首次注册流程。
- 已有节点的名称、云区域、跨模块标识和推送状态继续由服务端流程维护。
- 回滚本提交即可恢复原行为，无数据迁移和依赖变更。

## 验证

- `apps/node_mgmt/tests/test_issue_4644_sidecar_field_ownership_service.py`：4 passed
- 上述测试及三个直接关联既有测试文件：175 passed
- Standards、Spec、Runtime Contract 三轨均通过，P0/P1/P2 为 0

Fixes #4644
