### PR TITLE
fix(opspilot): 清理调试日志残留，统一走 opspilot_logger

### DIFF
--- a/server/apps/opspilot/metis/llm/agent/deep_agent.py
+++ b/server/apps/opspilot/metis/llm/agent/deep_agent.py
@@ -37,7 +37,6 @@ class DeepAgentGraph(BasicGraph):
         """编译 DeepAgent 执行图"""
 
         node_builder = DeepAgentNode()
-        import logging as _dg; _dg.warning("DEBUG_DG: about to call setup")
         await node_builder.setup(request)
 
         graph_builder = StateGraph(DeepAgentState)

--- a/server/apps/opspilot/services/chat_service.py
+++ b/server/apps/opspilot/services/chat_service.py
@@ -622,11 +622,9 @@ class ChatService:
                 }
             )
 
-        import logging as _dbg_log
-
         if kwargs.get("matched_skill_packages") is not None:
-            _dbg_log.warning(
-                "DEBUG_CHAT: matched_skill_packages count=%s, capabilities=%s",
+            logger.debug(
+                "matched_skill_packages count=%s, capabilities=%s",
                 len(kwargs.get("matched_skill_packages") or []),
                 kwargs.get("skill_package_capabilities"),
             )


### PR DESCRIPTION
## 问题

`server/apps/opspilot` 里有两处开发调试期遗留的日志语句，且都是就地 `import logging`，违反了仓库约定（`server/apps/<app>/` 日志统一使用 `from apps.core.logger import {app_name}_logger`）：

1. `metis/llm/agent/deep_agent.py` `compile_graph` 中的 `DEBUG_DG: about to call setup` —— 每次编译 DeepAgent 执行图都会以 warning 级别输出，纯调试标记，无信息量
2. `services/chat_service.py` `invoke` 路径中的 `DEBUG_CHAT: matched_skill_packages ...` —— 同样以 warning 级别刷屏

## 修改

- deep_agent.py：删除 DEBUG_DG 语句（无保留价值）
- chat_service.py：删除临时 `import logging as _dbg_log`，调试信息降级为 `logger.debug` 并复用模块头已有的 `opspilot_logger`，保留诊断能力、消除生产噪音

## 验证

- `uv run pytest apps/opspilot/tests/test_chat_service_k8s_instance_selection.py apps/opspilot/tests/test_chat_service_llm_timeout.py apps/opspilot/tests/test_agent_execute_timeout.py` → 20 passed
- 本地完整跑通 migrate / dev server，确认改动路径正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)