### PR TITLE
fix(monitor): 插件 bulk 导入失败时向上抛出

### DIFF
--- a/server/apps/monitor/management/services/plugin_migrate.py
+++ b/server/apps/monitor/management/services/plugin_migrate.py
@@ -262,6 +262,8 @@ def _import_plugins_from_files(path_list):
             logger.error(traceback.format_exc())
             error_count += success_count
             success_count = 0
+            # 整批 atomic 写失败不得伪装成初始化成功，否则 batch_init 绿但插件仍旧。
+            raise
 
     return success_count, error_count, supplementary_map
 


### PR DESCRIPTION
## Summary
- 整批 `import_monitor_plugins` atomic 写失败时重新抛出异常，避免 `plugin_init` / `batch_init` 伪装成功
- 单文件解析失败隔离逻辑不变；失败路径仍回滚本次写入，不会清空已有插件

## Test plan
- [ ] 模拟 `import_monitor_plugins` 抛错，确认 `plugin_init` / `batch_init` 非零退出
- [ ] 确认坏单个 `metrics.json` 仍只计失败、不拖垮整批解析
- [ ] 确认失败后库内既有插件未被清空（事务回滚）