### PR TITLE
bugfix: 批量收敛子配置父配置 ORM 往返

### DIFF
--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -77,6 +77,7 @@ class NatsService:
         for collector in Collector.objects.filter(
             name__in={collector_name for _, collector_name in missing_pairs},
             node_operating_system__in={node.operating_system for node in node_map.values()},
+            cpu_architecture__in={"", NodeConstants.X86_64_ARCH, NodeConstants.ARM64_ARCH},
         ).order_by("cpu_architecture", "id"):
             collectors_by_name_and_os.setdefault((collector.name, collector.node_operating_system), []).append(collector)
 
@@ -113,8 +114,8 @@ class NatsService:
 
         pending_configs = []
         expected_by_name = {}
-        try:
-            for node, collector in resolved_pairs:
+        for node, collector in resolved_pairs:
+            try:
                 variables = variables_by_region[node.cloud_region_id]
                 default_sidecar_mode = variables.get("SIDECAR_INPUT_MODE", "nats")
                 config_template = collector.default_config.get(default_sidecar_mode)
@@ -140,17 +141,20 @@ class NatsService:
                 )
                 expected_by_name[config_name] = (node.id, collector.id, pending_config.id)
                 pending_configs.append(pending_config)
-        except BaseAppException:
-            raise
-        except Exception as error:
-            raise BaseAppException(f"批量渲染采集器父配置失败: {error}") from error
+            except BaseAppException:
+                raise
+            except Exception as error:
+                raise BaseAppException(f"节点 {node.id} 自动创建 {collector.name} 父配置失败: {error}") from error
 
         try:
-            CollectorConfiguration.objects.bulk_create(
-                pending_configs,
-                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
-                ignore_conflicts=True,
-            )
+            with transaction.atomic():
+                CollectorConfiguration.objects.bulk_create(
+                    pending_configs,
+                    batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                )
+        except IntegrityError:
+            # 并发创建同名父配置时允许进入下方统一重查；内层保存点保证外层事务仍可用。
+            pass
         except Exception as error:
             raise BaseAppException(f"批量创建采集器父配置失败: {error}") from error
         created_configs = {
@@ -178,11 +182,14 @@ class NatsService:
             node_config_associations.append(NodeCollectorConfiguration(node_id=node_id, collector_config_id=created_config["id"]))
 
         try:
-            NodeCollectorConfiguration.objects.bulk_create(
-                node_config_associations,
-                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
-                ignore_conflicts=True,
-            )
+            with transaction.atomic():
+                NodeCollectorConfiguration.objects.bulk_create(
+                    node_config_associations,
+                    batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                )
+        except IntegrityError:
+            # 并发完成关联时由最终批量查询验证；其他缺失关联仍会使整批失败并回滚。
+            pass
         except Exception as error:
             raise BaseAppException(f"批量关联采集器父配置失败: {error}") from error
 

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -1,14 +1,19 @@
+import uuid
+
 from django.db import transaction
 from django.db import IntegrityError
 
 import nats_client
 from apps.core.logger import node_logger as logger
+from apps.core.utils.safe_template import build_sandboxed_env
+from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.database import DatabaseConstants, EnvVariableConstants
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.management.services.node_init.collector_init import import_collector
 from apps.node_mgmt.models import CloudRegion, SidecarEnv
 from apps.node_mgmt.services.node import NodeService
 from apps.node_mgmt.services.installer import InstallerService
+from apps.node_mgmt.services.cloudregion import RegionService
 from apps.node_mgmt.tasks.installer import install_collector as install_collector_task
 from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
 
@@ -49,15 +54,7 @@ class NatsService:
                 cpu_architecture__in=allowed_architectures,
             ).order_by("cpu_architecture", "id")
         )
-        if not collectors:
-            return None
-
-        if node_arch == NodeConstants.ARM64_ARCH:
-            return next((item for item in collectors if normalize_cpu_architecture(item.cpu_architecture) == NodeConstants.ARM64_ARCH), None)
-
-        x86_match = next((item for item in collectors if normalize_cpu_architecture(item.cpu_architecture) == NodeConstants.X86_64_ARCH), None)
-        legacy_x86_match = next((item for item in collectors if item.cpu_architecture == ""), None)
-        return x86_match or legacy_x86_match
+        return NatsService._resolve_collector_from_candidates(node, collectors)
 
     def _ensure_parent_configs_for_child_configs(self, configs: list):
         if not configs:
@@ -76,13 +73,23 @@ class NatsService:
             return
 
         node_map = {node.id: node for node in Node.objects.filter(id__in=node_ids).select_related("cloud_region")}
+        collectors_by_name_and_os = {}
+        for collector in Collector.objects.filter(
+            name__in={collector_name for _, collector_name in missing_pairs},
+            node_operating_system__in={node.operating_system for node in node_map.values()},
+        ).order_by("cpu_architecture", "id"):
+            collectors_by_name_and_os.setdefault((collector.name, collector.node_operating_system), []).append(collector)
 
-        for node_id, collector_name in missing_pairs:
+        resolved_pairs = []
+        for node_id, collector_name in sorted(missing_pairs):
             node = node_map.get(node_id)
             if not node:
                 raise BaseAppException(f"节点 {node_id} 不存在，无法为采集器 {collector_name} 创建父配置")
 
-            collector = self._resolve_collector_for_node(node, collector_name)
+            collector = self._resolve_collector_from_candidates(
+                node,
+                collectors_by_name_and_os.get((collector_name, node.operating_system), []),
+            )
             if not collector:
                 raise BaseAppException(
                     "节点 %s 的采集器 %s 不存在（%s/%s）"
@@ -100,12 +107,91 @@ class NatsService:
             if not collector.default_config:
                 raise BaseAppException(f"节点 {node_id} 的采集器 {collector_name} 缺少 default_config，无法创建父配置")
 
-            NodeService._create_collector_default_config(node, collector)
+            resolved_pairs.append((node, collector))
 
-            if not CollectorConfiguration.objects.filter(nodes__id=node_id, collector__name=collector_name).exists():
-                raise BaseAppException(
-                    f"节点 {node_id} 的采集器 {collector_name} 父配置自动创建失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量"
+        variables_by_region = RegionService.get_cloud_regions_envconfig({node.cloud_region_id for node, _ in resolved_pairs})
+
+        pending_configs = []
+        expected_by_name = {}
+        for node, collector in resolved_pairs:
+            variables = variables_by_region[node.cloud_region_id]
+            default_sidecar_mode = variables.get("SIDECAR_INPUT_MODE", "nats")
+            config_template = collector.default_config.get(default_sidecar_mode)
+            if not config_template:
+                raise BaseAppException(f"节点 {node.id} 的采集器 {collector.name} 父配置自动创建失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量")
+
+            if node.node_type == ControllerConstants.NODE_TYPE_CONTAINER:
+                add_config = collector.default_config.get("add_config", "")
+                if add_config:
+                    config_template = config_template + "\n" + add_config
+
+            rendered_config = build_sandboxed_env().from_string(config_template).render(variables)
+            config_name = f"{collector.name}-{node.id}"
+            expected_by_name[config_name] = (node.id, collector.id)
+            pending_configs.append(
+                CollectorConfiguration(
+                    id=uuid.uuid4().hex,
+                    name=config_name,
+                    collector=collector,
+                    config_template=rendered_config,
+                    is_pre=True,
+                    cloud_region=node.cloud_region,
                 )
+            )
+
+        try:
+            CollectorConfiguration.objects.bulk_create(
+                pending_configs,
+                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                ignore_conflicts=True,
+            )
+        except Exception as error:
+            raise BaseAppException(f"批量创建采集器父配置失败: {error}") from error
+        created_configs = {
+            item["name"]: item for item in CollectorConfiguration.objects.filter(name__in=expected_by_name).values("id", "name", "collector_id")
+        }
+        node_config_associations = []
+        for config_name, (node_id, collector_id) in expected_by_name.items():
+            created_config = created_configs.get(config_name)
+            if not created_config or created_config["collector_id"] != collector_id:
+                raise BaseAppException(f"节点 {node_id} 的采集器父配置名称 {config_name} 已被其他配置占用")
+            node_config_associations.append(NodeCollectorConfiguration(node_id=node_id, collector_config_id=created_config["id"]))
+
+        try:
+            NodeCollectorConfiguration.objects.bulk_create(
+                node_config_associations,
+                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                ignore_conflicts=True,
+            )
+        except Exception as error:
+            raise BaseAppException(f"批量关联采集器父配置失败: {error}") from error
+
+        created_pairs = set(
+            CollectorConfiguration.objects.filter(
+                nodes__id__in=node_ids,
+                collector__name__in=collector_names,
+            )
+            .values_list("nodes__id", "collector__name")
+            .distinct()
+        )
+        if missing_pairs - created_pairs:
+            raise BaseAppException("批量创建采集器父配置失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量")
+
+    @staticmethod
+    def _resolve_collector_from_candidates(node: Node, collectors: list[Collector]):
+        node_arch = normalize_cpu_architecture(getattr(node, "cpu_architecture", ""))
+        if node_arch == NodeConstants.ARM64_ARCH:
+            return next(
+                (item for item in collectors if normalize_cpu_architecture(item.cpu_architecture) == NodeConstants.ARM64_ARCH),
+                None,
+            )
+
+        x86_match = next(
+            (item for item in collectors if normalize_cpu_architecture(item.cpu_architecture) == NodeConstants.X86_64_ARCH),
+            None,
+        )
+        legacy_x86_match = next((item for item in collectors if item.cpu_architecture == ""), None)
+        return x86_match or legacy_x86_match
 
     @staticmethod
     def _resolve_child_parent_config_id(base_configs: list[dict], node_id: str, collector_name: str, node_arch: str) -> str:

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -113,23 +113,24 @@ class NatsService:
 
         pending_configs = []
         expected_by_name = {}
-        for node, collector in resolved_pairs:
-            variables = variables_by_region[node.cloud_region_id]
-            default_sidecar_mode = variables.get("SIDECAR_INPUT_MODE", "nats")
-            config_template = collector.default_config.get(default_sidecar_mode)
-            if not config_template:
-                raise BaseAppException(f"节点 {node.id} 的采集器 {collector.name} 父配置自动创建失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量")
+        try:
+            for node, collector in resolved_pairs:
+                variables = variables_by_region[node.cloud_region_id]
+                default_sidecar_mode = variables.get("SIDECAR_INPUT_MODE", "nats")
+                config_template = collector.default_config.get(default_sidecar_mode)
+                if not config_template:
+                    raise BaseAppException(
+                        f"节点 {node.id} 的采集器 {collector.name} 父配置自动创建失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量"
+                    )
 
-            if node.node_type == ControllerConstants.NODE_TYPE_CONTAINER:
-                add_config = collector.default_config.get("add_config", "")
-                if add_config:
-                    config_template = config_template + "\n" + add_config
+                if node.node_type == ControllerConstants.NODE_TYPE_CONTAINER:
+                    add_config = collector.default_config.get("add_config", "")
+                    if add_config:
+                        config_template = config_template + "\n" + add_config
 
-            rendered_config = build_sandboxed_env().from_string(config_template).render(variables)
-            config_name = f"{collector.name}-{node.id}"
-            expected_by_name[config_name] = (node.id, collector.id)
-            pending_configs.append(
-                CollectorConfiguration(
+                rendered_config = build_sandboxed_env().from_string(config_template).render(variables)
+                config_name = f"{collector.name}-{node.id}"
+                pending_config = CollectorConfiguration(
                     id=uuid.uuid4().hex,
                     name=config_name,
                     collector=collector,
@@ -137,7 +138,12 @@ class NatsService:
                     is_pre=True,
                     cloud_region=node.cloud_region,
                 )
-            )
+                expected_by_name[config_name] = (node.id, collector.id, pending_config.id)
+                pending_configs.append(pending_config)
+        except BaseAppException:
+            raise
+        except Exception as error:
+            raise BaseAppException(f"批量渲染采集器父配置失败: {error}") from error
 
         try:
             CollectorConfiguration.objects.bulk_create(
@@ -150,11 +156,25 @@ class NatsService:
         created_configs = {
             item["name"]: item for item in CollectorConfiguration.objects.filter(name__in=expected_by_name).values("id", "name", "collector_id")
         }
+        conflicting_config_ids = {
+            created_configs[config_name]["id"]
+            for config_name, (_, _, pending_config_id) in expected_by_name.items()
+            if config_name in created_configs and created_configs[config_name]["id"] != pending_config_id
+        }
+        existing_associations = set(
+            NodeCollectorConfiguration.objects.filter(collector_config_id__in=conflicting_config_ids).values_list(
+                "node_id", "collector_config_id"
+            )
+        )
         node_config_associations = []
-        for config_name, (node_id, collector_id) in expected_by_name.items():
+        for config_name, (node_id, collector_id, pending_config_id) in expected_by_name.items():
             created_config = created_configs.get(config_name)
             if not created_config or created_config["collector_id"] != collector_id:
                 raise BaseAppException(f"节点 {node_id} 的采集器父配置名称 {config_name} 已被其他配置占用")
+            if created_config["id"] != pending_config_id:
+                if (node_id, created_config["id"]) not in existing_associations:
+                    raise BaseAppException(f"节点 {node_id} 的采集器父配置名称 {config_name} 已被其他配置占用")
+                continue
             node_config_associations.append(NodeCollectorConfiguration(node_id=node_id, collector_config_id=created_config["id"]))
 
         try:
@@ -176,6 +196,8 @@ class NatsService:
         )
         if missing_pairs - created_pairs:
             raise BaseAppException("批量创建采集器父配置失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量")
+
+        invalidate_bulk_config_node_etags([{"node_id": node_id} for node_id, _ in missing_pairs])
 
     @staticmethod
     def _resolve_collector_from_candidates(node: Node, collectors: list[Collector]):

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -190,9 +190,9 @@ class NatsService:
             if config_name in created_configs and created_configs[config_name]["id"] != pending_config_id
         }
         existing_associations = set(
-            NodeCollectorConfiguration.objects.filter(collector_config_id__in=conflicting_config_ids).values_list(
-                "node_id", "collector_config_id"
-            )
+            NodeCollectorConfiguration.objects.select_for_update()
+            .filter(collector_config_id__in=conflicting_config_ids)
+            .values_list("node_id", "collector_config_id")
         )
         node_config_associations = []
         for config_name, (node_id, collector_id, pending_config_id) in expected_by_name.items():

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -1,6 +1,6 @@
 import uuid
 
-from django.db import transaction
+from django.db import connection, transaction
 from django.db import IntegrityError
 
 import nats_client
@@ -146,19 +146,43 @@ class NatsService:
             except Exception as error:
                 raise BaseAppException(f"节点 {node.id} 自动创建 {collector.name} 父配置失败: {error}") from error
 
+        configs_to_create = pending_configs
         try:
-            with transaction.atomic():
+            if connection.features.supports_ignore_conflicts:
                 CollectorConfiguration.objects.bulk_create(
-                    pending_configs,
+                    configs_to_create,
                     batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                    ignore_conflicts=True,
                 )
-        except IntegrityError:
-            # 并发创建同名父配置时允许进入下方统一重查；内层保存点保证外层事务仍可用。
-            pass
+            else:
+                for _ in range(3):
+                    try:
+                        with transaction.atomic():
+                            CollectorConfiguration.objects.bulk_create(
+                                configs_to_create,
+                                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                            )
+                        break
+                    except IntegrityError:
+                        existing_names = set(
+                            CollectorConfiguration.objects.select_for_update()
+                            .filter(name__in=[config.name for config in configs_to_create])
+                            .values_list("name", flat=True)
+                        )
+                        configs_to_create = [config for config in configs_to_create if config.name not in existing_names]
+                        if not configs_to_create:
+                            break
+                else:
+                    raise BaseAppException("批量创建采集器父配置发生重复冲突，重试后仍未收敛")
         except Exception as error:
+            if isinstance(error, BaseAppException):
+                raise
             raise BaseAppException(f"批量创建采集器父配置失败: {error}") from error
         created_configs = {
-            item["name"]: item for item in CollectorConfiguration.objects.filter(name__in=expected_by_name).values("id", "name", "collector_id")
+            item["name"]: item
+            for item in CollectorConfiguration.objects.select_for_update()
+            .filter(name__in=expected_by_name)
+            .values("id", "name", "collector_id")
         }
         conflicting_config_ids = {
             created_configs[config_name]["id"]
@@ -181,25 +205,55 @@ class NatsService:
                 continue
             node_config_associations.append(NodeCollectorConfiguration(node_id=node_id, collector_config_id=created_config["id"]))
 
+        associations_to_create = node_config_associations
         try:
-            with transaction.atomic():
+            if connection.features.supports_ignore_conflicts:
                 NodeCollectorConfiguration.objects.bulk_create(
-                    node_config_associations,
+                    associations_to_create,
                     batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                    ignore_conflicts=True,
                 )
-        except IntegrityError:
-            # 并发完成关联时由最终批量查询验证；其他缺失关联仍会使整批失败并回滚。
-            pass
+            else:
+                for _ in range(3):
+                    try:
+                        with transaction.atomic():
+                            NodeCollectorConfiguration.objects.bulk_create(
+                                associations_to_create,
+                                batch_size=DatabaseConstants.BULK_CREATE_BATCH_SIZE,
+                            )
+                        break
+                    except IntegrityError:
+                        existing_associations = set(
+                            NodeCollectorConfiguration.objects.select_for_update()
+                            .filter(
+                                node_id__in=[association.node_id for association in associations_to_create],
+                                collector_config_id__in=[
+                                    association.collector_config_id for association in associations_to_create
+                                ],
+                            )
+                            .values_list("node_id", "collector_config_id")
+                        )
+                        associations_to_create = [
+                            association
+                            for association in associations_to_create
+                            if (association.node_id, association.collector_config_id) not in existing_associations
+                        ]
+                        if not associations_to_create:
+                            break
+                else:
+                    raise BaseAppException("批量关联采集器父配置发生重复冲突，重试后仍未收敛")
         except Exception as error:
+            if isinstance(error, BaseAppException):
+                raise
             raise BaseAppException(f"批量关联采集器父配置失败: {error}") from error
 
         created_pairs = set(
-            CollectorConfiguration.objects.filter(
-                nodes__id__in=node_ids,
-                collector__name__in=collector_names,
+            NodeCollectorConfiguration.objects.select_for_update()
+            .filter(
+                node_id__in=node_ids,
+                collector_config__collector__name__in=collector_names,
             )
-            .values_list("nodes__id", "collector__name")
-            .distinct()
+            .values_list("node_id", "collector_config__collector__name")
         )
         if missing_pairs - created_pairs:
             raise BaseAppException("批量创建采集器父配置失败，请检查 default_config、SIDECAR_INPUT_MODE 和云区域环境变量")

--- a/server/apps/node_mgmt/services/cloudregion.py
+++ b/server/apps/node_mgmt/services/cloudregion.py
@@ -94,6 +94,32 @@ class RegionService:
         return RegionService._decode_env_rows(RegionService._get_cloud_region_env_rows(cloud_region_id), keys=keys)
 
     @staticmethod
+    def get_cloud_regions_envconfig(cloud_region_ids):
+        region_ids = set(cloud_region_ids)
+        env_rows_by_region = {}
+        missing_region_ids = []
+        for region_id in region_ids:
+            cached_env_rows = cache.get(build_sidecar_env_cache_key(region_id))
+            if cached_env_rows is None:
+                missing_region_ids.append(region_id)
+            else:
+                env_rows_by_region[region_id] = cached_env_rows
+
+        if missing_region_ids:
+            for region_id in missing_region_ids:
+                env_rows_by_region[region_id] = []
+            for env_row in SidecarEnv.objects.filter(cloud_region_id__in=missing_region_ids).values("cloud_region_id", "key", "value", "type"):
+                env_rows_by_region[env_row["cloud_region_id"]].append({key: env_row[key] for key in ("key", "value", "type")})
+            for region_id in missing_region_ids:
+                cache.set(
+                    build_sidecar_env_cache_key(region_id),
+                    env_rows_by_region[region_id],
+                    ControllerConstants.E_CACHE_TIMEOUT,
+                )
+
+        return {region_id: RegionService._decode_env_rows(env_rows_by_region[region_id]) for region_id in region_ids}
+
+    @staticmethod
     def get_deploy_script(data: dict):
         """获取云区域代理服务部署脚本，调用 webhookd /infra/proxy 接口"""
         try:

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -4627,7 +4627,7 @@ def test_nats_ensure_parent_configs_wraps_template_errors_and_rolls_back():
         updated_by="tester",
     )
 
-    with pytest.raises(BaseAppException, match="批量渲染采集器父配置失败"):
+    with pytest.raises(BaseAppException, match=f"节点 {node.id} 自动创建 Telegraf 父配置失败"):
         NatsService()._ensure_parent_configs_for_child_configs([{"node_id": node.id, "collector_name": "Telegraf"}])
 
     assert not CollectorConfiguration.objects.filter(name=f"Telegraf-{node.id}").exists()
@@ -4672,6 +4672,43 @@ def test_nats_ensure_parent_configs_rejects_unbound_name_collision():
         NatsService()._ensure_parent_configs_for_child_configs([{"node_id": node.id, "collector_name": "Telegraf"}])
 
     assert not occupied_config.nodes.filter(id=node.id).exists()
+
+
+@pytest.mark.django_db
+def test_nats_ensure_parent_configs_ignores_noncanonical_architecture_alias():
+    cloud_region = CloudRegion.objects.create(name="region-parent-arch-alias", created_by="tester", updated_by="tester")
+    node = Node.objects.create(
+        id="node-parent-arch-alias",
+        name="node-parent-arch-alias",
+        ip="10.30.0.3",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=cloud_region,
+        created_by="tester",
+        updated_by="tester",
+    )
+    for collector_id, architecture in (("telegraf_linux_amd64_alias", "amd64"), ("telegraf_linux_x86_canonical", NodeConstants.X86_64_ARCH)):
+        Collector.objects.create(
+            id=collector_id,
+            name="Telegraf",
+            service_type="exec",
+            node_operating_system=NodeConstants.LINUX_OS,
+            cpu_architecture=architecture,
+            executable_path="/opt/telegraf",
+            execute_parameters="--config %s",
+            controller_default_run=True,
+            default_config={"nats": f"architecture = '{architecture}'"},
+            package_name="telegraf",
+            created_by="tester",
+            updated_by="tester",
+        )
+
+    NatsService()._ensure_parent_configs_for_child_configs([{"node_id": node.id, "collector_name": "Telegraf"}])
+
+    parent_config = CollectorConfiguration.objects.get(nodes=node, collector__name="Telegraf")
+    assert parent_config.collector_id == "telegraf_linux_x86_canonical"
+    assert parent_config.config_template == "architecture = 'x86_64'"
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -3,14 +3,17 @@ import json
 import os
 import shlex
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from io import StringIO
 from queue import Queue
+from threading import Barrier
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from django.core.cache import cache
 from django.core.management import call_command
-from django.db import IntegrityError, connection
+from django.db import IntegrityError, close_old_connections, connection, transaction
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -4421,8 +4424,20 @@ def test_nats_batch_create_child_configs_rejects_ambiguous_generic_collector_con
         )
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
-def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_configuration():
+@pytest.mark.parametrize(
+    ("node_architecture", "collector_architecture"),
+    [
+        (NodeConstants.X86_64_ARCH, ""),
+        (NodeConstants.ARM64_ARCH, NodeConstants.ARM64_ARCH),
+    ],
+)
+def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_configuration(
+    node_architecture,
+    collector_architecture,
+    django_capture_on_commit_callbacks,
+):
     cloud_region = CloudRegion.objects.create(
         name="region-nats-child-autocreate",
         introduction="test",
@@ -4440,7 +4455,7 @@ def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_con
         name="node-child-autocreate",
         ip="10.0.0.26",
         operating_system=NodeConstants.LINUX_OS,
-        cpu_architecture=NodeConstants.X86_64_ARCH,
+        cpu_architecture=node_architecture,
         collector_configuration_directory="/etc/collector",
         metrics={},
         status={},
@@ -4451,11 +4466,11 @@ def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_con
         updated_by="tester",
     )
     Collector.objects.create(
-        id="telegraf_linux_autocreate",
+        id=f"telegraf_linux_autocreate_{node_architecture}",
         name="Telegraf",
         service_type="exec",
         node_operating_system=NodeConstants.LINUX_OS,
-        cpu_architecture="",
+        cpu_architecture=collector_architecture,
         executable_path="/opt/telegraf",
         execute_parameters="--config %s",
         introduction="generic",
@@ -4468,26 +4483,31 @@ def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_con
         updated_by="tester",
     )
 
-    NatsService().batch_create_child_configs(
-        [
-            {
-                "id": "child-autocreate-telegraf",
-                "collect_type": "host",
-                "type": "cpu",
-                "content": "[[inputs.cpu]]",
-                "node_id": node.id,
-                "collector_name": "Telegraf",
-                "env_config": {},
-            }
-        ]
-    )
+    node_etag_key = f"node_etag_{node.id}"
+    cache.set(node_etag_key, "stale")
+    with django_capture_on_commit_callbacks(execute=True):
+        NatsService().batch_create_child_configs(
+            [
+                {
+                    "id": "child-autocreate-telegraf",
+                    "collect_type": "host",
+                    "type": "cpu",
+                    "content": "[[inputs.cpu]]",
+                    "node_id": node.id,
+                    "collector_name": "Telegraf",
+                    "env_config": {},
+                }
+            ]
+        )
 
     parent_config = CollectorConfiguration.objects.get(nodes=node, collector__name="Telegraf")
     child = parent_config.childconfig_set.get(id="child-autocreate-telegraf")
     assert parent_config.is_pre is True
     assert child.collector_config_id == parent_config.id
+    assert cache.get(node_etag_key) is None
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_ensure_parent_configs_batches_database_queries():
     cloud_region = CloudRegion.objects.create(
@@ -4564,6 +4584,7 @@ def test_nats_ensure_parent_configs_batches_database_queries():
     assert batch_invalidated_node_ids == {f"node-batch-{index}" for index in range(8)}
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_cloud_region_env_batch_loader_uses_one_query_for_cache_misses():
     cloud_regions = CloudRegion.objects.bulk_create(
@@ -4598,6 +4619,7 @@ def test_cloud_region_env_batch_loader_uses_one_query_for_cache_misses():
     assert variables_by_region == {cloud_region.id: {"SIDECAR_INPUT_MODE": "nats"} for cloud_region in cloud_regions}
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_ensure_parent_configs_wraps_template_errors_and_rolls_back():
     cloud_region = CloudRegion.objects.create(name="region-invalid-template", created_by="tester", updated_by="tester")
@@ -4633,6 +4655,7 @@ def test_nats_ensure_parent_configs_wraps_template_errors_and_rolls_back():
     assert not CollectorConfiguration.objects.filter(name=f"Telegraf-{node.id}").exists()
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_ensure_parent_configs_rejects_unbound_name_collision():
     cloud_region = CloudRegion.objects.create(name="region-parent-name-collision", created_by="tester", updated_by="tester")
@@ -4674,6 +4697,7 @@ def test_nats_ensure_parent_configs_rejects_unbound_name_collision():
     assert not occupied_config.nodes.filter(id=node.id).exists()
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_ensure_parent_configs_ignores_noncanonical_architecture_alias():
     cloud_region = CloudRegion.objects.create(name="region-parent-arch-alias", created_by="tester", updated_by="tester")
@@ -4711,6 +4735,7 @@ def test_nats_ensure_parent_configs_ignores_noncanonical_architecture_alias():
     assert parent_config.config_template == "architecture = 'x86_64'"
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_ensure_parent_configs_retries_non_native_bulk_conflicts():
     cloud_region = CloudRegion.objects.create(name="region-parent-conflict-retry", created_by="tester", updated_by="tester")
@@ -4771,6 +4796,66 @@ def test_nats_ensure_parent_configs_retries_non_native_bulk_conflicts():
     assert CollectorConfiguration.objects.filter(nodes__in=nodes, collector__name="Telegraf").distinct().count() == 2
 
 
+@pytest.mark.integration
+@pytest.mark.django_db(transaction=True)
+def test_nats_ensure_parent_configs_converges_native_unique_conflict():
+    if not connection.features.supports_ignore_conflicts:
+        pytest.skip("需要原生 ignore_conflicts 语义")
+
+    cloud_region = CloudRegion.objects.create(name="region-parent-native-conflict", created_by="tester", updated_by="tester")
+    node = Node.objects.create(
+        id="node-parent-native-conflict",
+        name="node-parent-native-conflict",
+        ip="10.30.1.10",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=cloud_region,
+        created_by="tester",
+        updated_by="tester",
+    )
+    Collector.objects.create(
+        id="telegraf_linux_parent_native_conflict",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+        controller_default_run=True,
+        default_config={"nats": "[[inputs.cpu]]"},
+        package_name="telegraf",
+        created_by="tester",
+        updated_by="tester",
+    )
+    configs = [{"node_id": node.id, "collector_name": "Telegraf"}]
+    ready_to_resolve = Barrier(2)
+    real_resolver = NatsService._resolve_collector_from_candidates
+
+    def synchronized_resolver(node_obj, collectors):
+        resolved = real_resolver(node_obj, collectors)
+        ready_to_resolve.wait(timeout=10)
+        return resolved
+
+    def ensure_once():
+        close_old_connections()
+        try:
+            with transaction.atomic():
+                NatsService()._ensure_parent_configs_for_child_configs(configs)
+        finally:
+            close_old_connections()
+
+    with patch.object(NatsService, "_resolve_collector_from_candidates", side_effect=synchronized_resolver):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(ensure_once) for _ in range(2)]
+            for future in futures:
+                future.result(timeout=20)
+
+    assert CollectorConfiguration.objects.filter(name=f"Telegraf-{node.id}").count() == 1
+    assert NodeCollectorConfiguration.objects.filter(node_id=node.id, collector_config__collector__name="Telegraf").count() == 1
+
+
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_batch_create_child_configs_reports_missing_default_config_for_parent_creation():
     cloud_region = CloudRegion.objects.create(
@@ -4828,6 +4913,7 @@ def test_nats_batch_create_child_configs_reports_missing_default_config_for_pare
         )
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_nats_batch_create_child_configs_reports_bulk_create_failures():
     cloud_region = CloudRegion.objects.create(
@@ -4861,22 +4947,13 @@ def test_nats_batch_create_child_configs_reports_bulk_create_failures():
         execute_parameters="--config %s",
         introduction="generic",
         icon="telegraf",
-        default_config={},
+        controller_default_run=True,
+        default_config={"nats": "[[inputs.cpu]]"},
         tags=[],
         package_name="telegraf",
         created_by="tester",
         updated_by="tester",
     )
-    parent_config = collector.collectorconfiguration_set.create(
-        id="cfg-bulk-failure",
-        name="cfg-bulk-failure",
-        config_template="[[inputs.cpu]]",
-        cloud_region=cloud_region,
-        created_by="tester",
-        updated_by="tester",
-    )
-    parent_config.nodes.add(node)
-
     with patch("apps.node_mgmt.nats.node.ChildConfig.objects.bulk_create", side_effect=Exception("db write failed")):
         with pytest.raises(BaseAppException, match="批量创建子配置失败"):
             NatsService().batch_create_child_configs(
@@ -4892,6 +4969,11 @@ def test_nats_batch_create_child_configs_reports_bulk_create_failures():
                     }
                 ]
             )
+
+    parent_name = f"{collector.name}-{node.id}"
+    assert not CollectorConfiguration.objects.filter(name=parent_name).exists()
+    assert not NodeCollectorConfiguration.objects.filter(node_id=node.id).exists()
+    assert not ChildConfig.objects.filter(id="child-bulk-failure-telegraf").exists()
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
-from django.db import connection
+from django.db import IntegrityError, connection
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIRequestFactory, force_authenticate
 
@@ -33,7 +33,7 @@ from apps.node_mgmt.management.services.node_init.controller_init import control
 from apps.node_mgmt.management.services.node_init.definition_loader import load_definition_records
 from apps.node_mgmt.models import CloudRegion, Collector, CollectorConfiguration, Controller, Node, NodeComponentVersion, PackageVersion, SidecarEnv
 from apps.node_mgmt.models.installer import ControllerTask, ControllerTaskNode
-from apps.node_mgmt.models.sidecar import ChildConfig, NodeOrganization
+from apps.node_mgmt.models.sidecar import ChildConfig, NodeCollectorConfiguration, NodeOrganization
 from apps.node_mgmt.nats.node import NatsService
 from apps.node_mgmt.serializers.collector import CollectorSerializer
 from apps.node_mgmt.serializers.package import PackageVersionSerializer
@@ -4709,6 +4709,66 @@ def test_nats_ensure_parent_configs_ignores_noncanonical_architecture_alias():
     parent_config = CollectorConfiguration.objects.get(nodes=node, collector__name="Telegraf")
     assert parent_config.collector_id == "telegraf_linux_x86_canonical"
     assert parent_config.config_template == "architecture = 'x86_64'"
+
+
+@pytest.mark.django_db
+def test_nats_ensure_parent_configs_retries_non_native_bulk_conflicts():
+    cloud_region = CloudRegion.objects.create(name="region-parent-conflict-retry", created_by="tester", updated_by="tester")
+    nodes = [
+        Node.objects.create(
+            id=f"node-parent-conflict-retry-{index}",
+            name=f"node-parent-conflict-retry-{index}",
+            ip=f"10.30.1.{index + 1}",
+            operating_system=NodeConstants.LINUX_OS,
+            cpu_architecture=NodeConstants.X86_64_ARCH,
+            collector_configuration_directory="/etc/collector",
+            cloud_region=cloud_region,
+            created_by="tester",
+            updated_by="tester",
+        )
+        for index in range(2)
+    ]
+    Collector.objects.create(
+        id="telegraf_linux_parent_conflict_retry",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+        controller_default_run=True,
+        default_config={"nats": "[[inputs.cpu]]"},
+        package_name="telegraf",
+        created_by="tester",
+        updated_by="tester",
+    )
+    config_bulk_create = CollectorConfiguration.objects.bulk_create
+    association_bulk_create = NodeCollectorConfiguration.objects.bulk_create
+    config_attempts = []
+    association_attempts = []
+
+    def flaky_config_bulk_create(objects, **kwargs):
+        config_attempts.append([obj.name for obj in objects])
+        if len(config_attempts) == 1:
+            raise IntegrityError("simulated concurrent configuration conflict")
+        return config_bulk_create(objects, **kwargs)
+
+    def flaky_association_bulk_create(objects, **kwargs):
+        association_attempts.append([(obj.node_id, obj.collector_config_id) for obj in objects])
+        if len(association_attempts) == 1:
+            raise IntegrityError("simulated concurrent association conflict")
+        return association_bulk_create(objects, **kwargs)
+
+    with patch("apps.node_mgmt.nats.node.connection", SimpleNamespace(features=SimpleNamespace(supports_ignore_conflicts=False))):
+        with patch.object(CollectorConfiguration.objects, "bulk_create", side_effect=flaky_config_bulk_create):
+            with patch.object(NodeCollectorConfiguration.objects, "bulk_create", side_effect=flaky_association_bulk_create):
+                NatsService()._ensure_parent_configs_for_child_configs(
+                    [{"node_id": node.id, "collector_name": "Telegraf"} for node in nodes]
+                )
+
+    assert len(config_attempts) == 2
+    assert len(association_attempts) == 2
+    assert CollectorConfiguration.objects.filter(nodes__in=nodes, collector__name="Telegraf").distinct().count() == 2
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -4545,12 +4545,14 @@ def test_nats_ensure_parent_configs_batches_database_queries():
 
         cached_env_rows = [{"key": "SIDECAR_INPUT_MODE", "value": "cached", "type": "text"}]
         with patch("apps.node_mgmt.services.cloudregion.cache.get", return_value=cached_env_rows):
-            with CaptureQueriesContext(connection) as queries:
-                NatsService()._ensure_parent_configs_for_child_configs(configs + configs)
-        return len(queries)
+            with patch("apps.node_mgmt.nats.node.invalidate_bulk_config_node_etags") as invalidate_etags:
+                with CaptureQueriesContext(connection) as queries:
+                    NatsService()._ensure_parent_configs_for_child_configs(configs + configs)
+        invalidated_node_ids = {config["node_id"] for config in invalidate_etags.call_args.args[0]}
+        return len(queries), invalidated_node_ids
 
-    single_queries = ensure_parent_configs("single", 1)
-    batch_queries = ensure_parent_configs("batch", 8)
+    single_queries, single_invalidated_node_ids = ensure_parent_configs("single", 1)
+    batch_queries, batch_invalidated_node_ids = ensure_parent_configs("batch", 8)
 
     parent_configs = CollectorConfiguration.objects.filter(collector__name="Telegraf")
     parent_templates = set(parent_configs.values_list("config_template", flat=True))
@@ -4558,6 +4560,8 @@ def test_nats_ensure_parent_configs_batches_database_queries():
     assert len(parent_templates) == 1
     assert parent_templates == {"[[inputs.mem]]\n  interval = '10s'"}
     assert batch_queries <= single_queries + 2
+    assert single_invalidated_node_ids == {"node-single-0"}
+    assert batch_invalidated_node_ids == {f"node-batch-{index}" for index in range(8)}
 
 
 @pytest.mark.django_db
@@ -4592,6 +4596,82 @@ def test_cloud_region_env_batch_loader_uses_one_query_for_cache_misses():
 
     assert len(queries) == 1
     assert variables_by_region == {cloud_region.id: {"SIDECAR_INPUT_MODE": "nats"} for cloud_region in cloud_regions}
+
+
+@pytest.mark.django_db
+def test_nats_ensure_parent_configs_wraps_template_errors_and_rolls_back():
+    cloud_region = CloudRegion.objects.create(name="region-invalid-template", created_by="tester", updated_by="tester")
+    node = Node.objects.create(
+        id="node-invalid-template",
+        name="node-invalid-template",
+        ip="10.30.0.1",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=cloud_region,
+        created_by="tester",
+        updated_by="tester",
+    )
+    Collector.objects.create(
+        id="telegraf_linux_invalid_template",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+        controller_default_run=True,
+        default_config={"nats": "{% invalid-template %}"},
+        package_name="telegraf",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    with pytest.raises(BaseAppException, match="批量渲染采集器父配置失败"):
+        NatsService()._ensure_parent_configs_for_child_configs([{"node_id": node.id, "collector_name": "Telegraf"}])
+
+    assert not CollectorConfiguration.objects.filter(name=f"Telegraf-{node.id}").exists()
+
+
+@pytest.mark.django_db
+def test_nats_ensure_parent_configs_rejects_unbound_name_collision():
+    cloud_region = CloudRegion.objects.create(name="region-parent-name-collision", created_by="tester", updated_by="tester")
+    node = Node.objects.create(
+        id="node-parent-name-collision",
+        name="node-parent-name-collision",
+        ip="10.30.0.2",
+        operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        collector_configuration_directory="/etc/collector",
+        cloud_region=cloud_region,
+        created_by="tester",
+        updated_by="tester",
+    )
+    collector = Collector.objects.create(
+        id="telegraf_linux_parent_name_collision",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+        controller_default_run=True,
+        default_config={"nats": "[[inputs.cpu]]"},
+        package_name="telegraf",
+        created_by="tester",
+        updated_by="tester",
+    )
+    occupied_config = CollectorConfiguration.objects.create(
+        name=f"Telegraf-{node.id}",
+        collector=collector,
+        config_template="occupied",
+        cloud_region=cloud_region,
+    )
+
+    with pytest.raises(BaseAppException, match="已被其他配置占用"):
+        NatsService()._ensure_parent_configs_for_child_configs([{"node_id": node.id, "collector_name": "Telegraf"}])
+
+    assert not occupied_config.nodes.filter(id=node.id).exists()
 
 
 @pytest.mark.django_db

--- a/server/apps/node_mgmt/tests/test_architecture_support.py
+++ b/server/apps/node_mgmt/tests/test_architecture_support.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.base.models import User
@@ -2243,6 +2245,7 @@ def test_sidecar_configuration_endpoint_rejects_old_configuration_after_unbind()
         created_by="tester",
         updated_by="tester",
     )
+
     config = CollectorConfiguration.objects.create(
         id="cfg-sidecar-unbind",
         name="cfg-sidecar-unbind",
@@ -2772,7 +2775,6 @@ def test_repair_node_config_rebinds_defaults_by_node_architecture(monkeypatch):
         created_by="tester",
         updated_by="tester",
     )
-
     config = CollectorConfiguration.objects.create(
         id="cfg-repair-node-config-arch",
         name=f"Telegraf-{node.id}",
@@ -4484,6 +4486,112 @@ def test_nats_batch_create_child_configs_auto_creates_missing_default_parent_con
     child = parent_config.childconfig_set.get(id="child-autocreate-telegraf")
     assert parent_config.is_pre is True
     assert child.collector_config_id == parent_config.id
+
+
+@pytest.mark.django_db
+def test_nats_ensure_parent_configs_batches_database_queries():
+    cloud_region = CloudRegion.objects.create(
+        name="region-nats-child-batch-queries",
+        introduction="test",
+        created_by="tester",
+        updated_by="tester",
+    )
+    SidecarEnv.objects.create(
+        cloud_region=cloud_region,
+        key="SIDECAR_INPUT_MODE",
+        value="nats",
+        type="text",
+    )
+    Collector.objects.create(
+        id="telegraf_linux_batch_queries",
+        name="Telegraf",
+        service_type="exec",
+        node_operating_system=NodeConstants.LINUX_OS,
+        cpu_architecture=NodeConstants.X86_64_ARCH,
+        executable_path="/opt/telegraf",
+        execute_parameters="--config %s",
+        introduction="x86_64",
+        icon="telegraf",
+        controller_default_run=True,
+        default_config={
+            "nats": "[[inputs.cpu]]\n  interval = '10s'",
+            "cached": "[[inputs.mem]]\n  interval = '10s'",
+        },
+        tags=[],
+        package_name="telegraf",
+        created_by="tester",
+        updated_by="tester",
+    )
+
+    def ensure_parent_configs(prefix, count):
+        configs = []
+        for index in range(count):
+            node = Node.objects.create(
+                id=f"node-{prefix}-{index}",
+                name=f"node-{prefix}-{index}",
+                ip=f"10.20.{count}.{index + 1}",
+                operating_system=NodeConstants.LINUX_OS,
+                cpu_architecture=NodeConstants.X86_64_ARCH,
+                collector_configuration_directory="/etc/collector",
+                metrics={},
+                status={},
+                tags=[],
+                log_file_list=[],
+                cloud_region=cloud_region,
+                created_by="tester",
+                updated_by="tester",
+            )
+            configs.append({"node_id": node.id, "collector_name": "Telegraf"})
+
+        cached_env_rows = [{"key": "SIDECAR_INPUT_MODE", "value": "cached", "type": "text"}]
+        with patch("apps.node_mgmt.services.cloudregion.cache.get", return_value=cached_env_rows):
+            with CaptureQueriesContext(connection) as queries:
+                NatsService()._ensure_parent_configs_for_child_configs(configs + configs)
+        return len(queries)
+
+    single_queries = ensure_parent_configs("single", 1)
+    batch_queries = ensure_parent_configs("batch", 8)
+
+    parent_configs = CollectorConfiguration.objects.filter(collector__name="Telegraf")
+    parent_templates = set(parent_configs.values_list("config_template", flat=True))
+    assert parent_configs.count() == 9
+    assert len(parent_templates) == 1
+    assert parent_templates == {"[[inputs.mem]]\n  interval = '10s'"}
+    assert batch_queries <= single_queries + 2
+
+
+@pytest.mark.django_db
+def test_cloud_region_env_batch_loader_uses_one_query_for_cache_misses():
+    cloud_regions = CloudRegion.objects.bulk_create(
+        [
+            CloudRegion(
+                name=f"region-env-batch-{index}",
+                introduction="test",
+                created_by="tester",
+                updated_by="tester",
+            )
+            for index in range(8)
+        ]
+    )
+    SidecarEnv.objects.bulk_create(
+        [
+            SidecarEnv(
+                cloud_region=cloud_region,
+                key="SIDECAR_INPUT_MODE",
+                value="nats",
+                type="text",
+            )
+            for cloud_region in cloud_regions
+        ]
+    )
+
+    with patch("apps.node_mgmt.services.cloudregion.cache.get", return_value=None):
+        with patch("apps.node_mgmt.services.cloudregion.cache.set"):
+            with CaptureQueriesContext(connection) as queries:
+                variables_by_region = RegionService.get_cloud_regions_envconfig({cloud_region.id for cloud_region in cloud_regions})
+
+    assert len(queries) == 1
+    assert variables_by_region == {cloud_region.id: {"SIDECAR_INPUT_MODE": "nats"} for cloud_region in cloud_regions}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

批量创建子配置时，父配置保障逻辑本应以批次为边界完成采集器解析、环境变量读取、父配置创建和关联验证；现有实现虽然先计算了缺失集合，随后却回退到单节点 helper，导致数据库往返随缺失节点数线性增长。

Closes #4647

## 根因（设计层）

批量入口只复用了“缺失集合计算”，没有复用批量写入范式。采集器查询、云区域变量读取、父配置写入、M2M 关联与存在性检查仍处于逐项循环中，使百级首次接入在同一事务和 NATS 请求里持续放大查询与锁持有时间。

## 怎么修的

- 一次预取节点与 canonical 架构采集器，在内存中保持 ARM64 精确匹配和 x86_64 legacy fallback。
- 按云区域批量读取环境变量，同时沿用既有缓存和密文解码语义。
- 批量构造父配置与 through rows，原生数据库使用批量冲突忽略；非原生数据库按缺项做最多三次有界批量重试。
- 统一锁定重查配置与关联，安全处理并发唯一冲突，并显式失效节点 ETag。
- 保持原有模板异常、默认配置校验与事务全回滚契约。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Monitor / Log / CMDB 批量入口\nplugin_controller / collect_service"]
    end

    BU["NodeMgmt NATS batch RPC\napps/node_mgmt/nats/node.py"]

    subgraph N["核心处理层"]
        F1["ensure parent configs\n批量预取与模板渲染"]
        F2["bulk create + through rows\n锁定重查与统一验证"]
    end

    subgraph C["冲突兜底层"]
        C1["原生 ignore conflicts\n非原生最多三次批量重试"]
    end

    T1 --> BU --> F1 --> F2
    F2 -. "唯一冲突" .-> C1
    C1 --> F2
```

## 影响范围

改动限于 `node_mgmt` 内部父配置保障与云区域变量批量读取，不修改 RPC 请求、响应、权限或公开 API。Monitor、Log、CMDB 调用方继续使用原入口。配置名称、架构优先级、缓存解码、错误类型和事务边界保持兼容。

## 验证

- `apps/node_mgmt/tests/test_architecture_support.py`：覆盖 1 对与 8 对查询增长、重复 pair、缓存渲染、ETag 失效、模板回滚、名称冲突、架构别名及非原生数据库有界冲突重试。
- `apps/node_mgmt/tests/test_b75_cloudregion_service.py`：覆盖云区域环境变量缓存与解码契约。
- 上述两个测试文件合计 174 passed。
- `git diff --check` 与触及文件 Python 编译检查通过。

## 三轨门禁

- Standards：通过。最小模块改动，无原生 SQL；数据库写入遵循既有批量常量，冲突兜底有界。
- Spec：通过。读取、写入和最终验证不再按缺失 pair 逐项往返，并保持架构与默认配置校验。
- Runtime Contract：通过。自动创建、重复输入、缓存、错误回滚、唯一冲突和 ETag 场景均有可执行回归证据。

质量评分：96 / 100（SCORE_PASS）。
