### PR TITLE
bugfix(job_mgmt): 新增有上界的目标列表 v2（#3422）

### DIFF
--- a/server/apps/core/openapi/tests/tenant_coverage.py
+++ b/server/apps/core/openapi/tests/tenant_coverage.py
@@ -27,4 +27,9 @@ TENANT_ISOLATION_COVERAGE = {
         "apps.job_mgmt.tests.test_open_file_distribute_views::test_api_tenant_cannot_distribute_other_tenant_file",
         "apps.job_mgmt.tests.test_open_file_distribute_views::test_forged_team_is_rejected_without_side_effects",
     ],
+    "job-mgmt/targets-v2": [
+        "apps.job_mgmt.tests.test_open_file_distribute_views::test_target_list_v2_tenant_reads_only_own_targets",
+        "apps.job_mgmt.tests.test_open_file_distribute_views::test_target_list_v2_other_tenant_cannot_read_first_tenant_targets",
+        "apps.job_mgmt.tests.test_open_file_distribute_views::test_target_list_v2_rejects_forged_team",
+    ],
 }

--- a/server/apps/job_mgmt/apps.py
+++ b/server/apps/job_mgmt/apps.py
@@ -8,4 +8,5 @@ class JobMgmtConfig(AppConfig):
 
     def ready(self):
         import apps.job_mgmt.nats_api  # noqa
+        import apps.job_mgmt.openapi_api  # noqa
         import apps.job_mgmt.signals  # noqa

--- a/server/apps/job_mgmt/docs/nats_guide.md
+++ b/server/apps/job_mgmt/docs/nats_guide.md
@@ -103,10 +103,6 @@ class BKLiteNatsClient:
 # 使用示例
 client = BKLiteNatsClient(server="nats://localhost:4222")
 
-# 查询目标列表（新接入推荐 v2，按 next_cursor 继续翻页）
-targets = client.call("job_target_list_v2", {"caller_token": "<bklite_token>", "page_size": 100})
-print(targets)
-
 # 查询节点列表
 nodes = client.call("node_list", {"os": "linux", "page_size": -1})
 print(nodes)
@@ -144,7 +140,6 @@ print(limited_detail)
 |---------|------|----------|
 | `bklite.node_list` | 查询节点列表 | `{name, ip, os, page, page_size}` |
 | `bklite.job_target_list` | 查询目标列表 | `{name, ip, os_type, page, page_size}` |
-| `bklite.job_target_list_v2` | 有上界键集分页查询目标（推荐） | `{caller_token, name, ip, os_type, cursor, page_size}` |
 | `bklite.job_list` | 查询作业列表 | `{team, name, page, page_size}` |
 | `bklite.job_script_execute` | 脚本执行 | `{name, target_source, target_list, script_type, script_content, team, ...}` |
 | `bklite.job_file_distribute` | 文件分发（旧版，仅迁移兼容） | `{name, file_keys, target_source, target_list, target_path, team, ...}` |
@@ -155,7 +150,8 @@ print(limited_detail)
 
 ## 5. 注意事项
 
-- NATS 通道依赖内网边界；涉及调用方数据权限的 v2 接口还会校验 `caller_token`。确保 NATS Server 不对外暴露；新文件分发调用必须改用
+- NATS 通道依赖内网边界，确保 NATS Server 不对外暴露。新目标列表调用使用
+  `Authorization: Bearer <credential>` 的统一网关 `POST /openapi/v1/job-mgmt/targets-v2`；新文件分发调用必须改用
   `Authorization: Bearer <api_secret>` 的统一网关 `POST /openapi/v1/job-mgmt/file-distribute`，不要新增旧版 NATS 调用。
 - 迁移窗口内保持 `JOB_FILE_DISTRIBUTE_NATS_ENABLED=1`（默认），结合 listener subject 日志与 NATS 连接审计
   盘点调用方。流量归零后置 `0` 拒绝旧入口；若新路径异常，立即置回 `1` 回滚。

--- a/server/apps/job_mgmt/docs/nats_guide.md
+++ b/server/apps/job_mgmt/docs/nats_guide.md
@@ -47,7 +47,7 @@ async def call_nats(method: str, data: dict, server: str = "nats://localhost:422
     nc = await nats.connect(server)
     try:
         subject = f"{namespace}.{method}"
-        payload = json.dumps(data).encode()
+        payload = json.dumps({"args": [data], "kwargs": {}}).encode()
         response = await nc.request(subject, payload, timeout=timeout)
         return json.loads(response.data.decode())
     finally:
@@ -93,7 +93,7 @@ class BKLiteNatsClient:
         nc = await nats.connect(self.server)
         try:
             subject = f"{self.namespace}.{method}"
-            payload = json.dumps(data).encode()
+            payload = json.dumps({"args": [data], "kwargs": {}}).encode()
             response = await nc.request(subject, payload, timeout=self.timeout)
             return json.loads(response.data.decode())
         finally:
@@ -103,8 +103,8 @@ class BKLiteNatsClient:
 # 使用示例
 client = BKLiteNatsClient(server="nats://localhost:4222")
 
-# 查询目标列表
-targets = client.call("job_target_list", {"page_size": -1})
+# 查询目标列表（新接入推荐 v2，按 next_cursor 继续翻页）
+targets = client.call("job_target_list_v2", {"caller_token": "<bklite_token>", "page_size": 100})
 print(targets)
 
 # 查询节点列表
@@ -144,6 +144,7 @@ print(limited_detail)
 |---------|------|----------|
 | `bklite.node_list` | 查询节点列表 | `{name, ip, os, page, page_size}` |
 | `bklite.job_target_list` | 查询目标列表 | `{name, ip, os_type, page, page_size}` |
+| `bklite.job_target_list_v2` | 有上界键集分页查询目标（推荐） | `{caller_token, name, ip, os_type, cursor, page_size}` |
 | `bklite.job_list` | 查询作业列表 | `{team, name, page, page_size}` |
 | `bklite.job_script_execute` | 脚本执行 | `{name, target_source, target_list, script_type, script_content, team, ...}` |
 | `bklite.job_file_distribute` | 文件分发（旧版，仅迁移兼容） | `{name, file_keys, target_source, target_list, target_path, team, ...}` |
@@ -154,7 +155,7 @@ print(limited_detail)
 
 ## 5. 注意事项
 
-- NATS 接口无需鉴权，信任内网通道。确保 NATS Server 不对外暴露；新文件分发调用必须改用
+- NATS 通道依赖内网边界；涉及调用方数据权限的 v2 接口还会校验 `caller_token`。确保 NATS Server 不对外暴露；新文件分发调用必须改用
   `Authorization: Bearer <api_secret>` 的统一网关 `POST /openapi/v1/job-mgmt/file-distribute`，不要新增旧版 NATS 调用。
 - 迁移窗口内保持 `JOB_FILE_DISTRIBUTE_NATS_ENABLED=1`（默认），结合 listener subject 日志与 NATS 连接审计
   盘点调用方。流量归零后置 `0` 拒绝旧入口；若新路径异常，立即置回 `1` 回滚。

--- a/server/apps/job_mgmt/docs/open_api.md
+++ b/server/apps/job_mgmt/docs/open_api.md
@@ -8,7 +8,7 @@
 |------|------|------|------|
 | 查询节点列表 | NATS `bklite.node_list` | 无 | 同步，分页返回节点 |
 | 查询目标列表 | NATS `bklite.job_target_list` | 无 | 同步，分页返回目标 |
-| 查询目标列表 v2 | NATS `bklite.job_target_list_v2` | `caller_token` | 同步，有上界键集分页 |
+| 查询目标列表 v2 | OpenAPI `POST /openapi/v1/job-mgmt/targets-v2` | Authorization Bearer | 同步，有上界键集分页 |
 | 作业列表 | NATS `bklite.job_list` | 无 | 同步，返回脚本库与 Playbook 及参数定义 |
 | 作业列表 | REST `GET /api/v1/job_mgmt/api/open/job_list` | Api-Authorization | 同步，执行前获取作业背景信息 |
 | 脚本执行 | NATS `bklite.job_script_execute` | 无 | 异步，返回 task_id |
@@ -257,16 +257,15 @@ Query：
 
 ### 2.1 查询目标列表 v2（推荐）
 
-**NATS Subject**: `bklite.job_target_list_v2`
+**OpenAPI**: `POST /openapi/v1/job-mgmt/targets-v2`
 
-v2 根据 `caller_token` 的团队权限在数据库内过滤目标，再使用按 `target_id` 降序的键集分页。每页最多返回 100 条，不支持 `page_size=-1`。部署可用 `JOB_TARGET_LIST_V2_MAX_PAGE_SIZE` 在 1-100 内下调上限；非法值或超过 100 时恢复为 100。
+v2 由统一网关验证 Bearer 凭据、审计请求并注入不可伪造的授权团队，业务层在数据库内过滤目标，再使用按 `target_id` 降序的键集分页。调用方不得提交 `team`、`caller_token` 或其他身份字段。每页最多返回 100 条，不支持 `page_size=-1`。部署可用 `JOB_TARGET_LIST_V2_MAX_PAGE_SIZE` 在 1-100 内下调上限；非法值或超过 100 时恢复为 100。
 
-v2 默认关闭。滚动发布时，须先完成新版本部署并确认旧进程全部退出，再运行 `python manage.py reconcile_target_team_memberships --apply`，随后运行同命令的 `--check` 模式确认零漂移，最后设置 `JOB_TARGET_LIST_V2_ENABLED=true` 并滚动重启。未完成校验前不得启用，以避免迁移回填期间的旧进程写入造成授权投影漂移。
+v2 默认关闭。滚动发布时，须先完成新版本部署并确认旧进程全部退出，再运行 `python manage.py reconcile_target_team_memberships --apply`，随后运行同命令的 `--check` 模式确认零漂移，最后设置 `JOB_TARGET_LIST_V2_ENABLED=true` 并滚动重启。未完成校验前不得启用，以避免迁移回填期间的旧进程写入造成授权投影漂移。回滚时先将该开关恢复为 `false` 并确认所有实例停止接收 v2 请求，再回滚应用；投影表是可重建数据，不影响保留的 v1 读路径。若必须回退 migration，仅在 v2 已停用且旧版本已全部恢复后执行反向迁移；重新发布时再次按上述顺序回填与校验。
 
 **Request:**
 ```json
 {
-  "caller_token": "<bklite_token>",
   "name": "web",
   "ip": "10.0",
   "os_type": "linux",
@@ -277,7 +276,6 @@ v2 默认关闭。滚动发布时，须先完成新版本部署并确认旧进�
 
 | 字段 | 类型 | 必填 | 说明 |
 |------|------|------|------|
-| caller_token | string | 是 | BK-Lite 用户会话 token，用于确定可见团队 |
 | name | string | 否 | 按名称模糊搜索 |
 | ip | string | 否 | 按 IP 模糊搜索 |
 | os_type | string | 否 | `linux` 或 `windows` |

--- a/server/apps/job_mgmt/docs/open_api.md
+++ b/server/apps/job_mgmt/docs/open_api.md
@@ -8,6 +8,7 @@
 |------|------|------|------|
 | 查询节点列表 | NATS `bklite.node_list` | 无 | 同步，分页返回节点 |
 | 查询目标列表 | NATS `bklite.job_target_list` | 无 | 同步，分页返回目标 |
+| 查询目标列表 v2 | NATS `bklite.job_target_list_v2` | `caller_token` | 同步，有上界键集分页 |
 | 作业列表 | NATS `bklite.job_list` | 无 | 同步，返回脚本库与 Playbook 及参数定义 |
 | 作业列表 | REST `GET /api/v1/job_mgmt/api/open/job_list` | Api-Authorization | 同步，执行前获取作业背景信息 |
 | 脚本执行 | NATS `bklite.job_script_execute` | 无 | 异步，返回 task_id |
@@ -250,9 +251,58 @@ Query：
 }
 ```
 
+> 兼容说明：该 v1 入口保留 `page_size=-1` 的“返回全部”语义。新调用方应优先使用下方 v2，避免单次返回无上界。
+
 ---
 
-### 2.1 查询作业列表
+### 2.1 查询目标列表 v2（推荐）
+
+**NATS Subject**: `bklite.job_target_list_v2`
+
+v2 根据 `caller_token` 的团队权限在数据库内过滤目标，再使用按 `target_id` 降序的键集分页。每页最多返回 100 条，不支持 `page_size=-1`。部署可用 `JOB_TARGET_LIST_V2_MAX_PAGE_SIZE` 在 1-100 内下调上限；非法值或超过 100 时恢复为 100。
+
+v2 默认关闭。滚动发布时，须先完成新版本部署并确认旧进程全部退出，再运行 `python manage.py reconcile_target_team_memberships --apply`，随后运行同命令的 `--check` 模式确认零漂移，最后设置 `JOB_TARGET_LIST_V2_ENABLED=true` 并滚动重启。未完成校验前不得启用，以避免迁移回填期间的旧进程写入造成授权投影漂移。
+
+**Request:**
+```json
+{
+  "caller_token": "<bklite_token>",
+  "name": "web",
+  "ip": "10.0",
+  "os_type": "linux",
+  "page_size": 20,
+  "cursor": 1234
+}
+```
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| caller_token | string | 是 | BK-Lite 用户会话 token，用于确定可见团队 |
+| name | string | 否 | 按名称模糊搜索 |
+| ip | string | 否 | 按 IP 模糊搜索 |
+| os_type | string | 否 | `linux` 或 `windows` |
+| page_size | int | 否 | 每页最大返回数量，默认 20，范围 1-100 |
+| cursor | int | 否 | 上一页返回的 `next_cursor`；首页不传 |
+
+**Response:**
+```json
+{
+  "result": true,
+  "data": {
+    "items": [],
+    "next_cursor": 1200,
+    "has_more": true
+  }
+}
+```
+
+`has_more=false` 时 `next_cursor` 为 `null`。v2 不返回需要扫描全部命中记录的精确总数。
+
+键集分页在固定筛选条件下不会重复返回同一目标，但不是一致性快照：翻页期间新增的目标可能不进入本轮后续页，删除、团队权限或筛选字段变化可能导致跳项。
+
+---
+
+### 2.2 查询作业列表
 
 **NATS Subject**: `bklite.job_list`
 

--- a/server/apps/job_mgmt/management/commands/reconcile_target_team_memberships.py
+++ b/server/apps/job_mgmt/management/commands/reconcile_target_team_memberships.py
@@ -1,0 +1,52 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from apps.job_mgmt.models import Target, TargetTeamMembership
+from apps.job_mgmt.models.target import _replace_target_team_memberships
+from apps.job_mgmt.utils.team_authz import normalize_authorized_team_ids, normalize_team
+
+
+def _team_ids(team):
+    return normalize_team(team) | normalize_authorized_team_ids(team if isinstance(team, list) else [team])
+
+
+class Command(BaseCommand):
+    help = "校验或修复 Target.team 与可索引团队授权投影的差异"
+
+    def add_arguments(self, parser):
+        parser.add_argument("--apply", action="store_true", help="修复发现的投影差异；默认仅检查")
+        parser.add_argument("--check", action="store_true", help="仅检查；发现差异时返回非零状态")
+        parser.add_argument("--batch-size", type=int, default=500)
+
+    def handle(self, *args, **options):
+        if options["apply"] and options["check"]:
+            raise CommandError("--apply 与 --check 不能同时使用")
+        batch_size = options["batch_size"]
+        if batch_size < 1 or batch_size > 5000:
+            raise CommandError("--batch-size 范围为 1-5000")
+
+        apply_changes = options["apply"]
+        cursor = 0
+        drift_count = 0
+        while True:
+            with transaction.atomic():
+                queryset = Target.objects.filter(id__gt=cursor).order_by("id")
+                if apply_changes:
+                    queryset = queryset.select_for_update()
+                targets = list(queryset.only("id", "team")[:batch_size])
+                if not targets:
+                    break
+                target_ids = [target.id for target in targets]
+                actual = {target_id: set() for target_id in target_ids}
+                for target_id, team_id in TargetTeamMembership.objects.filter(target_id__in=target_ids).values_list("target_id", "team_id"):
+                    actual[target_id].add(team_id)
+                drifted = [target for target in targets if actual[target.id] != _team_ids(target.team)]
+                drift_count += len(drifted)
+                if apply_changes and drifted:
+                    _replace_target_team_memberships((target.id, target.team) for target in drifted)
+                cursor = targets[-1].id
+
+        if drift_count and not apply_changes:
+            raise CommandError(f"发现 {drift_count} 个目标的团队授权投影不一致")
+        action = "修复" if apply_changes else "检查"
+        self.stdout.write(self.style.SUCCESS(f"团队授权投影{action}完成，差异数: {drift_count}"))

--- a/server/apps/job_mgmt/migrations/0017_targetteammembership.py
+++ b/server/apps/job_mgmt/migrations/0017_targetteammembership.py
@@ -1,0 +1,52 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+def backfill_target_team_memberships(apps, schema_editor):
+    Target = apps.get_model("job_mgmt", "Target")
+    TargetTeamMembership = apps.get_model("job_mgmt", "TargetTeamMembership")
+    pending = []
+    for target in Target.objects.only("id", "team").iterator(chunk_size=1000):
+        team_ids = set()
+        values = target.team if isinstance(target.team, (list, tuple, set)) else [target.team]
+        for value in values:
+            if isinstance(value, dict):
+                value = value.get("id")
+            try:
+                team_ids.add(int(value))
+            except (TypeError, ValueError):
+                continue
+        pending.extend(TargetTeamMembership(target_id=target.id, team_id=team_id) for team_id in team_ids)
+        if len(pending) >= 1000:
+            TargetTeamMembership.objects.bulk_create(pending, batch_size=1000, ignore_conflicts=True)
+            pending.clear()
+    if pending:
+        TargetTeamMembership.objects.bulk_create(pending, batch_size=1000, ignore_conflicts=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("job_mgmt", "0016_jobexecution_enforce_scheduled_team_boundary")]
+
+    operations = [
+        migrations.CreateModel(
+            name="TargetTeamMembership",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("team_id", models.BigIntegerField()),
+                (
+                    "target",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="team_memberships",
+                        to="job_mgmt.target",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "job_target_team_membership",
+                "constraints": [models.UniqueConstraint(fields=("target", "team_id"), name="uniq_job_target_team")],
+                "indexes": [models.Index(fields=["team_id", "target"], name="job_target_team_idx")],
+            },
+        ),
+        migrations.RunPython(backfill_target_team_memberships, migrations.RunPython.noop),
+    ]

--- a/server/apps/job_mgmt/models/__init__.py
+++ b/server/apps/job_mgmt/models/__init__.py
@@ -6,11 +6,12 @@ from apps.job_mgmt.models.execution import JobExecution  # noqa
 from apps.job_mgmt.models.playbook import Playbook  # noqa
 from apps.job_mgmt.models.scheduled_task import ScheduledTask  # noqa
 from apps.job_mgmt.models.script import Script  # noqa
-from apps.job_mgmt.models.target import Target, TargetTeamMembership  # noqa
+from apps.job_mgmt.models.target import Target, TargetTeamConcurrentUpdateError, TargetTeamMembership  # noqa
 
 __all__ = [
     "Target",
     "TargetTeamMembership",
+    "TargetTeamConcurrentUpdateError",
     "Script",
     "Playbook",
     "DangerousRule",

--- a/server/apps/job_mgmt/models/__init__.py
+++ b/server/apps/job_mgmt/models/__init__.py
@@ -6,10 +6,11 @@ from apps.job_mgmt.models.execution import JobExecution  # noqa
 from apps.job_mgmt.models.playbook import Playbook  # noqa
 from apps.job_mgmt.models.scheduled_task import ScheduledTask  # noqa
 from apps.job_mgmt.models.script import Script  # noqa
-from apps.job_mgmt.models.target import Target  # noqa
+from apps.job_mgmt.models.target import Target, TargetTeamMembership  # noqa
 
 __all__ = [
     "Target",
+    "TargetTeamMembership",
     "Script",
     "Playbook",
     "DangerousRule",

--- a/server/apps/job_mgmt/models/target.py
+++ b/server/apps/job_mgmt/models/target.py
@@ -1,11 +1,12 @@
 """目标管理模型"""
 
-from django.db import models
+from django.db import models, transaction
 from django_minio_backend import MinioBackend
 
 from apps.core.models.maintainer_info import MaintainerInfo
 from apps.core.models.time_info import TimeInfo
 from apps.job_mgmt.constants import CredentialSource, ExecutorDriver, OSType, SSHCredentialType, WinRMScheme, WinRMTransport
+from apps.job_mgmt.utils.team_authz import normalize_authorized_team_ids, normalize_team
 
 # SSH 密钥文件存储 bucket
 SSH_KEY_BUCKET = "job-mgmt-private"
@@ -17,6 +18,30 @@ def ssh_key_upload_path(instance, filename):
 
     now = datetime.now()
     return f"ssh_keys/{now.year}/{now.month:02d}/{now.day:02d}/{filename}"
+
+
+class TargetQuerySet(models.QuerySet):
+    """确保所有批量团队写入都同步授权投影。"""
+
+    def update(self, **kwargs):
+        if "team" not in kwargs:
+            return super().update(**kwargs)
+        with transaction.atomic():
+            target_ids = list(self.select_for_update().values_list("id", flat=True))
+            updated = super().update(**kwargs)
+            target_teams = list(self.model._base_manager.filter(id__in=target_ids).values_list("id", "team"))
+            _replace_target_team_memberships(target_teams)
+            return updated
+
+    def bulk_create(self, objs, **kwargs):
+        if kwargs.get("ignore_conflicts") or kwargs.get("update_conflicts"):
+            raise ValueError("Target.bulk_create 不支持冲突忽略/更新，请使用原子 save 或 update")
+        with transaction.atomic():
+            created = super().bulk_create(objs, **kwargs)
+            if any(target.pk is None for target in created):
+                raise RuntimeError("当前数据库不支持安全同步 Target.bulk_create，请逐条 save")
+            _replace_target_team_memberships((target.pk, target.team) for target in created)
+            return created
 
 
 class Target(TimeInfo, MaintainerInfo):
@@ -74,6 +99,8 @@ class Target(TimeInfo, MaintainerInfo):
     # 组织归属（多组织）
     team = models.JSONField(default=list, verbose_name="团队ID列表")
 
+    objects = TargetQuerySet.as_manager()
+
     class Meta:
         verbose_name = "执行目标"
         verbose_name_plural = verbose_name
@@ -82,6 +109,17 @@ class Target(TimeInfo, MaintainerInfo):
 
     def __str__(self):
         return f"{self.name}({self.ip})"
+
+    def save(self, *args, **kwargs):
+        """将目标主体与团队授权投影作为同一事务提交。"""
+        update_fields = kwargs.get("update_fields")
+        with transaction.atomic():
+            if self.pk and not self._state.adding:
+                type(self).objects.select_for_update().filter(pk=self.pk).exists()
+            result = super().save(*args, **kwargs)
+            if update_fields is None or "team" in update_fields:
+                _replace_target_team_memberships([(self.pk, self.team)])
+            return result
 
     @property
     def is_manual_credential(self) -> bool:
@@ -99,3 +137,32 @@ class Target(TimeInfo, MaintainerInfo):
         if self.ssh_key_file:
             return self.ssh_key_file.name.split("/")[-1]
         return ""
+
+
+class TargetTeamMembership(models.Model):
+    """目标团队 JSON 字段的可索引关系投影。"""
+
+    target = models.ForeignKey(Target, related_name="team_memberships", on_delete=models.CASCADE)
+    team_id = models.BigIntegerField()
+
+    class Meta:
+        db_table = "job_target_team_membership"
+        constraints = [models.UniqueConstraint(fields=["target", "team_id"], name="uniq_job_target_team")]
+        indexes = [models.Index(fields=["team_id", "target"], name="job_target_team_idx")]
+
+
+def _replace_target_team_memberships(target_teams):
+    """在调用方事务内用 Target.team 原子替换授权投影。"""
+    normalized = []
+    target_ids = []
+    for target_id, team in target_teams:
+        target_ids.append(target_id)
+        team_ids = normalize_team(team) | normalize_authorized_team_ids(team if isinstance(team, list) else [team])
+        normalized.extend(TargetTeamMembership(target_id=target_id, team_id=team_id) for team_id in team_ids)
+    if not target_ids:
+        return
+    TargetTeamMembership.objects.filter(target_id__in=target_ids).delete()
+    TargetTeamMembership.objects.bulk_create(
+        normalized,
+        ignore_conflicts=True,
+    )

--- a/server/apps/job_mgmt/models/target.py
+++ b/server/apps/job_mgmt/models/target.py
@@ -1,5 +1,7 @@
 """目标管理模型"""
 
+from copy import deepcopy
+
 from django.db import models, transaction
 from django_minio_backend import MinioBackend
 
@@ -10,6 +12,10 @@ from apps.job_mgmt.utils.team_authz import normalize_authorized_team_ids, normal
 
 # SSH 密钥文件存储 bucket
 SSH_KEY_BUCKET = "job-mgmt-private"
+
+
+class TargetTeamConcurrentUpdateError(ValueError):
+    """目标团队在当前实例加载后已被其他事务修改。"""
 
 
 def ssh_key_upload_path(instance, filename):
@@ -27,8 +33,9 @@ class TargetQuerySet(models.QuerySet):
         if "team" not in kwargs:
             return super().update(**kwargs)
         with transaction.atomic():
-            target_ids = list(self.select_for_update().values_list("id", flat=True))
-            updated = super().update(**kwargs)
+            target_ids = list(self.select_for_update().order_by("id").values_list("id", flat=True))
+            locked_targets = self.filter(id__in=target_ids)
+            updated = super(TargetQuerySet, locked_targets).update(**kwargs)
             target_teams = list(self.model._base_manager.filter(id__in=target_ids).values_list("id", "team"))
             _replace_target_team_memberships(target_teams)
             return updated
@@ -110,16 +117,36 @@ class Target(TimeInfo, MaintainerInfo):
     def __str__(self):
         return f"{self.name}({self.ip})"
 
+    @classmethod
+    def from_db(cls, db, field_names, values):
+        instance = super().from_db(db, field_names, values)
+        if "team" in field_names:
+            instance._loaded_team = deepcopy(instance.team)
+        return instance
+
     def save(self, *args, **kwargs):
         """将目标主体与团队授权投影作为同一事务提交。"""
         update_fields = kwargs.get("update_fields")
         with transaction.atomic():
             if self.pk and not self._state.adding:
-                type(self).objects.select_for_update().filter(pk=self.pk).exists()
+                locked_team = type(self).objects.select_for_update().values_list("team", flat=True).get(pk=self.pk)
+                loaded_team = getattr(self, "_loaded_team", locked_team)
+                if locked_team != loaded_team and (update_fields is None or "team" in update_fields):
+                    if self.team != loaded_team:
+                        raise TargetTeamConcurrentUpdateError("Target.team 已被并发修改，请刷新后重试")
+                    self.team = locked_team
             result = super().save(*args, **kwargs)
             if update_fields is None or "team" in update_fields:
                 _replace_target_team_memberships([(self.pk, self.team)])
+            self._loaded_team = deepcopy(self.team)
             return result
+
+    def refresh_from_db(self, *args, **kwargs):
+        result = super().refresh_from_db(*args, **kwargs)
+        fields = kwargs.get("fields")
+        if fields is None or "team" in fields:
+            self._loaded_team = deepcopy(self.team)
+        return result
 
     @property
     def is_manual_credential(self) -> bool:

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -2,13 +2,15 @@
 
 import os
 
+from django.db.models import Exists, OuterRef
+
 import nats_client
 from apps.core.logger import job_logger as logger
 from apps.core.openapi.decorators import openapi_expose
 from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 from apps.core.utils.viewset_utils import build_json_membership_query
 from apps.job_mgmt.constants import CallbackType, ExecutionStatus, JobType, TriggerSource
-from apps.job_mgmt.models import DistributionFile, JobExecution, Playbook, Script, Target
+from apps.job_mgmt.models import DistributionFile, JobExecution, Playbook, Script, Target, TargetTeamMembership
 from apps.job_mgmt.openapi_serializers import FileDistributeRequestSerializer
 from apps.job_mgmt.services.ansible_callback_service import handle_ansible_task_callback
 from apps.job_mgmt.services.celery_dispatch import dispatch_celery_task
@@ -23,7 +25,7 @@ from apps.job_mgmt.services.param_crypto import ParamCrypto
 from apps.job_mgmt.services.script_normalize import normalize_script_line_endings
 from apps.job_mgmt.services.script_params_service import ScriptParamsService
 from apps.job_mgmt.tasks import distribute_files_task, execute_script_task
-from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_team
+from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_authorized_team_ids, normalize_team
 from apps.node_mgmt.models import Node
 from apps.system_mgmt.nats.common import _verify_token
 from apps.system_mgmt.utils.group_utils import GroupUtils
@@ -624,11 +626,7 @@ def job_task_terminate(data=None, task_id=None, **kwargs):
                 task_id = int(normalized_task_id)
             except ValueError:
                 task_id = None
-    if (
-        isinstance(task_id, bool)
-        or not isinstance(task_id, int)
-        or not 1 <= task_id <= 2**63 - 1
-    ):
+    if isinstance(task_id, bool) or not isinstance(task_id, int) or not 1 <= task_id <= 2**63 - 1:
         return {"result": False, "message": "task_id 必须为正整数或其字符串形式"}
     if not caller_token:
         return {"result": False, "message": "caller_token 不能为空"}
@@ -713,3 +711,100 @@ def job_target_list(data: dict):
         )
 
     return {"result": True, "data": {"count": total_count, "items": items}}
+
+
+_DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX = 100
+_HARD_TARGET_LIST_V2_PAGE_SIZE_MAX = 100
+
+
+def _target_list_v2_page_size_max():
+    try:
+        configured = int(os.getenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", str(_DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX)))
+    except (TypeError, ValueError):
+        return _DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX
+    if configured < 1 or configured > _HARD_TARGET_LIST_V2_PAGE_SIZE_MAX:
+        return _DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX
+    return configured
+
+
+def _parse_target_list_v2_int(value, error_message):
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return None, error_message
+    if isinstance(value, str) and not value.isdecimal():
+        return None, error_message
+    return int(value), None
+
+
+def _parse_target_list_v2_page(data: dict):
+    max_page_size = _target_list_v2_page_size_max()
+    page_size, error = _parse_target_list_v2_int(data.get("page_size", 20), "page_size 参数非法")
+    if error:
+        return None, error
+    if page_size < 1 or page_size > max_page_size:
+        return None, f"page_size 范围为 1-{max_page_size}"
+
+    raw_cursor = data.get("cursor")
+    if raw_cursor in (None, ""):
+        return (page_size, None), None
+    cursor, error = _parse_target_list_v2_int(raw_cursor, "cursor 必须为大于 0 的整数")
+    if error or cursor < 1:
+        return None, "cursor 必须为大于 0 的整数"
+    return (page_size, cursor), None
+
+
+@nats_client.register
+def job_target_list_v2(data: dict):
+    """按可信调用方团队范围返回有上界的目标键集分页。"""
+    data = data or {}
+    caller_token = data.get("caller_token", "")
+    if not caller_token:
+        return {"result": False, "message": "caller_token 不能为空"}
+    if os.getenv("JOB_TARGET_LIST_V2_ENABLED", "false").lower() not in {"1", "true", "yes"}:
+        return {"result": False, "message": "job_target_list_v2 尚未启用"}
+    try:
+        caller = _verify_token(caller_token)
+    except Exception:  # pylint: disable=broad-except
+        return {"result": False, "message": "Unauthorized: invalid caller_token"}
+
+    caller_group_list = getattr(caller, "group_list", [])
+    caller_team = normalize_authorized_team_ids(caller_group_list) | normalize_team(caller_group_list)
+    if not caller_team:
+        return {"result": False, "message": "无可用团队权限"}
+
+    page_info, error = _parse_target_list_v2_page(data)
+    if error:
+        return {"result": False, "message": error}
+    page_size, cursor = page_info
+
+    authorized_membership = TargetTeamMembership.objects.filter(target_id=OuterRef("id"), team_id__in=caller_team)
+    queryset = Target.objects.filter(Exists(authorized_membership))
+    name = data.get("name")
+    ip = data.get("ip")
+    os_type = data.get("os_type")
+    if name:
+        queryset = queryset.filter(name__icontains=name)
+    if ip:
+        queryset = queryset.filter(ip__icontains=ip)
+    if os_type:
+        queryset = queryset.filter(os_type=os_type)
+
+    if cursor is not None:
+        queryset = queryset.filter(id__lt=cursor)
+    rows = list(queryset.order_by("-id").values("id", "name", "ip", "os_type", "cloud_region_id")[: page_size + 1])
+    has_more = len(rows) > page_size
+    rows = rows[:page_size]
+    items = [
+        {
+            "target_id": row["id"],
+            "name": row["name"],
+            "ip": str(row["ip"]),
+            "os_type": row["os_type"],
+            "cloud_region_id": row["cloud_region_id"],
+        }
+        for row in rows
+    ]
+    next_cursor = rows[-1]["id"] if has_more else None
+    return {
+        "result": True,
+        "data": {"items": items, "next_cursor": next_cursor, "has_more": has_more},
+    }

--- a/server/apps/job_mgmt/nats_api.py
+++ b/server/apps/job_mgmt/nats_api.py
@@ -2,15 +2,13 @@
 
 import os
 
-from django.db.models import Exists, OuterRef
-
 import nats_client
 from apps.core.logger import job_logger as logger
 from apps.core.openapi.decorators import openapi_expose
 from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 from apps.core.utils.viewset_utils import build_json_membership_query
 from apps.job_mgmt.constants import CallbackType, ExecutionStatus, JobType, TriggerSource
-from apps.job_mgmt.models import DistributionFile, JobExecution, Playbook, Script, Target, TargetTeamMembership
+from apps.job_mgmt.models import DistributionFile, JobExecution, Playbook, Script, Target
 from apps.job_mgmt.openapi_serializers import FileDistributeRequestSerializer
 from apps.job_mgmt.services.ansible_callback_service import handle_ansible_task_callback
 from apps.job_mgmt.services.celery_dispatch import dispatch_celery_task
@@ -25,7 +23,7 @@ from apps.job_mgmt.services.param_crypto import ParamCrypto
 from apps.job_mgmt.services.script_normalize import normalize_script_line_endings
 from apps.job_mgmt.services.script_params_service import ScriptParamsService
 from apps.job_mgmt.tasks import distribute_files_task, execute_script_task
-from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_authorized_team_ids, normalize_team
+from apps.job_mgmt.utils.team_authz import is_team_authorized, normalize_team
 from apps.node_mgmt.models import Node
 from apps.system_mgmt.nats.common import _verify_token
 from apps.system_mgmt.utils.group_utils import GroupUtils
@@ -421,9 +419,7 @@ def _run_file_distribute(data: dict, *, trusted_actor=None):
 def _validate_openapi_distribute_scope(file_keys, target_source, target_list, authorized_team_ids):
     """校验网关文件与目标均属于可信身份绑定组织。"""
     files = list(DistributionFile.objects.filter(file_key__in=file_keys))
-    if len({item.file_key for item in files}) != len(set(file_keys)) or any(
-        not is_team_authorized(item.team, authorized_team_ids) for item in files
-    ):
+    if len({item.file_key for item in files}) != len(set(file_keys)) or any(not is_team_authorized(item.team, authorized_team_ids) for item in files):
         return "部分文件不存在、已过期或无权访问该组织的文件"
 
     id_field = "target_id" if target_source == "manual" else "node_id"
@@ -433,19 +429,12 @@ def _validate_openapi_distribute_scope(file_keys, target_source, target_list, au
 
     if target_source == "manual":
         targets = list(Target.objects.filter(id__in=target_ids))
-        authorized = len(targets) == len(target_ids) and all(
-            is_team_authorized(item.team, authorized_team_ids) for item in targets
-        )
+        authorized = len(targets) == len(target_ids) and all(is_team_authorized(item.team, authorized_team_ids) for item in targets)
     else:
-        authorized = (
-            Node.objects.filter(
-                id__in=target_ids,
-                nodeorganization__organization__in=authorized_team_ids,
-            )
-            .distinct()
-            .count()
-            == len(target_ids)
-        )
+        authorized = Node.objects.filter(
+            id__in=target_ids,
+            nodeorganization__organization__in=authorized_team_ids,
+        ).distinct().count() == len(target_ids)
     if not authorized:
         return "部分目标不存在或无权访问该组织的目标"
     return None
@@ -480,8 +469,7 @@ def openapi_file_distribute(
     if scope_error:
         id_field = "target_id" if target_source == "manual" else "node_id"
         logger.warning(
-            "[openapi_file_distribute] scope rejected: user=%s domain=%s team=%s file_keys=%s "
-            "target_source=%s target_ids=%s reason=%s",
+            "[openapi_file_distribute] scope rejected: user=%s domain=%s team=%s file_keys=%s " "target_source=%s target_ids=%s reason=%s",
             (user_info or {}).get("user", ""),
             (user_info or {}).get("domain", ""),
             authorized_team_id,
@@ -711,100 +699,3 @@ def job_target_list(data: dict):
         )
 
     return {"result": True, "data": {"count": total_count, "items": items}}
-
-
-_DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX = 100
-_HARD_TARGET_LIST_V2_PAGE_SIZE_MAX = 100
-
-
-def _target_list_v2_page_size_max():
-    try:
-        configured = int(os.getenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", str(_DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX)))
-    except (TypeError, ValueError):
-        return _DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX
-    if configured < 1 or configured > _HARD_TARGET_LIST_V2_PAGE_SIZE_MAX:
-        return _DEFAULT_TARGET_LIST_V2_PAGE_SIZE_MAX
-    return configured
-
-
-def _parse_target_list_v2_int(value, error_message):
-    if isinstance(value, bool) or not isinstance(value, (int, str)):
-        return None, error_message
-    if isinstance(value, str) and not value.isdecimal():
-        return None, error_message
-    return int(value), None
-
-
-def _parse_target_list_v2_page(data: dict):
-    max_page_size = _target_list_v2_page_size_max()
-    page_size, error = _parse_target_list_v2_int(data.get("page_size", 20), "page_size 参数非法")
-    if error:
-        return None, error
-    if page_size < 1 or page_size > max_page_size:
-        return None, f"page_size 范围为 1-{max_page_size}"
-
-    raw_cursor = data.get("cursor")
-    if raw_cursor in (None, ""):
-        return (page_size, None), None
-    cursor, error = _parse_target_list_v2_int(raw_cursor, "cursor 必须为大于 0 的整数")
-    if error or cursor < 1:
-        return None, "cursor 必须为大于 0 的整数"
-    return (page_size, cursor), None
-
-
-@nats_client.register
-def job_target_list_v2(data: dict):
-    """按可信调用方团队范围返回有上界的目标键集分页。"""
-    data = data or {}
-    caller_token = data.get("caller_token", "")
-    if not caller_token:
-        return {"result": False, "message": "caller_token 不能为空"}
-    if os.getenv("JOB_TARGET_LIST_V2_ENABLED", "false").lower() not in {"1", "true", "yes"}:
-        return {"result": False, "message": "job_target_list_v2 尚未启用"}
-    try:
-        caller = _verify_token(caller_token)
-    except Exception:  # pylint: disable=broad-except
-        return {"result": False, "message": "Unauthorized: invalid caller_token"}
-
-    caller_group_list = getattr(caller, "group_list", [])
-    caller_team = normalize_authorized_team_ids(caller_group_list) | normalize_team(caller_group_list)
-    if not caller_team:
-        return {"result": False, "message": "无可用团队权限"}
-
-    page_info, error = _parse_target_list_v2_page(data)
-    if error:
-        return {"result": False, "message": error}
-    page_size, cursor = page_info
-
-    authorized_membership = TargetTeamMembership.objects.filter(target_id=OuterRef("id"), team_id__in=caller_team)
-    queryset = Target.objects.filter(Exists(authorized_membership))
-    name = data.get("name")
-    ip = data.get("ip")
-    os_type = data.get("os_type")
-    if name:
-        queryset = queryset.filter(name__icontains=name)
-    if ip:
-        queryset = queryset.filter(ip__icontains=ip)
-    if os_type:
-        queryset = queryset.filter(os_type=os_type)
-
-    if cursor is not None:
-        queryset = queryset.filter(id__lt=cursor)
-    rows = list(queryset.order_by("-id").values("id", "name", "ip", "os_type", "cloud_region_id")[: page_size + 1])
-    has_more = len(rows) > page_size
-    rows = rows[:page_size]
-    items = [
-        {
-            "target_id": row["id"],
-            "name": row["name"],
-            "ip": str(row["ip"]),
-            "os_type": row["os_type"],
-            "cloud_region_id": row["cloud_region_id"],
-        }
-        for row in rows
-    ]
-    next_cursor = rows[-1]["id"] if has_more else None
-    return {
-        "result": True,
-        "data": {"items": items, "next_cursor": next_cursor, "has_more": has_more},
-    }

--- a/server/apps/job_mgmt/openapi_api.py
+++ b/server/apps/job_mgmt/openapi_api.py
@@ -1,0 +1,34 @@
+"""作业管理统一 OpenAPI 端点。"""
+
+import os
+
+from apps.core.openapi.decorators import openapi_expose
+from apps.job_mgmt.openapi_serializers import TargetListV2RequestSerializer
+from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
+from apps.job_mgmt.utils.team_authz import normalize_team
+from apps.system_mgmt.utils.group_utils import GroupUtils
+
+
+@openapi_expose(
+    path="job-mgmt/targets-v2",
+    method="POST",
+    schema=TargetListV2RequestSerializer,
+    inject="team_list",
+    permission="target-View",
+    permission_app="job",
+    summary="按调用方授权组织键集分页查询作业目标（最多 100 条）",
+)
+def openapi_target_list_v2(name="", ip="", os_type="", page_size=20, cursor=None, *, team=None):
+    """由统一网关认证、审计并注入不可伪造的精确团队集合。"""
+    if os.getenv("JOB_TARGET_LIST_V2_ENABLED", "false").lower() not in {"1", "true", "yes"}:
+        return {"result": False, "message": "target list v2 is not enabled"}
+    caller_team = set(GroupUtils.active_queryset(id__in=normalize_team(team)).values_list("id", flat=True))
+    if not caller_team:
+        return {"result": False, "message": "无权访问该组织：用户未关联活动团队"}
+    result = query_target_list_v2(
+        {"name": name, "ip": ip, "os_type": os_type, "page_size": page_size, "cursor": cursor},
+        caller_team,
+    )
+    if not result.get("result"):
+        return result
+    return result.get("data") or {}

--- a/server/apps/job_mgmt/openapi_serializers.py
+++ b/server/apps/job_mgmt/openapi_serializers.py
@@ -51,3 +51,13 @@ class FileDistributeRequestSerializer(OpenAPIRequestSerializer):
         if errors:
             raise serializers.ValidationError({"target_list": errors})
         return attrs
+
+
+class TargetListV2RequestSerializer(OpenAPIRequestSerializer):
+    """统一网关目标列表 v2 请求；调用方身份与团队只由网关注入。"""
+
+    name = serializers.CharField(required=False, allow_blank=True, max_length=128, default="")
+    ip = serializers.CharField(required=False, allow_blank=True, max_length=45, default="")
+    os_type = serializers.ChoiceField(required=False, allow_blank=True, choices=["", "linux", "windows"], default="")
+    page_size = serializers.IntegerField(required=False, min_value=1, max_value=100, default=20)
+    cursor = serializers.IntegerField(required=False, min_value=1, allow_null=True, default=None)

--- a/server/apps/job_mgmt/services/target_list_v2.py
+++ b/server/apps/job_mgmt/services/target_list_v2.py
@@ -1,0 +1,90 @@
+"""有上界、按可信团队范围过滤的目标列表查询。"""
+
+import os
+
+from django.db.models import Exists, OuterRef
+
+from apps.job_mgmt.models import Target, TargetTeamMembership
+
+_DEFAULT_PAGE_SIZE_MAX = 100
+_HARD_PAGE_SIZE_MAX = 100
+
+
+def _page_size_max():
+    try:
+        configured = int(os.getenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", str(_DEFAULT_PAGE_SIZE_MAX)))
+    except (TypeError, ValueError):
+        return _DEFAULT_PAGE_SIZE_MAX
+    if configured < 1 or configured > _HARD_PAGE_SIZE_MAX:
+        return _DEFAULT_PAGE_SIZE_MAX
+    return configured
+
+
+def _parse_int(value, error_message):
+    if isinstance(value, bool) or not isinstance(value, (int, str)):
+        return None, error_message
+    if isinstance(value, str) and not value.isdecimal():
+        return None, error_message
+    try:
+        return int(value), None
+    except ValueError:
+        return None, error_message
+
+
+def _parse_page(data):
+    max_page_size = _page_size_max()
+    page_size, error = _parse_int(data.get("page_size", 20), "page_size 参数非法")
+    if error:
+        return None, error
+    if page_size < 1 or page_size > max_page_size:
+        return None, f"page_size 范围为 1-{max_page_size}"
+
+    raw_cursor = data.get("cursor")
+    if raw_cursor in (None, ""):
+        return (page_size, None), None
+    cursor, error = _parse_int(raw_cursor, "cursor 必须为大于 0 的整数")
+    if error or cursor < 1:
+        return None, "cursor 必须为大于 0 的整数"
+    return (page_size, cursor), None
+
+
+def query_target_list_v2(data, authorized_team_ids):
+    """按已由服务端确认的活动团队集合执行键集分页查询。"""
+    if not isinstance(data, dict):
+        return {"result": False, "message": "请求参数必须为对象"}
+    page_info, error = _parse_page(data)
+    if error:
+        return {"result": False, "message": error}
+    page_size, cursor = page_info
+
+    authorized_membership = TargetTeamMembership.objects.filter(target_id=OuterRef("id"), team_id__in=authorized_team_ids)
+    queryset = Target.objects.filter(Exists(authorized_membership))
+    for field in ("name", "ip", "os_type"):
+        value = data.get(field)
+        if value:
+            lookup = f"{field}__icontains" if field in {"name", "ip"} else field
+            queryset = queryset.filter(**{lookup: value})
+
+    if cursor is not None:
+        queryset = queryset.filter(id__lt=cursor)
+    rows = list(queryset.order_by("-id").values("id", "name", "ip", "os_type", "cloud_region_id")[: page_size + 1])
+    has_more = len(rows) > page_size
+    rows = rows[:page_size]
+    items = [
+        {
+            "target_id": row["id"],
+            "name": row["name"],
+            "ip": str(row["ip"]),
+            "os_type": row["os_type"],
+            "cloud_region_id": row["cloud_region_id"],
+        }
+        for row in rows
+    ]
+    return {
+        "result": True,
+        "data": {
+            "items": items,
+            "next_cursor": rows[-1]["id"] if has_more else None,
+            "has_more": has_more,
+        },
+    }

--- a/server/apps/job_mgmt/tests/test_batch_delete_mixin_service.py
+++ b/server/apps/job_mgmt/tests/test_batch_delete_mixin_service.py
@@ -41,6 +41,7 @@ class _FakeViewSet(BatchDeleteMixin):
     def get_queryset(self):
         qs = MagicMock(name="queryset")
         qs.filter.return_value = self._instances
+        self._instances.count.return_value = self._deleted_count
         self._instances.delete.return_value = (self._deleted_count, {})
         return qs
 

--- a/server/apps/job_mgmt/tests/test_nats_open_api.py
+++ b/server/apps/job_mgmt/tests/test_nats_open_api.py
@@ -1,9 +1,11 @@
 """NATS 开放接口单元测试"""
 
 from datetime import timedelta
+from threading import Event, Thread
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.db import close_old_connections, connection, transaction
 
 
 @pytest.mark.unit
@@ -406,80 +408,76 @@ class TestJobTargetList:
         assert len(result["data"]["items"]) == 2
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 @pytest.mark.django_db
 class TestJobTargetListV2:
     @pytest.fixture(autouse=True)
     def enable_v2(self, monkeypatch):
+        from apps.system_mgmt.models import Group
+
         monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+        Group.objects.update_or_create(
+            id=1,
+            defaults={"name": "target-list-v2-active-team", "parent_id": 0, "is_delete": False},
+        )
 
-    def test_requires_caller_token(self):
-        from apps.job_mgmt.nats_api import job_target_list_v2
+    def test_rejects_non_object_and_oversized_numeric_input(self):
+        from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
 
-        assert job_target_list_v2({}) == {"result": False, "message": "caller_token 不能为空"}
-
-    def test_is_disabled_until_projection_is_reconciled(self, monkeypatch):
-        from apps.job_mgmt.nats_api import job_target_list_v2
-
-        monkeypatch.delenv("JOB_TARGET_LIST_V2_ENABLED")
-        caller = MagicMock(group_list=[1])
-        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
-            assert job_target_list_v2({"caller_token": "valid"}) == {
-                "result": False,
-                "message": "job_target_list_v2 尚未启用",
-            }
+        assert query_target_list_v2([], {1}) == {"result": False, "message": "请求参数必须为对象"}
+        result = query_target_list_v2({"cursor": "9" * 5000}, {1})
+        assert result == {"result": False, "message": "cursor 必须为大于 0 的整数"}
 
     def test_rejects_invalid_page_size_and_cursor(self, monkeypatch):
-        from apps.job_mgmt.nats_api import job_target_list_v2
+        from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
 
-        caller = MagicMock(group_list=[1])
-        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
-            assert job_target_list_v2({"caller_token": "valid", "page_size": -1}) == {
+        def query(data):
+            return query_target_list_v2(data, {1})
+
+        assert query({"page_size": -1}) == {
+            "result": False,
+            "message": "page_size 范围为 1-100",
+        }
+        assert query({"page_size": 101}) == {
+            "result": False,
+            "message": "page_size 范围为 1-100",
+        }
+        assert query({"cursor": 0}) == {
+            "result": False,
+            "message": "cursor 必须为大于 0 的整数",
+        }
+        for invalid in (True, 1.5):
+            assert query({"page_size": invalid}) == {
                 "result": False,
-                "message": "page_size 范围为 1-100",
+                "message": "page_size 参数非法",
             }
-            assert job_target_list_v2({"caller_token": "valid", "page_size": 101}) == {
-                "result": False,
-                "message": "page_size 范围为 1-100",
-            }
-            assert job_target_list_v2({"caller_token": "valid", "cursor": 0}) == {
+            assert query({"cursor": invalid}) == {
                 "result": False,
                 "message": "cursor 必须为大于 0 的整数",
             }
-            for invalid in (True, 1.5):
-                assert job_target_list_v2({"caller_token": "valid", "page_size": invalid}) == {
-                    "result": False,
-                    "message": "page_size 参数非法",
-                }
-                assert job_target_list_v2({"caller_token": "valid", "cursor": invalid}) == {
-                    "result": False,
-                    "message": "cursor 必须为大于 0 的整数",
-                }
-            monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", "2")
-            assert job_target_list_v2({"caller_token": "valid", "page_size": 3}) == {
+        monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", "2")
+        assert query({"page_size": 3}) == {
+            "result": False,
+            "message": "page_size 范围为 1-2",
+        }
+        for invalid_max in ("invalid", "0", "101", "1000"):
+            monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", invalid_max)
+            assert query({"page_size": 100})["result"] is True
+            assert query({"page_size": 101}) == {
                 "result": False,
-                "message": "page_size 范围为 1-2",
+                "message": "page_size 范围为 1-100",
             }
-            for invalid_max in ("invalid", "0", "101", "1000"):
-                monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", invalid_max)
-                assert job_target_list_v2({"caller_token": "valid", "page_size": 100})["result"] is True
-                assert job_target_list_v2({"caller_token": "valid", "page_size": 101}) == {
-                    "result": False,
-                    "message": "page_size 范围为 1-100",
-                }
 
     def test_returns_bounded_team_scoped_keyset_pages(self, django_assert_num_queries):
         from apps.job_mgmt.models import Target
-        from apps.job_mgmt.nats_api import job_target_list_v2
+        from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
 
         Target.objects.create(name="foreign", ip="10.0.1.1", os_type="linux", team=[2])
         owned = [Target.objects.create(name=f"owned-{index}", ip=f"10.0.0.{index}", os_type="linux", team=[1]) for index in range(1, 6)]
 
-        caller = MagicMock(group_list=[{"id": 1, "name": "team-one"}])
-        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
-            with django_assert_num_queries(2):
-                first = job_target_list_v2({"caller_token": "valid", "page_size": 2})
-                second = job_target_list_v2({"caller_token": "valid", "page_size": 2, "cursor": first["data"]["next_cursor"]})
+        with django_assert_num_queries(2):
+            first = query_target_list_v2({"page_size": 2}, {1})
+            second = query_target_list_v2({"page_size": 2, "cursor": first["data"]["next_cursor"]}, {1})
 
         assert first["result"] is True
         assert "count" not in first["data"]
@@ -491,17 +489,15 @@ class TestJobTargetListV2:
 
     def test_sparse_team_page_never_exposes_foreign_cursor(self, django_assert_num_queries):
         from apps.job_mgmt.models import Target
-        from apps.job_mgmt.nats_api import job_target_list_v2
+        from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
 
         owned = [Target.objects.create(name=f"owned-{index}", ip=f"10.0.0.{index}", os_type="linux", team=[1]) for index in range(1, 3)]
         foreign = [Target.objects.create(name=f"foreign-{index}", ip=f"10.0.1.{index}", os_type="linux", team=[2]) for index in range(1, 4)]
 
-        caller = MagicMock(group_list=[1])
-        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
-            with django_assert_num_queries(1):
-                first = job_target_list_v2({"caller_token": "valid", "page_size": 1})
-            with django_assert_num_queries(1):
-                second = job_target_list_v2({"caller_token": "valid", "page_size": 1, "cursor": first["data"]["next_cursor"]})
+        with django_assert_num_queries(1):
+            first = query_target_list_v2({"page_size": 1}, {1})
+        with django_assert_num_queries(1):
+            second = query_target_list_v2({"page_size": 1, "cursor": first["data"]["next_cursor"]}, {1})
 
         foreign_ids = {target.id for target in foreign}
         assert [item["target_id"] for item in first["data"]["items"]] == [owned[1].id]
@@ -533,6 +529,39 @@ class TestJobTargetListV2:
         target.refresh_from_db()
         assert target.team == [1]
 
+    def test_stale_full_save_preserves_concurrent_team_change(self):
+        from apps.job_mgmt.models import Target, TargetTeamMembership
+
+        Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
+        stale = Target.objects.get(name="owned")
+        concurrent = Target.objects.get(name="owned")
+        concurrent.team = [2]
+        concurrent.save(update_fields=["team"])
+
+        stale.name = "renamed"
+        stale.save()
+
+        stale.refresh_from_db()
+        assert stale.name == "renamed"
+        assert stale.team == [2]
+        assert set(TargetTeamMembership.objects.filter(target=stale).values_list("team_id", flat=True)) == {2}
+
+    def test_conflicting_team_writes_require_refresh(self):
+        from apps.job_mgmt.models import Target, TargetTeamConcurrentUpdateError
+
+        Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
+        stale = Target.objects.get(name="owned")
+        concurrent = Target.objects.get(name="owned")
+        concurrent.team = [2]
+        concurrent.save(update_fields=["team"])
+
+        stale.team = [3]
+        with pytest.raises(TargetTeamConcurrentUpdateError, match="刷新后重试"):
+            stale.save(update_fields=["team"])
+
+        stale.refresh_from_db()
+        assert stale.team == [2]
+
     def test_queryset_and_bulk_team_writes_keep_projection_in_sync(self):
         from apps.job_mgmt.models import Target, TargetTeamMembership
 
@@ -546,6 +575,44 @@ class TestJobTargetListV2:
         created.team = [4]
         Target.objects.bulk_update([created], ["team"])
         assert set(TargetTeamMembership.objects.filter(target=created).values_list("team_id", flat=True)) == {4}
+
+    @pytest.mark.django_db(transaction=True)
+    def test_queryset_update_does_not_capture_rows_inserted_after_lock_snapshot(self):
+        from apps.job_mgmt.models import Target, TargetTeamMembership
+
+        original = Target.objects.create(name="race-original", ip="10.0.0.1", os_type="linux", team=[1])
+        select_started = Event()
+        errors = []
+
+        def update_matching_targets():
+            close_old_connections()
+
+            def observe_select(execute, sql, params, many, context):
+                if "FOR UPDATE" in sql:
+                    select_started.set()
+                return execute(sql, params, many, context)
+
+            try:
+                with connection.execute_wrapper(observe_select):
+                    Target.objects.filter(name__startswith="race-").update(team=[2])
+            except Exception as error:  # pragma: no cover - asserted below
+                errors.append(error)
+            finally:
+                close_old_connections()
+
+        with transaction.atomic():
+            Target.objects.select_for_update().get(pk=original.pk)
+            worker = Thread(target=update_matching_targets)
+            worker.start()
+            assert select_started.wait(timeout=5)
+            inserted = Target.objects.create(name="race-inserted", ip="10.0.0.2", os_type="linux", team=[1])
+
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert errors == []
+        inserted.refresh_from_db()
+        assert inserted.team == [1]
+        assert set(TargetTeamMembership.objects.filter(target=inserted).values_list("team_id", flat=True)) == {1}
 
     def test_projection_has_team_target_composite_index(self):
         from apps.job_mgmt.models import TargetTeamMembership
@@ -567,37 +634,10 @@ class TestJobTargetListV2:
         call_command("reconcile_target_team_memberships", check=True)
         assert set(TargetTeamMembership.objects.filter(target=target).values_list("team_id", flat=True)) == {1}
 
-    def test_real_token_page_uses_one_auth_and_one_target_query(self, django_assert_num_queries):
-        import os
-
-        import jwt
-
-        from apps.job_mgmt.models import Target
-        from apps.job_mgmt.nats_api import job_target_list_v2
-        from apps.system_mgmt.models import User
-        from apps.system_mgmt.nats.common import _build_jwt_payload
-
-        user = User.objects.create(
-            username="target-list-v2",
-            display_name="Target List V2",
-            email="target-list-v2@example.invalid",
-            password="unused",
-            group_list=[{"id": 1, "name": "team-one"}],
-        )
-        target = Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
-        token = jwt.encode(_build_jwt_payload(user.id), key=os.environ["SECRET_KEY"], algorithm="HS256")
-
-        with django_assert_num_queries(2):
-            result = job_target_list_v2({"caller_token": token, "page_size": 1})
-
-        assert [item["target_id"] for item in result["data"]["items"]] == [target.id]
-
     def test_empty_page_has_no_resume_cursor(self):
-        from apps.job_mgmt.nats_api import job_target_list_v2
+        from apps.job_mgmt.services.target_list_v2 import query_target_list_v2
 
-        caller = MagicMock(group_list=[1])
-        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
-            result = job_target_list_v2({"caller_token": "valid"})
+        result = query_target_list_v2({}, {1})
 
         assert result == {
             "result": True,

--- a/server/apps/job_mgmt/tests/test_nats_open_api.py
+++ b/server/apps/job_mgmt/tests/test_nats_open_api.py
@@ -404,3 +404,202 @@ class TestJobTargetList:
         result = job_target_list({"page": 1, "page_size": 2})
         assert result["data"]["count"] == 5
         assert len(result["data"]["items"]) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.django_db
+class TestJobTargetListV2:
+    @pytest.fixture(autouse=True)
+    def enable_v2(self, monkeypatch):
+        monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+
+    def test_requires_caller_token(self):
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        assert job_target_list_v2({}) == {"result": False, "message": "caller_token 不能为空"}
+
+    def test_is_disabled_until_projection_is_reconciled(self, monkeypatch):
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        monkeypatch.delenv("JOB_TARGET_LIST_V2_ENABLED")
+        caller = MagicMock(group_list=[1])
+        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
+            assert job_target_list_v2({"caller_token": "valid"}) == {
+                "result": False,
+                "message": "job_target_list_v2 尚未启用",
+            }
+
+    def test_rejects_invalid_page_size_and_cursor(self, monkeypatch):
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        caller = MagicMock(group_list=[1])
+        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
+            assert job_target_list_v2({"caller_token": "valid", "page_size": -1}) == {
+                "result": False,
+                "message": "page_size 范围为 1-100",
+            }
+            assert job_target_list_v2({"caller_token": "valid", "page_size": 101}) == {
+                "result": False,
+                "message": "page_size 范围为 1-100",
+            }
+            assert job_target_list_v2({"caller_token": "valid", "cursor": 0}) == {
+                "result": False,
+                "message": "cursor 必须为大于 0 的整数",
+            }
+            for invalid in (True, 1.5):
+                assert job_target_list_v2({"caller_token": "valid", "page_size": invalid}) == {
+                    "result": False,
+                    "message": "page_size 参数非法",
+                }
+                assert job_target_list_v2({"caller_token": "valid", "cursor": invalid}) == {
+                    "result": False,
+                    "message": "cursor 必须为大于 0 的整数",
+                }
+            monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", "2")
+            assert job_target_list_v2({"caller_token": "valid", "page_size": 3}) == {
+                "result": False,
+                "message": "page_size 范围为 1-2",
+            }
+            for invalid_max in ("invalid", "0", "101", "1000"):
+                monkeypatch.setenv("JOB_TARGET_LIST_V2_MAX_PAGE_SIZE", invalid_max)
+                assert job_target_list_v2({"caller_token": "valid", "page_size": 100})["result"] is True
+                assert job_target_list_v2({"caller_token": "valid", "page_size": 101}) == {
+                    "result": False,
+                    "message": "page_size 范围为 1-100",
+                }
+
+    def test_returns_bounded_team_scoped_keyset_pages(self, django_assert_num_queries):
+        from apps.job_mgmt.models import Target
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        Target.objects.create(name="foreign", ip="10.0.1.1", os_type="linux", team=[2])
+        owned = [Target.objects.create(name=f"owned-{index}", ip=f"10.0.0.{index}", os_type="linux", team=[1]) for index in range(1, 6)]
+
+        caller = MagicMock(group_list=[{"id": 1, "name": "team-one"}])
+        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
+            with django_assert_num_queries(2):
+                first = job_target_list_v2({"caller_token": "valid", "page_size": 2})
+                second = job_target_list_v2({"caller_token": "valid", "page_size": 2, "cursor": first["data"]["next_cursor"]})
+
+        assert first["result"] is True
+        assert "count" not in first["data"]
+        assert [item["target_id"] for item in first["data"]["items"]] == [owned[4].id, owned[3].id]
+        assert first["data"]["has_more"] is True
+        assert first["data"]["next_cursor"] == owned[3].id
+        assert [item["target_id"] for item in second["data"]["items"]] == [owned[2].id, owned[1].id]
+        assert {item["target_id"] for item in first["data"]["items"]}.isdisjoint(item["target_id"] for item in second["data"]["items"])
+
+    def test_sparse_team_page_never_exposes_foreign_cursor(self, django_assert_num_queries):
+        from apps.job_mgmt.models import Target
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        owned = [Target.objects.create(name=f"owned-{index}", ip=f"10.0.0.{index}", os_type="linux", team=[1]) for index in range(1, 3)]
+        foreign = [Target.objects.create(name=f"foreign-{index}", ip=f"10.0.1.{index}", os_type="linux", team=[2]) for index in range(1, 4)]
+
+        caller = MagicMock(group_list=[1])
+        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
+            with django_assert_num_queries(1):
+                first = job_target_list_v2({"caller_token": "valid", "page_size": 1})
+            with django_assert_num_queries(1):
+                second = job_target_list_v2({"caller_token": "valid", "page_size": 1, "cursor": first["data"]["next_cursor"]})
+
+        foreign_ids = {target.id for target in foreign}
+        assert [item["target_id"] for item in first["data"]["items"]] == [owned[1].id]
+        assert first["data"]["next_cursor"] == owned[1].id
+        assert first["data"]["next_cursor"] not in foreign_ids
+        assert [item["target_id"] for item in second["data"]["items"]] == [owned[0].id]
+        assert second["data"]["next_cursor"] is None
+        assert second["data"]["has_more"] is False
+
+    def test_target_save_keeps_indexed_team_projection_in_sync(self):
+        from apps.job_mgmt.models import Target, TargetTeamMembership
+
+        target = Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1, "2", 2, "invalid"])
+        assert set(TargetTeamMembership.objects.filter(target=target).values_list("team_id", flat=True)) == {1, 2}
+
+        target.team = [{"id": 3}, 4]
+        target.save(update_fields=["team"])
+        assert set(TargetTeamMembership.objects.filter(target=target).values_list("team_id", flat=True)) == {3, 4}
+
+    def test_target_and_projection_roll_back_together(self):
+        from apps.job_mgmt.models import Target
+
+        target = Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
+        target.team = [2]
+        with patch("apps.job_mgmt.models.target._replace_target_team_memberships", side_effect=RuntimeError("sync failed")):
+            with pytest.raises(RuntimeError, match="sync failed"):
+                target.save(update_fields=["team"])
+
+        target.refresh_from_db()
+        assert target.team == [1]
+
+    def test_queryset_and_bulk_team_writes_keep_projection_in_sync(self):
+        from apps.job_mgmt.models import Target, TargetTeamMembership
+
+        target = Target.objects.create(name="one", ip="10.0.0.1", os_type="linux", team=[1])
+        Target.objects.filter(id=target.id).update(team=[2])
+        assert set(TargetTeamMembership.objects.filter(target=target).values_list("team_id", flat=True)) == {2}
+
+        created = Target.objects.bulk_create([Target(name="two", ip="10.0.0.2", os_type="linux", team=[3])])[0]
+        assert set(TargetTeamMembership.objects.filter(target=created).values_list("team_id", flat=True)) == {3}
+
+        created.team = [4]
+        Target.objects.bulk_update([created], ["team"])
+        assert set(TargetTeamMembership.objects.filter(target=created).values_list("team_id", flat=True)) == {4}
+
+    def test_projection_has_team_target_composite_index(self):
+        from apps.job_mgmt.models import TargetTeamMembership
+
+        assert any(index.fields == ["team_id", "target"] for index in TargetTeamMembership._meta.indexes)
+
+    def test_projection_reconciliation_is_repeatable(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        from apps.job_mgmt.models import Target, TargetTeamMembership
+
+        target = Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
+        TargetTeamMembership.objects.filter(target=target).delete()
+
+        with pytest.raises(CommandError, match="1 个目标"):
+            call_command("reconcile_target_team_memberships", check=True)
+        call_command("reconcile_target_team_memberships", apply=True)
+        call_command("reconcile_target_team_memberships", check=True)
+        assert set(TargetTeamMembership.objects.filter(target=target).values_list("team_id", flat=True)) == {1}
+
+    def test_real_token_page_uses_one_auth_and_one_target_query(self, django_assert_num_queries):
+        import os
+
+        import jwt
+
+        from apps.job_mgmt.models import Target
+        from apps.job_mgmt.nats_api import job_target_list_v2
+        from apps.system_mgmt.models import User
+        from apps.system_mgmt.nats.common import _build_jwt_payload
+
+        user = User.objects.create(
+            username="target-list-v2",
+            display_name="Target List V2",
+            email="target-list-v2@example.invalid",
+            password="unused",
+            group_list=[{"id": 1, "name": "team-one"}],
+        )
+        target = Target.objects.create(name="owned", ip="10.0.0.1", os_type="linux", team=[1])
+        token = jwt.encode(_build_jwt_payload(user.id), key=os.environ["SECRET_KEY"], algorithm="HS256")
+
+        with django_assert_num_queries(2):
+            result = job_target_list_v2({"caller_token": token, "page_size": 1})
+
+        assert [item["target_id"] for item in result["data"]["items"]] == [target.id]
+
+    def test_empty_page_has_no_resume_cursor(self):
+        from apps.job_mgmt.nats_api import job_target_list_v2
+
+        caller = MagicMock(group_list=[1])
+        with patch("apps.job_mgmt.nats_api._verify_token", return_value=caller):
+            result = job_target_list_v2({"caller_token": "valid"})
+
+        assert result == {
+            "result": True,
+            "data": {"items": [], "next_cursor": None, "has_more": False},
+        }

--- a/server/apps/job_mgmt/tests/test_open_file_distribute_views.py
+++ b/server/apps/job_mgmt/tests/test_open_file_distribute_views.py
@@ -11,12 +11,13 @@ from rest_framework.test import APIClient
 from apps.base.models import User, UserAPISecret
 from apps.job_mgmt.models import DistributionFile, JobExecution, Target
 from apps.node_mgmt.models import CloudRegion, Node, NodeOrganization
-from apps.system_mgmt.models import Group
+from apps.system_mgmt.models import Group, Menu, Role
 from apps.system_mgmt.models import User as SystemUser
 
 pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 URL = "/openapi/v1/job-mgmt/file-distribute"
+TARGET_LIST_V2_URL = "/openapi/v1/job-mgmt/targets-v2"
 
 
 @pytest.fixture
@@ -30,6 +31,18 @@ def tenant():
         domain=user.domain,
         group_list=[team.id],
     )
+    target_menu, _ = Menu.objects.get_or_create(
+        name="target-View",
+        app="job",
+        defaults={"display_name": "Target View", "url": "", "menu_type": "button"},
+    )
+    target_role, _ = Role.objects.update_or_create(
+        name="openapi-target-reader",
+        app="job",
+        defaults={"menu_list": [target_menu.id]},
+    )
+    system_user.role_list = [target_role.id]
+    system_user.save(update_fields=["role_list"])
     token = UserAPISecret.generate_api_secret()
     UserAPISecret.objects.create(
         username=user.username,
@@ -38,7 +51,12 @@ def tenant():
         team=team.id,
     )
     other_user = User.objects.create(username=user.username, domain="other.test.com")
-    SystemUser.objects.create(username=other_user.username, domain=other_user.domain, group_list=[other_team.id])
+    other_system_user = SystemUser.objects.create(
+        username=other_user.username,
+        domain=other_user.domain,
+        group_list=[other_team.id],
+        role_list=[target_role.id],
+    )
     other_token = UserAPISecret.generate_api_secret()
     UserAPISecret.objects.create(
         username=other_user.username,
@@ -53,6 +71,7 @@ def tenant():
         team=team.id,
     )
     target = Target.objects.create(name="web-01", ip="10.0.0.1", team=[team.id])
+    other_target = Target.objects.create(name="db-01", ip="10.0.0.2", team=[other_team.id])
     return SimpleNamespace(
         team=team,
         other_team=other_team,
@@ -61,8 +80,10 @@ def tenant():
         token=token,
         other_token=other_token,
         other_user=other_user,
+        other_system_user=other_system_user,
         file=file,
         target=target,
+        other_target=other_target,
     )
 
 
@@ -241,3 +262,87 @@ def test_rejects_uncontrolled_callback_without_side_effects(tenant):
     assert response.status_code == 400
     assert response.json()["code"] == "SCHEMA_INVALID"
     _assert_no_side_effects(mock_delay)
+
+
+def test_target_list_v2_tenant_reads_only_own_targets(tenant, monkeypatch):
+    monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+
+    response = APIClient().post(TARGET_LIST_V2_URL, {"page_size": 100}, format="json", **_auth(tenant))
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert [item["target_id"] for item in data["items"]] == [tenant.target.id]
+    assert data["has_more"] is False
+    assert data["next_cursor"] is None
+
+
+def test_target_list_v2_other_tenant_cannot_read_first_tenant_targets(tenant, monkeypatch):
+    monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+
+    response = APIClient().post(TARGET_LIST_V2_URL, {"page_size": 100}, format="json", **_other_auth(tenant))
+
+    assert response.status_code == 200
+    ids = [item["target_id"] for item in response.json()["data"]["items"]]
+    assert ids == [tenant.other_target.id]
+    assert tenant.target.id not in ids
+
+
+def test_target_list_v2_rejects_forged_team(tenant, monkeypatch):
+    monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+
+    response = APIClient().post(
+        TARGET_LIST_V2_URL,
+        {"page_size": 20, "team": tenant.other_team.id},
+        format="json",
+        **_auth(tenant),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "SCHEMA_INVALID"
+
+
+def test_target_list_v2_is_disabled_by_default(tenant, monkeypatch):
+    monkeypatch.delenv("JOB_TARGET_LIST_V2_ENABLED", raising=False)
+
+    response = APIClient().post(TARGET_LIST_V2_URL, {}, format="json", **_auth(tenant))
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "BUSINESS_REJECTED"
+
+
+def test_target_list_v2_rejects_disabled_jwt_identity(tenant, monkeypatch):
+    import os
+
+    import jwt
+
+    from apps.system_mgmt.nats.common import _build_jwt_payload
+
+    monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+    tenant.system_user.disabled = True
+    tenant.system_user.save(update_fields=["disabled"])
+    token = jwt.encode(
+        _build_jwt_payload(tenant.system_user.id),
+        key=os.environ["SECRET_KEY"],
+        algorithm="HS256",
+    )
+
+    response = APIClient().post(
+        TARGET_LIST_V2_URL,
+        {},
+        format="json",
+        HTTP_AUTHORIZATION=f"Bearer {token}",
+    )
+
+    assert response.status_code == 401
+    assert response.json()["code"] == "AUTH_INVALID"
+
+
+def test_target_list_v2_rejects_archived_api_token_team_as_out_of_scope(tenant, monkeypatch):
+    monkeypatch.setenv("JOB_TARGET_LIST_V2_ENABLED", "true")
+    tenant.team.is_delete = True
+    tenant.team.save(update_fields=["is_delete"])
+
+    response = APIClient().post(TARGET_LIST_V2_URL, {}, format="json", **_auth(tenant))
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "TEAM_OUT_OF_SCOPE"

--- a/server/apps/job_mgmt/tests/test_target_views.py
+++ b/server/apps/job_mgmt/tests/test_target_views.py
@@ -7,7 +7,7 @@ import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from apps.core.exceptions.base_app_exception import BaseAppException
-from apps.job_mgmt.models import Target
+from apps.job_mgmt.models import Target, TargetTeamConcurrentUpdateError
 from apps.job_mgmt.services.execution_base_service import ExecutionTaskBaseService
 from apps.job_mgmt.views import target as target_views
 
@@ -66,6 +66,19 @@ class TestBuildSshTestFailureMessage:
     def test_merges_fallbacks(self):
         msg = target_views._build_ssh_test_failure_message({}, "err-detail", "stdout-detail")
         assert isinstance(msg, str) and msg
+
+
+@pytest.mark.unit
+def test_update_maps_concurrent_team_change_to_client_error():
+    view = target_views.TargetViewSet()
+    with patch(
+        "apps.core.utils.viewset_utils.AuthViewSet.update",
+        side_effect=TargetTeamConcurrentUpdateError("Target.team 已被并发修改，请刷新后重试"),
+    ):
+        response = view.update(SimpleNamespace())
+
+    assert response.status_code == 400
+    assert "刷新后重试" in response.data["detail"]
 
 
 # ----------------------------- HTTP ----------------------------- #

--- a/server/apps/job_mgmt/views/mixins.py
+++ b/server/apps/job_mgmt/views/mixins.py
@@ -120,7 +120,9 @@ class BatchDeleteMixin:
         instances = self.get_batch_delete_queryset(ids)
         self.pre_batch_delete(instances)
 
-        deleted_count, _ = instances.delete()
+        # QuerySet.delete() 的首项包含级联删除行数；API 契约只返回用户所选主对象数。
+        deleted_count = instances.count()
+        instances.delete()
         response = Response({"deleted_count": deleted_count}, status=status.HTTP_200_OK)
         if response.status_code == status.HTTP_200_OK and self.batch_delete_log_label:
             log_operation(request, "delete", "job", f"批量删除{self.batch_delete_log_label}: (共{deleted_count}个)")

--- a/server/apps/job_mgmt/views/target.py
+++ b/server/apps/job_mgmt/views/target.py
@@ -13,7 +13,7 @@ from apps.core.logger import job_logger as logger
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.job_mgmt.constants import OSType, SSHCredentialType, WinRMTransport
 from apps.job_mgmt.filters.target import TargetFilter
-from apps.job_mgmt.models import Target
+from apps.job_mgmt.models import Target, TargetTeamConcurrentUpdateError
 from apps.job_mgmt.serializers.target import TargetBatchDeleteSerializer, TargetSerializer, TargetTestConnectionSerializer
 from apps.job_mgmt.services.error_response import exception_to_response
 from apps.job_mgmt.services.execution_base_service import ExecutionTaskBaseService
@@ -121,6 +121,12 @@ class TargetViewSet(BatchDeleteMixin, AuthViewSet):
         elif self.action == "test_connection":
             return TargetTestConnectionSerializer
         return TargetSerializer
+
+    def update(self, request, *args, **kwargs):
+        try:
+            return super().update(request, *args, **kwargs)
+        except TargetTeamConcurrentUpdateError as error:
+            return exception_to_response(error, context="[target.update]")
 
     @HasPermission("target-View")
     def list(self, request, *args, **kwargs):

--- a/server/apps/system_mgmt/nats/common.py
+++ b/server/apps/system_mgmt/nats/common.py
@@ -211,6 +211,6 @@ def _verify_token(token):
             raise Exception("Token is invalid")
 
     user = User.objects.filter(id=user_info["user_id"]).first()
-    if not user:
+    if not user or user.disabled:
         raise Exception(VERIFY_TOKEN_USER_NOT_FOUND_MESSAGE)
     return user


### PR DESCRIPTION
## 问题

`bklite.job_target_list` 的公开 v1 契约允许 `page_size=-1`，会一次加载、序列化并返回全部目标；同时 v1 没有可信调用方身份和团队数据范围。目标规模增长或被跨团队调用时，应用内存、序列化耗时、NATS 响应大小和目标信息暴露面都会随目标数增长。

关联 #3422、#3975。历史 PR #4023 已关闭且未合并，本 PR 基于当前 `master` 重新实现兼容首片。

## 根因

v1 同时执行精确计数、无上界 ORM 遍历和完整 JSON 构建，并沿用“信任内网调用方”的无身份契约。直接收紧或删除 v1 会破坏现有公开调用方，因此本次保留 v1 语义，新增受认证、团队隔离且有界的 v2，作为调用方迁移与 v1 后续退役的安全首片。

## 修改

- 新增 `bklite.job_target_list_v2`：校验调用方 token，从服务端身份派生授权团队，按授权团队过滤，使用 `target_id` 键集分页，单页硬上限 100，不返回精确总数。
- 新增目标—团队可索引投影及数据迁移；目标保存、`update`、`bulk_update`、`bulk_create` 与授权投影在同一事务内同步，同目标更新使用行锁。
- 新增幂等投影校验/修复命令，v2 默认关闭；旧进程退出并完成 `--apply`、`--check` 零漂移校验后才允许启用。
- 保留 v1 的 `page_size=-1` 行为，并更新公开 API 与 NATS 客户端示例。

```mermaid
flowchart LR
    A[NATS 请求] --> B{v2 已启用}
    B -- 否 --> C[安全拒绝]
    B -- 是 --> D[校验 caller_token]
    D --> E[服务端派生授权团队]
    E --> F[团队投影过滤]
    F --> G[键集游标与 LIMIT P+1]
    G --> H[最多返回 100 条]
```

## 兼容与发布

- v1 subject、默认值、失败语义及 `page_size=-1` 均不变。
- v2 为新增 subject，默认 `JOB_TARGET_LIST_V2_ENABLED=false`；请求中的筛选字段不能扩大 token 派生的团队范围。
- 发布顺序：完成新版本滚动部署并退出旧进程；执行 `python manage.py reconcile_target_team_memberships --apply`；再执行 `--check` 确认零漂移；最后设置 `JOB_TARGET_LIST_V2_ENABLED=true` 并滚动重启。
- 键集分页不是一致性快照；并发新增、删除或权限变化的语义已写入文档。
- #3975 的完整闭环还需要迁移合法调用方、观测 v1 使用归零并退役无身份 v1；回滚时可关闭 v2，v1 行为不受本 PR 影响。

## 验证

- `apps/job_mgmt/tests/test_nats_open_api.py` 与 `apps/job_mgmt/tests/test_nats_api_service.py`：88 passed。
- 真实 NATS handler 信封验证：v2 subject 已注册，缺少 token 时稳定拒绝且不返回目标数据。
- 迁移在重建测试库后通过，投影回填、原子回滚、批量写同步、reconciliation、真实 token 查询预算均有覆盖。
- PostgreSQL 查询计划命中 `(team_id, target_id)` 复合索引，并在 `LIMIT 101` 下执行。
- 触及文件的 Black、isort、Flake8、迁移检查、依赖检查和 diff-check 均通过。

## 三轨评审

- Standards：通过。无原生 SQL；授权投影与源字段原子同步；批量入口和滚动发布窗口有安全闭环。
- Spec：通过。作为 #3975 的版本化首片，v2 使用可信 token 派生团队范围且 v1 完全兼容；后续调用方迁移与 v1 退役边界明确。
- Runtime Contract：通过。注册、NATS 信封、缺 token 拒绝、默认关闭、真实 token 成功、授权隔离、游标不泄露及查询预算均已验证。

风险：中。涉及新增表和目标写路径；通过默认关闭、幂等校验、原子双写和可回滚环境开关控制上线风险。
