### PR TITLE
feat(monitor): 监控详情与全量指标支持多选指标查看

### DIFF
--- a/web/src/app/monitor/(pages)/view/monitorView.tsx
+++ b/web/src/app/monitor/(pages)/view/monitorView.tsx
@@ -26,7 +26,10 @@ import dayjs, { Dayjs } from 'dayjs';
 import { INIT_VIEW_MODAL_FORM } from '@/app/monitor/constants/view';
 import LazyMetricItem from '@/app/monitor/components/metric-views/lazyMetricItem';
 import { createMetricQueryWindow } from '@/app/monitor/components/metric-views/queryWindow';
-import { useMetricSelectOptions } from '@/app/monitor/components/metricSelectOptions';
+import {
+  filterMetricGroupsByIds,
+  useMetricSelectOptions,
+} from '@/app/monitor/components/metricSelectOptions';
 import {
   buildHostProcessLabelPairs,
   isHostMonitorObject,
@@ -50,7 +53,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const metricSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
-  const [metricId, setMetricId] = useState<number | null>();
+  const [metricIds, setMetricIds] = useState<number[]>([]);
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({
     timeRange: [],
     originValue: 15,
@@ -199,7 +202,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
       }, frequence);
     }
     return () => clearTimer();
-  }, [frequence, timeValues, metricId, activeTab]);
+  }, [frequence, timeValues, metricIds.join(','), activeTab]);
 
   useEffect(() => {
     handleSearch('refresh');
@@ -260,7 +263,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
       clearTimeout(metricSearchTimerRef.current);
     }
     setActiveTab(val);
-    setMetricId(null);
+    setMetricIds([]);
     setMetricPage(1);
     setMetricKeyword('');
     setProcessFilterNames([]);
@@ -343,34 +346,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
 
   // 清空所有指标数据，但保留分组结构，并根据当前筛选状态决定显示内容
   const clearAllMetricData = () => {
-    let clearedData;
-
-    if (metricId) {
-      // 如果有选中的指标，只显示该指标所在的分组
-      clearedData = originMetricData
-        .map((group) => ({
-          ...group,
-          isLoading: false,
-          child: (group?.child || [])
-            .filter((item) => item.id === metricId)
-            .map((item) => ({
-              ...item,
-              viewData: [],
-              seriesBudget: undefined,
-            })),
-        }))
-        .filter((item) => item.child?.find((tex) => tex.id === metricId));
-    } else {
-      // 如果没有选中指标，显示所有分组和指标
-      clearedData = originMetricData.map((group) => ({
-        ...group,
-        child: (group.child || []).map((item) => ({
-          ...item,
-          viewData: [],
-          seriesBudget: undefined,
-        })),
-      }));
-    }
+    const clearedData = filterMetricGroupsByIds(originMetricData, metricIds);
 
     setMetricData(clearedData);
     setExpandedIds((prev) => {
@@ -623,8 +599,9 @@ const MonitorView: React.FC<ViewModalProps> = ({
     }
   };
 
-  const handleMetricIdChange = (val: number) => {
-    setMetricId(val);
+  const handleMetricIdChange = (val: number[]) => {
+    const nextIds = val || [];
+    setMetricIds(nextIds);
 
     cancelAllRequests();
     setLoadedMetricIds(new Set());
@@ -633,40 +610,19 @@ const MonitorView: React.FC<ViewModalProps> = ({
     setResetCounter((prev) => prev + 1);
     setNeedsRefreshOnExpand(true);
 
-    if (val) {
-      const filteredData = originMetricData
-        .map((group) => ({
-          ...group,
-          isLoading: false,
-          child: (group?.child || [])
-            .filter((item) => item.id === val)
-            .map((item) => ({
-              ...item,
-              viewData: [],
-            })),
-        }))
-        .filter((item) => item.child?.find((tex) => tex.id === val));
-
-      setMetricData(filteredData);
-      if (filteredData.length > 0) {
-        setExpandedIds(new Set(filteredData.map((group) => group.id)));
-      }
-    } else {
-      // 切换回全部时，清空所有指标的viewData，但保留分组结构
-      const clearedData = originMetricData.map((group) => ({
-        ...group,
-        child: (group.child || []).map((item) => ({
-          ...item,
-          viewData: [], // 清空所有指标数据，让它们重新请求
-        })),
-      }));
-
-      setMetricData(clearedData);
-      setOriginMetricData(clearedData); // 同步更新originMetricData
-      setExpandedIds(
-        new Set(clearedData.map((group: IndexViewItem) => group.id))
-      );
+    const filteredData = filterMetricGroupsByIds(originMetricData, nextIds);
+    setMetricData(filteredData);
+    if (!nextIds.length) {
+      // 切换回全部时，同步清空 origin，让后续刷新重新请求
+      setOriginMetricData(filteredData);
     }
+    setExpandedIds(
+      new Set(
+        filteredData
+          .map((group: IndexViewItem) => group.id)
+          .filter((id): id is number => typeof id === 'number')
+      )
+    );
   };
 
   const handleMetricKeywordChange = (value: string) => {
@@ -676,7 +632,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
     }
     metricSearchTimerRef.current = setTimeout(() => {
       setMetricPage(1);
-      setMetricId(null);
+      setMetricIds([]);
       cancelAllRequests();
       getInitData(activeTab, undefined, 1, value);
     }, 300);
@@ -684,7 +640,7 @@ const MonitorView: React.FC<ViewModalProps> = ({
 
   const handleMetricPageChange = (page: number) => {
     setMetricPage(page);
-    setMetricId(null);
+    setMetricIds([]);
     cancelAllRequests();
     setResetCounter((prev) => prev + 1);
     getInitData(activeTab, undefined, page, metricKeyword);
@@ -819,9 +775,11 @@ const MonitorView: React.FC<ViewModalProps> = ({
       <div className="flex justify-between mb-[15px] gap-3">
         <div className="flex flex-wrap gap-2 min-w-0">
           <Select
-            className="w-[250px]"
+            className="min-w-[250px] max-w-[360px]"
+            mode="multiple"
+            maxTagCount="responsive"
             placeholder={t('common.searchPlaceHolder')}
-            value={metricId}
+            value={metricIds}
             allowClear
             {...metricSelect.selectSearchProps}
             options={metricSelect.options}

--- a/web/src/app/monitor/components/metric-views/index.tsx
+++ b/web/src/app/monitor/components/metric-views/index.tsx
@@ -28,7 +28,10 @@ import { attachGapIntervals, buildGapDetectionParams } from '@/app/monitor/utils
 
 import dayjs, { Dayjs } from 'dayjs';
 import LazyMetricItem from './lazyMetricItem';
-import { useMetricSelectOptions } from '@/app/monitor/components/metricSelectOptions';
+import {
+  filterMetricGroupsByIds,
+  useMetricSelectOptions,
+} from '@/app/monitor/components/metricSelectOptions';
 import {
   buildHostProcessLabelPairs,
   isHostMonitorObject,
@@ -127,7 +130,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const metricSearchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
-  const [metricId, setMetricId] = useState<number | null>();
+  const [metricIds, setMetricIds] = useState<number[]>([]);
   const [timeValues, setTimeValues] = useState<TimeValuesProps>({
     timeRange: [],
     originValue: 15
@@ -279,7 +282,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       }, activeFrequence);
     }
     return () => clearTimer();
-  }, [activeFrequence, activeTimeValues, metricId, activeTab]);
+  }, [activeFrequence, activeTimeValues, metricIds.join(','), activeTab]);
 
   useEffect(() => {
     handleSearch('refresh');
@@ -398,7 +401,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       clearTimeout(metricSearchTimerRef.current);
     }
     setActiveTab(val);
-    setMetricId(null);
+    setMetricIds([]);
     setMetricPage(1);
     setMetricKeyword('');
     setProcessFilterNames([]);
@@ -489,34 +492,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
 
   // 清空所有指标数据，但保留分组结构，并根据当前筛选状态决定显示内容
   const clearAllMetricData = () => {
-    let clearedData;
-
-    if (metricId) {
-      // 如果有选中的指标，只显示该指标所在的分组
-      clearedData = originMetricData
-        .map((group) => ({
-          ...group,
-          isLoading: false,
-          child: (group?.child || [])
-            .filter((item) => item.id === metricId)
-            .map((item) => ({
-              ...item,
-              viewData: [],
-              seriesBudget: undefined
-            }))
-        }))
-        .filter((item) => item.child?.find((tex) => tex.id === metricId));
-    } else {
-      // 如果没有选中指标，显示所有分组和指标
-      clearedData = originMetricData.map((group) => ({
-        ...group,
-        child: (group.child || []).map((item) => ({
-          ...item,
-          viewData: [],
-          seriesBudget: undefined
-        }))
-      }));
-    }
+    const clearedData = filterMetricGroupsByIds(originMetricData, metricIds);
 
     setMetricData(clearedData);
     // 刷新时保留已展开分组；若为空则展开全部，继续靠卡片滚入视图加载。
@@ -810,8 +786,9 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     []
   );
 
-  const handleMetricIdChange = (val: number) => {
-    setMetricId(val);
+  const handleMetricIdChange = (val: number[]) => {
+    const nextIds = val || [];
+    setMetricIds(nextIds);
 
     cancelAllRequests();
     setLoadedMetricIds(new Set());
@@ -820,40 +797,19 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     setResetCounter((prev) => prev + 1);
     setNeedsRefreshOnExpand(true);
 
-    if (val) {
-      const filteredData = originMetricData
-        .map((group) => ({
-          ...group,
-          isLoading: false,
-          child: (group?.child || [])
-            .filter((item) => item.id === val)
-            .map((item) => ({
-              ...item,
-              viewData: []
-            }))
-        }))
-        .filter((item) => item.child?.find((tex) => tex.id === val));
-
-      setMetricData(filteredData);
-      if (filteredData.length > 0) {
-        setExpandedIds(new Set(filteredData.map((group) => group.id)));
-      }
-    } else {
-      // 切换回全部时，清空所有指标的viewData，但保留分组结构
-      const clearedData = originMetricData.map((group) => ({
-        ...group,
-        child: (group.child || []).map((item) => ({
-          ...item,
-          viewData: [] // 清空所有指标数据，让它们重新请求
-        }))
-      }));
-
-      setMetricData(clearedData);
-      setOriginMetricData(clearedData); // 同步更新originMetricData
-      setExpandedIds(
-        new Set(clearedData.map((group: IndexViewItem) => group.id))
-      );
+    const filteredData = filterMetricGroupsByIds(originMetricData, nextIds);
+    setMetricData(filteredData);
+    if (!nextIds.length) {
+      // 切换回全部时，同步清空 origin，让后续刷新重新请求
+      setOriginMetricData(filteredData);
     }
+    setExpandedIds(
+      new Set(
+        filteredData
+          .map((group: IndexViewItem) => group.id)
+          .filter((id): id is number => typeof id === 'number')
+      )
+    );
   };
 
   const handleMetricKeywordChange = (value: string) => {
@@ -863,7 +819,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
     }
     metricSearchTimerRef.current = setTimeout(() => {
       setMetricPage(1);
-      setMetricId(null);
+      setMetricIds([]);
       cancelAllRequests();
       getInitData(activeTab, undefined, 1, value);
     }, 300);
@@ -871,7 +827,7 @@ const MetricViews: React.FC<ViewDetailProps> = ({
 
   const handleMetricPageChange = (page: number) => {
     setMetricPage(page);
-    setMetricId(null);
+    setMetricIds([]);
     cancelAllRequests();
     setResetCounter((prev) => prev + 1);
     getInitData(activeTab, undefined, page, metricKeyword);
@@ -989,9 +945,11 @@ const MetricViews: React.FC<ViewDetailProps> = ({
       <div className="flex justify-between mb-[16px] gap-3">
         <div className="flex flex-wrap gap-2 min-w-0">
           <Select
-            className="w-[250px]"
+            className="min-w-[250px] max-w-[360px]"
+            mode="multiple"
+            maxTagCount="responsive"
             placeholder={t('common.searchPlaceHolder')}
-            value={metricId}
+            value={metricIds}
             allowClear
             {...metricSelect.selectSearchProps}
             options={metricSelect.options}

--- a/web/src/app/monitor/components/metricSelectOptions.tsx
+++ b/web/src/app/monitor/components/metricSelectOptions.tsx
@@ -68,7 +68,41 @@ export const buildGroupedMetricSelectOptions = (
     .filter((group): group is NonNullable<typeof group> => group != null);
 };
 
-/** 单实例指标 Select：管理搜索词并生成已过滤 options。 */
+/**
+ * 按选中指标 id 过滤分组；空数组表示展示全部。
+ * clearViewData 为 true 时清空卡片时序，便于重新懒加载。
+ */
+export const filterMetricGroupsByIds = (
+  groups: IndexViewItem[],
+  metricIds: number[],
+  options?: { clearViewData?: boolean },
+): IndexViewItem[] => {
+  const clearViewData = options?.clearViewData ?? true;
+  const mapChild = (item: MetricItem) =>
+    clearViewData
+      ? { ...item, viewData: [], seriesBudget: undefined }
+      : { ...item };
+
+  if (!metricIds.length) {
+    return groups.map((group) => ({
+      ...group,
+      child: (group.child || []).map(mapChild),
+    }));
+  }
+
+  const idSet = new Set(metricIds);
+  return groups
+    .map((group) => ({
+      ...group,
+      isLoading: false,
+      child: (group.child || [])
+        .filter((item) => idSet.has(item.id))
+        .map(mapChild),
+    }))
+    .filter((group) => (group.child || []).length > 0);
+};
+
+/** 指标筛选 Select：管理搜索词并生成已过滤 options（单选/多选均可）。 */
 export const useMetricSelectOptions = (groups: MetricSelectGroup[]) => {
   const [search, setSearch] = useState('');
   const options = useMemo(


### PR DESCRIPTION
## Summary
- 监控详情抽屉与全量指标页（`MetricViews`）的指标下拉改为多选
- 选中 1..N 个指标时仅展示对应卡片网格；清空/未选仍展示当前分类全部指标
- 抽出共享 `filterMetricGroupsByIds`，搜索/翻页/切页签时清空选中（与原行为一致）

## Test plan
- [ ] 打开主机监控详情「监控视图」，多选 2–4 个指标，确认只出对应卡片
- [ ] 清空多选，确认恢复当前分类全部指标
- [ ] 打开「主机全量指标」，验证同样多选行为
- [ ] 切换插件页签 / 关键词搜索 / 翻页后，选中被清空且列表正常
- [ ] 主机进程页签的进程名多选过滤仍可用

## Review notes
- 已检查提交范围：仅 3 个监控相关文件；未纳入 icons、`next-env.d.ts`、设计文档或测试文件
- Code review（Standards/Spec + bug/perf）：无高置信新问题；候选项均为既有行为或方案约定