### PR TITLE
bugfix: 增加节点列表权限旁路兼容观测

### DIFF
--- a/agents/stargazer/service/collection_service.py
+++ b/agents/stargazer/service/collection_service.py
@@ -479,6 +479,7 @@ class CollectionService:
                 query["organization_ids"] = [organization_id]
             else:
                 query["skip_permission"] = True
+                query["legacy_callsite"] = "stargazer.node_info"
 
             exec_params = {"args": [query], "kwargs": {}}
             subject = f"{self.namespace}.node_list"

--- a/agents/stargazer/tests/test_collection_service_node_query.py
+++ b/agents/stargazer/tests/test_collection_service_node_query.py
@@ -39,8 +39,10 @@ async def test_set_node_info_scopes_query_and_filters_ip(
     if organization_id:
         assert query["organization_ids"] == [organization_id]
         assert "skip_permission" not in query
+        assert "legacy_callsite" not in query
     else:
         assert query["skip_permission"] is True
+        assert query["legacy_callsite"] == "stargazer.node_info"
 
 
 @pytest.mark.asyncio

--- a/server/apps/alerts/action/target_resolver.py
+++ b/server/apps/alerts/action/target_resolver.py
@@ -23,6 +23,7 @@ def resolve_node_target(host_value, team) -> dict:
     query = {
         "ip": host_value,
         "skip_permission": True,
+        "legacy_callsite": "alerts.target_resolver",
         "organization_ids": list(team),
         "page": 1,
         "page_size": 50,

--- a/server/apps/cmdb/services/node_mgmt_sync_service.py
+++ b/server/apps/cmdb/services/node_mgmt_sync_service.py
@@ -129,7 +129,10 @@ class NodeMgmtSyncService:
     MAX_EXISTING_HOSTS = _get_positive_int_env("CMDB_NODE_MGMT_MAX_EXISTING_HOSTS", 100_000)
     MAX_EXISTING_HOST_BYTES = _get_positive_int_env("CMDB_NODE_MGMT_MAX_EXISTING_HOST_BYTES", 128 * 1024 * 1024)
     EXISTING_HOST_PAGE_SIZE = _get_positive_int_env("CMDB_NODE_MGMT_EXISTING_HOST_PAGE_SIZE", 500)
-    SYSTEM_NODE_QUERY = {"skip_permission": True}
+    SYSTEM_NODE_QUERY = {
+        "skip_permission": True,
+        "legacy_callsite": "cmdb.node_sync",
+    }
     RAW_DATA_FIELDS = RAW_DATA_FIELDS
     RAW_DATA_METRIC_MODEL_IDS = RAW_DATA_METRIC_MODEL_IDS
     RAW_TEXT_LIMITS = RAW_TEXT_LIMITS

--- a/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
+++ b/server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py
@@ -229,10 +229,22 @@ class TestRpcWrappers:
         assert node["model_id"] == "host"
         assert rpc.node_list.call_args_list == [
             mocker.call(
-                {"is_container": False, "skip_permission": True, "page": 1, "page_size": 2}
+                {
+                    "is_container": False,
+                    "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
+                    "page": 1,
+                    "page_size": 2,
+                }
             ),
             mocker.call(
-                {"is_container": False, "skip_permission": True, "page": 2, "page_size": 2}
+                {
+                    "is_container": False,
+                    "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
+                    "page": 2,
+                    "page_size": 2,
+                }
             ),
         ]
 
@@ -251,13 +263,31 @@ class TestRpcWrappers:
         assert len(nodes) == 1200
         assert rpc.node_list.call_args_list == [
             mocker.call(
-                {"is_container": False, "skip_permission": True, "page": 1, "page_size": 500}
+                {
+                    "is_container": False,
+                    "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
+                    "page": 1,
+                    "page_size": 500,
+                }
             ),
             mocker.call(
-                {"is_container": False, "skip_permission": True, "page": 2, "page_size": 500}
+                {
+                    "is_container": False,
+                    "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
+                    "page": 2,
+                    "page_size": 500,
+                }
             ),
             mocker.call(
-                {"is_container": False, "skip_permission": True, "page": 3, "page_size": 500}
+                {
+                    "is_container": False,
+                    "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
+                    "page": 3,
+                    "page_size": 500,
+                }
             ),
         ]
 
@@ -269,7 +299,12 @@ class TestRpcWrappers:
         S._fetch_node_mgmt_pages({"skip_permission": False, "page_size": 999999})
 
         assert rpc.node_list.call_args == mocker.call(
-            {"skip_permission": True, "page_size": 500, "page": 1}
+            {
+                "skip_permission": True,
+                "legacy_callsite": "cmdb.node_sync",
+                "page_size": 500,
+                "page": 1,
+            }
         )
 
     def test_fetch_node_mgmt_pages_非法页大小回退到硬上限(self, mocker):
@@ -280,7 +315,12 @@ class TestRpcWrappers:
         S._fetch_node_mgmt_pages({"page_size": "invalid"})
 
         assert rpc.node_list.call_args == mocker.call(
-            {"page_size": 500, "skip_permission": True, "page": 1}
+            {
+                "page_size": 500,
+                "skip_permission": True,
+                "legacy_callsite": "cmdb.node_sync",
+                "page": 1,
+            }
         )
 
     @pytest.mark.parametrize(
@@ -472,6 +512,7 @@ class TestRpcWrappers:
                     "cloud_region_id": 1,
                     "is_container": True,
                     "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
                     "page": 1,
                     "page_size": 2,
                 }
@@ -481,6 +522,7 @@ class TestRpcWrappers:
                     "cloud_region_id": 1,
                     "is_container": True,
                     "skip_permission": True,
+                    "legacy_callsite": "cmdb.node_sync",
                     "page": 2,
                     "page_size": 2,
                 }

--- a/server/apps/job_mgmt/services/execution_base_service.py
+++ b/server/apps/job_mgmt/services/execution_base_service.py
@@ -328,7 +328,16 @@ class ExecutionTaskBaseService(object):
             ValueError: 未找到可用的 Ansible 执行节点
         """
         node_mgmt = NodeMgmt()
-        result = node_mgmt.node_list({"cloud_region_id": cloud_region_id, "is_container": True, "page": 1, "page_size": 1, "skip_permission": True})
+        result = node_mgmt.node_list(
+            {
+                "cloud_region_id": cloud_region_id,
+                "is_container": True,
+                "page": 1,
+                "page_size": 1,
+                "skip_permission": True,
+                "legacy_callsite": "job_mgmt.execution",
+            }
+        )
         if not isinstance(result, dict):
             raise ValueError(f"云区域 {cloud_region_id} 下未找到可用的 Ansible 执行节点")
         nodes = result.get("nodes", [])

--- a/server/apps/job_mgmt/views/target.py
+++ b/server/apps/job_mgmt/views/target.py
@@ -48,6 +48,7 @@ def _get_executor_node(cloud_region_id: int) -> str:
             "page": 1,
             "page_size": 1,
             "skip_permission": True,
+            "legacy_callsite": "job_mgmt.connection_test",
         }
     )
     if not isinstance(result, dict):

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -1,3 +1,4 @@
+import threading
 import uuid
 
 from django.db import connection, transaction
@@ -31,6 +32,30 @@ from apps.node_mgmt.services.sidecar_cache import (
     invalidate_bulk_config_node_etags,
 )
 from apps.core.utils.crypto.aes_crypto import AESCryptor
+
+LEGACY_NODE_LIST_CALLSITES = frozenset(
+    {
+        "alerts.target_resolver",
+        "cmdb.node_sync",
+        "job_mgmt.connection_test",
+        "job_mgmt.execution",
+        "stargazer.node_info",
+    }
+)
+_observed_legacy_node_list_callsites: set[str] = set()
+_legacy_node_list_observation_lock = threading.Lock()
+
+
+def _observe_legacy_node_list_callsite(declared_callsite: str) -> None:
+    with _legacy_node_list_observation_lock:
+        if declared_callsite in _observed_legacy_node_list_callsites:
+            return
+        _observed_legacy_node_list_callsites.add(declared_callsite)
+
+    logger.warning(
+        "legacy node_list skip_permission used; declared_callsite=%s authorization_source=untrusted_payload",
+        declared_callsite,
+    )
 
 
 class NatsService:
@@ -769,6 +794,14 @@ def node_list(query_data: dict):
     is_container = query_data.get("is_container")
     permission_data = query_data.get("permission_data", {})
     skip_permission = query_data.get("skip_permission", False)
+    if skip_permission:
+        declared_callsite = query_data.get("legacy_callsite")
+        if (
+            not isinstance(declared_callsite, str)
+            or declared_callsite not in LEGACY_NODE_LIST_CALLSITES
+        ):
+            declared_callsite = "unknown"
+        _observe_legacy_node_list_callsite(declared_callsite)
     return NodeService.get_node_list(
         organization_ids,
         cloud_region_id,

--- a/server/apps/node_mgmt/tests/test_issue_3125_node_list_observability_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_3125_node_list_observability_service.py
@@ -1,0 +1,146 @@
+"""Issue #3125 legacy node_list 观测首片的跨模块契约测试。"""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from apps.alerts.action import target_resolver
+from apps.cmdb.services.node_mgmt_sync_service import NodeMgmtSyncService
+from apps.job_mgmt.services.execution_base_service import ExecutionTaskBaseService
+from apps.job_mgmt.views import target as target_views
+from apps.node_mgmt.nats import node as nats_node
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("declared_callsite", "expected_callsite"),
+    [
+        ("job_mgmt.connection_test", "job_mgmt.connection_test"),
+        ("forged\nlog-entry", "unknown"),
+        (["job_mgmt.connection_test"], "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_legacy_skip_permission_logs_only_normalized_declared_callsite(
+    monkeypatch,
+    caplog,
+    declared_callsite,
+    expected_callsite,
+):
+    expected_result = {"count": 1, "nodes": [{"id": "node-1"}]}
+    captured = {}
+
+    def fake_get_node_list(*args):
+        captured["args"] = args
+        return expected_result
+
+    monkeypatch.setattr(nats_node, "_observed_legacy_node_list_callsites", set(), raising=False)
+    monkeypatch.setattr(nats_node.NodeService, "get_node_list", fake_get_node_list)
+    query = {"skip_permission": True}
+    if declared_callsite is not None:
+        query["legacy_callsite"] = declared_callsite
+
+    caplog.set_level(logging.WARNING, logger="node")
+    result = nats_node.node_list(query)
+    repeated_result = nats_node.node_list(query)
+
+    assert result is expected_result
+    assert repeated_result is expected_result
+    assert captured["args"][-1] is True
+    matching_records = [record for record in caplog.records if "legacy node_list skip_permission" in record.getMessage()]
+    assert len(matching_records) == 1
+    assert f"declared_callsite={expected_callsite}" in matching_records[0].getMessage()
+    assert "forged\nlog-entry" not in caplog.text
+
+
+def test_legacy_observation_is_bounded_per_normalized_callsite(monkeypatch, caplog):
+    monkeypatch.setattr(nats_node, "_observed_legacy_node_list_callsites", set(), raising=False)
+    monkeypatch.setattr(nats_node.NodeService, "get_node_list", lambda *args: {"nodes": []})
+    caplog.set_level(logging.WARNING, logger="node")
+
+    nats_node.node_list({"skip_permission": True, "legacy_callsite": "job_mgmt.connection_test"})
+    nats_node.node_list({"skip_permission": True, "legacy_callsite": "cmdb.node_sync"})
+    nats_node.node_list({"skip_permission": True, "legacy_callsite": "forged"})
+
+    messages = [record.getMessage() for record in caplog.records if "legacy node_list skip_permission" in record.getMessage()]
+    assert len(messages) == 3
+    assert any("declared_callsite=job_mgmt.connection_test" in message for message in messages)
+    assert any("declared_callsite=cmdb.node_sync" in message for message in messages)
+    assert any("declared_callsite=unknown" in message for message in messages)
+
+
+def test_regular_node_list_keeps_behavior_without_legacy_observation(monkeypatch, caplog):
+    expected_result = {"count": 0, "nodes": []}
+    captured = {}
+
+    def fake_get_node_list(*args):
+        captured["args"] = args
+        return expected_result
+
+    monkeypatch.setattr(nats_node.NodeService, "get_node_list", fake_get_node_list)
+    caplog.set_level(logging.WARNING, logger="node")
+
+    result = nats_node.node_list(
+        {
+            "permission_data": {"username": "user"},
+            "legacy_callsite": "forged\nlog-entry",
+        }
+    )
+
+    assert result is expected_result
+    assert captured["args"][-1] is False
+    assert "legacy node_list skip_permission" not in caplog.text
+    assert "forged\nlog-entry" not in caplog.text
+
+
+def test_job_connection_test_declares_legacy_callsite():
+    with patch.object(target_views, "NodeMgmt") as node_mgmt:
+        node_mgmt.return_value.node_list.return_value = {"nodes": [{"id": "executor-1"}]}
+
+        assert target_views._get_executor_node(3) == "executor-1"
+
+    query = node_mgmt.return_value.node_list.call_args.args[0]
+    assert query["legacy_callsite"] == "job_mgmt.connection_test"
+
+
+def test_job_execution_declares_legacy_callsite():
+    with patch("apps.job_mgmt.services.execution_base_service.NodeMgmt") as node_mgmt:
+        node_mgmt.return_value.node_list.return_value = {"nodes": [{"id": "executor-2"}]}
+
+        assert ExecutionTaskBaseService._get_ansible_node(4) == "executor-2"
+
+    query = node_mgmt.return_value.node_list.call_args.args[0]
+    assert query["legacy_callsite"] == "job_mgmt.execution"
+
+
+def test_cmdb_sync_declares_legacy_callsite(monkeypatch):
+    with patch("apps.cmdb.services.node_mgmt_sync_service.NodeMgmt") as client:
+        client.return_value.node_list.return_value = {"count": 0, "nodes": []}
+        monkeypatch.setattr(NodeMgmtSyncService, "_node_mgmt_client", classmethod(lambda cls: client.return_value))
+
+        assert NodeMgmtSyncService._fetch_node_mgmt_pages({}) == []
+
+    query = client.return_value.node_list.call_args.args[0]
+    assert query["legacy_callsite"] == "cmdb.node_sync"
+
+
+def test_alert_target_resolver_declares_legacy_callsite():
+    with patch.object(target_resolver, "NodeMgmt") as node_mgmt:
+        node_mgmt.return_value.node_list.return_value = {
+            "nodes": [
+                {
+                    "id": "node-3",
+                    "name": "host",
+                    "ip": "10.0.0.3",
+                    "operating_system": "linux",
+                    "cloud_region": 1,
+                }
+            ]
+        }
+
+        target_resolver.resolve_node_target("10.0.0.3", team=[1])
+
+    query = node_mgmt.return_value.node_list.call_args.args[0]
+    assert query["legacy_callsite"] == "alerts.target_resolver"

--- a/server/apps/node_mgmt/tests/test_issue_3125_node_list_observability_service.py
+++ b/server/apps/node_mgmt/tests/test_issue_3125_node_list_observability_service.py
@@ -1,6 +1,8 @@
 """Issue #3125 legacy node_list 观测首片的跨模块契约测试。"""
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import patch
 
 import pytest
@@ -71,6 +73,25 @@ def test_legacy_observation_is_bounded_per_normalized_callsite(monkeypatch, capl
     assert any("declared_callsite=unknown" in message for message in messages)
 
 
+def test_legacy_observation_logs_once_under_concurrency(monkeypatch, caplog):
+    monkeypatch.setattr(nats_node, "_observed_legacy_node_list_callsites", set(), raising=False)
+    monkeypatch.setattr(nats_node.NodeService, "get_node_list", lambda *args: {"nodes": []})
+    caplog.set_level(logging.WARNING, logger="node")
+    barrier = Barrier(8)
+
+    def call_node_list(_):
+        barrier.wait()
+        nats_node.node_list({"skip_permission": True, "legacy_callsite": "cmdb.node_sync"})
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(call_node_list, range(8)))
+
+    messages = [record.getMessage() for record in caplog.records if "legacy node_list skip_permission" in record.getMessage()]
+    assert messages == [
+        "legacy node_list skip_permission used; declared_callsite=cmdb.node_sync authorization_source=untrusted_payload"
+    ]
+
+
 def test_regular_node_list_keeps_behavior_without_legacy_observation(monkeypatch, caplog):
     expected_result = {"count": 0, "nodes": []}
     captured = {}
@@ -103,6 +124,25 @@ def test_job_connection_test_declares_legacy_callsite():
 
     query = node_mgmt.return_value.node_list.call_args.args[0]
     assert query["legacy_callsite"] == "job_mgmt.connection_test"
+
+
+def test_job_connection_payload_keeps_legacy_consumer_contract():
+    """新生产者可由不识别 legacy_callsite 的旧 handler 按原契约消费。"""
+    with patch.object(target_views, "NodeMgmt") as node_mgmt:
+        node_mgmt.return_value.node_list.return_value = {"nodes": [{"id": "executor-1"}]}
+        target_views._get_executor_node(3)
+
+    query = node_mgmt.return_value.node_list.call_args.args[0]
+    with patch.object(nats_node.NodeService, "get_node_list", return_value={"nodes": [{"id": "executor-1"}]}) as service:
+        result = nats_node.NodeService.get_node_list(
+            query.get("organization_ids"), query.get("cloud_region_id"), query.get("name"), query.get("ip"),
+            query.get("os"), query.get("page", 1), query.get("page_size", 10), query.get("is_active"),
+            query.get("is_manual"), query.get("is_container"), query.get("permission_data", {}),
+            query.get("skip_permission", False),
+        )
+
+    assert result == {"nodes": [{"id": "executor-1"}]}
+    assert service.call_args.args == (None, 3, None, None, None, 1, 1, None, None, True, {}, True)
 
 
 def test_job_execution_declares_legacy_callsite():


### PR DESCRIPTION
Relates to #3125

## 问题

共享 NATS `node_list` 契约允许消息体自报 `skip_permission`；服务端没有 Broker 认证主体可用于判断调用者，因此该字段不能构成可信授权边界。与此同时，Job、CMDB、Alerts 与 Stargazer 都有依赖该旁路的合法调用，直接拒绝会破坏连接测试、作业执行、节点同步或旧采集任务。

## 根因

当前协议把“系统调用能力”与业务参数放在同一份不可信 payload 中，监听和分发链没有把认证身份传给业务 handler。完整修复需要服务身份、subject ACL、服务端 capability 映射和调用方迁移协同完成，不能靠改名或新增另一个自报字段解决。

## 本 PR 的边界

这是兼容迁移的安全首片：建立旧旁路调用库存，不宣称已经完成最终鉴权修复。`legacy_callsite` 明确标记为 `authorization_source=untrusted_payload`，只用于观测，绝不参与授权。

## 怎么修的

- 为仓内 5 个合法调用点补充稳定标记：Job 连接测试、Job 执行、CMDB 同步、Alerts 目标解析、Stargazer 无组织上下文回退。
- handler 只接受 allowlist 中的字符串作为观测值；缺失、伪造、换行、非字符串输入统一归一为 `unknown`，不记录原始值。
- 观测使用线程安全集合，按归一化调用点每进程最多记录一次 WARNING；总键数最多 6 个，避免分页或恶意请求放大日志。
- 保持既有 `skip_permission`、授权分支、响应和异常语义不变。

## 调用链

```mermaid
flowchart TD
    subgraph T["调用方"]
        J["Job / CMDB / Alerts\nserver/apps/*"]
        S["Stargazer\ncollection_service.py"]
    end

    subgraph R["RPC / NATS"]
        C["NodeMgmt.node_list\nrpc/node_mgmt.py"]
        H["node_list handler\nnode_mgmt/nats/node.py"]
    end

    subgraph O["兼容观测"]
        N["归一化 claimed callsite\nknown 或 unknown"]
        L["每进程每类一次 WARNING\n最多 6 类"]
    end

    Q["NodeService.get_node_list\n原授权与查询语义"]

    J --> C --> H
    S --> H
    H --> N --> L
    N --> Q
```

## 影响范围与兼容性

- Server 先发布：旧调用方缺少标记时记为 `unknown`，请求继续按旧语义执行。
- 调用方先发布：旧 handler 会忽略额外字段，响应不变。
- 不新增数据库、持久化状态、配置或依赖；回滚只需 revert 本提交。
- 后续仍需完成独立服务身份、最小 subject ACL、可信 caller 映射、v2 契约、双栈迁移与旧凭据轮换，Issue 保持 OPEN。

## 验证

- `server/apps/node_mgmt/tests/test_issue_3125_node_list_observability_service.py`：10 passed。覆盖合法/缺失/伪造/换行/非字符串标记、普通权限路径、重复调用有界日志及 4 个 Server 调用方。
- `server/apps/cmdb/tests/test_node_mgmt_sync_helpers.py` 直接相关场景：32 passed，31 deselected。覆盖分页、系统身份参数、异常响应、截止时间与接入点选择。
- `server/apps/alerts/tests/test_action_target_resolve_service.py`：4 passed。
- `agents/stargazer/tests/test_collection_service_node_query.py`：3 passed，1 条依赖弃用 warning。
- Job 两个既有 DB 标记测试文件在固定基线验证环境中因未配置数据库名称停在 Django test DB setup；未进入业务断言。对应改动函数由新增纯契约测试覆盖。
- 触及文件语法检查、Flake8（排除固定基线既有 C901）、新增文件 Black/isort 与 `git diff --check` 均通过。固定基线已有的全文件 Black/isort/C901 不合规未在本 PR 扩大。

## 三轨门禁

- Standards：PASS。不可信输入封闭归一，日志严格有界，无秘密、原始 payload、新依赖或持久化变更。
- Spec：PASS。5 个仓内合法调用点全部纳入，且明确这是迁移观测首片而非最终鉴权。
- Runtime Contract：PASS。旧/新调用双向兼容，授权、响应、异常、超时、重试与回滚语义不变。
- 质量评分：96/100，`SCORE_PASS`。

评分：漏洞修复完整性 27/30、方案设计 20/20、向后兼容 15/15、测试覆盖 19/20、风险评估 15/15。
