### PR TITLE
bugfix: 清理 K8s 镜像下载临时文件

### DIFF
--- a/server/apps/alerts/tests/test_alert_source_views.py
+++ b/server/apps/alerts/tests/test_alert_source_views.py
@@ -240,6 +240,7 @@ def k8s_image_response(monkeypatch):
     )
 
 
+@pytest.mark.unit
 def test_k8s_image_tar_is_removed_after_response_stream_finishes(k8s_image_export_paths, k8s_image_response):
     response = k8s_image_response()
     exported_path = k8s_image_export_paths[0]
@@ -252,6 +253,7 @@ def test_k8s_image_tar_is_removed_after_response_stream_finishes(k8s_image_expor
     assert not exported_path.exists()
 
 
+@pytest.mark.unit
 def test_k8s_image_tar_is_removed_when_response_closes_early(k8s_image_export_paths, k8s_image_response):
     response = k8s_image_response()
     exported_path = k8s_image_export_paths[0]
@@ -261,6 +263,7 @@ def test_k8s_image_tar_is_removed_when_response_closes_early(k8s_image_export_pa
     assert not exported_path.exists()
 
 
+@pytest.mark.unit
 def test_k8s_image_tar_is_removed_when_docker_save_fails(monkeypatch, k8s_image_export_paths):
     from apps.alerts.views import alert_source as alert_source_module
 
@@ -278,6 +281,7 @@ def test_k8s_image_tar_is_removed_when_docker_save_fails(monkeypatch, k8s_image_
     assert not k8s_image_export_paths[0].exists()
 
 
+@pytest.mark.unit
 def test_k8s_image_tar_is_removed_when_export_is_interrupted(monkeypatch, k8s_image_export_paths):
     from apps.alerts.views import alert_source as alert_source_module
 

--- a/server/apps/alerts/tests/test_alert_source_views.py
+++ b/server/apps/alerts/tests/test_alert_source_views.py
@@ -4,6 +4,8 @@
 """
 
 import json
+import subprocess
+from pathlib import Path
 
 import pytest
 from rest_framework import status
@@ -207,6 +209,90 @@ def test_k8s_deploy_yaml_embeds_secret_hash_for_rolling_restart():
     assert f"bk-lite.tencent.com/secret-hash: {hash_b}" in yaml_b
     # 幂等：相同 secret 同 hash → apply 不会无谓滚动
     assert yaml_a == yaml_a2
+
+
+@pytest.fixture
+def k8s_image_export_paths(monkeypatch, tmp_path):
+    from apps.alerts.views import alert_source as alert_source_module
+
+    exported_paths = []
+
+    def fake_docker_save(command, **kwargs):
+        output_path = Path(command[3])
+        output_path.write_bytes(b"image-tar")
+        exported_paths.append(output_path)
+
+    monkeypatch.setattr(alert_source_module.tempfile, "tempdir", str(tmp_path))
+    monkeypatch.setattr(alert_source_module.subprocess, "run", fake_docker_save)
+    return exported_paths
+
+
+@pytest.fixture
+def k8s_image_response(monkeypatch):
+    from django.http import response as django_response
+
+    from apps.core.utils.web_utils import WebUtils
+
+    monkeypatch.setattr(django_response.signals.request_finished, "send", lambda **kwargs: [])
+    return lambda: WebUtils.response_file(
+        AlertSourceModelViewSet._build_k8s_image_tar_file(),
+        "kubernetes-event-exporter.tar",
+    )
+
+
+def test_k8s_image_tar_is_removed_after_response_stream_finishes(k8s_image_export_paths, k8s_image_response):
+    response = k8s_image_response()
+    exported_path = k8s_image_export_paths[0]
+
+    assert b"".join(response.streaming_content) == b"image-tar"
+    assert exported_path.exists()
+
+    response.close()
+
+    assert not exported_path.exists()
+
+
+def test_k8s_image_tar_is_removed_when_response_closes_early(k8s_image_export_paths, k8s_image_response):
+    response = k8s_image_response()
+    exported_path = k8s_image_export_paths[0]
+
+    response.close()
+
+    assert not exported_path.exists()
+
+
+def test_k8s_image_tar_is_removed_when_docker_save_fails(monkeypatch, k8s_image_export_paths):
+    from apps.alerts.views import alert_source as alert_source_module
+
+    def failing_docker_save(command, **kwargs):
+        output_path = Path(command[3])
+        output_path.write_bytes(b"partial-image-tar")
+        k8s_image_export_paths.append(output_path)
+        raise subprocess.CalledProcessError(1, command, stderr="docker save failed")
+
+    monkeypatch.setattr(alert_source_module.subprocess, "run", failing_docker_save)
+
+    with pytest.raises(RuntimeError, match="docker save failed"):
+        AlertSourceModelViewSet._build_k8s_image_tar_file()
+
+    assert not k8s_image_export_paths[0].exists()
+
+
+def test_k8s_image_tar_is_removed_when_export_is_interrupted(monkeypatch, k8s_image_export_paths):
+    from apps.alerts.views import alert_source as alert_source_module
+
+    def interrupted_docker_save(command, **kwargs):
+        output_path = Path(command[3])
+        output_path.write_bytes(b"partial-image-tar")
+        k8s_image_export_paths.append(output_path)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(alert_source_module.subprocess, "run", interrupted_docker_save)
+
+    with pytest.raises(KeyboardInterrupt):
+        AlertSourceModelViewSet._build_k8s_image_tar_file()
+
+    assert not k8s_image_export_paths[0].exists()
 
 
 @pytest.mark.django_db

--- a/server/apps/alerts/views/alert_source.py
+++ b/server/apps/alerts/views/alert_source.py
@@ -124,8 +124,7 @@ class AlertSourceModelViewSet(ModelViewSet):
 
     @staticmethod
     def _build_k8s_image_tar_file():
-        temp_file = tempfile.NamedTemporaryFile(prefix="k8s-event-exporter-", suffix=".tar", delete=False)
-        temp_file.close()
+        temp_file = tempfile.NamedTemporaryFile(prefix="k8s-event-exporter-", suffix=".tar")
         try:
             subprocess.run(
                 ["docker", "save", "-o", temp_file.name, K8S_IMAGE_REFERENCE],
@@ -133,9 +132,14 @@ class AlertSourceModelViewSet(ModelViewSet):
                 capture_output=True,
                 text=True,
             )
+            temp_file.seek(0)
         except subprocess.CalledProcessError as error:
+            temp_file.close()
             raise RuntimeError(error.stderr or error.stdout or "Failed to export image") from error
-        return open(temp_file.name, "rb")
+        except BaseException:
+            temp_file.close()
+            raise
+        return temp_file
 
     @classmethod
     def _resolve_k8s_team_secret(cls, request, source: AlertSource) -> str:


### PR DESCRIPTION
## 问题

K8s 离线镜像下载本应只在响应存续期间占用临时 tar。原实现将临时文件设为永久保留，再重新打开交给响应；响应关闭只能关闭文件描述符，无法删除磁盘路径，生成失败时的部分 tar 也会残留。

## 根因（设计层）

临时文件的磁盘生命周期与响应资源生命周期被拆开：创建者放弃了自动删除责任，响应层又只持有重新打开的普通文件句柄，因此成功、断连和异常路径都没有统一的资源所有者。

## 怎么修的

- 保持临时文件的自动删除语义，并直接把同一文件对象交给 `FileResponse`。
- `docker save` 成功后将读指针复位，下载内容与文件名保持不变。
- `docker save` 失败或进程被中断时立即关闭文件对象，让临时路径同步回收。

## 影响范围

仅触及 alerts 的 K8s 离线镜像导出函数及其测试。REST 路径、`Integration-View` 权限、响应文件名、镜像引用和 tar 内容均不变；无数据库迁移、配置迁移或调用方改造。回滚可直接 revert 本提交。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["k8s_download/image_tar\nalert_source.py"]
    end

    subgraph N["核心处理层"]
        F1["NamedTemporaryFile\n自动删除路径"]
        F2["docker save\n写入临时 tar"]
        F3["FileResponse\n持有同一文件对象"]
    end

    subgraph C["清理层"]
        C1["响应完成或断连\nclose 后删除"]
        C2["生成失败或中断\n立即 close 删除"]
    end

    T1 --> F1 --> F2 --> F3 --> C1
    F2 -. "异常" .-> C2
```

## 验证

- `server/apps/alerts/tests/test_alert_source_views.py`：30 passed。
- 回归测试覆盖完整消费后关闭、客户端提前关闭、`docker save` 失败和导出中断；修复前四类清理断言均失败，修复后全部通过。
- 独立子进程写入仍打开的临时文件后，读指针复位可读取完整内容，关闭后路径消失。

## 三轨门禁

- Standards：pass。最小两文件 diff，静态检查与迁移检查通过。
- Spec：pass。下载完成、断连、生成失败和中断路径均统一回收临时 tar。
- Runtime Contract：pass。真实 `FileResponse.close` 资源关闭链、异常链及独立进程文件写入契约均已验证。

Closes #4670
