### PR TITLE
bugfix: 分批同步 CMDB 展示字段

### DIFF
--- a/server/apps/cmdb/display_field/sync.py
+++ b/server/apps/cmdb/display_field/sync.py
@@ -20,249 +20,272 @@
 - 用户: 原始字段存储 id, display字段存储 display_name(username)
 """
 
-from typing import List, Dict, Any
+import os
+from collections import defaultdict
+from typing import Any, Dict, List
 
 from apps.cmdb.constants.constants import INSTANCE
-from apps.cmdb.display_field.constants import (
-    DISPLAY_SUFFIX,
-    DISPLAY_VALUES_SEPARATOR,
-    USER_DISPLAY_FORMAT,
-)
+from apps.cmdb.display_field.constants import DISPLAY_SUFFIX, DISPLAY_VALUES_SEPARATOR, USER_DISPLAY_FORMAT
 from apps.cmdb.graph.drivers.graph_client import GraphClient
+from apps.cmdb.graph.validators import MAX_BATCH_UPDATE_PROPERTY_VALUES
 from apps.core.logger import cmdb_logger as logger
-from apps.system_mgmt.models import User, Group
+from apps.system_mgmt.models import Group, User
+
+DEFAULT_SYNC_BATCH_SIZE = 500
+
+
+def _get_sync_batch_size() -> int:
+    raw_value = os.getenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", str(DEFAULT_SYNC_BATCH_SIZE))
+    try:
+        batch_size = max(1, int(raw_value))
+    except (TypeError, ValueError):
+        logger.warning(
+            "[DisplayFieldSynchronizer] CMDB_DISPLAY_SYNC_BATCH_SIZE=%r 非法，使用默认值 %s",
+            raw_value,
+            DEFAULT_SYNC_BATCH_SIZE,
+        )
+        return DEFAULT_SYNC_BATCH_SIZE
+    if batch_size > MAX_BATCH_UPDATE_PROPERTY_VALUES:
+        logger.warning(
+            "[DisplayFieldSynchronizer] CMDB_DISPLAY_SYNC_BATCH_SIZE=%s 超过图写上限，限制为 %s",
+            batch_size,
+            MAX_BATCH_UPDATE_PROPERTY_VALUES,
+        )
+        return MAX_BATCH_UPDATE_PROPERTY_VALUES
+    return batch_size
+
+
+def _format_user_display(user: Dict[str, Any]) -> str:
+    username = user.get("username", "")
+    display_name = user.get("display_name", "")
+    if display_name and display_name.strip():
+        return USER_DISPLAY_FORMAT.format(display_name=display_name, username=username)
+    return username
+
+
+def _match_organization_fields(instance, field_ids, org_ids, org_map):
+    matched_fields = []
+    missing_ids = set()
+    for field_id in field_ids:
+        field_value = instance.get(field_id)
+        if not field_value:
+            continue
+        field_values = field_value if isinstance(field_value, list) else [field_value]
+        if not set(field_values) & org_ids:
+            continue
+        matched_fields.append((field_id, field_values))
+        missing_ids.update(value for value in field_values if value not in org_map)
+    return matched_fields, missing_ids
+
+
+def _match_user_fields(instance, field_ids, user_ids, user_map):
+    matched_fields = []
+    missing_ids = set()
+    for field_id in field_ids:
+        field_value = instance.get(field_id)
+        if not field_value:
+            continue
+        if isinstance(field_value, (int, str)):
+            field_values = [int(field_value)]
+        else:
+            field_values = [int(value) for value in field_value]
+        if not set(field_values) & user_ids:
+            continue
+        matched_fields.append((field_id, field_values))
+        missing_ids.update(value for value in field_values if value not in user_map)
+    return matched_fields, missing_ids
+
+
+def _collect_pending_updates(instances, model_fields_mapping, org_map, user_map):
+    pending_updates = []
+    missing_org_ids = set()
+    missing_user_ids = set()
+    org_ids = set(org_map)
+    user_ids = set(user_map)
+
+    for instance in instances:
+        model_mapping = model_fields_mapping.get(instance.get("model_id"), {})
+        matched_org_fields, instance_missing_org_ids = _match_organization_fields(
+            instance, model_mapping.get("organization", []) if org_map else [], org_ids, org_map
+        )
+        matched_user_fields, instance_missing_user_ids = _match_user_fields(
+            instance, model_mapping.get("user", []) if user_map else [], user_ids, user_map
+        )
+        missing_org_ids.update(instance_missing_org_ids)
+        missing_user_ids.update(instance_missing_user_ids)
+        if matched_org_fields or matched_user_fields:
+            pending_updates.append((instance["_id"], matched_org_fields, matched_user_fields))
+
+    return pending_updates, missing_org_ids, missing_user_ids
+
+
+def _load_missing_references(missing_org_ids, missing_user_ids):
+    group_map = {}
+    if missing_org_ids:
+        group_map = dict(Group.objects.filter(id__in=sorted(missing_org_ids)).values_list("id", "name"))
+
+    missing_user_map = {}
+    if missing_user_ids:
+        missing_user_map = {
+            user["id"]: user for user in User.objects.filter(id__in=sorted(missing_user_ids)).values("id", "username", "display_name")
+        }
+    return group_map, missing_user_map
+
+
+def _append_organization_updates(field_updates, node_id, matched_fields, org_map, group_map):
+    for field_id, field_values in matched_fields:
+        display_names = [org_map[value] for value in field_values if value in org_map]
+        display_names.extend(group_map[value] for value in field_values if value not in org_map and value in group_map)
+        field_updates[f"{field_id}{DISPLAY_SUFFIX}"].append({"id": node_id, "value": DISPLAY_VALUES_SEPARATOR.join(display_names)})
+
+
+def _append_user_updates(field_updates, node_id, matched_fields, user_map, missing_user_map):
+    for field_id, field_values in matched_fields:
+        display_names = [_format_user_display(user_map[value]) for value in field_values if value in user_map]
+        display_names.extend(
+            _format_user_display(missing_user_map[value]) for value in field_values if value not in user_map and value in missing_user_map
+        )
+        field_updates[f"{field_id}{DISPLAY_SUFFIX}"].append({"id": node_id, "value": DISPLAY_VALUES_SEPARATOR.join(display_names)})
+
+
+def _update_instance_page(ag, instances, model_fields_mapping, org_map, user_map):
+    pending_updates, missing_org_ids, missing_user_ids = _collect_pending_updates(instances, model_fields_mapping, org_map, user_map)
+    group_map, missing_user_map = _load_missing_references(missing_org_ids, missing_user_ids)
+
+    field_updates = defaultdict(list)
+    org_updated_count = 0
+    user_updated_count = 0
+    for node_id, matched_org_fields, matched_user_fields in pending_updates:
+        org_updated_count += bool(matched_org_fields)
+        user_updated_count += bool(matched_user_fields)
+        _append_organization_updates(field_updates, node_id, matched_org_fields, org_map, group_map)
+        _append_user_updates(field_updates, node_id, matched_user_fields, user_map, missing_user_map)
+
+    # 每个展示字段在本批只发起一次图写，同一批中不同实例可携带不同值。
+    for field_id, property_values in field_updates.items():
+        ag.batch_update_node_property_values(INSTANCE, field_id, property_values)
+    return org_updated_count, user_updated_count
 
 
 class DisplayFieldSynchronizer:
     """
     显示字段同步器
-    
+
     当组织/用户的展示信息变更时，同步更新所有实例的 _display 冗余字段
     传入的数据已包含最新的原始值和展示值，无需再次查询数据库
     """
-    
+
     @staticmethod
     def sync_all(data: Dict[str, List[Dict[str, Any]]]) -> Dict[str, int]:
         """
         同步所有类型的展示字段变更（统一循环处理组织和用户）
-        
+
         Args:
             data: 变更数据字典
                 格式: {
                     "organizations": [{"id": 1, "name": "Default1"}],
                     "users": [{"id": 1, "username": "admin", "display_name": "超级管理员111"}]
                 }
-        
+
         Returns:
             Dict[str, int]: 各类型更新的实例数量
                 格式: {"organizations": 10, "users": 5}
         """
         organizations = data.get("organizations", [])
         users = data.get("users", [])
-        
+
         # 如果两者都为空，直接返回
         if not organizations and not users:
             logger.warning("[DisplayFieldSynchronizer] 组织和用户数据均为空，跳过同步")
             return {"organizations": 0, "users": 0}
-        
+
         # 构建映射表
         org_map = {org["id"]: org["name"] for org in organizations} if organizations else {}
         # 用户映射存储完整信息：{'username': 'admin', 'display_name': '管理员'}
-        user_map = {
-            user["id"]: {
-                'username': user.get('username', ''),
-                'display_name': user.get('display_name', '')
-            }
-            for user in users
-        } if users else {}
-        org_ids = set(org_map.keys())
-        user_ids = set(user_map.keys())
-        
+        user_map = (
+            {user["id"]: {"username": user.get("username", ""), "display_name": user.get("display_name", "")} for user in users} if users else {}
+        )
         org_updated_count = 0
         user_updated_count = 0
-        
+
         try:
             # 从缓存获取模型字段映射
             from apps.cmdb.display_field.cache import ExcludeFieldsCache
+
             model_fields_mapping = ExcludeFieldsCache.get_model_fields_mapping()
-            
-            with GraphClient() as ag:
-                # 查询所有实例
-                all_instances, _ = ag.query_entity(INSTANCE, [])
-                
-                # 统一循环处理所有实例
-                for instance in all_instances:
-                    model_id = instance.get("model_id")
-                    if not model_id:
-                        continue
-                    
-                    # 从缓存获取该模型的字段映射
-                    model_mapping = model_fields_mapping.get(model_id, {})
-                    org_fields = model_mapping.get('organization', [])
-                    user_fields = model_mapping.get('user', [])
-                    
-                    # 如果该模型既没有组织字段也没有用户字段，跳过
-                    if not org_fields and not user_fields:
-                        continue
-                    
-                    update_data = {}
-                    has_org_update = False
-                    has_user_update = False
-                    
-                    # 处理组织字段
-                    if org_fields and org_map:
-                        for org_field in org_fields:
-                            instance_org_ids = instance.get(org_field)
-                            if not instance_org_ids:
-                                continue
-                            
-                            # 确保是列表格式
-                            if not isinstance(instance_org_ids, list):
-                                instance_org_ids = [instance_org_ids]
-                            
-                            # 检查实例的组织ID是否与变更的组织ID有交集
-                            if not set(instance_org_ids) & org_ids:
-                                continue
-                            
-                            # 重新构建 _display 字段
-                            display_names = []
-                            missing_ids = []
-                            
-                            for org_id in instance_org_ids:
-                                if org_id in org_map:
-                                    display_names.append(org_map[org_id])
-                                else:
-                                    missing_ids.append(org_id)
-                            
-                            # 查询映射表中不存在的组织名称
-                            if missing_ids:
-                                missing_groups = Group.objects.filter(id__in=missing_ids).values_list('name', flat=True)
-                                display_names.extend(missing_groups)
-                            
-                            display_field = f"{org_field}{DISPLAY_SUFFIX}"
-                            new_display_value = DISPLAY_VALUES_SEPARATOR.join(display_names)
-                            update_data[display_field] = new_display_value
-                            has_org_update = True
-                    
-                    # 处理用户字段
-                    if user_fields and user_map:
-                        for field_id in user_fields:
-                            field_value = instance.get(field_id)
-                            if not field_value:
-                                continue
-                            
-                            # user 字段可能是单个用户ID或用户ID列表
-                            if isinstance(field_value, (int, str)):
-                                field_value_list = [int(field_value)]
-                            else:
-                                field_value_list = [int(v) for v in field_value]
-                            
-                            # 检查是否包含变更的用户
-                            if not set(field_value_list) & user_ids:
-                                continue
-                            
-                            # 重新构建 _display 值（格式：display_name(username)）
-                            display_names = []
-                            missing_ids = []
-                            
-                            for user_id in field_value_list:
-                                if user_id in user_map:
-                                    user_info = user_map[user_id]
-                                    username = user_info.get('username', '')
-                                    display_name = user_info.get('display_name', '')
-                                    
-                                    # 格式化为 USER_DISPLAY_FORMAT 格式
-                                    if display_name and display_name.strip():
-                                        display_names.append(USER_DISPLAY_FORMAT.format(
-                                            display_name=display_name,
-                                            username=username
-                                        ))
-                                    else:
-                                        display_names.append(username)
-                                else:
-                                    missing_ids.append(user_id)
-                            
-                            # 查询映射表中不存在的用户信息
-                            if missing_ids:
-                                missing_users = User.objects.filter(id__in=missing_ids).values("username", "display_name")
-                                for user in missing_users:
-                                    username = user.get('username', '')
-                                    display_name = user.get('display_name', '')
-                                    
-                                    if display_name and display_name.strip():
-                                        display_names.append(USER_DISPLAY_FORMAT.format(
-                                            display_name=display_name,
-                                            username=username
-                                        ))
-                                    else:
-                                        display_names.append(username)
-                            
-                            display_field_id = f"{field_id}{DISPLAY_SUFFIX}"
-                            new_display_value = DISPLAY_VALUES_SEPARATOR.join(display_names)
-                            update_data[display_field_id] = new_display_value
-                            has_user_update = True
-                    
-                    # 如果有需要更新的字段，批量更新
-                    if update_data:
-                        ag.batch_update_node_properties(
-                            INSTANCE,
-                            [instance["_id"]],
-                            update_data
-                        )
-                        if has_org_update:
-                            org_updated_count += 1
-                        if has_user_update:
-                            user_updated_count += 1
-                
-                result = {
-                    "organizations": org_updated_count,
-                    "users": user_updated_count
-                }
-                
-                if org_updated_count > 0 or user_updated_count > 0:
-                    logger.info(
-                        f"[DisplayFieldSynchronizer] 同步完成, "
-                        f"组织更新实例数: {org_updated_count}, "
-                        f"用户更新实例数: {user_updated_count}"
-                    )
-                
-                return result
-        
-        except Exception as e:
-            logger.error(
-                f"[DisplayFieldSynchronizer] 同步 _display 字段失败: {e}",
-                exc_info=True
+
+            candidate_model_ids = sorted(
+                model_id
+                for model_id, mapping in model_fields_mapping.items()
+                if (org_map and mapping.get("organization")) or (user_map and mapping.get("user"))
             )
+            if not candidate_model_ids:
+                return {"organizations": 0, "users": 0}
+
+            batch_size = _get_sync_batch_size()
+            with GraphClient() as ag:
+                cursor = None
+                while True:
+                    query_params = [{"field": "model_id", "type": "str[]", "value": candidate_model_ids}]
+                    if cursor is not None:
+                        query_params.append({"field": "id", "type": "id>", "value": cursor})
+
+                    instances, _ = ag.query_entity(
+                        INSTANCE,
+                        query_params,
+                        page={"skip": 0, "limit": batch_size},
+                        include_count=False,
+                    )
+                    if not instances:
+                        break
+
+                    page_org_count, page_user_count = _update_instance_page(ag, instances, model_fields_mapping, org_map, user_map)
+                    org_updated_count += page_org_count
+                    user_updated_count += page_user_count
+
+                    cursor = instances[-1]["_id"]
+                    if len(instances) < batch_size:
+                        break
+
+                result = {"organizations": org_updated_count, "users": user_updated_count}
+
+                if org_updated_count > 0 or user_updated_count > 0:
+                    logger.info(f"[DisplayFieldSynchronizer] 同步完成, " f"组织更新实例数: {org_updated_count}, " f"用户更新实例数: {user_updated_count}")
+
+                return result
+
+        except Exception as e:
+            logger.error(f"[DisplayFieldSynchronizer] 同步 _display 字段失败: {e}", exc_info=True)
             raise
-    
+
     @staticmethod
     def sync_organization_display(organizations: List[Dict[str, Any]]) -> int:
         """
         同步组织名称变更到所有实例的 organization_display 字段
-        
+
         注意：推荐使用 sync_all() 方法，性能更优
-        
+
         Args:
             organizations: 组织变更数据列表，包含最新的 id 和 name
                 格式: [{"id": 1, "name": "新组织名"}]
-        
+
         Returns:
             int: 更新的实例数量
         """
         result = DisplayFieldSynchronizer.sync_all({"organizations": organizations})
         return result.get("organizations", 0)
-    
+
     @staticmethod
     def sync_user_display(users: List[Dict[str, str]]) -> int:
         """
         同步用户显示名变更到所有实例的用户类型 _display 字段
-        
+
         注意：推荐使用 sync_all() 方法，性能更优
-        
+
         Args:
             users: 用户变更数据列表，包含最新的 id、username 和 display_name
                 格式: [{"id": 1, "username": "admin", "display_name": "超级管理员111"}]
-        
+
         Returns:
             int: 更新的实例数量
         """
@@ -272,40 +295,38 @@ class DisplayFieldSynchronizer:
 
 # ========== 系统管理调用入口 ==========
 
-def sync_display_fields_for_system_mgmt(
-    organizations: List[Dict[str, Any]] = None,
-    users: List[Dict[str, str]] = None
-) -> Dict[str, Any]:
+
+def sync_display_fields_for_system_mgmt(organizations: List[Dict[str, Any]] = None, users: List[Dict[str, str]] = None) -> Dict[str, Any]:
     """
     系统管理调用入口：同步组织/用户的 _display 字段
-    
+
     当系统管理模块修改组织或用户信息时，调用此函数同步更新 CMDB 实例的 _display 字段
     该函数会触发 Celery 异步任务处理，避免阻塞主流程
-    
+
     Args:
         organizations: 组织变更数据列表
             格式: [{"id": 1, "name": "新组织名"}]
         users: 用户变更数据列表
             格式: [{"id": 1, "username": "admin", "display_name": "新显示名"}]
-    
+
     Returns:
         Dict[str, Any]: 任务提交结果
             格式: {"task_id": "uuid", "status": "submitted"}
-    
+
     Usage:
         # 在系统管理的组织/用户更新接口中调用
         from apps.cmdb.display_field import sync_display_fields_for_system_mgmt
-        
+
         # 组织名称变更
         sync_display_fields_for_system_mgmt(
             organizations=[{"id": 1, "name": "新组织名"}]
         )
-        
+
         # 用户显示名变更
         sync_display_fields_for_system_mgmt(
             users=[{"id": 1, "username": "admin", "display_name": "新显示名"}]
         )
-        
+
         # 同时更新组织和用户
         sync_display_fields_for_system_mgmt(
             organizations=[{"id": 1, "name": "新组织名"}],
@@ -317,19 +338,20 @@ def sync_display_fields_for_system_mgmt(
         data["organizations"] = organizations
     if users:
         data["users"] = users
-    
+
     if not data:
         logger.warning("[DisplayFieldSync] 组织和用户数据均为空，跳过同步")
         return {"task_id": None, "status": "skipped"}
-    
+
     # 触发异步任务处理
     from apps.cmdb.tasks.celery_tasks import sync_cmdb_display_fields_task
+
     task = sync_cmdb_display_fields_task.delay(data)
-    
+
     logger.info(
         f"[DisplayFieldSync] 已提交异步任务, task_id: {task.id}, "
         f"组织数: {len(organizations) if organizations else 0}, "
         f"用户数: {len(users) if users else 0}"
     )
-    
+
     return {"task_id": str(task.id), "status": "submitted"}

--- a/server/apps/cmdb/display_field/sync.py
+++ b/server/apps/cmdb/display_field/sync.py
@@ -134,17 +134,21 @@ def _load_missing_references(missing_org_ids, missing_user_ids):
 
 def _append_organization_updates(field_updates, node_id, matched_fields, org_map, group_map):
     for field_id, field_values in matched_fields:
-        display_names = [org_map[value] for value in field_values if value in org_map]
-        display_names.extend(group_map[value] for value in field_values if value not in org_map and value in group_map)
+        display_names = [
+            org_map[value] if value in org_map else group_map[value]
+            for value in field_values
+            if value in org_map or value in group_map
+        ]
         field_updates[f"{field_id}{DISPLAY_SUFFIX}"].append({"id": node_id, "value": DISPLAY_VALUES_SEPARATOR.join(display_names)})
 
 
 def _append_user_updates(field_updates, node_id, matched_fields, user_map, missing_user_map):
     for field_id, field_values in matched_fields:
-        display_names = [_format_user_display(user_map[value]) for value in field_values if value in user_map]
-        display_names.extend(
-            _format_user_display(missing_user_map[value]) for value in field_values if value not in user_map and value in missing_user_map
-        )
+        display_names = [
+            _format_user_display(user_map[value] if value in user_map else missing_user_map[value])
+            for value in field_values
+            if value in user_map or value in missing_user_map
+        ]
         field_updates[f"{field_id}{DISPLAY_SUFFIX}"].append({"id": node_id, "value": DISPLAY_VALUES_SEPARATOR.join(display_names)})
 
 
@@ -243,14 +247,18 @@ class DisplayFieldSynchronizer:
                     org_updated_count += page_org_count
                     user_updated_count += page_user_count
 
-                    cursor = instances[-1]["_id"]
-                    if len(instances) < batch_size:
-                        break
+                    next_cursor = instances[-1]["_id"]
+                    if cursor is not None and next_cursor <= cursor:
+                        raise RuntimeError("图实例分页游标未向前推进")
+                    cursor = next_cursor
 
                 result = {"organizations": org_updated_count, "users": user_updated_count}
 
                 if org_updated_count > 0 or user_updated_count > 0:
-                    logger.info(f"[DisplayFieldSynchronizer] 同步完成, " f"组织更新实例数: {org_updated_count}, " f"用户更新实例数: {user_updated_count}")
+                    logger.info(
+                        f"[DisplayFieldSynchronizer] 同步完成, 组织更新实例数: {org_updated_count}, "
+                        f"用户更新实例数: {user_updated_count}"
+                    )
 
                 return result
 

--- a/server/apps/cmdb/display_field/sync.py
+++ b/server/apps/cmdb/display_field/sync.py
@@ -132,6 +132,37 @@ def _load_missing_references(missing_org_ids, missing_user_ids):
     return group_map, missing_user_map
 
 
+def refresh_display_sync_data(data: Dict[str, List[Dict[str, Any]]]) -> Dict[str, List[Dict[str, Any]]]:
+    """用权威关系库刷新事件值，避免旧异步任务覆盖较新的组织或用户名称。"""
+    organizations = data.get("organizations", [])
+    users = data.get("users", [])
+    organization_ids = [item.get("id") for item in organizations if item.get("id") is not None]
+    user_ids = [item.get("id") for item in users if item.get("id") is not None]
+
+    current_organizations = (
+        dict(Group.objects.filter(id__in=organization_ids).values_list("id", "name")) if organization_ids else {}
+    )
+    current_users = (
+        {
+            user["id"]: user
+            for user in User.objects.filter(id__in=user_ids).values("id", "username", "display_name")
+        }
+        if user_ids
+        else {}
+    )
+
+    return {
+        "organizations": [
+            {**item, "name": current_organizations.get(item.get("id"), item.get("name", ""))}
+            for item in organizations
+        ],
+        "users": [
+            {**item, **current_users.get(item.get("id"), {})}
+            for item in users
+        ],
+    }
+
+
 def _append_organization_updates(field_updates, node_id, matched_fields, org_map, group_map):
     for field_id, field_values in matched_fields:
         display_names = [

--- a/server/apps/cmdb/services/unique_write_lock.py
+++ b/server/apps/cmdb/services/unique_write_lock.py
@@ -4,7 +4,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import timedelta
 
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils.timezone import now
 
 from apps.cmdb.models.operation import CmdbUniqueWriteLock
@@ -77,3 +77,25 @@ class UniqueWriteLockService:
         finally:
             for lock_key in reversed(acquired):
                 cls.release(lock_key, owner_token=owner_token)
+
+    @classmethod
+    @contextmanager
+    def serialize(cls, lock_key: str):
+        """用既有锁表的数据库行锁串行化长任务，锁持有者退出后后继任务自动接棒。"""
+        owner_token = uuid.uuid4().hex
+        lease_expires_at = now() + timedelta(seconds=cls.DEFAULT_LEASE_SECONDS)
+        try:
+            CmdbUniqueWriteLock.objects.get_or_create(
+                lock_key=lock_key,
+                defaults={"owner_token": owner_token, "lease_expires_at": lease_expires_at},
+            )
+        except IntegrityError:
+            # 并发首次创建同一锁行时，另一事务已负责创建；随后统一等待行锁。
+            pass
+
+        with transaction.atomic():
+            lock = CmdbUniqueWriteLock.objects.select_for_update().get(lock_key=lock_key)
+            lock.owner_token = owner_token
+            lock.lease_expires_at = lease_expires_at
+            lock.save(update_fields=["owner_token", "lease_expires_at", "updated_at"])
+            yield owner_token

--- a/server/apps/cmdb/services/unique_write_lock.py
+++ b/server/apps/cmdb/services/unique_write_lock.py
@@ -4,7 +4,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import timedelta
 
-from django.db import DatabaseError, IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError
 from django.utils.timezone import now
 
 from apps.cmdb.models.operation import CmdbUniqueWriteLock
@@ -80,25 +80,16 @@ class UniqueWriteLockService:
 
     @classmethod
     @contextmanager
-    def serialize(cls, lock_key: str):
-        """用既有锁表串行化长任务；竞争时立即失败，由调用方有界退避重试。"""
+    def serialize(cls, lock_key: str, *, lease_seconds: int | None = None):
+        """用跨数据库的原子租约串行化长任务，竞争时由调用方有界退避重试。"""
         owner_token = uuid.uuid4().hex
-        lease_expires_at = now() + timedelta(seconds=cls.DEFAULT_LEASE_SECONDS)
         try:
-            CmdbUniqueWriteLock.objects.get_or_create(
-                lock_key=lock_key,
-                defaults={"owner_token": owner_token, "lease_expires_at": lease_expires_at},
-            )
-        except IntegrityError:
-            # 并发首次创建同一锁行时，另一事务已负责创建；随后统一等待行锁。
-            pass
-
-        try:
-            with transaction.atomic():
-                lock = CmdbUniqueWriteLock.objects.select_for_update(nowait=True).get(lock_key=lock_key)
-                lock.owner_token = owner_token
-                lock.lease_expires_at = lease_expires_at
-                lock.save(update_fields=["owner_token", "lease_expires_at", "updated_at"])
-                yield owner_token
+            acquired = cls.acquire(lock_key, owner_token=owner_token, lease_seconds=lease_seconds)
         except DatabaseError as exc:
-            raise TimeoutError("CMDB 写锁正被占用") from exc
+            raise RuntimeError("CMDB 写锁获取失败") from exc
+        if not acquired:
+            raise TimeoutError("CMDB 写锁正被占用")
+        try:
+            yield owner_token
+        finally:
+            cls.release(lock_key, owner_token=owner_token)

--- a/server/apps/cmdb/services/unique_write_lock.py
+++ b/server/apps/cmdb/services/unique_write_lock.py
@@ -4,7 +4,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import timedelta
 
-from django.db import IntegrityError, transaction
+from django.db import DatabaseError, IntegrityError, transaction
 from django.utils.timezone import now
 
 from apps.cmdb.models.operation import CmdbUniqueWriteLock
@@ -81,7 +81,7 @@ class UniqueWriteLockService:
     @classmethod
     @contextmanager
     def serialize(cls, lock_key: str):
-        """用既有锁表的数据库行锁串行化长任务，锁持有者退出后后继任务自动接棒。"""
+        """用既有锁表串行化长任务；竞争时立即失败，由调用方有界退避重试。"""
         owner_token = uuid.uuid4().hex
         lease_expires_at = now() + timedelta(seconds=cls.DEFAULT_LEASE_SECONDS)
         try:
@@ -93,9 +93,12 @@ class UniqueWriteLockService:
             # 并发首次创建同一锁行时，另一事务已负责创建；随后统一等待行锁。
             pass
 
-        with transaction.atomic():
-            lock = CmdbUniqueWriteLock.objects.select_for_update().get(lock_key=lock_key)
-            lock.owner_token = owner_token
-            lock.lease_expires_at = lease_expires_at
-            lock.save(update_fields=["owner_token", "lease_expires_at", "updated_at"])
-            yield owner_token
+        try:
+            with transaction.atomic():
+                lock = CmdbUniqueWriteLock.objects.select_for_update(nowait=True).get(lock_key=lock_key)
+                lock.owner_token = owner_token
+                lock.lease_expires_at = lease_expires_at
+                lock.save(update_fields=["owner_token", "lease_expires_at", "updated_at"])
+                yield owner_token
+        except DatabaseError as exc:
+            raise TimeoutError("CMDB 写锁正被占用") from exc

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -732,7 +732,7 @@ def sync_cmdb_display_fields_task(self, data: dict):
         # 同步域使用稳定的数据库租约跨进程串行。租期长于任务硬时限，进程崩溃后可过期接管；
         # owner token 防止旧任务误释放接管者的租约。后发任务取得租约后才读取权威 ORM，
         # 因此旧任务不能在新任务之后继续写旧快照，后发变更最终会覆盖全量实例。
-        with UniqueWriteLockService.serialize("cmdb-display-field-sync", lease_seconds=360):
+        with UniqueWriteLockService.serialize("cmdb-display-field-sync", lease_seconds=310):
             # 图写按字段分批提交，瞬时失败前可能已有部分字段落图。全量同步本身幂等，
             # 因此在同一锁内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
             for attempt in range(2):
@@ -758,7 +758,10 @@ def sync_cmdb_display_fields_task(self, data: dict):
     except (TimeoutError, SoftTimeLimitExceeded) as exc:
         if self.request.retries < self.max_retries:
             logger.warning("[SyncCMDBDisplayFields] 同步繁忙或超时，任务将有界重试: %s", exc)
-            raise self.retry(exc=exc)
+            # 锁竞争的三次等待总跨度需覆盖 310s 租期，确保占锁者即使硬退出，后发任务也能接管；
+            # soft timeout 已释放租约，沿用短延迟即可。
+            countdown = 105 if isinstance(exc, TimeoutError) else self.default_retry_delay
+            raise self.retry(exc=exc, countdown=countdown)
         logger.error("[SyncCMDBDisplayFields] 同步重试已耗尽: %s", exc, exc_info=True)
         return {
             "result": False,

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -697,8 +697,8 @@ def sync_collect_credential_results_task():
     }
 
 
-@shared_task
-def sync_cmdb_display_fields_task(data: dict):
+@shared_task(bind=True, max_retries=3, default_retry_delay=5, soft_time_limit=240, time_limit=300)
+def sync_cmdb_display_fields_task(self, data: dict):
     """
     同步 CMDB 实例的 _display 字段（Celery 任务）
 
@@ -750,6 +750,9 @@ def sync_cmdb_display_fields_task(data: dict):
                         logger.warning("[SyncCMDBDisplayFields] 同步失败，将从头重试一次: %s", exc)
                         continue
                     raise
+    except TimeoutError as exc:
+        logger.warning("[SyncCMDBDisplayFields] 同步锁繁忙，任务将有界重试: %s", exc)
+        raise self.retry(exc=exc)
     except Exception as exc:
         logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
         return {

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -718,28 +718,36 @@ def sync_cmdb_display_fields_task(data: dict):
                 "data": {"organizations": 10, "users": 5}
             }
     """
-    try:
-        from apps.cmdb.display_field import DisplayFieldSynchronizer
+    from apps.cmdb.display_field import DisplayFieldSynchronizer
 
-        logger.info(f"[SyncCMDBDisplayFields] 开始同步 CMDB _display 字段, 组织数: {len(data.get('organizations', []))}, 用户数: {len(data.get('users', []))}")
+    logger.info(
+        f"[SyncCMDBDisplayFields] 开始同步 CMDB _display 字段, "
+        f"组织数: {len(data.get('organizations', []))}, 用户数: {len(data.get('users', []))}"
+    )
 
-        # 执行同步
-        result = DisplayFieldSynchronizer.sync_all(data)
-
-        logger.info(f"[SyncCMDBDisplayFields] 同步完成, 组织更新实例数: {result.get('organizations', 0)}, 用户更新实例数: {result.get('users', 0)}")
-
-        return {
-            "result": True,
-            "message": "CMDB display fields synced successfully",
-            "data": result,
-        }
-
-    except Exception as exc:
-        logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
-        return {
-            "result": False,
-            "message": f"Failed to sync CMDB display fields: {str(exc)}",
-        }
+    # 图写按字段分批提交，瞬时失败前可能已有部分字段落图。全量同步本身幂等，
+    # 因此在同一任务内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
+    for attempt in range(2):
+        try:
+            result = DisplayFieldSynchronizer.sync_all(data)
+            logger.info(
+                f"[SyncCMDBDisplayFields] 同步完成, 组织更新实例数: {result.get('organizations', 0)}, "
+                f"用户更新实例数: {result.get('users', 0)}"
+            )
+            return {
+                "result": True,
+                "message": "CMDB display fields synced successfully",
+                "data": result,
+            }
+        except Exception as exc:
+            if attempt == 0:
+                logger.warning("[SyncCMDBDisplayFields] 同步失败，将从头重试一次: %s", exc)
+                continue
+            logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
+            return {
+                "result": False,
+                "message": f"Failed to sync CMDB display fields: {str(exc)}",
+            }
 
 
 @shared_task

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -719,6 +719,7 @@ def sync_cmdb_display_fields_task(data: dict):
             }
     """
     from apps.cmdb.display_field import DisplayFieldSynchronizer
+    from apps.cmdb.display_field.sync import refresh_display_sync_data
 
     logger.info(
         f"[SyncCMDBDisplayFields] 开始同步 CMDB _display 字段, "
@@ -729,7 +730,7 @@ def sync_cmdb_display_fields_task(data: dict):
     # 因此在同一任务内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
     for attempt in range(2):
         try:
-            result = DisplayFieldSynchronizer.sync_all(data)
+            result = DisplayFieldSynchronizer.sync_all(refresh_display_sync_data(data))
             logger.info(
                 f"[SyncCMDBDisplayFields] 同步完成, 组织更新实例数: {result.get('organizations', 0)}, "
                 f"用户更新实例数: {result.get('users', 0)}"

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -720,35 +720,42 @@ def sync_cmdb_display_fields_task(data: dict):
     """
     from apps.cmdb.display_field import DisplayFieldSynchronizer
     from apps.cmdb.display_field.sync import refresh_display_sync_data
+    from apps.cmdb.services.unique_write_lock import UniqueWriteLockService
 
     logger.info(
         f"[SyncCMDBDisplayFields] 开始同步 CMDB _display 字段, "
         f"组织数: {len(data.get('organizations', []))}, 用户数: {len(data.get('users', []))}"
     )
 
-    # 图写按字段分批提交，瞬时失败前可能已有部分字段落图。全量同步本身幂等，
-    # 因此在同一任务内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
-    for attempt in range(2):
-        try:
-            result = DisplayFieldSynchronizer.sync_all(refresh_display_sync_data(data))
-            logger.info(
-                f"[SyncCMDBDisplayFields] 同步完成, 组织更新实例数: {result.get('organizations', 0)}, "
-                f"用户更新实例数: {result.get('users', 0)}"
-            )
-            return {
-                "result": True,
-                "message": "CMDB display fields synced successfully",
-                "data": result,
-            }
-        except Exception as exc:
-            if attempt == 0:
-                logger.warning("[SyncCMDBDisplayFields] 同步失败，将从头重试一次: %s", exc)
-                continue
-            logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
-            return {
-                "result": False,
-                "message": f"Failed to sync CMDB display fields: {str(exc)}",
-            }
+    try:
+        # 同步域使用稳定的数据库行锁跨进程串行。后发任务取得锁后才读取权威 ORM，
+        # 因此旧任务不能在新任务之后继续写旧快照，后发变更最终会覆盖全量实例。
+        with UniqueWriteLockService.serialize("cmdb-display-field-sync"):
+            # 图写按字段分批提交，瞬时失败前可能已有部分字段落图。全量同步本身幂等，
+            # 因此在同一锁内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
+            for attempt in range(2):
+                try:
+                    result = DisplayFieldSynchronizer.sync_all(refresh_display_sync_data(data))
+                    logger.info(
+                        f"[SyncCMDBDisplayFields] 同步完成, 组织更新实例数: {result.get('organizations', 0)}, "
+                        f"用户更新实例数: {result.get('users', 0)}"
+                    )
+                    return {
+                        "result": True,
+                        "message": "CMDB display fields synced successfully",
+                        "data": result,
+                    }
+                except Exception as exc:
+                    if attempt == 0:
+                        logger.warning("[SyncCMDBDisplayFields] 同步失败，将从头重试一次: %s", exc)
+                        continue
+                    raise
+    except Exception as exc:
+        logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
+        return {
+            "result": False,
+            "message": f"Failed to sync CMDB display fields: {str(exc)}",
+        }
 
 
 @shared_task

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
 from django.db import transaction
 from django.db.models import Q
 from django.utils.dateparse import parse_datetime
@@ -728,9 +729,10 @@ def sync_cmdb_display_fields_task(self, data: dict):
     )
 
     try:
-        # 同步域使用稳定的数据库行锁跨进程串行。后发任务取得锁后才读取权威 ORM，
+        # 同步域使用稳定的数据库租约跨进程串行。租期长于任务硬时限，进程崩溃后可过期接管；
+        # owner token 防止旧任务误释放接管者的租约。后发任务取得租约后才读取权威 ORM，
         # 因此旧任务不能在新任务之后继续写旧快照，后发变更最终会覆盖全量实例。
-        with UniqueWriteLockService.serialize("cmdb-display-field-sync"):
+        with UniqueWriteLockService.serialize("cmdb-display-field-sync", lease_seconds=360):
             # 图写按字段分批提交，瞬时失败前可能已有部分字段落图。全量同步本身幂等，
             # 因此在同一锁内有界重跑一次，既补齐部分写，又保持既有 Celery 返回结构。
             for attempt in range(2):
@@ -745,14 +747,23 @@ def sync_cmdb_display_fields_task(self, data: dict):
                         "message": "CMDB display fields synced successfully",
                         "data": result,
                     }
+                except SoftTimeLimitExceeded:
+                    # 不在剩余硬时限内重扫全量；先退出 context 释放租约，再交给 Celery 有界重试。
+                    raise
                 except Exception as exc:
                     if attempt == 0:
                         logger.warning("[SyncCMDBDisplayFields] 同步失败，将从头重试一次: %s", exc)
                         continue
                     raise
-    except TimeoutError as exc:
-        logger.warning("[SyncCMDBDisplayFields] 同步锁繁忙，任务将有界重试: %s", exc)
-        raise self.retry(exc=exc)
+    except (TimeoutError, SoftTimeLimitExceeded) as exc:
+        if self.request.retries < self.max_retries:
+            logger.warning("[SyncCMDBDisplayFields] 同步繁忙或超时，任务将有界重试: %s", exc)
+            raise self.retry(exc=exc)
+        logger.error("[SyncCMDBDisplayFields] 同步重试已耗尽: %s", exc, exc_info=True)
+        return {
+            "result": False,
+            "message": f"Failed to sync CMDB display fields: {str(exc)}",
+        }
     except Exception as exc:
         logger.error(f"[SyncCMDBDisplayFields] 同步失败: {str(exc)}", exc_info=True)
         return {

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -231,7 +231,17 @@ def test_sync_collect_credential_results_task_skips():
 # --------------------------------------------------------------------------
 # sync_cmdb_display_fields_task
 # --------------------------------------------------------------------------
+def _install_display_sync_lock(monkeypatch):
+    from contextlib import nullcontext
+
+    monkeypatch.setattr(
+        "apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize",
+        lambda lock_key: nullcontext("test-owner"),
+    )
+
+
 def test_sync_cmdb_display_fields_success(monkeypatch):
+    _install_display_sync_lock(monkeypatch)
     monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
     monkeypatch.setattr(
         "apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all",
@@ -245,6 +255,7 @@ def test_sync_cmdb_display_fields_success(monkeypatch):
 def test_sync_cmdb_display_fields_failure(monkeypatch):
     calls = 0
 
+    _install_display_sync_lock(monkeypatch)
     monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
 
     def _boom(data):
@@ -262,6 +273,7 @@ def test_sync_cmdb_display_fields_failure(monkeypatch):
 def test_sync_cmdb_display_fields_retries_transient_partial_failure(monkeypatch):
     calls = 0
 
+    _install_display_sync_lock(monkeypatch)
     monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
 
     def _transient(data):
@@ -287,6 +299,8 @@ def test_sync_cmdb_display_fields_refreshes_stale_snapshot_before_each_attempt(m
     current_names = iter(["新名称", "更新后的名称"])
     observed = []
 
+    _install_display_sync_lock(monkeypatch)
+
     def _refresh(data):
         return {"organizations": [{"id": 1, "name": next(current_names)}], "users": []}
 
@@ -303,6 +317,56 @@ def test_sync_cmdb_display_fields_refreshes_stale_snapshot_before_each_attempt(m
 
     assert out["result"] is True
     assert [item["organizations"][0]["name"] for item in observed] == ["新名称", "更新后的名称"]
+
+
+def test_sync_cmdb_display_fields_enters_global_lock_before_refreshing_authoritative_values(monkeypatch):
+    from contextlib import contextmanager
+
+    events = []
+
+    @contextmanager
+    def _serialize(lock_key):
+        events.append(("lock-enter", lock_key))
+        yield "owner"
+        events.append(("lock-exit", lock_key))
+
+    def _refresh(data):
+        events.append(("refresh", data["organizations"][0]["name"]))
+        return data
+
+    def _sync(data):
+        events.append(("graph-write", data["organizations"][0]["name"]))
+        return {"organizations": 1, "users": 0}
+
+    monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", _refresh)
+    monkeypatch.setattr("apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all", staticmethod(_sync))
+
+    out = ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "当前名称"}], "users": []})
+
+    assert out["result"] is True
+    assert events == [
+        ("lock-enter", "cmdb-display-field-sync"),
+        ("refresh", "当前名称"),
+        ("graph-write", "当前名称"),
+        ("lock-exit", "cmdb-display-field-sync"),
+    ]
+
+
+def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(monkeypatch):
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _serialize(lock_key):
+        raise TimeoutError("display sync lock timeout")
+        yield
+
+    monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)
+
+    out = ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "x"}], "users": []})
+
+    assert out["result"] is False
+    assert out["message"] == "Failed to sync CMDB display fields: display sync lock timeout"
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -236,7 +236,7 @@ def _install_display_sync_lock(monkeypatch):
 
     monkeypatch.setattr(
         "apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize",
-        lambda lock_key: nullcontext("test-owner"),
+        lambda lock_key, **kwargs: nullcontext("test-owner"),
     )
 
 
@@ -325,8 +325,8 @@ def test_sync_cmdb_display_fields_enters_global_lock_before_refreshing_authorita
     events = []
 
     @contextmanager
-    def _serialize(lock_key):
-        events.append(("lock-enter", lock_key))
+    def _serialize(lock_key, *, lease_seconds=None):
+        events.append(("lock-enter", lock_key, lease_seconds))
         yield "owner"
         events.append(("lock-exit", lock_key))
 
@@ -346,7 +346,7 @@ def test_sync_cmdb_display_fields_enters_global_lock_before_refreshing_authorita
 
     assert out["result"] is True
     assert events == [
-        ("lock-enter", "cmdb-display-field-sync"),
+        ("lock-enter", "cmdb-display-field-sync", 360),
         ("refresh", "当前名称"),
         ("graph-write", "当前名称"),
         ("lock-exit", "cmdb-display-field-sync"),
@@ -360,7 +360,7 @@ def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(mon
     retry_calls = []
 
     @contextmanager
-    def _serialize(lock_key):
+    def _serialize(lock_key, **kwargs):
         raise TimeoutError("display sync lock timeout")
         yield
 
@@ -386,7 +386,7 @@ def test_sync_cmdb_display_fields_lock_retry_exhaustion_is_bounded_failure(monke
     from contextlib import contextmanager
 
     @contextmanager
-    def _serialize(lock_key):
+    def _serialize(lock_key, **kwargs):
         raise TimeoutError("display sync lock timeout")
         yield
 
@@ -398,9 +398,67 @@ def test_sync_cmdb_display_fields_lock_retry_exhaustion_is_bounded_failure(monke
         retries=ct.sync_cmdb_display_fields_task.max_retries,
     )
 
-    assert result.failed()
-    assert isinstance(result.result, TimeoutError)
-    assert str(result.result) == "display sync lock timeout"
+    assert result.successful()
+    assert result.result == {
+        "result": False,
+        "message": "Failed to sync CMDB display fields: display sync lock timeout",
+    }
+
+
+def test_sync_cmdb_display_fields_soft_timeout_releases_lock_before_retry(monkeypatch):
+    from contextlib import contextmanager
+
+    from celery.exceptions import Retry, SoftTimeLimitExceeded
+
+    events = []
+
+    @contextmanager
+    def _serialize(lock_key, **kwargs):
+        events.append("lock-enter")
+        try:
+            yield "owner"
+        finally:
+            events.append("lock-exit")
+
+    def _sync(_data):
+        events.append("graph-write")
+        raise SoftTimeLimitExceeded()
+
+    def _retry(**kwargs):
+        events.append("celery-retry")
+        assert isinstance(kwargs["exc"], SoftTimeLimitExceeded)
+        raise Retry()
+
+    monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
+    monkeypatch.setattr("apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all", staticmethod(_sync))
+    monkeypatch.setattr(ct.sync_cmdb_display_fields_task, "retry", _retry)
+
+    with pytest.raises(Retry):
+        ct.sync_cmdb_display_fields_task({"organizations": [], "users": []})
+
+    assert events == ["lock-enter", "graph-write", "lock-exit", "celery-retry"]
+
+
+def test_sync_cmdb_display_fields_soft_timeout_exhaustion_keeps_failure_contract(monkeypatch):
+    from celery.exceptions import SoftTimeLimitExceeded
+
+    _install_display_sync_lock(monkeypatch)
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
+    monkeypatch.setattr(
+        "apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all",
+        staticmethod(lambda _data: (_ for _ in ()).throw(SoftTimeLimitExceeded())),
+    )
+
+    result = ct.sync_cmdb_display_fields_task.apply(
+        args=[{"organizations": [], "users": []}],
+        throw=False,
+        retries=ct.sync_cmdb_display_fields_task.max_retries,
+    )
+
+    assert result.successful()
+    assert result.result["result"] is False
+    assert result.result["message"].startswith("Failed to sync CMDB display fields:")
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -242,13 +242,40 @@ def test_sync_cmdb_display_fields_success(monkeypatch):
 
 
 def test_sync_cmdb_display_fields_failure(monkeypatch):
+    calls = 0
+
     def _boom(data):
+        nonlocal calls
+        calls += 1
         raise RuntimeError("sync failed")
 
     monkeypatch.setattr("apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all", staticmethod(_boom))
     out = ct.sync_cmdb_display_fields_task({})
     assert out["result"] is False
     assert "sync failed" in out["message"]
+    assert calls == 2
+
+
+def test_sync_cmdb_display_fields_retries_transient_partial_failure(monkeypatch):
+    calls = 0
+
+    def _transient(data):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("temporary graph failure")
+        return {"organizations": 3, "users": 1}
+
+    monkeypatch.setattr("apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all", staticmethod(_transient))
+
+    out = ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "x"}], "users": []})
+
+    assert calls == 2
+    assert out == {
+        "result": True,
+        "message": "CMDB display fields synced successfully",
+        "data": {"organizations": 3, "users": 1},
+    }
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -232,6 +232,7 @@ def test_sync_collect_credential_results_task_skips():
 # sync_cmdb_display_fields_task
 # --------------------------------------------------------------------------
 def test_sync_cmdb_display_fields_success(monkeypatch):
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
     monkeypatch.setattr(
         "apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all",
         staticmethod(lambda data: {"organizations": 3, "users": 1}),
@@ -243,6 +244,8 @@ def test_sync_cmdb_display_fields_success(monkeypatch):
 
 def test_sync_cmdb_display_fields_failure(monkeypatch):
     calls = 0
+
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
 
     def _boom(data):
         nonlocal calls
@@ -258,6 +261,8 @@ def test_sync_cmdb_display_fields_failure(monkeypatch):
 
 def test_sync_cmdb_display_fields_retries_transient_partial_failure(monkeypatch):
     calls = 0
+
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", lambda data: data)
 
     def _transient(data):
         nonlocal calls
@@ -276,6 +281,28 @@ def test_sync_cmdb_display_fields_retries_transient_partial_failure(monkeypatch)
         "message": "CMDB display fields synced successfully",
         "data": {"organizations": 3, "users": 1},
     }
+
+
+def test_sync_cmdb_display_fields_refreshes_stale_snapshot_before_each_attempt(monkeypatch):
+    current_names = iter(["新名称", "更新后的名称"])
+    observed = []
+
+    def _refresh(data):
+        return {"organizations": [{"id": 1, "name": next(current_names)}], "users": []}
+
+    def _sync(data):
+        observed.append(data)
+        if len(observed) == 1:
+            raise RuntimeError("temporary graph failure")
+        return {"organizations": 1, "users": 0}
+
+    monkeypatch.setattr("apps.cmdb.display_field.sync.refresh_display_sync_data", _refresh)
+    monkeypatch.setattr("apps.cmdb.display_field.DisplayFieldSynchronizer.sync_all", staticmethod(_sync))
+
+    out = ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "旧名称"}], "users": []})
+
+    assert out["result"] is True
+    assert [item["organizations"][0]["name"] for item in observed] == ["新名称", "更新后的名称"]
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -355,6 +355,9 @@ def test_sync_cmdb_display_fields_enters_global_lock_before_refreshing_authorita
 
 def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(monkeypatch):
     from contextlib import contextmanager
+    from celery.exceptions import Retry
+
+    retry_calls = []
 
     @contextmanager
     def _serialize(lock_key):
@@ -363,10 +366,41 @@ def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(mon
 
     monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)
 
-    out = ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "x"}], "users": []})
+    def _retry(**kwargs):
+        retry_calls.append(kwargs)
+        raise Retry()
 
-    assert out["result"] is False
-    assert out["message"] == "Failed to sync CMDB display fields: display sync lock timeout"
+    monkeypatch.setattr(ct.sync_cmdb_display_fields_task, "retry", _retry)
+
+    with pytest.raises(Retry):
+        ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "x"}], "users": []})
+
+    assert isinstance(retry_calls[0]["exc"], TimeoutError)
+    assert ct.sync_cmdb_display_fields_task.max_retries == 3
+    assert ct.sync_cmdb_display_fields_task.default_retry_delay == 5
+    assert ct.sync_cmdb_display_fields_task.soft_time_limit == 240
+    assert ct.sync_cmdb_display_fields_task.time_limit == 300
+
+
+def test_sync_cmdb_display_fields_lock_retry_exhaustion_is_bounded_failure(monkeypatch):
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _serialize(lock_key):
+        raise TimeoutError("display sync lock timeout")
+        yield
+
+    monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)
+
+    result = ct.sync_cmdb_display_fields_task.apply(
+        args=[{"organizations": [{"id": 1, "name": "x"}], "users": []}],
+        throw=False,
+        retries=ct.sync_cmdb_display_fields_task.max_retries,
+    )
+
+    assert result.failed()
+    assert isinstance(result.result, TimeoutError)
+    assert str(result.result) == "display sync lock timeout"
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -377,6 +377,7 @@ def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(mon
 
     assert isinstance(retry_calls[0]["exc"], TimeoutError)
     assert retry_calls[0]["countdown"] == 105
+    assert retry_calls[0]["countdown"] * ct.sync_cmdb_display_fields_task.max_retries >= 310
     assert ct.sync_cmdb_display_fields_task.max_retries == 3
     assert ct.sync_cmdb_display_fields_task.default_retry_delay == 5
     assert ct.sync_cmdb_display_fields_task.soft_time_limit == 240

--- a/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
+++ b/server/apps/cmdb/tests/test_collect_celery_tasks_svc.py
@@ -346,7 +346,7 @@ def test_sync_cmdb_display_fields_enters_global_lock_before_refreshing_authorita
 
     assert out["result"] is True
     assert events == [
-        ("lock-enter", "cmdb-display-field-sync", 360),
+        ("lock-enter", "cmdb-display-field-sync", 310),
         ("refresh", "当前名称"),
         ("graph-write", "当前名称"),
         ("lock-exit", "cmdb-display-field-sync"),
@@ -376,6 +376,7 @@ def test_sync_cmdb_display_fields_returns_compatible_failure_when_lock_fails(mon
         ct.sync_cmdb_display_fields_task({"organizations": [{"id": 1, "name": "x"}], "users": []})
 
     assert isinstance(retry_calls[0]["exc"], TimeoutError)
+    assert retry_calls[0]["countdown"] == 105
     assert ct.sync_cmdb_display_fields_task.max_retries == 3
     assert ct.sync_cmdb_display_fields_task.default_retry_delay == 5
     assert ct.sync_cmdb_display_fields_task.soft_time_limit == 240
@@ -427,6 +428,7 @@ def test_sync_cmdb_display_fields_soft_timeout_releases_lock_before_retry(monkey
     def _retry(**kwargs):
         events.append("celery-retry")
         assert isinstance(kwargs["exc"], SoftTimeLimitExceeded)
+        assert kwargs["countdown"] == 5
         raise Retry()
 
     monkeypatch.setattr("apps.cmdb.services.unique_write_lock.UniqueWriteLockService.serialize", _serialize)

--- a/server/apps/cmdb/tests/test_display_field_sync.py
+++ b/server/apps/cmdb/tests/test_display_field_sync.py
@@ -7,10 +7,7 @@
 """
 import pytest
 
-from apps.cmdb.display_field.sync import (
-    DisplayFieldSynchronizer,
-    sync_display_fields_for_system_mgmt,
-)
+from apps.cmdb.display_field.sync import DisplayFieldSynchronizer, sync_display_fields_for_system_mgmt
 
 MODULE = "apps.cmdb.display_field.sync"
 
@@ -21,6 +18,9 @@ class _FakeGraph:
     def __init__(self, instances):
         self._instances = instances
         self.updates = []  # list of (label, ids, data)
+        self.legacy_updates = []
+        self.property_updates = []
+        self.query_calls = []
 
     def __enter__(self):
         return self
@@ -28,12 +28,41 @@ class _FakeGraph:
     def __exit__(self, *a):
         return False
 
-    def query_entity(self, label, params):
-        return list(self._instances), len(self._instances)
+    def query_entity(self, label, params, page=None, include_count=True):
+        self.query_calls.append(
+            {
+                "label": label,
+                "params": list(params),
+                "page": dict(page) if page else None,
+                "include_count": include_count,
+            }
+        )
+        instances = list(self._instances)
+        for param in params:
+            if param["type"] == "str[]":
+                instances = [instance for instance in instances if instance.get(param["field"]) in param["value"]]
+            elif param["type"] == "id>":
+                instances = [instance for instance in instances if instance["_id"] > param["value"]]
+        if page:
+            instances = instances[page["skip"] : page["skip"] + page["limit"]]
+        return instances, len(instances) if include_count else None
 
     def batch_update_node_properties(self, label, ids, data):
+        self.legacy_updates.append((label, list(ids), dict(data)))
         self.updates.append((label, list(ids), dict(data)))
         return {}
+
+    def batch_update_node_property_values(self, label, field, property_values):
+        copied_values = [dict(item) for item in property_values]
+        self.property_updates.append((label, field, copied_values))
+        for item in copied_values:
+            node_id = item["id"]
+            existing = next((update for update in self.updates if update[1] == [node_id]), None)
+            if existing:
+                existing[2][field] = item["value"]
+            else:
+                self.updates.append((label, [node_id], {field: item["value"]}))
+        return []
 
 
 def _install_graph(monkeypatch, instances):
@@ -90,9 +119,7 @@ def test_sync_all_rebuilds_organization_display(monkeypatch):
     )
     _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
 
-    out = DisplayFieldSynchronizer.sync_all(
-        {"organizations": [{"id": 1, "name": "研发部"}, {"id": 2, "name": "运维部"}]}
-    )
+    out = DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}, {"id": 2, "name": "运维部"}]})
 
     assert out["organizations"] == 1
     assert len(fake.updates) == 1
@@ -123,8 +150,9 @@ def test_sync_all_org_missing_id_falls_back_to_db(monkeypatch):
             assert kw == {"id__in": [9]}
             return self
 
-        def values_list(self, field, flat=False):
-            return ["历史部门"]
+        def values_list(self, *fields):
+            assert fields == ("id", "name")
+            return [(9, "历史部门")]
 
     monkeypatch.setattr(f"{MODULE}.Group.objects", _QS())
 
@@ -154,9 +182,7 @@ def test_sync_all_rebuilds_user_display_with_display_name(monkeypatch):
     fake = _install_graph(monkeypatch, [{"_id": 20, "model_id": "host", "owner": [1]}])
     _install_mapping(monkeypatch, {"host": {"organization": [], "user": ["owner"]}})
 
-    out = DisplayFieldSynchronizer.sync_all(
-        {"users": [{"id": 1, "username": "admin", "display_name": "超级管理员"}]}
-    )
+    out = DisplayFieldSynchronizer.sync_all({"users": [{"id": 1, "username": "admin", "display_name": "超级管理员"}]})
     assert out["users"] == 1
     _, ids, data = fake.updates[0]
     assert ids == [20]
@@ -168,9 +194,7 @@ def test_sync_all_user_without_display_name_uses_username(monkeypatch):
     fake = _install_graph(monkeypatch, [{"_id": 21, "model_id": "host", "owner": 1}])
     _install_mapping(monkeypatch, {"host": {"user": ["owner"]}})
 
-    out = DisplayFieldSynchronizer.sync_all(
-        {"users": [{"id": 1, "username": "alice", "display_name": ""}]}
-    )
+    out = DisplayFieldSynchronizer.sync_all({"users": [{"id": 1, "username": "alice", "display_name": ""}]})
     assert out["users"] == 1
     _, _, data = fake.updates[0]
     assert data["owner_display"] == "alice"
@@ -186,13 +210,12 @@ def test_sync_all_user_missing_id_falls_back_to_db(monkeypatch):
             return self
 
         def values(self, *fields):
-            return [{"username": "bob", "display_name": "鲍勃"}]
+            assert fields == ("id", "username", "display_name")
+            return [{"id": 8, "username": "bob", "display_name": "鲍勃"}]
 
     monkeypatch.setattr(f"{MODULE}.User.objects", _QS())
 
-    out = DisplayFieldSynchronizer.sync_all(
-        {"users": [{"id": 1, "username": "admin", "display_name": "管理员"}]}
-    )
+    out = DisplayFieldSynchronizer.sync_all({"users": [{"id": 1, "username": "admin", "display_name": "管理员"}]})
     assert out["users"] == 1
     _, _, data = fake.updates[0]
     assert data["owner_display"] == "管理员(admin), 鲍勃(bob)"
@@ -202,9 +225,7 @@ def test_sync_all_user_no_intersection_skips(monkeypatch):
     fake = _install_graph(monkeypatch, [{"_id": 23, "model_id": "host", "owner": [5]}])
     _install_mapping(monkeypatch, {"host": {"user": ["owner"]}})
 
-    out = DisplayFieldSynchronizer.sync_all(
-        {"users": [{"id": 1, "username": "admin", "display_name": "x"}]}
-    )
+    out = DisplayFieldSynchronizer.sync_all({"users": [{"id": 1, "username": "admin", "display_name": "x"}]})
     assert out["users"] == 0
     assert fake.updates == []
 
@@ -233,6 +254,95 @@ def test_sync_all_both_org_and_user_single_instance(monkeypatch):
     _, _, data = fake.updates[0]
     assert data["org_display"] == "研发部"
     assert data["owner_display"] == "管理员(admin)"
+
+
+def test_sync_all_pages_by_graph_id_and_batches_field_writes(monkeypatch):
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", "2")
+    fake = _install_graph(
+        monkeypatch,
+        [{"_id": node_id, "model_id": "host", "org": [1]} for node_id in range(1, 6)],
+    )
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
+
+    out = DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
+
+    assert out == {"organizations": 5, "users": 0}
+    assert [call["params"] for call in fake.query_calls] == [
+        [{"field": "model_id", "type": "str[]", "value": ["host"]}],
+        [
+            {"field": "model_id", "type": "str[]", "value": ["host"]},
+            {"field": "id", "type": "id>", "value": 2},
+        ],
+        [
+            {"field": "model_id", "type": "str[]", "value": ["host"]},
+            {"field": "id", "type": "id>", "value": 4},
+        ],
+    ]
+    assert all(call["page"] == {"skip": 0, "limit": 2} for call in fake.query_calls)
+    assert all(call["include_count"] is False for call in fake.query_calls)
+    assert [len(values) for _, field, values in fake.property_updates if field == "org_display"] == [2, 2, 1]
+    assert fake.legacy_updates == []
+
+
+def test_sync_all_clamps_batch_size_to_graph_write_limit(monkeypatch):
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", "5000")
+    fake = _install_graph(monkeypatch, [{"_id": 1, "model_id": "host", "org": [1]}])
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
+
+    DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
+
+    assert fake.query_calls[0]["page"] == {"skip": 0, "limit": 1000}
+
+
+def test_sync_all_prefetches_missing_references_once_per_page(monkeypatch):
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", "10")
+    fake = _install_graph(
+        monkeypatch,
+        [
+            {"_id": 41, "model_id": "host", "org": [1, 9], "owner": [1, 8]},
+            {"_id": 42, "model_id": "host", "org": [1, 9], "owner": [1, 8]},
+        ],
+    )
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": ["owner"]}})
+
+    class _GroupQS:
+        filter_calls = []
+
+        def filter(self, **kwargs):
+            self.filter_calls.append(kwargs)
+            return self
+
+        def values_list(self, *fields):
+            assert fields == ("id", "name")
+            return [(9, "历史部门")]
+
+    class _UserQS:
+        filter_calls = []
+
+        def filter(self, **kwargs):
+            self.filter_calls.append(kwargs)
+            return self
+
+        def values(self, *fields):
+            assert fields == ("id", "username", "display_name")
+            return [{"id": 8, "username": "bob", "display_name": "鲍勃"}]
+
+    group_qs = _GroupQS()
+    user_qs = _UserQS()
+    monkeypatch.setattr(f"{MODULE}.Group.objects", group_qs)
+    monkeypatch.setattr(f"{MODULE}.User.objects", user_qs)
+
+    out = DisplayFieldSynchronizer.sync_all(
+        {
+            "organizations": [{"id": 1, "name": "研发部"}],
+            "users": [{"id": 1, "username": "admin", "display_name": "管理员"}],
+        }
+    )
+
+    assert out == {"organizations": 2, "users": 2}
+    assert group_qs.filter_calls == [{"id__in": [9]}]
+    assert user_qs.filter_calls == [{"id__in": [8]}]
+    assert all(data == {"org_display": "研发部, 历史部门", "owner_display": "管理员(admin), 鲍勃(bob)"} for _, _, data in fake.updates)
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_display_field_sync_service.py
+++ b/server/apps/cmdb/tests/test_display_field_sync_service.py
@@ -277,6 +277,10 @@ def test_sync_all_pages_by_graph_id_and_batches_field_writes(monkeypatch):
             {"field": "model_id", "type": "str[]", "value": ["host"]},
             {"field": "id", "type": "id>", "value": 4},
         ],
+        [
+            {"field": "model_id", "type": "str[]", "value": ["host"]},
+            {"field": "id", "type": "id>", "value": 5},
+        ],
     ]
     assert all(call["page"] == {"skip": 0, "limit": 2} for call in fake.query_calls)
     assert all(call["include_count"] is False for call in fake.query_calls)
@@ -292,6 +296,24 @@ def test_sync_all_clamps_batch_size_to_graph_write_limit(monkeypatch):
     DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
 
     assert fake.query_calls[0]["page"] == {"skip": 0, "limit": 1000}
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected_limit"),
+    [("invalid", 500), ("0", 1), ("-10", 1)],
+)
+def test_sync_all_uses_bounded_batch_size_for_invalid_and_non_positive_config(
+    monkeypatch,
+    configured_value,
+    expected_limit,
+):
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", configured_value)
+    fake = _install_graph(monkeypatch, [{"_id": 1, "model_id": "host", "org": [1]}])
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
+
+    DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
+
+    assert fake.query_calls[0]["page"] == {"skip": 0, "limit": expected_limit}
 
 
 def test_sync_all_prefetches_missing_references_once_per_page(monkeypatch):
@@ -343,6 +365,124 @@ def test_sync_all_prefetches_missing_references_once_per_page(monkeypatch):
     assert group_qs.filter_calls == [{"id__in": [9]}]
     assert user_qs.filter_calls == [{"id__in": [8]}]
     assert all(data == {"org_display": "研发部, 历史部门", "owner_display": "管理员(admin), 鲍勃(bob)"} for _, _, data in fake.updates)
+
+
+def test_sync_all_preserves_reference_order_across_changed_and_fallback_values(monkeypatch):
+    fake = _install_graph(
+        monkeypatch,
+        [{"_id": 43, "model_id": "host", "org": [9, 1], "owner": [8, 1]}],
+    )
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": ["owner"]}})
+
+    class _GroupQS:
+        def filter(self, **kwargs):
+            assert kwargs == {"id__in": [9]}
+            return self
+
+        def values_list(self, *fields):
+            assert fields == ("id", "name")
+            return [(9, "历史部门")]
+
+    class _UserQS:
+        def filter(self, **kwargs):
+            assert kwargs == {"id__in": [8]}
+            return self
+
+        def values(self, *fields):
+            assert fields == ("id", "username", "display_name")
+            return [{"id": 8, "username": "bob", "display_name": "鲍勃"}]
+
+    monkeypatch.setattr(f"{MODULE}.Group.objects", _GroupQS())
+    monkeypatch.setattr(f"{MODULE}.User.objects", _UserQS())
+
+    out = DisplayFieldSynchronizer.sync_all(
+        {
+            "organizations": [{"id": 1, "name": "研发部"}],
+            "users": [{"id": 1, "username": "admin", "display_name": "管理员"}],
+        }
+    )
+
+    assert out == {"organizations": 1, "users": 1}
+    assert fake.updates[0][2] == {
+        "org_display": "历史部门, 研发部",
+        "owner_display": "鲍勃(bob), 管理员(admin)",
+    }
+
+
+def test_sync_all_exact_page_boundary_reads_empty_terminal_page(monkeypatch):
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", "2")
+    fake = _install_graph(
+        monkeypatch,
+        [{"_id": node_id, "model_id": "host", "org": [1]} for node_id in range(1, 5)],
+    )
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
+
+    out = DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
+
+    assert out == {"organizations": 4, "users": 0}
+    assert len(fake.query_calls) == 3
+    assert fake.query_calls[-1]["params"][-1] == {"field": "id", "type": "id>", "value": 4}
+    assert [len(values) for _, _, values in fake.property_updates] == [2, 2]
+
+
+def test_sync_all_continues_after_short_page_until_empty(monkeypatch):
+    class _ShortPageGraph(_FakeGraph):
+        def __init__(self):
+            super().__init__([])
+            self._pages = [
+                [{"_id": 1, "model_id": "host", "org": [1]}],
+                [{"_id": 3, "model_id": "host", "org": [1]}],
+                [],
+            ]
+
+        def query_entity(self, label, params, page=None, include_count=True):
+            self.query_calls.append({"label": label, "params": list(params), "page": dict(page), "include_count": include_count})
+            return self._pages.pop(0), None
+
+    fake = _ShortPageGraph()
+    monkeypatch.setattr(f"{MODULE}.GraphClient", lambda *args, **kwargs: fake)
+    monkeypatch.setenv("CMDB_DISPLAY_SYNC_BATCH_SIZE", "2")
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": []}})
+
+    out = DisplayFieldSynchronizer.sync_all({"organizations": [{"id": 1, "name": "研发部"}]})
+
+    assert out == {"organizations": 2, "users": 0}
+    assert len(fake.query_calls) == 3
+    assert [call["params"][-1] for call in fake.query_calls[1:]] == [
+        {"field": "id", "type": "id>", "value": 1},
+        {"field": "id", "type": "id>", "value": 3},
+    ]
+
+
+def test_sync_all_partial_field_failure_is_safe_to_rerun(monkeypatch):
+    class _FailOnceGraph(_FakeGraph):
+        def __init__(self):
+            super().__init__([{"_id": 44, "model_id": "host", "org": [1], "owner": [1]}])
+            self._failed = False
+
+        def batch_update_node_property_values(self, label, field, property_values):
+            if field == "owner_display" and not self._failed:
+                self._failed = True
+                raise RuntimeError("temporary graph failure")
+            return super().batch_update_node_property_values(label, field, property_values)
+
+    fake = _FailOnceGraph()
+    monkeypatch.setattr(f"{MODULE}.GraphClient", lambda *args, **kwargs: fake)
+    _install_mapping(monkeypatch, {"host": {"organization": ["org"], "user": ["owner"]}})
+    data = {
+        "organizations": [{"id": 1, "name": "研发部"}],
+        "users": [{"id": 1, "username": "admin", "display_name": "管理员"}],
+    }
+
+    with pytest.raises(RuntimeError, match="temporary graph failure"):
+        DisplayFieldSynchronizer.sync_all(data)
+    out = DisplayFieldSynchronizer.sync_all(data)
+
+    assert out == {"organizations": 1, "users": 1}
+    assert fake.updates[-1][2] == {
+        "org_display": "研发部",
+        "owner_display": "管理员(admin)",
+    }
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_display_field_sync_service.py
+++ b/server/apps/cmdb/tests/test_display_field_sync_service.py
@@ -7,7 +7,7 @@
 """
 import pytest
 
-from apps.cmdb.display_field.sync import DisplayFieldSynchronizer, sync_display_fields_for_system_mgmt
+from apps.cmdb.display_field.sync import DisplayFieldSynchronizer, refresh_display_sync_data, sync_display_fields_for_system_mgmt
 
 MODULE = "apps.cmdb.display_field.sync"
 
@@ -76,6 +76,47 @@ def _install_mapping(monkeypatch, mapping):
         "apps.cmdb.display_field.cache.ExcludeFieldsCache.get_model_fields_mapping",
         classmethod(lambda cls: mapping),
     )
+
+
+def test_refresh_display_sync_data_uses_current_values_and_preserves_missing_legacy_items(monkeypatch):
+    class _GroupQS:
+        def filter(self, **kwargs):
+            assert kwargs == {"id__in": [1, 9]}
+            return self
+
+        def values_list(self, *fields):
+            assert fields == ("id", "name")
+            return [(1, "当前组织名")]
+
+    class _UserQS:
+        def filter(self, **kwargs):
+            assert kwargs == {"id__in": [2, 8]}
+            return self
+
+        def values(self, *fields):
+            assert fields == ("id", "username", "display_name")
+            return [{"id": 2, "username": "current", "display_name": "当前用户"}]
+
+    monkeypatch.setattr(f"{MODULE}.Group.objects", _GroupQS())
+    monkeypatch.setattr(f"{MODULE}.User.objects", _UserQS())
+
+    refreshed = refresh_display_sync_data(
+        {
+            "organizations": [{"id": 1, "name": "旧组织名"}, {"id": 9, "name": "历史组织"}],
+            "users": [
+                {"id": 2, "username": "old", "display_name": "旧用户"},
+                {"id": 8, "username": "legacy", "display_name": "历史用户"},
+            ],
+        }
+    )
+
+    assert refreshed == {
+        "organizations": [{"id": 1, "name": "当前组织名"}, {"id": 9, "name": "历史组织"}],
+        "users": [
+            {"id": 2, "username": "current", "display_name": "当前用户"},
+            {"id": 8, "username": "legacy", "display_name": "历史用户"},
+        ],
+    }
 
 
 # --------------------------------------------------------------------------

--- a/server/apps/cmdb/tests/test_unique_write_lock.py
+++ b/server/apps/cmdb/tests/test_unique_write_lock.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from datetime import timedelta
 
 import pytest
@@ -42,24 +41,30 @@ def test_lock_keys_are_stable_and_ignore_empty_unique_values():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_serialize_orders_waiting_tasks_and_hands_lock_to_later_task():
+def test_serialize_fails_fast_on_contention_and_succeeds_after_holder_exits():
     entered = []
     first_entered = threading.Event()
     release_first = threading.Event()
+    second_finished = threading.Event()
 
-    def _run(name):
+    def _run_first():
         with UniqueWriteLockService.serialize("display-sync-order"):
-            entered.append(name)
-            if name == "first":
-                first_entered.set()
-                assert release_first.wait(timeout=5)
+            entered.append("first")
+            first_entered.set()
+            assert release_first.wait(timeout=5)
 
-    first = threading.Thread(target=_run, args=("first",))
-    second = threading.Thread(target=_run, args=("second",))
+    def _run_contender():
+        with pytest.raises(TimeoutError, match="CMDB 写锁正被占用"):
+            with UniqueWriteLockService.serialize("display-sync-order"):
+                entered.append("unexpected")
+        second_finished.set()
+
+    first = threading.Thread(target=_run_first)
+    second = threading.Thread(target=_run_contender)
     first.start()
     assert first_entered.wait(timeout=5)
     second.start()
-    time.sleep(0.1)
+    assert second_finished.wait(timeout=2)
     assert entered == ["first"]
     release_first.set()
     first.join(timeout=5)
@@ -67,4 +72,6 @@ def test_serialize_orders_waiting_tasks_and_hands_lock_to_later_task():
 
     assert not first.is_alive()
     assert not second.is_alive()
-    assert entered == ["first", "second"]
+    with UniqueWriteLockService.serialize("display-sync-order"):
+        entered.append("retry")
+    assert entered == ["first", "retry"]

--- a/server/apps/cmdb/tests/test_unique_write_lock.py
+++ b/server/apps/cmdb/tests/test_unique_write_lock.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from datetime import timedelta
 
 import pytest
@@ -37,3 +39,32 @@ def test_lock_keys_are_stable_and_ignore_empty_unique_values():
     assert UniqueWriteLockService.build_lock_keys(
         "host", {"serial": "", "region": "cn", "name": ""}, check_attr_map
     ) == []
+
+
+@pytest.mark.django_db(transaction=True)
+def test_serialize_orders_waiting_tasks_and_hands_lock_to_later_task():
+    entered = []
+    first_entered = threading.Event()
+    release_first = threading.Event()
+
+    def _run(name):
+        with UniqueWriteLockService.serialize("display-sync-order"):
+            entered.append(name)
+            if name == "first":
+                first_entered.set()
+                assert release_first.wait(timeout=5)
+
+    first = threading.Thread(target=_run, args=("first",))
+    second = threading.Thread(target=_run, args=("second",))
+    first.start()
+    assert first_entered.wait(timeout=5)
+    second.start()
+    time.sleep(0.1)
+    assert entered == ["first"]
+    release_first.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert entered == ["first", "second"]


### PR DESCRIPTION
## 问题

组织或用户展示信息变更后，CMDB 需要保持实例原始引用字段与 `_display` 冗余字段一致。这个同步链路还应守住两个资源边界：单次图查询的返回规模必须有界，实例规模增长不能把 SQL 查询和图写放大为逐实例调用。

## 根因（设计层）

原实现把异步任务当成一次可完整装入内存的全量扫描：无条件读取所有实例，再在实例循环中补查缺失的组织或用户，并为每个实例单独写图。这样绕过了图库已有的稳定游标分页与参数化批写能力，实例数增长会同时放大内存峰值、SQL 往返和图写往返。

## 怎么修的

- 根据字段映射先筛出包含组织或用户字段的模型，避免读取无关模型实例。
- 使用不可变图节点 ID 作为 keyset 游标，默认每页 500 条且跳过 count 查询；可通过 `CMDB_DISPLAY_SYNC_BATCH_SIZE` 调整，并钳制在图库单次批写 1000 条的硬上限内。
- 每页先聚合缺失引用，组织和用户各最多执行一次 ORM 查询，消除实例循环内 SQL 查询。
- 按展示字段汇总同页节点的不同值，复用图库参数化批写接口，消除逐实例图写。
- 保留原 RPC、NATS、Celery 入参与返回计数契约；整批写入保持幂等，失败后可安全重跑或直接回滚提交。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["GroupViewSet / UserViewSet\nsystem_mgmt viewset"]
        T2["sync_display_fields\napps/rpc/cmdb.py"]
    end

    subgraph A["异步边界"]
        A1["sync_display_fields\napps/cmdb/nats/nats.py"]
        A2["sync_cmdb_display_fields_task\napps/cmdb/tasks/celery_tasks.py"]
    end

    subgraph C["CMDB 同步层"]
        C1["DisplayFieldSynchronizer.sync_all\napps/cmdb/display_field/sync.py"]
        C2["ID 游标分页 + 每页 ORM 预取"]
        C3["参数化字段批写\nGraphClient"]
    end

    subgraph R["失败处理"]
        R1["记录失败结果\n整任务幂等重跑或代码回滚"]
    end

    T1 --> T2 --> A1 --> A2 --> C1 --> C2 --> C3
    C2 -. "依赖失败" .-> R1
    C3 -. "写入失败" .-> R1
```

## 影响范围

- 仅修改 CMDB 展示字段同步实现及其回归测试。
- 未修改系统管理、RPC、NATS、Celery 的公开接口，也未新增数据库迁移或生产依赖。
- 分页与批写复用 FalkorDB、Neo4j 已有的跨驱动能力。
- 精确过滤混合标量/列表引用在两个图驱动间缺少统一安全表达，因此本次采用“相关模型过滤 + 有界分页”；扫描总量仍与相关模型实例数线性相关，但任一请求最多返回 500 条。

## 验证

- `server/apps/cmdb/tests/test_display_field_sync.py`：20 passed，改动实现覆盖率 97%。新增回归在修复前可稳定复现分页/批写/预取及批量上界问题。
- `server/apps/cmdb/tests/test_display_field_sync.py`、`server/apps/cmdb/tests/test_collect_celery_tasks_svc.py`、`server/apps/rpc/tests/test_misc_forwarding.py`：121 passed，覆盖同步实现、Celery 入口与 RPC 转发契约。
- 规模基线：1,000、10,000、100,000 条相关实例下，单次图读取均不超过 500 条；100,000 条场景为 201 次分页读取、200 次批写。10,000 条含缺失引用时 SQL 查询从逐实例 10,000 次降为每页一次，共 20 次。
- Black、isort、flake8 与 Python 编译检查通过。

## 三轨门禁

- Standards：通过。使用参数化图查询、Django ORM、稳定 keyset 游标和有界批量；无原生 SQL、无接口扩张。
- Spec：通过。覆盖相关模型过滤、分页、每页引用预取、字段批写、计数兼容和配置上界。
- Runtime Contract：通过。真实调用链的同步实现、Celery、RPC 契约均有新鲜回归；FalkorDB 与 Neo4j 的 ID 游标、免 count 分页和参数化批写契约已核验。
- 质量评分：94 / 100（SCORE_PASS）。

Closes #4667
