### PR TITLE
bugfix: 收敛告警事件异常日志上下文

### DIFF
--- a/server/apps/alerts/common/source_adapter/base.py
+++ b/server/apps/alerts/common/source_adapter/base.py
@@ -208,30 +208,39 @@ class AlertSourceAdapter(ABC):
         event_dicts = []
         skipped_missing = 0  # 预期内丢弃：缺必填字段
         errored = 0  # 非预期错误：转换异常
-        for add_event in add_events:
+        for event_index, add_event in enumerate(add_events):
             try:
                 data = self.mapping_fields_to_event(add_event)
                 if not data:
                     # 缺少必填字段（如 title）→ 丢弃，避免构造出 start_time=None 的空事件，
                     # 否则会在 bulk_create 时因 NOT NULL 约束令整批写入失败。
                     skipped_missing += 1
-                    logger.warning("[AlertSource] 事件缺少必填字段，已跳过: %s", add_event)
+                    logger.warning(
+                        "[AlertSource] 事件缺少必填字段，已跳过: source_id=%s event_index=%s",
+                        self.alert_source.source_id,
+                        event_index,
+                    )
                     continue
                 data["team"] = self._resolve_event_team(add_event)
                 data.setdefault("enrichment", {})
-                event_dicts.append((data, add_event))
+                event_dicts.append((data, add_event, event_index))
             except Exception as e:
                 errored += 1
-                logger.error("[AlertSource] 事件映射失败: %s, error: %s", add_event, e, exc_info=True)
+                logger.error(
+                    "[AlertSource] 事件映射失败: source_id=%s event_index=%s error_type=%s",
+                    self.alert_source.source_id,
+                    event_index,
+                    type(e).__name__,
+                )
 
         # 整批丰富（尽力而为，内部已隔离异常）
         try:
-            EnrichmentEngine().enrich_batch([d for d, _ in event_dicts])
+            EnrichmentEngine().enrich_batch([data for data, _, _ in event_dicts])
         except Exception:
             logger.error("[AlertSource] 批量丰富失败，跳过", exc_info=True)
 
         events = []
-        for data, add_event in event_dicts:
+        for data, add_event, event_index in event_dicts:
             try:
                 # 取出"系统补全 start_time"标记（非模型字段，不能传入 Event(**data)）
                 synthesized = data.pop("_start_time_synthesized", False)
@@ -241,7 +250,12 @@ class AlertSourceAdapter(ABC):
                 events.append(event)
             except Exception as e:
                 errored += 1
-                logger.error("[AlertSource] 事件转换失败: %s, error: %s", add_event, e, exc_info=True)
+                logger.error(
+                    "[AlertSource] 事件转换失败: source_id=%s event_index=%s error_type=%s",
+                    self.alert_source.source_id,
+                    event_index,
+                    type(e).__name__,
+                )
         # D3：让接入过程中的丢弃可观测，区分"预期跳过"与"非预期错误"，避免静默丢数据。
         if skipped_missing or errored:
             logger.warning(

--- a/server/apps/alerts/tests/test_event_log_receiver_views.py
+++ b/server/apps/alerts/tests/test_event_log_receiver_views.py
@@ -256,16 +256,64 @@ def test_receiver_reports_partial_ingestion(monkeypatch):
         staticmethod(lambda src: FakeAdapter),
     )
 
+    response = receiver_module.receiver_data(_post_body({"source_id": "src-partial"}, secret="sec"))
+    payload = json.loads(response.content)
+
+    assert response.status_code == 207
+    assert payload["status"] == "partial"
+    assert payload["ingestion"] == {"received": 2, "accepted": 1, "skipped": 1, "errored": 0}
+
+
+@pytest.mark.django_db
+def test_receiver_real_adapter_preserves_partial_response_and_safe_log(caplog):
+    from apps.alerts.constants.constants import LevelType
+    from apps.alerts.models.models import Level
+    from apps.alerts.utils.util import encode_team_secret
+    from apps.alerts.views import receiver as receiver_module
+
+    for level_id in (0, 1, 2, 3):
+        Level.objects.create(
+            level_id=level_id,
+            level_name=f"L{level_id}",
+            level_display_name=f"等级{level_id}",
+            level_type=LevelType.EVENT,
+        )
+    team_secret = encode_team_secret("source-secret", "1")
+    _make_source(
+        source_id="src-real-partial",
+        source_type="restful",
+        secret="source-secret",
+        team_secrets={"1": team_secret},
+        config={"event_fields_mapping": {"title": "title", "level": "level"}},
+    )
+    marker = "SECRET-HTTP-4671"
+
     response = receiver_module.receiver_data(
-        _post_body({"source_id": "src-partial"}, secret="sec")
+        _post_body(
+            {
+                "source_id": "src-real-partial",
+                "events": [
+                    {"title": "HTTP 正常事件", "level": "0"},
+                    {"description": marker, "secret": marker},
+                ],
+            },
+            secret=team_secret,
+        )
     )
     payload = json.loads(response.content)
 
     assert response.status_code == 207
     assert payload["status"] == "partial"
     assert payload["ingestion"] == {
-        "received": 2, "accepted": 1, "skipped": 1, "errored": 0
+        "received": 2,
+        "accepted": 1,
+        "skipped": 1,
+        "errored": 0,
+        "duplicates": 0,
+        "rejected": 1,
     }
+    assert Event.objects.filter(title="HTTP 正常事件", team=[1]).exists()
+    assert marker not in caplog.text
 
 
 @pytest.mark.django_db

--- a/server/apps/alerts/tests/test_issue_4671_log_safety_service.py
+++ b/server/apps/alerts/tests/test_issue_4671_log_safety_service.py
@@ -1,0 +1,131 @@
+from types import SimpleNamespace
+
+import pytest
+
+from apps.alerts.common.source_adapter import base
+from apps.alerts.common.source_adapter.base import AlertSourceAdapter
+
+pytestmark = pytest.mark.unit
+
+
+class _ProbeAdapter(AlertSourceAdapter):
+    def fetch_alerts(self):
+        return []
+
+
+class _SensitiveLookup(dict):
+    def __init__(self, payload_marker, exception_marker):
+        super().__init__(
+            title="event",
+            secret=payload_marker,
+            labels={"sensitive": payload_marker},
+        )
+        self.exception_marker = exception_marker
+
+    def get(self, key, default=None):
+        if key == "service":
+            raise RuntimeError(self.exception_marker)
+        return super().get(key, default)
+
+
+def _adapter(mapping):
+    adapter = object.__new__(_ProbeAdapter)
+    adapter.mapping = mapping
+    adapter.unique_fields = ["title"]
+    adapter.info_level = "3"
+    adapter.levels = ["0", "1", "2", "3"]
+    adapter.alert_source = SimpleNamespace(source_id="log-safety-probe")
+    adapter.trusted_internal = False
+    adapter.resolved_team = []
+    return adapter
+
+
+@pytest.fixture(autouse=True)
+def _disable_enrichment(monkeypatch):
+    enrichment = SimpleNamespace(enrich_batch=lambda events: None)
+    monkeypatch.setattr(base, "EnrichmentEngine", lambda: enrichment)
+
+
+def test_missing_required_field_log_excludes_event_payload(caplog):
+    marker = "SECRET-MISSING-TITLE-4671"
+    adapter = _adapter({"title": "title"})
+
+    adapter.create_events([{"description": marker, "secret": marker}])
+
+    assert marker not in caplog.text
+    assert "source_id=log-safety-probe" in caplog.text
+    assert "event_index=0" in caplog.text
+    assert adapter.last_ingestion_result == {
+        "received": 1,
+        "accepted": 0,
+        "skipped": 1,
+        "errored": 0,
+        "duplicates": 0,
+        "rejected": 1,
+    }
+
+
+def test_mapping_error_log_excludes_payload_exception_and_traceback(caplog):
+    payload_marker = "SECRET-MAPPING-PAYLOAD-4671"
+    exception_marker = "SECRET-MAPPING-EXCEPTION-4671"
+    adapter = _adapter({"title": "title", "service": "service"})
+
+    adapter.create_events([_SensitiveLookup(payload_marker, exception_marker)])
+
+    assert payload_marker not in caplog.text
+    assert exception_marker not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "source_id=log-safety-probe" in caplog.text
+    assert "event_index=0" in caplog.text
+    assert "error_type=RuntimeError" in caplog.text
+    assert adapter.last_ingestion_result["errored"] == 1
+
+
+def test_conversion_error_log_excludes_payload_exception_and_traceback(caplog):
+    payload_marker = "SECRET-CONVERSION-PAYLOAD-4671"
+    exception_marker = "SECRET-CONVERSION-EXCEPTION-4671"
+    adapter = _adapter({"title": "title", exception_marker: "secret"})
+
+    adapter.create_events(
+        [
+            {
+                "title": "event",
+                "secret": payload_marker,
+                "labels": {"sensitive": payload_marker},
+            }
+        ]
+    )
+
+    assert payload_marker not in caplog.text
+    assert exception_marker not in caplog.text
+    assert "Traceback" not in caplog.text
+    assert "source_id=log-safety-probe" in caplog.text
+    assert "event_index=0" in caplog.text
+    assert "error_type=TypeError" in caplog.text
+    assert adapter.last_ingestion_result["errored"] == 1
+
+
+def test_failure_logs_keep_original_mixed_batch_indexes(caplog):
+    marker = "SECRET-MIXED-BATCH-4671"
+    adapter = _adapter({"title": "title", "service": "service"})
+
+    adapter.create_events(
+        [
+            {"description": marker},
+            _SensitiveLookup(marker, marker),
+            {"title": "conversion failure"},
+        ]
+    )
+
+    assert marker not in caplog.text
+    assert "event_index=0" in caplog.text
+    assert "event_index=1" in caplog.text
+    assert "event_index=2" in caplog.text
+    assert adapter.last_ingestion_result == {
+        "received": 3,
+        "accepted": 0,
+        "skipped": 1,
+        "errored": 2,
+        "duplicates": 0,
+        "rejected": 1,
+    }

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -1360,6 +1360,54 @@ def test_receive_alert_events_reports_partial_ingestion(monkeypatch):
     assert result["data"]["ingestion"]["skipped"] == 1
 
 
+@pytest.mark.parametrize("pusher", ["lite-monitor", "lite-log", "lite-apm"])
+@pytest.mark.django_db
+def test_receive_alert_events_real_adapter_preserves_partial_contract_and_safe_log(pusher, caplog):
+    from apps.alerts.models.alert_source import AlertSource
+
+    for level_id in (0, 1, 2, 3):
+        Level.objects.create(
+            level_id=level_id,
+            level_name=f"L{level_id}",
+            level_display_name=f"等级{level_id}",
+            level_type=LevelType.EVENT,
+        )
+    AlertSource.objects.create(
+        name="NATS 兼容源",
+        source_id="nats-real-partial",
+        source_type="nats",
+        secret="source-secret",
+        team_secrets={},
+        is_active=True,
+        is_effective=True,
+        config={"event_fields_mapping": {"title": "title", "level": "level"}},
+    )
+    marker = f"SECRET-NATS-{pusher}-4671"
+    events = [
+        {"title": f"{pusher} 正常事件", "level": "0", "organizations": [3]},
+        {"description": marker, "secret": marker, "organizations": [3]},
+    ]
+
+    result = N.receive_alert_events(
+        source_id="nats-real-partial",
+        events=events,
+        pusher=pusher,
+    )
+
+    assert result["result"] is False
+    assert result["data"]["processed_events"] == 1
+    assert result["data"]["ingestion"] == {
+        "received": 2,
+        "accepted": 1,
+        "skipped": 1,
+        "errored": 0,
+        "duplicates": 0,
+        "rejected": 1,
+    }
+    assert Event.objects.get(title=f"{pusher} 正常事件").team == [3]
+    assert marker not in caplog.text
+
+
 @pytest.mark.django_db
 @pytest.mark.integration
 def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(monkeypatch):


### PR DESCRIPTION
Closes #4671

## 问题与根因

告警源事件在缺少必填字段、字段映射异常和模型转换异常时，会把完整外部事件及异常文本写入日志。外部 payload 可能携带密钥、标签和业务数据，异常 traceback 也可能重复暴露这些内容。

根因是 `AlertSourceAdapter.create_events` 的逐事件错误日志直接格式化原始事件，并在异常分支启用 traceback。

## 修复方案

- 三类逐事件失败日志只保留 `source_id`、原始批内 `event_index`，异常分支额外保留 `error_type`。
- 原始索引随映射结果传递到转换阶段，前序事件被跳过或报错时仍能准确定位。
- 不修改字段映射、鉴权、落库、错误计数、部分成功或 HTTP/NATS 返回契约。
- 增加外部 HTTP receiver 及 `lite-monitor`、`lite-log`、`lite-apm` 三类 NATS 推送方的真实适配器兼容测试。

```mermaid
flowchart LR
    A[HTTP webhook / NATS event] --> B[AlertSourceAdapter.create_events]
    B --> C{映射与转换}
    C -->|成功| D[沿用既有批量落库和返回契约]
    C -->|失败| E[仅记录来源、原始索引和异常类型]
```

## 影响范围与兼容性

变更仅收敛 `alerts` 告警源适配器的异常日志内容。外部 webhook 的组织级密钥解析、三个可信 NATS pusher 的组织归属、成功事件落库、接入计数以及部分成功状态均保持原行为；无需数据迁移，可通过回退本提交恢复。

## 验证

- `server/apps/alerts/tests/test_issue_4671_log_safety_service.py`：4 passed。
- `server/apps/alerts/tests/test_event_log_receiver_views.py`、`server/apps/alerts/tests/test_nats_handlers.py` 与上述安全测试：126 passed。
- `server/apps/alerts/tests/test_source_adapter.py`：58 passed；另有 1 个与本变更无关且在基线可复现的既有失败。
- 触及文件通过 Black、isort、flake8 与 `git diff --check`。

## 评审结论

Standards、Spec、Runtime Contract 三轨均已完成；自动深审确认不改变鉴权、调用方或返回契约。
