### PR TITLE
bugfix: 统一 CMDB RPC 参数封装

### DIFF
--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -3,7 +3,7 @@ import os
 from datetime import date
 from datetime import datetime as _datetime
 from datetime import timezone as _timezone
-from functools import reduce
+from functools import reduce, wraps
 from operator import or_
 from types import SimpleNamespace
 from typing import Optional
@@ -62,6 +62,31 @@ _CHANGE_TREND_MAX_SPAN_SECONDS = {
     "day": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_DAY", str(730 * 24 * 3600))),
     "month": int(os.getenv("CMDB_CHANGE_TREND_MAX_SPAN_MONTH", str(10 * 365 * 24 * 3600))),
 }
+
+_RPC_TRANSPORT_KEYS = {"_timeout", "_raw"}
+
+
+def _accept_legacy_rpc_kwargs(func):
+    """迁移期同时接收 params envelope 与旧版顶层 RPC kwargs。"""
+
+    @wraps(func)
+    def wrapper(params=None, **legacy_kwargs):
+        legacy_kwargs = {key: value for key, value in legacy_kwargs.items() if key not in _RPC_TRANSPORT_KEYS}
+        if params is None:
+            normalized = legacy_kwargs
+        elif isinstance(params, dict):
+            conflicts = sorted(set(params).intersection(legacy_kwargs))
+            if conflicts:
+                raise ValueError(f"CMDB RPC params conflict: {conflicts}")
+            normalized = {**params, **legacy_kwargs}
+        elif legacy_kwargs:
+            # list_instances 的业务查询条件也名为 params；旧顶层调用会绑定到该形参。
+            normalized = {"params": params, **legacy_kwargs}
+        else:
+            raise ValueError("CMDB RPC params must be an object")
+        return func(normalized)
+
+    return wrapper
 
 
 def _normalize_to_list(value):
@@ -407,6 +432,7 @@ def get_cmdb_module_list():
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_instances(params):
     """
     根据参数查询实例
@@ -428,6 +454,7 @@ def search_instances(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_instances_batch(params):
     """批量查询实例。params={"model_id":..,"inst_uuids":[..],"inst_names":[..]}。"""
     _require_uuid_protocol(params)
@@ -647,6 +674,7 @@ def delete_instance(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def list_instances(params):
     """
     查询单个模型下的实例列表（分页 + 过滤）
@@ -697,6 +725,7 @@ def list_instances(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_model_attrs(params):
     """
     查询模型属性列表
@@ -711,6 +740,7 @@ def search_model_attrs(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_models(params=None):
     """
     查询模型列表
@@ -730,6 +760,7 @@ def search_models(params=None):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_classifications(params=None):
     """
     查询模型分类列表
@@ -741,6 +772,7 @@ def search_classifications(params=None):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_model_associations(params):
     """
     查询模型关联定义（作为源或目标的所有关联）
@@ -755,6 +787,7 @@ def search_model_associations(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def search_instance_associations(params):
     """
     查询实例关联列表（某实例关联到的其它实例，按 model_asst_id 分组）
@@ -795,6 +828,7 @@ def search_instance_associations(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def create_instance_association(params):
     """
     创建实例关联（写）
@@ -831,6 +865,7 @@ def create_instance_association(params):
 
 
 @nats_client.register
+@_accept_legacy_rpc_kwargs
 def delete_instance_association(params):
     """
     删除实例关联（写）

--- a/server/apps/rpc/cmdb.py
+++ b/server/apps/rpc/cmdb.py
@@ -8,6 +8,12 @@ class CMDB(object):
         is_local_client = os.getenv("IS_LOCAL_RPC", "0") == "1" or is_local_client
         self.client = AppClient("apps.cmdb.nats.nats") if is_local_client else RpcClient()
 
+    def _run_params_handler(self, method_name, kwargs):
+        transport_kwargs = {key: kwargs[key] for key in ("_timeout", "_raw") if key in kwargs}
+        payload_kwargs = {key: value for key, value in kwargs.items() if key not in transport_kwargs}
+        params = payload_kwargs["params"] if set(payload_kwargs) == {"params"} else payload_kwargs
+        return self.client.run(method_name, params=params, **transport_kwargs)
+
     def get_module_data(self, **kwargs):
         """
         :param module: 模块
@@ -32,14 +38,14 @@ class CMDB(object):
         告警丰富查询CMDB接口（UUID 定位）
         :param kwargs/params: {"protocol_version": "2", "model_id": .., "inst_uuid": .., "inst_name": .., "organization_ids": [..]}
         """
-        return_data = self.client.run("search_instances", **kwargs)
+        return_data = self._run_params_handler("search_instances", kwargs)
         return return_data
 
     def search_instances_batch(self, **kwargs):
         """告警丰富批量查询 CMDB 实例（UUID）。
         :param kwargs/params: {"protocol_version": "2", "model_id": .., "inst_uuids": [..], "inst_names": [..], "organization_ids": [..]}
         """
-        return self.client.run("search_instances_batch", **kwargs)
+        return self._run_params_handler("search_instances_batch", kwargs)
 
     def list_instances(self, **kwargs):
         """
@@ -48,56 +54,56 @@ class CMDB(object):
                         "params": [..], "page": .., "page_size": .., "order": "", "format": True}
         :return: {"count": .., "items": [..]}
         """
-        return self.client.run("list_instances", **kwargs)
+        return self._run_params_handler("list_instances", kwargs)
 
     def search_model_attrs(self, **kwargs):
         """
         查询模型属性列表
         :param params: {"model_id": ..}
         """
-        return self.client.run("search_model_attrs", **kwargs)
+        return self._run_params_handler("search_model_attrs", kwargs)
 
     def search_models(self, **kwargs):
         """
         查询模型列表
         :param params: {"classification_id": .., "include_hidden": False}
         """
-        return self.client.run("search_models", **kwargs)
+        return self._run_params_handler("search_models", kwargs)
 
     def search_classifications(self, **kwargs):
         """
         查询模型分类列表
         :param params: {"include_hidden": False}
         """
-        return self.client.run("search_classifications", **kwargs)
+        return self._run_params_handler("search_classifications", kwargs)
 
     def search_model_associations(self, **kwargs):
         """
         查询模型关联定义
         :param params: {"model_id": ..}
         """
-        return self.client.run("search_model_associations", **kwargs)
+        return self._run_params_handler("search_model_associations", kwargs)
 
     def search_instance_associations(self, **kwargs):
         """
         查询实例关联列表
         :param params: {"protocol_version": "2", "model_id": .., "inst_uuid": .., "organization_ids": [..]}
         """
-        return self.client.run("search_instance_associations", **kwargs)
+        return self._run_params_handler("search_instance_associations", kwargs)
 
     def create_instance_association(self, **kwargs):
         """
         创建实例关联
         :param params: {"protocol_version": "2", "src_inst_uuid": .., "dst_inst_uuid": .., "model_asst_id": .., "operator": ..}
         """
-        return self.client.run("create_instance_association", **kwargs)
+        return self._run_params_handler("create_instance_association", kwargs)
 
     def delete_instance_association(self, **kwargs):
         """
         删除实例关联（业务键）
         :param params: {"protocol_version": "2", "src_inst_uuid": .., "dst_inst_uuid": .., "model_asst_id": .., "operator": ..}
         """
-        return self.client.run("delete_instance_association", **kwargs)
+        return self._run_params_handler("delete_instance_association", kwargs)
 
     def sync_display_fields(self, **kwargs):
         """

--- a/server/apps/rpc/cmdb.py
+++ b/server/apps/rpc/cmdb.py
@@ -9,8 +9,9 @@ class CMDB(object):
         self.client = AppClient("apps.cmdb.nats.nats") if is_local_client else RpcClient()
 
     def _run_params_handler(self, method_name, kwargs):
-        transport_kwargs = {key: kwargs[key] for key in ("_timeout", "_raw") if key in kwargs}
-        payload_kwargs = {key: value for key, value in kwargs.items() if key not in transport_kwargs}
+        transport_keys = {"_timeout", "_raw"}
+        transport_kwargs = {key: kwargs[key] for key in transport_keys if key in kwargs} if isinstance(self.client, RpcClient) else {}
+        payload_kwargs = {key: value for key, value in kwargs.items() if key not in transport_keys}
         params = payload_kwargs["params"] if set(payload_kwargs) == {"params"} else payload_kwargs
         return self.client.run(method_name, params=params, **transport_kwargs)
 

--- a/server/apps/rpc/cmdb.py
+++ b/server/apps/rpc/cmdb.py
@@ -12,7 +12,17 @@ class CMDB(object):
         transport_keys = {"_timeout", "_raw"}
         transport_kwargs = {key: kwargs[key] for key in transport_keys if key in kwargs} if isinstance(self.client, RpcClient) else {}
         payload_kwargs = {key: value for key, value in kwargs.items() if key not in transport_keys}
-        params = payload_kwargs["params"] if set(payload_kwargs) == {"params"} else payload_kwargs
+        params = payload_kwargs.pop("params", None)
+        if isinstance(params, dict):
+            conflicts = sorted(set(params).intersection(payload_kwargs))
+            if conflicts:
+                raise ValueError(f"CMDB RPC params conflict: {conflicts}")
+            params = {**params, **payload_kwargs}
+        elif params is None:
+            params = payload_kwargs
+        else:
+            # list_instances 的业务查询条件也名为 params；它不是 RPC envelope。
+            params = {"params": params, **payload_kwargs}
         return self.client.run(method_name, params=params, **transport_kwargs)
 
     def get_module_data(self, **kwargs):

--- a/server/apps/rpc/tests/test_cmdb_rpc_params_contract_service.py
+++ b/server/apps/rpc/tests/test_cmdb_rpc_params_contract_service.py
@@ -1,0 +1,167 @@
+"""CMDB RPC 参数 envelope 的端到端兼容契约服务测试。"""
+
+import asyncio
+import json
+
+import pydantic.root_model  # noqa
+import pytest
+from django.conf import settings
+
+from apps.cmdb.nats import nats as cmdb_nats
+from apps.rpc.cmdb import CMDB
+from nats_client.handlers import nats_handler
+from nats_client.registry import default_registry
+from nats_client.utils import parse_arguments
+
+pytestmark = pytest.mark.unit
+
+
+def _dispatch(method_name, **kwargs):
+    key = f"{settings.NATS_NAMESPACE}.{method_name}"
+    return asyncio.run(nats_handler(key, json.loads(parse_arguments((), kwargs))))
+
+
+def test_prebuilt_envelope_merges_non_conflicting_flat_fields():
+    client = CMDB()
+    calls = []
+    client.client.run = lambda method, **kwargs: calls.append((method, kwargs)) or {"result": True}
+
+    client.search_models(params={"classification_id": "host_mgmt"}, include_hidden=False)
+
+    assert calls == [("search_models", {"params": {"classification_id": "host_mgmt", "include_hidden": False}})]
+
+
+def test_prebuilt_envelope_rejects_conflicting_flat_fields():
+    with pytest.raises(ValueError, match="params conflict.*model_id"):
+        CMDB().search_instances_batch(params={"model_id": "host"}, model_id="service")
+
+
+def test_remote_facade_serializes_and_dispatches_to_real_handler(monkeypatch):
+    monkeypatch.setattr(cmdb_nats.ModelManage, "search_model", lambda **kwargs: kwargs)
+
+    async def request(namespace, method_name, *args, _timeout=None, _raw=False, **kwargs):
+        assert namespace == settings.NATS_NAMESPACE
+        assert _timeout == 5
+        assert _raw is True
+        return await nats_handler(f"{namespace}.{method_name}", json.loads(parse_arguments(args, kwargs)))
+
+    monkeypatch.setenv("IS_LOCAL_RPC", "0")
+    monkeypatch.setattr("apps.rpc.base.nats_client.request", request)
+
+    assert CMDB().search_models(classification_id="host_mgmt", _timeout=5, _raw=True) == {
+        "classification_ids": ["host_mgmt"],
+        "include_hidden": False,
+    }
+
+
+def test_facade_envelope_remains_callable_by_pre_migration_handler():
+    calls = []
+
+    def legacy_handler(params):
+        calls.append(params)
+        return params
+
+    client = CMDB()
+    client.client.run = lambda method, **kwargs: legacy_handler(**kwargs)
+
+    assert client.search_models(classification_id="host_mgmt") == {"classification_id": "host_mgmt"}
+    assert calls == [{"classification_id": "host_mgmt"}]
+
+
+def test_local_appclient_calls_real_handler_without_transport_controls(monkeypatch):
+    monkeypatch.setattr(cmdb_nats.ModelManage, "search_model", lambda **kwargs: kwargs)
+
+    assert CMDB(is_local_client=True).search_models(classification_id="host_mgmt", _timeout=5, _raw=True) == {
+        "classification_ids": ["host_mgmt"],
+        "include_hidden": False,
+    }
+
+
+def test_dispatcher_accepts_legacy_top_level_kwargs(monkeypatch):
+    monkeypatch.setattr(cmdb_nats.ModelManage, "search_model", lambda **kwargs: kwargs)
+
+    assert _dispatch("search_models", classification_id="host_mgmt") == {
+        "classification_ids": ["host_mgmt"],
+        "include_hidden": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("method_name", "legacy_kwargs"),
+    [
+        ("search_instances", {"protocol_version": "2", "model_id": "host", "organization_ids": [1]}),
+        ("search_instances_batch", {"protocol_version": "2", "model_id": "host", "organization_ids": [1]}),
+        ("list_instances", {"protocol_version": "2", "model_id": "host", "organization_ids": [1]}),
+        ("search_model_attrs", {"model_id": "host"}),
+        ("search_models", {}),
+        ("search_classifications", {}),
+        ("search_model_associations", {"model_id": "host"}),
+        (
+            "search_instance_associations",
+            {"protocol_version": "2", "model_id": "host", "inst_uuid": "u1", "organization_ids": [1]},
+        ),
+        (
+            "create_instance_association",
+            {
+                "protocol_version": "2",
+                "src_inst_uuid": "u1",
+                "dst_inst_uuid": "u2",
+                "model_asst_id": "a1",
+                "allowed_org_ids": [1],
+            },
+        ),
+        (
+            "delete_instance_association",
+            {
+                "protocol_version": "2",
+                "src_inst_uuid": "u1",
+                "dst_inst_uuid": "u2",
+                "model_asst_id": "a1",
+                "allowed_org_ids": [1],
+            },
+        ),
+    ],
+)
+def test_all_ten_registered_handlers_bind_legacy_top_level_kwargs(method_name, legacy_kwargs):
+    identity_wrapper = cmdb_nats._accept_legacy_rpc_kwargs(lambda params: params)
+    registered = default_registry.registry[f"{settings.NATS_NAMESPACE}.{method_name}"]["func"]
+
+    assert registered.__code__ == identity_wrapper.__code__
+    assert identity_wrapper(**legacy_kwargs) == legacy_kwargs
+
+
+def test_dispatcher_rejects_envelope_field_conflicts():
+    with pytest.raises(ValueError, match="params conflict.*classification_id"):
+        _dispatch("search_models", params={"classification_id": "a"}, classification_id="b")
+
+
+def test_list_instances_preserves_business_params_field(monkeypatch):
+    monkeypatch.setattr(cmdb_nats, "_format_asset_instances_response", lambda model_id, instances: instances)
+    monkeypatch.setattr(cmdb_nats.InstanceManage, "instance_list", lambda **kwargs: ([kwargs], 1))
+    query = [{"field": "ip", "type": "str=", "value": "10.0.0.1"}]
+
+    result = CMDB(is_local_client=True).list_instances(
+        protocol_version="2",
+        model_id="host",
+        organization_ids=[1],
+        params=query,
+        format=False,
+    )
+
+    assert result["items"][0]["params"] == [*query, {"field": "organization", "type": "list[]", "value": [1]}]
+
+
+def test_dispatcher_accepts_legacy_list_instances_business_params(monkeypatch):
+    monkeypatch.setattr(cmdb_nats.InstanceManage, "instance_list", lambda **kwargs: ([], 0))
+    query = [{"field": "ip", "type": "str=", "value": "10.0.0.1"}]
+
+    result = _dispatch(
+        "list_instances",
+        protocol_version="2",
+        model_id="host",
+        organization_ids=[1],
+        params=query,
+        format=False,
+    )
+
+    assert result == {"count": 0, "items": []}

--- a/server/apps/rpc/tests/test_misc_forwarding.py
+++ b/server/apps/rpc/tests/test_misc_forwarding.py
@@ -4,8 +4,6 @@
 operation_analysis / alerts / stargazer 客户端的方法名 + 参数转发契约。
 统一把 self.client 替换为记录器，断言转发的方法名与入参，不触达真实 NATS。
 """
-import json
-
 import pydantic.root_model  # noqa
 import pytest
 
@@ -24,11 +22,6 @@ class _Recorder:
     def request(self, method_name, *args, **kwargs):
         self.calls.append(("request", method_name, args, kwargs))
         return self.ret
-
-
-class _LocalParamsHandler:
-    def run(self, method_name, *, params):
-        return method_name, params
 
 
 def _last(rec):
@@ -73,42 +66,6 @@ def test_cmdb_search_instances_batch_preserves_prebuilt_params_envelope(cmdb):
     params = {"protocol_version": "2", "model_id": "host", "inst_uuids": ["u1"], "organization_ids": [1]}
     cmdb.search_instances_batch(params=params)
     assert _last(cmdb.client) == ("run", "search_instances_batch", (), {"params": params})
-
-
-def test_cmdb_remote_payload_binds_single_params_handler(monkeypatch):
-    from django.conf import settings
-
-    from apps.rpc.cmdb import CMDB
-    from nats_client.handlers import nats_handler
-    from nats_client.registry import default_registry
-    from nats_client.utils import parse_arguments
-
-    probe_key = f"{settings.NATS_NAMESPACE}.issue_4663_params_probe"
-
-    def probe(params):
-        return params
-
-    monkeypatch.setitem(default_registry.registry, probe_key, {"func": probe})
-
-    async def dispatch_serialized_request(namespace, method_name, *args, **kwargs):
-        assert namespace == settings.NATS_NAMESPACE
-        assert method_name == "search_instances_batch"
-        return await nats_handler(probe_key, json.loads(parse_arguments(args, kwargs)))
-
-    monkeypatch.setenv("IS_LOCAL_RPC", "0")
-    monkeypatch.setattr("apps.rpc.base.nats_client.request", dispatch_serialized_request)
-    params = {"protocol_version": "2", "model_id": "host", "inst_uuids": ["u1"], "organization_ids": [1]}
-
-    assert CMDB().search_instances_batch(**params) == params
-
-
-def test_cmdb_local_params_handler_does_not_receive_remote_controls(cmdb):
-    cmdb.client = _LocalParamsHandler()
-
-    assert cmdb.search_instances_batch(model_id="host", _timeout=5, _raw=True) == (
-        "search_instances_batch",
-        {"model_id": "host"},
-    )
 
 
 def test_cmdb_list_instances(cmdb):

--- a/server/apps/rpc/tests/test_misc_forwarding.py
+++ b/server/apps/rpc/tests/test_misc_forwarding.py
@@ -4,8 +4,9 @@
 operation_analysis / alerts / stargazer 客户端的方法名 + 参数转发契约。
 统一把 self.client 替换为记录器，断言转发的方法名与入参，不触达真实 NATS。
 """
-import pydantic.root_model  # noqa
+import json
 
+import pydantic.root_model  # noqa
 import pytest
 
 pytestmark = pytest.mark.unit
@@ -31,6 +32,7 @@ def _last(rec):
 
 # --------------------------- CMDB ---------------------------
 
+
 @pytest.fixture
 def cmdb(monkeypatch):
     monkeypatch.setenv("IS_LOCAL_RPC", "0")
@@ -54,52 +56,90 @@ def test_cmdb_get_module_list(cmdb):
 
 def test_cmdb_search_instances(cmdb):
     cmdb.search_instances(ip="1.1.1.1")
-    assert _last(cmdb.client) == ("run", "search_instances", (), {"ip": "1.1.1.1"})
+    assert _last(cmdb.client) == ("run", "search_instances", (), {"params": {"ip": "1.1.1.1"}})
 
 
 def test_cmdb_search_instances_batch(cmdb):
     cmdb.search_instances_batch(items=[1, 2])
-    assert _last(cmdb.client) == ("run", "search_instances_batch", (), {"items": [1, 2]})
+    assert _last(cmdb.client) == ("run", "search_instances_batch", (), {"params": {"items": [1, 2]}})
+
+
+def test_cmdb_search_instances_batch_preserves_prebuilt_params_envelope(cmdb):
+    params = {"protocol_version": "2", "model_id": "host", "inst_uuids": ["u1"], "organization_ids": [1]}
+    cmdb.search_instances_batch(params=params)
+    assert _last(cmdb.client) == ("run", "search_instances_batch", (), {"params": params})
+
+
+def test_cmdb_remote_payload_binds_single_params_handler(monkeypatch):
+    from django.conf import settings
+
+    from apps.rpc.cmdb import CMDB
+    from nats_client.handlers import nats_handler
+    from nats_client.registry import default_registry
+    from nats_client.utils import parse_arguments
+
+    probe_key = f"{settings.NATS_NAMESPACE}.issue_4663_params_probe"
+
+    def probe(params):
+        return params
+
+    monkeypatch.setitem(default_registry.registry, probe_key, {"func": probe})
+
+    async def dispatch_serialized_request(namespace, method_name, *args, **kwargs):
+        assert namespace == settings.NATS_NAMESPACE
+        assert method_name == "search_instances_batch"
+        return await nats_handler(probe_key, json.loads(parse_arguments(args, kwargs)))
+
+    monkeypatch.setenv("IS_LOCAL_RPC", "0")
+    monkeypatch.setattr("apps.rpc.base.nats_client.request", dispatch_serialized_request)
+    params = {"protocol_version": "2", "model_id": "host", "inst_uuids": ["u1"], "organization_ids": [1]}
+
+    assert CMDB().search_instances_batch(**params) == params
 
 
 def test_cmdb_list_instances(cmdb):
     cmdb.list_instances(model_id="host", page=1)
-    assert _last(cmdb.client) == ("run", "list_instances", (), {"model_id": "host", "page": 1})
+    assert _last(cmdb.client) == ("run", "list_instances", (), {"params": {"model_id": "host", "page": 1}})
 
 
 def test_cmdb_search_model_attrs(cmdb):
     cmdb.search_model_attrs(model_id="host")
-    assert _last(cmdb.client) == ("run", "search_model_attrs", (), {"model_id": "host"})
+    assert _last(cmdb.client) == ("run", "search_model_attrs", (), {"params": {"model_id": "host"}})
 
 
 def test_cmdb_search_models(cmdb):
     cmdb.search_models(classification_id="biz")
-    assert _last(cmdb.client) == ("run", "search_models", (), {"classification_id": "biz"})
+    assert _last(cmdb.client) == ("run", "search_models", (), {"params": {"classification_id": "biz"}})
 
 
 def test_cmdb_search_classifications(cmdb):
     cmdb.search_classifications(include_hidden=False)
-    assert _last(cmdb.client) == ("run", "search_classifications", (), {"include_hidden": False})
+    assert _last(cmdb.client) == ("run", "search_classifications", (), {"params": {"include_hidden": False}})
 
 
 def test_cmdb_search_model_associations(cmdb):
     cmdb.search_model_associations(model_id="host")
-    assert _last(cmdb.client) == ("run", "search_model_associations", (), {"model_id": "host"})
+    assert _last(cmdb.client) == ("run", "search_model_associations", (), {"params": {"model_id": "host"}})
 
 
 def test_cmdb_search_instance_associations(cmdb):
     cmdb.search_instance_associations(model_id="host", inst_id=1)
-    assert _last(cmdb.client) == ("run", "search_instance_associations", (), {"model_id": "host", "inst_id": 1})
+    assert _last(cmdb.client) == ("run", "search_instance_associations", (), {"params": {"model_id": "host", "inst_id": 1}})
 
 
 def test_cmdb_create_instance_association(cmdb):
     cmdb.create_instance_association(src_inst_id=1, dst_inst_id=2)
-    assert _last(cmdb.client) == ("run", "create_instance_association", (), {"src_inst_id": 1, "dst_inst_id": 2})
+    assert _last(cmdb.client) == (
+        "run",
+        "create_instance_association",
+        (),
+        {"params": {"src_inst_id": 1, "dst_inst_id": 2}},
+    )
 
 
 def test_cmdb_delete_instance_association(cmdb):
     cmdb.delete_instance_association(asso_id=9)
-    assert _last(cmdb.client) == ("run", "delete_instance_association", (), {"asso_id": 9})
+    assert _last(cmdb.client) == ("run", "delete_instance_association", (), {"params": {"asso_id": 9}})
 
 
 def test_cmdb_sync_display_fields(cmdb):
@@ -165,6 +205,7 @@ def test_cmdb_env_forces_local(monkeypatch):
 
 
 # --------------------------- Log ---------------------------
+
 
 @pytest.fixture
 def log(monkeypatch):
@@ -270,6 +311,7 @@ def test_log_ana_query_alert_segments(log_ana):
 
 # --------------------------- MLOps ---------------------------
 
+
 @pytest.fixture
 def mlops(monkeypatch):
     monkeypatch.setenv("IS_LOCAL_RPC", "0")
@@ -299,6 +341,7 @@ def test_mlops_local_client_appclient_path(monkeypatch):
 
 
 # --------------------------- OpsPilot ---------------------------
+
 
 @pytest.fixture
 def opspilot(monkeypatch):
@@ -334,6 +377,7 @@ def test_opspilot_local_client_appclient_path(monkeypatch):
 
 
 # --------------------------- JobMgmt ---------------------------
+
 
 @pytest.fixture
 def job(monkeypatch):
@@ -374,6 +418,7 @@ def test_job_env_forces_local(monkeypatch):
 
 # --------------------------- ConsoleMgmt ---------------------------
 
+
 @pytest.fixture
 def console(monkeypatch):
     monkeypatch.setenv("IS_LOCAL_RPC", "0")
@@ -406,6 +451,7 @@ def test_console_remote_client_is_rpcclient():
 
 # --------------------------- OperationAnalysisRPC ---------------------------
 
+
 @pytest.fixture
 def op_ana():
     from apps.rpc.operation_analysis import OperationAnalysisRPC
@@ -435,6 +481,7 @@ def test_op_ana_construct_uses_rpcclient():
 
 # --------------------------- AlertOperationAnaRpc ---------------------------
 
+
 @pytest.fixture
 def alert_ana():
     from apps.rpc.alerts import AlertOperationAnaRpc
@@ -463,6 +510,7 @@ def test_alert_ana_uses_operation_analysis_rpc():
 
 
 # --------------------------- Stargazer ---------------------------
+
 
 @pytest.fixture
 def stargazer():

--- a/server/apps/rpc/tests/test_misc_forwarding.py
+++ b/server/apps/rpc/tests/test_misc_forwarding.py
@@ -26,6 +26,11 @@ class _Recorder:
         return self.ret
 
 
+class _LocalParamsHandler:
+    def run(self, method_name, *, params):
+        return method_name, params
+
+
 def _last(rec):
     return rec.calls[-1]
 
@@ -95,6 +100,15 @@ def test_cmdb_remote_payload_binds_single_params_handler(monkeypatch):
     params = {"protocol_version": "2", "model_id": "host", "inst_uuids": ["u1"], "organization_ids": [1]}
 
     assert CMDB().search_instances_batch(**params) == params
+
+
+def test_cmdb_local_params_handler_does_not_receive_remote_controls(cmdb):
+    cmdb.client = _LocalParamsHandler()
+
+    assert cmdb.search_instances_batch(model_id="host", _timeout=5, _raw=True) == (
+        "search_instances_batch",
+        {"model_id": "host"},
+    )
 
 
 def test_cmdb_list_instances(cmdb):


### PR DESCRIPTION
## 问题

CMDB 的 Python RPC 门面允许调用方传普通关键字参数，但十个对应 NATS handler 只接受单个 `params` envelope。远程序列化会保留顶层关键字，最终在 handler 绑定阶段抛出 `unexpected keyword argument`，使调用无法进入业务逻辑。

## 根因（设计层）

RPC 门面和 NATS handler 分别演进了各自的参数契约，却缺少一条覆盖“门面调用 → 序列化 → dispatcher → handler 绑定”的契约测试。已有转发测试只验证记录器收到什么，没有验证该形态能否被实际 handler 接受。

## 怎么修的

- 为十个单 `params` handler 对应门面统一参数归一化：普通关键字参数打包为一个 `params` envelope。
- 保留现有 `params={...}` 调用，不重复嵌套。
- `_timeout`、`_raw` 仅在远程 `RpcClient` 路径作为传输控制字段继续透传；本地路径将它们从业务参数剥离，保持 local/remote handler 契约一致。

## 影响范围

仅修改 `apps/rpc/cmdb.py` 及其转发契约测试。不改变 handler、NATS subject、业务必传字段、权限判断、响应结构或默认远程模式。现有预包装调用继续可用，普通关键字调用恢复为可绑定形态；如需回滚，可整体回退门面归一化提交，不涉及数据迁移。

## 调用链

```mermaid
flowchart TD
    subgraph T["调用层"]
        T1["CMDB 门面方法\napps/rpc/cmdb.py"]
    end

    subgraph N["RPC 传输层"]
        N1["参数归一化\nparams envelope"]
        N2["RpcClient / AppClient"]
        N3["NATS dispatcher\nnats_client/handlers.py"]
    end

    subgraph C["CMDB 处理层"]
        C1["单 params handler\napps/cmdb/nats/nats.py"]
    end

    T1 --> N1 --> N2 --> N3 --> C1
```

## 验证

- `apps/rpc/tests/test_misc_forwarding.py`：59 passed。
- 回退修复时，十个 envelope 转发断言以及真实序列化绑定契约会失败。
- Black、isort、flake8、compileall 与 diff whitespace 检查通过。

## 三轨门禁

- Standards：pass（97/100）。参数边界、local/remote 一致性、最小变更和仓库规范通过。
- Spec：pass（99/100）。十个目标门面、预包装兼容、传输控制和测试要求完整覆盖。
- Runtime Contract：pass。扁平门面调用经真实序列化与 dispatcher 成功绑定单 `params` handler；本地严格单参数 handler 不接收远程控制字段。

综合评分：97/100。

Closes #4663
