### PR TITLE
fix(monitor): 侧栏对象名与 Website Enum 跟随账号语言

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -47,6 +47,7 @@ from apps.monitor.services.network_device_resource_top import NetworkDeviceResou
 from apps.monitor.services.network_device_resource_top import validate_metric_type as validate_network_metric_type
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.instance_id_keys import resolve_monitor_object_instance_id_keys
+from apps.monitor.utils.metric_enum_locale import localize_metric_enum_unit
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 from apps.rpc.system_mgmt import SystemMgmt
@@ -675,6 +676,11 @@ def monitor_metrics(monitor_obj_id: str, *args, **kwargs):
         lan_key = f"{LanguageConstants.MONITOR_OBJECT_METRIC}.{monitor_obj.name}.{result['name']}"
         result["display_name"] = lan.get(f"{lan_key}.name") or result.get("display_name") or result["name"]
         result["display_description"] = lan.get(f"{lan_key}.desc") or result.get("description")
+        if (result.get("data_type") or "").lower() == "enum":
+            result["unit"] = localize_metric_enum_unit(
+                result.get("unit") or "",
+                enum_translations=lan.get(f"{lan_key}.enum"),
+            )
     return {"result": True, "data": results, "message": ""}
 
 

--- a/server/apps/monitor/support-files/plugins/Telegraf/web/web/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/web/web/language/en.yaml
@@ -14,6 +14,14 @@ monitor_object_metric:
         field. 0 means success, while non-zero values represent response string mismatch,
         body read error, connection failure, timeout, DNS error, or response status
         code mismatch.
+      enum:
+        "0": Success
+        "1": Content Mismatch
+        "2": Body Read Error
+        "3": Connection Failed
+        "4": Timeout
+        "5": DNS Error
+        "6": Status Code Mismatch
     http_node_success_rate:
       name: Node Success Rate
       desc: Calculate the 5-minute probe success rate for each probing node, reflecting

--- a/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/en.yaml
@@ -3,3 +3,9 @@ K3S:
   desc: Leveraging K3S' active monitoring data reporting capability, collect
     the status and health of the K3S cluster, including performance metrics
     for nodes, containers, and pods.
+monitor_object:
+  K3SCluster: K3S Cluster
+  K3SNode: K3S Node
+  K3SPod: K3S Pod
+monitor_object_type:
+  K3S: K3S

--- a/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k3s/k3s/language/zh-Hans.yaml
@@ -1,3 +1,9 @@
 K3S:
   name: K3S
   desc: 利用K3S主动上报监控数据的能力，收集K3S集群的状态和健康，包括节点、容器和pod的性能指标。
+monitor_object:
+  K3SCluster: K3S 集群
+  K3SNode: K3S 节点
+  K3SPod: K3S Pod
+monitor_object_type:
+  K3S: K3S

--- a/server/apps/monitor/utils/metric_enum_locale.py
+++ b/server/apps/monitor/utils/metric_enum_locale.py
@@ -1,0 +1,68 @@
+"""Metric Enum unit 按语言包 enum 映射本地化。
+
+metrics.json / DB 中 Enum 的 unit 多为中文硬编码。语言包提供
+``monitor_object_metric.<Object>.<metric>.enum``（id→译名）时按 id 覆盖 name。
+LanguageLoader 已按账号 locale 加载，中文界面无 enum 条目则保持原样。
+"""
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping, Optional
+
+
+def _enum_id_key(value: Any) -> str:
+    if isinstance(value, bool):
+        return str(int(value))
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def localize_metric_enum_unit(
+    unit: str,
+    *,
+    enum_translations: Optional[Mapping[Any, Any]] = None,
+) -> str:
+    """用 language yaml 的 enum 映射本地化 Enum 指标 unit。无映射或解析失败时原样返回。"""
+    if not unit or not isinstance(unit, str):
+        return unit
+    if not isinstance(enum_translations, Mapping) or not enum_translations:
+        return unit
+
+    stripped = unit.strip()
+    if not stripped.startswith("["):
+        return unit
+
+    try:
+        options = json.loads(stripped)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return unit
+    if not isinstance(options, list):
+        return unit
+
+    yaml_map: dict[str, str] = {}
+    for key, value in enum_translations.items():
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            yaml_map[_enum_id_key(key)] = text
+
+    if not yaml_map:
+        return unit
+
+    changed = False
+    for option in options:
+        if not isinstance(option, dict):
+            continue
+        name = option.get("name")
+        if not isinstance(name, str):
+            continue
+        translated = yaml_map.get(_enum_id_key(option.get("id")))
+        if translated is not None and translated != name:
+            option["name"] = translated
+            changed = True
+
+    if not changed:
+        return unit
+    return json.dumps(options, ensure_ascii=False, separators=(",", ":"))

--- a/server/apps/monitor/views/monitor_metrics.py
+++ b/server/apps/monitor/views/monitor_metrics.py
@@ -14,6 +14,7 @@ from apps.monitor.models import MonitorPlugin
 from apps.monitor.models.monitor_metrics import Metric, MetricGroup
 from apps.monitor.models.monitor_object import MonitorObject
 from apps.monitor.serializers.monitor_metrics import MetricGroupSerializer, MetricSerializer
+from apps.monitor.utils.metric_enum_locale import localize_metric_enum_unit
 from apps.monitor.utils.snmp_ifmib_capability import (
     COMMON_IFMIB_METRIC_NAMES,
     IFMIB_ZH_DISPLAY_TEXTS,
@@ -429,6 +430,11 @@ class MetricViewSet(viewsets.ModelViewSet):
                 or lan.get(f"{lan_key}.desc")
                 or result["description"]
             )
+            if (result.get("data_type") or "").lower() == "enum":
+                result["unit"] = localize_metric_enum_unit(
+                    result.get("unit") or "",
+                    enum_translations=lan.get(f"{lan_key}.enum"),
+                )
 
         metric_groups = MetricGroup.objects.filter(
             id__in={metric.metric_group_id for metric in page}

--- a/web/src/app/monitor/dashboards/metadata.ts
+++ b/web/src/app/monitor/dashboards/metadata.ts
@@ -102,8 +102,16 @@ export const getProfessionalDashboardKey = (objectName?: string | null, objectDi
   return findProfessionalDashboardMeta(objectName, objectDisplayName)?.key || '';
 };
 
-/** 侧栏/列表展示名：优先 API display_name；TCPPort 等技术名回退到注册表 objectDisplayName（→ TCP）。 */
-export const getProfessionalObjectDisplayName = (objectName?: string | null, objectDisplayName?: string | null) => {
+/**
+ * 侧栏/列表展示名：优先 API display_name（后端已按账号语言翻译）。
+ * 注册表 objectDisplayName 不得在英文等语言下覆盖 API 译名
+ * （例如 Host→Host 被错盖成「主机」）。
+ * 仅当 API 仍为技术 slug TCPPort 时，回退到友好名 TCP。
+ */
+export const getProfessionalObjectDisplayName = (
+  objectName?: string | null,
+  objectDisplayName?: string | null
+) => {
   const matched = findProfessionalDashboardMeta(objectName, objectDisplayName);
   const apiName = String(objectDisplayName || '').trim();
   const technicalName = String(objectName || '').trim();
@@ -111,10 +119,11 @@ export const getProfessionalObjectDisplayName = (objectName?: string | null, obj
   const techKey = normalizeDashboardKey(technicalName);
 
   if (techKey === 'tcpport' || apiKey === 'tcpport') {
+    if (apiName && apiKey !== 'tcpport') return apiName;
     return matched?.objectDisplayName || 'TCP';
   }
-  if (apiName && apiName !== technicalName) return apiName;
-  return matched?.objectDisplayName || apiName || technicalName || '';
+  if (apiName) return apiName;
+  return technicalName || matched?.objectDisplayName || '';
 };
 
 export const getProfessionalDashboardUrl = (


### PR DESCRIPTION
## Summary
- 英文界面侧栏优先使用 API 已翻译的 `display_name`，不再在 `Host===Host` 时被注册表中文覆盖。
- Website 拨测结果 Enum（如「成功」）通过 language yaml `enum` 按账号语言映射；无 yaml 条目时保持原样（中文界面仍为中文）。
- 补齐 K3S 监控对象展示名语言包。

相对 #4805 收缩范围：去掉中英硬编码大表、注册表批量改名与 dashboard fallback 文案改动。

## Test plan
- [ ] 英文账号打开监控 View 侧栏：Host / Process / Website 等显示英文；中文账号显示中文
- [ ] 英文账号查看 Website 列表 Probe Result：显示 Success 等英文，不再出现「成功」
- [ ] 中文账号同样路径仍为中文
- [ ] TCPPort 仍显示为 TCP

## Scope note
- 已检查提交范围：仅含本次 i18n 最小修复 7 个文件；测试文件与无关工作区改动未纳入。
- 本地已验证：`localize_metric_enum_unit` yaml 映射、Website/K3S yaml 结构、展示名 apiName-first 行为复现。