### PR TITLE
bugfix: 修复控制器任务长密码落库失败

### DIFF
--- a/server/apps/node_mgmt/migrations/0043_alter_controllertasknode_password.py
+++ b/server/apps/node_mgmt/migrations/0043_alter_controllertasknode_password.py
@@ -1,15 +1,34 @@
 from django.db import migrations, models
 
 
+def widen_password_column(apps, schema_editor):
+    controller_task_node = apps.get_model("node_mgmt", "ControllerTaskNode")
+    old_field = controller_task_node._meta.get_field("password")
+    new_field = models.TextField(verbose_name="密码")
+    new_field.set_attributes_from_name("password")
+    new_field.model = controller_task_node
+    schema_editor.alter_field(controller_task_node, old_field, new_field)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("node_mgmt", "0042_controllertasknode_connectivity_observation"),
     ]
 
     operations = [
-        migrations.AlterField(
-            model_name="controllertasknode",
-            name="password",
-            field=models.TextField(verbose_name="密码"),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunPython(
+                    widen_password_column,
+                    reverse_code=migrations.RunPython.noop,
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="controllertasknode",
+                    name="password",
+                    field=models.TextField(verbose_name="密码"),
+                ),
+            ],
         ),
     ]

--- a/server/apps/node_mgmt/migrations/0043_alter_controllertasknode_password.py
+++ b/server/apps/node_mgmt/migrations/0043_alter_controllertasknode_password.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("node_mgmt", "0042_controllertasknode_connectivity_observation"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="controllertasknode",
+            name="password",
+            field=models.TextField(verbose_name="密码"),
+        ),
+    ]

--- a/server/apps/node_mgmt/models/installer.py
+++ b/server/apps/node_mgmt/models/installer.py
@@ -69,7 +69,7 @@ class ControllerTaskNode(models.Model):
     organizations = JSONField(default=list, verbose_name="所属组织")
     port = models.IntegerField(verbose_name="端口")
     username = models.CharField(max_length=100, verbose_name="用户名")
-    password = models.CharField(max_length=100, verbose_name="密码")
+    password = models.TextField(verbose_name="密码")
     private_key = models.TextField(default="", blank=True, verbose_name="SSH私钥")
     passphrase = models.TextField(default="", blank=True, verbose_name="私钥密码短语")
     winrm_scheme = models.CharField(max_length=16, blank=True, default="https", verbose_name="WinRM协议")

--- a/server/apps/node_mgmt/services/installer.py
+++ b/server/apps/node_mgmt/services/installer.py
@@ -1,6 +1,7 @@
 import shlex
 
 from asgiref.sync import async_to_sync
+from django.db import transaction
 from django.db.models import Q
 
 from apps.core.exceptions.base_app_exception import BaseAppException
@@ -188,6 +189,7 @@ class InstallerService:
         return install_command
 
     @staticmethod
+    @transaction.atomic
     def install_controller(
         cloud_region_id,
         work_node,
@@ -268,6 +270,7 @@ class InstallerService:
         return result
 
     @staticmethod
+    @transaction.atomic
     def uninstall_controller(
         cloud_region_id,
         work_node,

--- a/server/apps/node_mgmt/tests/test_b75_installer_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_installer_service.py
@@ -11,7 +11,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from django.db import DataError, models
+from django.db import DataError
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
 
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.utils.crypto.aes_crypto import AESCryptor
@@ -143,6 +145,7 @@ def test_install_controller_creates_task_and_nodes():
     # 密码被加密（不等于明文）
     assert node.password != "secret"
     assert node.password
+    assert AESCryptor().decode(node.password) == "secret"
 
 
 @pytest.mark.django_db
@@ -178,40 +181,90 @@ def test_uninstall_controller_creates_task_and_nodes():
     assert node.node_name == "controller-to-remove"
     assert node.organizations == [1]
     assert node.private_key != "key"
+    assert AESCryptor().decode(node.private_key) == "key"
 
 
 @pytest.mark.django_db
-def test_controller_task_password_storage_accepts_encrypted_long_password():
-    region = CloudRegion.objects.create(name="cr-long-password")
-    plaintext = "p" * 48
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+@pytest.mark.parametrize("plaintext", ["p" * 47, "p" * 48, "p" * 100, "密码" * 48])
+def test_controller_task_password_storage_round_trips_supported_passwords(operation, plaintext):
+    region = CloudRegion.objects.create(name=f"cr-{operation}-{len(plaintext)}")
+    node = {
+        "ip": "10.0.0.48",
+        "node_id": "node-long-password",
+        "node_name": "long-password",
+        "os": "linux",
+        "cpu_architecture": "x86_64",
+        "organizations": [1],
+        "port": 22,
+        "username": "root",
+        "password": plaintext,
+        "private_key": "",
+        "passphrase": "",
+    }
 
-    task_id = InstallerService.install_controller(
-        region.id,
-        "work-long-password",
-        5,
-        [
-            {
-                "ip": "10.0.0.48",
-                "node_id": "node-long-password",
-                "node_name": "long-password",
-                "os": "linux",
-                "cpu_architecture": "x86_64",
-                "organizations": [1],
-                "port": 22,
-                "username": "root",
-                "password": plaintext,
-                "private_key": "",
-                "passphrase": "",
-            }
-        ],
-        "x86_64",
+    if operation == "install":
+        task_id = InstallerService.install_controller(
+            region.id,
+            "work-long-password",
+            5,
+            [node],
+            "x86_64",
+        )
+    else:
+        task_id = InstallerService.uninstall_controller(
+            region.id,
+            "work-long-password",
+            [node],
+        )
+
+    task_node = ControllerTaskNode.objects.get(task_id=task_id)
+    assert AESCryptor().decode(task_node.password) == plaintext
+
+
+@pytest.mark.django_db(transaction=True)
+def test_password_migration_preserves_legacy_and_oversized_data_across_state_rollback():
+    executor = MigrationExecutor(connection)
+    executor.migrate([("node_mgmt", "0042_controllertasknode_connectivity_observation")])
+    legacy_apps = executor.loader.project_state(
+        [("node_mgmt", "0042_controllertasknode_connectivity_observation")]
+    ).apps
+    legacy_region = legacy_apps.get_model("node_mgmt", "CloudRegion").objects.create(name="cr-migration")
+    legacy_task = legacy_apps.get_model("node_mgmt", "ControllerTask").objects.create(
+        cloud_region=legacy_region,
+        type="install",
+        status="waiting",
+    )
+    legacy_node_model = legacy_apps.get_model("node_mgmt", "ControllerTaskNode")
+    legacy_node_model.objects.create(
+        task=legacy_task,
+        ip="10.0.0.52",
+        os="linux",
+        organizations=[1],
+        port=22,
+        username="root",
+        password="legacy-short",
     )
 
-    password_field = ControllerTaskNode._meta.get_field("password")
-    task_node = ControllerTaskNode.objects.get(task_id=task_id)
-    assert isinstance(password_field, models.TextField)
-    assert len(task_node.password) > 100
-    assert AESCryptor().decode(task_node.password) == plaintext
+    executor = MigrationExecutor(connection)
+    executor.migrate([("node_mgmt", "0043_alter_controllertasknode_password")])
+    widened_apps = executor.loader.project_state([("node_mgmt", "0043_alter_controllertasknode_password")]).apps
+    widened_node_model = widened_apps.get_model("node_mgmt", "ControllerTaskNode")
+    task_node = widened_node_model.objects.get(ip="10.0.0.52")
+    assert task_node.password == "legacy-short"
+    task_node.password = "x" * 101
+    task_node.save(update_fields=["password"])
+
+    executor = MigrationExecutor(connection)
+    executor.migrate([("node_mgmt", "0042_controllertasknode_connectivity_observation")])
+    rolled_back_apps = executor.loader.project_state(
+        [("node_mgmt", "0042_controllertasknode_connectivity_observation")]
+    ).apps
+    rolled_back_node = rolled_back_apps.get_model("node_mgmt", "ControllerTaskNode").objects.get(ip="10.0.0.52")
+    assert rolled_back_node.password == "x" * 101
+
+    executor = MigrationExecutor(connection)
+    executor.migrate([("node_mgmt", "0043_alter_controllertasknode_password")])
 
 
 @pytest.mark.django_db
@@ -232,10 +285,16 @@ def test_controller_task_creation_rolls_back_parent_when_node_insert_fails(opera
         "passphrase": "",
     }
 
+    nodes = [node, {**node, "ip": "10.0.0.50", "node_id": "node-rollback-second"}]
+
+    def insert_first_then_fail(objects, *args, **kwargs):
+        objects[0].save()
+        raise DataError("second node insert failed")
+
     with patch.object(
         ControllerTaskNode.objects,
         "bulk_create",
-        side_effect=DataError("value too long for type character varying(100)"),
+        side_effect=insert_first_then_fail,
     ):
         with pytest.raises(DataError):
             if operation == "install":
@@ -243,17 +302,18 @@ def test_controller_task_creation_rolls_back_parent_when_node_insert_fails(opera
                     region.id,
                     "work-rollback",
                     5,
-                    [node],
+                    nodes,
                     "x86_64",
                 )
             else:
                 InstallerService.uninstall_controller(
                     region.id,
                     "work-rollback",
-                    [node],
+                    nodes,
                 )
 
     assert ControllerTask.objects.filter(cloud_region=region).exists() is False
+    assert ControllerTaskNode.objects.filter(ip="10.0.0.49").exists() is False
 
 
 # --------------------------------------------------------------------------- #

--- a/server/apps/node_mgmt/tests/test_b75_installer_service.py
+++ b/server/apps/node_mgmt/tests/test_b75_installer_service.py
@@ -11,8 +11,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from django.db import DataError, models
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models import Node, NodeOrganization, PackageVersion
 from apps.node_mgmt.models.cloud_region import CloudRegion, SidecarEnv
@@ -176,6 +178,82 @@ def test_uninstall_controller_creates_task_and_nodes():
     assert node.node_name == "controller-to-remove"
     assert node.organizations == [1]
     assert node.private_key != "key"
+
+
+@pytest.mark.django_db
+def test_controller_task_password_storage_accepts_encrypted_long_password():
+    region = CloudRegion.objects.create(name="cr-long-password")
+    plaintext = "p" * 48
+
+    task_id = InstallerService.install_controller(
+        region.id,
+        "work-long-password",
+        5,
+        [
+            {
+                "ip": "10.0.0.48",
+                "node_id": "node-long-password",
+                "node_name": "long-password",
+                "os": "linux",
+                "cpu_architecture": "x86_64",
+                "organizations": [1],
+                "port": 22,
+                "username": "root",
+                "password": plaintext,
+                "private_key": "",
+                "passphrase": "",
+            }
+        ],
+        "x86_64",
+    )
+
+    password_field = ControllerTaskNode._meta.get_field("password")
+    task_node = ControllerTaskNode.objects.get(task_id=task_id)
+    assert isinstance(password_field, models.TextField)
+    assert len(task_node.password) > 100
+    assert AESCryptor().decode(task_node.password) == plaintext
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("operation", ["install", "uninstall"])
+def test_controller_task_creation_rolls_back_parent_when_node_insert_fails(operation):
+    region = CloudRegion.objects.create(name=f"cr-{operation}-rollback")
+    node = {
+        "ip": "10.0.0.49",
+        "node_id": "node-rollback",
+        "node_name": "rollback",
+        "os": "linux",
+        "cpu_architecture": "x86_64",
+        "organizations": [1],
+        "port": 22,
+        "username": "root",
+        "password": "secret",
+        "private_key": "",
+        "passphrase": "",
+    }
+
+    with patch.object(
+        ControllerTaskNode.objects,
+        "bulk_create",
+        side_effect=DataError("value too long for type character varying(100)"),
+    ):
+        with pytest.raises(DataError):
+            if operation == "install":
+                InstallerService.install_controller(
+                    region.id,
+                    "work-rollback",
+                    5,
+                    [node],
+                    "x86_64",
+                )
+            else:
+                InstallerService.uninstall_controller(
+                    region.id,
+                    "work-rollback",
+                    [node],
+                )
+
+    assert ControllerTask.objects.filter(cloud_region=region).exists() is False
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## 问题

控制器远程安装和卸载本应完整保存合法登录凭据，并且只在父任务与全部节点任务一起落库后启动执行。现有实现把 AES 密文写入 100 字符字段：48 个 ASCII 字符已会膨胀为 107 字符，节点写入失败时先前创建的父任务仍会保留为永久等待状态。

## 根因（设计层）

凭据入口、加密信封和持久化字段没有共享同一容量契约；同时，父任务与节点任务位于两个独立提交边界。于是合法输入经过加密后可能越过存储上限，而后半段失败无法撤销前半段副作用。

## 怎么修的

- 将控制器任务节点的密码密文字段改为 `TextField`，与同模型的私钥、私钥口令密文存储方式保持一致，不改变明文输入、AES 格式或解密逻辑。
- 将安装、卸载两条父子任务创建链放入同一事务；任一节点写入失败时，父任务同步回滚。
- 保留现有合法输入能力，不新增任意密码长度上限；短密码、私钥认证、重试读取和任务派发契约不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        I["controller_install / controller_uninstall\nviews/installer.py"]
        S["请求校验\nserializers/installer.py"]
    end

    subgraph N["核心处理层"]
        F["install_controller / uninstall_controller\nservices/installer.py"]
        E["AES 凭据加密\naes_crypto.py"]
        DB["父任务 + 节点任务\n同一数据库事务"]
    end

    subgraph C["失败兜底层"]
        R["节点写入失败\n回滚父子任务"]
    end

    I --> S --> F --> E --> DB
    DB -. "写入失败" .-> R
```

## 影响范围与回滚

改动仅位于 `node_mgmt` 的控制器任务模型、安装服务及对应迁移。HTTP 路由、权限、请求/响应、Celery 参数和 Agent 协议均未变化；脚本入口复用同一服务，也获得相同原子性。

应用代码可直接回滚并继续使用已扩展的字段；若未来需要反向执行字段迁移，应先确认没有长度超过 100 的新密文记录，避免把已合法写入的数据重新压回旧上限。

## 验证

- `apps/node_mgmt/tests/test_b75_installer_service.py`：42 passed。
- 回归覆盖 48 字符密码加密后超过 100 字符仍可完整解密，以及安装/卸载节点写入失败时父任务均不存在。
- 迁移状态检查：`No changes detected in app 'node_mgmt'`。
- 测试在回退对应实现时分别命中字段溢出和父任务残留，满足回归测试的 revert-fail 准则。

## 三轨门禁

- Standards：通过；迁移命名、语法、导入顺序和新增 diff 均无新增问题。
- Spec：通过；密文容量与父子事务两个根因均已闭环。
- Runtime Contract：通过；正常短/长凭据、安装/卸载失败回滚、既有读取兼容和真实迁移均已验证。

Closes #4650
