### PR TITLE
bugfix(cmdb): 透传枚举展示刷新失败

### DIFF
--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -1291,7 +1291,7 @@ class ModelManage(object):
                 f"[update_enum_instances_display] 更新实例枚举 _display 字段失败: 模型={model_id}, 字段={attr_id}, 错误={e}",
                 exc_info=True,
             )
-            # 不抛出异常，避免中断主流程
+            raise BaseAppException("枚举属性已更新，但实例展示字段刷新失败，请重试保存") from e
 
         return updated_count
 

--- a/server/apps/cmdb/tests/test_model_service_methods.py
+++ b/server/apps/cmdb/tests/test_model_service_methods.py
@@ -331,7 +331,7 @@ def test_update_enum_instances_display(fake_graph):
 
 
 @pytest.mark.unit
-def test_update_enum_instances_display_backend_failure_is_non_blocking(fake_graph):
+def test_update_enum_instances_display_backend_failure_is_reported_after_retry(fake_graph):
     def _raise(*args, **kwargs):
         raise RuntimeError("graph unavailable")
 
@@ -341,13 +341,15 @@ def test_update_enum_instances_display_backend_failure_is_non_blocking(fake_grap
         batch_update_node_property_values=_raise,
     )
 
-    count = ModelManage.update_enum_instances_display(
-        "host",
-        "status",
-        [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}],
-    )
-
-    assert count == 0
+    with pytest.raises(
+        BaseAppException,
+        match="枚举属性已更新，但实例展示字段刷新失败，请重试保存",
+    ):
+        ModelManage.update_enum_instances_display(
+            "host",
+            "status",
+            [{"id": "1", "name": "运行"}, {"id": "2", "name": "停止"}],
+        )
 
 
 @pytest.mark.unit
@@ -506,7 +508,11 @@ def test_update_enum_instances_display_resumes_after_later_batch_failure(
     )
 
     options = [{"id": "1", "name": "运行"}]
-    assert ModelManage.update_enum_instances_display("host", "status", options) == 1000
+    with pytest.raises(
+        BaseAppException,
+        match="枚举属性已更新，但实例展示字段刷新失败，请重试保存",
+    ):
+        ModelManage.update_enum_instances_display("host", "status", options)
     assert write_calls == 3
     assert [checkpoint["cursor"] for checkpoint in enum_backfill_checkpoints.values()] == [1000]
 
@@ -609,7 +615,7 @@ def test_update_enum_instances_display_ignores_checkpoint_for_old_options(
 
 
 @pytest.mark.unit
-def test_update_enum_instances_display_cache_failure_is_non_blocking(fake_graph, monkeypatch):
+def test_update_enum_instances_display_cache_failure_is_reported(fake_graph, monkeypatch):
     def _raise_cache_error(*_args, **_kwargs):
         raise RuntimeError("cache unavailable")
 
@@ -621,11 +627,15 @@ def test_update_enum_instances_display_cache_failure_is_non_blocking(fake_graph,
         query_entity=_paged_query_entity([{"_id": 1, "status": "1"}]),
     )
 
-    assert ModelManage.update_enum_instances_display(
-        "host",
-        "status",
-        [{"id": "1", "name": "运行"}],
-    ) == 0
+    with pytest.raises(
+        BaseAppException,
+        match="枚举属性已更新，但实例展示字段刷新失败，请重试保存",
+    ):
+        ModelManage.update_enum_instances_display(
+            "host",
+            "status",
+            [{"id": "1", "name": "运行"}],
+        )
 
 
 @pytest.mark.unit

--- a/server/apps/cmdb/tests/test_model_views.py
+++ b/server/apps/cmdb/tests/test_model_views.py
@@ -13,7 +13,6 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.cmdb.models.field_group import FieldGroup
-from apps.cmdb.services.model import ModelManage
 from apps.cmdb.views.model import ModelViewSet
 from apps.core.exceptions.base_app_exception import BaseAppException
 
@@ -478,6 +477,35 @@ def test_model_attr_update_enum(superuser, monkeypatch):
     )
     assert response.status_code == status.HTTP_200_OK
     assert called.get("hit") is True
+
+
+@pytest.mark.django_db
+def test_model_attr_update_enum_propagates_display_refresh_failure(superuser, monkeypatch, fake_graph):
+    monkeypatch.setattr(f"{VIEWS}.ModelManage.search_model_info", lambda mid: {"model_id": mid, "group": [1]})
+    monkeypatch.setattr(f"{VIEWS}.ModelManage.update_model_attr", lambda *a, **k: {"attr_id": "status"})
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("graph unavailable")
+
+    pages = iter([([{"_id": 1, "status": "1"}], 1), ([], 0)])
+    fake_graph(
+        "apps.cmdb.services.model",
+        query_entity=lambda *_args, **_kwargs: next(pages),
+        batch_update_node_property_values=_raise,
+    )
+
+    with pytest.raises(
+        BaseAppException,
+        match="枚举属性已更新，但实例展示字段刷新失败，请重试保存",
+    ):
+        ModelViewSet.as_view({"put": "model_attr_update"})(
+            _req(
+                "put",
+                superuser,
+                data={"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行"}]},
+            ),
+            model_id="host",
+        )
 
 
 @pytest.mark.django_db

--- a/server/apps/cmdb/tests/test_model_views.py
+++ b/server/apps/cmdb/tests/test_model_views.py
@@ -463,24 +463,29 @@ def test_model_attr_create_ok(superuser, monkeypatch):
     assert "ip" in fg.attr_orders
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
-def test_model_attr_update_enum(superuser, monkeypatch):
+def test_model_attr_update_enum(api_client, superuser, monkeypatch, fake_graph):
     monkeypatch.setattr(f"{VIEWS}.ModelManage.search_model_info", lambda mid: {"model_id": mid, "group": [1]})
-    monkeypatch.setattr(f"{VIEWS}.ModelManage.update_model_attr", lambda *a, **k: {"attr_id": "status"})
     called = {}
-    monkeypatch.setattr(
-        f"{VIEWS}.ModelManage.update_enum_instances_display",
-        lambda mid, aid, opts: called.setdefault("hit", True),
-    )
-    response = ModelViewSet.as_view({"put": "model_attr_update"})(
-        _req("put", superuser, data={"attr_id": "status", "attr_type": "enum", "option": []}), model_id="host"
+    monkeypatch.setattr(f"{VIEWS}.ModelManage.update_model_attr", lambda *a, **k: called.setdefault("definition", {"attr_id": "status"}))
+    pages = iter([([{"_id": 1, "status": "1"}], 1), ([], 0)])
+    graph = fake_graph("apps.cmdb.services.model", query_entity=lambda *_args, **_kwargs: next(pages))
+    api_client.force_authenticate(user=superuser)
+
+    response = api_client.put(
+        "/api/v1/cmdb/api/model/host/attr_update/",
+        {"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行"}]},
+        format="json",
     )
     assert response.status_code == status.HTTP_200_OK
-    assert called.get("hit") is True
+    assert called["definition"] == {"attr_id": "status"}
+    assert any(name == "batch_update_node_property_values" for name, _args, _kwargs in graph.calls)
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
-def test_model_attr_update_enum_propagates_display_refresh_failure(superuser, monkeypatch, fake_graph):
+def test_model_attr_update_enum_propagates_display_refresh_failure(api_client, superuser, monkeypatch, fake_graph):
     monkeypatch.setattr(f"{VIEWS}.ModelManage.search_model_info", lambda mid: {"model_id": mid, "group": [1]})
     monkeypatch.setattr(f"{VIEWS}.ModelManage.update_model_attr", lambda *a, **k: {"attr_id": "status"})
 
@@ -494,18 +499,15 @@ def test_model_attr_update_enum_propagates_display_refresh_failure(superuser, mo
         batch_update_node_property_values=_raise,
     )
 
-    with pytest.raises(
-        BaseAppException,
-        match="枚举属性已更新，但实例展示字段刷新失败，请重试保存",
-    ):
-        ModelViewSet.as_view({"put": "model_attr_update"})(
-            _req(
-                "put",
-                superuser,
-                data={"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行"}]},
-            ),
-            model_id="host",
-        )
+    api_client.force_authenticate(user=superuser)
+    response = api_client.put(
+        "/api/v1/cmdb/api/model/host/attr_update/",
+        {"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行"}]},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert response.json()["message"] == "枚举属性已更新，但实例展示字段刷新失败，请重试保存"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 问题

CMDB 修改枚举属性时，模型定义会先保存，随后同步实例的 `_display` 冗余字段。图库写入在内部重试后仍失败时，原实现只记录日志并返回部分计数，接口继续按成功响应，用户会误以为展示字段已经全部刷新。

关联 Issue #3382。

## 根因

枚举定义写入与实例展示字段回填属于前后两个阶段。回填层虽然已有按枚举选项哈希隔离的断点续扫和一次图写重试，但最外层捕获了所有最终异常，破坏了“同步未完成必须可感知”的失败边界。

## 怎么修的

- 保留现有分页、批量图写、一次重试、成功游标与选项哈希断点；
- 最终图库写失败或安全断点无法读取时，抛出明确业务异常，提示枚举定义已更新并要求重试保存；
- 同一枚举修改重提时从最近成功游标续扫，避免已完成批次丢失；
- 保持成功路径的返回计数、权限校验和 API 数据结构不变。

## 影响范围与回滚

仅影响 CMDB 模型枚举属性更新的失败路径。成功请求、文件字段回填、其他模型操作和权限结果不变。Web 继续复用现有错误处理：请求失败时展示服务端消息，且不会执行成功提示或关闭编辑框。

回滚只需撤销本提交；没有数据库迁移、配置变更或存量数据重解释。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["model_attr_update\nserver/apps/cmdb/views/model.py"]
    end

    BU["保存枚举定义\nModelManage.update_model_attr"]

    subgraph N["核心处理层"]
        F1["update_enum_instances_display\nserver/apps/cmdb/services/model.py"]
        F2["批量图写 + 一次重试\nGraphClient"]
    end

    subgraph C["失败与恢复层"]
        C1["BaseAppException\n明确提示重试"]
        C2["options hash + cursor\n同配置断点续扫"]
    end

    T1 --> BU --> F1 --> F2
    F2 -. "最终失败" .-> C1
    F2 --> C2
    C1 -. "重提同一修改" .-> C2
    C2 --> F1
```

## 验证

- RED：`apps/cmdb/tests/test_model_service_methods.py` 在固定基线为 1 failed、26 passed，失败原因为最终异常未抛出；
- GREEN：`apps/cmdb/tests/test_model_service_methods.py`、`apps/cmdb/tests/test_model_views.py`、`apps/core/tests/test_middlewares_exception_timing_service.py` 共 116 passed；
- 覆盖成功路径、图写两次失败、后续批次部分成功、同配置断点续跑、断点读取失败、分页/幂等、视图传播和中间件错误响应。

## 三轨门禁

- Standards：pass，无 P0/P1/P2；
- Spec：pass，无 P0/P1/P2；
- Runtime Contract：pass，无 P0/P1/P2；
- 质量评分：96/100（SCORE_PASS）。
