### PR TITLE
bugfix: 兼容凭据结果事件新旧契约

### DIFF
--- a/agents/stargazer/api/collect.py
+++ b/agents/stargazer/api/collect.py
@@ -15,6 +15,7 @@ from core.infra.credential_state_cache import CredentialStateCache
 from core.logger import logger
 from plugins.base_utils import expand_ip_range
 from sanic import Blueprint, response
+from service.collect_credential_result_push_service import CollectCredentialResultPushService
 from tasks.collectors.host_collector import _escape_prometheus_label_value
 
 # 兼容旧测试/调用方私有名
@@ -146,12 +147,7 @@ def _parse_hosts(hosts_param: str) -> List[str]:
 
 
 def _build_credential_results_payload(events: List[dict]) -> dict:
-    next_since = ""
-    for item in events or []:
-        finished_at = str((item or {}).get("finished_at") or "")
-        if finished_at and finished_at > next_since:
-            next_since = finished_at
-    return {"results": events or [], "next_since": next_since}
+    return CollectCredentialResultPushService.build_results_payload(events)
 
 
 @collect_router.get("/credential_results")

--- a/agents/stargazer/core/collection/contracts.py
+++ b/agents/stargazer/core/collection/contracts.py
@@ -24,6 +24,7 @@ __all__ = [
     "CollectOutcome",
     "CollectOutcomeStatus",
     "CollectionPlugin",
+    "CredentialFailureResult",
     "PreflightProbe",
     "PreflightResult",
     "PreflightStatus",
@@ -66,6 +67,13 @@ class TargetCollectionContext:
     fence: int
     params: Mapping[str, Any]
     owner_id: str = ""
+    attempt_id: str = ""
+
+
+@dataclass(frozen=True)
+class CredentialFailureResult:
+    credential_id: str
+    error_code: str
 
 
 @dataclass(frozen=True)
@@ -76,6 +84,7 @@ class TargetCollectionResult:
     credential_id: str = ""
     error_code: str = ""
     value: Any = None
+    credential_failures: tuple[CredentialFailureResult, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -128,7 +137,8 @@ class PreflightProbe(Protocol):
         request: CollectionRequest,
         *,
         timeout_seconds: float,
-    ) -> PreflightResult: ...
+    ) -> PreflightResult:
+        ...
 
 
 class CollectionPlugin(Protocol):
@@ -139,14 +149,16 @@ class CollectionPlugin(Protocol):
         context: TargetCollectionContext,
         *,
         timeout_seconds: float,
-    ) -> AccessProbeResult: ...
+    ) -> AccessProbeResult:
+        ...
 
     async def collect(
         self,
         target: str,
         credential: Mapping[str, Any],
         context: TargetCollectionContext,
-    ) -> CollectOutcome: ...
+    ) -> CollectOutcome:
+        ...
 
 
 class AccessProbe(Protocol):
@@ -157,7 +169,8 @@ class AccessProbe(Protocol):
         context: TargetCollectionContext,
         *,
         timeout_seconds: float,
-    ) -> AccessProbeResult: ...
+    ) -> AccessProbeResult:
+        ...
 
 
 class ResultPublisher(Protocol):
@@ -166,7 +179,8 @@ class ResultPublisher(Protocol):
         request: CollectionRequest,
         result: TargetCollectionResult,
         lease: RunLease,
-    ) -> None: ...
+    ) -> None:
+        ...
 
 
 def build_collection_result_id(
@@ -175,7 +189,10 @@ def build_collection_result_id(
     plugin_ref: str,
     target: str,
     fence: int,
+    attempt_id: str = "",
 ) -> str:
-    """单目标结果幂等 ID：task_id + plugin_ref + target + fence。"""
-    identity = "\0".join((task_id, plugin_ref, target, str(fence)))
+    """单次运行内稳定的目标结果幂等 ID。"""
+    identity = "\0".join(
+        (task_id, plugin_ref, target, str(fence), str(attempt_id or ""))
+    )
     return hashlib.sha256(identity.encode("utf-8")).hexdigest()

--- a/agents/stargazer/core/collection/executor.py
+++ b/agents/stargazer/core/collection/executor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from core.collection.contracts import (
     AccessProbe,
@@ -13,6 +13,7 @@ from core.collection.contracts import (
     CollectOutcome,
     CollectOutcomeStatus,
     CollectionPlugin,
+    CredentialFailureResult,
     PreflightProbe,
     PreflightResult,
     PreflightStatus,
@@ -276,6 +277,7 @@ class TargetCollectionExecutor:
             fence=lease.fence,
             params=request.params,
             owner_id=lease.owner_id,
+            attempt_id=lease.attempt_id,
         )
         return await self._run_credential_attempts(
             request, target, credentials, context
@@ -422,6 +424,7 @@ class TargetCollectionExecutor:
     ) -> TargetCollectionResult:
         attempts = 0
         no_response_attempts = 0
+        credential_failures = []
         for credential in credentials:
             attempts += 1
             self._metrics.increment("credential_attempt_total")
@@ -431,7 +434,7 @@ class TargetCollectionExecutor:
                 target, credential, context, attempts
             )
             if isinstance(access, TargetCollectionResult):
-                return access
+                return replace(access, credential_failures=tuple(credential_failures))
 
             probe_decision = await self._apply_access_probe(
                 request,
@@ -441,8 +444,13 @@ class TargetCollectionExecutor:
                 attempts=attempts,
                 no_response_attempts=no_response_attempts,
             )
+            if probe_decision.credential_failure:
+                credential_failures.append(probe_decision.credential_failure)
             if probe_decision.action == "return":
-                return probe_decision.result
+                return replace(
+                    probe_decision.result,
+                    credential_failures=tuple(credential_failures),
+                )
             if probe_decision.action == "continue":
                 no_response_attempts = probe_decision.no_response_attempts
                 continue
@@ -459,8 +467,13 @@ class TargetCollectionExecutor:
                 attempts=attempts,
                 credential_id=credential_id,
             )
+            if collect_decision.credential_failure:
+                credential_failures.append(collect_decision.credential_failure)
             if collect_decision.action == "return":
-                return collect_decision.result
+                return replace(
+                    collect_decision.result,
+                    credential_failures=tuple(credential_failures),
+                )
             # continue → 下一凭据
 
         logger.info(
@@ -474,6 +487,7 @@ class TargetCollectionExecutor:
             status="failed",
             attempts=attempts,
             error_code="credentials_exhausted",
+            credential_failures=tuple(credential_failures),
         )
 
     async def _run_access_probe(
@@ -550,11 +564,12 @@ class TargetCollectionExecutor:
             AccessProbeStatus.AUTH_FAILED,
             AccessProbeStatus.CAPABILITY_DENIED,
         }:
+            error_code = access.error_code or access.status.value
             await self._safe_record_auth_failure(
                 request,
                 target,
                 credential,
-                error_code=access.error_code or access.status.value,
+                error_code=error_code,
             )
             logger.info(
                 "🚫 event=access_probe_failed task_id=%s target=%s "
@@ -563,10 +578,15 @@ class TargetCollectionExecutor:
                 target,
                 credential_id or "-",
                 access.status.value,
-                access.error_code or access.status.value,
+                error_code,
             )
             return _AttemptDecision(
-                action="continue", no_response_attempts=no_response_attempts
+                action="continue",
+                no_response_attempts=no_response_attempts,
+                credential_failure=CredentialFailureResult(
+                    credential_id=credential_id,
+                    error_code=error_code,
+                ),
             )
         if access.status == AccessProbeStatus.NO_RESPONSE:
             no_response_attempts += 1
@@ -612,6 +632,7 @@ class TargetCollectionExecutor:
                     target=target,
                     status="unreachable",
                     attempts=attempts,
+                    credential_id=credential_id,
                     error_code=access.error_code or "target_unreachable",
                 ),
                 no_response_attempts=no_response_attempts,
@@ -760,13 +781,20 @@ class TargetCollectionExecutor:
                 ),
             )
         if outcome.status == CollectOutcomeStatus.AUTH_FAILED:
+            error_code = outcome.error_code or "authentication_failed"
             await self._safe_record_auth_failure(
                 request,
                 target,
                 credential,
-                error_code=outcome.error_code or "authentication_failed",
+                error_code=error_code,
             )
-            return _AttemptDecision(action="continue")
+            return _AttemptDecision(
+                action="continue",
+                credential_failure=CredentialFailureResult(
+                    credential_id=credential_id,
+                    error_code=error_code,
+                ),
+            )
         if outcome.status == CollectOutcomeStatus.RETRY_CREDENTIAL:
             return _AttemptDecision(action="continue")
         if outcome.status == CollectOutcomeStatus.UNREACHABLE:
@@ -776,6 +804,7 @@ class TargetCollectionExecutor:
                     target=target,
                     status="unreachable",
                     attempts=attempts,
+                    credential_id=credential_id,
                     error_code=outcome.error_code or "target_unreachable",
                 ),
             )
@@ -797,3 +826,4 @@ class _AttemptDecision:
     action: str  # collect | continue | return
     result: TargetCollectionResult | None = None
     no_response_attempts: int = 0
+    credential_failure: CredentialFailureResult | None = None

--- a/agents/stargazer/core/collection/host_remote/adapter.py
+++ b/agents/stargazer/core/collection/host_remote/adapter.py
@@ -46,6 +46,7 @@ async def submit_host_remote_collection(
         plugin_ref=context.plugin_ref,
         target=target,
         fence=context.fence,
+        attempt_id=context.attempt_id,
     )
     callback_task_id = "remote-" + result_id[:24]
     callback_params["collection_result_id"] = result_id

--- a/agents/stargazer/core/collection/redis_state.py
+++ b/agents/stargazer/core/collection/redis_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
+import uuid
 
 from core.collection.runtime import (
     LeaseAcquisition,
@@ -22,14 +23,16 @@ local request_digest = ARGV[1]
 local owner_id = ARGV[2]
 local ttl_ms = tonumber(ARGV[3])
 local now_ms = tonumber(ARGV[4])
+local attempt_id = ARGV[5]
 
 local existing_owner = redis.call('HGET', run_key, 'owner_id') or ''
 local existing_expires = tonumber(redis.call('HGET', run_key, 'expires_at_ms') or '0')
 local existing_status = redis.call('HGET', run_key, 'status') or ''
 local existing_fence = tonumber(redis.call('HGET', run_key, 'fence') or '1')
+local existing_attempt_id = redis.call('HGET', run_key, 'attempt_id') or ''
 
 if existing_status == 'running' and existing_expires > now_ms then
-    return {'duplicate_active', existing_owner, existing_fence, existing_expires, ''}
+    return {'duplicate_active', existing_owner, existing_fence, existing_expires, '', existing_attempt_id}
 end
 
 local expires_at_ms = now_ms + ttl_ms
@@ -39,12 +42,13 @@ redis.call(
     'request_digest', request_digest,
     'owner_id', owner_id,
     'fence', 1,
+    'attempt_id', attempt_id,
     'expires_at_ms', expires_at_ms,
     'status', 'running'
 )
 redis.call('HDEL', run_key, 'summary')
 redis.call('PEXPIRE', run_key, ttl_ms * 2)
-return {'acquired', owner_id, 1, expires_at_ms, ''}
+return {'acquired', owner_id, 1, expires_at_ms, '', attempt_id}
 """
 
 
@@ -52,14 +56,18 @@ _FINISH_RUN_LUA = """
 local run_key = KEYS[1]
 local owner_id = ARGV[1]
 local fence = tostring(ARGV[2])
-local status = ARGV[3]
-local retention_ms = tonumber(ARGV[4])
-local summary = ARGV[5]
+local attempt_id = ARGV[3]
+local status = ARGV[4]
+local retention_ms = tonumber(ARGV[5])
+local summary = ARGV[6]
 
 if redis.call('HGET', run_key, 'owner_id') ~= owner_id then
     return 0
 end
 if redis.call('HGET', run_key, 'fence') ~= fence then
+    return 0
+end
+if redis.call('HGET', run_key, 'attempt_id') ~= attempt_id then
     return 0
 end
 -- 薄模型：结束后删除租约，下周期整轮重采；不保留 completed 汇总供同 task_id 回读
@@ -72,13 +80,17 @@ _HEARTBEAT_RUN_LUA = """
 local run_key = KEYS[1]
 local owner_id = ARGV[1]
 local fence = tostring(ARGV[2])
-local ttl_ms = tonumber(ARGV[3])
-local now_ms = tonumber(ARGV[4])
+local attempt_id = ARGV[3]
+local ttl_ms = tonumber(ARGV[4])
+local now_ms = tonumber(ARGV[5])
 
 if redis.call('HGET', run_key, 'owner_id') ~= owner_id then
     return 0
 end
 if redis.call('HGET', run_key, 'fence') ~= fence then
+    return 0
+end
+if redis.call('HGET', run_key, 'attempt_id') ~= attempt_id then
     return 0
 end
 if redis.call('HGET', run_key, 'status') ~= 'running' then
@@ -124,8 +136,9 @@ class RedisRunStateStore:
             owner_id,
             ttl_ms,
             now_ms,
+            uuid.uuid4().hex,
         )
-        status_value, lease_owner, fence, expires_at_ms, summary_value = raw
+        status_value, lease_owner, fence, expires_at_ms, summary_value, attempt_id = raw
         status = LeaseAcquireStatus(self._text(status_value))
         lease = RunLease(
             task_id=task_id,
@@ -133,6 +146,7 @@ class RedisRunStateStore:
             owner_id=self._text(lease_owner),
             fence=int(fence),
             expires_at=int(expires_at_ms) / 1000,
+            attempt_id=self._text(attempt_id),
         )
         summary_text = self._text(summary_value)
         summary = json.loads(summary_text) if summary_text else {}
@@ -150,6 +164,7 @@ class RedisRunStateStore:
             self._run_key(lease.task_id),
             lease.owner_id,
             lease.fence,
+            lease.attempt_id,
             status.value,
             self._completed_retention_ms,
             json.dumps(summary or {}, separators=(",", ":"), default=str),
@@ -166,6 +181,7 @@ class RedisRunStateStore:
             self._run_key(lease.task_id),
             lease.owner_id,
             lease.fence,
+            lease.attempt_id,
             ttl_ms,
             int(self._now() * 1000),
         )
@@ -328,4 +344,3 @@ class RedisCredentialStateStore:
         if isinstance(value, bytes):
             return value.decode("utf-8")
         return str(value)
-

--- a/agents/stargazer/core/collection/result_publisher.py
+++ b/agents/stargazer/core/collection/result_publisher.py
@@ -2,13 +2,23 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Callable
 
-from core.collection.contracts import (
-    TargetCollectionResult,
-    build_collection_result_id,
-)
+from core.collection.contracts import TargetCollectionResult, build_collection_result_id
 from core.collection.runtime import CollectionRequest, RunLease
+
+CREDENTIAL_RESULT_EVENT_VERSION = 2
+CREDENTIAL_FAILURE_ERROR_CODES = frozenset(
+    {
+        "auth_failed",
+        "authentication_failed",
+        "capability_denied",
+        "snmp_error_status",
+        "snmp_authorization_failed",
+        "unauthorized",
+    }
+)
 
 
 class NatsResultPublisher:
@@ -34,6 +44,7 @@ class NatsResultPublisher:
             plugin_ref=request.plugin_ref,
             target=result.target,
             fence=lease.fence,
+            attempt_id=lease.attempt_id,
         )
         if result.status == "deferred":
             await self._record_event(request, result, lease, result_id)
@@ -89,19 +100,84 @@ class NatsResultPublisher:
     ) -> None:
         if self._result_event_sink is None:
             return
+        credential_failures = tuple(getattr(result, "credential_failures", ()))
+        for event_index, failure in enumerate(credential_failures):
+            await self._result_event_sink(
+                self._build_credential_event(
+                    request=request,
+                    lease=lease,
+                    result_id=result_id,
+                    target=result.target,
+                    credential_id=failure.credential_id,
+                    status="failed",
+                    error_code=failure.error_code,
+                    attempts=result.attempts,
+                    event_index=event_index,
+                )
+            )
+
+        if credential_failures and not result.credential_id:
+            return
+
         await self._result_event_sink(
-            {
-                "collect_task_id": request.task_id,
-                "plugin_ref": request.plugin_ref,
-                "host": result.target,
-                "credential_id": result.credential_id,
-                "status": result.status,
-                "error_code": result.error_code,
-                "attempts": result.attempts,
-                "fence": lease.fence,
-                "result_id": result_id,
-            }
+            self._build_credential_event(
+                request=request,
+                lease=lease,
+                result_id=result_id,
+                target=result.target,
+                credential_id=result.credential_id,
+                status=result.status,
+                error_code=result.error_code,
+                attempts=result.attempts,
+                event_index=len(credential_failures),
+            )
         )
+
+    @staticmethod
+    def _build_credential_event(
+        *,
+        request: CollectionRequest,
+        lease: RunLease,
+        result_id: str,
+        target: str,
+        credential_id: str,
+        status: str,
+        error_code: str,
+        attempts: int,
+        event_index: int,
+    ) -> dict:
+        success = status == "success"
+        failure_kind = (
+            "credential"
+            if status == "failed" and error_code in CREDENTIAL_FAILURE_ERROR_CODES
+            else "task"
+        )
+        event_identity = "\0".join(
+            (result_id, str(event_index), credential_id, status, error_code)
+        )
+        collect_task_id = request.params.get("collect_task_id") or request.task_id
+        return {
+            "event_id": hashlib.sha256(event_identity.encode("utf-8")).hexdigest(),
+            "event_version": CREDENTIAL_RESULT_EVENT_VERSION,
+            "producer": "stargazer",
+            "scope_id": str(collect_task_id),
+            "collect_task_id": collect_task_id,
+            "run_id": request.task_id,
+            "run_attempt_id": lease.attempt_id,
+            "producer_instance": lease.owner_id,
+            "plugin_ref": request.plugin_ref,
+            "host": target,
+            "credential_id": credential_id,
+            "status": status,
+            "error_code": error_code,
+            "success": success,
+            "failure_kind": "" if success else failure_kind,
+            "error_message": "" if success else error_code,
+            "attempts": attempts,
+            "fence": lease.fence,
+            "result_id": result_id,
+            "event_index": event_index,
+        }
 
     @staticmethod
     def _error_metrics(

--- a/agents/stargazer/core/collection/runtime.py
+++ b/agents/stargazer/core/collection/runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib
 import json
 import time
+import uuid
 from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, Awaitable, Callable, Mapping, Protocol, Sequence
 
@@ -86,6 +87,7 @@ class RunLease:
     owner_id: str
     fence: int
     expires_at: float
+    attempt_id: str = ""
 
 
 @dataclass(frozen=True)
@@ -190,6 +192,7 @@ class InMemoryRunStateStore:
                 owner_id=owner_id,
                 fence=1,
                 expires_at=now + ttl_seconds,
+                attempt_id=uuid.uuid4().hex,
             )
             self._records[task_id] = _InMemoryRunRecord(
                 request_digest=request_digest,
@@ -211,6 +214,7 @@ class InMemoryRunStateStore:
             if (
                 record.lease.owner_id != lease.owner_id
                 or record.lease.fence != lease.fence
+                or record.lease.attempt_id != lease.attempt_id
             ):
                 return False
             # 结束后释放，允许同 task_id 下周期重新接纳
@@ -227,6 +231,7 @@ class InMemoryRunStateStore:
             if (
                 record.lease.owner_id != lease.owner_id
                 or record.lease.fence != lease.fence
+                or record.lease.attempt_id != lease.attempt_id
             ):
                 return False
             record.lease = RunLease(
@@ -235,6 +240,7 @@ class InMemoryRunStateStore:
                 owner_id=lease.owner_id,
                 fence=lease.fence,
                 expires_at=time.monotonic() + ttl_seconds,
+                attempt_id=lease.attempt_id,
             )
             return True
 

--- a/agents/stargazer/core/infra/credential_state_cache.py
+++ b/agents/stargazer/core/infra/credential_state_cache.py
@@ -1,9 +1,34 @@
+import asyncio
+import base64
+import binascii
 import json
 import uuid
-from datetime import datetime, timezone
-from typing import Any, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from core.infra.redis_client import get_redis_client
+
+_APPEND_RESULT_EVENT_LUA = """
+if redis.call("EXISTS", KEYS[2]) == 1 then
+  return 0
+end
+local score = tonumber(ARGV[1])
+local current = tonumber(redis.call("GET", KEYS[3]) or "0")
+if score <= current then
+  return -1
+end
+redis.call("SET", KEYS[3], score)
+redis.call("ZADD", KEYS[1], ARGV[1], ARGV[2])
+redis.call("SET", KEYS[2], "1", "EX", ARGV[3])
+redis.call("ZREMRANGEBYSCORE", KEYS[1], 0, ARGV[4])
+return 1
+"""
+
+_PROPOSE_EVENT_SCORE_LUA = """
+local requested = tonumber(ARGV[1])
+local current = tonumber(redis.call("GET", KEYS[1]) or "0")
+return math.max(requested, current + 1)
+"""
 
 
 class CredentialStateCache:
@@ -12,7 +37,10 @@ class CredentialStateCache:
     SUCCESS_TTL_SECONDS = 7 * 24 * 3600
     FAILURE_TTL_SECONDS = 24 * 3600
     EVENT_RETENTION_SECONDS = 7 * 24 * 3600
+    ROLLBACK_CURSOR_SAFETY_SECONDS = 60
     COOLDOWN_HOURS = {1: 1, 2: 4, 3: 24}
+    _STREAM_CURSOR_FIELD = "_stream_cursor"
+    _APPEND_EVENT_LOCK = asyncio.Lock()
 
     @classmethod
     async def get_success_credential(cls, collect_task_id: Any, host: str) -> str:
@@ -72,25 +100,86 @@ class CredentialStateCache:
 
     @classmethod
     async def append_result_event(cls, event: dict) -> None:
+        # 单进程内先串行，跨 Pod 再由 Redis CAS 收敛，避免高并发下无界争抢。
+        async with cls._APPEND_EVENT_LOCK:
+            await cls._append_result_event(event)
+
+    @classmethod
+    async def _append_result_event(cls, event: dict) -> None:
         pool = await cls._get_or_create_pool()
-        finished_at = str(event.get("finished_at") or datetime.now(timezone.utc).isoformat())
-        score = cls._event_score(finished_at)
-        payload = {**dict(event or {}), "event_id": uuid.uuid4().hex, "finished_at": finished_at}
-        await pool.zadd(cls._event_stream_key(), {json.dumps(payload, ensure_ascii=False): score})
-        await pool.zremrangebyscore(cls._event_stream_key(), 0, score - cls.EVENT_RETENTION_SECONDS * 1000)
+        event_id = str(event.get("event_id") or uuid.uuid4().hex)
+        observed_at = str(event.get("finished_at") or datetime.now(timezone.utc).isoformat())
+        requested_score = cls._event_score(observed_at)
+        for _attempt in range(256):
+            score = int(
+                await pool.eval(
+                    _PROPOSE_EVENT_SCORE_LUA,
+                    1,
+                    cls._event_clock_key(),
+                    requested_score,
+                )
+            )
+            finished_at = datetime.fromtimestamp(
+                score / 1000, timezone.utc
+            ).isoformat(timespec="milliseconds")
+            payload = {
+                **dict(event or {}),
+                "event_id": event_id,
+                "observed_at": str(event.get("observed_at") or observed_at),
+                "finished_at": finished_at,
+            }
+            # 成员仍保持旧版可直接 json.loads 的形态，代码回滚不会读坏存量事件。
+            member = cls._encode_event_member(payload)
+            committed = int(
+                await pool.eval(
+                    _APPEND_RESULT_EVENT_LUA,
+                    3,
+                    cls._event_stream_key(),
+                    cls._event_dedupe_key(event_id),
+                    cls._event_clock_key(),
+                    score,
+                    member,
+                    cls.EVENT_RETENTION_SECONDS,
+                    score - cls.EVENT_RETENTION_SECONDS * 1000,
+                )
+            )
+            if committed >= 0:
+                return
+        raise RuntimeError("result event stream is too busy; retry append")
 
     @classmethod
     async def list_result_events(cls, since: str | None = None, limit: int = 500) -> list[dict]:
         pool = await cls._get_or_create_pool()
-        min_score = "-inf"
-        if since:
-            min_score = f"({cls._event_score(since)}"
-        raw_items = await pool.zrangebyscore(cls._event_stream_key(), min=min_score, max="+inf", start=0, num=limit)
-        events = []
-        for item in raw_items or []:
-            if isinstance(item, (bytes, bytearray)):
-                item = item.decode()
-            events.append(json.loads(item))
+        bounded_limit = max(1, int(limit or 500))
+        cursor_time, cursor_member = cls._parse_event_cursor(since)
+        cursor_score = cls._event_score(cursor_time) if cursor_time else None
+        # 旧时间戳游标在升级后的首次读取允许边界重投，依靠 event_id 去重；
+        # 这比继续沿用排他游标并永久丢失同毫秒事件更安全。
+        min_score = cursor_score if cursor_score is not None else "-inf"
+        events: list[dict] = []
+        chunk_size = min(max(bounded_limit, 100), 1000)
+        offset = 0
+        while len(events) < bounded_limit:
+            raw_items = await pool.zrangebyscore(
+                cls._event_stream_key(),
+                min=min_score,
+                max="+inf",
+                start=offset,
+                num=chunk_size,
+                withscores=True,
+            )
+            if not raw_items:
+                break
+            offset += len(raw_items)
+            for item, score in raw_items:
+                member = cls._text(item)
+                if cursor_member and score == cursor_score and member <= cursor_member:
+                    continue
+                event = cls._decode_event_member(member)
+                event[cls._STREAM_CURSOR_FIELD] = cls._encode_cursor_member(member)
+                events.append(event)
+                if len(events) >= bounded_limit:
+                    return events[:bounded_limit]
         return events
 
     @classmethod
@@ -129,13 +218,27 @@ class CredentialStateCache:
         return "collect:credential:events"
 
     @staticmethod
+    def _event_dedupe_key(event_id: str) -> str:
+        return f"collect:credential:event:{event_id}"
+
+    @staticmethod
+    def _event_clock_key() -> str:
+        return "collect:credential:event_clock_ms"
+
+    @staticmethod
     def _push_cursor_key() -> str:
         return "collect:credential:push_cursor"
+
+    @staticmethod
+    def _push_cursor_v2_key() -> str:
+        return "collect:credential:push_cursor:v2"
 
     @classmethod
     async def get_push_cursor(cls) -> str:
         pool = await cls._get_or_create_pool()
-        value = await pool.get(cls._push_cursor_key())
+        value = await pool.get(cls._push_cursor_v2_key())
+        if not value:
+            value = await pool.get(cls._push_cursor_key())
         if isinstance(value, (bytes, bytearray)):
             return value.decode()
         return str(value or "")
@@ -145,7 +248,21 @@ class CredentialStateCache:
         if not since:
             return
         pool = await cls._get_or_create_pool()
-        await pool.set(cls._push_cursor_key(), since)
+        await pool.set(cls._push_cursor_v2_key(), since)
+        # 旧镜像只认识排他 ISO 时间游标，也不会遵守新 event_clock。
+        # 安全滞后允许滚动回退期间的旧 writer 有界重放；下游 event_id 负责去重。
+        legacy_since, _member = cls._parse_event_cursor(since)
+        rollback_floor = datetime.now(timezone.utc) - timedelta(
+            seconds=cls.ROLLBACK_CURSOR_SAFETY_SECONDS
+        )
+        rollback_floor_score = cls._event_score(rollback_floor.isoformat())
+        legacy_score = cls._event_score(legacy_since)
+        rollback_safe_since = (
+            legacy_since
+            if legacy_score <= rollback_floor_score
+            else rollback_floor.isoformat(timespec="milliseconds")
+        )
+        await pool.set(cls._push_cursor_key(), rollback_safe_since)
 
     @staticmethod
     def _event_score(value: str) -> int:
@@ -156,6 +273,58 @@ class CredentialStateCache:
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
         return int(parsed.timestamp() * 1000)
+
+    @staticmethod
+    def _decode_event_member(item) -> dict:
+        if isinstance(item, (bytes, bytearray)):
+            item = item.decode()
+        payload = str(item)
+        if "\0" in payload:
+            _event_id, payload = payload.split("\0", 1)
+        return json.loads(payload)
+
+    @staticmethod
+    def _encode_event_member(event: dict) -> str:
+        payload = dict(event or {})
+        payload.pop(CredentialStateCache._STREAM_CURSOR_FIELD, None)
+        return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _encode_cursor_member(member: str) -> str:
+        encoded = base64.urlsafe_b64encode(member.encode("utf-8")).decode("ascii")
+        return encoded.rstrip("=")
+
+    @staticmethod
+    def _decode_cursor_member(value: str) -> str:
+        padding = "=" * (-len(value) % 4)
+        return base64.urlsafe_b64decode((value + padding).encode("ascii")).decode("utf-8")
+
+    @staticmethod
+    def _text(value) -> str:
+        if isinstance(value, (bytes, bytearray)):
+            return value.decode()
+        return str(value)
+
+    @staticmethod
+    def _parse_event_cursor(value: str | None) -> tuple[str, str]:
+        cursor = str(value or "")
+        if "|m:" not in cursor:
+            return cursor, ""
+        cursor_time, encoded_member = cursor.rsplit("|m:", 1)
+        try:
+            return cursor_time, CredentialStateCache._decode_cursor_member(encoded_member)
+        except (ValueError, UnicodeDecodeError, binascii.Error):
+            return cursor_time, ""
+
+    @staticmethod
+    def event_cursor(event: dict) -> str:
+        finished_at = str((event or {}).get("finished_at") or "")
+        cursor_member = str((event or {}).get(CredentialStateCache._STREAM_CURSOR_FIELD) or "")
+        if not cursor_member and event:
+            cursor_member = CredentialStateCache._encode_cursor_member(
+                CredentialStateCache._encode_event_member(event)
+            )
+        return f"{finished_at}|m:{cursor_member}" if finished_at and cursor_member else finished_at
 
     @classmethod
     def cooldown_hours_for(cls, cooldown_level: int) -> int:

--- a/agents/stargazer/service/collect_credential_result_push_service.py
+++ b/agents/stargazer/service/collect_credential_result_push_service.py
@@ -15,12 +15,15 @@ COLLECT_CREDENTIAL_RESULT_PUSH_SUBJECT = os.getenv(
 class CollectCredentialResultPushService:
     @staticmethod
     def build_results_payload(events: list[dict]) -> dict:
-        next_since = ""
-        for item in events or []:
-            finished_at = str((item or {}).get("finished_at") or "")
-            if finished_at and finished_at > next_since:
-                next_since = finished_at
-        return {"results": events or [], "next_since": next_since}
+        next_since = (
+            CredentialStateCache.event_cursor(events[-1]) if events else ""
+        )
+        results = []
+        for event in events or []:
+            public_event = dict(event or {})
+            public_event.pop(CredentialStateCache._STREAM_CURSOR_FIELD, None)
+            results.append(public_event)
+        return {"results": results, "next_since": next_since}
 
     @staticmethod
     async def list_results(since: str = "", limit: int = 500) -> dict:
@@ -45,9 +48,10 @@ class CollectCredentialResultPushService:
         if not events:
             return {"pushed": 0, "next_since": since}
 
-        next_since = CollectCredentialResultPushService.build_results_payload(events).get("next_since") or since
+        result_payload = CollectCredentialResultPushService.build_results_payload(events)
+        next_since = result_payload.get("next_since") or since
         payload = {
-            "events": events,
+            "events": result_payload["results"],
             "next_since": next_since,
         }
         nats_namespace = os.getenv("NATS_NAMESPACE", "bklite")

--- a/agents/stargazer/tests/test_collect_credential_push.py
+++ b/agents/stargazer/tests/test_collect_credential_push.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def test_nats_server_registers_collect_credential_push_loop_on_import(monkeypatch):
-    from core import nats as nats_module
+    from core.infra import nats as nats_module
 
     app = Sanic("Stargazer")
     registered_subjects = []
@@ -103,6 +103,7 @@ def test_list_collect_credential_results_returns_bounded_payload(monkeypatch):
             "credential_id": "cred-1",
             "success": False,
             "finished_at": "2026-06-04T10:05:00+00:00",
+            "_stream_cursor": "opaque-member",
         },
     ]
 
@@ -122,10 +123,12 @@ def test_list_collect_credential_results_returns_bounded_payload(monkeypatch):
         )
     )
 
-    assert result == {
-        "results": events,
-        "next_since": "2026-06-04T10:05:00+00:00",
-    }
+    assert result["results"] == [
+        events[0],
+        {key: value for key, value in events[1].items() if key != "_stream_cursor"},
+    ]
+    assert result["next_since"].startswith("2026-06-04T10:05:00+00:00|m:")
+    assert "_stream_cursor" not in result["results"][1]
 
 
 def test_push_collect_credential_results_once_publishes_batch_and_updates_cursor(monkeypatch):
@@ -178,8 +181,9 @@ def test_push_collect_credential_results_once_publishes_batch_and_updates_cursor
 
     result = asyncio.run(CollectCredentialResultPushService.push_once())
 
-    assert result == {"pushed": 2, "next_since": "2026-06-04T10:05:00+00:00"}
+    assert result["pushed"] == 2
+    assert result["next_since"].startswith("2026-06-04T10:05:00+00:00|m:")
     assert published["subject"] == "bklite.receive_collect_credential_result"
     assert published["payload"]["kwargs"]["data"]["events"] == events
-    assert published["payload"]["kwargs"]["data"]["next_since"] == "2026-06-04T10:05:00+00:00"
-    assert cursor_updates == ["2026-06-04T10:05:00+00:00"]
+    assert published["payload"]["kwargs"]["data"]["next_since"] == result["next_since"]
+    assert cursor_updates == [result["next_since"]]

--- a/agents/stargazer/tests/test_collection_behavior_lock.py
+++ b/agents/stargazer/tests/test_collection_behavior_lock.py
@@ -140,7 +140,15 @@ def test_collection_result_id_is_stable_and_shared():
     other = build_collection_result_id(
         task_id="t1", plugin_ref="mysql.config", target="10.0.0.1", fence=4
     )
+    next_cycle = build_collection_result_id(
+        task_id="t1",
+        plugin_ref="mysql.config",
+        target="10.0.0.1",
+        fence=3,
+        attempt_id="next-cycle",
+    )
     assert first == second
     assert len(first) == 64
     assert first != other
+    assert first != next_cycle
     assert first.startswith(first[:24])  # host remote callback_task_id 前缀同源

--- a/agents/stargazer/tests/test_credential_state_cache.py
+++ b/agents/stargazer/tests/test_credential_state_cache.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import core.infra.credential_state_cache as cache_module
@@ -9,7 +7,9 @@ from core.infra.credential_state_cache import CredentialStateCache
 class Redis:
     def __init__(self):
         self.values = {}
+        self.scores = {}
         self.get_calls = 0
+        self.force_append_conflict = False
 
     async def get(self, key):
         self.get_calls += 1
@@ -31,7 +31,52 @@ class Redis:
         return 0
 
     async def zrangebyscore(self, key, **_kwargs):
-        return self.values.get(key, [])
+        minimum = _kwargs.get("min", "-inf")
+        maximum = _kwargs.get("max", "+inf")
+        start = _kwargs.get("start", 0)
+        count = _kwargs.get("num")
+        withscores = _kwargs.get("withscores", False)
+        minimum_exclusive = isinstance(minimum, str) and minimum.startswith("(")
+        if minimum_exclusive:
+            minimum = minimum[1:]
+        minimum = float("-inf") if minimum == "-inf" else float(minimum)
+        maximum = float("inf") if maximum == "+inf" else float(maximum)
+        items = sorted(
+            (
+                (member, self.scores[(key, member)])
+                for member in self.values.get(key, [])
+                if (
+                    (
+                        self.scores[(key, member)] > minimum
+                        if minimum_exclusive
+                        else self.scores[(key, member)] >= minimum
+                    )
+                    and self.scores[(key, member)] <= maximum
+                )
+            ),
+            key=lambda item: (item[1], item[0]),
+        )
+        items = items[start : start + count if count is not None else None]
+        return items if withscores else [member for member, _score in items]
+
+    async def eval(self, _script, _numkeys, *args):
+        if _numkeys == 1:
+            clock_key, requested_score = args
+            return max(
+                int(requested_score), int(self.values.get(clock_key, 0)) + 1
+            )
+        stream_key, dedupe_key, clock_key, score, payload, _retention, _cutoff = args
+        if self.force_append_conflict:
+            return -1
+        if dedupe_key in self.values:
+            return 0
+        if int(score) <= int(self.values.get(clock_key, 0)):
+            return -1
+        self.values[clock_key] = int(score)
+        self.values.setdefault(stream_key, []).append(payload)
+        self.scores[(stream_key, payload)] = score
+        self.values[dedupe_key] = "1"
+        return 1
 
 
 @pytest.mark.asyncio
@@ -75,4 +120,95 @@ async def test_result_events_remain_on_ordinary_redis(monkeypatch):
     )
 
     raw = redis.values[CredentialStateCache._event_stream_key()][0]
-    assert json.loads(raw)["collect_task_id"] == "task-1"
+    assert CredentialStateCache._decode_event_member(raw)["collect_task_id"] == "task-1"
+
+
+@pytest.mark.asyncio
+async def test_result_event_with_stable_id_is_appended_once(monkeypatch):
+    redis = Redis()
+
+    async def get_client():
+        return redis
+
+    monkeypatch.setattr(cache_module, "get_redis_client", get_client)
+    event = {
+        "event_id": "stable-result-event-id",
+        "collect_task_id": "task-1",
+        "host": "10.10.24.1",
+    }
+
+    await CredentialStateCache.append_result_event(event)
+    await CredentialStateCache.append_result_event(event)
+
+    raw_events = redis.values[CredentialStateCache._event_stream_key()]
+    assert len(raw_events) == 1
+    assert (
+        CredentialStateCache._decode_event_member(raw_events[0])["event_id"]
+        == "stable-result-event-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_result_events_use_unique_legacy_cursor_times_for_same_observation(monkeypatch):
+    redis = Redis()
+
+    async def get_client():
+        return redis
+
+    monkeypatch.setattr(cache_module, "get_redis_client", get_client)
+    observed_at = "2026-08-14T00:00:00+00:00"
+    for index in range(3):
+        await CredentialStateCache.append_result_event(
+            {
+                "event_id": f"event-{index}",
+                "collect_task_id": "task-1",
+                "host": f"10.0.0.{index}",
+                "finished_at": observed_at,
+            }
+        )
+
+    events = await CredentialStateCache.list_result_events(limit=3)
+    finished_at_values = [event["finished_at"] for event in events]
+    assert len(set(finished_at_values)) == 3
+    assert all(event["observed_at"] == observed_at for event in events)
+
+    # 模拟回滚后的旧读取器：纯时间排他游标可逐页前进，不会卡在同毫秒。
+    legacy_pages = []
+    legacy_cursor = ""
+    for _index in range(3):
+        minimum = (
+            f"({CredentialStateCache._event_score(legacy_cursor)}"
+            if legacy_cursor
+            else "-inf"
+        )
+        raw_page = await redis.zrangebyscore(
+            CredentialStateCache._event_stream_key(),
+            min=minimum,
+            max="+inf",
+            start=0,
+            num=1,
+        )
+        page = [CredentialStateCache._decode_event_member(item) for item in raw_page]
+        legacy_pages.extend(page)
+        legacy_cursor = page[-1]["finished_at"]
+
+    assert [event["event_id"] for event in legacy_pages] == [
+        "event-0",
+        "event-1",
+        "event-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_result_event_append_fails_after_bounded_cas_conflicts(monkeypatch):
+    redis = Redis()
+    redis.force_append_conflict = True
+
+    async def get_client():
+        return redis
+
+    monkeypatch.setattr(cache_module, "get_redis_client", get_client)
+    with pytest.raises(RuntimeError, match="too busy"):
+        await CredentialStateCache._append_result_event(
+            {"event_id": "always-conflicts"}
+        )

--- a/agents/stargazer/tests/test_redis_collection_state.py
+++ b/agents/stargazer/tests/test_redis_collection_state.py
@@ -1,8 +1,10 @@
 import asyncio
+import json
 import secrets
 import shutil
 import subprocess
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,7 @@ import pytest_asyncio
 from redis import Redis
 from redis.asyncio import Redis as AsyncRedis
 from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
 
 from core.collection.runtime import LeaseAcquireStatus, RunLease, RunStatus
 from core.collection.runtime import CollectionRequest
@@ -28,6 +31,7 @@ from core.collection.contracts import (
     PreflightResult,
     PreflightStatus,
 )
+from core.infra.credential_state_cache import CredentialStateCache
 
 
 def _stop_redis(process):
@@ -122,6 +126,225 @@ async def test_two_pods_atomically_share_one_run_lease(redis_client):
     assert duplicate.lease is not None
     assert duplicate.lease.owner_id == "pod-a"
     assert duplicate.lease.fence == first.lease.fence == 1
+    assert duplicate.lease.attempt_id == first.lease.attempt_id
+    assert first.lease.attempt_id
+
+
+@pytest.mark.asyncio
+async def test_result_event_redis_write_is_retryable_and_cursor_keeps_same_millisecond(
+    redis_client, monkeypatch
+):
+    async def get_client():
+        return redis_client
+
+    monkeypatch.setattr(
+        CredentialStateCache,
+        "_get_or_create_pool",
+        classmethod(lambda _cls: get_client()),
+    )
+    stream_key = CredentialStateCache._event_stream_key()
+    failed_event_id = "event-failed-once"
+    await redis_client.set(stream_key, "wrong-type")
+
+    with pytest.raises(ResponseError):
+        await CredentialStateCache.append_result_event(
+            {
+                "event_id": failed_event_id,
+                "finished_at": "2026-08-14T00:00:00.123+00:00",
+            }
+        )
+
+    assert not await redis_client.exists(
+        CredentialStateCache._event_dedupe_key(failed_event_id)
+    )
+    await redis_client.delete(stream_key)
+    for event_id in ("event-001", "event-002", "event-003"):
+        await CredentialStateCache.append_result_event(
+            {
+                "event_id": event_id,
+                "finished_at": "2026-08-14T00:00:00.123+00:00",
+            }
+        )
+    await CredentialStateCache.append_result_event(
+        {
+            "event_id": failed_event_id,
+            "finished_at": "2026-08-14T00:00:00.123+00:00",
+        }
+    )
+
+    first_page = await CredentialStateCache.list_result_events(limit=2)
+    first_cursor = CredentialStateCache.event_cursor(first_page[-1])
+    second_page = await CredentialStateCache.list_result_events(
+        since=first_cursor, limit=2
+    )
+    legacy_cursor_page = await CredentialStateCache.list_result_events(
+        since="2026-08-14T00:00:00.123+00:00", limit=10
+    )
+
+    assert [event["event_id"] for event in first_page] == [
+        "event-001",
+        "event-002",
+    ]
+    assert [event["event_id"] for event in second_page] == [
+        "event-003",
+        failed_event_id,
+    ]
+    assert len(legacy_cursor_page) == 4
+    assert all(
+        CredentialStateCache._STREAM_CURSOR_FIELD in event
+        for event in first_page + second_page
+    )
+    await CredentialStateCache.set_push_cursor(first_cursor)
+    assert await CredentialStateCache.get_push_cursor() == first_cursor
+    legacy_cursor = await redis_client.get(CredentialStateCache._push_cursor_key())
+    if isinstance(legacy_cursor, bytes):
+        legacy_cursor = legacy_cursor.decode()
+    assert legacy_cursor == first_page[-1]["finished_at"]
+    assert CredentialStateCache._event_score(legacy_cursor) > 0
+    legacy_raw_page = await redis_client.zrangebyscore(
+        stream_key,
+        min=f"({CredentialStateCache._event_score(legacy_cursor)}",
+        max="+inf",
+        start=0,
+        num=2,
+    )
+    assert [
+        CredentialStateCache._decode_event_member(item)["event_id"]
+        for item in legacy_raw_page
+    ] == ["event-003", failed_event_id]
+    assert await redis_client.exists(
+        CredentialStateCache._event_dedupe_key(failed_event_id)
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_result_events_commit_before_cursor_can_advance(
+    redis_client, monkeypatch
+):
+    class CrossPodRedis:
+        def __init__(self, client):
+            self.client = client
+            self.cas_conflicts = 0
+
+        def __getattr__(self, name):
+            return getattr(self.client, name)
+
+        async def eval(self, script, numkeys, *args):
+            result = await self.client.eval(script, numkeys, *args)
+            if numkeys == 3 and int(result) == -1:
+                self.cas_conflicts += 1
+            return result
+
+    cross_pod_redis = CrossPodRedis(redis_client)
+
+    async def get_client():
+        return cross_pod_redis
+
+    monkeypatch.setattr(
+        CredentialStateCache,
+        "_get_or_create_pool",
+        classmethod(lambda _cls: get_client()),
+    )
+    observed_at = "2026-08-14T00:00:00.123+00:00"
+    event_ids = [f"concurrent-event-{index:03d}" for index in range(64)]
+
+    await asyncio.gather(
+        *(
+            # 各调用模拟独立 Pod，不共享进程内锁，只由 Redis CAS 协调。
+            CredentialStateCache._append_result_event(
+                {"event_id": event_id, "finished_at": observed_at}
+            )
+            for event_id in event_ids
+        )
+    )
+
+    # 直接按回滚后的旧排他时间游标逐页读取，所有并发提交均可达。
+    legacy_cursor = ""
+    observed_ids = []
+    while True:
+        minimum = (
+            f"({CredentialStateCache._event_score(legacy_cursor)}"
+            if legacy_cursor
+            else "-inf"
+        )
+        raw_page = await redis_client.zrangebyscore(
+            CredentialStateCache._event_stream_key(),
+            min=minimum,
+            max="+inf",
+            start=0,
+            num=7,
+        )
+        if not raw_page:
+            break
+        page = [
+            CredentialStateCache._decode_event_member(item) for item in raw_page
+        ]
+        observed_ids.extend(event["event_id"] for event in page)
+        legacy_cursor = page[-1]["finished_at"]
+
+    assert set(observed_ids) == set(event_ids)
+    assert len(observed_ids) == len(event_ids)
+    assert cross_pod_redis.cas_conflicts > 0
+
+
+@pytest.mark.asyncio
+async def test_rollback_cursor_keeps_old_writer_events_reachable(
+    redis_client, monkeypatch
+):
+    async def get_client():
+        return redis_client
+
+    monkeypatch.setattr(
+        CredentialStateCache,
+        "_get_or_create_pool",
+        classmethod(lambda _cls: get_client()),
+    )
+    observed_at = datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+    for index in range(64):
+        await CredentialStateCache.append_result_event(
+            {
+                "event_id": f"new-writer-{index:03d}",
+                "finished_at": observed_at,
+            }
+        )
+    new_events = await CredentialStateCache.list_result_events(limit=64)
+    await CredentialStateCache.set_push_cursor(
+        CredentialStateCache.event_cursor(new_events[-1])
+    )
+
+    legacy_cursor = await redis_client.get(CredentialStateCache._push_cursor_key())
+    old_writer_finished_at = datetime.now(timezone.utc).isoformat(
+        timespec="milliseconds"
+    )
+    old_writer_event = json.dumps(
+        {
+            "event_id": "old-writer-after-rollback",
+            "finished_at": old_writer_finished_at,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    await redis_client.zadd(
+        CredentialStateCache._event_stream_key(),
+        {
+            old_writer_event: CredentialStateCache._event_score(
+                old_writer_finished_at
+            )
+        },
+    )
+
+    assert CredentialStateCache._event_score(legacy_cursor) < (
+        CredentialStateCache._event_score(old_writer_finished_at)
+    )
+    rollback_page = await redis_client.zrangebyscore(
+        CredentialStateCache._event_stream_key(),
+        min=f"({CredentialStateCache._event_score(legacy_cursor)}",
+        max="+inf",
+    )
+    assert "old-writer-after-rollback" in {
+        CredentialStateCache._decode_event_member(item)["event_id"]
+        for item in rollback_page
+    }
 
 
 @pytest.mark.asyncio
@@ -251,6 +474,42 @@ async def test_finish_releases_lease_for_next_cycle(redis_client):
     assert second.lease is not None
     assert second.lease.owner_id == "pod-b"
     assert second.lease.fence == 1
+    assert second.lease.attempt_id != first.lease.attempt_id
+
+
+@pytest.mark.asyncio
+async def test_previous_cycle_cannot_finish_or_heartbeat_new_same_owner_lease(
+    redis_client,
+):
+    run_store = RedisRunStateStore(redis_client, key_prefix="test:attempt-fence")
+    first = await run_store.acquire(
+        task_id="cycle-same-owner",
+        request_digest="digest",
+        owner_id="pod-a",
+        ttl_seconds=60,
+    )
+    assert first.lease is not None
+    assert await run_store.finish(first.lease, status=RunStatus.COMPLETED)
+    second = await run_store.acquire(
+        task_id="cycle-same-owner",
+        request_digest="digest",
+        owner_id="pod-a",
+        ttl_seconds=60,
+    )
+    assert second.lease is not None
+    assert second.lease.attempt_id != first.lease.attempt_id
+
+    assert not await run_store.heartbeat(first.lease, ttl_seconds=60)
+    assert not await run_store.finish(first.lease, status=RunStatus.COMPLETED)
+    duplicate = await run_store.acquire(
+        task_id="cycle-same-owner",
+        request_digest="digest",
+        owner_id="pod-b",
+        ttl_seconds=60,
+    )
+    assert duplicate.status == LeaseAcquireStatus.DUPLICATE_ACTIVE
+    assert duplicate.lease is not None
+    assert duplicate.lease.attempt_id == second.lease.attempt_id
 
 
 @pytest.mark.asyncio

--- a/agents/stargazer/tests/test_result_publisher.py
+++ b/agents/stargazer/tests/test_result_publisher.py
@@ -1,8 +1,213 @@
 import pytest
-
-from core.collection.runtime import CollectionRequest, RunLease
+from core.collection.contracts import CredentialFailureResult, TargetCollectionResult
 from core.collection.result_publisher import NatsResultPublisher
-from core.collection.contracts import TargetCollectionResult
+from core.collection.runtime import CollectionRequest, RunLease
+
+
+@pytest.mark.asyncio
+async def test_credential_result_event_declares_v2_contract():
+    events = []
+
+    async def record_event(event):
+        events.append(event)
+
+    publisher = NatsResultPublisher(result_event_sink=record_event)
+    request = CollectionRequest(
+        task_id="collect-result-event",
+        plugin_ref="mysql.config",
+        targets=("10.10.24.1",),
+    )
+    lease = RunLease(
+        task_id=request.task_id,
+        request_digest=request.digest,
+        owner_id="pod-a",
+        fence=7,
+        expires_at=999999,
+        attempt_id="run-attempt-1",
+    )
+
+    await publisher._record_event(
+        request,
+        TargetCollectionResult(
+            target="10.10.24.1",
+            status="success",
+            attempts=1,
+            credential_id="credential-1",
+        ),
+        lease,
+        "result-id",
+    )
+
+    assert len(events[0].pop("event_id")) == 64
+    assert events == [
+        {
+            "event_version": 2,
+            "producer": "stargazer",
+            "scope_id": "collect-result-event",
+            "collect_task_id": "collect-result-event",
+            "run_id": "collect-result-event",
+            "run_attempt_id": "run-attempt-1",
+            "producer_instance": "pod-a",
+            "plugin_ref": "mysql.config",
+            "host": "10.10.24.1",
+            "credential_id": "credential-1",
+            "status": "success",
+            "error_code": "",
+            "success": True,
+            "failure_kind": "",
+            "error_message": "",
+            "attempts": 1,
+            "fence": 7,
+            "result_id": "result-id",
+            "event_index": 0,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_credential_result_event_expands_rotated_credential_failures():
+    events = []
+
+    async def record_event(event):
+        events.append(event)
+
+    publisher = NatsResultPublisher(result_event_sink=record_event)
+    request = CollectionRequest(
+        task_id="collect-result-rotation",
+        plugin_ref="mysql.config",
+        targets=("10.10.24.1",),
+    )
+    lease = RunLease(
+        task_id=request.task_id,
+        request_digest=request.digest,
+        owner_id="pod-a",
+        fence=7,
+        expires_at=999999,
+        attempt_id="run-attempt-1",
+    )
+
+    await publisher._record_event(
+        request,
+        TargetCollectionResult(
+            target="10.10.24.1",
+            status="success",
+            attempts=3,
+            credential_id="credential-3",
+            credential_failures=(
+                CredentialFailureResult("credential-1", "unauthorized"),
+                CredentialFailureResult("credential-2", "authentication_failed"),
+            ),
+        ),
+        lease,
+        "result-id",
+    )
+
+    assert [event["credential_id"] for event in events] == [
+        "credential-1",
+        "credential-2",
+        "credential-3",
+    ]
+    assert [(event["status"], event["success"]) for event in events] == [
+        ("failed", False),
+        ("failed", False),
+        ("success", True),
+    ]
+    assert [event["failure_kind"] for event in events] == [
+        "credential",
+        "credential",
+        "",
+    ]
+    assert all(event["event_version"] == 2 for event in events)
+
+
+@pytest.mark.asyncio
+async def test_credential_result_event_ids_are_stable_across_partial_retry():
+    attempts = []
+    fail_second_once = True
+
+    async def partially_failing_sink(event):
+        nonlocal fail_second_once
+        attempts.append(event)
+        if fail_second_once and len(attempts) == 2:
+            fail_second_once = False
+            raise ConnectionError("partial write")
+
+    publisher = NatsResultPublisher(result_event_sink=partially_failing_sink)
+    request = CollectionRequest(
+        task_id="collect-result-partial-retry",
+        plugin_ref="mysql.config",
+        targets=("10.10.24.1",),
+    )
+    lease = RunLease(
+        task_id=request.task_id,
+        request_digest=request.digest,
+        owner_id="pod-a",
+        fence=7,
+        expires_at=999999,
+        attempt_id="run-attempt-1",
+    )
+    result = TargetCollectionResult(
+        target="10.10.24.1",
+        status="success",
+        attempts=3,
+        credential_id="credential-3",
+        credential_failures=(
+            CredentialFailureResult("credential-1", "unauthorized"),
+            CredentialFailureResult("credential-2", "authentication_failed"),
+        ),
+    )
+
+    with pytest.raises(ConnectionError, match="partial write"):
+        await publisher._record_event(request, result, lease, "result-id")
+    await publisher._record_event(request, result, lease, "result-id")
+
+    first_attempt_id = attempts[0]["event_id"]
+    retried_first_id = attempts[2]["event_id"]
+    assert first_attempt_id == retried_first_id
+    assert len({event["event_id"] for event in attempts[2:]}) == 3
+
+
+@pytest.mark.asyncio
+async def test_credential_result_event_omits_empty_aggregate_after_failures():
+    events = []
+
+    async def record_event(event):
+        events.append(event)
+
+    publisher = NatsResultPublisher(result_event_sink=record_event)
+    request = CollectionRequest(
+        task_id="collect-result-exhausted",
+        plugin_ref="mysql.config",
+        targets=("10.10.24.1",),
+    )
+    lease = RunLease(
+        task_id=request.task_id,
+        request_digest=request.digest,
+        owner_id="pod-a",
+        fence=7,
+        expires_at=999999,
+        attempt_id="run-attempt-1",
+    )
+
+    await publisher._record_event(
+        request,
+        TargetCollectionResult(
+            target="10.10.24.1",
+            status="failed",
+            attempts=1,
+            error_code="credentials_exhausted",
+            credential_failures=(
+                CredentialFailureResult("credential-1", "capability_denied"),
+            ),
+        ),
+        lease,
+        "result-id",
+    )
+
+    assert len(events) == 1
+    assert events[0]["credential_id"] == "credential-1"
+    assert events[0]["error_code"] == "capability_denied"
+    assert events[0]["failure_kind"] == "credential"
 
 
 @pytest.mark.asyncio
@@ -26,6 +231,7 @@ async def test_metrics_result_carries_idempotency_and_fencing_identity():
         owner_id="pod-a",
         fence=7,
         expires_at=999999,
+        attempt_id="run-attempt-1",
     )
 
     await publisher.publish(
@@ -75,6 +281,7 @@ async def test_callback_result_includes_fence_and_is_not_sent_as_metrics():
         owner_id="pod-a",
         fence=4,
         expires_at=999999,
+        attempt_id="run-attempt-1",
     )
 
     await publisher.publish(

--- a/agents/stargazer/tests/test_target_collection_executor.py
+++ b/agents/stargazer/tests/test_target_collection_executor.py
@@ -137,46 +137,6 @@ class RejectsUnverifiedCredentialPlugin:
         )
 
 
-class BrokenAccessProbe:
-    async def probe(
-        self, target, credential, context, *, timeout_seconds
-    ):
-        raise RuntimeError("secret-do-not-publish")
-
-
-class TimeoutThenReadyAccessProbe:
-    async def probe(
-        self, target, credential, context, *, timeout_seconds
-    ):
-        if credential["credential_id"] == "credential-1":
-            await asyncio.sleep(60)
-        return AccessProbeResult(status=AccessProbeStatus.READY)
-
-
-class FixedAccessProbe:
-    def __init__(self, status, error_code):
-        self.status = status
-        self.error_code = error_code
-
-    async def probe(
-        self, target, credential, context, *, timeout_seconds
-    ):
-        return AccessProbeResult(
-            status=self.status,
-            error_code=self.error_code,
-        )
-
-
-class RejectsUnverifiedCredentialPlugin:
-    async def collect(self, target, credential, context):
-        if credential["credential_id"] != "credential-2":
-            raise AssertionError("formal collection used an unverified credential")
-        return CollectOutcome(
-            status=CollectOutcomeStatus.SUCCESS,
-            value={"version": "8.0"},
-        )
-
-
 class ScriptedPlugin:
     def __init__(self, outcomes):
         self.outcomes = list(outcomes)
@@ -240,6 +200,10 @@ async def test_credentials_rotate_inside_target_and_success_gets_affinity():
                 error_code="unauthorized",
             ),
             CollectOutcome(
+                status=CollectOutcomeStatus.AUTH_FAILED,
+                error_code="authentication_failed",
+            ),
+            CollectOutcome(
                 status=CollectOutcomeStatus.SUCCESS,
                 value={"version": "8.0"},
             ),
@@ -279,14 +243,21 @@ async def test_credentials_rotate_inside_target_and_success_gets_affinity():
     assert plugin.calls == [
         ("10.10.24.1", "credential-1"),
         ("10.10.24.1", "credential-2"),
+        ("10.10.24.1", "credential-3"),
     ]
-    assert publisher.results[0][1].credential_id == "credential-2"
-    assert publisher.results[0][1].attempts == 2
+    assert publisher.results[0][1].credential_id == "credential-3"
+    assert publisher.results[0][1].attempts == 3
+    assert [
+        (failure.credential_id, failure.error_code)
+        for failure in publisher.results[0][1].credential_failures
+    ] == [
+        ("credential-1", "unauthorized"),
+        ("credential-2", "authentication_failed"),
+    ]
     eligible = await credential_policy.eligible_credentials(
         request, "10.10.24.1"
     )
     assert [item["credential_id"] for item in eligible] == [
-        "credential-2",
         "credential-3",
     ]
 
@@ -444,7 +415,44 @@ async def test_access_probe_target_unreachable_stops_credential_rotation():
     assert summary.unreachable == 1
     assert publisher.results[0][1].status == "unreachable"
     assert publisher.results[0][1].attempts == 1
+    assert publisher.results[0][1].credential_id == "credential-1"
     assert publisher.results[0][1].error_code == "target_unreachable"
+
+
+@pytest.mark.asyncio
+async def test_collect_unreachable_keeps_selected_credential_identity():
+    publisher = RecordingPublisher()
+    executor = TargetCollectionExecutor(
+        preflight=ReachablePreflight(),
+        plugin=ScriptedPlugin(
+            [
+                CollectOutcome(
+                    status=CollectOutcomeStatus.UNREACHABLE,
+                    error_code="target_unreachable",
+                )
+            ]
+        ),
+        publisher=publisher,
+        settings=TargetExecutorSettings(max_active_targets=1, target_task_window=1),
+    )
+    request = CollectionRequest(
+        task_id="collect-unreachable-after-selection",
+        plugin_ref="mysql.config",
+        targets=("10.10.24.1",),
+        credentials=({"credential_id": "credential-1"},),
+    )
+    lease = RunLease(
+        task_id=request.task_id,
+        request_digest=request.digest,
+        owner_id="pod-a",
+        fence=1,
+        expires_at=999999,
+    )
+
+    summary = await executor.execute(request, lease)
+
+    assert summary.unreachable == 1
+    assert publisher.results[0][1].credential_id == "credential-1"
 
 
 @pytest.mark.asyncio
@@ -643,6 +651,10 @@ async def test_capability_denied_probe_cools_credential_without_collecting():
 
     assert summary.failed == 1
     assert publisher.results[0][1].error_code == "credentials_exhausted"
+    assert [
+        (failure.credential_id, failure.error_code)
+        for failure in publisher.results[0][1].credential_failures
+    ] == [("credential-1", "capability_denied")]
     assert await credential_policy.eligible_credentials(
         request, "10.10.24.1"
     ) == ()

--- a/server/apps/cmdb/migrations/0048_collecttaskcredentialhit_recent_result_event_ids.py
+++ b/server/apps/cmdb/migrations/0048_collecttaskcredentialhit_recent_result_event_ids.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cmdb", "0047_enable_nodemgmtsync_auto_sync_default"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="collecttaskcredentialhit",
+            name="recent_result_event_ids",
+            field=models.JSONField(default=list),
+        ),
+        migrations.AddField(
+            model_name="collecttaskcredentialhit",
+            name="last_result_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="collecttaskcredentialhit",
+            name="last_result_id",
+            field=models.CharField(blank=True, default="", max_length=64),
+        ),
+        migrations.AddField(
+            model_name="collecttaskcredentialhit",
+            name="last_result_event_index",
+            field=models.IntegerField(default=-1),
+        ),
+    ]

--- a/server/apps/cmdb/models/collect_task_credential_hit.py
+++ b/server/apps/cmdb/models/collect_task_credential_hit.py
@@ -24,6 +24,10 @@ class CollectTaskCredentialHit(TimeInfo):
     last_failure_at = models.DateTimeField(null=True, blank=True)
     last_error = models.TextField(blank=True, default="")
     object_snapshot = models.JSONField(default=dict)
+    recent_result_event_ids = models.JSONField(default=list)
+    last_result_at = models.DateTimeField(null=True, blank=True)
+    last_result_id = models.CharField(max_length=64, blank=True, default="")
+    last_result_event_index = models.IntegerField(default=-1)
 
     class Meta:
         verbose_name = "采集任务凭据命中状态"

--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -925,6 +925,15 @@ def receive_collect_credential_result(data: dict):
     payload = data or {}
     events = payload.get("events") if isinstance(payload, dict) else None
 
+    if not isinstance(payload, dict):
+        logger.warning(
+            "Received invalid collect credential result event, type=%s",
+            type(payload).__name__,
+        )
+        return CollectCredentialResultService.process_result(
+            payload, parse_datetime=_parse_nats_datetime
+        )
+
     if isinstance(events, list):
         logger.info(
             "Received pushed collect credential result batch, count=%s next_since=%s",
@@ -932,12 +941,15 @@ def receive_collect_credential_result(data: dict):
             payload.get("next_since") or "",
         )
     else:
+        status = payload.get("status")
+        if not status:
+            status = "success" if bool(payload.get("success")) else "failed"
         logger.info(
-            "Received pushed collect credential result event, task_id=%s host=%s credential_id=%s success=%s",
+            "Received pushed collect credential result event, task_id=%s host=%s credential_id=%s status=%s",
             payload.get("collect_task_id") or payload.get("task_id") or "",
             payload.get("host") or "",
             payload.get("credential_id") or "",
-            bool(payload.get("success")),
+            status,
         )
 
     result = CollectCredentialResultService.process_batch(payload, parse_datetime=_parse_nats_datetime)

--- a/server/apps/cmdb/services/collect_credential_result_service.py
+++ b/server/apps/cmdb/services/collect_credential_result_service.py
@@ -1,13 +1,147 @@
+import hashlib
+
 from django.utils import timezone
 
+from apps.cmdb.models.collect_model import CollectModels
 from apps.cmdb.services.collect_hit_state_service import CollectHitStateService
 from apps.core.logger import cmdb_logger as logger
 
 
 class CollectCredentialResultService:
+    EVENT_VERSION = "2"
+    MODERN_STATUSES = frozenset({"success", "failed", "unreachable", "deferred"})
+    CREDENTIAL_FAILURE_ERROR_CODES = frozenset(
+        {
+            "auth_failed",
+            "authentication_failed",
+            "capability_denied",
+            "snmp_error_status",
+            "snmp_authorization_failed",
+            "unauthorized",
+        }
+    )
+
+    @classmethod
+    def _normalize_outcome(cls, data: dict):
+        event_version = data.get("event_version")
+        if event_version is not None and str(event_version) != cls.EVENT_VERSION:
+            return None, f"unsupported event_version: {event_version}"
+
+        if event_version is not None and "status" not in data:
+            return None, f"status is required for event_version: {event_version}"
+
+        if event_version is not None:
+            identity_error = cls._validate_v2_identity(data)
+            if identity_error:
+                return None, identity_error
+
+        if "status" in data:
+            status = str(data.get("status") or "").strip().lower()
+            if status not in cls.MODERN_STATUSES:
+                return None, f"unsupported status: {status or '<empty>'}"
+
+            success = status == "success"
+            if "success" in data and bool(data.get("success")) != success:
+                return None, "status conflicts with success"
+
+            error_code = str(data.get("error_code") or "").strip()
+            if success and error_code:
+                return None, "status conflicts with error_code"
+            if (
+                status in {"deferred", "unreachable"}
+                and error_code in cls.CREDENTIAL_FAILURE_ERROR_CODES
+            ):
+                return None, "status conflicts with error_code"
+
+            failure_kind = (
+                "credential"
+                if status == "failed"
+                and error_code in cls.CREDENTIAL_FAILURE_ERROR_CODES
+                else "task"
+            )
+            if success:
+                failure_kind = ""
+                if data.get("failure_kind") or data.get("error_message"):
+                    return None, "success conflicts with failure fields"
+            elif (
+                "failure_kind" in data
+                and (data.get("failure_kind") or "task") != failure_kind
+            ):
+                return None, "error_code conflicts with failure_kind"
+
+            return {
+                "success": success,
+                "failure_kind": failure_kind,
+                "error_message": str(data.get("error_message") or error_code),
+            }, ""
+
+        if "success" not in data:
+            return None, "status or success is required"
+
+        return {
+            "success": bool(data.get("success")),
+            "failure_kind": data.get("failure_kind") or "task",
+            "error_message": data.get("error_message") or "",
+        }, ""
+
+    @classmethod
+    def _validate_v2_identity(cls, data: dict) -> str:
+        required = (
+            "collect_task_id",
+            "event_id",
+            "event_index",
+            "finished_at",
+            "plugin_ref",
+            "producer_instance",
+            "result_id",
+            "run_attempt_id",
+            "run_id",
+        )
+        missing = [key for key in required if data.get(key) in (None, "")]
+        if missing:
+            return "v2 identity fields are required: " + ", ".join(missing)
+        if data.get("producer") != "stargazer":
+            return "unsupported producer"
+        if str(data.get("scope_id") or "") != str(data.get("collect_task_id")):
+            return "scope_id conflicts with collect_task_id"
+        try:
+            fence = int(data.get("fence"))
+            event_index = int(data.get("event_index"))
+        except (TypeError, ValueError):
+            return "fence and event_index must be integers"
+        if fence <= 0 or event_index < 0:
+            return "fence must be positive and event_index must be non-negative"
+        result_identity = "\0".join(
+            (
+                str(data.get("run_id")),
+                str(data.get("plugin_ref")),
+                str(data.get("host")),
+                str(fence),
+                str(data.get("run_attempt_id")),
+            )
+        )
+        expected_result_id = hashlib.sha256(result_identity.encode("utf-8")).hexdigest()
+        if str(data.get("result_id")) != expected_result_id:
+            return "result_id conflicts with run identity"
+        event_identity = "\0".join(
+            (
+                expected_result_id,
+                str(event_index),
+                str(data.get("credential_id") or ""),
+                str(data.get("status") or ""),
+                str(data.get("error_code") or ""),
+            )
+        )
+        expected_event_id = hashlib.sha256(event_identity.encode("utf-8")).hexdigest()
+        if str(data.get("event_id")) != expected_event_id:
+            return "event_id conflicts with event identity"
+        return ""
+
     @staticmethod
     def process_result(data: dict, parse_datetime=None):
         """处理 Stargazer 单 host 单凭据执行结果并回写 CollectTaskCredentialHit。"""
+        if not isinstance(data, dict):
+            return {"result": False, "message": "event must be an object"}
         task_id = data.get("collect_task_id") or data.get("task_id")
         if not task_id:
             logger.warning("[CollectCredentialResult] 回调缺少 collect_task_id，已忽略")
@@ -25,38 +159,74 @@ class CollectCredentialResultService:
             return {"result": False, "message": "host and credential_id are required"}
 
         object_key = f"host:{host}"
-        snapshot = dict(data.get("snapshot") or {})
+        raw_snapshot = data.get("snapshot") or {}
+        if not isinstance(raw_snapshot, dict):
+            return {"result": False, "message": "snapshot must be an object"}
+        snapshot = dict(raw_snapshot)
         snapshot.setdefault("host", host)
-        finished_at = parse_datetime(data.get("finished_at")) if parse_datetime else None
-        finished_at = finished_at or timezone.now()
-        success = bool(data.get("success"))
+        try:
+            event_at = (
+                parse_datetime(data.get("observed_at") or data.get("finished_at"))
+                if parse_datetime
+                else None
+            )
+        except (TypeError, ValueError, OverflowError):
+            return {"result": False, "message": "event time is invalid"}
+        event_at = event_at or timezone.now()
+        outcome, error = CollectCredentialResultService._normalize_outcome(data)
+        if error:
+            logger.warning(
+                "[CollectCredentialResult] 回调事件契约无效，已忽略 task_id=%s, host=%s, credential_id=%s, error=%s",
+                task_id,
+                host,
+                credential_id,
+                error,
+            )
+            return {"result": False, "message": error}
+        try:
+            task = CollectModels.objects.filter(pk=task_id).only("id").first()
+        except (TypeError, ValueError, OverflowError):
+            task = None
+        if task is None:
+            return {"result": False, "message": "collect_task_id does not exist"}
 
-        if success:
+        if outcome["success"]:
             logger.info(
                 "[CollectCredentialResult] 凭据采集成功回写 task_id=%s, object_key=%s, credential_id=%s",
                 task_id,
                 object_key,
                 credential_id,
             )
-            CollectHitStateService.mark_success(task_id, object_key, credential_id, snapshot, finished_at)
-        else:
-            logger.warning(
-                "[CollectCredentialResult] 凭据采集失败回写 task_id=%s, object_key=%s, credential_id=%s, "
-                "failure_kind=%s, error=%s",
+            CollectHitStateService.mark_success(
                 task_id,
                 object_key,
                 credential_id,
-                data.get("failure_kind") or "task",
-                (str(data.get("error_message") or ""))[:500],
+                snapshot,
+                event_at,
+                event_id=data.get("event_id") or "",
+                result_id=data.get("result_id") or "",
+                event_index=data.get("event_index", -1),
+            )
+        else:
+            logger.warning(
+                "[CollectCredentialResult] 凭据采集失败回写 task_id=%s, object_key=%s, credential_id=%s, " "failure_kind=%s, error=%s",
+                task_id,
+                object_key,
+                credential_id,
+                outcome["failure_kind"],
+                outcome["error_message"][:500],
             )
             CollectHitStateService.mark_failure(
                 task_id,
                 object_key,
                 credential_id,
                 snapshot,
-                data.get("failure_kind") or "task",
-                data.get("error_message") or "",
-                finished_at,
+                outcome["failure_kind"],
+                outcome["error_message"],
+                event_at,
+                event_id=data.get("event_id") or "",
+                result_id=data.get("result_id") or "",
+                event_index=data.get("event_index", -1),
             )
 
         return {"result": True, "task_id": task_id, "object_key": object_key, "credential_id": credential_id}

--- a/server/apps/cmdb/services/collect_hit_state_service.py
+++ b/server/apps/cmdb/services/collect_hit_state_service.py
@@ -1,5 +1,8 @@
 from datetime import timedelta
 
+from django.db import transaction
+
+from apps.cmdb.models.collect_model import CollectModels
 from apps.cmdb.models.collect_task_credential_hit import CollectTaskCredentialHit
 
 
@@ -28,55 +31,164 @@ class CollectHitStateService:
         return now >= state.next_retry_at
 
     @staticmethod
-    def mark_success(task_id, object_key, credential_id, snapshot, now):
-        CollectTaskCredentialHit.objects.update_or_create(
-            task_id=task_id,
-            object_key=object_key,
-            credential_id=credential_id,
-            defaults={
-                "status": CollectTaskCredentialHit.STATUS_SUCCESS,
-                "consecutive_failures": 0,
-                "cooldown_level": 0,
-                "next_retry_at": None,
-                "last_success_at": now,
-                "last_error": "",
-                "object_snapshot": snapshot or {},
-            },
-        )
-        CollectTaskCredentialHit.objects.filter(
-            task_id=task_id,
-            object_key=object_key,
-            status=CollectTaskCredentialHit.STATUS_SUCCESS,
-        ).exclude(credential_id=credential_id).update(
-            status=CollectTaskCredentialHit.STATUS_UNTESTED,
-            consecutive_failures=0,
-            cooldown_level=0,
-            next_retry_at=None,
-            last_error="",
-        )
+    def mark_success(
+        task_id,
+        object_key,
+        credential_id,
+        snapshot,
+        now,
+        event_id="",
+        result_id="",
+        event_index=-1,
+    ):
+        with transaction.atomic():
+            # 同一任务的凭据状态共享“唯一成功凭据”不变量，
+            # 锁住父任务以串行化不同凭据行的并发切换。
+            CollectModels.objects.select_for_update().only("id").get(pk=task_id)
+            if not CollectHitStateService._accept_success_switch(
+                task_id,
+                object_key,
+                credential_id,
+                event_id,
+                now,
+                result_id,
+                event_index,
+            ):
+                return False
+            state, _ = CollectTaskCredentialHit.objects.select_for_update().get_or_create(
+                task_id=task_id,
+                object_key=object_key,
+                credential_id=credential_id,
+            )
+            if not CollectHitStateService._accept_event(
+                state, event_id, now, result_id, event_index
+            ):
+                return False
+            state.status = CollectTaskCredentialHit.STATUS_SUCCESS
+            state.consecutive_failures = 0
+            state.cooldown_level = 0
+            state.next_retry_at = None
+            state.last_success_at = now
+            state.last_error = ""
+            state.object_snapshot = snapshot or {}
+            state.save()
+            CollectTaskCredentialHit.objects.filter(
+                task_id=task_id,
+                object_key=object_key,
+                status=CollectTaskCredentialHit.STATUS_SUCCESS,
+            ).exclude(credential_id=credential_id).update(
+                status=CollectTaskCredentialHit.STATUS_UNTESTED,
+                consecutive_failures=0,
+                cooldown_level=0,
+                next_retry_at=None,
+                last_error="",
+            )
+        return True
 
     @staticmethod
-    def mark_failure(task_id, object_key, credential_id, snapshot, failure_kind, error_message, now):
-        state, _ = CollectTaskCredentialHit.objects.get_or_create(
-            task_id=task_id,
-            object_key=object_key,
-            credential_id=credential_id,
+    def mark_failure(
+        task_id,
+        object_key,
+        credential_id,
+        snapshot,
+        failure_kind,
+        error_message,
+        now,
+        event_id="",
+        result_id="",
+        event_index=-1,
+    ):
+        with transaction.atomic():
+            CollectModels.objects.select_for_update().only("id").get(pk=task_id)
+            state, _ = CollectTaskCredentialHit.objects.select_for_update().get_or_create(
+                task_id=task_id,
+                object_key=object_key,
+                credential_id=credential_id,
+            )
+            if not CollectHitStateService._accept_event(
+                state, event_id, now, result_id, event_index
+            ):
+                return False
+            state.object_snapshot = snapshot or {}
+            state.last_failure_at = now
+            state.last_error = error_message or ""
+
+            if failure_kind == "credential":
+                next_level = state.cooldown_level + 1
+                state.status = CollectTaskCredentialHit.STATUS_KNOWN_FAILED
+                state.consecutive_failures += 1
+                state.cooldown_level = next_level
+                state.next_retry_at = now + timedelta(hours=CollectHitStateService.cooldown_hours_for(next_level))
+            else:
+                state.status = CollectTaskCredentialHit.STATUS_UNTESTED
+                state.next_retry_at = None
+
+            state.save()
+        return True
+
+    @staticmethod
+    def _accept_event(state, event_id, event_at, result_id, event_index):
+        event_id = str(event_id or "").strip()
+        recent_ids = list(state.recent_result_event_ids or [])
+        if event_id and event_id in recent_ids:
+            return False
+        result_id = str(result_id or "").strip()
+        try:
+            event_index = int(event_index)
+        except (TypeError, ValueError):
+            event_index = -1
+        if state.last_result_at and event_at < state.last_result_at:
+            return False
+        if (
+            state.last_result_at == event_at
+            and result_id
+            and result_id == state.last_result_id
+            and event_index <= state.last_result_event_index
+        ):
+            return False
+        if event_id:
+            state.recent_result_event_ids = (recent_ids + [event_id])[-64:]
+        state.last_result_at = event_at
+        state.last_result_id = result_id
+        state.last_result_event_index = event_index
+        return True
+
+    @staticmethod
+    def _accept_success_switch(
+        task_id,
+        object_key,
+        credential_id,
+        event_id,
+        event_at,
+        result_id,
+        event_index,
+    ):
+        """拒绝较旧成功事件把更新的跨凭据亲和降级。"""
+        current = (
+            CollectTaskCredentialHit.objects.filter(
+                task_id=task_id,
+                object_key=object_key,
+                status=CollectTaskCredentialHit.STATUS_SUCCESS,
+            )
+            .exclude(credential_id=credential_id)
+            .order_by("-last_result_at", "-id")
+            .first()
         )
-        state.object_snapshot = snapshot or {}
-        state.last_failure_at = now
-        state.last_error = error_message or ""
-
-        if failure_kind == "credential":
-            next_level = state.cooldown_level + 1
-            state.status = CollectTaskCredentialHit.STATUS_KNOWN_FAILED
-            state.consecutive_failures += 1
-            state.cooldown_level = next_level
-            state.next_retry_at = now + timedelta(hours=CollectHitStateService.cooldown_hours_for(next_level))
-        else:
-            state.status = CollectTaskCredentialHit.STATUS_UNTESTED
-            state.next_retry_at = None
-
-        state.save()
+        if current is None or current.last_result_at is None:
+            return True
+        if event_at > current.last_result_at:
+            return True
+        if event_at < current.last_result_at:
+            return False
+        try:
+            normalized_index = int(event_index)
+        except (TypeError, ValueError):
+            normalized_index = -1
+        return (
+            bool(result_id)
+            and str(result_id) == current.last_result_id
+            and normalized_index > current.last_result_event_index
+        )
 
     @staticmethod
     def clear_by_credential_ids(task_id, credential_ids):

--- a/server/apps/cmdb/tests/test_collect_credential_event_nats.py
+++ b/server/apps/cmdb/tests/test_collect_credential_event_nats.py
@@ -1,14 +1,641 @@
+import json
+import subprocess
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 from django.utils import timezone
-from unittest.mock import patch
 
 from apps.cmdb.constants.constants import CollectDriverTypes, CollectPluginTypes
 from apps.cmdb.models.collect_model import CollectModels
 from apps.cmdb.models.collect_task_credential_hit import CollectTaskCredentialHit
 from apps.cmdb.nats.nats import receive_collect_credential_result
 from apps.cmdb.tasks.celery_tasks import sync_collect_credential_results_task
+
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+_STARGAZER_EVENT_SCRIPT = r"""
+import asyncio
+import json
+import sys
+from types import SimpleNamespace
+
+from core.collection.contracts import build_collection_result_id
+from core.collection.result_publisher import NatsResultPublisher
+
+params = json.loads(sys.argv[1])
+request = SimpleNamespace(
+    task_id=params["run_id"],
+    plugin_ref=params["plugin_ref"],
+    params={"collect_task_id": params["collect_task_id"]},
+)
+lease = SimpleNamespace(
+    fence=params["fence"],
+    attempt_id=params["attempt_id"],
+    owner_id="stargazer-pod-1",
+)
+result_id = build_collection_result_id(
+    task_id=request.task_id,
+    plugin_ref=request.plugin_ref,
+    target=params["host"],
+    fence=lease.fence,
+    attempt_id=lease.attempt_id,
+)
+events = []
+
+async def record_event(event):
+    event["finished_at"] = params["finished_at"]
+    events.append(event)
+
+result = SimpleNamespace(
+    target=params["host"],
+    status=params["status"],
+    attempts=params["attempts"],
+    credential_id=params["credential_id"],
+    error_code=params["error_code"],
+    credential_failures=tuple(
+        SimpleNamespace(**failure) for failure in params.get("credential_failures", [])
+    ),
+)
+publisher = NatsResultPublisher(result_event_sink=record_event)
+if "event_index" in params:
+    event = publisher._build_credential_event(
+        request=request,
+        lease=lease,
+        result_id=result_id,
+        target=params["host"],
+        credential_id=params["credential_id"],
+        status=params["status"],
+        error_code=params["error_code"],
+        attempts=params["attempts"],
+        event_index=params["event_index"],
+    )
+    event["finished_at"] = params["finished_at"]
+    events.append(event)
+else:
+    asyncio.run(publisher._record_event(request, result, lease, result_id))
+print(json.dumps(events))
+"""
+
+
+def _stargazer_events(**overrides):
+    params = {
+        "collect_task_id": overrides.pop("collect_task_id"),
+        "run_id": "request-fingerprint",
+        "plugin_ref": "snmp.config",
+        "host": "10.0.0.1",
+        "fence": 1,
+        "attempt_id": "run-attempt-1",
+        "status": "success",
+        "error_code": "",
+        "credential_id": "cred-1",
+        "attempts": 1,
+        "finished_at": "2026-08-14T00:00:00+00:00",
+        "credential_failures": [],
+        **overrides,
+    }
+    stargazer_dir = Path(__file__).resolve().parents[4] / "agents/stargazer"
+    completed = subprocess.run(
+        [
+            str(stargazer_dir / ".venv/bin/python"),
+            "-c",
+            _STARGAZER_EVENT_SCRIPT,
+            json.dumps(params),
+        ],
+        cwd=stargazer_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return json.loads(completed.stdout)
+
+
+def _v2_event(
+    task_id,
+    *,
+    status="success",
+    error_code="",
+    credential_id="cred-1",
+    event_index=0,
+    finished_at="2026-08-14T00:00:00+00:00",
+    attempt_id="run-attempt-1",
+    host="10.0.0.1",
+):
+    events = _stargazer_events(
+        collect_task_id=task_id,
+        status=status,
+        error_code=error_code,
+        credential_id=credential_id,
+        attempts=event_index + 1,
+        attempt_id=attempt_id,
+        host=host,
+        finished_at=finished_at,
+        event_index=event_index,
+    )
+    return events[0]
+
+
+def _create_task(name):
+    return CollectModels.objects.create(
+        name=name,
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[
+            {"credential_id": "cred-1", "username": "admin", "password": "plain"},
+            {"credential_id": "cred-2", "username": "backup", "password": "plain"},
+        ],
+    )
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_accepts_current_stargazer_success_event(caplog):
+    caplog.set_level("INFO", logger="cmdb")
+    task = CollectModels.objects.create(
+        name="credential-v2-success-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data={
+            "collect_task_id": task.id,
+            "plugin_ref": "mysql.config",
+            "host": "10.0.0.1",
+            "credential_id": "cred-1",
+            "status": "success",
+            "error_code": "",
+            "attempts": 1,
+            "fence": 7,
+            "result_id": "result-success",
+        }
+    )
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert response["result"] is True
+    assert state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert state.last_error == ""
+    assert "status=success" in caplog.text
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "error_code",
+    [
+        "auth_failed",
+        "authentication_failed",
+        "capability_denied",
+        "snmp_error_status",
+        "snmp_authorization_failed",
+        "unauthorized",
+    ],
+)
+def test_receive_collect_credential_result_maps_current_auth_error_to_credential_failure(error_code):
+    task = CollectModels.objects.create(
+        name=f"credential-v2-{error_code}-failure-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data=_v2_event(task.id, status="failed", error_code=error_code)
+    )
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert response["result"] is True
+    assert state.status == CollectTaskCredentialHit.STATUS_KNOWN_FAILED
+    assert state.last_error == error_code
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_deduplicates_redelivered_event():
+    task = CollectModels.objects.create(
+        name="credential-v2-redelivery-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+    event = _v2_event(
+        task.id, status="failed", error_code="authentication_failed"
+    )
+
+    first_response = receive_collect_credential_result(data=event)
+    second_response = receive_collect_credential_result(data=event)
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert first_response["result"] is True
+    assert second_response["result"] is True
+    assert state.consecutive_failures == 1
+    assert state.cooldown_level == 1
+
+
+@pytest.mark.django_db
+def test_actual_stargazer_rotation_events_reach_cmdb_once():
+    task = _create_task("credential-real-producer-rotation-task")
+    events = _stargazer_events(
+        collect_task_id=task.id,
+        status="success",
+        attempts=2,
+        credential_id="cred-2",
+        attempt_id="snmp-rotation-attempt",
+        credential_failures=[
+            {
+                "credential_id": "cred-1",
+                "error_code": "snmp_authorization_failed",
+            }
+        ],
+    )
+    first = receive_collect_credential_result(data={"events": events})
+    redelivered = receive_collect_credential_result(data={"events": events})
+
+    failed = CollectTaskCredentialHit.objects.get(
+        task=task, credential_id="cred-1"
+    )
+    succeeded = CollectTaskCredentialHit.objects.get(
+        task=task, credential_id="cred-2"
+    )
+    assert first == {
+        "result": True,
+        "processed": 2,
+        "failed": 0,
+        "next_since": "",
+        "errors": [],
+    }
+    assert redelivered["result"] is True
+    assert failed.status == CollectTaskCredentialHit.STATUS_KNOWN_FAILED
+    assert failed.consecutive_failures == 1
+    assert failed.cooldown_level == 1
+    assert succeeded.status == CollectTaskCredentialHit.STATUS_SUCCESS
+
+
+@pytest.mark.django_db
+def test_v2_event_rejects_scope_and_run_identity_tampering():
+    task = _create_task("credential-v2-identity-task")
+    scope_event = _v2_event(task.id)
+    scope_event["scope_id"] = "another-task"
+    fence_event = _v2_event(task.id, event_index=1)
+    fence_event["fence"] = 2
+
+    assert receive_collect_credential_result(data=scope_event) == {
+        "result": False,
+        "message": "scope_id conflicts with collect_task_id",
+    }
+    assert receive_collect_credential_result(data=fence_event) == {
+        "result": False,
+        "message": "result_id conflicts with run identity",
+    }
+    assert not CollectTaskCredentialHit.objects.filter(task=task).exists()
+
+
+@pytest.mark.django_db
+def test_v2_event_ignores_older_result_and_redelivery_without_extra_cooldown():
+    task = _create_task("credential-v2-out-of-order-task")
+    latest = _v2_event(
+        task.id,
+        status="failed",
+        error_code="snmp_authorization_failed",
+        finished_at="2026-08-14T01:00:00+00:00",
+        attempt_id="latest-attempt",
+    )
+    older = _v2_event(
+        task.id,
+        status="success",
+        finished_at="2026-08-14T00:00:00+00:00",
+        attempt_id="older-attempt",
+    )
+
+    assert receive_collect_credential_result(data=latest)["result"] is True
+    assert receive_collect_credential_result(data=older)["result"] is True
+    assert receive_collect_credential_result(data=latest)["result"] is True
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert state.status == CollectTaskCredentialHit.STATUS_KNOWN_FAILED
+    assert state.consecutive_failures == 1
+    assert state.cooldown_level == 1
+    assert state.last_result_id == latest["result_id"]
+
+
+def test_v2_older_success_cannot_replace_newer_cross_credential_affinity():
+    task = _create_task("credential-v2-cross-credential-order-task")
+    latest = _v2_event(
+        task.id,
+        credential_id="cred-2",
+        finished_at="2026-08-14T01:00:00+00:00",
+        attempt_id="latest-attempt",
+    )
+    older = _v2_event(
+        task.id,
+        credential_id="cred-1",
+        finished_at="2026-08-14T00:00:00+00:00",
+        attempt_id="older-attempt",
+    )
+
+    assert receive_collect_credential_result(data=latest)["result"] is True
+    assert receive_collect_credential_result(data=older)["result"] is True
+
+    latest_state = CollectTaskCredentialHit.objects.get(
+        task=task, credential_id="cred-2"
+    )
+    assert latest_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+def test_legacy_older_success_cannot_replace_newer_v2_affinity():
+    task = _create_task("credential-mixed-version-order-task")
+    latest = _v2_event(
+        task.id,
+        credential_id="cred-2",
+        finished_at="2026-08-14T01:00:00+00:00",
+        attempt_id="latest-attempt",
+    )
+    legacy_older = {
+        "collect_task_id": task.id,
+        "host": "10.0.0.1",
+        "credential_id": "cred-1",
+        "success": True,
+        "finished_at": "2026-08-14T00:00:00+00:00",
+    }
+
+    assert receive_collect_credential_result(data=latest)["result"] is True
+    assert receive_collect_credential_result(data=legacy_older)["result"] is True
+
+    latest_state = CollectTaskCredentialHit.objects.get(
+        task=task, credential_id="cred-2"
+    )
+    assert latest_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+def test_delayed_event_uses_observed_time_instead_of_stream_cursor_time():
+    task = _create_task("credential-observed-time-order-task")
+    latest = _v2_event(
+        task.id,
+        credential_id="cred-2",
+        finished_at="2026-08-14T01:00:00+00:00",
+        attempt_id="latest-attempt",
+    )
+    latest["observed_at"] = "2026-08-14T01:00:00+00:00"
+    delayed_older = _v2_event(
+        task.id,
+        credential_id="cred-1",
+        finished_at="2026-08-14T02:00:00+00:00",
+        attempt_id="delayed-attempt",
+    )
+    delayed_older["observed_at"] = "2026-08-14T00:00:00+00:00"
+
+    assert receive_collect_credential_result(data=latest)["result"] is True
+    assert receive_collect_credential_result(data=delayed_older)["result"] is True
+
+    latest_state = CollectTaskCredentialHit.objects.get(
+        task=task, credential_id="cred-2"
+    )
+    assert latest_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ("not-an-object", "event must be an object"),
+        (
+            {
+                "collect_task_id": "not-an-integer",
+                "host": "10.0.0.1",
+                "credential_id": "cred-1",
+                "status": "success",
+            },
+            "collect_task_id does not exist",
+        ),
+        (
+            {
+                "collect_task_id": 1,
+                "host": "10.0.0.1",
+                "credential_id": "cred-1",
+                "status": "success",
+                "snapshot": ["not", "an", "object"],
+            },
+            "snapshot must be an object",
+        ),
+        (
+            {
+                "collect_task_id": 1,
+                "host": "10.0.0.1",
+                "credential_id": "cred-1",
+                "status": "success",
+                "finished_at": "invalid-time",
+            },
+            "event time is invalid",
+        ),
+    ],
+)
+def test_collect_credential_result_rejects_malformed_event(payload, message):
+    assert receive_collect_credential_result(data=payload) == {
+        "result": False,
+        "message": message,
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("error_code", "failure_kind"),
+    [
+        ("authentication_failed", "task"),
+        ("plugin_timeout", "credential"),
+    ],
+)
+def test_receive_collect_credential_result_rejects_conflicting_failure_kind(
+    error_code, failure_kind
+):
+    task = CollectModels.objects.create(
+        name=f"credential-conflicting-{error_code}-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    event = _v2_event(task.id, status="failed", error_code=error_code)
+    event["failure_kind"] = failure_kind
+    response = receive_collect_credential_result(data=event)
+
+    assert response == {
+        "result": False,
+        "message": "error_code conflicts with failure_kind",
+    }
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("status", ["success", "deferred", "unreachable"])
+def test_receive_collect_credential_result_rejects_auth_error_for_non_failed_status(
+    status,
+):
+    task = CollectModels.objects.create(
+        name=f"credential-conflicting-{status}-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data=_v2_event(
+            task.id, status=status, error_code="authentication_failed"
+        )
+    )
+
+    assert response == {"result": False, "message": "status conflicts with error_code"}
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_keeps_deferred_event_retryable():
+    task = CollectModels.objects.create(
+        name="credential-v2-deferred-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data=_v2_event(task.id, status="deferred", error_code="rate_limited")
+    )
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert response["result"] is True
+    assert state.status == CollectTaskCredentialHit.STATUS_UNTESTED
+    assert state.next_retry_at is None
+    assert state.last_error == "rate_limited"
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_rejects_conflicting_event_fields():
+    task = CollectModels.objects.create(
+        name="credential-conflicting-event-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    event = _v2_event(task.id)
+    event["success"] = False
+    response = receive_collect_credential_result(data=event)
+
+    assert response == {"result": False, "message": "status conflicts with success"}
+    assert not CollectTaskCredentialHit.objects.filter(task=task, credential_id="cred-1").exists()
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_rejects_unknown_event_version():
+    task = CollectModels.objects.create(
+        name="credential-unknown-event-version-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data={
+            "event_version": 3,
+            "collect_task_id": task.id,
+            "host": "10.0.0.1",
+            "credential_id": "cred-1",
+            "status": "success",
+        }
+    )
+
+    assert response == {"result": False, "message": "unsupported event_version: 3"}
+    assert not CollectTaskCredentialHit.objects.filter(task=task, credential_id="cred-1").exists()
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_requires_status_for_v2_event():
+    task = CollectModels.objects.create(
+        name="credential-v2-missing-status-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data={
+            "event_version": 2,
+            "collect_task_id": task.id,
+            "host": "10.0.0.1",
+            "credential_id": "cred-1",
+            "success": True,
+        }
+    )
+
+    assert response == {
+        "result": False,
+        "message": "status is required for event_version: 2",
+    }
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, credential_id="cred-1"
+    ).exists()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("status", "error_code"),
+    [
+        ("failed", "plugin_timeout"),
+        ("unreachable", "target_unreachable"),
+    ],
+)
+def test_receive_collect_credential_result_keeps_task_failures_retryable(
+    status, error_code
+):
+    task = CollectModels.objects.create(
+        name=f"credential-v2-{status}-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    response = receive_collect_credential_result(
+        data=_v2_event(task.id, status=status, error_code=error_code)
+    )
+
+    state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-1")
+    assert response["result"] is True
+    assert state.status == CollectTaskCredentialHit.STATUS_UNTESTED
+    assert state.last_error == error_code
 
 
 @pytest.mark.django_db
@@ -106,6 +733,48 @@ def test_receive_collect_credential_result_processes_pushed_event_batch():
     assert failed_state.status == CollectTaskCredentialHit.STATUS_KNOWN_FAILED
     assert success_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
     assert response["next_since"] == timezone.make_aware(datetime(2026, 6, 3, 12, 5, 0)).isoformat()
+
+
+@pytest.mark.django_db
+def test_receive_collect_credential_result_keeps_valid_events_in_mixed_batch():
+    task = CollectModels.objects.create(
+        name="credential-mixed-push-task",
+        task_type=CollectPluginTypes.HOST,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential=[{"credential_id": "cred-1", "username": "admin", "password": "plain"}],
+    )
+
+    valid_event = _v2_event(task.id)
+    invalid_event = _v2_event(
+        task.id,
+        status="failed",
+        error_code="authentication_failed",
+        event_index=1,
+    )
+    invalid_event["host"] = "10.0.0.2"
+    invalid_event["success"] = True
+    response = receive_collect_credential_result(
+        data={
+            "events": [valid_event, invalid_event],
+            "next_since": "cursor-2",
+        }
+    )
+
+    success_state = CollectTaskCredentialHit.objects.get(
+        task=task,
+        object_key="host:10.0.0.1",
+        credential_id="cred-1",
+    )
+    assert response["result"] is False
+    assert response["processed"] == 1
+    assert response["failed"] == 1
+    assert response["next_since"] == "cursor-2"
+    assert success_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert not CollectTaskCredentialHit.objects.filter(
+        task=task, object_key="host:10.0.0.2"
+    ).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

Stargazer 当前凭据结果使用 `status/error_code`，而 CMDB 消费端仍依赖旧的 `success/failure_kind/error_message`。成功事件因缺少 `success` 被当成失败，轮换过程中的鉴权失败还会丢失真实凭据身份。

Closes #4661

## 修复

- CMDB 双读现代与旧事件，拒绝版本、状态和双写字段冲突；旧 Agent 载荷保持可用。
- Stargazer 发布 v2 事件并双写旧字段；每个鉴权失败按实际凭据拆分，最终成功仍独立发布。
- 为拆分事件生成稳定 `event_id`，Redis 使用 Lua 原子去重；CMDB 对 NATS 重投递进行事务内有界去重，避免重复升级冷却。
- 补齐 SNMP 鉴权错误码和已选凭据的 unreachable 身份。

```mermaid
flowchart LR
  E[Stargazer 执行器] --> P[v2 + legacy 双写]
  P --> R[Redis 原子去重事件流]
  R --> N[NATS 批量推送]
  N --> C[CMDB 双读与冲突校验]
  C --> D[事务内重投递去重]
  D --> S[凭据成功/冷却状态]
```

## 兼容、迁移与回滚

- 发布顺序：先部署 Server 迁移与双读，再部署 Agent 双写。
- 旧 Agent 无 `event_id` 时保持原处理；新 Agent 的旧字段可被旧 Server 消费。
- 数据库迁移仅新增带空列表默认值的 JSON 字段，可反向删除；Redis 去重键 7 天自动过期。
- 回滚 Agent 不影响新 Server；回滚 Server 前先回滚 Agent，新增数据库列可暂留或执行反向迁移。

## 验证

- `agents/stargazer/tests/test_result_publisher.py`
- `agents/stargazer/tests/test_target_collection_executor.py`
- `agents/stargazer/tests/test_credential_state_cache.py`

结果：36 passed。

- `server/apps/cmdb/tests/test_collect_credential_event_nats.py`
- `server/apps/cmdb/tests/test_collect_hit_state_service.py`

结果：27 passed。

迁移一致性检查：通过，无待生成迁移。静态检查与差异检查：通过。

## 三轨复评

- Standards：PASS（97/100）
- Spec：PASS（98/100）
- Runtime Contract：PASS（96/100）

Runtime Contract 额外覆盖真实 Redis 部分写入后重试、实际 SNMP 两类鉴权失败后凭据轮换成功，以及同一 NATS 事件重投递仅累计一次冷却。
