### PR TITLE
feat(log): Vector 日志补充主机元数据

### DIFF
--- a/server/apps/log/management/commands/reconcile_vector_host_metadata.py
+++ b/server/apps/log/management/commands/reconcile_vector_host_metadata.py
@@ -1,0 +1,229 @@
+import hashlib
+from collections import Counter
+from datetime import datetime
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from apps.core.logger import log_logger as logger
+from apps.log.models import CollectConfig
+from apps.log.services.vector_host_metadata import PatchState, VectorHostMetadataPatch
+from apps.rpc.node_mgmt import NodeMgmt
+
+SUMMARY_KEYS = (
+    "scanned",
+    "eligible",
+    "current",
+    "would_apply",
+    "would_revert",
+    "applied",
+    "reverted",
+    "conflict",
+    "invalid",
+    "cas_conflict",
+    "failed",
+)
+ERROR_KEYS = ("conflict", "invalid", "cas_conflict", "failed")
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def _safe_content_hash(content) -> str:
+    return _content_hash(content) if isinstance(content, str) else ""
+
+
+def _get_keyset_page(queryset, cursor: tuple[datetime, str] | None, batch_size: int):
+    page = queryset
+    if cursor is not None:
+        created_at, config_id = cursor
+        page = page.filter(Q(created_at__gt=created_at) | Q(created_at=created_at, pk__gt=config_id))
+    return list(page.order_by("created_at", "pk")[:batch_size])
+
+
+def _validate_candidate(config) -> str | None:
+    collect_type = config.collect_instance.collect_type
+    if collect_type.collector != "Vector" or collect_type.name not in {"file", "docker"}:
+        return "log-side collect type ownership mismatch"
+    if config.file_type != "toml" or config.is_child is not True:
+        return "log-side config role mismatch"
+    return None
+
+
+def _validate_snapshot(config, snapshot: dict) -> str | None:
+    expected_collect_type = config.collect_instance.collect_type.name
+    if str(snapshot.get("id") or "") != str(config.id):
+        return "child snapshot id mismatch"
+    if snapshot.get("collect_type") != expected_collect_type or snapshot.get("config_type") != expected_collect_type:
+        return "child snapshot collect/config type mismatch"
+    if snapshot.get("collector_name") != "Vector" or not snapshot.get("collector_config_id"):
+        return "child snapshot parent collector mismatch"
+    if not isinstance(snapshot.get("content"), str) or not snapshot["content"]:
+        return "child snapshot content is empty"
+    return None
+
+
+class Command(BaseCommand):
+    help = (
+        "Safely reconcile managed host_name/host_ip enrich blocks for existing Vector file/docker child configs. "
+        "Defaults to dry-run; use --apply to write and --revert --apply to remove the exact managed block. "
+        "安全补齐或回退 Vector file/docker 存量子配置中的托管主机元数据块；默认仅预检。"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="Persist each safe CAS update / 执行逐项 CAS 写入")
+        parser.add_argument("--revert", action="store_true", help="Inspect or remove the exact managed v1 block / 检查或删除规范 v1 托管块")
+        parser.add_argument("--batch-size", type=int, default=100, help="Stable keyset page size / 稳定游标批次大小（默认 100）")
+
+    def handle(self, *args, **options):
+        apply_changes = bool(options["apply"])
+        revert = bool(options["revert"])
+        batch_size = int(options["batch_size"])
+        if batch_size < 1:
+            raise CommandError("--batch-size must be greater than zero")
+
+        cursor = None
+        queryset = CollectConfig.objects.filter(
+            is_child=True,
+            file_type="toml",
+            collect_instance__collect_type__collector="Vector",
+            collect_instance__collect_type__name__in=("file", "docker"),
+        ).select_related("collect_instance__collect_type")
+        node_mgmt = NodeMgmt(is_local_client=True)
+        if not node_mgmt.is_local_client:
+            raise CommandError("reconcile requires the local NodeMgmt client")
+
+        stats = Counter({key: 0 for key in SUMMARY_KEYS})
+        while True:
+            configs = _get_keyset_page(queryset, cursor, batch_size)
+            if not configs:
+                break
+            cursor = (configs[-1].created_at, str(configs[-1].pk))
+            stats["scanned"] += len(configs)
+            self._process_batch(
+                configs,
+                node_mgmt=node_mgmt,
+                stats=stats,
+                apply_changes=apply_changes,
+                revert=revert,
+            )
+
+        summary = " ".join(f"{key}={stats[key]}" for key in SUMMARY_KEYS)
+        self.stdout.write(summary)
+        if any(stats[key] for key in ERROR_KEYS):
+            raise CommandError("Vector host metadata reconcile did not converge; inspect item statuses and rerun")
+        self.stdout.write(self.style.SUCCESS("Vector host metadata reconcile completed"))
+
+    def _process_batch(self, configs, *, node_mgmt, stats, apply_changes: bool, revert: bool) -> None:
+        eligible = []
+        for config in configs:
+            error = _validate_candidate(config)
+            if error:
+                stats["invalid"] += 1
+                self._write_item("invalid", config.id, "", error)
+                continue
+            stats["eligible"] += 1
+            eligible.append(config)
+
+        snapshots_by_id = self._load_snapshots(eligible, node_mgmt=node_mgmt, stats=stats)
+        if snapshots_by_id is None:
+            return
+        for config in eligible:
+            self._process_config(
+                config,
+                snapshots_by_id.get(str(config.id)),
+                node_mgmt=node_mgmt,
+                stats=stats,
+                apply_changes=apply_changes,
+                revert=revert,
+            )
+
+    def _load_snapshots(self, configs, *, node_mgmt, stats) -> dict | None:
+        if not configs:
+            return {}
+        expected_ids = {str(config.id) for config in configs}
+        try:
+            snapshots = node_mgmt.get_child_configs_by_ids([config.id for config in configs]) or []
+        except Exception as exc:
+            logger.exception("Failed to fetch Vector child config snapshots")
+            stats["failed"] += len(configs)
+            for config in configs:
+                self._write_item("failed", config.id, "", f"snapshot fetch failed: {type(exc).__name__}: {exc}")
+            return None
+
+        returned_ids = [str(snapshot.get("id") or "") for snapshot in snapshots if isinstance(snapshot, dict)]
+        if len(returned_ids) != len(set(returned_ids)) or set(returned_ids) - expected_ids:
+            stats["failed"] += len(configs)
+            for config in configs:
+                self._write_item("failed", config.id, "", "snapshot batch contains duplicate or unexpected ids")
+            return None
+        return {str(snapshot["id"]): snapshot for snapshot in snapshots if isinstance(snapshot, dict) and snapshot.get("id")}
+
+    def _process_config(self, config, snapshot, *, node_mgmt, stats, apply_changes: bool, revert: bool) -> None:
+        if snapshot is None:
+            stats["invalid"] += 1
+            self._write_item("invalid", config.id, "", "child snapshot is missing")
+            return
+        snapshot_error = _validate_snapshot(config, snapshot)
+        if snapshot_error:
+            stats["invalid"] += 1
+            self._write_item("invalid", config.id, _safe_content_hash(snapshot.get("content")), snapshot_error)
+            return
+
+        original_content = snapshot["content"]
+        content_hash = _content_hash(original_content)
+        patch_method = VectorHostMetadataPatch.revert if revert else VectorHostMetadataPatch.apply
+        try:
+            result = patch_method(
+                original_content,
+                collect_type=config.collect_instance.collect_type.name,
+                config_id=str(config.id),
+                instance_id=str(config.collect_instance_id),
+            )
+        except Exception as exc:
+            stats["failed"] += 1
+            logger.exception("Vector host metadata patch failed: config_id=%s", config.id)
+            self._write_item("failed", config.id, content_hash, f"{type(exc).__name__}: {exc}")
+            return
+
+        if result.state is PatchState.UNMANAGED_CONFLICT:
+            stats["conflict"] += 1
+            self._write_item("conflict", config.id, content_hash, result.reason)
+            return
+        if result.state in {PatchState.INVALID, PatchState.MANAGED_DRIFT}:
+            stats["invalid"] += 1
+            self._write_item("invalid", config.id, content_hash, result.reason)
+            return
+        if not result.changed:
+            stats["current"] += 1
+            self._write_item("current", config.id, content_hash, "")
+            return
+        if not apply_changes:
+            action = "would_revert" if revert else "would_apply"
+            stats[action] += 1
+            self._write_item(action, config.id, content_hash, "")
+            return
+
+        try:
+            updated = node_mgmt.compare_and_swap_child_config_content_local(config.id, original_content, result.content)
+        except Exception as exc:
+            stats["failed"] += 1
+            logger.exception("Vector host metadata CAS failed: config_id=%s", config.id)
+            self._write_item("failed", config.id, content_hash, f"{type(exc).__name__}: {exc}")
+            return
+        if not updated:
+            stats["cas_conflict"] += 1
+            self._write_item("cas_conflict", config.id, content_hash, "concurrent content change")
+            return
+        action = "reverted" if revert else "applied"
+        stats[action] += 1
+        self._write_item(action, config.id, _content_hash(result.content), "")
+
+    def _write_item(self, status: str, config_id, content_hash: str, reason: str) -> None:
+        fields = [f"status={status}", f"config_id={config_id}"]
+        if content_hash:
+            fields.append(f"content_sha256={content_hash}")
+        if reason:
+            fields.append(f"reason={reason}")
+        self.stdout.write(" ".join(fields))

--- a/server/apps/log/services/vector_host_metadata.py
+++ b/server/apps/log/services/vector_host_metadata.py
@@ -1,0 +1,232 @@
+import re
+from dataclasses import dataclass
+from enum import Enum
+
+import toml
+
+MANAGED_BLOCK_BEGIN = "# bk-lite:vector-host-metadata:v1 begin"
+MANAGED_BLOCK_END = "# bk-lite:vector-host-metadata:v1 end"
+MANAGED_BLOCK = (
+    f"{MANAGED_BLOCK_BEGIN}\n"
+    '.host_name = decode_base64!("${node.name_b64}")\n'
+    '.host_ip = decode_base64!("${node.ip_b64}")\n'
+    f"{MANAGED_BLOCK_END}\n"
+)
+HOST_ASSIGNMENT_PATTERN = re.compile(r"(?<![\w.])\.(host_name|host_ip)\s*=")
+MANAGED_MARKER_PATTERN = re.compile(r"(?m)^\s*#\s*bk-lite:vector-host-metadata:[^\r\n]*$")
+
+
+class PatchState(str, Enum):
+    ABSENT = "absent"
+    CURRENT = "current"
+    MANAGED_DRIFT = "managed_drift"
+    UNMANAGED_CONFLICT = "unmanaged_conflict"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class PatchResult:
+    state: PatchState
+    content: str
+    changed: bool = False
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class _TargetTransform:
+    name: str
+    source: str
+    source_start: int
+    source_end: int
+
+
+class VectorHostMetadataPatch:
+    """Inspect and patch the owned Vector host-metadata block without rewriting TOML."""
+
+    @classmethod
+    def inspect(cls, content: str, *, collect_type: str, config_id: str, instance_id: str) -> PatchResult:
+        try:
+            target = cls._find_target(content, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+            source = target.source
+            markers = MANAGED_MARKER_PATTERN.findall(source)
+            begin_count = source.count(MANAGED_BLOCK_BEGIN)
+            end_count = source.count(MANAGED_BLOCK_END)
+            assignment_count = len(HOST_ASSIGNMENT_PATTERN.findall(source))
+
+            if not markers:
+                if assignment_count:
+                    return PatchResult(PatchState.UNMANAGED_CONFLICT, content, reason="unmanaged host metadata assignment")
+                return PatchResult(PatchState.ABSENT, content)
+
+            if (
+                len(markers) != 2
+                or begin_count != 1
+                or end_count != 1
+                or {marker.strip() for marker in markers} != {MANAGED_BLOCK_BEGIN, MANAGED_BLOCK_END}
+            ):
+                return PatchResult(PatchState.INVALID, content, reason="invalid or unknown managed markers")
+
+            begin_index = source.find(MANAGED_BLOCK_BEGIN)
+            end_marker_index = source.find(MANAGED_BLOCK_END)
+            if begin_index < 0 or end_marker_index < begin_index:
+                return PatchResult(PatchState.INVALID, content, reason="managed markers are out of order")
+            end_index = end_marker_index + len(MANAGED_BLOCK_END)
+            block_end = end_index + (1 if source[end_index : end_index + 1] == "\n" else 0)
+            managed_block = source[begin_index:block_end]
+            outside = source[:begin_index] + source[block_end:]
+            if HOST_ASSIGNMENT_PATTERN.search(outside):
+                return PatchResult(PatchState.UNMANAGED_CONFLICT, content, reason="host metadata assignment outside managed block")
+            if managed_block == MANAGED_BLOCK:
+                return PatchResult(PatchState.CURRENT, content)
+            return PatchResult(PatchState.MANAGED_DRIFT, content, reason="managed block differs from v1")
+        except (TypeError, ValueError, toml.TomlDecodeError) as exc:
+            return PatchResult(PatchState.INVALID, content, reason=str(exc))
+
+    @classmethod
+    def apply(cls, content: str, *, collect_type: str, config_id: str, instance_id: str) -> PatchResult:
+        inspection = cls.inspect(content, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+        if inspection.state in {PatchState.CURRENT, PatchState.UNMANAGED_CONFLICT, PatchState.INVALID}:
+            return inspection
+
+        try:
+            target = cls._find_target(content, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+            if inspection.state is PatchState.ABSENT:
+                updated_source = target.source + MANAGED_BLOCK
+            else:
+                updated_source = cls._replace_managed_block(target.source, MANAGED_BLOCK)
+            updated = content[: target.source_start] + updated_source + content[target.source_end :]
+            cls._validate_only_target_source_changed(content, updated, target.name)
+        except (TypeError, ValueError, toml.TomlDecodeError) as exc:
+            return PatchResult(PatchState.INVALID, content, reason=str(exc))
+        final = cls.inspect(updated, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+        if final.state is not PatchState.CURRENT:
+            return PatchResult(PatchState.INVALID, content, reason="patched content did not reach current state")
+        return PatchResult(PatchState.CURRENT, updated, changed=True)
+
+    @classmethod
+    def revert(cls, content: str, *, collect_type: str, config_id: str, instance_id: str) -> PatchResult:
+        inspection = cls.inspect(content, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+        if inspection.state is PatchState.ABSENT:
+            return inspection
+        if inspection.state is not PatchState.CURRENT:
+            return inspection
+
+        try:
+            target = cls._find_target(content, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+            updated_source = target.source.replace(MANAGED_BLOCK, "", 1)
+            updated = content[: target.source_start] + updated_source + content[target.source_end :]
+            cls._validate_only_target_source_changed(content, updated, target.name)
+        except (TypeError, ValueError, toml.TomlDecodeError) as exc:
+            return PatchResult(PatchState.INVALID, content, reason=str(exc))
+        final = cls.inspect(updated, collect_type=collect_type, config_id=config_id, instance_id=instance_id)
+        if final.state is not PatchState.ABSENT:
+            return PatchResult(PatchState.INVALID, content, reason="reverted content did not reach absent state")
+        return PatchResult(PatchState.ABSENT, updated, changed=True)
+
+    @staticmethod
+    def _expected_names(collect_type: str, config_id: str, instance_id: str) -> tuple[str, str, tuple[str, ...]]:
+        if collect_type == "file":
+            suffix = str(config_id).lower().replace("-", "_")
+            return f"file_enrich_{suffix}", f"vmlogs_{suffix}", (f"file_{suffix}", f"file_parse_{suffix}")
+        if collect_type == "docker":
+            suffix = str(instance_id)
+            return f"docker_enrich_{suffix}", f"vmlogs_{suffix}", (f"docker_{suffix}",)
+        raise ValueError(f"unsupported collect type: {collect_type}")
+
+    @classmethod
+    def _find_target(cls, content: str, *, collect_type: str, config_id: str, instance_id: str) -> _TargetTransform:
+        if not isinstance(content, str) or not content:
+            raise ValueError("child config content is empty")
+        parsed = toml.loads(content)
+        expected_transform, expected_sink, expected_inputs = cls._expected_names(collect_type, config_id, instance_id)
+        sources = parsed.get("sources")
+        transforms = parsed.get("transforms")
+        sinks = parsed.get("sinks")
+        if not isinstance(sources, dict) or not isinstance(transforms, dict) or not isinstance(sinks, dict):
+            raise ValueError("missing sources, transforms, or sinks")
+        enrich_names = [name for name in transforms if name.startswith(f"{collect_type}_enrich_")]
+        if enrich_names != [expected_transform]:
+            raise ValueError("missing or ambiguous enrich transform")
+        transform = transforms[expected_transform]
+        if not isinstance(transform, dict) or transform.get("type") != "remap" or not isinstance(transform.get("source"), str):
+            raise ValueError("invalid enrich transform")
+        inputs = transform.get("inputs")
+        if not isinstance(inputs, list) or len(inputs) != 1 or inputs[0] not in expected_inputs:
+            raise ValueError("invalid enrich input")
+        cls._validate_enrich_input_topology(sources, transforms, collect_type, inputs[0], expected_inputs[0])
+        sink = sinks.get(expected_sink)
+        if not isinstance(sink, dict) or sink.get("type") != "nats" or sink.get("inputs") != [expected_transform]:
+            raise ValueError("invalid Vector NATS sink topology")
+        source = transform["source"]
+        if not source.endswith("\n"):
+            raise ValueError("enrich source must end with a newline")
+        cls._validate_identity_assignment(source, "collector", "Vector")
+        cls._validate_identity_assignment(source, "collect_type", collect_type)
+        cls._validate_identity_assignment(source, "instance_id", str(instance_id))
+        if collect_type == "file":
+            cls._validate_identity_assignment(source, "config_id", str(config_id), case_sensitive=False)
+
+        table_pattern = re.compile(rf"(?m)^\[transforms\.{re.escape(expected_transform)}\]\s*$")
+        table_match = table_pattern.search(content)
+        if not table_match:
+            raise ValueError("target transform table not found in raw content")
+        next_table_match = re.search(r"(?m)^\[", content[table_match.end() :])
+        section_end = table_match.end() + next_table_match.start() if next_table_match else len(content)
+        section = content[table_match.end() : section_end]
+        source_matches = list(re.finditer(r"(?ms)^source\s*=\s*'''\n(.*?)'''\s*$", section))
+        if len(source_matches) != 1:
+            raise ValueError("target source is not a unique triple-single-quoted block")
+        source_match = source_matches[0]
+        source_start = table_match.end() + source_match.start(1)
+        source_end = table_match.end() + source_match.end(1)
+        raw_source = content[source_start:source_end]
+        if raw_source != source:
+            raise ValueError("raw and parsed enrich source differ")
+        return _TargetTransform(expected_transform, source, source_start, source_end)
+
+    @staticmethod
+    def _validate_enrich_input_topology(sources: dict, transforms: dict, collect_type: str, input_name: str, source_name: str) -> None:
+        source = sources.get(source_name)
+        expected_source_type = "file" if collect_type == "file" else "docker_logs"
+        if not isinstance(source, dict) or source.get("type") != expected_source_type:
+            raise ValueError("invalid Vector source topology")
+        if input_name == source_name:
+            return
+        parser = transforms.get(input_name)
+        if (
+            collect_type != "file"
+            or not isinstance(parser, dict)
+            or parser.get("type") != "remap"
+            or parser.get("inputs") != [source_name]
+            or not isinstance(parser.get("source"), str)
+        ):
+            raise ValueError("invalid file parser topology")
+
+    @staticmethod
+    def _validate_identity_assignment(source: str, field: str, expected: str, *, case_sensitive: bool = True) -> None:
+        matches = re.findall(rf'(?m)^\s*\.{re.escape(field)}\s*=\s*"([^"\r\n]*)"\s*$', source)
+        if len(matches) != 1:
+            raise ValueError(f"invalid {field} identity assignment")
+        actual = matches[0]
+        if case_sensitive:
+            matches_expected = actual == expected
+        else:
+            matches_expected = actual.casefold() == expected.casefold()
+        if not matches_expected:
+            raise ValueError(f"mismatched {field} identity assignment")
+
+    @staticmethod
+    def _replace_managed_block(source: str, replacement: str) -> str:
+        begin_index = source.index(MANAGED_BLOCK_BEGIN)
+        end_index = source.index(MANAGED_BLOCK_END, begin_index) + len(MANAGED_BLOCK_END)
+        block_end = end_index + (1 if source[end_index : end_index + 1] == "\n" else 0)
+        return source[:begin_index] + replacement + source[block_end:]
+
+    @staticmethod
+    def _validate_only_target_source_changed(original: str, updated: str, transform_name: str) -> None:
+        before = toml.loads(original)
+        after = toml.loads(updated)
+        before_source = before["transforms"][transform_name].pop("source")
+        after_source = after["transforms"][transform_name].pop("source")
+        if before != after or not isinstance(before_source, str) or not isinstance(after_source, str):
+            raise ValueError("patch changed content outside the target enrich source")

--- a/server/apps/log/support-files/plugins/Vector/docker/collect_type.json
+++ b/server/apps/log/support-files/plugins/Vector/docker/collect_type.json
@@ -12,6 +12,8 @@
     "container_id",
     "container_name",
     "host",
+    "host_name",
+    "host_ip",
     "image",
     "label",
     "message",

--- a/server/apps/log/support-files/plugins/Vector/docker/docker.child.toml.j2
+++ b/server/apps/log/support-files/plugins/Vector/docker/docker.child.toml.j2
@@ -41,6 +41,10 @@ source = '''
 .collector = "Vector"
 .collect_type = "docker"
 .instance_id = "{{ instance_id }}"
+# bk-lite:vector-host-metadata:v1 begin
+.host_name = decode_base64!("${node.name_b64}")
+.host_ip = decode_base64!("${node.ip_b64}")
+# bk-lite:vector-host-metadata:v1 end
 '''
 
 # ====================================

--- a/server/apps/log/support-files/plugins/Vector/file/collect_type.json
+++ b/server/apps/log/support-files/plugins/Vector/file/collect_type.json
@@ -10,6 +10,8 @@
     "instance_id",
     "file",
     "host",
+    "host_name",
+    "host_ip",
     "message",
     "source_type",
     "timestamp",

--- a/server/apps/log/support-files/plugins/Vector/file/file.child.toml.j2
+++ b/server/apps/log/support-files/plugins/Vector/file/file.child.toml.j2
@@ -64,6 +64,10 @@ source = '''
 .collect_type = "file"
 .instance_id = "{{ instance_id }}"
 .config_id = "{{ config_id | default('', true) }}"
+# bk-lite:vector-host-metadata:v1 begin
+.host_name = decode_base64!("${node.name_b64}")
+.host_ip = decode_base64!("${node.ip_b64}")
+# bk-lite:vector-host-metadata:v1 end
 '''
 
 # ====================================

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -558,7 +558,7 @@ class NatsService:
 
     def get_child_configs_by_ids(self, ids: list):
         """根据子配置ID列表获取子配置对象"""
-        child_configs = ChildConfig.objects.filter(id__in=ids)
+        child_configs = ChildConfig.objects.filter(id__in=ids).select_related("collector_config__collector")
         return [
             {
                 "id": config.id,
@@ -566,6 +566,8 @@ class NatsService:
                 "config_type": config.config_type,
                 "content": config.content,
                 "env_config": config.env_config,
+                "collector_config_id": config.collector_config_id,
+                "collector_name": config.collector_config.collector.name,
             }
             for config in child_configs
         ]

--- a/server/apps/node_mgmt/services/node_host_metadata.py
+++ b/server/apps/node_mgmt/services/node_host_metadata.py
@@ -1,0 +1,70 @@
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Mapping
+
+HOST_METADATA_CACHE_VERSION = 1
+HOST_METADATA_FINGERPRINT_KEY = "host_identity_fingerprint"
+HOST_METADATA_RESERVED_KEYS = frozenset(
+    {
+        "node.name_b64",
+        "node.ip_b64",
+        "node__name_b64",
+        "node__ip_b64",
+    }
+)
+
+
+def _encode_utf8_base64(value: str) -> str:
+    return base64.b64encode(str(value or "").encode("utf-8")).decode("ascii")
+
+
+@dataclass(frozen=True)
+class NodeHostMetadataRenderContext:
+    """Trusted render values and cache identity for Node host metadata."""
+
+    variables: Mapping[str, str]
+    fingerprint: str
+
+    @classmethod
+    def build(cls, name: str, ip: str):
+        normalized_name = str(name or "")
+        normalized_ip = str(ip or "")
+        identity = json.dumps([normalized_name, normalized_ip], ensure_ascii=False, separators=(",", ":"))
+        encoded_name = _encode_utf8_base64(normalized_name)
+        encoded_ip = _encode_utf8_base64(normalized_ip)
+        return cls(
+            variables={
+                "node.name_b64": encoded_name,
+                "node.ip_b64": encoded_ip,
+                "node__name_b64": encoded_name,
+                "node__ip_b64": encoded_ip,
+            },
+            fingerprint=hashlib.sha256(identity.encode("utf-8")).hexdigest(),
+        )
+
+    @staticmethod
+    def without_reserved_variables(variables: Mapping | None) -> dict:
+        return {key: value for key, value in (variables or {}).items() if key not in HOST_METADATA_RESERVED_KEYS}
+
+    @classmethod
+    def prepare_template_variables(cls, variables: Mapping | None, trusted_reserved_variables: Mapping | None = None) -> dict:
+        prepared = cls.without_reserved_variables(variables)
+        prepared.update({key: value for key, value in (trusted_reserved_variables or {}).items() if key in HOST_METADATA_RESERVED_KEYS})
+        return prepared
+
+    def build_cache_entry(self, etag: str) -> dict:
+        return {
+            "version": HOST_METADATA_CACHE_VERSION,
+            "etag": etag,
+            HOST_METADATA_FINGERPRINT_KEY: self.fingerprint,
+        }
+
+    def matches_cache_entry(self, cached_entry, client_etag: str | None) -> bool:
+        return (
+            isinstance(cached_entry, dict)
+            and cached_entry.get("version") == HOST_METADATA_CACHE_VERSION
+            and cached_entry.get("etag") == client_etag
+            and cached_entry.get(HOST_METADATA_FINGERPRINT_KEY) == self.fingerprint
+        )

--- a/server/apps/node_mgmt/services/sidecar.py
+++ b/server/apps/node_mgmt/services/sidecar.py
@@ -22,7 +22,8 @@ from apps.node_mgmt.models.action import CollectorActionTask, CollectorActionTas
 from apps.node_mgmt.models.installer import ControllerTaskNode
 from apps.node_mgmt.models.sidecar import Collector, CollectorConfiguration, Node, NodeCollectorConfiguration, NodeOrganization
 from apps.node_mgmt.services.cloudregion import RegionService
-from apps.node_mgmt.services.sidecar_cache import build_configuration_etag_cache_key
+from apps.node_mgmt.services.node_host_metadata import NodeHostMetadataRenderContext
+from apps.node_mgmt.services.sidecar_cache import build_configuration_etag_cache_key, invalidate_node_configuration_etags
 from apps.node_mgmt.tasks.action_task import converge_collector_action_task_for_node
 from apps.node_mgmt.tasks.installer import _matches_install_connectivity_target, converge_controller_install_connectivity_for_node
 from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
@@ -395,24 +396,28 @@ class Sidecar:
         return task_node.ip
 
     @staticmethod
-    def _cached_heartbeat_updates(node_id: str, node_details: dict) -> tuple[dict, str]:
+    def _cached_heartbeat_updates(node_id: str, node_details: dict) -> tuple[dict, str, bool]:
         """Build the bounded metadata update allowed on an ETag cache hit."""
         request_data = dict(node_details)
-        missing_fields = [field for field in ("ip", "operating_system") if not request_data.get(field)]
-        if missing_fields:
-            existing_node = Node.objects.filter(id=node_id).values(*missing_fields).first() or {}
-            for field in missing_fields:
+        existing_node = Node.objects.filter(id=node_id).values("ip", "operating_system").first() or {}
+        for field in ("ip", "operating_system"):
+            if not request_data.get(field):
                 request_data[field] = existing_node.get(field, "")
+
+        resolved_ip = Sidecar._resolve_reported_ip(node_id, request_data.get("ip", ""))
+        ip_changed = bool(existing_node) and resolved_ip != existing_node.get("ip", "")
 
         updates = {
             "updated_at": datetime.now(timezone.utc).isoformat(),
             "status": node_details.get("status", {}),
         }
+        if ip_changed:
+            updates["ip"] = resolved_ip
         cpu_architecture = Sidecar._fallback_cpu_architecture(node_id, request_data)
         if cpu_architecture:
             updates["cpu_architecture"] = cpu_architecture
 
-        return updates, request_data.get("ip", "")
+        return updates, resolved_ip, ip_changed
 
     @staticmethod
     def _filter_reported_node_details(node_id: str, node_details: dict) -> dict:
@@ -502,8 +507,10 @@ class Sidecar:
 
         # 如果缓存的ETag存在且与客户端的相同，则返回304 Not Modified
         if cached_etag and cached_etag == if_none_match:
-            updates, node_ip = Sidecar._cached_heartbeat_updates(node_id, node_details)
-            Node.objects.filter(id=node_id).update(**updates)
+            updates, node_ip, ip_changed = Sidecar._cached_heartbeat_updates(node_id, node_details)
+            updated_count = Node.objects.filter(id=node_id).update(**updates)
+            if updated_count and ip_changed:
+                invalidate_node_configuration_etags([node_id])
             Sidecar.trigger_converge_tasks_if_needed(node_id, node_ip, updates["status"])
 
             response = HttpResponse(status=304)
@@ -595,7 +602,9 @@ class Sidecar:
             node_info = {key: val for key, val in request_data.items() if key != "name"}
             if not node_info.get("cpu_architecture"):
                 node_info.pop("cpu_architecture", None)
-            Node.objects.filter(id=node_id).update(**node_info)
+            updated_count = Node.objects.filter(id=node_id).update(**node_info)
+            if updated_count and request_data.get("ip", "") != node.ip:
+                invalidate_node_configuration_etags([node_id])
 
             # Existing node organization ownership is managed by the server/UI.
             # Sidecar may heartbeat with stale group tags before sidecar.yaml is
@@ -731,19 +740,26 @@ class Sidecar:
 
         # 从缓存中获取配置的 ETag
         cache_key = build_configuration_etag_cache_key(node_id, configuration_id)
-        cached_etag = cache.get(cache_key)
+        cached_entry = cache.get(cache_key)
 
-        # 对比客户端的 ETag 和缓存的 ETag
-        if cached_etag and cached_etag == if_none_match:
-            if not Sidecar.configuration_bound_to_node(node_id, configuration_id):
+        # 缓存命中仍校验当前绑定与 Node 主机身份，避免并发旧请求复活旧配置。
+        if isinstance(cached_entry, dict) and if_none_match:
+            node_identity = (
+                NodeCollectorConfiguration.objects.filter(node_id=node_id, collector_config_id=configuration_id)
+                .values_list("node__name", "node__ip")
+                .first()
+            )
+            if node_identity is None:
                 node, error_response = Sidecar.get_node_or_404(request, node_id)
                 if error_response:
                     return error_response
                 return EncryptedJsonResponse(status=404, data={"error": "Configuration not found"}, request=request)
 
-            response = HttpResponse(status=304)
-            response["ETag"] = cached_etag
-            return response
+            current_host_context = NodeHostMetadataRenderContext.build(*node_identity)
+            if current_host_context.matches_cache_entry(cached_entry, if_none_match):
+                response = HttpResponse(status=304)
+                response["ETag"] = cached_entry["etag"]
+                return response
 
         assignment, error_response = Sidecar.get_bound_assignment_or_404(
             request,
@@ -757,6 +773,7 @@ class Sidecar:
 
         node = assignment.node
         configuration = assignment.collector_config
+        host_context = NodeHostMetadataRenderContext.build(node.name, node.ip)
 
         collector = configuration.collector
         section_headers = {}
@@ -815,13 +832,17 @@ class Sidecar:
         variables.update(child_render_variables)
 
         # 渲染配置模板
-        configuration_data["template"] = Sidecar.render_template(configuration_data["template"], variables)
+        configuration_data["template"] = Sidecar.render_template(
+            configuration_data["template"],
+            variables,
+            trusted_reserved_variables=host_context.variables,
+        )
 
         # 生成新的 ETag - 基于实际响应内容
         new_etag = Sidecar.generate_response_etag(configuration_data, request)
 
         # 更新缓存中的 ETag
-        cache.set(cache_key, new_etag, ControllerConstants.E_CACHE_TIMEOUT)
+        cache.set(cache_key, host_context.build_cache_entry(new_etag), ControllerConstants.E_CACHE_TIMEOUT)
 
         # 返回配置信息和新的 ETag
         return EncryptedJsonResponse(configuration_data, headers={"ETag": new_etag}, request=request)
@@ -921,7 +942,7 @@ class Sidecar:
         return variables
 
     @staticmethod
-    def render_template(template_str, variables):
+    def render_template(template_str, variables, *, trusted_reserved_variables=None):
         """
         渲染字符串模板，将 ${变量} 替换为给定的值。
 
@@ -931,6 +952,10 @@ class Sidecar:
         """
         # 排除password相关的变量渲染，走env_config渲染
         _variables = {k: v for k, v in variables.items() if "password" not in k.lower()}
+        _variables = NodeHostMetadataRenderContext.prepare_template_variables(
+            _variables,
+            trusted_reserved_variables,
+        )
         template_str = template_str.replace("node.", "node__")
         template = Template(template_str)
         return template.safe_substitute(_variables)

--- a/server/apps/node_mgmt/services/sidecar_cache.py
+++ b/server/apps/node_mgmt/services/sidecar_cache.py
@@ -95,6 +95,22 @@ def invalidate_configuration_etags(configuration_ids: Iterable | None):
         transaction.on_commit(lambda: cache.delete_many(keys))
 
 
+def invalidate_node_configuration_etags(node_ids: Iterable | None):
+    normalized_node_ids = _normalize_ids(node_ids)
+    if not normalized_node_ids:
+        return
+
+    from apps.node_mgmt.models.sidecar import NodeCollectorConfiguration
+
+    assignments = NodeCollectorConfiguration.objects.filter(node_id__in=normalized_node_ids).values_list(
+        "node_id",
+        "collector_config_id",
+    )
+    keys = [build_configuration_etag_cache_key(node_id, configuration_id) for node_id, configuration_id in assignments]
+    if keys:
+        transaction.on_commit(lambda: cache.delete_many(keys))
+
+
 def invalidate_bulk_config_node_etags(configs: Iterable | None):
     invalidate_node_etags([config.get("node_id") for config in configs or [] if isinstance(config, dict)])
 

--- a/server/apps/node_mgmt/views/node.py
+++ b/server/apps/node_mgmt/views/node.py
@@ -28,6 +28,7 @@ from apps.node_mgmt.services.module_push import (
     parse_retire_linked_flag,
 )
 from apps.node_mgmt.services.node import NodeService
+from apps.node_mgmt.services.sidecar_cache import invalidate_node_configuration_etags
 from apps.node_mgmt.tasks.sidecar_config import sync_node_properties_to_sidecar
 from apps.node_mgmt.utils.permission import (
     add_node_permissions,
@@ -322,9 +323,12 @@ class NodeViewSet(mixins.DestroyModelMixin, GenericViewSet):
         if error_response:
             return error_response
 
+        name_changed = name is not None and name != node.name
         if name is not None:
             node.name = name
             node.save()
+            if name_changed:
+                invalidate_node_configuration_etags([node.id])
 
         if organizations is not None:
             NodeOrganization.objects.filter(node=node).delete()


### PR DESCRIPTION
## Summary
- Vector **file / docker** 采集在 enrich 阶段补充 `host_name`、`host_ip`（来自节点 `name` / `ip`，Sidecar 可信渲染）
- 存量 child 配置可通过 `reconcile_vector_host_metadata`（默认 dry-run，`--apply` 写入）无损补齐；冲突项跳过不覆盖
- 节点 name/ip 变更时失效配置 ETag，避免旧主机身份 304

## Test plan
- [ ] 新建 Vector file/docker 采集后，下发配置 enrich 含可解码的 `host_name`/`host_ip`
- [ ] 日志检索可见 `host_name`、`host_ip`，值与节点 name/ip 一致
- [ ] 存量：`python manage.py reconcile_vector_host_metadata` 预检后 `--apply`；有非托管字段的项为 conflict
- [ ] 修改节点 name 或 ip 后，sidecar 重新拉配置拿到新值

## Notes
- PR 仅包含 commit `8a71fcea`（11 个生产文件）；相关测试按约定未纳入本 PR
- 发版后存量需执行 reconcile 才会补齐字段