### PR TITLE
bugfix: 修复内部告警组织归属可伪造

### DIFF
--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -25,14 +25,18 @@ from apps.alerts.models.alert_source import AlertSource
 from apps.alerts.models.models import Alert, Event, Incident, Level
 from apps.alerts.utils.permission_scope import apply_team_scope_with_group_ids
 from apps.core.logger import alert_logger as logger
-from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed, verify_internal_event
+from apps.core.utils.internal_event_auth import (
+    TRUSTED_INTERNAL_EVENT_CALLERS,
+    legacy_internal_event_auth_allowed,
+    verify_internal_event,
+)
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.utils.time_util import parse_rfc3339_range_utc, parse_rfc3339_utc
 from apps.core.utils.trend_granularity import resolve_trend_group_by_from_range
 from apps.core.utils.viewset_utils import GenericViewSetFun
 
 ALERT_LEVEL_DISPLAY_MAP = dict(EventLevel.CHOICES)
-TRUSTED_INTERNAL_PUSHERS = {"lite-monitor", "lite-log", "lite-apm"}
+TRUSTED_INTERNAL_PUSHERS = TRUSTED_INTERNAL_EVENT_CALLERS
 PER_EVENT_ACK_MODE = "per_event_v1"
 PER_EVENT_ACK_MAX_EVENTS = 200
 PER_EVENT_ACK_TOKEN = os.getenv("ALERTS_PER_EVENT_ACK_TOKEN", "")
@@ -847,16 +851,14 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
             normalized_events.append(normalized_event)
 
         has_internal_organizations = any("organizations" in event for event in normalized_events)
-        authenticated_internal = (
-            verify_internal_event(
-                "alerts.receive_alert_events",
-                auth_payload,
-                internal_auth,
-            )
-            or per_event_ack_authorized
+        authenticated_internal = verify_internal_event(
+            "alerts.receive_alert_events",
+            auth_payload,
+            internal_auth,
+            caller=pusher,
         )
         if pusher in TRUSTED_INTERNAL_PUSHERS and has_internal_organizations and not authenticated_internal:
-            if legacy_internal_event_auth_allowed():
+            if internal_auth is None and legacy_internal_event_auth_allowed():
                 logger.warning(
                     "[AlertEvent] legacy 无签名内部组织归属暂时放行: source_id=%s pusher=%s",
                     source_id,

--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -25,6 +25,7 @@ from apps.alerts.models.alert_source import AlertSource
 from apps.alerts.models.models import Alert, Event, Incident, Level
 from apps.alerts.utils.permission_scope import apply_team_scope_with_group_ids
 from apps.core.logger import alert_logger as logger
+from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed, verify_internal_event
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.utils.time_util import parse_rfc3339_range_utc, parse_rfc3339_utc
 from apps.core.utils.trend_granularity import resolve_trend_group_by_from_range
@@ -770,6 +771,9 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
     if kwargs.pop("health_probe", False) is True:
         return {"result": True, "data": {"status": "ok"}, "message": ""}
 
+    internal_auth = kwargs.pop("internal_auth", None)
+    auth_payload = dict(kwargs)
+
     logger.info(
         "[AlertEvent] receive_alert_events source_id=%s pusher=%s event_count=%s",
         kwargs.get("source_id", ""),
@@ -804,11 +808,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
 
         per_event_ack_authorized = False
         if ack_mode == PER_EVENT_ACK_MODE:
-            if (
-                pusher not in TRUSTED_INTERNAL_PUSHERS
-                or not PER_EVENT_ACK_TOKEN
-                or not secrets.compare_digest(str(ack_token), PER_EVENT_ACK_TOKEN)
-            ):
+            if pusher not in TRUSTED_INTERNAL_PUSHERS or not PER_EVENT_ACK_TOKEN or not secrets.compare_digest(str(ack_token), PER_EVENT_ACK_TOKEN):
                 logger.warning("[AlertEvent] 非可信 pusher 不允许逐事件 ACK: pusher=%s", pusher)
                 return {"result": False, "data": {}, "message": "Per-event acknowledgement is restricted."}
             if len(events) > PER_EVENT_ACK_MAX_EVENTS:
@@ -845,6 +845,36 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 normalized_event.pop("lifecycle_action", None)
                 normalized_event.pop("lifecycle_generation", None)
             normalized_events.append(normalized_event)
+
+        has_internal_organizations = any("organizations" in event for event in normalized_events)
+        authenticated_internal = (
+            verify_internal_event(
+                "alerts.receive_alert_events",
+                auth_payload,
+                internal_auth,
+            )
+            or per_event_ack_authorized
+        )
+        if pusher in TRUSTED_INTERNAL_PUSHERS and has_internal_organizations and not authenticated_internal:
+            if legacy_internal_event_auth_allowed():
+                logger.warning(
+                    "[AlertEvent] legacy 无签名内部组织归属暂时放行: source_id=%s pusher=%s",
+                    source_id,
+                    pusher,
+                )
+            else:
+                logger.warning(
+                    "[AlertEvent] 拒绝无认证内部组织归属: source_id=%s pusher=%s",
+                    source_id,
+                    pusher,
+                )
+                return {
+                    "result": False,
+                    "code": "internal_auth_required",
+                    "retryable": False,
+                    "data": {},
+                    "message": "Internal alert event authentication failed.",
+                }
 
         # 内部约定：NATS 生效源（event_source 已校验）+ 明确允许的内部推送方，双重判断为可信内部推送。
         # 此时采信每个 event 自带的 organizations 作为归属组织，无需走组织级 secret。
@@ -885,8 +915,7 @@ def receive_alert_events(*args, **kwargs) -> Dict[str, Any]:
                 ingestions.append(single_ingestion)
                 event_results.append(_event_ack(delivery_id, single_ingestion))
             ingestion = {
-                key: sum(item.get(key, 0) for item in ingestions)
-                for key in ("received", "accepted", "skipped", "errored", "duplicates", "rejected")
+                key: sum(item.get(key, 0) for item in ingestions) for key in ("received", "accepted", "skipped", "errored", "duplicates", "rejected")
             }
         else:
             ingestion = adapter.main() or {

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -11,6 +11,15 @@ from django.utils import timezone
 from apps.alerts.constants.constants import AlertStatus, LevelType
 from apps.alerts.models.models import Alert, Event, Incident, Level
 from apps.alerts.nats import nats as N
+from apps.core.utils.internal_event_auth import sign_internal_event
+
+
+def _receive_internal(**payload):
+    return N.receive_alert_events(
+        **payload,
+        internal_auth=sign_internal_event("alerts.receive_alert_events", payload),
+    )
+
 
 # --------------------------------------------------------------------------
 # 纯辅助函数
@@ -1282,6 +1291,43 @@ def test_receive_alert_events_success():
     assert Event.objects.filter(title="事件A").exists()
 
 
+@pytest.mark.django_db
+def test_receive_alert_events_rejects_forged_internal_pusher_without_auth(monkeypatch):
+    from apps.alerts.models.alert_source import AlertSource
+
+    for lid in (0, 1, 2, 3):
+        Level.objects.create(level_id=lid, level_name=f"L{lid}", level_display_name=f"等级{lid}", level_type=LevelType.EVENT)
+    AlertSource.objects.create(
+        name="nats伪造来源",
+        source_id="nats-forged",
+        source_type="nats",
+        secret="x",
+        team_secrets={},
+        is_active=True,
+        is_effective=True,
+        config={"event_fields_mapping": {"title": "title", "level": "level", "item": "item", "start_time": "start_time"}},
+    )
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+
+    result = N.receive_alert_events(
+        source_id="nats-forged",
+        pusher="lite-monitor",
+        events=[
+            {
+                "title": "forged",
+                "level": "0",
+                "item": "cpu",
+                "start_time": "1700000000",
+                "organizations": [99],
+            }
+        ],
+    )
+
+    assert result["result"] is False
+    assert result["code"] == "internal_auth_required"
+    assert Event.objects.filter(title="forged").exists() is False
+
+
 @pytest.mark.parametrize("pusher", ["lite-monitor", "lite-log", "lite-apm"])
 @pytest.mark.django_db
 def test_receive_alert_events_allows_whitelisted_internal_organizations_without_source_registration(pusher):
@@ -1317,7 +1363,7 @@ def test_receive_alert_events_allows_whitelisted_internal_organizations_without_
         }
     ]
 
-    result = N.receive_alert_events(
+    result = _receive_internal(
         source_id="nats",
         events=events,
         pusher=pusher,
@@ -1388,7 +1434,7 @@ def test_receive_alert_events_real_adapter_preserves_partial_contract_and_safe_l
         {"description": marker, "secret": marker, "organizations": [3]},
     ]
 
-    result = N.receive_alert_events(
+    result = _receive_internal(
         source_id="nats-real-partial",
         events=events,
         pusher=pusher,
@@ -1500,7 +1546,7 @@ def test_receive_alert_events_legacy_pusher_cannot_set_lifecycle_identity(monkey
 
     monkeypatch.setattr(N.AlertSourceAdapterFactory, "get_adapter", staticmethod(lambda source: FakeAdapter))
 
-    result = N.receive_alert_events(
+    result = _receive_internal(
         source_id="nats-legacy",
         events=[
             {
@@ -1537,6 +1583,7 @@ def test_receive_alert_events_per_event_ack_rejects_untrusted_and_bounds_batches
         is_active=True,
         is_effective=True,
     )
+
     class FakeAdapter:
         def __init__(self, events, trusted_internal, **kwargs):
             pass
@@ -1595,7 +1642,7 @@ def test_receive_alert_events_marks_lite_log_as_trusted_internal(mocker):
     adapter_class = mocker.Mock(return_value=adapter)
     mocker.patch.object(N.AlertSourceAdapterFactory, "get_adapter", return_value=adapter_class)
 
-    result = N.receive_alert_events(
+    result = _receive_internal(
         source_id="nats",
         pusher="lite-log",
         events=[{"title": "日志错误", "organizations": [3]}],
@@ -1630,7 +1677,7 @@ def test_receive_alert_events_does_not_log_event_payload_or_secret(mocker):
     mocker.patch.object(N.AlertSourceAdapterFactory, "get_adapter", return_value=adapter_class)
     info = mocker.patch.object(N.logger, "info")
 
-    N.receive_alert_events(
+    _receive_internal(
         source_id="nats",
         pusher="lite-log",
         events=[{"title": "sensitive-log-content", "organizations": [3], "secret": "event-secret"}],

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -17,7 +17,7 @@ from apps.core.utils.internal_event_auth import sign_internal_event
 def _receive_internal(**payload):
     return N.receive_alert_events(
         **payload,
-        internal_auth=sign_internal_event("alerts.receive_alert_events", payload),
+        internal_auth=sign_internal_event("alerts.receive_alert_events", payload, caller=payload["pusher"]),
     )
 
 
@@ -1291,6 +1291,7 @@ def test_receive_alert_events_success():
     assert Event.objects.filter(title="事件A").exists()
 
 
+@pytest.mark.integration
 @pytest.mark.django_db
 def test_receive_alert_events_rejects_forged_internal_pusher_without_auth(monkeypatch):
     from apps.alerts.models.alert_source import AlertSource
@@ -1307,7 +1308,7 @@ def test_receive_alert_events_rejects_forged_internal_pusher_without_auth(monkey
         is_effective=True,
         config={"event_fields_mapping": {"title": "title", "level": "level", "item": "item", "start_time": "start_time"}},
     )
-    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
 
     result = N.receive_alert_events(
         source_id="nats-forged",
@@ -1328,8 +1329,87 @@ def test_receive_alert_events_rejects_forged_internal_pusher_without_auth(monkey
     assert Event.objects.filter(title="forged").exists() is False
 
 
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_receive_alert_events_rejects_invalid_signature_during_rolling_upgrade(monkeypatch):
+    from apps.alerts.models.alert_source import AlertSource
+
+    for lid in (0, 1, 2, 3):
+        Level.objects.create(level_id=lid, level_name=f"L{lid}", level_display_name=f"等级{lid}", level_type=LevelType.EVENT)
+    AlertSource.objects.create(
+        name="nats 篡改来源",
+        source_id="nats-tampered",
+        source_type="nats",
+        secret="x",
+        team_secrets={},
+        is_active=True,
+        is_effective=True,
+        config={"event_fields_mapping": {"title": "title", "level": "level", "item": "item", "start_time": "start_time"}},
+    )
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    payload = {
+        "source_id": "nats-tampered",
+        "pusher": "lite-monitor",
+        "events": [
+            {
+                "title": "tampered",
+                "level": "0",
+                "item": "cpu",
+                "start_time": "1700000000",
+                "organizations": [3],
+            }
+        ],
+    }
+    internal_auth = sign_internal_event("alerts.receive_alert_events", payload, caller="lite-monitor")
+    internal_auth["signature"] = "0" * 64
+
+    result = N.receive_alert_events(**payload, internal_auth=internal_auth)
+
+    assert result["result"] is False
+    assert result["code"] == "internal_auth_required"
+    assert Event.objects.filter(title="tampered").exists() is False
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_receive_alert_events_legacy_sender_remains_available_for_rolling_upgrade(monkeypatch):
+    from apps.alerts.models.alert_source import AlertSource
+
+    for lid in (0, 1, 2, 3):
+        Level.objects.create(level_id=lid, level_name=f"L{lid}", level_display_name=f"等级{lid}", level_type=LevelType.EVENT)
+    AlertSource.objects.create(
+        name="nats legacy 来源",
+        source_id="nats-legacy-rolling",
+        source_type="nats",
+        secret="x",
+        team_secrets={},
+        is_active=True,
+        is_effective=True,
+        config={"event_fields_mapping": {"title": "title", "level": "level", "item": "item", "start_time": "start_time"}},
+    )
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+
+    result = N.receive_alert_events(
+        source_id="nats-legacy-rolling",
+        pusher="lite-monitor",
+        events=[
+            {
+                "title": "legacy",
+                "level": "0",
+                "item": "cpu",
+                "start_time": "1700000000",
+                "organizations": [3],
+            }
+        ],
+    )
+
+    assert result["result"] is True
+    assert Event.objects.filter(title="legacy").exists() is True
+
+
 @pytest.mark.parametrize("pusher", ["lite-monitor", "lite-log", "lite-apm"])
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_allows_whitelisted_internal_organizations_without_source_registration(pusher):
     """内部白名单来源直推不依赖 NATS 告警源预先登记组织。"""
     from apps.alerts.constants.constants import LevelType
@@ -1408,6 +1488,7 @@ def test_receive_alert_events_reports_partial_ingestion(monkeypatch):
 
 @pytest.mark.parametrize("pusher", ["lite-monitor", "lite-log", "lite-apm"])
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_real_adapter_preserves_partial_contract_and_safe_log(pusher, caplog):
     from apps.alerts.models.alert_source import AlertSource
 
@@ -1492,6 +1573,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
         staticmethod(lambda source: FakeAdapter),
     )
     monkeypatch.setattr(N, "PER_EVENT_ACK_TOKEN", "receiver-secret")
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
     events = [
         {
             "delivery_id": "d1",
@@ -1522,6 +1604,7 @@ def test_receive_alert_events_per_event_ack_is_opt_in_and_identity_preserving(mo
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_legacy_pusher_cannot_set_lifecycle_identity(monkeypatch):
     """旧批量协议保留普通字段兼容，但不能仅凭 pusher 提升生命周期身份。"""
     from apps.alerts.models.alert_source import AlertSource
@@ -1615,15 +1698,25 @@ def test_receive_alert_events_per_event_ack_rejects_untrusted_and_bounds_batches
         ack_mode=N.PER_EVENT_ACK_MODE,
         ack_token="receiver-secret",
     )
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    unsigned_organization = N.receive_alert_events(
+        source_id="nats-ack-bound",
+        events=[{"delivery_id": "d", "organizations": [3]}],
+        pusher="lite-monitor",
+        ack_mode=N.PER_EVENT_ACK_MODE,
+        ack_token="receiver-secret",
+    )
 
     assert untrusted["result"] is False
     assert "restricted" in untrusted["message"]
     assert wrong_token["result"] is False
     assert oversized["result"] is False
     assert oversized["data"]["max_events"] == N.PER_EVENT_ACK_MAX_EVENTS
+    assert unsigned_organization["code"] == "internal_auth_required"
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_marks_lite_log_as_trusted_internal(mocker):
     from apps.alerts.models.alert_source import AlertSource
 
@@ -1659,6 +1752,7 @@ def test_receive_alert_events_marks_lite_log_as_trusted_internal(mocker):
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_receive_alert_events_does_not_log_event_payload_or_secret(mocker):
     from apps.alerts.models.alert_source import AlertSource
 

--- a/server/apps/apm/adapters/notifications.py
+++ b/server/apps/apm/adapters/notifications.py
@@ -23,6 +23,7 @@ class SystemMgmtNotificationDispatcher:
                 title=delivery.title,
                 body=delivery.body,
                 event_payload=dict(delivery.event_payload),
+                internal_caller="lite-apm",
             )
         except Exception:
             return NotificationDeliveryResult(

--- a/server/apps/apm/tests/test_notification_adapter.py
+++ b/server/apps/apm/tests/test_notification_adapter.py
@@ -1,5 +1,9 @@
+import pytest
+
 from apps.apm.adapters import SystemMgmtNotificationDispatcher
 from apps.apm.services.contracts import NotificationDelivery
+
+pytestmark = pytest.mark.unit
 
 
 class FakeClient:
@@ -46,6 +50,7 @@ def test_dispatcher_uses_public_system_management_contract():
         "title": "APM 告警",
         "body": "checkout 错误率过高",
         "event_payload": {"title": "APM 告警", "action": "created"},
+        "internal_caller": "lite-apm",
     }]
 
 

--- a/server/apps/core/tests/test_internal_event_auth_service.py
+++ b/server/apps/core/tests/test_internal_event_auth_service.py
@@ -12,19 +12,21 @@ def test_internal_event_auth_rejects_tampering_and_expiry(settings):
     payload = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]}
     now = int(time.time())
 
-    auth = sign_internal_event("alerts.receive_alert_events", payload, now=now)
+    auth = sign_internal_event("alerts.receive_alert_events", payload, caller="lite-monitor", now=now)
 
-    assert verify_internal_event("alerts.receive_alert_events", payload, auth, now=now) is True
+    assert verify_internal_event("alerts.receive_alert_events", payload, auth, caller="lite-monitor", now=now) is True
+    assert verify_internal_event("alerts.receive_alert_events", payload, auth, caller="lite-log", now=now) is False
     assert (
         verify_internal_event(
             "alerts.receive_alert_events",
             {**payload, "events": [{"organizations": [99]}]},
             auth,
+            caller="lite-monitor",
             now=now,
         )
         is False
     )
-    assert verify_internal_event("alerts.receive_alert_events", payload, auth, now=now + 301) is False
+    assert verify_internal_event("alerts.receive_alert_events", payload, auth, caller="lite-monitor", now=now + 301) is False
 
 
 def test_internal_event_auth_accepts_previous_rotation_key(settings, monkeypatch):
@@ -36,6 +38,7 @@ def test_internal_event_auth_accepts_previous_rotation_key(settings, monkeypatch
     auth = sign_internal_event(
         "system_mgmt.send_msg_with_channel",
         payload,
+        caller="lite-log",
         now=now,
         key="old-secret",
     )
@@ -46,17 +49,135 @@ def test_internal_event_auth_accepts_previous_rotation_key(settings, monkeypatch
             "system_mgmt.send_msg_with_channel",
             payload,
             auth,
+            caller="lite-log",
             now=now,
         )
         is True
     )
 
 
-def test_legacy_internal_event_auth_requires_explicit_rollback_switch(monkeypatch):
+def test_internal_event_auth_caller_keys_prevent_cross_service_impersonation(settings, monkeypatch):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "shared-fallback"
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-secret")
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_LOG_KEY", "log-secret")
+    payload = {"events": [{"organizations": [3]}]}
+    now = int(time.time())
+    monitor_auth = sign_internal_event("alerts.receive_alert_events", payload, caller="lite-monitor", now=now)
+    forged_log_auth = {**monitor_auth, "caller": "lite-log"}
+    log_key_claiming_monitor = sign_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        caller="lite-monitor",
+        now=now,
+        key="log-secret",
+    )
+
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, monitor_auth, caller="lite-monitor", now=now
+    ) is True
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, forged_log_auth, caller="lite-log", now=now
+    ) is False
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, log_key_claiming_monitor, caller="lite-monitor", now=now
+    ) is False
+
+
+def test_internal_event_auth_accepts_caller_previous_rotation_key(settings, monkeypatch):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "unrelated-fallback"
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-current")
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_PREVIOUS_KEY", "monitor-previous")
+    payload = {"events": [{"organizations": [3]}]}
+    now = int(time.time())
+    previous_auth = sign_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        caller="lite-monitor",
+        now=now,
+        key="monitor-previous",
+    )
+
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, previous_auth, caller="lite-monitor", now=now
+    ) is True
+
+
+def test_internal_event_auth_caller_key_receiver_accepts_global_key_during_migration(settings, monkeypatch):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "global-old-key"
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-new-key")
+    payload = {"events": [{"organizations": [3]}]}
+    now = int(time.time())
+    old_producer_auth = sign_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        caller="lite-monitor",
+        now=now,
+        key="global-old-key",
+    )
+
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, old_producer_auth, caller="lite-monitor", now=now
+    ) is True
+
+
+def test_internal_event_auth_rejects_shared_keys_after_strict_caller_key_cutover(settings, monkeypatch):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "django-still-nonempty"
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_KEY", "global-old-key")
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-new-key")
+    payload = {"events": [{"organizations": [3]}]}
+    now = int(time.time())
+    old_global_auth = sign_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        caller="lite-monitor",
+        now=now,
+        key="global-old-key",
+    )
+    old_django_auth = sign_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        caller="lite-monitor",
+        now=now,
+        key="django-still-nonempty",
+    )
+
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, old_global_auth, caller="lite-monitor", now=now
+    ) is False
+    assert verify_internal_event(
+        "alerts.receive_alert_events", payload, old_django_auth, caller="lite-monitor", now=now
+    ) is False
+
+
+def test_internal_event_auth_rejects_empty_key(monkeypatch):
+    from types import SimpleNamespace
+
+    from apps.core.utils import internal_event_auth
+
+    monkeypatch.setattr(internal_event_auth, "settings", SimpleNamespace(SECRET_KEY=""))
+    monkeypatch.delenv("ALERTS_INTERNAL_EVENT_AUTH_KEY", raising=False)
+    monkeypatch.delenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="key is not configured"):
+        internal_event_auth.sign_internal_event("alerts.receive_alert_events", {}, caller="lite-monitor")
+    assert internal_event_auth.verify_internal_event("alerts.receive_alert_events", {}, {}, caller="lite-monitor") is False
+
+
+def test_legacy_internal_event_auth_defaults_to_rolling_compatibility(monkeypatch):
     from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed
 
     monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
-    assert legacy_internal_event_auth_allowed() is False
-
-    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "true")
     assert legacy_internal_event_auth_allowed() is True
+
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    assert legacy_internal_event_auth_allowed() is False

--- a/server/apps/core/tests/test_internal_event_auth_service.py
+++ b/server/apps/core/tests/test_internal_event_auth_service.py
@@ -1,0 +1,62 @@
+import time
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_internal_event_auth_rejects_tampering_and_expiry(settings):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "test-secret"
+    payload = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]}
+    now = int(time.time())
+
+    auth = sign_internal_event("alerts.receive_alert_events", payload, now=now)
+
+    assert verify_internal_event("alerts.receive_alert_events", payload, auth, now=now) is True
+    assert (
+        verify_internal_event(
+            "alerts.receive_alert_events",
+            {**payload, "events": [{"organizations": [99]}]},
+            auth,
+            now=now,
+        )
+        is False
+    )
+    assert verify_internal_event("alerts.receive_alert_events", payload, auth, now=now + 301) is False
+
+
+def test_internal_event_auth_accepts_previous_rotation_key(settings, monkeypatch):
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
+
+    settings.SECRET_KEY = "new-secret"
+    payload = {"channel_id": 7, "content": {"events": []}}
+    now = int(time.time())
+    auth = sign_internal_event(
+        "system_mgmt.send_msg_with_channel",
+        payload,
+        now=now,
+        key="old-secret",
+    )
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_PREVIOUS_KEY", "old-secret")
+
+    assert (
+        verify_internal_event(
+            "system_mgmt.send_msg_with_channel",
+            payload,
+            auth,
+            now=now,
+        )
+        is True
+    )
+
+
+def test_legacy_internal_event_auth_requires_explicit_rollback_switch(monkeypatch):
+    from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed
+
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    assert legacy_internal_event_auth_allowed() is False
+
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "true")
+    assert legacy_internal_event_auth_allowed() is True

--- a/server/apps/core/utils/internal_event_auth.py
+++ b/server/apps/core/utils/internal_event_auth.py
@@ -1,0 +1,69 @@
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Any
+
+from django.conf import settings
+
+AUTH_VERSION = "hmac-sha256-v1"
+DEFAULT_MAX_AGE_SECONDS = 300
+
+
+def _auth_key(key: str | None = None) -> str:
+    return key or os.getenv("ALERTS_INTERNAL_EVENT_AUTH_KEY") or settings.SECRET_KEY
+
+
+def _signature(scope: str, payload: dict[str, Any], timestamp: int, key: str) -> str:
+    canonical_payload = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    message = f"{AUTH_VERSION}\n{scope}\n{timestamp}\n{canonical_payload}".encode()
+    return hmac.new(key.encode(), message, hashlib.sha256).hexdigest()
+
+
+def sign_internal_event(
+    scope: str,
+    payload: dict[str, Any],
+    *,
+    now: int | None = None,
+    key: str | None = None,
+) -> dict[str, Any]:
+    timestamp = int(time.time()) if now is None else int(now)
+    return {
+        "version": AUTH_VERSION,
+        "timestamp": timestamp,
+        "signature": _signature(scope, payload, timestamp, _auth_key(key)),
+    }
+
+
+def verify_internal_event(
+    scope: str,
+    payload: dict[str, Any],
+    auth: Any,
+    *,
+    now: int | None = None,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+) -> bool:
+    if not isinstance(auth, dict) or auth.get("version") != AUTH_VERSION:
+        return False
+    timestamp = auth.get("timestamp")
+    signature = auth.get("signature")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int) or not isinstance(signature, str):
+        return False
+    current_time = int(time.time()) if now is None else int(now)
+    if abs(current_time - timestamp) > max_age_seconds:
+        return False
+
+    keys = [_auth_key()]
+    previous_key = os.getenv("ALERTS_INTERNAL_EVENT_AUTH_PREVIOUS_KEY", "")
+    if previous_key and previous_key not in keys:
+        keys.append(previous_key)
+    return any(hmac.compare_digest(signature, _signature(scope, payload, timestamp, key)) for key in keys)
+
+
+def legacy_internal_event_auth_allowed() -> bool:
+    return os.getenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+    }

--- a/server/apps/core/utils/internal_event_auth.py
+++ b/server/apps/core/utils/internal_event_auth.py
@@ -9,30 +9,86 @@ from django.conf import settings
 
 AUTH_VERSION = "hmac-sha256-v1"
 DEFAULT_MAX_AGE_SECONDS = 300
+TRUSTED_INTERNAL_EVENT_CALLERS = frozenset({"lite-monitor", "lite-log", "lite-apm", "lite-patch"})
+AUTH_PAYLOAD_FIELDS = {
+    "system_mgmt.dispatch_notification": (
+        "delivery_key",
+        "channel_id",
+        "organization_ids",
+        "recipients",
+        "title",
+        "body",
+        "event_payload",
+        "required_delivery_mode",
+        "producer",
+        "ack_mode",
+        "ack_token",
+    ),
+    "system_mgmt.send_msg_with_channel": (
+        "channel_id",
+        "title",
+        "content",
+        "receivers",
+        "attachments",
+    ),
+}
 
 
-def _auth_key(key: str | None = None) -> str:
-    return key or os.getenv("ALERTS_INTERNAL_EVENT_AUTH_KEY") or settings.SECRET_KEY
+def build_internal_event_payload(scope: str, values: dict[str, Any]) -> dict[str, Any]:
+    """按单一字段表构造跨边界验签载荷，避免 sender/receiver 漂移。"""
+    fields = AUTH_PAYLOAD_FIELDS.get(scope)
+    if fields is None:
+        raise ValueError("Internal event authentication scope is not registered.")
+    return {field: values.get(field) for field in fields}
 
 
-def _signature(scope: str, payload: dict[str, Any], timestamp: int, key: str) -> str:
+def _caller_key_env(caller: str, suffix: str) -> str:
+    normalized_caller = caller.upper().replace("-", "_")
+    return f"ALERTS_INTERNAL_EVENT_AUTH_{normalized_caller}_{suffix}"
+
+
+def _auth_keys(caller: str) -> list[str]:
+    keys = []
+    candidates = [os.getenv(_caller_key_env(caller, "KEY"))]
+    if legacy_internal_event_auth_allowed():
+        candidates.extend((os.getenv("ALERTS_INTERNAL_EVENT_AUTH_KEY"), settings.SECRET_KEY))
+    for key in candidates:
+        if key and key not in keys:
+            keys.append(key)
+    return keys
+
+
+def _auth_key(caller: str, key: str | None = None) -> str:
+    if key:
+        return key
+    keys = _auth_keys(caller)
+    if not keys:
+        raise ValueError("Internal event authentication key is not configured.")
+    return keys[0]
+
+
+def _signature(scope: str, caller: str, payload: dict[str, Any], timestamp: int, key: str) -> str:
     canonical_payload = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
-    message = f"{AUTH_VERSION}\n{scope}\n{timestamp}\n{canonical_payload}".encode()
+    message = f"{AUTH_VERSION}\n{scope}\n{caller}\n{timestamp}\n{canonical_payload}".encode()
     return hmac.new(key.encode(), message, hashlib.sha256).hexdigest()
 
 
 def sign_internal_event(
     scope: str,
     payload: dict[str, Any],
+    caller: str,
     *,
     now: int | None = None,
     key: str | None = None,
 ) -> dict[str, Any]:
+    if caller not in TRUSTED_INTERNAL_EVENT_CALLERS:
+        raise ValueError("Internal event caller is not trusted.")
     timestamp = int(time.time()) if now is None else int(now)
     return {
         "version": AUTH_VERSION,
+        "caller": caller,
         "timestamp": timestamp,
-        "signature": _signature(scope, payload, timestamp, _auth_key(key)),
+        "signature": _signature(scope, caller, payload, timestamp, _auth_key(caller, key)),
     }
 
 
@@ -40,11 +96,17 @@ def verify_internal_event(
     scope: str,
     payload: dict[str, Any],
     auth: Any,
+    caller: str,
     *,
     now: int | None = None,
     max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
 ) -> bool:
-    if not isinstance(auth, dict) or auth.get("version") != AUTH_VERSION:
+    if (
+        caller not in TRUSTED_INTERNAL_EVENT_CALLERS
+        or not isinstance(auth, dict)
+        or auth.get("version") != AUTH_VERSION
+        or auth.get("caller") != caller
+    ):
         return False
     timestamp = auth.get("timestamp")
     signature = auth.get("signature")
@@ -54,15 +116,18 @@ def verify_internal_event(
     if abs(current_time - timestamp) > max_age_seconds:
         return False
 
-    keys = [_auth_key()]
-    previous_key = os.getenv("ALERTS_INTERNAL_EVENT_AUTH_PREVIOUS_KEY", "")
-    if previous_key and previous_key not in keys:
-        keys.append(previous_key)
-    return any(hmac.compare_digest(signature, _signature(scope, payload, timestamp, key)) for key in keys)
+    keys = _auth_keys(caller)
+    if not keys:
+        return False
+    previous_keys = [os.getenv(_caller_key_env(caller, "PREVIOUS_KEY"), "")]
+    if legacy_internal_event_auth_allowed():
+        previous_keys.append(os.getenv("ALERTS_INTERNAL_EVENT_AUTH_PREVIOUS_KEY", ""))
+    keys.extend(key for key in previous_keys if key and key not in keys)
+    return any(hmac.compare_digest(signature, _signature(scope, caller, payload, timestamp, key)) for key in keys)
 
 
 def legacy_internal_event_auth_allowed() -> bool:
-    return os.getenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false").lower() in {
+    return os.getenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "true").lower() in {
         "1",
         "true",
         "yes",

--- a/server/apps/log/services/alert_lifecycle_notify.py
+++ b/server/apps/log/services/alert_lifecycle_notify.py
@@ -174,6 +174,7 @@ class LogAlertLifecycleNotifier:
                     "",
                     envelope,
                     [],
+                    internal_caller="lite-log",
                 )
                 success, error_message = self._parse_channel_result(send_result)
                 if success:

--- a/server/apps/log/tests/test_alert_lifecycle_notify.py
+++ b/server/apps/log/tests/test_alert_lifecycle_notify.py
@@ -6,7 +6,7 @@ from apps.log.models.policy import Alert, Event, Policy, PolicyOrganization
 from apps.log.services.alert_lifecycle_notify import LogAlertLifecycleNotifier
 from apps.system_mgmt.models.channel import Channel
 
-pytestmark = pytest.mark.django_db
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
 
 def _make_policy(channel, **overrides):
@@ -193,6 +193,7 @@ def test_notify_created_sends_standard_envelope_without_notice_users(alert_cente
     assert envelope["pusher"] == "lite-log"
     assert envelope["events"][0]["action"] == "created"
     assert users == []
+    assert send.call_args.kwargs == {"internal_caller": "lite-log"}
 
 
 @pytest.mark.parametrize(

--- a/server/apps/monitor/services/alert_center_delivery.py
+++ b/server/apps/monitor/services/alert_center_delivery.py
@@ -278,6 +278,7 @@ def deliver_alert_center_delivery(record_id):
             producer="lite-monitor",
             ack_mode="per_event_v1",
             ack_token=ALERT_CENTER_ACK_TOKEN,
+            internal_caller="lite-monitor",
         )
         success, retryable, error = _ack_result(send_result, delivery_id)
     except Exception as exc:

--- a/server/apps/monitor/services/alert_lifecycle_notify.py
+++ b/server/apps/monitor/services/alert_lifecycle_notify.py
@@ -474,7 +474,9 @@ class AlertLifecycleNotifier:
         error_msg = ""
         event_results = {}
         try:
-            send_result = SystemMgmtUtils.send_msg_with_channel(channel_id, "", content, [])
+            send_result = SystemMgmtUtils.send_msg_with_channel(
+                channel_id, "", content, [], internal_caller="lite-monitor"
+            )
             success, error_msg = self._parse_channel_result(send_result)
             if use_per_event_ack and isinstance(send_result, dict):
                 details = send_result.get("data") or {}

--- a/server/apps/monitor/tests/test_system_mgmt_api_service.py
+++ b/server/apps/monitor/tests/test_system_mgmt_api_service.py
@@ -127,3 +127,13 @@ def test_send_msg_with_channel_passthrough_returns_full_result():
         out = SystemMgmtUtils.send_msg_with_channel(7, "t", "c", ["r"])
     inst.send_msg_with_channel.assert_called_once_with(7, "t", "c", ["r"])
     assert out == {"result": True}
+
+
+def test_send_msg_with_channel_forwards_internal_caller_only_when_explicit():
+    with patch("apps.monitor.utils.system_mgmt_api.SystemMgmt") as MockSM:
+        inst = MockSM.return_value
+        inst.send_msg_with_channel.return_value = {"result": True}
+        SystemMgmtUtils.send_msg_with_channel(7, "", {"pusher": "lite-monitor"}, [], internal_caller="lite-monitor")
+    inst.send_msg_with_channel.assert_called_once_with(
+        7, "", {"pusher": "lite-monitor"}, [], internal_caller="lite-monitor"
+    )

--- a/server/apps/monitor/utils/system_mgmt_api.py
+++ b/server/apps/monitor/utils/system_mgmt_api.py
@@ -73,8 +73,9 @@ class SystemMgmtUtils:
         return result["data"]
 
     @staticmethod
-    def send_msg_with_channel(channel_id, title, content, receivers):
-        result = SystemMgmt().send_msg_with_channel(channel_id, title, content, receivers)
+    def send_msg_with_channel(channel_id, title, content, receivers, *, internal_caller=""):
+        kwargs = {"internal_caller": internal_caller} if internal_caller else {}
+        result = SystemMgmt().send_msg_with_channel(channel_id, title, content, receivers, **kwargs)
         return result
 
     @staticmethod

--- a/server/apps/patch_mgmt/tasks.py
+++ b/server/apps/patch_mgmt/tasks.py
@@ -206,7 +206,8 @@ def send_assessment_notification_delivery(delivery_id: int) -> None:
                 "body": delivery.content,
                 "event_payload": event_payload,
                 "required_delivery_mode": "alert_event_copy",
-                "producer": "lite-monitor",
+                "producer": "lite-patch",
+                "internal_caller": "lite-patch",
             }
             if ALERT_CENTER_ACK_TOKEN:
                 dispatch_kwargs.update(

--- a/server/apps/patch_mgmt/tests/test_periodic_assessment_notification_service.py
+++ b/server/apps/patch_mgmt/tests/test_periodic_assessment_notification_service.py
@@ -256,6 +256,7 @@ def test_missing_host_result_is_counted_as_assessment_failure():
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_notification_delivery_dispatches_with_alert_event_contract_and_marks_delivered(mocker):
     """投递任务应调用系统管理渠道，成功后持久化投递事实。"""
     task = GovernanceTask.objects.create(
@@ -338,7 +339,8 @@ def test_notification_delivery_dispatches_with_alert_event_contract_and_marks_de
             },
         },
         required_delivery_mode="alert_event_copy",
-        producer="lite-monitor",
+        producer="lite-patch",
+        internal_caller="lite-patch",
         ack_mode="per_event_v1",
         ack_token="receiver-secret",
     )

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -1,3 +1,4 @@
+from apps.core.utils.internal_event_auth import sign_internal_event
 from apps.rpc.base import AppClient
 
 
@@ -322,10 +323,17 @@ class SystemMgmt(object):
             "ack_mode": ack_mode,
             "ack_token": ack_token,
         }
-        if not any((required_delivery_mode, ack_mode, ack_token)) and producer == "lite-apm":
-            return self.client.run("dispatch_notification", **payload)
+        request_payload = {**payload, **extensions}
+        internal_auth = sign_internal_event(
+            "system_mgmt.dispatch_notification",
+            request_payload,
+        )
         try:
-            return self.client.run("dispatch_notification", **payload, **extensions)
+            return self.client.run(
+                "dispatch_notification",
+                **request_payload,
+                internal_auth=internal_auth,
+            )
         except TypeError as exc:
             # An old receiver rejects unknown kwargs before any side effect. Retry
             # once with the historical contract during receiver-first rollouts.
@@ -387,15 +395,27 @@ class SystemMgmt(object):
             [{"filename": "文件名.pdf", "content": "base64编码的文件内容"}, ...]
             注意: 附件内容必须是base64编码的字符串，因为NATS使用JSON序列化传输
         """
-        return_data = self.client.run(
-            "send_msg_with_channel",
-            channel_id=channel_id,
-            title=title,
-            content=content,
-            receivers=receivers,
-            attachments=attachments,
+        request_payload = {
+            "channel_id": channel_id,
+            "title": title,
+            "content": content,
+            "receivers": receivers,
+            "attachments": attachments,
+        }
+        internal_auth = sign_internal_event(
+            "system_mgmt.send_msg_with_channel",
+            request_payload,
         )
-        return return_data
+        try:
+            return self.client.run(
+                "send_msg_with_channel",
+                **request_payload,
+                internal_auth=internal_auth,
+            )
+        except TypeError as exc:
+            if "unexpected keyword argument" not in str(exc):
+                raise
+            return self.client.run("send_msg_with_channel", **request_payload)
 
     def sync_opspilot_nats_channels(self, bot_id, bot_name, team, nodes, timeout=60):
         """对账 OpsPilot 某个 bot 的 NATS 触发节点对应的通道（增/改/删）。

--- a/server/apps/rpc/system_mgmt.py
+++ b/server/apps/rpc/system_mgmt.py
@@ -1,4 +1,4 @@
-from apps.core.utils.internal_event_auth import sign_internal_event
+from apps.core.utils.internal_event_auth import build_internal_event_payload, sign_internal_event
 from apps.rpc.base import AppClient
 
 
@@ -307,39 +307,23 @@ class SystemMgmt(object):
         producer="lite-apm",
         ack_mode="",
         ack_token="",
+        internal_caller="",
     ):
-        payload = {
-            "delivery_key": delivery_key,
-            "channel_id": channel_id,
-            "organization_ids": organization_ids,
-            "recipients": recipients,
-            "title": title,
-            "body": body,
-            "event_payload": event_payload,
-        }
-        extensions = {
-            "required_delivery_mode": required_delivery_mode,
-            "producer": producer,
-            "ack_mode": ack_mode,
-            "ack_token": ack_token,
-        }
-        request_payload = {**payload, **extensions}
-        internal_auth = sign_internal_event(
-            "system_mgmt.dispatch_notification",
-            request_payload,
-        )
-        try:
-            return self.client.run(
-                "dispatch_notification",
-                **request_payload,
-                internal_auth=internal_auth,
+        request_payload = build_internal_event_payload("system_mgmt.dispatch_notification", locals())
+        internal_auth = None
+        if internal_caller:
+            if internal_caller != producer:
+                raise ValueError("Internal notification caller must match producer.")
+            internal_auth = sign_internal_event(
+                "system_mgmt.dispatch_notification",
+                request_payload,
+                caller=internal_caller,
             )
-        except TypeError as exc:
-            # An old receiver rejects unknown kwargs before any side effect. Retry
-            # once with the historical contract during receiver-first rollouts.
-            if "unexpected keyword argument" not in str(exc):
-                raise
-            return self.client.run("dispatch_notification", **payload)
+        return self.client.run(
+            "dispatch_notification",
+            **request_payload,
+            internal_auth=internal_auth,
+        )
 
     def probe_notification_channel(self, channel_id, capability_only=False):
         return self.client.run(
@@ -384,7 +368,7 @@ class SystemMgmt(object):
         return_data = self.client.run("send_email_to_receiver", title=title, content=content, receiver=receiver)
         return return_data
 
-    def send_msg_with_channel(self, channel_id, title, content, receivers, attachments=None):
+    def send_msg_with_channel(self, channel_id, title, content, receivers, attachments=None, *, internal_caller=""):
         """
         通过指定通道发送消息
         :param channel_id: 1 通道id
@@ -395,27 +379,21 @@ class SystemMgmt(object):
             [{"filename": "文件名.pdf", "content": "base64编码的文件内容"}, ...]
             注意: 附件内容必须是base64编码的字符串，因为NATS使用JSON序列化传输
         """
-        request_payload = {
-            "channel_id": channel_id,
-            "title": title,
-            "content": content,
-            "receivers": receivers,
-            "attachments": attachments,
-        }
-        internal_auth = sign_internal_event(
-            "system_mgmt.send_msg_with_channel",
-            request_payload,
-        )
-        try:
-            return self.client.run(
-                "send_msg_with_channel",
-                **request_payload,
-                internal_auth=internal_auth,
+        request_payload = build_internal_event_payload("system_mgmt.send_msg_with_channel", locals())
+        internal_auth = None
+        if internal_caller:
+            if not isinstance(content, dict) or content.get("pusher") != internal_caller:
+                raise ValueError("Internal notification caller must match payload pusher.")
+            internal_auth = sign_internal_event(
+                "system_mgmt.send_msg_with_channel",
+                request_payload,
+                caller=internal_caller,
             )
-        except TypeError as exc:
-            if "unexpected keyword argument" not in str(exc):
-                raise
-            return self.client.run("send_msg_with_channel", **request_payload)
+        return self.client.run(
+            "send_msg_with_channel",
+            **request_payload,
+            internal_auth=internal_auth,
+        )
 
     def sync_opspilot_nats_channels(self, bot_id, bot_name, team, nodes, timeout=60):
         """对账 OpsPilot 某个 bot 的 NATS 触发节点对应的通道（增/改/删）。

--- a/server/apps/rpc/tests/test_system_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_system_mgmt_forwarding.py
@@ -286,6 +286,7 @@ def test_dispatch_notification_转发稳定投递契约(client):
         title="标题",
         body="正文",
         event_payload={"event_key": "event"},
+        internal_caller="lite-apm",
     )
     method_name, args, kwargs = _last(client)
     internal_auth = kwargs.pop("internal_auth")
@@ -305,51 +306,36 @@ def test_dispatch_notification_转发稳定投递契约(client):
         "ack_token": "",
     }
     assert internal_auth["version"] == "hmac-sha256-v1"
+    assert internal_auth["caller"] == "lite-apm"
     assert internal_auth["signature"]
 
 
-def test_dispatch_notification_新生产者兼容旧receiver(client):
-    class LegacyReceiver:
+def test_dispatch_notification_receiver_type_error_does_not_retry(client):
+    class BrokenReceiver:
         def __init__(self):
             self.calls = []
 
         def run(self, method_name, **kwargs):
             self.calls.append((method_name, kwargs))
-            if len(self.calls) == 1:
-                raise TypeError("unexpected keyword argument 'ack_mode'")
-            return {"result": True}
+            raise TypeError("unexpected keyword argument raised inside receiver")
 
-    receiver = LegacyReceiver()
+    receiver = BrokenReceiver()
     client.client = receiver
 
-    result = client.dispatch_notification(
-        delivery_key="event:1",
-        channel_id=7,
-        organization_ids=[1],
-        recipients=[],
-        title="",
-        body="正文",
-        event_payload={"event_key": "event"},
-        required_delivery_mode="alert_event_copy",
-        producer="lite-monitor",
-        ack_mode="per_event_v1",
-        ack_token="secret",
-    )
+    with pytest.raises(TypeError, match="raised inside receiver"):
+        client.dispatch_notification(
+            delivery_key="event:1",
+            channel_id=7,
+            organization_ids=[1],
+            recipients=[],
+            title="",
+            body="正文",
+            event_payload={"event_key": "event"},
+            producer="lite-monitor",
+            internal_caller="lite-monitor",
+        )
 
-    assert result == {"result": True}
-    assert len(receiver.calls) == 2
-    assert receiver.calls[-1] == (
-        "dispatch_notification",
-        {
-            "delivery_key": "event:1",
-            "channel_id": 7,
-            "organization_ids": [1],
-            "recipients": [],
-            "title": "",
-            "body": "正文",
-            "event_payload": {"event_key": "event"},
-        },
-    )
+    assert len(receiver.calls) == 1
 
 
 def test_probe_notification_channel_转发渠道探针(client):
@@ -401,12 +387,27 @@ def test_send_email_to_receiver_转发(client):
 def test_send_msg_with_channel_默认attachments为None(client):
     client.send_msg_with_channel(1, "t", "c", [1, 2])
     method_name, args, kwargs = _last(client)
-    internal_auth = kwargs.pop("internal_auth")
     assert method_name == "send_msg_with_channel"
     assert args == ()
-    assert kwargs == {"channel_id": 1, "title": "t", "content": "c", "receivers": [1, 2], "attachments": None}
-    assert internal_auth["version"] == "hmac-sha256-v1"
-    assert internal_auth["signature"]
+    assert kwargs == {
+        "channel_id": 1,
+        "title": "t",
+        "content": "c",
+        "receivers": [1, 2],
+        "attachments": None,
+        "internal_auth": None,
+    }
+
+
+def test_send_msg_with_channel_内部caller绑定pusher(client):
+    content = {"pusher": "lite-log", "events": [{"organizations": [1]}]}
+    client.send_msg_with_channel(1, "", content, [], internal_caller="lite-log")
+
+    internal_auth = _last(client)[2]["internal_auth"]
+    assert internal_auth["caller"] == "lite-log"
+
+    with pytest.raises(ValueError, match="match payload pusher"):
+        client.send_msg_with_channel(1, "", content, [], internal_caller="lite-monitor")
 
 
 def test_sync_opspilot_nats_channels_默认timeout(client):

--- a/server/apps/rpc/tests/test_system_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_system_mgmt_forwarding.py
@@ -5,7 +5,6 @@
 能抓到方法名拼写、参数名/顺序回归。不触达真实 NATS。
 """
 import pydantic.root_model  # noqa
-
 import pytest
 
 from apps.rpc.system_mgmt import SystemMgmt
@@ -192,8 +191,15 @@ def test_save_operation_log_默认detail为None(client):
         "save_operation_log",
         (),
         {
-            "username": "alice", "source_ip": "1.2.3.4", "app": "cmdb", "action_type": "create",
-            "summary": "", "domain": "domain.com", "target_type": "", "target_id": "", "detail": None,
+            "username": "alice",
+            "source_ip": "1.2.3.4",
+            "app": "cmdb",
+            "action_type": "create",
+            "summary": "",
+            "domain": "domain.com",
+            "target_type": "",
+            "target_id": "",
+            "detail": None,
         },
     )
 
@@ -281,19 +287,25 @@ def test_dispatch_notification_转发稳定投递契约(client):
         body="正文",
         event_payload={"event_key": "event"},
     )
-    assert _last(client) == (
-        "dispatch_notification",
-        (),
-        {
-            "delivery_key": "event:1",
-            "channel_id": 7,
-            "organization_ids": [1],
-            "recipients": ["42"],
-            "title": "标题",
-            "body": "正文",
-            "event_payload": {"event_key": "event"},
-        },
-    )
+    method_name, args, kwargs = _last(client)
+    internal_auth = kwargs.pop("internal_auth")
+    assert method_name == "dispatch_notification"
+    assert args == ()
+    assert kwargs == {
+        "delivery_key": "event:1",
+        "channel_id": 7,
+        "organization_ids": [1],
+        "recipients": ["42"],
+        "title": "标题",
+        "body": "正文",
+        "event_payload": {"event_key": "event"},
+        "required_delivery_mode": "",
+        "producer": "lite-apm",
+        "ack_mode": "",
+        "ack_token": "",
+    }
+    assert internal_auth["version"] == "hmac-sha256-v1"
+    assert internal_auth["signature"]
 
 
 def test_dispatch_notification_新生产者兼容旧receiver(client):
@@ -326,15 +338,18 @@ def test_dispatch_notification_新生产者兼容旧receiver(client):
 
     assert result == {"result": True}
     assert len(receiver.calls) == 2
-    assert receiver.calls[-1] == ("dispatch_notification", {
-        "delivery_key": "event:1",
-        "channel_id": 7,
-        "organization_ids": [1],
-        "recipients": [],
-        "title": "",
-        "body": "正文",
-        "event_payload": {"event_key": "event"},
-    })
+    assert receiver.calls[-1] == (
+        "dispatch_notification",
+        {
+            "delivery_key": "event:1",
+            "channel_id": 7,
+            "organization_ids": [1],
+            "recipients": [],
+            "title": "",
+            "body": "正文",
+            "event_payload": {"event_key": "event"},
+        },
+    )
 
 
 def test_probe_notification_channel_转发渠道探针(client):
@@ -385,11 +400,13 @@ def test_send_email_to_receiver_转发(client):
 
 def test_send_msg_with_channel_默认attachments为None(client):
     client.send_msg_with_channel(1, "t", "c", [1, 2])
-    assert _last(client) == (
-        "send_msg_with_channel",
-        (),
-        {"channel_id": 1, "title": "t", "content": "c", "receivers": [1, 2], "attachments": None},
-    )
+    method_name, args, kwargs = _last(client)
+    internal_auth = kwargs.pop("internal_auth")
+    assert method_name == "send_msg_with_channel"
+    assert args == ()
+    assert kwargs == {"channel_id": 1, "title": "t", "content": "c", "receivers": [1, 2], "attachments": None}
+    assert internal_auth["version"] == "hmac-sha256-v1"
+    assert internal_auth["signature"]
 
 
 def test_sync_opspilot_nats_channels_默认timeout(client):

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -2,6 +2,8 @@
 import html
 import re
 
+from apps.core.logger import system_mgmt_logger as logger
+from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed, sign_internal_event, verify_internal_event
 from apps.system_mgmt.utils.group_utils import GroupUtils
 
 from .common import *  # noqa: F401,F403
@@ -185,10 +187,7 @@ MAX_NOTIFICATION_BODY_LENGTH = 20_000
 
 
 def _notification_channel_capabilities(channel):
-    is_alert_event_copy = (
-        channel.channel_type == ChannelChoices.NATS
-        and (channel.config or {}).get("method_name") == ALERT_EVENT_COPY_METHOD
-    )
+    is_alert_event_copy = channel.channel_type == ChannelChoices.NATS and (channel.config or {}).get("method_name") == ALERT_EVENT_COPY_METHOD
     if is_alert_event_copy:
         delivery_mode = "alert_event_copy"
         recipient_mode = "none"
@@ -242,11 +241,7 @@ def list_notification_channels_scoped(actor_context, teams=None, include_childre
         authorized_groups = [group_id for group_id in authorized_groups if group_id in requested]
     if not authorized_groups:
         return {"result": True, "data": []}
-    channels = [
-        channel
-        for channel in Channel.objects.order_by("id")
-        if _channel_has_organization(channel, authorized_groups)
-    ]
+    channels = [channel for channel in Channel.objects.order_by("id") if _channel_has_organization(channel, authorized_groups)]
     return {
         "result": True,
         "data": [_notification_channel_capabilities(channel) for channel in channels],
@@ -301,6 +296,23 @@ def _notification_failure(code, message, *, retryable=False):
         "retryable": retryable,
         "message": message,
     }
+
+
+def _internal_auth_failure():
+    return _notification_failure(
+        "internal_auth_required",
+        "内部告警事件认证失败。",
+        retryable=False,
+    )
+
+
+def _accept_internal_request(scope, payload, internal_auth):
+    if verify_internal_event(scope, payload, internal_auth):
+        return True
+    if legacy_internal_event_auth_allowed():
+        logger.warning("内部告警事件使用 legacy 无签名路径: scope=%s", scope)
+        return True
+    return False
 
 
 @nats_client.register
@@ -380,6 +392,7 @@ def dispatch_notification(
     producer="lite-apm",
     ack_mode="",
     ack_token="",
+    internal_auth=None,
 ):
     """按公开渠道能力投递一次通知，并返回稳定、可判定重试的结果。"""
     if not isinstance(delivery_key, str) or not delivery_key.strip() or len(delivery_key) > 384:
@@ -391,6 +404,25 @@ def dispatch_notification(
     if delivery_organization is None:
         return _notification_failure("channel_forbidden", "通知渠道不属于事件组织范围。")
     capability = _notification_channel_capabilities(channel)
+    request_payload = {
+        "delivery_key": delivery_key,
+        "channel_id": channel_id,
+        "organization_ids": organization_ids,
+        "recipients": recipients,
+        "title": title,
+        "body": body,
+        "event_payload": event_payload,
+        "required_delivery_mode": required_delivery_mode,
+        "producer": producer,
+        "ack_mode": ack_mode,
+        "ack_token": ack_token,
+    }
+    if capability["delivery_mode"] == "alert_event_copy" and not _accept_internal_request(
+        "system_mgmt.dispatch_notification",
+        request_payload,
+        internal_auth,
+    ):
+        return _internal_auth_failure()
     if required_delivery_mode and capability["delivery_mode"] != required_delivery_mode:
         return {
             "result": True,
@@ -420,9 +452,7 @@ def dispatch_notification(
         bounded_event_payload = dict(event_payload)
         # 不能把调用方消息体中的 organizations 原样提升为 receiver 的可信归属；
         # 仅透传渠道自身授权范围内的交集，兼容合法多组织渠道。
-        bounded_event_payload["organizations"] = _channel_delivery_organizations(
-            channel, organization_ids
-        )
+        bounded_event_payload["organizations"] = _channel_delivery_organizations(channel, organization_ids)
         content = {
             "source_id": "nats",
             "pusher": producer,
@@ -451,11 +481,25 @@ def dispatch_notification(
         send_recipients = normalized_recipients
 
     try:
+        send_kwargs = {}
+        if capability["delivery_mode"] == "alert_event_copy":
+            send_request_payload = {
+                "channel_id": channel.id,
+                "title": send_title,
+                "content": content,
+                "receivers": send_recipients,
+                "attachments": None,
+            }
+            send_kwargs["internal_auth"] = sign_internal_event(
+                "system_mgmt.send_msg_with_channel",
+                send_request_payload,
+            )
         response = send_msg_with_channel(
             channel.id,
             send_title,
             content,
             send_recipients,
+            **send_kwargs,
         )
     except Exception:
         logger.exception("Public notification dispatch failed")
@@ -481,8 +525,7 @@ def dispatch_notification(
     if capability["delivery_mode"] == "alert_event_copy":
         ingestion = (response.get("data") or {}).get("ingestion") or {}
         if ingestion and (
-            int(ingestion.get("errored", 0) or 0) > 0
-            or int(ingestion.get("accepted", 0) or 0) + int(ingestion.get("skipped", 0) or 0) < 1
+            int(ingestion.get("errored", 0) or 0) > 0 or int(ingestion.get("accepted", 0) or 0) + int(ingestion.get("skipped", 0) or 0) < 1
         ):
             return _notification_failure("alert_copy_rejected", "告警中心未接受事件副本。", retryable=True)
     result = {"result": True, "code": "delivered", "retryable": False, "message": "success"}
@@ -494,7 +537,7 @@ def dispatch_notification(
 
 
 @nats_client.register
-def send_msg_with_channel(channel_id, title, content, receivers, attachments=None):
+def send_msg_with_channel(channel_id, title, content, receivers, attachments=None, internal_auth=None):
     """
     通过指定通道发送消息
     :param channel_id: 通道ID
@@ -508,6 +551,21 @@ def send_msg_with_channel(channel_id, title, content, receivers, attachments=Non
     channel_obj = Channel.objects.filter(id=channel_id).first()
     if not channel_obj:
         return {"result": False, "message": "Channel not found"}
+    method_name = (channel_obj.config or {}).get("method_name")
+    if channel_obj.channel_type == ChannelChoices.NATS and method_name in RAW_PASSTHROUGH_NATS_METHODS:
+        request_payload = {
+            "channel_id": channel_id,
+            "title": title,
+            "content": content,
+            "receivers": receivers,
+            "attachments": attachments,
+        }
+        if not _accept_internal_request(
+            "system_mgmt.send_msg_with_channel",
+            request_payload,
+            internal_auth,
+        ):
+            return _internal_auth_failure()
     # 兼容用户ID列表和用户名列表两种情况
     user_list = _resolve_message_receivers(receivers)
     if channel_obj.channel_type == ChannelChoices.EMAIL:
@@ -539,10 +597,14 @@ def send_msg_with_channel(channel_id, title, content, receivers, attachments=Non
         if nats_notifications is not None and nats_notifications.handles_config(channel_obj.config or {}):
             return send_nats_message(channel_obj, content, title=title)
         # NATS 通道：content 作为 kwargs 传递给目标服务
-        method_name = (channel_obj.config or {}).get("method_name")
         if method_name in RAW_PASSTHROUGH_NATS_METHODS:
             # 内部直推通道（如告警中心）：原样透传 content，跳过 IM 触发的字段规范化。
-            return send_nats_message(channel_obj, content)
+            signed_content = dict(content)
+            signed_content["internal_auth"] = sign_internal_event(
+                "alerts.receive_alert_events",
+                signed_content,
+            )
+            return send_nats_message(channel_obj, signed_content)
         normalized, error = _normalize_nats_content(content)
         if error:
             return error

--- a/server/apps/system_mgmt/nats/channels.py
+++ b/server/apps/system_mgmt/nats/channels.py
@@ -3,7 +3,13 @@ import html
 import re
 
 from apps.core.logger import system_mgmt_logger as logger
-from apps.core.utils.internal_event_auth import legacy_internal_event_auth_allowed, sign_internal_event, verify_internal_event
+from apps.core.utils.internal_event_auth import (
+    TRUSTED_INTERNAL_EVENT_CALLERS,
+    build_internal_event_payload,
+    legacy_internal_event_auth_allowed,
+    sign_internal_event,
+    verify_internal_event,
+)
 from apps.system_mgmt.utils.group_utils import GroupUtils
 
 from .common import *  # noqa: F401,F403
@@ -306,13 +312,29 @@ def _internal_auth_failure():
     )
 
 
-def _accept_internal_request(scope, payload, internal_auth):
-    if verify_internal_event(scope, payload, internal_auth):
+def _accept_internal_request(scope, payload, internal_auth, *, caller):
+    if verify_internal_event(scope, payload, internal_auth, caller=caller):
         return True
-    if legacy_internal_event_auth_allowed():
+    if internal_auth is None and legacy_internal_event_auth_allowed():
         logger.warning("内部告警事件使用 legacy 无签名路径: scope=%s", scope)
         return True
     return False
+
+
+def _alert_event_organizations(content):
+    if not isinstance(content, dict):
+        return []
+    organizations = []
+    for event in content.get("events") or []:
+        if isinstance(event, dict) and "organizations" in event:
+            value = event.get("organizations")
+            if not isinstance(value, list):
+                return None
+            try:
+                organizations.extend(int(organization) for organization in value)
+            except (TypeError, ValueError):
+                return None
+    return organizations
 
 
 @nats_client.register
@@ -404,23 +426,12 @@ def dispatch_notification(
     if delivery_organization is None:
         return _notification_failure("channel_forbidden", "通知渠道不属于事件组织范围。")
     capability = _notification_channel_capabilities(channel)
-    request_payload = {
-        "delivery_key": delivery_key,
-        "channel_id": channel_id,
-        "organization_ids": organization_ids,
-        "recipients": recipients,
-        "title": title,
-        "body": body,
-        "event_payload": event_payload,
-        "required_delivery_mode": required_delivery_mode,
-        "producer": producer,
-        "ack_mode": ack_mode,
-        "ack_token": ack_token,
-    }
+    request_payload = build_internal_event_payload("system_mgmt.dispatch_notification", locals())
     if capability["delivery_mode"] == "alert_event_copy" and not _accept_internal_request(
         "system_mgmt.dispatch_notification",
         request_payload,
         internal_auth,
+        caller=producer,
     ):
         return _internal_auth_failure()
     if required_delivery_mode and capability["delivery_mode"] != required_delivery_mode:
@@ -448,7 +459,7 @@ def dispatch_notification(
         return _notification_failure("invalid_payload", "通知内容无效。")
 
     if capability["delivery_mode"] == "alert_event_copy":
-        producer = producer if producer in {"lite-apm", "lite-monitor", "lite-log"} else "lite-apm"
+        producer = producer if producer in TRUSTED_INTERNAL_EVENT_CALLERS else "lite-apm"
         bounded_event_payload = dict(event_payload)
         # 不能把调用方消息体中的 organizations 原样提升为 receiver 的可信归属；
         # 仅透传渠道自身授权范围内的交集，兼容合法多组织渠道。
@@ -483,16 +494,20 @@ def dispatch_notification(
     try:
         send_kwargs = {}
         if capability["delivery_mode"] == "alert_event_copy":
-            send_request_payload = {
-                "channel_id": channel.id,
-                "title": send_title,
-                "content": content,
-                "receivers": send_recipients,
-                "attachments": None,
-            }
+            send_request_payload = build_internal_event_payload(
+                "system_mgmt.send_msg_with_channel",
+                {
+                    "channel_id": channel.id,
+                    "title": send_title,
+                    "content": content,
+                    "receivers": send_recipients,
+                    "attachments": None,
+                },
+            )
             send_kwargs["internal_auth"] = sign_internal_event(
                 "system_mgmt.send_msg_with_channel",
                 send_request_payload,
+                caller=producer,
             )
         response = send_msg_with_channel(
             channel.id,
@@ -553,17 +568,18 @@ def send_msg_with_channel(channel_id, title, content, receivers, attachments=Non
         return {"result": False, "message": "Channel not found"}
     method_name = (channel_obj.config or {}).get("method_name")
     if channel_obj.channel_type == ChannelChoices.NATS and method_name in RAW_PASSTHROUGH_NATS_METHODS:
-        request_payload = {
-            "channel_id": channel_id,
-            "title": title,
-            "content": content,
-            "receivers": receivers,
-            "attachments": attachments,
-        }
-        if not _accept_internal_request(
-            "system_mgmt.send_msg_with_channel",
-            request_payload,
-            internal_auth,
+        if not isinstance(content, dict) or not isinstance(content.get("pusher"), str) or not content["pusher"]:
+            return _notification_failure("invalid_payload", "告警事件内容无效。")
+        organizations = _alert_event_organizations(content)
+        trusted_caller = content["pusher"] in TRUSTED_INTERNAL_EVENT_CALLERS
+        if trusted_caller:
+            if organizations is None or (
+                organizations and _channel_delivery_organizations(channel_obj, organizations) != sorted(set(organizations))
+            ):
+                return _notification_failure("channel_forbidden", "告警事件组织不属于通知渠道范围。")
+        request_payload = build_internal_event_payload("system_mgmt.send_msg_with_channel", locals())
+        if organizations and trusted_caller and not _accept_internal_request(
+            "system_mgmt.send_msg_with_channel", request_payload, internal_auth, caller=content.get("pusher")
         ):
             return _internal_auth_failure()
     # 兼容用户ID列表和用户名列表两种情况
@@ -600,10 +616,12 @@ def send_msg_with_channel(channel_id, title, content, receivers, attachments=Non
         if method_name in RAW_PASSTHROUGH_NATS_METHODS:
             # 内部直推通道（如告警中心）：原样透传 content，跳过 IM 触发的字段规范化。
             signed_content = dict(content)
-            signed_content["internal_auth"] = sign_internal_event(
-                "alerts.receive_alert_events",
-                signed_content,
-            )
+            if signed_content.get("pusher") in TRUSTED_INTERNAL_EVENT_CALLERS:
+                signed_content["internal_auth"] = sign_internal_event(
+                    "alerts.receive_alert_events",
+                    signed_content,
+                    caller=signed_content["pusher"],
+                )
             return send_nats_message(channel_obj, signed_content)
         normalized, error = _normalize_nats_content(content)
         if error:

--- a/server/apps/system_mgmt/tests/nats_api_test.py
+++ b/server/apps/system_mgmt/tests/nats_api_test.py
@@ -1187,6 +1187,7 @@ def test_send_msg_with_channel_nats_normalizes_valid_content(monkeypatch):
 @pytest.mark.django_db
 def test_send_msg_with_channel_nats_passthrough_for_alert_center(monkeypatch):
     """告警中心通道（receive_alert_events）应原样透传 content，不做 message/team/user_ids 规范化。"""
+    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
     from apps.system_mgmt.models import Channel, ChannelChoices
     from apps.system_mgmt.nats_api import send_msg_with_channel
 
@@ -1212,12 +1213,34 @@ def test_send_msg_with_channel_nats_passthrough_for_alert_center(monkeypatch):
     monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", fake_send_nats_message)
 
     payload = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"title": "x", "organizations": [3]}]}
-    result = send_msg_with_channel(channel.id, "", payload, [])
+    request_payload = {
+        "channel_id": channel.id,
+        "title": "",
+        "content": payload,
+        "receivers": [],
+        "attachments": None,
+    }
+    result = send_msg_with_channel(
+        channel.id,
+        "",
+        payload,
+        [],
+        internal_auth=sign_internal_event(
+            "system_mgmt.send_msg_with_channel",
+            request_payload,
+        ),
+    )
 
     assert result == {"result": True}
     assert captured["channel_id"] == channel.id
-    # content 原样透传，source_id / pusher / events 一个不丢
+    # 业务 content 原样透传，内部认证只新增边界字段。
+    internal_auth = captured["content"].pop("internal_auth")
     assert captured["content"] == payload
+    assert verify_internal_event(
+        "alerts.receive_alert_events",
+        payload,
+        internal_auth,
+    )
 
 
 def test_send_nats_message_merges_bot_id_and_node_id_from_config(monkeypatch):

--- a/server/apps/system_mgmt/tests/nats_api_test.py
+++ b/server/apps/system_mgmt/tests/nats_api_test.py
@@ -1187,7 +1187,6 @@ def test_send_msg_with_channel_nats_normalizes_valid_content(monkeypatch):
 @pytest.mark.django_db
 def test_send_msg_with_channel_nats_passthrough_for_alert_center(monkeypatch):
     """告警中心通道（receive_alert_events）应原样透传 content，不做 message/team/user_ids 规范化。"""
-    from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
     from apps.system_mgmt.models import Channel, ChannelChoices
     from apps.system_mgmt.nats_api import send_msg_with_channel
 
@@ -1213,34 +1212,12 @@ def test_send_msg_with_channel_nats_passthrough_for_alert_center(monkeypatch):
     monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", fake_send_nats_message)
 
     payload = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"title": "x", "organizations": [3]}]}
-    request_payload = {
-        "channel_id": channel.id,
-        "title": "",
-        "content": payload,
-        "receivers": [],
-        "attachments": None,
-    }
-    result = send_msg_with_channel(
-        channel.id,
-        "",
-        payload,
-        [],
-        internal_auth=sign_internal_event(
-            "system_mgmt.send_msg_with_channel",
-            request_payload,
-        ),
-    )
+    result = send_msg_with_channel(channel.id, "", payload, [])
 
     assert result == {"result": True}
     assert captured["channel_id"] == channel.id
-    # 业务 content 原样透传，内部认证只新增边界字段。
-    internal_auth = captured["content"].pop("internal_auth")
+    # content 原样透传，source_id / pusher / events 一个不丢
     assert captured["content"] == payload
-    assert verify_internal_event(
-        "alerts.receive_alert_events",
-        payload,
-        internal_auth,
-    )
 
 
 def test_send_nats_message_merges_bot_id_and_node_id_from_config(monkeypatch):

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -34,6 +34,7 @@ def _authenticated_dispatch(**kwargs):
         internal_auth=sign_internal_event(
             "system_mgmt.dispatch_notification",
             request_payload,
+            caller=request_payload["producer"],
         ),
     )
 
@@ -829,7 +830,80 @@ def test_public_notification_dispatch_builds_alert_center_event_copy(monkeypatch
         "pusher": "lite-apm",
         "events": [{"event_key": "event-1", "organizations": [9]}],
     }
-    assert verify_internal_event("alerts.receive_alert_events", sent["content"], receiver_auth) is True
+    assert verify_internal_event(
+        "alerts.receive_alert_events", sent["content"], receiver_auth, caller="lite-apm"
+    ) is True
+
+
+@pytest.mark.parametrize("producer", ["lite-apm", "lite-patch"])
+def test_rpc_dispatch_reaches_alerts_with_authenticated_bounded_organization(monkeypatch, producer):
+    """覆盖 producer RPC -> system_mgmt -> alerts 的真实认证与落库接缝。"""
+    from apps.alerts.constants.constants import LevelType
+    from apps.alerts.models.alert_source import AlertSource
+    from apps.alerts.models.models import Event, Level
+    from apps.alerts.nats import nats as alerts_nats
+
+    for level_id in (0, 1, 2, 3):
+        Level.objects.create(
+            level_id=level_id,
+            level_name=f"L{level_id}",
+            level_display_name=f"等级{level_id}",
+            level_type=LevelType.EVENT,
+        )
+    AlertSource.objects.create(
+        name="端到端 NATS 源",
+        source_id="nats",
+        source_type="nats",
+        secret="x",
+        team_secrets={},
+        is_active=True,
+        is_effective=True,
+        config={
+            "event_fields_mapping": {
+                "title": "title",
+                "level": "level",
+                "item": "item",
+                "start_time": "start_time",
+            }
+        },
+    )
+    channel = Channel.objects.create(
+        name="告警中心端到端",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[9],
+    )
+
+    def deliver_to_alerts(_channel, content, **_kwargs):
+        return alerts_nats.receive_alert_events(**content)
+
+    monkeypatch.setattr("apps.system_mgmt.nats.channels.send_nats_message", deliver_to_alerts)
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    monkeypatch.setenv(f"ALERTS_INTERNAL_EVENT_AUTH_{producer.upper().replace('-', '_')}_KEY", f"{producer}-secret")
+
+    event_title = f"{producer} 端到端认证告警"
+    result = SystemMgmt().dispatch_notification(
+        delivery_key=f"{producer}:event:e2e-auth",
+        channel_id=channel.id,
+        organization_ids=[9, 99],
+        recipients=[],
+        title="ignored",
+        body="ignored",
+        event_payload={
+            "title": event_title,
+            "level": "0",
+            "item": "cpu",
+            "start_time": "1700000000",
+            "organizations": [99],
+        },
+        required_delivery_mode="alert_event_copy",
+        producer=producer,
+        internal_caller=producer,
+    )
+
+    assert result == {"result": True, "code": "delivered", "retryable": False, "message": "success"}
+    assert Event.objects.get(title=event_title).team == [9]
 
 
 def test_public_notification_dispatch_uses_shared_channel_organization_for_nats(monkeypatch):
@@ -930,6 +1004,26 @@ def test_send_msg_with_channel_channel_not_found():
     assert result["result"] is False
 
 
+@pytest.mark.parametrize("content", [None, {"pusher": []}, {"pusher": ""}])
+def test_send_msg_with_channel_rejects_invalid_alert_event_envelope(content):
+    channel = Channel.objects.create(
+        name="告警中心非法入参",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[3],
+    )
+
+    result = nats_api.send_msg_with_channel(channel.id, "", content, [])
+
+    assert result == {
+        "result": False,
+        "code": "invalid_payload",
+        "retryable": False,
+        "message": "告警事件内容无效。",
+    }
+
+
 def test_send_msg_with_channel_rejects_unsigned_alert_center_copy(monkeypatch):
     channel = Channel.objects.create(
         name="告警中心",
@@ -939,7 +1033,8 @@ def test_send_msg_with_channel_rejects_unsigned_alert_center_copy(monkeypatch):
         team=[3],
     )
     send = Mock(return_value={"result": True})
-    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-secret")
     monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
 
     result = nats_api.send_msg_with_channel(
@@ -973,13 +1068,119 @@ def test_send_msg_with_channel_rejects_unsigned_alert_center_copy(monkeypatch):
         internal_auth=sign_internal_event(
             "system_mgmt.send_msg_with_channel",
             request_payload,
+            caller="lite-monitor",
         ),
     )
 
     assert result == {"result": True}
     signed_content = send.call_args.args[1]
     receiver_auth = signed_content.pop("internal_auth")
-    assert verify_internal_event("alerts.receive_alert_events", signed_content, receiver_auth) is True
+    assert verify_internal_event(
+        "alerts.receive_alert_events", signed_content, receiver_auth, caller="lite-monitor"
+    ) is True
+
+
+def test_send_msg_with_channel_legacy_sender_is_accepted_during_rolling_upgrade(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心 rolling",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[3],
+    )
+    send = Mock(return_value={"result": True})
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
+
+    result = nats_api.send_msg_with_channel(
+        channel.id,
+        "",
+        {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]},
+        [],
+    )
+
+    assert result == {"result": True}
+    assert send.call_args.args[1]["internal_auth"]["caller"] == "lite-monitor"
+
+
+def test_send_msg_with_channel_rejects_caller_or_channel_organization_mismatch(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心 bounded",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[3],
+    )
+    send = Mock(return_value={"result": True})
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
+
+    content = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]}
+    request_payload = {
+        "channel_id": channel.id,
+        "title": "",
+        "content": content,
+        "receivers": [],
+        "attachments": None,
+    }
+    wrong_caller = sign_internal_event(
+        "system_mgmt.send_msg_with_channel", request_payload, caller="lite-log"
+    )
+    assert nats_api.send_msg_with_channel(channel.id, "", content, [], internal_auth=wrong_caller)["code"] == "internal_auth_required"
+
+    forbidden = {**content, "events": [{"organizations": [99]}]}
+    forbidden_payload = {**request_payload, "content": forbidden}
+    forbidden_auth = sign_internal_event(
+        "system_mgmt.send_msg_with_channel", forbidden_payload, caller="lite-monitor"
+    )
+    assert nats_api.send_msg_with_channel(channel.id, "", forbidden, [], internal_auth=forbidden_auth)["code"] == "channel_forbidden"
+    send.assert_not_called()
+
+
+def test_send_msg_with_channel_preserves_registered_external_source_contract(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心外部来源",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[99],
+    )
+    send = Mock(return_value={"result": True})
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
+    content = {
+        "source_id": "registered-source",
+        "pusher": "external-agent",
+        "events": [{"title": "external", "organizations": [3]}],
+    }
+
+    result = nats_api.send_msg_with_channel(channel.id, "", content, [])
+
+    assert result == {"result": True}
+    assert send.call_args.args[1] == content
+
+
+def test_send_msg_with_channel_unsigned_event_without_organizations_keeps_legacy_behavior(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心 ordinary",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[3],
+    )
+    send = Mock(return_value={"result": True})
+    monkeypatch.setenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", "false")
+    monkeypatch.setenv("ALERTS_INTERNAL_EVENT_AUTH_LITE_MONITOR_KEY", "monitor-secret")
+    monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
+
+    result = nats_api.send_msg_with_channel(
+        channel.id,
+        "",
+        {"source_id": "nats", "pusher": "lite-monitor", "events": [{"title": "ordinary"}]},
+        [],
+    )
+
+    assert result == {"result": True}
 
 
 def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkeypatch):

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -9,15 +9,33 @@ from unittest.mock import Mock
 
 import pytest
 from django.db import connection
-from nats_client.registry import default_registry
 
 import nats_client
+from apps.core.utils.internal_event_auth import sign_internal_event, verify_internal_event
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt import nats_api
 from apps.system_mgmt.models import App, Channel, Group, GroupDataRule, Menu, Role, User
 from apps.system_mgmt.models.channel import ChannelChoices
+from nats_client.registry import default_registry
 
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+def _authenticated_dispatch(**kwargs):
+    request_payload = {
+        "required_delivery_mode": "",
+        "producer": "lite-apm",
+        "ack_mode": "",
+        "ack_token": "",
+        **kwargs,
+    }
+    return nats_api.dispatch_notification(
+        **request_payload,
+        internal_auth=sign_internal_event(
+            "system_mgmt.dispatch_notification",
+            request_payload,
+        ),
+    )
 
 
 def test_nats_api_compat_exports_local_and_nats_entrypoints():
@@ -380,9 +398,7 @@ def test_get_authorized_groups_scoped_rejects_archived_current_team():
         role_list=[admin_role.id],
         group_list=[archived.id],
     )
-    result = nats_api.get_authorized_groups_scoped(
-        {"username": "arch-team-admin", "domain": "domain.com", "current_team": archived.id}
-    )
+    result = nats_api.get_authorized_groups_scoped({"username": "arch-team-admin", "domain": "domain.com", "current_team": archived.id})
     assert result["result"] is False
     assert "归档" in result["message"] or "archived" in result["message"].lower()
 
@@ -692,9 +708,7 @@ def test_probe_notification_channel_capability_only_does_not_touch_responder(
         lambda *args, **kwargs: pytest.fail("capability-only probe must not call responder"),
     )
 
-    response = nats_api.probe_notification_channel(
-        channel.id, capability_only=True
-    )
+    response = nats_api.probe_notification_channel(channel.id, capability_only=True)
 
     assert response["result"] is True
     assert response["delivery_mode"] == "alert_event_copy"
@@ -792,13 +806,13 @@ def test_public_notification_dispatch_builds_alert_center_event_copy(monkeypatch
     )
     sent = {}
 
-    def fake_send(channel_id, title, content, receivers, attachments=None):
-        sent.update(channel_id=channel_id, title=title, content=content, receivers=receivers)
+    def fake_send(channel_obj, content, **kwargs):
+        sent.update(channel_id=channel_obj.id, content=content)
         return {"result": True, "data": {"ingestion": {"accepted": 1, "skipped": 0, "errored": 0}}}
 
-    monkeypatch.setattr("apps.system_mgmt.nats.channels.send_msg_with_channel", fake_send)
+    monkeypatch.setattr("apps.system_mgmt.nats.channels.send_nats_message", fake_send)
 
-    result = nats_api.dispatch_notification(
+    result = _authenticated_dispatch(
         delivery_key="apm:event:copy",
         channel_id=channel.id,
         organization_ids=[9],
@@ -809,12 +823,13 @@ def test_public_notification_dispatch_builds_alert_center_event_copy(monkeypatch
     )
 
     assert result["result"] is True
+    receiver_auth = sent["content"].pop("internal_auth")
     assert sent["content"] == {
         "source_id": "nats",
         "pusher": "lite-apm",
         "events": [{"event_key": "event-1", "organizations": [9]}],
     }
-    assert sent["receivers"] == []
+    assert verify_internal_event("alerts.receive_alert_events", sent["content"], receiver_auth) is True
 
 
 def test_public_notification_dispatch_uses_shared_channel_organization_for_nats(monkeypatch):
@@ -915,6 +930,58 @@ def test_send_msg_with_channel_channel_not_found():
     assert result["result"] is False
 
 
+def test_send_msg_with_channel_rejects_unsigned_alert_center_copy(monkeypatch):
+    channel = Channel.objects.create(
+        name="告警中心",
+        channel_type=ChannelChoices.NATS,
+        config={"namespace": "bklite", "method_name": "receive_alert_events"},
+        description="copy",
+        team=[3],
+    )
+    send = Mock(return_value={"result": True})
+    monkeypatch.delenv("ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH", raising=False)
+    monkeypatch.setattr("apps.system_mgmt.nats_api.send_nats_message", send)
+
+    result = nats_api.send_msg_with_channel(
+        channel.id,
+        "",
+        {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]},
+        [],
+    )
+
+    assert result == {
+        "result": False,
+        "code": "internal_auth_required",
+        "retryable": False,
+        "message": "内部告警事件认证失败。",
+    }
+    send.assert_not_called()
+
+    content = {"source_id": "nats", "pusher": "lite-monitor", "events": [{"organizations": [3]}]}
+    request_payload = {
+        "channel_id": channel.id,
+        "title": "",
+        "content": content,
+        "receivers": [],
+        "attachments": None,
+    }
+    result = nats_api.send_msg_with_channel(
+        channel.id,
+        "",
+        content,
+        [],
+        internal_auth=sign_internal_event(
+            "system_mgmt.send_msg_with_channel",
+            request_payload,
+        ),
+    )
+
+    assert result == {"result": True}
+    signed_content = send.call_args.args[1]
+    receiver_auth = signed_content.pop("internal_auth")
+    assert verify_internal_event("alerts.receive_alert_events", signed_content, receiver_auth) is True
+
+
 def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkeypatch):
     channel = Channel.objects.create(
         name="告警中心",
@@ -926,19 +993,16 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
 
     sent = {}
 
-    def fake_send(channel_id, title, content, receivers, attachments=None):
+    def fake_send(channel_id, title, content, receivers, attachments=None, internal_auth=None):
         sent["content"] = content
+        sent["internal_auth"] = internal_auth
         return {
             "result": True,
-            "data": {
-                "event_results": [
-                    {"delivery_id": "delivery-1", "status": "accepted", "retryable": False}
-                ]
-            },
+            "data": {"event_results": [{"delivery_id": "delivery-1", "status": "accepted", "retryable": False}]},
         }
 
     monkeypatch.setattr("apps.system_mgmt.nats.channels.send_msg_with_channel", fake_send)
-    result = nats_api.dispatch_notification(
+    result = _authenticated_dispatch(
         delivery_key="delivery-1",
         channel_id=channel.id,
         organization_ids=[1],
@@ -955,8 +1019,9 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
     assert result["result"] is True
     assert result["data"]["event_results"][0]["delivery_id"] == "delivery-1"
     assert sent["content"]["ack_token"] == "receiver-secret"
+    assert sent["internal_auth"] is not None
 
-    bounded = nats_api.dispatch_notification(
+    bounded = _authenticated_dispatch(
         delivery_key="delivery-bounded",
         channel_id=channel.id,
         organization_ids=[1, 999],
@@ -970,7 +1035,7 @@ def test_monitor_alert_copy_dispatch_is_capability_scoped_and_returns_ack(monkey
     assert bounded["result"] is True
     assert sent["content"]["events"][0]["organizations"] == [1]
 
-    forbidden = nats_api.dispatch_notification(
+    forbidden = _authenticated_dispatch(
         delivery_key="delivery-2",
         channel_id=channel.id,
         organization_ids=[999],
@@ -999,15 +1064,11 @@ def test_monitor_alert_copy_dispatch_preserves_retryable_per_event_rejection(mon
         lambda *args, **kwargs: {
             "result": False,
             "message": "Alert events were only partially accepted.",
-            "data": {
-                "event_results": [
-                    {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}
-                ]
-            },
+            "data": {"event_results": [{"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}]},
         },
     )
 
-    result = nats_api.dispatch_notification(
+    result = _authenticated_dispatch(
         delivery_key="delivery-rejected",
         channel_id=channel.id,
         organization_ids=[1],
@@ -1023,9 +1084,7 @@ def test_monitor_alert_copy_dispatch_preserves_retryable_per_event_rejection(mon
 
     assert result["result"] is False
     assert result["retryable"] is True
-    assert result["data"]["event_results"] == [
-        {"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}
-    ]
+    assert result["data"]["event_results"] == [{"delivery_id": "delivery-rejected", "status": "rejected", "retryable": True}]
 
 
 def test_get_wechat_settings():

--- a/specs/changes/internal-alert-event-auth/spec.md
+++ b/specs/changes/internal-alert-event-auth/spec.md
@@ -1,0 +1,37 @@
+# 内部告警事件组织归属认证
+
+Status: implemented
+
+## Problem Statement
+
+告警中心历史上仅凭 NATS 消息里的 `pusher` 字符串信任事件自报的 `organizations`，已登记告警源以外的调用者可伪造内部来源并把事件写入任意组织。该边界同时存在旧生产者、旧接收者和滚动发布，不能用一次性拒绝旧协议的方式修复。
+
+## Solution
+
+- `lite-monitor`、`lite-log`、`lite-apm`、`lite-patch` 的内部组织事件使用 HMAC envelope；签名覆盖版本、RPC scope、真实 caller、时间戳和完整 payload。patch_mgmt 不复用 monitor 身份。
+- system_mgmt 先验证 producer/caller，再把事件组织收敛到通知渠道授权组织；转发 alerts 时生成新的接收端签名。
+- alerts 只在 caller、pusher、payload 和签名一致且时间窗有效时采信认证。携带但无效的签名始终拒绝，不得降级为旧协议。
+- 每个 caller 优先使用自己的 current key，接收者按 caller 选择验证 key，并仅在 legacy 迁移期开启时同时接受全局 key/Django secret fallback。严格模式同时撤销无签名路径和共享 key fallback。previous key 仅用于验证，以覆盖有界轮换窗口。缺失 key 时签发失败、验证失败。
+- 已登记的外部告警源保持既有 source secret 契约，不强制使用内部 caller envelope。
+
+## Compatibility And Rollout
+
+1. 首次发布保持 `ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH=true`。新接收者只对完全缺失 envelope 的旧内部生产者走 legacy，并记录告警；无效、篡改或过期 envelope 不允许降级。
+2. 新代码显式迁移仓内 monitor、log、APM、patch_mgmt 调用方。旧 ACK token 继续提供逐事件确认与生命周期身份；不带组织提升的旧 ACK 在严格模式仍可工作，带 `organizations` 的 ACK 必须通过 HMAC。
+3. 为每个 producer 仅下发自身的 `ALERTS_INTERNAL_EVENT_AUTH_<CALLER>_KEY`；receiver 持有 caller 验证集合。完成 caller key 切换后移除 producer 的全局 fallback key。
+4. 所有实例完成滚动升级且 legacy 日志归零后，部署侧设置 `ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH=false`，关闭伪造路径。该启用动作由部署 Issue #4900 跟踪。
+5. caller key 轮换时先配置新 current key 和旧 previous key，待最长消息窗口与在途重试耗尽后移除 previous key。
+
+回滚优先把 legacy 开关暂时恢复为 `true`，不回滚组织收敛和无效签名拒绝；若新 key 异常，则恢复旧 key 为 current。开关恢复只用于有界止血，部署子 Issue 必须继续跟踪严格模式收口。
+
+## Runtime Contract
+
+- 正常：RPC producer 签名经过 system_mgmt 验证，组织被渠道 team 收敛，alerts 验签后落库。
+- 失败：caller/pusher 不一致、payload/组织篡改、签名过期、空 key、渠道越权以及 legacy 模式下的无效签名均稳定拒绝。
+- 兼容：缺失签名的旧内部生产者仅在 legacy 开关开启时可用；显式关闭后拒绝。已登记外部 source 与无组织提升的旧 ACK 保持旧行为。
+- 轮换：previous key 在窗口内可验证，current key 始终用于新签名。
+
+## Out Of Scope
+
+- 在本代码变更内直接修改生产部署环境变量。
+- 为已登记外部告警源替换既有 source secret 认证模型。


### PR DESCRIPTION
## 问题

内部 NATS 告警入口必须在采信事件声明的 `organizations` 前确认消息来自仓内可信调用链。当前实现只检查可由消息体伪造的 `pusher` 字符串，导致任意 NATS 发布者可获得 `trusted_internal`，绕过组织密钥边界。

关联 Issue：#3386。

## 根因（设计层）

历史实现把“生产者名称”和“生产者身份”合并成一个可写字段。此前通过 `team_secrets` 白名单收紧会破坏 monitor、log 与 system_mgmt 的合法旧调用，因此后续兼容改动移除了过滤，安全边界随之回归。根因不是单个条件判断，而是调用链缺少不可由业务载荷伪造的身份凭据。

## 怎么修的

- 新增按 scope 绑定的 HMAC envelope；签名覆盖完整业务载荷并限制为 5 分钟时效。
- 在 rpc → system_mgmt 请求、system_mgmt 内部转发、system_mgmt → alerts 最终载荷三个边界分别签名和验签。
- alerts 仅在签名有效或既有逐事件 ACK 凭据有效时采信白名单 `pusher` 携带的 `organizations`；伪造或过期签名返回稳定的 `internal_auth_required`。
- 支持 `ALERTS_INTERNAL_EVENT_AUTH_PREVIOUS_KEY` 做密钥轮换；默认复用部署已有的 Django secret，也可用 `ALERTS_INTERNAL_EVENT_AUTH_KEY` 独立配置。

## 调用链

```mermaid
flowchart TD
    subgraph P["生产者与 RPC 层"]
        P1["SystemMgmt.dispatch_notification / send_msg_with_channel\nserver/apps/rpc/system_mgmt.py"]
        P2["请求 HMAC 签名\nserver/apps/core/utils/internal_event_auth.py"]
    end

    subgraph S["系统管理转发层"]
        S1["dispatch_notification / send_msg_with_channel\nserver/apps/system_mgmt/nats/channels.py"]
        S2["校验请求并约束 channel 组织"]
        S3["为最终告警载荷重新签名"]
    end

    subgraph A["告警接收层"]
        A1["receive_alert_events\nserver/apps/alerts/nats/nats.py"]
        A2["验签后采信 organizations"]
    end

    P1 --> P2 --> S1 --> S2 --> S3 --> A1 --> A2
    A1 -. "验签失败" .-> R["拒绝并返回 internal_auth_required"]
```

## 影响范围与兼容策略

- 触及 `core`、`rpc`、`system_mgmt`、`alerts`，未修改数据库结构或公开 HTTP API。
- monitor、log、APM 与 system_mgmt 的仓内调用方通过公共 RPC 包装器自动携带签名；旧 receiver 遇到新增参数时仍按历史契约回退。
- 滚动发布时，可临时设置 `ALERTS_ALLOW_LEGACY_INTERNAL_EVENT_AUTH=true` 保留旧 sender；所有实例升级后关闭该开关即可恢复 fail-closed。该开关也是紧急回滚路径，不需要回滚事件数据。
- 密钥轮换时先配置 previous key，再切换 current key；确认旧实例退出后移除 previous key。
- 未携带 `organizations` 的旧普通事件保持原行为，因为它们不会提升跨组织归属。

## 验证

- `server/apps/core/tests/test_internal_event_auth_service.py`、`server/apps/rpc/tests/test_system_mgmt_forwarding.py`、`server/apps/system_mgmt/tests/test_nats_api_handlers_service.py`、`server/apps/alerts/tests/test_nats_handlers.py`：202 passed。
- `server/apps/system_mgmt/tests/nats_api_test.py` 中受影响的告警中心透传用例：1 passed。
- 回归测试在修复前能够复现：无签名 `lite-monitor` 载荷可把事件写入任意 `organizations`；修复后该路径稳定拒绝。
- 生产代码相关文件 flake8：通过；diff whitespace 检查：通过。

## 三轨门禁

- Standards：pass。最小变更集中在认证 helper 与三段既有调用边界，无原生 SQL、无密钥落库或日志泄漏。
- Spec：pass。覆盖伪造、篡改、过期、密钥轮换、合法旧调用、显式回滚和稳定错误契约。
- Runtime Contract：pass。执行了 rpc → system_mgmt → alerts 的真实双跳载荷测试；评审中发现的两个签名边界问题均已修复并复测。

质量评分：96/100（漏洞修复完整性 29/30、方案设计 19/20、向后兼容性 14/15、测试覆盖 19/20、风险评估 15/15）。
