### PR TITLE
bugfix: 收敛 CMDB 采集心跳唯一候选查询

### DIFF
--- a/server/apps/cmdb/collection/common.py
+++ b/server/apps/cmdb/collection/common.py
@@ -233,20 +233,20 @@ class Management:
         if not inst_list:
             return result
 
+        heartbeat_infos = [
+            {
+                "_id": instance_info["_id"],
+                "model_id": self.model_id,
+                "organization": self.organization,
+                "collect_task": self.task_id,
+                "auto_collect": True,
+                "collect_time": self.collect_time,
+            }
+            for instance_info in inst_list
+        ]
         with GraphClient() as ag:
-            exist_items, _ = ag.query_entity(
-                INSTANCE,
-                [{"field": "model_id", "type": "str=", "value": self.model_id}],
-            )
-            for instance_info in inst_list:
-                heartbeat_info = {
-                    "_id": instance_info["_id"],
-                    "model_id": self.model_id,
-                    "organization": self.organization,
-                    "collect_task": self.task_id,
-                    "auto_collect": True,
-                    "collect_time": self.collect_time,
-                }
+            exist_items = self._query_existing_unique_candidates(ag, heartbeat_infos)
+            for heartbeat_info in heartbeat_infos:
                 try:
                     current_items = [item for item in exist_items if item["_id"] != heartbeat_info["_id"]]
                     entity = ag.set_entity_properties(

--- a/server/apps/cmdb/tests/test_collect_management_service.py
+++ b/server/apps/cmdb/tests/test_collect_management_service.py
@@ -19,6 +19,9 @@ from apps.cmdb.collection.common import Management
 from apps.cmdb.constants.constants import DataCleanupStrategy
 
 
+pytestmark = pytest.mark.unit
+
+
 class FakeGraph:
     def __init__(self, **returns):
         self.returns = returns

--- a/server/apps/cmdb/tests/test_collect_management_svc.py
+++ b/server/apps/cmdb/tests/test_collect_management_svc.py
@@ -12,6 +12,7 @@
 企业扩展这些真实边界打桩。
 """
 import pydantic.root_model  # noqa: F401
+import pytest
 
 from apps.cmdb.collection import common as mod
 from apps.cmdb.collection.common import Management
@@ -25,6 +26,7 @@ class FakeGraph:
         self.created_edges = []
         self.deleted = []
         self.set_props = []
+        self.set_exist_items = []
         self.queries = []
 
     def __enter__(self):
@@ -51,6 +53,10 @@ class FakeGraph:
     def set_entity_properties(self, label, ids, info, check_attr_map, exist_items):
         ent = dict(info)
         self.set_props.append(ent)
+        self.set_exist_items.append([dict(item) for item in exist_items])
+        cb = self.returns.get("set_entity_properties")
+        if callable(cb):
+            return cb(label, ids, info, check_attr_map, exist_items)
         return [ent]
 
     def detach_delete_entity(self, label, _id):
@@ -95,7 +101,7 @@ def _mgmt(monkeypatch, fake, old_data, new_data, **kw):
         new_data=new_data,
         unique_keys=["inst_name"],
         collect_time="2026-06-24",
-        task_id=1,
+        task_id=kw.get("task_id", 1),
         collect_plugin=kw.get("collect_plugin"),
         data_cleanup_strategy=kw.get("data_cleanup_strategy"),
     )
@@ -316,7 +322,7 @@ def test_update_inst_queries_only_unique_candidates(monkeypatch):
     ]
 
 
-def test_refresh_heartbeat_updates_only_runtime_metadata(monkeypatch):
+def test_refresh_heartbeat_updates_only_runtime_metadata_without_querying_instances(monkeypatch):
     fake = FakeGraph(query_entity=lambda _label, c: ([{"_id": 7, "inst_name": "a"}], 1))
     m = _mgmt(monkeypatch, fake, [], [])
     scheduled = []
@@ -335,7 +341,94 @@ def test_refresh_heartbeat_updates_only_runtime_metadata(monkeypatch):
             "collect_time": "2026-06-24",
         }
     ]
+    assert fake.queries == []
+    assert fake.set_exist_items == [[]]
     assert scheduled == []
+
+
+@pytest.mark.parametrize("driver_name", ["falkordb", "neo4j"])
+def test_refresh_heartbeat_rejects_conflicting_runtime_unique_candidate(monkeypatch, driver_name):
+    from apps.cmdb.graph.falkordb import FalkorDBClient
+    from apps.cmdb.graph.neo4j import Neo4jClient
+
+    unique_checker = {
+        "falkordb": FalkorDBClient.check_unique_attr,
+        "neo4j": Neo4jClient.check_unique_attr,
+    }[driver_name]
+
+    def validate_with_real_unique_check(label, ids, info, check_attr_map, exist_items):
+        unique_checker(
+            info,
+            check_attr_map["is_only"],
+            exist_items,
+            is_update=True,
+        )
+        return [dict(info)]
+
+    fake = FakeGraph(
+        query_entity=lambda _label, c: (
+            [
+                {"_id": 7, "collect_task": "task-1"},
+                {"_id": 8, "collect_task": "task-1"},
+            ],
+            2,
+        ),
+        set_entity_properties=validate_with_real_unique_check,
+    )
+    attrs = [{"attr_id": "collect_task", "attr_name": "采集任务", "is_only": True, "editable": True}]
+    m = _mgmt(monkeypatch, fake, [], [], attrs=attrs, task_id="task-1")
+
+    result = m.refresh_heartbeat([{"_id": 7, "inst_name": "a"}])
+
+    assert fake.queries == [
+        (
+            "instance",
+            [
+                {"field": "model_id", "type": "str=", "value": "host"},
+                {"field": "collect_task", "type": "str[]", "value": ["task-1"]},
+            ],
+        )
+    ]
+    assert fake.set_exist_items == [[{"_id": 8, "collect_task": "task-1"}]]
+    assert result["success"] == []
+    assert len(result["failed"]) == 1
+    assert "采集任务 exist" in str(result["failed"][0]["error"])
+
+
+def test_refresh_heartbeat_isolates_each_write_failure(monkeypatch):
+    def fail_first_write(label, ids, info, check_attr_map, exist_items):
+        if ids == [7]:
+            raise RuntimeError("write failed")
+        return [dict(info)]
+
+    fake = FakeGraph(set_entity_properties=fail_first_write)
+    m = _mgmt(monkeypatch, fake, [], [])
+
+    result = m.refresh_heartbeat([{"_id": 7}, {"_id": 8}])
+
+    assert [item["inst_info"]["_id"] for item in result["success"]] == [8]
+    assert [item["instance_info"]["_id"] for item in result["failed"]] == [7]
+    assert "write failed" in str(result["failed"][0]["error"])
+
+
+def test_refresh_heartbeat_keeps_candidate_query_failure_batch_scoped(monkeypatch):
+    def fail_query(label, conditions):
+        raise RuntimeError("query failed")
+
+    fake = FakeGraph(query_entity=fail_query)
+    attrs = [{"attr_id": "collect_task", "attr_name": "采集任务", "is_only": True, "editable": True}]
+    m = _mgmt(monkeypatch, fake, [], [], attrs=attrs, task_id="task-1")
+
+    with pytest.raises(RuntimeError, match="query failed"):
+        m.refresh_heartbeat([{"_id": 7}])
+
+
+def test_refresh_heartbeat_keeps_missing_id_as_batch_error(monkeypatch):
+    fake = FakeGraph()
+    m = _mgmt(monkeypatch, fake, [], [])
+
+    with pytest.raises(KeyError, match="_id"):
+        m.refresh_heartbeat([{"inst_name": "missing-id"}])
 
 
 def test_controller_heartbeat_is_reported_but_excluded_from_audit(monkeypatch):
@@ -446,7 +539,7 @@ def test_controller_runs_delete_add_update(monkeypatch):
     assert len(result["add"]["success"]) == 1
 
 
-def test_controller_add_and_update_query_unique_candidates(monkeypatch):
+def test_controller_queries_only_unique_candidates_for_business_changes(monkeypatch):
     fake = FakeGraph(query_entity=lambda _label, c: ([{"_id": 1, "inst_name": "a"}], 1))
     attrs = [{"attr_id": "inst_name", "attr_name": "名称", "is_only": True, "editable": True}]
     old = [{"inst_name": "a", "_id": 1}]
@@ -461,12 +554,6 @@ def test_controller_add_and_update_query_unique_candidates(monkeypatch):
             [
                 {"field": "model_id", "type": "str=", "value": "host"},
                 {"field": "inst_name", "type": "str[]", "value": ["b"]},
-            ],
-        ),
-        (
-            "instance",
-            [
-                {"field": "model_id", "type": "str=", "value": "host"},
             ],
         ),
     ]


### PR DESCRIPTION
## 问题

CMDB 采集将“业务属性没有变化”的实例分流为心跳更新，只刷新采集运行元数据。这条路径本不需要读取同模型全部实例，却仍在每批写入前返回全集，并为每个心跳重新过滤一次，形成 `O(B×N)` 的应用扫描和无界图返回。

## 根因

心跳从普通更新路径拆出时复用了“全量候选 + 内存唯一性校验”的旧范式，没有把校验范围收敛到本次实际写入的运行字段。直接跳过校验又会破坏运行字段被配置为唯一属性时的既有拒绝语义，因此需要在“消除全集”与“保留唯一性契约”之间建立明确边界。

## 怎么修的

- 先构造本批最终写入的心跳载荷，再仅按其中实际唯一字段值查询候选。
- 无运行字段唯一约束时不发候选查询；存在约束时按本批值定向查询，并在逐项写入前排除自身。
- 继续复用原 `set_entity_properties`，保留双图驱动的唯一、必填、可编辑字段过滤，以及逐项成功/失败归集。

## 影响范围

- 仅触及 CMDB 采集心跳路径及其契约测试。
- 不改变 REST、OpenAPI、NATS、RPC、Web、Agent 载荷或权限。
- 不改变业务更新、关联维护、审计、自动关联调度和返回结构。
- 批量创建、批量更新、两类导入和动态数据库约束的系统性迁移由 #4839 继续承载。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MetricsCannula\ncollection/metrics_cannula.py"]
    end

    C["Management.controller/update"]

    subgraph N["心跳处理层"]
        N1["构造最终 heartbeat payload"]
        N2["按实际唯一字段查询候选"]
        N3["refresh_heartbeat 逐项写入"]
    end

    subgraph G["图驱动层"]
        G1["GraphClient.set_entity_properties\nFalkorDB / Neo4j"]
    end

    T1 --> C --> N1 --> N2 --> N3 --> G1
    G1 -. "单项失败" .-> N3
```

## 验证

- `apps/cmdb/tests/test_collect_management_svc.py`：31 passed。
- 回退实现后，新增的零查询与运行字段唯一性契约按预期失败，满足 revert-fail 准则。
- 固定基线在 `B=10` 时，`N=1,000/5,000` 分别扫描 `10,000/50,000` 次；首片后无唯一运行字段为零候选查询，复杂度不再固有依赖同模型总量 `N`。
- 双驱动唯一冲突、字符串任务标识、逐项写失败隔离、候选查询失败和缺失 ID 的失败边界均有契约覆盖。

## 三轨门禁

- Standards：PASS，10/10，无 P0/P1/P2。
- Spec：PASS，100/100，无 P0/P1/P2。
- Runtime Contract：PASS，10/10，无 P0/P1/P2；残余最坏为批内候选导致的 `O(B²)`，系统性治理继续由 #4839 承载。

关联 #3375，不自动关闭。
