### PR TITLE
fix(stargazer): 监控 scrape 预检与主机私钥转发

### DIFF
--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -217,11 +217,12 @@ async def qcloud_metrics(request):
 @monitor_router.get("/oceanstor/metrics")
 async def oceanstor_metrics(request):
     def build_params(req):
-        # Do not use the incoming HTTP Host header here. Telegraf sets it to the
-        # Stargazer service address, while OceanStor collection needs the target
-        # device endpoint carried in base_url.
-        base_url = req.headers.get("base_url")
-        host = base_url
+        # Prefer base_url (REST templates). Host-only templates overwrite HTTP
+        # Host with the device address, so Host remains a valid fallback.
+        base_url = (req.headers.get("base_url") or "").strip()
+        device_host = (req.headers.get("device_host") or "").strip()
+        http_host = (req.headers.get("host") or "").strip()
+        host = base_url or device_host or http_host
         instance_id = req.headers.get("instance_id", "")
         logger.info("Request: Host=%s, instance_id=%s", host, instance_id)
         return {
@@ -229,7 +230,9 @@ async def oceanstor_metrics(request):
             "username": req.headers.get("username"),
             "password": req.headers.get("password"),
             "host": host,
-            "base_url": base_url,
+            "base_url": base_url or host,
+            "preflight_kind": "https",
+            "preflight_kind_explicit": True,
             "instance_id": instance_id,
             "tags": _standard_tags(
                 req,
@@ -322,6 +325,10 @@ async def host_metrics(request):
     os_type = request.headers.get("os_type", "linux")
     username = request.headers.get("username")
     password = request.headers.get("password")
+    auth_type = request.headers.get("auth_type", "password")
+    private_key_content = request.headers.get("private_key_content", "")
+    private_key_passphrase = request.headers.get("private_key_passphrase", "")
+    credential_encoding = request.headers.get("credential_encoding", "url")
     port = request.headers.get("port", "22" if os_type == "linux" else "5986")
     metrics_modules = request.headers.get(
         "metrics_modules", "cpu,mem,disk,diskio,net,processes,system"
@@ -332,8 +339,24 @@ async def host_metrics(request):
         "tmpfs,devtmpfs,devfs,iso9660,overlay,aufs,squashfs,vfat,exfat,fat,fat32",
     )
     ansible_node_id = request.headers.get("ansible_node_id", "")
+    winrm_scheme = request.headers.get("winrm_scheme", "https")
+    winrm_transport = request.headers.get("winrm_transport", "ntlm")
+    winrm_cert_validation = request.headers.get("winrm_cert_validation", "false")
 
-    if not host or not username or not password:
+    if not host or not username:
+        return _monitor_error_response(
+            "host",
+            "missing required headers: host, username",
+            status=400,
+        )
+    if auth_type == "private_key":
+        if not private_key_content:
+            return _monitor_error_response(
+                "host",
+                "missing required headers: private_key_content",
+                status=400,
+            )
+    elif not password:
         return _monitor_error_response(
             "host",
             "missing required headers: host, username, password",
@@ -365,6 +388,13 @@ async def host_metrics(request):
             "disk_include_fstypes": disk_include_fstypes,
             "disk_exclude_fstypes": disk_exclude_fstypes,
             "ansible_node_id": ansible_node_id,
+            "auth_type": auth_type,
+            "private_key_content": private_key_content,
+            "private_key_passphrase": private_key_passphrase,
+            "credential_encoding": credential_encoding,
+            "winrm_scheme": winrm_scheme,
+            "winrm_transport": winrm_transport,
+            "winrm_cert_validation": winrm_cert_validation,
             "tags": _standard_tags(
                 req,
                 defaults={

--- a/agents/stargazer/core/collection/yaml_target_policy.py
+++ b/agents/stargazer/core/collection/yaml_target_policy.py
@@ -28,7 +28,16 @@ def apply_yaml_target_policy(
 
     一次 run 调用一次即可；yaml 解析有缓存。
     yaml 有声明时覆盖 request_builder 兜底猜测；无声明则保留原 params。
+    监控采集若已显式设置 preflight_kind（或 plugin_family=monitor），
+    不得用同名 CMDB plugin.yml 的 tls/443 覆盖，否则 SNMP 存储会被 HTTPS
+    预检挡死。
     """
+    if str(request.params.get("plugin_family") or "") == "monitor":
+        return request
+    if str(request.params.get("preflight_kind") or "").strip() and request.params.get(
+        "preflight_kind_explicit"
+    ):
+        return request
     plugin_name = _plugin_name(request)
     executor_type = str(request.params.get("executor_type") or "").strip()
     if not executor_type:


### PR DESCRIPTION
## Summary
- YAML overlay 在 `plugin_family=monitor` 或 `preflight_kind_explicit` 时不再用同名 CMDB `plugin.yml` 覆盖监控预检（例如 SNMP 被 tls:443 盖掉）。
- 主机监控入口转发 `auth_type` / `private_key_*` / `winrm_*`，私钥认证不再强制 password。
- 社区 OceanStor 入口按 `base_url` → `device_host` → HTTP `Host` 解析设备地址，并显式 HTTPS 预检。

## Test plan
- [ ] host.toml 私钥认证 scrape 能入队（不再因缺 password 400）
- [ ] 同名 CMDB plugin.yml 不会把监控 SNMP 预检改成 TLS/443
- [ ] 社区 `/api/monitor/oceanstor/metrics` 打到设备地址而非 Stargazer 自身 Host

提交范围已检查：仅 `agents/stargazer/api/monitor.py` 与 `yaml_target_policy.py`；测试与无关仪表盘/icons 未提交。