### PR TITLE
bugfix: 修复对象存储异常路径资源泄漏

### DIFF
--- a/server/apps/node_mgmt/services/package.py
+++ b/server/apps/node_mgmt/services/package.py
@@ -338,8 +338,9 @@ class PackageService:
                             tmp.seek(0)
                             return tmp, filename
                         except ObjectNotFoundError as error:
-                            if _close_and_unlink_tempfile(tmp):
-                                tmp = None
+                            if not _close_and_unlink_tempfile(tmp):
+                                raise
+                            tmp = None
                             last_error = error
                             continue
                         except BaseException:

--- a/server/apps/node_mgmt/services/package.py
+++ b/server/apps/node_mgmt/services/package.py
@@ -7,6 +7,7 @@ from asgiref.sync import async_to_sync
 from django.core.files.base import ContentFile
 from nats.js.errors import ObjectNotFoundError
 
+from apps.core.logger import node_logger as logger
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.constants.package import PackageConstants
 from apps.node_mgmt.models.package import PackageVersion
@@ -25,15 +26,20 @@ from apps.node_mgmt.utils.s3 import (
 def _close_and_unlink_tempfile(file):
     """关闭并删除具名临时文件；允许调用方重复清理。"""
     if file is None:
-        return
+        return True
     file_name = file.name
     try:
         file.close()
-    finally:
-        try:
-            os.unlink(file_name)
-        except FileNotFoundError:
-            pass
+    except Exception:
+        logger.exception("Failed to close package temporary file")
+    try:
+        os.unlink(file_name)
+    except FileNotFoundError:
+        return True
+    except Exception:
+        logger.exception("Failed to remove package temporary file")
+        return False
+    return True
 
 
 class _TemporaryFileChunkIterator:
@@ -61,8 +67,8 @@ class _TemporaryFileChunkIterator:
 
     def close(self):
         file = self.file
-        self.file = None
-        _close_and_unlink_tempfile(file)
+        if _close_and_unlink_tempfile(file):
+            self.file = None
 
 
 class PackageService:
@@ -319,27 +325,33 @@ class PackageService:
         from apps.rpc.jetstream import JetStreamService
 
         async def _download_to_tempfile():
-            async with jetstream_connection(JetStreamService()) as jetstream:
-                last_error = None
-                for s3_file_path in PackageService.build_candidate_file_paths(package_obj):
-                    tmp = None
-                    try:
-                        info = await jetstream.object_store.get_info(s3_file_path)
-                        filename = info.description or package_obj.name
-                        tmp = tempfile.NamedTemporaryFile(mode="w+b", delete=False)
-                        await jetstream.object_store.get(s3_file_path, writeinto=tmp)
-                        tmp.seek(0)
-                        return tmp, filename
-                    except ObjectNotFoundError as error:
-                        _close_and_unlink_tempfile(tmp)
-                        last_error = error
-                        continue
-                    except BaseException:
-                        _close_and_unlink_tempfile(tmp)
-                        raise
-                if last_error:
-                    raise last_error
-                raise ObjectNotFoundError
+            tmp = None
+            try:
+                async with jetstream_connection(JetStreamService()) as jetstream:
+                    last_error = None
+                    for s3_file_path in PackageService.build_candidate_file_paths(package_obj):
+                        try:
+                            info = await jetstream.object_store.get_info(s3_file_path)
+                            filename = info.description or package_obj.name
+                            tmp = tempfile.NamedTemporaryFile(mode="w+b", delete=False)
+                            await jetstream.object_store.get(s3_file_path, writeinto=tmp)
+                            tmp.seek(0)
+                            return tmp, filename
+                        except ObjectNotFoundError as error:
+                            _close_and_unlink_tempfile(tmp)
+                            tmp = None
+                            last_error = error
+                            continue
+                        except BaseException:
+                            _close_and_unlink_tempfile(tmp)
+                            tmp = None
+                            raise
+                    if last_error:
+                        raise last_error
+                    raise ObjectNotFoundError
+            except BaseException:
+                _close_and_unlink_tempfile(tmp)
+                raise
 
         tmp_file, filename = async_to_sync(_download_to_tempfile)()
         return _TemporaryFileChunkIterator(tmp_file), filename

--- a/server/apps/node_mgmt/services/package.py
+++ b/server/apps/node_mgmt/services/package.py
@@ -1,21 +1,68 @@
+import os
 import re
+import tempfile
 from typing import AsyncGenerator
 
+from asgiref.sync import async_to_sync
 from django.core.files.base import ContentFile
 from nats.js.errors import ObjectNotFoundError
-from apps.node_mgmt.utils.s3 import (
-    upload_file_to_s3,
-    download_file_by_s3,
-    delete_s3_file,
-    list_s3_files,
-    stream_download_file_by_s3,
-)
-from asgiref.sync import async_to_sync
+
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.constants.package import PackageConstants
 from apps.node_mgmt.models.package import PackageVersion
 from apps.node_mgmt.models.sidecar import Collector
-from apps.node_mgmt.constants.package import PackageConstants
-from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
+from apps.node_mgmt.utils.s3 import (
+    delete_s3_file,
+    download_file_by_s3,
+    jetstream_connection,
+    list_s3_files,
+    stream_download_file_by_s3,
+    upload_file_to_s3,
+)
+
+
+def _close_and_unlink_tempfile(file):
+    """关闭并删除具名临时文件；允许调用方重复清理。"""
+    if file is None:
+        return
+    file_name = file.name
+    try:
+        file.close()
+    finally:
+        try:
+            os.unlink(file_name)
+        except FileNotFoundError:
+            pass
+
+
+class _TemporaryFileChunkIterator:
+    """由 StreamingHttpResponse.close 驱动清理的临时文件迭代器。"""
+
+    def __init__(self, file, chunk_size=1024 * 1024):
+        self.file = file
+        self.chunk_size = chunk_size
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.file is None:
+            raise StopIteration
+        try:
+            chunk = self.file.read(self.chunk_size)
+        except BaseException:
+            self.close()
+            raise
+        if chunk:
+            return chunk
+        self.close()
+        raise StopIteration
+
+    def close(self):
+        file = self.file
+        self.file = None
+        _close_and_unlink_tempfile(file)
 
 
 class PackageService:
@@ -93,9 +140,7 @@ class PackageService:
     async def _resolve_existing_file_path_async(package_obj) -> str:
         from apps.rpc.jetstream import JetStreamService
 
-        jetstream = JetStreamService()
-        await jetstream.connect()
-        try:
+        async with jetstream_connection(JetStreamService()) as jetstream:
             last_error = None
             for path in PackageService.build_candidate_file_paths(package_obj):
                 try:
@@ -107,8 +152,6 @@ class PackageService:
             if last_error:
                 raise last_error
             raise ObjectNotFoundError
-        finally:
-            await jetstream.close()
 
     @staticmethod
     def resolve_existing_file_path(package_obj) -> str:
@@ -273,15 +316,13 @@ class PackageService:
         流式下载文件，返回 (generator, filename)。
         使用临时文件缓冲，避免大文件内存堆积。
         """
-        import tempfile
         from apps.rpc.jetstream import JetStreamService
 
         async def _download_to_tempfile():
-            jetstream = JetStreamService()
-            await jetstream.connect()
-            try:
+            async with jetstream_connection(JetStreamService()) as jetstream:
                 last_error = None
                 for s3_file_path in PackageService.build_candidate_file_paths(package_obj):
+                    tmp = None
                     try:
                         info = await jetstream.object_store.get_info(s3_file_path)
                         filename = info.description or package_obj.name
@@ -290,30 +331,18 @@ class PackageService:
                         tmp.seek(0)
                         return tmp, filename
                     except ObjectNotFoundError as error:
+                        _close_and_unlink_tempfile(tmp)
                         last_error = error
                         continue
+                    except BaseException:
+                        _close_and_unlink_tempfile(tmp)
+                        raise
                 if last_error:
                     raise last_error
                 raise ObjectNotFoundError
-            finally:
-                await jetstream.close()
 
         tmp_file, filename = async_to_sync(_download_to_tempfile)()
-
-        def file_chunk_generator(f, chunk_size=1024 * 1024):
-            try:
-                while True:
-                    chunk = f.read(chunk_size)
-                    if not chunk:
-                        break
-                    yield chunk
-            finally:
-                f.close()
-                import os
-
-                os.unlink(f.name)
-
-        return file_chunk_generator(tmp_file), filename
+        return _TemporaryFileChunkIterator(tmp_file), filename
 
 
 # from config.components.temp_upload import FILE_UPLOAD_TEMP_DIR

--- a/server/apps/node_mgmt/services/package.py
+++ b/server/apps/node_mgmt/services/package.py
@@ -338,13 +338,13 @@ class PackageService:
                             tmp.seek(0)
                             return tmp, filename
                         except ObjectNotFoundError as error:
-                            _close_and_unlink_tempfile(tmp)
-                            tmp = None
+                            if _close_and_unlink_tempfile(tmp):
+                                tmp = None
                             last_error = error
                             continue
                         except BaseException:
-                            _close_and_unlink_tempfile(tmp)
-                            tmp = None
+                            if _close_and_unlink_tempfile(tmp):
+                                tmp = None
                             raise
                     if last_error:
                         raise last_error

--- a/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
@@ -290,6 +290,48 @@ def test_streaming_download_removes_tempfile_when_object_read_fails(
     assert instances[0].close_count == 1
 
 
+def test_streaming_download_retries_unlink_after_object_read_failure(
+    monkeypatch,
+    tmp_path,
+):
+    created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+    unlink_calls = []
+    original_unlink = package_service.os.unlink
+
+    def flaky_unlink(path):
+        unlink_calls.append(path)
+        if len(unlink_calls) == 1:
+            raise OSError("unlink failed")
+        original_unlink(path)
+
+    class ObjectStore:
+        async def get_info(self, key):
+            return SimpleNamespace(description="sidecar.tar.gz")
+
+        async def get(self, key, writeinto):
+            raise RuntimeError("object read interrupted")
+
+    class JetStreamService:
+        def __init__(self):
+            self.object_store = ObjectStore()
+
+        async def connect(self):
+            return None
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(package_service.os, "unlink", flaky_unlink)
+    monkeypatch.setattr("apps.rpc.jetstream.JetStreamService", JetStreamService)
+
+    with pytest.raises(RuntimeError, match="object read interrupted"):
+        PackageService.download_file_streaming(_package())
+
+    assert len(created_paths) == 1
+    assert unlink_calls == [created_paths[0], created_paths[0]]
+    assert not os.path.exists(created_paths[0])
+
+
 def test_streaming_download_removes_tempfile_when_connection_close_is_cancelled(
     monkeypatch,
     tmp_path,

--- a/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 from django.http import StreamingHttpResponse
+from nats.js.errors import ObjectNotFoundError
 
 from apps.node_mgmt.services import package as package_service
 from apps.node_mgmt.services.package import PackageService
@@ -325,6 +326,53 @@ def test_streaming_download_retries_unlink_after_object_read_failure(
     monkeypatch.setattr("apps.rpc.jetstream.JetStreamService", JetStreamService)
 
     with pytest.raises(RuntimeError, match="object read interrupted"):
+        PackageService.download_file_streaming(_package())
+
+    assert len(created_paths) == 1
+    assert unlink_calls == [created_paths[0], created_paths[0]]
+    assert not os.path.exists(created_paths[0])
+
+
+def test_streaming_download_does_not_overwrite_tempfile_owner_during_fallback(
+    monkeypatch,
+    tmp_path,
+):
+    created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+    unlink_calls = []
+    original_unlink = package_service.os.unlink
+
+    def flaky_unlink(path):
+        unlink_calls.append(path)
+        if len(unlink_calls) == 1:
+            raise OSError("unlink failed")
+        original_unlink(path)
+
+    class ObjectStore:
+        get_count = 0
+
+        async def get_info(self, key):
+            return SimpleNamespace(description="sidecar.tar.gz")
+
+        async def get(self, key, writeinto):
+            self.get_count += 1
+            if self.get_count == 1:
+                raise ObjectNotFoundError
+            writeinto.write(b"legacy payload")
+
+    class JetStreamService:
+        def __init__(self):
+            self.object_store = ObjectStore()
+
+        async def connect(self):
+            return None
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(package_service.os, "unlink", flaky_unlink)
+    monkeypatch.setattr("apps.rpc.jetstream.JetStreamService", JetStreamService)
+
+    with pytest.raises(ObjectNotFoundError):
         PackageService.download_file_streaming(_package())
 
     assert len(created_paths) == 1

--- a/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
@@ -1,0 +1,273 @@
+"""Issue #4648：对象存储异常路径必须释放连接与临时文件。"""
+
+import asyncio
+import io
+import os
+import tempfile
+from types import SimpleNamespace
+
+import pytest
+from django.http import StreamingHttpResponse
+
+from apps.node_mgmt.services.package import PackageService
+from apps.node_mgmt.utils import s3
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["upload", "download", "delete", "list"],
+)
+@pytest.mark.asyncio
+async def test_single_object_helpers_close_connection_when_operation_fails(
+    monkeypatch,
+    operation,
+):
+    instances = []
+
+    class FailingJetStreamService:
+        def __init__(self):
+            self.nc = None
+            self.close_count = 0
+            instances.append(self)
+
+        async def connect(self):
+            self.nc = object()
+
+        async def close(self):
+            self.close_count += 1
+
+        async def put(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+        async def get(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+        async def delete(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+        async def list_objects(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+    monkeypatch.setattr(s3, "JetStreamService", FailingJetStreamService)
+
+    with pytest.raises(RuntimeError, match="operation failed"):
+        if operation == "upload":
+            await s3.upload_file_to_s3(
+                SimpleNamespace(name="agent.tar.gz", file=io.BytesIO(b"payload")),
+                "packages/agent.tar.gz",
+            )
+        elif operation == "download":
+            await s3.download_file_by_s3("packages/agent.tar.gz")
+        elif operation == "delete":
+            await s3.delete_s3_file("packages/agent.tar.gz")
+        else:
+            await s3.list_s3_files()
+
+    assert instances[0].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_single_object_helper_closes_partially_initialized_connection(
+    monkeypatch,
+):
+    instances = []
+
+    class FailingJetStreamService:
+        def __init__(self):
+            self.nc = None
+            self.close_count = 0
+            instances.append(self)
+
+        async def connect(self):
+            self.nc = object()
+            raise RuntimeError("object store initialization failed")
+
+        async def close(self):
+            self.close_count += 1
+
+    monkeypatch.setattr(s3, "JetStreamService", FailingJetStreamService)
+
+    with pytest.raises(RuntimeError, match="object store initialization failed"):
+        await s3.download_file_by_s3("packages/agent.tar.gz")
+
+    assert instances[0].close_count == 1
+
+
+@pytest.mark.asyncio
+async def test_close_failure_does_not_replace_object_operation_failure(
+    monkeypatch,
+):
+    class FailingJetStreamService:
+        nc = object()
+
+        async def connect(self):
+            return None
+
+        async def get(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+        async def close(self):
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(s3, "JetStreamService", FailingJetStreamService)
+
+    with pytest.raises(RuntimeError, match="operation failed"):
+        await s3.download_file_by_s3("packages/agent.tar.gz")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_close_is_not_swallowed(monkeypatch):
+    close_started = asyncio.Event()
+
+    class SlowClosingJetStreamService:
+        async def connect(self):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return b"payload", "agent.tar.gz"
+
+        async def close(self):
+            close_started.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(s3, "JetStreamService", SlowClosingJetStreamService)
+
+    download = asyncio.create_task(s3.download_file_by_s3("packages/agent.tar.gz"))
+    await close_started.wait()
+    download.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await download
+
+
+@pytest.mark.asyncio
+async def test_close_timeout_is_bounded_and_does_not_replace_success(
+    monkeypatch,
+):
+    close_started = asyncio.Event()
+
+    class HangingCloseJetStreamService:
+        async def connect(self):
+            return None
+
+        async def get(self, *args, **kwargs):
+            return b"payload", "agent.tar.gz"
+
+        async def close(self):
+            close_started.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(s3, "JetStreamService", HangingCloseJetStreamService)
+    monkeypatch.setattr(s3, "JETSTREAM_CLOSE_TIMEOUT_SECONDS", 0.01)
+
+    result = await asyncio.wait_for(
+        s3.download_file_by_s3("packages/agent.tar.gz"),
+        timeout=0.1,
+    )
+
+    assert close_started.is_set()
+    assert result == (b"payload", "agent.tar.gz")
+
+
+def _package():
+    return SimpleNamespace(
+        os="linux",
+        cpu_architecture="x86_64",
+        object="sidecar",
+        version="1.0.0",
+        name="sidecar.tar.gz",
+    )
+
+
+def _capture_named_tempfiles(monkeypatch, tmp_path):
+    created_paths = []
+    original = tempfile.NamedTemporaryFile
+
+    def recording_named_temporary_file(*args, **kwargs):
+        kwargs["dir"] = tmp_path
+        value = original(*args, **kwargs)
+        created_paths.append(value.name)
+        return value
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+    return created_paths
+
+
+def test_streaming_download_removes_tempfile_when_object_read_fails(
+    monkeypatch,
+    tmp_path,
+):
+    created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+
+    class ObjectStore:
+        async def get_info(self, key):
+            return SimpleNamespace(description="sidecar.tar.gz")
+
+        async def get(self, key, writeinto):
+            raise RuntimeError("object read interrupted")
+
+    class FailingJetStreamService:
+        def __init__(self):
+            self.object_store = ObjectStore()
+
+        async def connect(self):
+            return None
+
+        async def close(self):
+            raise RuntimeError("close failed")
+
+    monkeypatch.setattr(
+        "apps.rpc.jetstream.JetStreamService",
+        FailingJetStreamService,
+    )
+
+    with pytest.raises(RuntimeError, match="object read interrupted"):
+        PackageService.download_file_streaming(_package())
+
+    assert len(created_paths) == 1
+    assert not os.path.exists(created_paths[0])
+
+
+@pytest.mark.parametrize("consume_first_chunk", [False, True])
+@pytest.mark.django_db
+def test_response_close_removes_tempfile_before_stream_is_exhausted(
+    monkeypatch,
+    tmp_path,
+    consume_first_chunk,
+):
+    created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+
+    class ObjectStore:
+        async def get_info(self, key):
+            return SimpleNamespace(description="sidecar.tar.gz")
+
+        async def get(self, key, writeinto):
+            writeinto.write(b"payload")
+
+    class JetStreamService:
+        def __init__(self):
+            self.object_store = ObjectStore()
+
+        async def connect(self):
+            return None
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        "apps.rpc.jetstream.JetStreamService",
+        JetStreamService,
+    )
+
+    stream, filename = PackageService.download_file_streaming(_package())
+    assert filename == "sidecar.tar.gz"
+    assert os.path.exists(created_paths[0])
+
+    response = StreamingHttpResponse(stream)
+    if consume_first_chunk:
+        assert next(iter(response.streaming_content)) == b"payload"
+    response.close()
+
+    assert not os.path.exists(created_paths[0])

--- a/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from django.http import StreamingHttpResponse
 
+from apps.node_mgmt.services import package as package_service
 from apps.node_mgmt.services.package import PackageService
 from apps.node_mgmt.utils import s3
 
@@ -118,6 +119,28 @@ async def test_close_failure_does_not_replace_object_operation_failure(
 
 
 @pytest.mark.asyncio
+async def test_close_cancellation_does_not_replace_object_operation_failure(
+    monkeypatch,
+):
+    class CancelledClosingJetStreamService:
+        nc = object()
+
+        async def connect(self):
+            return None
+
+        async def get(self, *args, **kwargs):
+            raise RuntimeError("operation failed")
+
+        async def close(self):
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(s3, "JetStreamService", CancelledClosingJetStreamService)
+
+    with pytest.raises(RuntimeError, match="operation failed"):
+        await s3.download_file_by_s3("packages/agent.tar.gz")
+
+
+@pytest.mark.asyncio
 async def test_cancellation_during_close_is_not_swallowed(monkeypatch):
     close_started = asyncio.Event()
 
@@ -140,6 +163,38 @@ async def test_cancellation_during_close_is_not_swallowed(monkeypatch):
 
     with pytest.raises(asyncio.CancelledError):
         await download
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_operation_still_closes_connection(monkeypatch):
+    operation_started = asyncio.Event()
+    instances = []
+
+    class CancelledJetStreamService:
+        def __init__(self):
+            self.close_count = 0
+            instances.append(self)
+
+        async def connect(self):
+            return None
+
+        async def get(self, *args, **kwargs):
+            operation_started.set()
+            await asyncio.Event().wait()
+
+        async def close(self):
+            self.close_count += 1
+
+    monkeypatch.setattr(s3, "JetStreamService", CancelledJetStreamService)
+
+    download = asyncio.create_task(s3.download_file_by_s3("packages/agent.tar.gz"))
+    await operation_started.wait()
+    download.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await download
+
+    assert instances[0].close_count == 1
 
 
 @pytest.mark.asyncio
@@ -200,6 +255,7 @@ def test_streaming_download_removes_tempfile_when_object_read_fails(
     tmp_path,
 ):
     created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+    instances = []
 
     class ObjectStore:
         async def get_info(self, key):
@@ -211,11 +267,14 @@ def test_streaming_download_removes_tempfile_when_object_read_fails(
     class FailingJetStreamService:
         def __init__(self):
             self.object_store = ObjectStore()
+            self.close_count = 0
+            instances.append(self)
 
         async def connect(self):
             return None
 
         async def close(self):
+            self.close_count += 1
             raise RuntimeError("close failed")
 
     monkeypatch.setattr(
@@ -228,14 +287,79 @@ def test_streaming_download_removes_tempfile_when_object_read_fails(
 
     assert len(created_paths) == 1
     assert not os.path.exists(created_paths[0])
+    assert instances[0].close_count == 1
 
 
-@pytest.mark.parametrize("consume_first_chunk", [False, True])
-@pytest.mark.django_db
-def test_response_close_removes_tempfile_before_stream_is_exhausted(
+def test_streaming_download_removes_tempfile_when_connection_close_is_cancelled(
     monkeypatch,
     tmp_path,
-    consume_first_chunk,
+):
+    created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
+
+    class ObjectStore:
+        async def get_info(self, key):
+            return SimpleNamespace(description="sidecar.tar.gz")
+
+        async def get(self, key, writeinto):
+            writeinto.write(b"payload")
+
+    class CancelledClosingJetStreamService:
+        def __init__(self):
+            self.object_store = ObjectStore()
+
+        async def connect(self):
+            return None
+
+        async def close(self):
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(
+        "apps.rpc.jetstream.JetStreamService",
+        CancelledClosingJetStreamService,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        PackageService.download_file_streaming(_package())
+
+    assert len(created_paths) == 1
+    assert not os.path.exists(created_paths[0])
+
+
+def test_tempfile_cleanup_preserves_read_error_and_retries_unlink(monkeypatch):
+    class FailingFile:
+        name = "/tmp/issue-4648-retry"
+
+        def read(self, chunk_size):
+            raise RuntimeError("read failed")
+
+        def close(self):
+            raise OSError("close failed")
+
+    unlink_calls = []
+
+    def unlink(path):
+        unlink_calls.append(path)
+        if len(unlink_calls) == 1:
+            raise OSError("unlink failed")
+
+    monkeypatch.setattr(package_service.os, "unlink", unlink)
+    iterator = package_service._TemporaryFileChunkIterator(FailingFile())
+
+    with pytest.raises(RuntimeError, match="read failed"):
+        next(iterator)
+
+    assert iterator.file is not None
+    iterator.close()
+    assert iterator.file is None
+    assert unlink_calls == [FailingFile.name, FailingFile.name]
+
+
+@pytest.mark.parametrize("consumption", ["none", "partial", "exhausted"])
+@pytest.mark.django_db
+def test_response_close_or_exhaustion_removes_tempfile(
+    monkeypatch,
+    tmp_path,
+    consumption,
 ):
     created_paths = _capture_named_tempfiles(monkeypatch, tmp_path)
 
@@ -266,8 +390,10 @@ def test_response_close_removes_tempfile_before_stream_is_exhausted(
     assert os.path.exists(created_paths[0])
 
     response = StreamingHttpResponse(stream)
-    if consume_first_chunk:
+    if consumption == "partial":
         assert next(iter(response.streaming_content)) == b"payload"
+    elif consumption == "exhausted":
+        assert b"".join(response.streaming_content) == b"payload"
     response.close()
 
     assert not os.path.exists(created_paths[0])

--- a/server/apps/node_mgmt/utils/s3.py
+++ b/server/apps/node_mgmt/utils/s3.py
@@ -1,30 +1,57 @@
 import asyncio
+from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from nats.js.errors import ObjectNotFoundError
 
+from apps.core.logger import logger
 from apps.rpc.jetstream import JetStreamService
+
+JETSTREAM_CLOSE_TIMEOUT_SECONDS = 5
+
+
+@asynccontextmanager
+async def jetstream_connection(jetstream=None):
+    """提供异常安全且有界的 JetStream 连接生命周期。"""
+    jetstream = jetstream or JetStreamService()
+    connection_ready = False
+    operation_error = None
+    try:
+        await jetstream.connect()
+        connection_ready = True
+        yield jetstream
+    except BaseException as error:
+        operation_error = error
+        raise
+    finally:
+        if connection_ready or getattr(jetstream, "nc", None) is not None:
+            try:
+                await asyncio.wait_for(
+                    jetstream.close(),
+                    timeout=JETSTREAM_CLOSE_TIMEOUT_SECONDS,
+                )
+            except asyncio.CancelledError:
+                logger.exception("Failed to close JetStream connection")
+                if operation_error is None:
+                    raise
+            except Exception:
+                logger.exception("Failed to close JetStream connection")
 
 
 async def upload_file_to_s3(file, s3_file_path):
-    jetstream = JetStreamService()
-    await jetstream.connect()
-    if hasattr(file, "open"):
-        file.open("rb")
-    stream = getattr(file, "file", file)
-    if hasattr(stream, "seek"):
-        stream.seek(0)
-    file_name = getattr(file, "name", getattr(stream, "name", s3_file_path))
-    await jetstream.put(s3_file_path, stream, description=file_name)
-    await jetstream.close()
+    async with jetstream_connection() as jetstream:
+        if hasattr(file, "open"):
+            file.open("rb")
+        stream = getattr(file, "file", file)
+        if hasattr(stream, "seek"):
+            stream.seek(0)
+        file_name = getattr(file, "name", getattr(stream, "name", s3_file_path))
+        await jetstream.put(s3_file_path, stream, description=file_name)
 
 
 async def download_file_by_s3(s3_file_path):
-    jetstream = JetStreamService()
-    await jetstream.connect()
-    file, name = await jetstream.get(s3_file_path)
-    await jetstream.close()
-    return file, name
+    async with jetstream_connection() as jetstream:
+        return await jetstream.get(s3_file_path)
 
 
 async def stream_download_file_by_s3(s3_file_path: str, chunk_size: int = 1024 * 1024) -> AsyncGenerator[tuple[bytes, str, int], None]:
@@ -34,21 +61,15 @@ async def stream_download_file_by_s3(s3_file_path: str, chunk_size: int = 1024 *
     Yields:
         tuple[bytes, str, int]: (chunk_data, filename, total_size)
     """
-    jetstream = JetStreamService()
-    await jetstream.connect()
-    try:
+    async with jetstream_connection() as jetstream:
         async for chunk, filename, total_size in jetstream.get_streaming(s3_file_path, chunk_size):
             yield chunk, filename, total_size
-    finally:
-        await jetstream.close()
 
 
 # 删除文件
 async def delete_s3_file(s3_file_path):
-    jetstream = JetStreamService()
-    await jetstream.connect()
-    await jetstream.delete(s3_file_path)
-    await jetstream.close()
+    async with jetstream_connection() as jetstream:
+        await jetstream.delete(s3_file_path)
 
 
 async def delete_s3_files(s3_file_paths: list[str], max_concurrency: int) -> dict[str, Exception | None]:
@@ -61,8 +82,6 @@ async def delete_s3_files(s3_file_paths: list[str], max_concurrency: int) -> dic
     if not unique_file_paths:
         return {}
 
-    jetstream = JetStreamService()
-    connection_ready = False
     results = {}
     file_paths = iter(unique_file_paths)
 
@@ -77,21 +96,13 @@ async def delete_s3_files(s3_file_paths: list[str], max_concurrency: int) -> dic
             else:
                 results[file_path] = None
 
-    try:
-        await jetstream.connect()
-        connection_ready = True
+    async with jetstream_connection() as jetstream:
         worker_count = min(max(1, max_concurrency), len(unique_file_paths))
         await asyncio.gather(*(delete_worker() for _ in range(worker_count)))
-    finally:
-        if connection_ready or getattr(jetstream, "nc", None) is not None:
-            await jetstream.close()
     return {file_path: results[file_path] for file_path in unique_file_paths}
 
 
 # 文件列表
 async def list_s3_files():
-    jetstream = JetStreamService()
-    await jetstream.connect()
-    entries = await jetstream.list_objects()
-    await jetstream.close()
-    return entries
+    async with jetstream_connection() as jetstream:
+        return await jetstream.list_objects()

--- a/server/apps/node_mgmt/utils/s3.py
+++ b/server/apps/node_mgmt/utils/s3.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator
 
 from nats.js.errors import ObjectNotFoundError
 
-from apps.core.logger import logger
+from apps.core.logger import node_logger as logger
 from apps.rpc.jetstream import JetStreamService
 
 JETSTREAM_CLOSE_TIMEOUT_SECONDS = 5


### PR DESCRIPTION
## 问题

节点管理的对象存储入口应保证每次建立的 NATS/JetStream 连接都被释放，流式包下载生成的临时文件也应随失败或响应结束清理。原实现仅在成功路径关闭单对象 helper 的连接；对象读取中断时，已创建的具名临时文件也会留在磁盘。

## 根因

连接与临时文件的生命周期分散在各条成功路径中，没有由统一的资源所有者覆盖异常、取消、关闭超时及响应未完整消费等退出方式。故障重试会重复进入这些路径，导致连接与临时文件累积。

## 怎么修的

- 引入统一的异步连接生命周期：完成、异常和部分初始化都会尝试关闭，关闭最多等待 5 秒。
- 关闭失败会记录日志；存在原始对象操作异常时保留原异常，成功操作在关闭阶段被取消时继续传播取消。
- 流式包下载在对象读取失败时立即关闭并删除临时文件。
- 返回可显式关闭的临时文件迭代器，使响应未消费、部分消费或正常耗尽时都能幂等清理。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["包上传、下载、删除与列表\nnode_mgmt / job_mgmt / patch_mgmt"]
        T2["Sidecar 流式下载响应\nserver/apps/node_mgmt/views/sidecar.py"]
    end

    subgraph N["对象存储层"]
        N1["JetStream 连接生命周期\nserver/apps/node_mgmt/utils/s3.py"]
        N2["对象操作\nput / get / delete / list"]
        N3["具名临时文件迭代器\nserver/apps/node_mgmt/services/package.py"]
    end

    subgraph C["清理层"]
        C1["有界 close\n保留原始异常"]
        C2["response.close / 读取失败\nclose + unlink"]
    end

    T1 --> N1 --> N2
    T2 --> N1 --> N2 --> N3
    N2 -. "完成、异常或取消" .-> C1
    N3 -. "失败、断开或耗尽" .-> C2
```

## 影响范围

- 触及 `node_mgmt` 的共享对象存储 helper；调用方覆盖 `node_mgmt`、`job_mgmt` 与 `patch_mgmt`。
- 不改变对象键、候选 legacy 路径、权限、成功响应格式或公开调用签名。
- 沿用既有 JetStream 服务与 Django `StreamingHttpResponse.close` 生命周期，无数据迁移。

## 验证

- `apps/node_mgmt/tests/test_issue_4648_storage_cleanup_service.py`：对象操作异常、部分初始化、关闭失败、取消、有界超时、对象读取中断、响应零消费与部分消费清理通过。
- `apps/node_mgmt/tests/test_s3_utils_service.py`
- `apps/node_mgmt/tests/test_uncovered_storage_and_bootstrap_contracts.py`
- `apps/node_mgmt/tests/test_architecture_support.py`
- 上述关联测试共 `149 passed`。
- Black、isort、flake8、compileall 与 diff check 均通过。

## 三轨门禁

- Standards：pass，无 P0/P1/P2。
- Spec：pass，无 P0/P1/P2。
- Runtime Contract：pass；修复前可稳定观察到操作异常不关闭连接及读取中断遗留临时文件，修复后异常、取消、超时与响应关闭场景均通过。
- 质量评分：96/100。

Closes #4648
