### PR TITLE
fix(监控): K8s Pod 状态查询只取 Running 阶段

### DIFF
--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
@@ -84,7 +84,7 @@
           "unit": "[{\"name\":\"未运行\",\"id\":0,\"color\":\"#faad14\"},{\"name\":\"运行中\",\"id\":1,\"color\":\"#1ac44a\"}]",
           "dimensions": [],
           "description": "Indicates the current lifecycle phase of a Pod. This metric is used to quickly assess Pod health.",
-          "query": "prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",__$labels__}"
+          "query": "prometheus_remote_write_kube_pod_status_phase{instance_type=\"k8s\",phase=\"Running\",__$labels__}"
         },
         {
           "metric_group": "Status",

--- a/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
+++ b/web/src/app/monitor/dashboards/objects/k8s-pod/config.ts
@@ -20,7 +20,7 @@ export const POD_DASHBOARD_CONFIG: SimpleDashboardConfig = {
       display_name: 'Pod 状态',
       description: 'Pod 当前生命周期阶段(0 未运行 / 1 运行中),用于快速判断 Pod 健康。',
       unit: 'none',
-      query: 'prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",__$labels__}',
+      query: 'prometheus_remote_write_kube_pod_status_phase{instance_type="k8s",phase="Running",__$labels__}',
       color: '#27c274'
     },
     {


### PR DESCRIPTION
## Summary
- `kube_pod_status_phase` 是 kube-state-metrics 的 one-hot 指标。K8s 未过滤 `phase` 时，仪表盘会把最后一条 Unknown=0 显示成「未运行」，列表页同时间戳取 max 则显示「运行中」。
- 与 K3s / Node Ready 口径对齐，插件指标与 Pod 仪表盘查询都加上 `phase="Running"`，使 0/1 枚举真正表示未运行/运行中。
- 列表页使用库中已导入的指标查询，需重新导入 K8S 插件后才会带上该过滤；仪表盘走前端 config，刷新即可生效。

## Test plan
- [ ] 打开正在运行的 K8s Pod 仪表盘，「Pod 状态」应显示「运行中」，与采集正常、CPU/内存曲线一致
- [ ] 视图列表同一实例的「Pod 阶段」与仪表盘「Pod 状态」一致
- [ ] 重新导入 K8S 插件后，Pending/Failed Pod 列表应显示「未运行」，不再被 one-hot max 误标为「运行中」