### PR TITLE
bugfix: 为日志正则预览增加可终止边界

### DIFF
--- a/server/apps/log/services/log_extractor/preview_runtime.py
+++ b/server/apps/log/services/log_extractor/preview_runtime.py
@@ -1,0 +1,123 @@
+import json
+import math
+import multiprocessing
+import os
+import threading
+from typing import TYPE_CHECKING, Any
+
+from apps.core.logger import log_logger as logger
+
+if TYPE_CHECKING:
+    from apps.log.services.log_extractor.semantics import ExecutionResult, NormalizedRule
+
+
+def _positive_number_env(name: str, default: int | float, caster):
+    try:
+        value = caster(os.getenv(name, str(default)))
+        valid = math.isfinite(value) and value > 0
+    except (OverflowError, TypeError, ValueError):
+        return default
+    return value if valid else default
+
+
+REGEX_PREVIEW_TIMEOUT_SECONDS = _positive_number_env("LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS", 1.0, float)
+REGEX_PREVIEW_MAX_CONCURRENCY = _positive_number_env("LOG_EXTRACTOR_PREVIEW_MAX_CONCURRENCY", 1, int)
+# Packetbeat HTTP 采集允许 10 MiB 正文；默认边界保留这一存量合法形态，并给事件元数据留出余量。
+REGEX_PREVIEW_MAX_FIELD_BYTES = _positive_number_env("LOG_EXTRACTOR_PREVIEW_MAX_FIELD_BYTES", 10 * 1024 * 1024, int)
+REGEX_PREVIEW_MAX_EVENT_BYTES = _positive_number_env("LOG_EXTRACTOR_PREVIEW_MAX_EVENT_BYTES", 12 * 1024 * 1024, int)
+_REGEX_PREVIEW_SLOTS = threading.BoundedSemaphore(REGEX_PREVIEW_MAX_CONCURRENCY)
+
+
+class RuleExecutionTimeoutError(ValueError):
+    pass
+
+
+class RuleExecutionBusyError(ValueError):
+    pass
+
+
+class RuleExecutionLimitError(ValueError):
+    pass
+
+
+def _ensure_event_within_limits(event: dict[str, Any]) -> None:
+    total_bytes = 0
+    encoder = json.JSONEncoder(ensure_ascii=False, separators=(",", ":"))
+    for chunk in encoder.iterencode(event):
+        chunk_bytes = len(chunk.encode("utf-8"))
+        total_bytes += chunk_bytes
+        if total_bytes > REGEX_PREVIEW_MAX_EVENT_BYTES:
+            raise RuleExecutionLimitError("正则预览事件大小超过上限")
+
+    pending: list[Any] = [event]
+    while pending:
+        value = pending.pop()
+        if isinstance(value, dict):
+            pending.extend(value.keys())
+            pending.extend(value.values())
+        elif isinstance(value, (list, tuple)):
+            pending.extend(value)
+        elif isinstance(value, str) and len(value.encode("utf-8")) > REGEX_PREVIEW_MAX_FIELD_BYTES:
+            raise RuleExecutionLimitError("正则预览字段大小超过上限")
+
+
+def _execute_rules_worker(connection, event: dict[str, Any], rules: list["NormalizedRule"]) -> None:
+    from apps.log.services.log_extractor.semantics import _execute_rules_inline
+
+    try:
+        payload = ("success", _execute_rules_inline(event, rules))
+    except Exception as exc:
+        logger.exception("正则预览子进程执行失败")
+        payload = ("error", type(exc).__name__)
+    try:
+        connection.send(payload)
+    finally:
+        connection.close()
+
+
+def _stop_process(process: multiprocessing.Process) -> None:
+    process.join(timeout=0.1)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=1)
+    if process.is_alive():
+        raise RuntimeError("正则预览执行进程无法回收")
+    process.close()
+
+
+def _execute_rules_isolated(event: dict[str, Any], rules: list["NormalizedRule"], timeout_seconds: float) -> "ExecutionResult":
+    context = multiprocessing.get_context("spawn")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(target=_execute_rules_worker, args=(child_connection, event, rules))
+    started = False
+    try:
+        process.start()
+        started = True
+        child_connection.close()
+        if not parent_connection.poll(timeout_seconds):
+            raise RuleExecutionTimeoutError("正则预览执行超时")
+        try:
+            status, payload = parent_connection.recv()
+        except EOFError as exc:
+            raise RuntimeError("正则预览执行进程意外退出") from exc
+        if status == "error":
+            raise RuntimeError(f"正则预览执行失败: {payload}")
+        return payload
+    finally:
+        parent_connection.close()
+        child_connection.close()
+        if started:
+            _stop_process(process)
+        else:
+            process.close()
+
+
+def execute_regex_preview(event: dict[str, Any], rules: list["NormalizedRule"], *, timeout_seconds: float | None = None) -> "ExecutionResult":
+    _ensure_event_within_limits(event)
+    if not _REGEX_PREVIEW_SLOTS.acquire(blocking=False):
+        raise RuleExecutionBusyError("正则预览并发已达上限，请稍后重试")
+    try:
+        timeout = timeout_seconds or REGEX_PREVIEW_TIMEOUT_SECONDS
+        return _execute_rules_isolated(event, rules, timeout)
+    finally:
+        _REGEX_PREVIEW_SLOTS.release()

--- a/server/apps/log/services/log_extractor/semantics.py
+++ b/server/apps/log/services/log_extractor/semantics.py
@@ -1,12 +1,15 @@
 import copy
 import json
-import math
-import multiprocessing
-import os
 import re
-import threading
 from dataclasses import dataclass
 from typing import Any
+
+from apps.log.services.log_extractor.preview_runtime import (
+    RuleExecutionBusyError,
+    RuleExecutionLimitError,
+    RuleExecutionTimeoutError,
+    execute_regex_preview,
+)
 
 PROTECTED_FIELDS = {"instance_id", "source_type", "timestamp", "_msg", "log_message", "raw_message", "trap_message"}
 EXTRACTOR_TYPES = {"copy", "split", "kv", "regex", "regex_replace", "json"}
@@ -16,36 +19,7 @@ _MISSING = object()
 _REGEX_EXTRACTOR_TYPES = {"regex", "regex_replace"}
 
 
-def _positive_float_env(name: str, default: float) -> float:
-    try:
-        value = float(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-    return value if math.isfinite(value) and value > 0 else default
-
-
-def _positive_int_env(name: str, default: int) -> int:
-    try:
-        value = int(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-    return value if value > 0 else default
-
-
-REGEX_PREVIEW_TIMEOUT_SECONDS = _positive_float_env("LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS", 1.0)
-REGEX_PREVIEW_MAX_CONCURRENCY = _positive_int_env("LOG_EXTRACTOR_PREVIEW_MAX_CONCURRENCY", 1)
-_REGEX_PREVIEW_SLOTS = threading.BoundedSemaphore(REGEX_PREVIEW_MAX_CONCURRENCY)
-
-
 class RuleValidationError(ValueError):
-    pass
-
-
-class RuleExecutionTimeoutError(ValueError):
-    pass
-
-
-class RuleExecutionBusyError(ValueError):
     pass
 
 
@@ -486,57 +460,7 @@ def _execute_rules_inline(event: dict[str, Any], rules: list[NormalizedRule]) ->
     return ExecutionResult(event=current, results=results)
 
 
-def _execute_rules_worker(connection, event: dict[str, Any], rules: list[NormalizedRule]) -> None:
-    try:
-        payload = ("success", _execute_rules_inline(event, rules))
-    except Exception as exc:  # pragma: no cover - parent converts unexpected child failures into a stable error
-        payload = ("error", (type(exc).__name__, str(exc)))
-    try:
-        connection.send(payload)
-    finally:
-        connection.close()
-
-
-def _stop_process(process: multiprocessing.Process) -> None:
-    process.join(timeout=0.1)
-    if process.is_alive():
-        process.kill()
-        process.join()
-    process.close()
-
-
-def _execute_rules_isolated(event: dict[str, Any], rules: list[NormalizedRule], timeout_seconds: float) -> ExecutionResult:
-    context = multiprocessing.get_context("spawn")
-    parent_connection, child_connection = context.Pipe(duplex=False)
-    process = context.Process(target=_execute_rules_worker, args=(child_connection, event, rules))
-    started = False
-    try:
-        process.start()
-        started = True
-        child_connection.close()
-        if not parent_connection.poll(timeout_seconds):
-            raise RuleExecutionTimeoutError("正则预览执行超时")
-        try:
-            status, payload = parent_connection.recv()
-        except EOFError as exc:
-            raise RuntimeError("正则预览执行进程意外退出") from exc
-        if status == "error":
-            error_type, message = payload
-            raise RuntimeError(f"正则预览执行失败: {error_type}: {message}")
-        return payload
-    finally:
-        parent_connection.close()
-        child_connection.close()
-        if started:
-            _stop_process(process)
-
-
 def execute_rules(event: dict[str, Any], rules: list[NormalizedRule], *, timeout_seconds: float | None = None) -> ExecutionResult:
     if not any(rule.extractor_type in _REGEX_EXTRACTOR_TYPES for rule in rules):
         return _execute_rules_inline(event, rules)
-    if not _REGEX_PREVIEW_SLOTS.acquire(blocking=False):
-        raise RuleExecutionBusyError("正则预览并发已达上限，请稍后重试")
-    try:
-        return _execute_rules_isolated(event, rules, timeout_seconds or REGEX_PREVIEW_TIMEOUT_SECONDS)
-    finally:
-        _REGEX_PREVIEW_SLOTS.release()
+    return execute_regex_preview(event, rules, timeout_seconds=timeout_seconds)

--- a/server/apps/log/services/log_extractor/semantics.py
+++ b/server/apps/log/services/log_extractor/semantics.py
@@ -1,6 +1,10 @@
 import copy
 import json
+import math
+import multiprocessing
+import os
 import re
+import threading
 from dataclasses import dataclass
 from typing import Any
 
@@ -9,9 +13,39 @@ EXTRACTOR_TYPES = {"copy", "split", "kv", "regex", "regex_replace", "json"}
 CONDITION_OPERATORS = {"==", "!=", "contains", "!contains", "startswith", "endswith", "exists", "!exists"}
 _SIMPLE_SEGMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 _MISSING = object()
+_REGEX_EXTRACTOR_TYPES = {"regex", "regex_replace"}
+
+
+def _positive_float_env(name: str, default: float) -> float:
+    try:
+        value = float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) and value > 0 else default
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+REGEX_PREVIEW_TIMEOUT_SECONDS = _positive_float_env("LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS", 1.0)
+REGEX_PREVIEW_MAX_CONCURRENCY = _positive_int_env("LOG_EXTRACTOR_PREVIEW_MAX_CONCURRENCY", 1)
+_REGEX_PREVIEW_SLOTS = threading.BoundedSemaphore(REGEX_PREVIEW_MAX_CONCURRENCY)
 
 
 class RuleValidationError(ValueError):
+    pass
+
+
+class RuleExecutionTimeoutError(ValueError):
+    pass
+
+
+class RuleExecutionBusyError(ValueError):
     pass
 
 
@@ -426,7 +460,7 @@ def _execute_action(event: dict[str, Any], rule: NormalizedRule, source: Any) ->
     return True
 
 
-def execute_rules(event: dict[str, Any], rules: list[NormalizedRule]) -> ExecutionResult:
+def _execute_rules_inline(event: dict[str, Any], rules: list[NormalizedRule]) -> ExecutionResult:
     current = copy.deepcopy(event)
     results: list[RuleExecutionResult] = []
     for rule in rules:
@@ -450,3 +484,59 @@ def execute_rules(event: dict[str, Any], rules: list[NormalizedRule]) -> Executi
             _delete(current, rule.source_path)
         results.append(RuleExecutionResult("success"))
     return ExecutionResult(event=current, results=results)
+
+
+def _execute_rules_worker(connection, event: dict[str, Any], rules: list[NormalizedRule]) -> None:
+    try:
+        payload = ("success", _execute_rules_inline(event, rules))
+    except Exception as exc:  # pragma: no cover - parent converts unexpected child failures into a stable error
+        payload = ("error", (type(exc).__name__, str(exc)))
+    try:
+        connection.send(payload)
+    finally:
+        connection.close()
+
+
+def _stop_process(process: multiprocessing.Process) -> None:
+    process.join(timeout=0.1)
+    if process.is_alive():
+        process.kill()
+        process.join()
+    process.close()
+
+
+def _execute_rules_isolated(event: dict[str, Any], rules: list[NormalizedRule], timeout_seconds: float) -> ExecutionResult:
+    context = multiprocessing.get_context("spawn")
+    parent_connection, child_connection = context.Pipe(duplex=False)
+    process = context.Process(target=_execute_rules_worker, args=(child_connection, event, rules))
+    started = False
+    try:
+        process.start()
+        started = True
+        child_connection.close()
+        if not parent_connection.poll(timeout_seconds):
+            raise RuleExecutionTimeoutError("正则预览执行超时")
+        try:
+            status, payload = parent_connection.recv()
+        except EOFError as exc:
+            raise RuntimeError("正则预览执行进程意外退出") from exc
+        if status == "error":
+            error_type, message = payload
+            raise RuntimeError(f"正则预览执行失败: {error_type}: {message}")
+        return payload
+    finally:
+        parent_connection.close()
+        child_connection.close()
+        if started:
+            _stop_process(process)
+
+
+def execute_rules(event: dict[str, Any], rules: list[NormalizedRule], *, timeout_seconds: float | None = None) -> ExecutionResult:
+    if not any(rule.extractor_type in _REGEX_EXTRACTOR_TYPES for rule in rules):
+        return _execute_rules_inline(event, rules)
+    if not _REGEX_PREVIEW_SLOTS.acquire(blocking=False):
+        raise RuleExecutionBusyError("正则预览并发已达上限，请稍后重试")
+    try:
+        return _execute_rules_isolated(event, rules, timeout_seconds or REGEX_PREVIEW_TIMEOUT_SECONDS)
+    finally:
+        _REGEX_PREVIEW_SLOTS.release()

--- a/server/apps/log/tests/test_log_extractor_preview_runtime_service.py
+++ b/server/apps/log/tests/test_log_extractor_preview_runtime_service.py
@@ -1,0 +1,264 @@
+import os
+import subprocess
+import sys
+import threading
+
+import pytest
+
+from apps.log.services.log_extractor import preview_runtime
+from apps.log.services.log_extractor import semantics
+from apps.log.services.log_extractor.semantics import execute_rules, normalize_rule
+
+
+def _regex_rule():
+    return normalize_rule(
+        {
+            "extractor_type": "regex_replace",
+            "source_field": "message",
+            "target_field": "result",
+            "condition": {},
+            "config": {"pattern": "a+$", "replacement": "masked"},
+            "delete_source": False,
+        }
+    )
+
+
+@pytest.mark.unit
+def test_extreme_integer_environment_value_falls_back_without_import_failure(monkeypatch):
+    monkeypatch.setenv("LOG_EXTRACTOR_PREVIEW_TEST_LIMIT", "9" * 10_000)
+
+    assert preview_runtime._positive_number_env("LOG_EXTRACTOR_PREVIEW_TEST_LIMIT", 7, int) == 7
+
+
+@pytest.mark.integration
+def test_regex_preview_terminates_catastrophic_backtracking():
+    probe = """
+from apps.log.services.log_extractor.semantics import execute_rules, normalize_rule
+
+rule = normalize_rule(
+    {
+        "extractor_type": "regex_replace",
+        "source_field": "message",
+        "target_field": "result",
+        "condition": {},
+        "config": {"pattern": "(a+)+$", "replacement": "masked"},
+        "delete_source": False,
+    }
+)
+try:
+    execute_rules({"message": "a" * 27 + "!"}, [rule])
+except ValueError as exc:
+    print(f"{type(exc).__name__}:{exc}")
+"""
+    env = {**os.environ, "LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS": "0.1"}
+
+    try:
+        completed = subprocess.run([sys.executable, "-c", probe], check=True, capture_output=True, text=True, timeout=3, env=env)
+    except subprocess.TimeoutExpired:
+        pytest.fail("灾难性回溯未被预览超时终止")
+
+    assert completed.stdout.strip() == "RuleExecutionTimeoutError:正则预览执行超时"
+
+
+@pytest.mark.unit
+def test_regex_preview_rejects_work_when_local_capacity_is_exhausted(monkeypatch):
+    slots = threading.BoundedSemaphore(1)
+    slots.acquire()
+    monkeypatch.setattr(preview_runtime, "_REGEX_PREVIEW_SLOTS", slots)
+
+    with pytest.raises(preview_runtime.RuleExecutionBusyError, match="并发已达上限"):
+        execute_rules({"message": "aaaa"}, [_regex_rule()])
+
+    slots.release()
+
+
+@pytest.mark.unit
+def test_regex_preview_rejects_oversized_field_before_starting_process(monkeypatch):
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_MAX_FIELD_BYTES", 3)
+    started = False
+
+    def unexpected_start(*args, **kwargs):
+        nonlocal started
+        started = True
+
+    monkeypatch.setattr(preview_runtime, "_execute_rules_isolated", unexpected_start)
+
+    with pytest.raises(preview_runtime.RuleExecutionLimitError, match="字段大小超过上限"):
+        execute_rules({"message": "aaaa"}, [_regex_rule()])
+
+    assert started is False
+
+
+@pytest.mark.unit
+def test_regex_preview_rejects_oversized_event_before_starting_process(monkeypatch):
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_MAX_FIELD_BYTES", 100)
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_MAX_EVENT_BYTES", 10)
+    started = False
+
+    def unexpected_start(*args, **kwargs):
+        nonlocal started
+        started = True
+
+    monkeypatch.setattr(preview_runtime, "_execute_rules_isolated", unexpected_start)
+
+    with pytest.raises(preview_runtime.RuleExecutionLimitError, match="事件大小超过上限"):
+        execute_rules({"message": "aaaa"}, [_regex_rule()])
+
+    assert started is False
+
+
+@pytest.mark.unit
+def test_non_regex_preview_preserves_legacy_path_without_regex_size_limit(monkeypatch):
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_MAX_FIELD_BYTES", 3)
+    rule = normalize_rule(
+        {
+            "extractor_type": "copy",
+            "source_field": "message",
+            "target_field": "result",
+            "condition": {},
+            "config": {},
+            "delete_source": False,
+        }
+    )
+
+    result = execute_rules({"message": "a" * 100}, [rule])
+
+    assert result.event["result"] == "a" * 100
+
+
+@pytest.mark.unit
+def test_regex_preview_releases_capacity_after_worker_failure(monkeypatch):
+    slots = threading.BoundedSemaphore(1)
+    monkeypatch.setattr(preview_runtime, "_REGEX_PREVIEW_SLOTS", slots)
+
+    def fail_worker(*args, **kwargs):
+        raise RuntimeError("worker failed")
+
+    monkeypatch.setattr(preview_runtime, "_execute_rules_isolated", fail_worker)
+
+    with pytest.raises(RuntimeError, match="worker failed"):
+        execute_rules({"message": "aaaa"}, [_regex_rule()])
+
+    assert slots.acquire(blocking=False) is True
+    slots.release()
+
+
+class _FakeConnection:
+    def __init__(self, *, poll_result: bool, eof: bool = False):
+        self.poll_result = poll_result
+        self.eof = eof
+        self.closed = False
+        self.sent = None
+
+    def poll(self, timeout):
+        return self.poll_result
+
+    def recv(self):
+        if self.eof:
+            raise EOFError
+        return "success", None
+
+    def send(self, payload):
+        self.sent = payload
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeProcess:
+    def __init__(self):
+        self.alive = True
+        self.started = False
+        self.killed = False
+        self.closed = False
+        self.join_timeouts = []
+
+    def start(self):
+        self.started = True
+
+    def join(self, timeout=None):
+        self.join_timeouts.append(timeout)
+        if self.killed:
+            self.alive = False
+
+    def is_alive(self):
+        return self.alive
+
+    def kill(self):
+        self.killed = True
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("poll_result", "eof", "error"), [(False, False, ValueError), (True, True, RuntimeError)])
+def test_isolated_preview_reaps_process_on_timeout_or_eof(monkeypatch, poll_result, eof, error):
+    parent = _FakeConnection(poll_result=poll_result, eof=eof)
+    child = _FakeConnection(poll_result=False)
+    process = _FakeProcess()
+
+    class FakeContext:
+        @staticmethod
+        def Pipe(duplex):
+            return parent, child
+
+        @staticmethod
+        def Process(target, args):
+            return process
+
+    monkeypatch.setattr(preview_runtime.multiprocessing, "get_context", lambda method: FakeContext())
+
+    with pytest.raises(error):
+        preview_runtime._execute_rules_isolated({"message": "aaaa"}, [_regex_rule()], 0.01)
+
+    assert process.started and process.killed and process.closed
+    assert process.join_timeouts == [0.1, 1]
+    assert parent.closed and child.closed
+
+
+@pytest.mark.unit
+def test_isolated_preview_closes_process_handle_when_start_fails(monkeypatch):
+    parent = _FakeConnection(poll_result=False)
+    child = _FakeConnection(poll_result=False)
+    process = _FakeProcess()
+
+    def fail_start():
+        raise RuntimeError("spawn failed")
+
+    process.start = fail_start
+
+    class FakeContext:
+        @staticmethod
+        def Pipe(duplex):
+            return parent, child
+
+        @staticmethod
+        def Process(target, args):
+            return process
+
+    monkeypatch.setattr(preview_runtime.multiprocessing, "get_context", lambda method: FakeContext())
+
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        preview_runtime._execute_rules_isolated({"message": "aaaa"}, [_regex_rule()], 0.01)
+
+    assert process.closed is True
+    assert parent.closed and child.closed
+
+
+@pytest.mark.unit
+def test_worker_reports_unexpected_failure_type_and_logs_traceback(monkeypatch, caplog):
+    connection = _FakeConnection(poll_result=False)
+
+    def fail_inline(event, rules):
+        raise RuntimeError("unexpected worker failure")
+
+    monkeypatch.setattr(semantics, "_execute_rules_inline", fail_inline)
+
+    with caplog.at_level("ERROR", logger="log"):
+        preview_runtime._execute_rules_worker(connection, {"message": "safe"}, [_regex_rule()])
+
+    assert connection.sent == ("error", "RuntimeError")
+    assert connection.closed is True
+    assert "正则预览子进程执行失败" in caplog.text
+    assert "unexpected worker failure" in caplog.text

--- a/server/apps/log/tests/test_log_extractor_semantics_pure.py
+++ b/server/apps/log/tests/test_log_extractor_semantics_pure.py
@@ -1,5 +1,11 @@
+import os
+import subprocess
+import sys
+import threading
+
 import pytest
 
+from apps.log.services.log_extractor import semantics
 from apps.log.services.log_extractor.semantics import RuleValidationError, execute_rules, normalize_rule
 
 
@@ -150,6 +156,65 @@ def test_regex_rejects_python_constructs_unsupported_by_vector_048(pattern):
                 "delete_source": False,
             }
         )
+
+
+@pytest.mark.integration
+def test_regex_preview_terminates_catastrophic_backtracking():
+    probe = """
+from apps.log.services.log_extractor.semantics import execute_rules, normalize_rule
+
+rule = normalize_rule(
+    {
+        "extractor_type": "regex_replace",
+        "source_field": "message",
+        "target_field": "result",
+        "condition": {},
+        "config": {"pattern": "(a+)+$", "replacement": "masked"},
+        "delete_source": False,
+    }
+)
+try:
+    execute_rules({"message": "a" * 27 + "!"}, [rule])
+except ValueError as exc:
+    print(f"{type(exc).__name__}:{exc}")
+"""
+    env = {**os.environ, "LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS": "0.1"}
+
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-c", probe],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3,
+            env=env,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail("灾难性回溯未被预览超时终止")
+
+    assert completed.stdout.strip() == "RuleExecutionTimeoutError:正则预览执行超时"
+
+
+@pytest.mark.unit
+def test_regex_preview_rejects_work_when_local_capacity_is_exhausted(monkeypatch):
+    slots = threading.BoundedSemaphore(1)
+    slots.acquire()
+    monkeypatch.setattr(semantics, "_REGEX_PREVIEW_SLOTS", slots)
+    rule = normalize_rule(
+        {
+            "extractor_type": "regex_replace",
+            "source_field": "message",
+            "target_field": "result",
+            "condition": {},
+            "config": {"pattern": "a+$", "replacement": "masked"},
+            "delete_source": False,
+        }
+    )
+
+    with pytest.raises(semantics.RuleExecutionBusyError, match="并发已达上限"):
+        execute_rules({"message": "aaaa"}, [rule])
+
+    slots.release()
 
 
 @pytest.mark.unit

--- a/server/apps/log/tests/test_log_extractor_semantics_pure.py
+++ b/server/apps/log/tests/test_log_extractor_semantics_pure.py
@@ -1,11 +1,5 @@
-import os
-import subprocess
-import sys
-import threading
-
 import pytest
 
-from apps.log.services.log_extractor import semantics
 from apps.log.services.log_extractor.semantics import RuleValidationError, execute_rules, normalize_rule
 
 
@@ -156,65 +150,6 @@ def test_regex_rejects_python_constructs_unsupported_by_vector_048(pattern):
                 "delete_source": False,
             }
         )
-
-
-@pytest.mark.integration
-def test_regex_preview_terminates_catastrophic_backtracking():
-    probe = """
-from apps.log.services.log_extractor.semantics import execute_rules, normalize_rule
-
-rule = normalize_rule(
-    {
-        "extractor_type": "regex_replace",
-        "source_field": "message",
-        "target_field": "result",
-        "condition": {},
-        "config": {"pattern": "(a+)+$", "replacement": "masked"},
-        "delete_source": False,
-    }
-)
-try:
-    execute_rules({"message": "a" * 27 + "!"}, [rule])
-except ValueError as exc:
-    print(f"{type(exc).__name__}:{exc}")
-"""
-    env = {**os.environ, "LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS": "0.1"}
-
-    try:
-        completed = subprocess.run(
-            [sys.executable, "-c", probe],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=3,
-            env=env,
-        )
-    except subprocess.TimeoutExpired:
-        pytest.fail("灾难性回溯未被预览超时终止")
-
-    assert completed.stdout.strip() == "RuleExecutionTimeoutError:正则预览执行超时"
-
-
-@pytest.mark.unit
-def test_regex_preview_rejects_work_when_local_capacity_is_exhausted(monkeypatch):
-    slots = threading.BoundedSemaphore(1)
-    slots.acquire()
-    monkeypatch.setattr(semantics, "_REGEX_PREVIEW_SLOTS", slots)
-    rule = normalize_rule(
-        {
-            "extractor_type": "regex_replace",
-            "source_field": "message",
-            "target_field": "result",
-            "condition": {},
-            "config": {"pattern": "a+$", "replacement": "masked"},
-            "delete_source": False,
-        }
-    )
-
-    with pytest.raises(semantics.RuleExecutionBusyError, match="并发已达上限"):
-        execute_rules({"message": "aaaa"}, [rule])
-
-    slots.release()
 
 
 @pytest.mark.unit

--- a/server/apps/log/tests/test_log_extractor_views.py
+++ b/server/apps/log/tests/test_log_extractor_views.py
@@ -1,10 +1,11 @@
+import json
 import threading
 
 import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.log.models import CollectInstance, CollectInstanceOrganization, CollectType, LogExtractor, SystemVectorConfigState
-from apps.log.services.log_extractor import semantics
+from apps.log.services.log_extractor import preview_runtime
 from apps.log.views.extractor import LogExtractorViewSet
 from apps.system_mgmt.models.operation_log import OperationLog
 
@@ -21,6 +22,19 @@ def _allow_current_team(mocker):
     mocker.patch(
         "apps.core.utils.current_team_scope.SystemMgmt.get_authorized_groups_scoped",
         return_value={"result": True, "data": [1]},
+    )
+
+
+def _allow_view_permission(mocker, collect_instance):
+    mocker.patch(
+        "apps.log.views.extractor.get_permissions_rules",
+        return_value={
+            "data": {
+                str(collect_instance.collect_type_id): {
+                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
+                }
+            }
+        },
     )
 
 
@@ -66,16 +80,7 @@ def test_create_rule_saves_resource_and_marks_one_global_generation(authenticate
 @pytest.mark.django_db
 def test_view_user_cannot_create_rule(authenticated_user, collect_instance, mocker):
     _allow_current_team(mocker)
-    mocker.patch(
-        "apps.log.views.extractor.get_permissions_rules",
-        return_value={
-            "data": {
-                str(collect_instance.collect_type_id): {
-                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
-                }
-            }
-        },
-    )
+    _allow_view_permission(mocker, collect_instance)
     request = APIRequestFactory().post(
         "/api/v1/log/log_extractors/",
         {"collect_instance": collect_instance.id},
@@ -105,16 +110,7 @@ def test_view_user_can_list_rules_in_current_team(authenticated_user, collect_in
         delete_source=False,
         sort_order=0,
     )
-    mocker.patch(
-        "apps.log.views.extractor.get_permissions_rules",
-        return_value={
-            "data": {
-                str(collect_instance.collect_type_id): {
-                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
-                }
-            }
-        },
-    )
+    _allow_view_permission(mocker, collect_instance)
     request = APIRequestFactory().get("/api/v1/log/log_extractors/", {"collect_instance": collect_instance.id})
     request.COOKIES["current_team"] = "1"
     force_authenticate(request, user=authenticated_user)
@@ -155,17 +151,8 @@ def test_view_user_gets_bounded_error_for_catastrophic_regex_preview(authenticat
         delete_source=False,
         sort_order=0,
     )
-    mocker.patch(
-        "apps.log.views.extractor.get_permissions_rules",
-        return_value={
-            "data": {
-                str(collect_instance.collect_type_id): {
-                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
-                }
-            }
-        },
-    )
-    monkeypatch.setattr(semantics, "REGEX_PREVIEW_TIMEOUT_SECONDS", 0.1)
+    _allow_view_permission(mocker, collect_instance)
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_TIMEOUT_SECONDS", 0.1)
     request = APIRequestFactory().post(
         "/api/v1/log/log_extractors/preview/",
         {
@@ -188,26 +175,21 @@ def test_view_user_gets_bounded_error_for_catastrophic_regex_preview(authenticat
     response = LogExtractorViewSet.as_view({"post": "preview"})(request)
 
     assert response.status_code == 400
-    assert str(response.data["rule"]) == "正则预览执行超时"
+    assert response.data == {
+        "detail": "正则预览执行超时",
+        "data": {"error_code": "log_extractor_preview_timeout"},
+    }
+    assert json.loads(response.render().content)["data"] == {"error_code": "log_extractor_preview_timeout"}
 
 
 @pytest.mark.integration
 @pytest.mark.django_db
 def test_regex_preview_capacity_exhaustion_returns_retryable_status(authenticated_user, collect_instance, mocker, monkeypatch):
     _allow_current_team(mocker)
-    mocker.patch(
-        "apps.log.views.extractor.get_permissions_rules",
-        return_value={
-            "data": {
-                str(collect_instance.collect_type_id): {
-                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
-                }
-            }
-        },
-    )
+    _allow_view_permission(mocker, collect_instance)
     slots = threading.BoundedSemaphore(1)
     slots.acquire()
-    monkeypatch.setattr(semantics, "_REGEX_PREVIEW_SLOTS", slots)
+    monkeypatch.setattr(preview_runtime, "_REGEX_PREVIEW_SLOTS", slots)
     request = APIRequestFactory().post(
         "/api/v1/log/log_extractors/preview/",
         {
@@ -233,3 +215,39 @@ def test_regex_preview_capacity_exhaustion_returns_retryable_status(authenticate
     assert response["Retry-After"] == "1"
     assert response.data == {"detail": "正则预览并发已达上限，请稍后重试"}
     slots.release()
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_regex_preview_oversized_field_returns_structured_400(authenticated_user, collect_instance, mocker, monkeypatch):
+    _allow_current_team(mocker)
+    authenticated_user.is_superuser = True
+    authenticated_user.save(update_fields=("is_superuser",))
+    monkeypatch.setattr(preview_runtime, "REGEX_PREVIEW_MAX_FIELD_BYTES", 3)
+    request = APIRequestFactory().post(
+        "/api/v1/log/log_extractors/preview/",
+        {
+            "collect_instance": collect_instance.id,
+            "event": {"message": "aaaa"},
+            "draft": {
+                "extractor_type": "regex_replace",
+                "source_field": "message",
+                "target_field": "result",
+                "condition": {},
+                "config": {"pattern": "a+$", "replacement": "masked"},
+                "delete_source": False,
+            },
+        },
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=authenticated_user)
+
+    response = LogExtractorViewSet.as_view({"post": "preview"})(request)
+
+    assert response.status_code == 400
+    assert response.data == {
+        "detail": "正则预览字段大小超过上限",
+        "data": {"error_code": "log_extractor_preview_too_large"},
+    }
+    assert json.loads(response.render().content)["data"] == {"error_code": "log_extractor_preview_too_large"}

--- a/server/apps/log/tests/test_log_extractor_views.py
+++ b/server/apps/log/tests/test_log_extractor_views.py
@@ -1,7 +1,10 @@
+import threading
+
 import pytest
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.log.models import CollectInstance, CollectInstanceOrganization, CollectType, LogExtractor, SystemVectorConfigState
+from apps.log.services.log_extractor import semantics
 from apps.log.views.extractor import LogExtractorViewSet
 from apps.system_mgmt.models.operation_log import OperationLog
 
@@ -135,3 +138,98 @@ def test_instance_outside_current_team_is_hidden(authenticated_user, collect_ins
     response = LogExtractorViewSet.as_view({"get": "list"})(request)
 
     assert response.status_code == 404
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_view_user_gets_bounded_error_for_catastrophic_regex_preview(authenticated_user, collect_instance, mocker, monkeypatch):
+    _allow_current_team(mocker)
+    LogExtractor.objects.create(
+        name="stored catastrophic rule",
+        collect_instance=collect_instance,
+        extractor_type="regex_replace",
+        source_field="message",
+        target_field="result",
+        condition={},
+        config={"pattern": "(a+)+$", "replacement": "masked"},
+        delete_source=False,
+        sort_order=0,
+    )
+    mocker.patch(
+        "apps.log.views.extractor.get_permissions_rules",
+        return_value={
+            "data": {
+                str(collect_instance.collect_type_id): {
+                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(semantics, "REGEX_PREVIEW_TIMEOUT_SECONDS", 0.1)
+    request = APIRequestFactory().post(
+        "/api/v1/log/log_extractors/preview/",
+        {
+            "collect_instance": collect_instance.id,
+            "event": {"message": "a" * 27 + "!"},
+            "draft": {
+                "extractor_type": "copy",
+                "source_field": "message",
+                "target_field": "copy",
+                "condition": {},
+                "config": {},
+                "delete_source": False,
+            },
+        },
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=authenticated_user)
+
+    response = LogExtractorViewSet.as_view({"post": "preview"})(request)
+
+    assert response.status_code == 400
+    assert str(response.data["rule"]) == "正则预览执行超时"
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_regex_preview_capacity_exhaustion_returns_retryable_status(authenticated_user, collect_instance, mocker, monkeypatch):
+    _allow_current_team(mocker)
+    mocker.patch(
+        "apps.log.views.extractor.get_permissions_rules",
+        return_value={
+            "data": {
+                str(collect_instance.collect_type_id): {
+                    "instance": [{"id": collect_instance.id, "permission": ["View"]}],
+                }
+            }
+        },
+    )
+    slots = threading.BoundedSemaphore(1)
+    slots.acquire()
+    monkeypatch.setattr(semantics, "_REGEX_PREVIEW_SLOTS", slots)
+    request = APIRequestFactory().post(
+        "/api/v1/log/log_extractors/preview/",
+        {
+            "collect_instance": collect_instance.id,
+            "event": {"message": "aaaa"},
+            "draft": {
+                "extractor_type": "regex_replace",
+                "source_field": "message",
+                "target_field": "result",
+                "condition": {},
+                "config": {"pattern": "a+$", "replacement": "masked"},
+                "delete_source": False,
+            },
+        },
+        format="json",
+    )
+    request.COOKIES["current_team"] = "1"
+    force_authenticate(request, user=authenticated_user)
+
+    response = LogExtractorViewSet.as_view({"post": "preview"})(request)
+
+    assert response.status_code == 429
+    assert response["Retry-After"] == "1"
+    assert response.data == {"detail": "正则预览并发已达上限，请稍后重试"}
+    slots.release()

--- a/server/apps/log/views/extractor.py
+++ b/server/apps/log/views/extractor.py
@@ -11,6 +11,7 @@ from apps.log.serializers.extractor import LogExtractorSerializer
 from apps.log.services.access_scope import LogAccessScopeService
 from apps.log.services.log_extractor.publication import get_publication_status, retry_publication
 from apps.log.services.log_extractor.rules import create_rule, delete_rule, load_samples, preview_rule, reorder_rules, update_rule
+from apps.log.services.log_extractor.semantics import RuleExecutionBusyError
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
@@ -140,6 +141,8 @@ class LogExtractorViewSet(ViewSet):
         instance = self._authorize_instance(request, request.data.get("collect_instance"), "View")
         try:
             result = preview_rule(instance, request.data.get("event"), request.data.get("draft"), request.data.get("rule_id"))
+        except RuleExecutionBusyError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_429_TOO_MANY_REQUESTS, headers={"Retry-After": "1"})
         except ValueError as exc:
             raise ValidationError({"rule": str(exc)}) from exc
         return Response(result)

--- a/server/apps/log/views/extractor.py
+++ b/server/apps/log/views/extractor.py
@@ -11,7 +11,7 @@ from apps.log.serializers.extractor import LogExtractorSerializer
 from apps.log.services.access_scope import LogAccessScopeService
 from apps.log.services.log_extractor.publication import get_publication_status, retry_publication
 from apps.log.services.log_extractor.rules import create_rule, delete_rule, load_samples, preview_rule, reorder_rules, update_rule
-from apps.log.services.log_extractor.semantics import RuleExecutionBusyError
+from apps.log.services.log_extractor.semantics import RuleExecutionBusyError, RuleExecutionLimitError, RuleExecutionTimeoutError
 from apps.system_mgmt.utils.operation_log_utils import log_operation
 
 
@@ -143,6 +143,16 @@ class LogExtractorViewSet(ViewSet):
             result = preview_rule(instance, request.data.get("event"), request.data.get("draft"), request.data.get("rule_id"))
         except RuleExecutionBusyError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_429_TOO_MANY_REQUESTS, headers={"Retry-After": "1"})
+        except RuleExecutionTimeoutError as exc:
+            return Response(
+                {"detail": str(exc), "data": {"error_code": "log_extractor_preview_timeout"}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        except RuleExecutionLimitError as exc:
+            return Response(
+                {"detail": str(exc), "data": {"error_code": "log_extractor_preview_too_large"}},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         except ValueError as exc:
             raise ValidationError({"rule": str(exc)}) from exc
         return Response(result)

--- a/specs/changes/log-file-extractor/spec.md
+++ b/specs/changes/log-file-extractor/spec.md
@@ -252,6 +252,7 @@ Status: implemented
 - 上线前管理命令生成初始 no-op 快照，因此即使没有规则，中心系统 Vector 也能得到完整拓扑。非关键快照重建失败不得加入 Server 通用启动必经路径；部署探测负责阻止中心 Vector 在无快照时启动。
 - 回滚应用版本时，最后成功快照仍保留在数据库；回退中心 Vector 部署可恢复原静态配置。删除新表前必须先停止 HTTP provider 并恢复静态中心配置，避免运行端在下一次重启时没有初始拓扑。
 - 第一版发布是新增能力，不改变既有采集模板的 `instance_id`、区域转发、日志查询和 VictoriaLogs 存量数据；历史日志不重新处理。
+- 正则预览的 Python 执行必须始终保留在可强制终止的隔离进程内，应用回滚不得恢复为请求 worker 内直接执行。紧急降级只允许通过 `LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS`、`LOG_EXTRACTOR_PREVIEW_MAX_CONCURRENCY`、`LOG_EXTRACTOR_PREVIEW_MAX_FIELD_BYTES` 与 `LOG_EXTRACTOR_PREVIEW_MAX_EVENT_BYTES` 调整有界参数，非法或非正数配置回退到安全默认值，不提供关闭隔离的开关。默认字段上限 10 MiB，与现有 Packetbeat HTTP 消息上限兼容；默认事件上限 12 MiB。纯非正则预览不经过该隔离与大小边界，保持旧调用路径；正则预览超时和超限继续返回 400，并分别携带稳定的 `log_extractor_preview_timeout`、`log_extractor_preview_too_large` 错误标识，容量满返回 429 与 `Retry-After`。
 
 ## Testing Decisions
 


### PR DESCRIPTION
## 问题

日志提取规则预览应在有限资源内返回结果或明确失败，但原实现会在 Django 请求 worker 内直接执行 Python 回溯正则。资源耗尽型正则输入可能长期占用 worker CPU，且普通异常处理无法中断正在执行的匹配。

## 根因

线上 Vector 使用线性时间的 Rust 正则引擎，而预览复用了 Python 正则语义，却没有独立的执行边界、超时或并发背压。规则校验只能判断语法兼容，不能为 Python 回溯成本提供上界。

## 怎么修的

- 仅当规则链包含正则动作时，将整批预览放入独立 spawn 子进程，保持存量规则与 draft 的执行顺序。
- 默认 1 秒未完成即终止并回收子进程；每个 Uvicorn worker 默认只允许 1 个正则预览子进程。
- 容量已满时快速返回 HTTP 429 与 `Retry-After: 1`；普通校验和执行超时继续沿用现有 400 错误契约。
- `LOG_EXTRACTOR_PREVIEW_TIMEOUT_SECONDS` 与 `LOG_EXTRACTOR_PREVIEW_MAX_CONCURRENCY` 可显式调节；无数据迁移，回滚不影响已保存规则或 Vector 配置。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["LogExtractorViewSet.preview\nviews/extractor.py"]
    end

    subgraph N["规则处理层"]
        N1["preview_rule\nrules.py"]
        N2["execute_rules\nsemantics.py"]
    end

    subgraph I["隔离执行层"]
        I1["spawn 正则预览进程"]
        I2["超时终止与资源回收"]
        I3["容量满返回 429"]
    end

    T1 --> N1 --> N2 --> I1
    I1 -- "超时" --> I2
    N2 -- "无可用槽位" --> I3
```

## 影响范围

改动只涉及 `log` 模块的预览执行与错误映射。规则持久化、权限判断、成功响应、命名组与替换语义、Vector 0.48 发布配置均保持不变；纯非正则规则仍在当前进程直接执行。

## 验证

- `server/apps/log/tests/test_log_extractor_semantics_pure.py`
- `server/apps/log/tests/test_log_extractor_views.py`
- `server/apps/log/tests/test_log_extractor_vector_contract.py`
- 结果：39 passed，包含资源耗尽型正则的有界终止、存量规则链、容量背压、正常提取/替换和 Vector 0.48 容器契约。
- 回归测试满足 revert-fail：修复前有界终止用例无法在外部 3 秒保护时间内完成；容量耗尽用例返回 400 而非 429。

## 三轨门禁

- Standards：pass（97/100）
- Spec：pass（98/100）
- Runtime Contract：pass（96/100）

关联 Issue #4658。
