### PR TITLE
fix(monitor): 监控对象名与 Enum 枚举值跟随账号语言

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -47,6 +47,7 @@ from apps.monitor.services.network_device_resource_top import NetworkDeviceResou
 from apps.monitor.services.network_device_resource_top import validate_metric_type as validate_network_metric_type
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.instance_id_keys import resolve_monitor_object_instance_id_keys
+from apps.monitor.utils.metric_enum_locale import localize_metric_enum_unit
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 from apps.rpc.system_mgmt import SystemMgmt
@@ -675,6 +676,12 @@ def monitor_metrics(monitor_obj_id: str, *args, **kwargs):
         lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC}.{monitor_obj.name}.{result['name']}"
         result["display_name"] = lan.get(f"{lan_key}.name") or result.get("display_name") or result["name"]
         result["display_description"] = lan.get(f"{lan_key}.desc") or result.get("description")
+        if (result.get("data_type") or "").lower() == "enum":
+            result["unit"] = localize_metric_enum_unit(
+                result.get("unit") or "",
+                locale,
+                enum_translations=lan.get(f"{lan_key}.enum"),
+            )
     return {"result": True, "data": results, "message": ""}
 
 

--- a/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/en.yaml
@@ -3,3 +3,9 @@ K3S:
   desc: Leveraging K3S' active monitoring data reporting capability, collect
     the status and health of the K3S cluster, including performance metrics
     for nodes, containers, and pods.
+monitor_object:
+  K3SCluster: K3S Cluster
+  K3SNode: K3S Node
+  K3SPod: K3S Pod
+monitor_object_type:
+  K3S: K3S

--- a/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/zh-Hans.yaml
@@ -1,3 +1,9 @@
 K3S:
   name: K3S
   desc: 利用K3S主动上报监控数据的能力，收集K3S集群的状态和健康，包括节点、容器和pod的性能指标。
+monitor_object:
+  K3SCluster: K3S 集群
+  K3SNode: K3S 节点
+  K3SPod: K3S Pod
+monitor_object_type:
+  K3S: K3S

--- a/server/apps/monitor/utils/metric_enum_locale.py
+++ b/server/apps/monitor/utils/metric_enum_locale.py
@@ -1,0 +1,136 @@
+"""Metric Enum unit 按账号语言本地化。
+
+metrics.json / DB 中 Enum 的 unit 多为中文硬编码。英文界面下按精确中文名映射为英文；
+若 language yaml 提供 ``monitor_object_metric.<Object>.<metric>.enum``（id→译名），优先使用。
+中文 locale 保持原样（或被 yaml enum 覆盖）。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional
+
+# 审定过的 Enum 标签中→英映射（精确匹配，避免误翻任意中文文案）。
+_ENUM_ZH_TO_EN: dict[str, str] = {
+    "正常": "Normal",
+    "异常": "Abnormal",
+    "未知": "Unknown",
+    "成功": "Success",
+    "失败": "Failure",
+    "警告": "Warning",
+    "告警": "Alert",
+    "危险": "Critical",
+    "严重": "Critical",
+    "健康": "Healthy",
+    "不健康": "Unhealthy",
+    "不正常": "Abnormal",
+    "通过": "Pass",
+    "未通过": "Fail",
+    "在位": "Present",
+    "缺失": "Missing",
+    "超时": "Timeout",
+    "连接失败": "Connection Failed",
+    "读取失败": "Read Failed",
+    "返回不匹配": "Response Mismatch",
+    "响应内容不匹配": "Content Mismatch",
+    "响应体读取失败": "Body Read Error",
+    "DNS错误": "DNS Error",
+    "响应状态码不匹配": "Status Code Mismatch",
+    "失活": "Inactive",
+    "存活": "Alive",
+    "部分失活": "Partially Inactive",
+    "错误": "Error",
+    "无法解析": "Unresolved",
+    "未命中": "Not Found",
+    "命中": "Found",
+    "采集正常": "Scrape OK",
+    "采集报错": "Scrape Error",
+    "其它节点": "Other Broker",
+    "首选Broker节点": "Preferred Broker",
+    "副本不足": "Under-replicated",
+    "提交偏移量大于LEO": "Committed Offset Ahead of LEO",
+    "开机": "Power On",
+    "关机": "Power Off",
+    "工作": "Working",
+    "停止": "Stopped",
+    "启用": "Enabled",
+    "禁用": "Disabled",
+    "在线": "Online",
+    "离线": "Offline",
+    "就绪": "Ready",
+    "不可用": "Unavailable",
+    "静止": "Idle",
+    "运行中": "Running",
+    "无主节点": "No Leader",
+    "有主节点": "Has Leader",
+    "从节点": "Follower",
+    "主节点": "Leader",
+    "是": "Yes",
+    "否": "No",
+}
+
+
+def _is_english_locale(locale: Optional[str]) -> bool:
+    value = str(locale or "").strip().lower().replace("_", "-")
+    return value == "en" or value.startswith("en-")
+
+
+def _enum_id_key(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def localize_metric_enum_unit(
+    unit: str,
+    locale: Optional[str] = None,
+    *,
+    enum_translations: Optional[Mapping[Any, Any]] = None,
+) -> str:
+    """本地化 Enum 指标的 unit JSON。非 Enum / 解析失败时原样返回。"""
+    if not unit or not isinstance(unit, str):
+        return unit
+    stripped = unit.strip()
+    if not stripped.startswith("["):
+        return unit
+
+    try:
+        options = json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return unit
+    if not isinstance(options, list):
+        return unit
+
+    yaml_map: dict[str, str] = {}
+    if isinstance(enum_translations, Mapping):
+        for key, value in enum_translations.items():
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                yaml_map[_enum_id_key(key)] = text
+
+    english = _is_english_locale(locale)
+    if not yaml_map and not english:
+        return unit
+
+    changed = False
+    for option in options:
+        if not isinstance(option, dict):
+            continue
+        name = option.get("name")
+        if not isinstance(name, str):
+            continue
+
+        translated = yaml_map.get(_enum_id_key(option.get("id"))) if yaml_map else None
+        if translated is None and english:
+            translated = _ENUM_ZH_TO_EN.get(name)
+
+        if translated is not None and translated != name:
+            option["name"] = translated
+            changed = True
+
+    if not changed:
+        return unit
+    return json.dumps(options, ensure_ascii=False, separators=(",", ":"))

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -14,6 +14,7 @@ from apps.monitor.models import MonitorPlugin
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
+from apps.monitor.utils.metric_enum_locale import localize_metric_enum_unit
 from apps.monitor.utils.snmp_ifmib_capability import (
     COMMON_IFMIB_METRIC_NAMES,
     IFMIB_ZH_DISPLAY_TEXTS,
@@ -421,6 +422,12 @@ class MetricViewSet(viewsets.ModelViewSet):
                 or lan.get(f"{lan_key}.desc")
                 or result["description"]
             )
+            if (result.get("data_type") or "").lower() == "enum":
+                result["unit"] = localize_metric_enum_unit(
+                    result.get("unit") or "",
+                    request.user.locale,
+                    enum_translations=lan.get(f"{lan_key}.enum"),
+                )
 
         metric_groups = MetricGroup.objects.filter(
             id__in={metric.metric_group_id for metric in page}

--- a/web/src/app/monitor/dashboards/metadata.ts
+++ b/web/src/app/monitor/dashboards/metadata.ts
@@ -33,26 +33,27 @@ const COMMUNITY_DASHBOARD_METADATA: ProfessionalDashboardMetaItem[] = [
   { key: 'elasticsearch', groupKey: 'database', objectName: 'ElasticSearch', objectDisplayName: 'Elasticsearch', inheritedPermissionPath: '/monitor/view' },
   { key: 'oracle', groupKey: 'database', objectName: 'Oracle', objectDisplayName: 'Oracle', inheritedPermissionPath: '/monitor/view' },
   { key: 'influxdb', groupKey: 'database', objectName: 'InfluxDB', objectDisplayName: 'InfluxDB', inheritedPermissionPath: '/monitor/view' },
-  { key: 'host', aliases: ['os', '主机'], groupKey: 'os', objectName: 'Host', objectDisplayName: '主机', inheritedPermissionPath: '/monitor/view' },
-  { key: 'process', aliases: ['进程'], groupKey: 'os', objectName: 'Process', objectDisplayName: '进程', inheritedPermissionPath: '/monitor/view' },
-  { key: 'website', aliases: ['web', '网站'], groupKey: 'network', objectName: 'Website', objectDisplayName: '网站', inheritedPermissionPath: '/monitor/view' },
+  // objectDisplayName 用英文技术友好名作兜底；中文展示名由 API display_name + aliases 匹配。
+  { key: 'host', aliases: ['os', '主机'], groupKey: 'os', objectName: 'Host', objectDisplayName: 'Host', inheritedPermissionPath: '/monitor/view' },
+  { key: 'process', aliases: ['进程'], groupKey: 'os', objectName: 'Process', objectDisplayName: 'Process', inheritedPermissionPath: '/monitor/view' },
+  { key: 'website', aliases: ['web', '网站'], groupKey: 'network', objectName: 'Website', objectDisplayName: 'Website', inheritedPermissionPath: '/monitor/view' },
   { key: 'ping', groupKey: 'network', objectName: 'Ping', objectDisplayName: 'Ping', inheritedPermissionPath: '/monitor/view' },
   { key: 'tcp', aliases: ['TCPPort', 'TCP端口'], groupKey: 'network', objectName: 'TCPPort', objectDisplayName: 'TCP', inheritedPermissionPath: '/monitor/view' },
-  { key: 'switch', aliases: ['交换机'], groupKey: 'network', objectName: 'Switch', objectDisplayName: '交换机', inheritedPermissionPath: '/monitor/view' },
-  { key: 'firewall', aliases: ['防火墙'], groupKey: 'network', objectName: 'Firewall', objectDisplayName: '防火墙', inheritedPermissionPath: '/monitor/view' },
-  { key: 'loadbalance', aliases: ['负载均衡'], groupKey: 'network', objectName: 'Loadbalance', objectDisplayName: '负载均衡', inheritedPermissionPath: '/monitor/view' },
-  { key: 'router', aliases: ['路由器'], groupKey: 'network', objectName: 'Router', objectDisplayName: '路由器', inheritedPermissionPath: '/monitor/view' },
-  { key: 'wireless', aliases: ['无线设备'], groupKey: 'network', objectName: 'Wireless', objectDisplayName: '无线设备', inheritedPermissionPath: '/monitor/view' },
-  { key: 'transmission', aliases: ['传输设备'], groupKey: 'network', objectName: 'Transmission', objectDisplayName: '传输设备', inheritedPermissionPath: '/monitor/view' },
-  { key: 'access', aliases: ['接入设备'], groupKey: 'network', objectName: 'Access', objectDisplayName: '接入设备', inheritedPermissionPath: '/monitor/view' },
-  { key: 'network_service', aliases: ['网络服务'], groupKey: 'network', objectName: 'NetworkService', objectDisplayName: '网络服务', inheritedPermissionPath: '/monitor/view' },
-  { key: 'console_server', aliases: ['控制台服务器'], groupKey: 'network', objectName: 'ConsoleServer', objectDisplayName: '控制台服务器', inheritedPermissionPath: '/monitor/view' },
-  { key: 'voice_gateway', aliases: ['语音网关'], groupKey: 'network', objectName: 'VoiceGateway', objectDisplayName: '语音网关', inheritedPermissionPath: '/monitor/view' },
-  { key: 'k8s-cluster', aliases: ['cluster'], groupKey: 'container', objectName: 'Cluster', objectDisplayName: '集群', inheritedPermissionPath: '/monitor/view' },
-  { key: 'k8s-node', aliases: ['node'], groupKey: 'container', objectName: 'Node', objectDisplayName: '节点', inheritedPermissionPath: '/monitor/view' },
+  { key: 'switch', aliases: ['交换机'], groupKey: 'network', objectName: 'Switch', objectDisplayName: 'Switch', inheritedPermissionPath: '/monitor/view' },
+  { key: 'firewall', aliases: ['防火墙'], groupKey: 'network', objectName: 'Firewall', objectDisplayName: 'Firewall', inheritedPermissionPath: '/monitor/view' },
+  { key: 'loadbalance', aliases: ['负载均衡'], groupKey: 'network', objectName: 'Loadbalance', objectDisplayName: 'Load Balance', inheritedPermissionPath: '/monitor/view' },
+  { key: 'router', aliases: ['路由器'], groupKey: 'network', objectName: 'Router', objectDisplayName: 'Router', inheritedPermissionPath: '/monitor/view' },
+  { key: 'wireless', aliases: ['无线设备'], groupKey: 'network', objectName: 'Wireless', objectDisplayName: 'Wireless', inheritedPermissionPath: '/monitor/view' },
+  { key: 'transmission', aliases: ['传输设备'], groupKey: 'network', objectName: 'Transmission', objectDisplayName: 'Transmission', inheritedPermissionPath: '/monitor/view' },
+  { key: 'access', aliases: ['接入设备'], groupKey: 'network', objectName: 'Access', objectDisplayName: 'Access', inheritedPermissionPath: '/monitor/view' },
+  { key: 'network_service', aliases: ['网络服务'], groupKey: 'network', objectName: 'NetworkService', objectDisplayName: 'Network Service', inheritedPermissionPath: '/monitor/view' },
+  { key: 'console_server', aliases: ['控制台服务器'], groupKey: 'network', objectName: 'ConsoleServer', objectDisplayName: 'Console Server', inheritedPermissionPath: '/monitor/view' },
+  { key: 'voice_gateway', aliases: ['语音网关'], groupKey: 'network', objectName: 'VoiceGateway', objectDisplayName: 'Voice Gateway', inheritedPermissionPath: '/monitor/view' },
+  { key: 'k8s-cluster', aliases: ['cluster', '集群'], groupKey: 'container', objectName: 'Cluster', objectDisplayName: 'Cluster', inheritedPermissionPath: '/monitor/view' },
+  { key: 'k8s-node', aliases: ['node', '节点'], groupKey: 'container', objectName: 'Node', objectDisplayName: 'Node', inheritedPermissionPath: '/monitor/view' },
   { key: 'k8s-pod', aliases: ['pod'], groupKey: 'container', objectName: 'Pod', objectDisplayName: 'Pod', inheritedPermissionPath: '/monitor/view' },
-  { key: 'k3s-cluster', groupKey: 'container', objectName: 'K3SCluster', objectDisplayName: 'K3S 集群', inheritedPermissionPath: '/monitor/view' },
-  { key: 'k3s-node', groupKey: 'container', objectName: 'K3SNode', objectDisplayName: 'K3S 节点', inheritedPermissionPath: '/monitor/view' },
+  { key: 'k3s-cluster', aliases: ['K3S 集群'], groupKey: 'container', objectName: 'K3SCluster', objectDisplayName: 'K3S Cluster', inheritedPermissionPath: '/monitor/view' },
+  { key: 'k3s-node', aliases: ['K3S 节点'], groupKey: 'container', objectName: 'K3SNode', objectDisplayName: 'K3S Node', inheritedPermissionPath: '/monitor/view' },
   { key: 'k3s-pod', groupKey: 'container', objectName: 'K3SPod', objectDisplayName: 'K3S Pod', inheritedPermissionPath: '/monitor/view' }
 ];
 
@@ -102,8 +103,16 @@ export const getProfessionalDashboardKey = (objectName?: string | null, objectDi
   return findProfessionalDashboardMeta(objectName, objectDisplayName)?.key || '';
 };
 
-/** 侧栏/列表展示名：优先 API display_name；TCPPort 等技术名回退到注册表 objectDisplayName（→ TCP）。 */
-export const getProfessionalObjectDisplayName = (objectName?: string | null, objectDisplayName?: string | null) => {
+/**
+ * 侧栏/列表展示名：优先 API display_name（后端已按账号语言翻译）。
+ * 注册表 objectDisplayName 含中文别名，不得在英文等语言下覆盖 API 译名
+ * （例如 Host→Host 被错盖成「主机」）。
+ * 仅当 API 仍为技术 slug TCPPort 时，回退到友好名 TCP。
+ */
+export const getProfessionalObjectDisplayName = (
+  objectName?: string | null,
+  objectDisplayName?: string | null
+) => {
   const matched = findProfessionalDashboardMeta(objectName, objectDisplayName);
   const apiName = String(objectDisplayName || '').trim();
   const technicalName = String(objectName || '').trim();
@@ -111,10 +120,11 @@ export const getProfessionalObjectDisplayName = (objectName?: string | null, obj
   const techKey = normalizeDashboardKey(technicalName);
 
   if (techKey === 'tcpport' || apiKey === 'tcpport') {
+    if (apiName && apiKey !== 'tcpport') return apiName;
     return matched?.objectDisplayName || 'TCP';
   }
-  if (apiName && apiName !== technicalName) return apiName;
-  return matched?.objectDisplayName || apiName || technicalName || '';
+  if (apiName) return apiName;
+  return technicalName || matched?.objectDisplayName || '';
 };
 
 export const getProfessionalDashboardUrl = (

--- a/web/src/app/monitor/dashboards/objects/host/config.ts
+++ b/web/src/app/monitor/dashboards/objects/host/config.ts
@@ -3,7 +3,7 @@ import type { SimpleDashboardConfig } from '../common/simple-dashboard-core';
 export const HOST_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'host',
   pageTitle: '主机监控仪表盘',
-  objectFallbackName: '主机',
+  objectFallbackName: 'Host',
   instanceType: 'os',
   // 覆盖 Telegraf host / HTTP 远程 / Windows WMI（均为 instance_type=os）
   collectionStatusQuery: "count({instance_type='os', __$labels__}) by (instance_id)",

--- a/web/src/app/monitor/dashboards/objects/host/host-process-metrics-tab.ts
+++ b/web/src/app/monitor/dashboards/objects/host/host-process-metrics-tab.ts
@@ -14,7 +14,7 @@ export function isHostProcessMetricsTab(tab: string | number | null | undefined)
 export interface HostProcessMetricsTarget {
   processObjectId: string;
   processPluginId: string;
-  /** 与 Process 对象页签一致，如「进程 (Telegraf)」 */
+  /** 与 Process 对象页签一致，如 Process (Telegraf) / 进程（Telegraf） */
   processPluginLabel: string;
 }
 
@@ -58,7 +58,8 @@ export async function resolveHostProcessMetricsTarget(api: {
     return {
       processObjectId,
       processPluginId: String(first.id),
-      processPluginLabel: String(first.display_name || first.name || '进程 (Telegraf)')
+      // 插件 display_name 已按账号语言翻译；缺省用英文技术名，避免英文界面回落到中文。
+      processPluginLabel: String(first.display_name || first.name || 'Process (Telegraf)')
     };
   } catch {
     return null;
@@ -68,7 +69,7 @@ export async function resolveHostProcessMetricsTarget(api: {
 export function withHostProcessMetricsTab<T extends { label: string; value: string }>(
   plugins: T[],
   enabled: boolean,
-  label = '进程 (Telegraf)'
+  label = 'Process (Telegraf)'
 ): T[] {
   if (!enabled) return plugins;
   if (plugins.some((item) => String(item.value) === HOST_PROCESS_METRICS_TAB)) {

--- a/web/src/app/monitor/dashboards/objects/process/config.ts
+++ b/web/src/app/monitor/dashboards/objects/process/config.ts
@@ -15,7 +15,7 @@ const PROCESS_PORT_ALIVE_ENUM: MetricEnumMap = {
 export const PROCESS_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'process',
   pageTitle: '进程监控仪表盘',
-  objectFallbackName: '进程',
+  objectFallbackName: 'Process',
   instanceType: 'process',
   collectionStatusQuery:
     "count({instance_type='process', collect_type='host', __$labels__}) by (instance_id, process_name)",

--- a/web/src/app/monitor/dashboards/objects/website/config.ts
+++ b/web/src/app/monitor/dashboards/objects/website/config.ts
@@ -9,7 +9,7 @@ const SUCCESS_RATE_EXPR =
 export const WEBSITE_DASHBOARD_CONFIG: SimpleDashboardConfig = {
   routeKey: 'website',
   pageTitle: '网站监控仪表盘',
-  objectFallbackName: '网站',
+  objectFallbackName: 'Website',
   instanceType: 'web',
   // Layer 0：任意 result_type 样本即表示采集在跑；不要求 success，避免失败时误报「无采集」。
   collectionStatusQuery: "count(http_response_result_type{instance_type='web', collect_type='web', __$labels__}) by (instance_id)",


### PR DESCRIPTION
## Summary
- 修复英文界面侧栏仍显示「主机 / 进程 / 网站」等问题：优先使用 API 已按语言翻译的 `display_name`，不再被注册表中文兜底覆盖。
- 英文界面 Enum 指标标签（如拨测结果「成功」）按语言映射为英文；中文界面保持中文。
- 补齐 K3S 监控对象展示名语言包。

## Test plan
- [ ] 英文账号打开监控 View 侧栏：Host / Process / Website 等显示英文；中文账号显示中文
- [ ] 英文账号查看 Website 列表 Probe Result：显示 Success 等英文，不再出现「成功」
- [ ] 中文账号同样路径仍为中文
- [ ] TCPPort 仍显示为 TCP

## Scope note
- 已检查提交范围：仅含本次 i18n 修复相关 10 个文件；测试文件与无关工作区改动未纳入。