### PR TITLE
fix(mobile): 资产列表改用 inst_uuid，避免 UUID 切换后空列表

### DIFF
--- a/mobile/scripts/mobile-monitor-assets-test.mjs
+++ b/mobile/scripts/mobile-monitor-assets-test.mjs
@@ -446,15 +446,37 @@ test('关注配置与 Web 同结构、倒序且最多保留 100 条', async () =
   const { addFollowedAsset, assetRequestErrorKind, normalizeFollowedConfig, serializeFollowedConfig } = await loadModel('src/features/assets/model.ts');
   const config = normalizeFollowedConfig({ items: [
     { model_id: 'host', inst_id: 1, followed_at: '2026-01-01T00:00:00Z' },
-    { model_id: 'host', inst_id: 2, followed_at: '2026-02-01T00:00:00Z' },
+    { model_id: 'host', inst_id: 'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee', followed_at: '2026-01-15T00:00:00Z' },
+    { model_id: 'host', inst_uuid: 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee', followed_at: '2026-02-01T00:00:00Z' },
   ] });
-  assert.deepEqual(config.items.map((item) => item.instanceId), [2, 1]);
+  assert.deepEqual(config.items.map((item) => item.instanceId), [
+    'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+    'bbbbbbbb-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+  ]);
   let many = { items: [] };
   for (let index = 0; index < 105; index += 1) many = addFollowedAsset(many, 'host', index, new Date(index * 1000).toISOString());
   assert.equal(many.items.length, 100);
-  assert.deepEqual(Object.keys(serializeFollowedConfig(config).items[0]), ['model_id', 'inst_id', 'followed_at']);
+  assert.deepEqual(Object.keys(serializeFollowedConfig(config).items[0]), ['model_id', 'inst_uuid', 'followed_at']);
   assert.equal(assetRequestErrorKind(new Error('API Error: 403')), 'forbidden');
   assert.equal(assetRequestErrorKind(new Error('API Error: 404')), 'missing');
+  assert.equal(assetRequestErrorKind(new Error('API Error: 400 - 请使用 inst_uuid 定位实例')), 'missing');
+});
+
+test('资产列表把 search 响应的 inst_uuid 当主键，不因缺少 _id 被滤空', async () => {
+  const { keepMappedAssetInstance, mapAssetInstance } = await loadModel('src/features/assets/model.ts');
+  const insts = Array.from({ length: 5 }, (_, index) => ({
+    inst_name: `MOBILE-UX-DEMO-ASSET-0${index + 1}`,
+    inst_uuid: `aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee0${index + 1}`,
+    model_id: 'mobile_ux_demo_asset',
+    organization_display: '默认组织',
+  }));
+  const items = insts.map((item) => mapAssetInstance(item, 'mobile_ux_demo_asset')).filter(keepMappedAssetInstance);
+  assert.equal(items.length, 5);
+  assert.equal(items[0].id, 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeee01');
+  assert.equal(items[0].name, 'MOBILE-UX-DEMO-ASSET-01');
+  assert.equal(items[0].organizationName, '默认组织');
+  assert.equal(keepMappedAssetInstance(mapAssetInstance({ inst_name: 'ghost' }, 'host')), false);
+  assert.equal(keepMappedAssetInstance(mapAssetInstance({ _id: 12, inst_name: 'legacy' }, 'host')), false);
 });
 
 test('资产复用 Web CMDB 接口、两阶段搜索和元数据字段详情', async () => {
@@ -465,7 +487,11 @@ test('资产复用 Web CMDB 接口、两阶段搜索和元数据字段详情', a
   assert.match(adapter, /fulltext_search\/stats/);
   assert.match(adapter, /fulltext_search\/by_model/);
   assert.match(adapter, /field_groups\/full_info/);
-  assert.match(adapter, /organizationName:\s*text\(item\.organization_display\)/);
+  assert.match(adapter, /mapAssetInstance/);
+  assert.match(adapter, /field: 'inst_uuid', type: 'str\[\]'/);
+  assert.match(adapter, /encodeURIComponent\(String\(instanceId\)\)/);
+  assert.doesNotMatch(adapter, /item\._id as string/);
+  assert.doesNotMatch(adapter, /field: 'id', type: 'id\[\]'/);
   // 模型内筛选须用 str*（contains）；裸 type "str" 会被 CMDB format_search_params 静默跳过
   assert.match(adapter, /field:\s*'inst_name',\s*type:\s*'str\*',\s*value:\s*keyword/);
   assert.doesNotMatch(adapter, /field:\s*'inst_name',\s*type:\s*'str',\s*value:\s*keyword/);

--- a/mobile/src/features/assets/adapter.ts
+++ b/mobile/src/features/assets/adapter.ts
@@ -1,22 +1,11 @@
 import { apiGet, apiPost } from '@/api/request';
-import { FOLLOWED_ASSETS_CONFIG_KEY, normalizeFollowedConfig, serializeFollowedConfig, type AssetClassification, type AssetFieldGroup, type AssetInstance, type AssetModel, type FollowedAssetsConfig, type PageResult, type SearchModelStat } from './model';
+import { FOLLOWED_ASSETS_CONFIG_KEY, isAssetInstanceUuid, keepMappedAssetInstance, mapAssetInstance, normalizeFollowedConfig, serializeFollowedConfig, type AssetClassification, type AssetFieldGroup, type AssetInstance, type AssetModel, type FollowedAssetsConfig, type PageResult, type SearchModelStat } from './model';
 
 function record(value: unknown): Record<string, unknown> { return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {}; }
 function text(value: unknown) { return value === null || value === undefined ? '' : String(value); }
 function number(value: unknown) { const parsed = Number(value); return Number.isFinite(parsed) ? parsed : 0; }
 function unwrap<T>(value: unknown): T { const data = record(value); if (typeof data.result !== 'boolean') return value as T; if (!data.result) throw new Error(text(data.message) || 'Server returned an error'); return data.data as T; }
 function unwrapDeep(value: unknown) { let current = value; for (let index = 0; index < 2; index += 1) { const next = record(current); if (typeof next.result !== 'boolean') break; if (!next.result) throw new Error(text(next.message) || 'Server returned an error'); current = next.data; } return current; }
-function mapInstance(value: unknown, fallbackModelId: string): AssetInstance {
-  const item = record(value);
-  const id = item._id as string | number;
-  return {
-    id,
-    modelId: text(item.model_id || fallbackModelId),
-    name: text(item.inst_name || item.ip_addr || id),
-    organizationName: text(item.organization_display),
-    values: item,
-  };
-}
 
 export async function listAssetCatalog(signal?: AbortSignal) {
   const [classRaw, modelRaw, countRaw] = await Promise.all([
@@ -31,21 +20,26 @@ export async function listAssetCatalog(signal?: AbortSignal) {
 export async function listAssetInstances(modelId: string, page = 1, keyword = '', signal?: AbortSignal): Promise<PageResult<AssetInstance>> {
   // Web searchFilter 对 str 字段用 str*（contains）；裸 type "str" 会被 CMDB format_search_params 静默跳过
   const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/search/', { query_list: keyword ? [{ field: 'inst_name', type: 'str*', value: keyword }] : [], page, page_size: 20, order: '', model_id: modelId, role: '', case_sensitive: false }, { signal })));
-  return { count: number(raw.count), items: (Array.isArray(raw.insts) ? raw.insts : []).map((item) => mapInstance(item, modelId)).filter((item) => item.id !== undefined && item.id !== null) };
+  return { count: number(raw.count), items: (Array.isArray(raw.insts) ? raw.insts : []).map((item) => mapAssetInstance(item, modelId)).filter(keepMappedAssetInstance) };
 }
 
 export async function resolveFollowedAssets(config: FollowedAssetsConfig, models: readonly AssetModel[], signal?: AbortSignal) {
-  const grouped = new Map<string, Array<string | number>>(); config.items.forEach((item) => grouped.set(item.modelId, [...(grouped.get(item.modelId) || []), item.instanceId]));
+  const grouped = new Map<string, string[]>(); config.items.forEach((item) => {
+    if (!isAssetInstanceUuid(item.instanceId)) return;
+    grouped.set(item.modelId, [...(grouped.get(item.modelId) || []), String(item.instanceId)]);
+  });
   const settled = await Promise.allSettled(Array.from(grouped.entries()).map(async ([modelId, ids]) => {
-    const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/search/', { model_id: modelId, query_list: [{ field: 'id', type: 'id[]', value: ids }], page: 1, page_size: ids.length }, { signal })));
-    return (Array.isArray(raw.insts) ? raw.insts : []).map((item) => mapInstance(item, modelId));
+    const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/search/', { model_id: modelId, query_list: [{ field: 'inst_uuid', type: 'str[]', value: ids }], page: 1, page_size: ids.length }, { signal })));
+    return (Array.isArray(raw.insts) ? raw.insts : []).map((item) => mapAssetInstance(item, modelId)).filter(keepMappedAssetInstance);
   }));
   const byKey = new Map<string, AssetInstance>(); settled.forEach((result) => { if (result.status === 'fulfilled') result.value.forEach((item) => byKey.set(`${item.modelId}:${String(item.id)}`, item)); });
   const modelIds = new Set(models.map((model) => model.id));
   return config.items.flatMap((item) => { if (!modelIds.has(item.modelId)) return []; const detail = byKey.get(`${item.modelId}:${String(item.instanceId)}`); return detail ? [detail] : []; });
 }
 
-export async function getAssetInstance(instanceId: string | number, signal?: AbortSignal) { return mapInstance(unwrap<unknown>(await apiGet(`/cmdb/api/instance/${instanceId}/`, undefined, { signal })), ''); }
+export async function getAssetInstance(instanceId: string | number, signal?: AbortSignal) {
+  return mapAssetInstance(unwrap<unknown>(await apiGet(`/cmdb/api/instance/${encodeURIComponent(String(instanceId))}/`, undefined, { signal })), '');
+}
 
 export async function getAssetFileUrl(fileId: string, download = false, signal?: AbortSignal) {
   const raw = record(unwrap<unknown>(await apiGet(
@@ -67,10 +61,12 @@ export async function getAssetModel(modelId: string, signal?: AbortSignal): Prom
 }
 export async function getAssetFieldGroups(modelId: string, signal?: AbortSignal): Promise<{ modelId: string; modelName: string; groups: AssetFieldGroup[] }> {
   const raw = record(unwrap<unknown>(await apiGet('/cmdb/api/field_groups/full_info/', { model_id: modelId }, { signal })));
-  const groups = (Array.isArray(raw.groups) ? raw.groups : []).map((value) => { const item = record(value); return {
-    id: item.id as string | number, name: text(item.group_name), order: number(item.order), collapsed: Boolean(item.is_collapsed),
-    fields: (Array.isArray(item.attrs) ? item.attrs : []).map((rawField) => { const field = record(rawField); return { id: text(field.attr_id), name: text(field.attr_name || field.attr_id), type: text(field.attr_type), option: field.option, order: number(field.order) }; }).filter((field) => field.id).sort((a, b) => a.order - b.order),
-  }; }).sort((a, b) => a.order - b.order);
+  const groups = (Array.isArray(raw.groups) ? raw.groups : []).map((value) => {
+    const item = record(value); return {
+      id: item.id as string | number, name: text(item.group_name), order: number(item.order), collapsed: Boolean(item.is_collapsed),
+      fields: (Array.isArray(item.attrs) ? item.attrs : []).map((rawField) => { const field = record(rawField); return { id: text(field.attr_id), name: text(field.attr_name || field.attr_id), type: text(field.attr_type), option: field.option, order: number(field.order) }; }).filter((field) => field.id).sort((a, b) => a.order - b.order),
+    };
+  }).sort((a, b) => a.order - b.order);
   return { modelId: text(raw.model_id || modelId), modelName: text(raw.model_name || raw.model_id || modelId), groups };
 }
 
@@ -78,4 +74,4 @@ export async function getFollowedConfig(signal?: AbortSignal) { const raw = unwr
 export async function updateFollowedConfig(config: FollowedAssetsConfig, signal?: AbortSignal) { await apiPost('/cmdb/api/user_configs/update_key/', { config_key: FOLLOWED_ASSETS_CONFIG_KEY, config_value: serializeFollowedConfig(config) }, { signal }); }
 
 export async function searchAssetStats(search: string, exact: boolean, signal?: AbortSignal) { const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/fulltext_search/stats/', { search, case_sensitive: exact }, { signal }))); return { count: number(raw.total), models: (Array.isArray(raw.model_stats) ? raw.model_stats : []).map((value) => { const item = record(value); return { modelId: text(item.model_id), count: number(item.count) } as SearchModelStat; }).filter((item) => item.modelId && item.count > 0) }; }
-export async function searchAssetsByModel(search: string, modelId: string, exact: boolean, page = 1, signal?: AbortSignal): Promise<PageResult<AssetInstance>> { const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/fulltext_search/by_model/', { search, model_id: modelId, page, page_size: 20, case_sensitive: exact }, { signal }))); return { count: number(raw.total), items: (Array.isArray(raw.data) ? raw.data : []).map((item) => mapInstance(item, modelId)) }; }
+export async function searchAssetsByModel(search: string, modelId: string, exact: boolean, page = 1, signal?: AbortSignal): Promise<PageResult<AssetInstance>> { const raw = record(unwrap<unknown>(await apiPost('/cmdb/api/instance/fulltext_search/by_model/', { search, model_id: modelId, page, page_size: 20, case_sensitive: exact }, { signal }))); return { count: number(raw.total), items: (Array.isArray(raw.data) ? raw.data : []).map((item) => mapAssetInstance(item, modelId)).filter(keepMappedAssetInstance) }; }

--- a/mobile/src/features/assets/model.ts
+++ b/mobile/src/features/assets/model.ts
@@ -20,10 +20,42 @@ export interface PageResult<T> { count: number; items: T[]; }
 export interface AssetTableColumn { id: string; name: string; type: string; order: number; }
 export interface AssetFileMeta { fileId: string; fileName: string; fileSize: number | null; mimeType: string; }
 
+const ASSET_INSTANCE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : {};
+}
+
+function asText(value: unknown) {
+  return value === null || value === undefined ? '' : String(value);
+}
+
+/** 对外实例主键必须是 UUID；纯数字是已剥离的图 _id。 */
+export function isAssetInstanceUuid(value: unknown): value is string {
+  return ASSET_INSTANCE_UUID.test(asText(value).trim());
+}
+
+/** CMDB 对外主键是 inst_uuid；search/retrieve 已剥离图内部 _id。 */
+export function mapAssetInstance(value: unknown, fallbackModelId = ''): AssetInstance {
+  const item = asRecord(value);
+  const id = isAssetInstanceUuid(item.inst_uuid) ? asText(item.inst_uuid).trim() : '';
+  return {
+    id,
+    modelId: asText(item.model_id || fallbackModelId),
+    name: asText(item.inst_name || item.ip_addr || id),
+    organizationName: asText(item.organization_display),
+    values: item,
+  };
+}
+
+export function keepMappedAssetInstance(item: AssetInstance) {
+  return isAssetInstanceUuid(item.id);
+}
+
 export function assetRequestErrorKind(error: unknown): 'forbidden' | 'missing' | 'error' {
   if (!(error instanceof Error)) return 'error';
   if (/API Error:\s*403\b/.test(error.message)) return 'forbidden';
-  if (/API Error:\s*404\b/.test(error.message)) return 'missing';
+  if (/API Error:\s*404\b/.test(error.message) || /API Error:\s*400\b/.test(error.message)) return 'missing';
   return 'error';
 }
 
@@ -32,9 +64,10 @@ export function normalizeFollowedConfig(value: unknown): FollowedAssetsConfig {
   const source = typeof value === 'object' && value !== null ? value as { items?: unknown } : {};
   const items = (Array.isArray(source.items) ? source.items : []).flatMap((raw) => {
     if (typeof raw !== 'object' || raw === null) return [];
-    const item = raw as Record<string, unknown>; const modelId = String(item.model_id || ''); const instanceId = item.inst_id as string | number;
-    if (!modelId || instanceId === undefined || instanceId === null) return [];
-    return [{ modelId, instanceId, followedAt: String(item.followed_at || '') }];
+    const item = raw as Record<string, unknown>; const modelId = String(item.model_id || '');
+    const instanceId = item.inst_uuid ?? item.inst_id;
+    if (!modelId || !isAssetInstanceUuid(instanceId)) return [];
+    return [{ modelId, instanceId: asText(instanceId).trim(), followedAt: String(item.followed_at || '') }];
   }).sort((a, b) => new Date(b.followedAt || 0).getTime() - new Date(a.followedAt || 0).getTime()).slice(0, MAX_FOLLOWED_ASSETS);
   return { items };
 }
@@ -43,7 +76,7 @@ export function addFollowedAsset(config: FollowedAssetsConfig, modelId: string, 
   return { items: [{ modelId, instanceId, followedAt }, ...config.items.filter((item) => !sameAsset(item, modelId, instanceId))].slice(0, MAX_FOLLOWED_ASSETS) };
 }
 export function removeFollowedAsset(config: FollowedAssetsConfig, modelId: string, instanceId: string | number): FollowedAssetsConfig { return { items: config.items.filter((item) => !sameAsset(item, modelId, instanceId)) }; }
-export function serializeFollowedConfig(config: FollowedAssetsConfig) { return { items: config.items.map((item) => ({ model_id: item.modelId, inst_id: item.instanceId, followed_at: item.followedAt })) }; }
+export function serializeFollowedConfig(config: FollowedAssetsConfig) { return { items: config.items.map((item) => ({ model_id: item.modelId, inst_uuid: item.instanceId, followed_at: item.followedAt })) }; }
 
 export function groupAssetModels(classifications: readonly AssetClassification[], models: readonly AssetModel[]) {
   return classifications.filter((item) => item.visible).sort((a, b) => a.order - b.order).map((classification) => ({


### PR DESCRIPTION
CMDB 对外已剥离图 _id，Mobile 仍按 _id 过滤会导致 search 有数据却显示暂无资产。