### PR TITLE
bugfix: 工作流执行前校验图结构

### DIFF
--- a/server/apps/opspilot/tests/test_workflow_structure_validation.py
+++ b/server/apps/opspilot/tests/test_workflow_structure_validation.py
@@ -1,0 +1,110 @@
+"""工作流执行前的结构校验契约。"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+
+import pytest
+
+from apps.opspilot.utils.chat_flow_utils.engine.engine import ChatFlowEngine
+
+
+@pytest.mark.parametrize(
+    ("flow_json", "expected_error"),
+    [
+        ([], "流程数据必须是对象"),
+        ({"nodes": {}, "edges": []}, "nodes 必须是数组"),
+        ({"nodes": [], "edges": {}}, "edges 必须是数组"),
+        ({"nodes": ["invalid"], "edges": []}, "节点 1 必须是对象"),
+        ({"nodes": [{"type": "restful"}], "edges": []}, "节点 1 缺少有效 id"),
+        ({"nodes": [{"id": 0, "type": "restful"}], "edges": []}, "节点 1 缺少有效 id"),
+        ({"nodes": [{"id": False, "type": "restful"}], "edges": []}, "节点 1 缺少有效 id"),
+        ({"nodes": [{"id": 42, "type": "restful"}], "edges": []}, "节点 1 缺少有效 id"),
+        ({"nodes": [{"id": "entry", "type": []}], "edges": []}, "节点 1 的 type 必须是字符串"),
+        ({"nodes": [{"id": "entry", "type": {}}], "edges": []}, "节点 1 的 type 必须是字符串"),
+        (
+            {"nodes": [{"id": "entry", "type": "restful"}], "edges": ["invalid"]},
+            "边 1 必须是对象",
+        ),
+        (
+            {"nodes": [{"id": "entry", "type": "restful"}], "edges": [{"target": "entry"}]},
+            "边 1 缺少有效 source",
+        ),
+        (
+            {"nodes": [{"id": "entry", "type": "restful"}], "edges": [{"source": 0, "target": "entry"}]},
+            "边 1 缺少有效 source",
+        ),
+        (
+            {"nodes": [{"id": "entry", "type": "restful"}], "edges": [{"source": "entry"}]},
+            "边 1 缺少有效 target",
+        ),
+        (
+            {"nodes": [{"id": "entry", "type": "restful"}], "edges": [{"source": "entry", "target": False}]},
+            "边 1 缺少有效 target",
+        ),
+    ],
+)
+def test_execute_rejects_malformed_workflow_with_readable_error(flow_json, expected_error):
+    workflow = SimpleNamespace(id=3763, flow_json=flow_json)
+
+    result = ChatFlowEngine(workflow).execute()
+
+    assert result["success"] is False
+    assert expected_error in result["error"]
+    assert result["execution_time"] == 0
+
+
+def test_structure_validation_preserves_minimal_legacy_node_shape():
+    workflow = SimpleNamespace(
+        id=3763,
+        flow_json={"nodes": [{"id": "entry", "type": "restful"}], "edges": []},
+    )
+
+    assert ChatFlowEngine(workflow).validate_flow() == []
+
+
+def test_structure_validation_does_not_mutate_persisted_flow_json():
+    flow_json = {
+        "nodes": [{"id": "entry", "type": "restful"}, {"type": "restful"}],
+        "edges": [{"source": "entry"}],
+        "metadata": {"schema_version": "legacy"},
+    }
+    original = deepcopy(flow_json)
+
+    ChatFlowEngine(SimpleNamespace(id=3763, flow_json=flow_json)).execute()
+
+    assert flow_json == original
+
+
+@pytest.mark.parametrize(
+    ("flow_json", "expected_error"),
+    [
+        (
+            {
+                "nodes": [
+                    {"id": "entry", "type": "restful"},
+                    {"id": "entry", "type": "restful"},
+                ],
+                "edges": [],
+            },
+            "节点 2 的 id 重复: entry",
+        ),
+        (
+            {
+                "nodes": [{"id": "entry", "type": "restful"}],
+                "edges": [{"source": "missing", "target": "entry"}],
+            },
+            "边 1 的 source 未引用现有节点: missing",
+        ),
+        (
+            {
+                "nodes": [{"id": "entry", "type": "restful"}],
+                "edges": [{"source": "entry", "target": "missing"}],
+            },
+            "边 1 的 target 未引用现有节点: missing",
+        ),
+    ],
+)
+def test_validate_flow_rejects_ambiguous_graph_references(flow_json, expected_error):
+    workflow = SimpleNamespace(id=3763, flow_json=flow_json)
+
+    assert expected_error in ChatFlowEngine(workflow).validate_flow()

--- a/server/apps/opspilot/tests/test_workflow_structure_validation_pure.py
+++ b/server/apps/opspilot/tests/test_workflow_structure_validation_pure.py
@@ -1,11 +1,22 @@
 """工作流执行前的结构校验契约。"""
 
+import asyncio
+import json
 from copy import deepcopy
 from types import SimpleNamespace
 
 import pytest
 
 from apps.opspilot.utils.chat_flow_utils.engine.engine import ChatFlowEngine
+
+pytestmark = pytest.mark.unit
+
+
+async def _stream_content(response):
+    chunks = []
+    async for chunk in response.streaming_content:
+        chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+    return "".join(chunks)
 
 
 @pytest.mark.parametrize(
@@ -21,6 +32,8 @@ from apps.opspilot.utils.chat_flow_utils.engine.engine import ChatFlowEngine
         ({"nodes": [{"id": 42, "type": "restful"}], "edges": []}, "节点 1 缺少有效 id"),
         ({"nodes": [{"id": "entry", "type": []}], "edges": []}, "节点 1 的 type 必须是字符串"),
         ({"nodes": [{"id": "entry", "type": {}}], "edges": []}, "节点 1 的 type 必须是字符串"),
+        ({"nodes": [{"id": "entry", "type": ""}], "edges": []}, "节点 1 缺少有效 type"),
+        ({"nodes": [{"id": "entry", "type": "  "}], "edges": []}, "节点 1 缺少有效 type"),
         (
             {"nodes": [{"id": "entry", "type": "restful"}], "edges": ["invalid"]},
             "边 1 必须是对象",
@@ -62,6 +75,23 @@ def test_structure_validation_preserves_minimal_legacy_node_shape():
     assert ChatFlowEngine(workflow).validate_flow() == []
 
 
+def test_execute_preserves_minimal_legacy_node_shape(monkeypatch):
+    workflow = SimpleNamespace(
+        id=3763,
+        bot_id=1,
+        flow_json={"nodes": [{"id": "entry", "type": "compat_echo"}], "edges": []},
+    )
+    engine = ChatFlowEngine(workflow)
+    engine.custom_node_executors["compat_echo"] = lambda _node_id, _node, data: {"last_message": f"{data['last_message']} ok"}
+    monkeypatch.setattr(engine, "_ensure_execution_result_started", lambda *args: None)
+    monkeypatch.setattr(engine, "_record_conversation_history", lambda *args: None)
+    monkeypatch.setattr(engine, "_record_execution_result", lambda *args: None)
+    monkeypatch.setattr(engine, "_record_node_execution_result", lambda *args: None)
+    monkeypatch.setattr(engine, "_check_interrupt_requested", lambda: False)
+
+    assert engine.execute({"last_message": "hello"}) == "hello ok"
+
+
 def test_structure_validation_does_not_mutate_persisted_flow_json():
     flow_json = {
         "nodes": [{"id": "entry", "type": "restful"}, {"type": "restful"}],
@@ -73,6 +103,24 @@ def test_structure_validation_does_not_mutate_persisted_flow_json():
     ChatFlowEngine(SimpleNamespace(id=3763, flow_json=flow_json)).execute()
 
     assert flow_json == original
+
+
+def test_sse_structure_validation_returns_detail_before_conversation_side_effect(monkeypatch):
+    workflow = SimpleNamespace(
+        id=3763,
+        bot_id=1,
+        flow_json={"nodes": [{"type": "restful"}], "edges": []},
+    )
+    engine = ChatFlowEngine(workflow)
+    recorded_messages = []
+    monkeypatch.setattr(engine, "_record_conversation_history", lambda *args: recorded_messages.append(args))
+
+    response = engine.sse_execute({"last_message": "hello"})
+    content = asyncio.run(_stream_content(response))
+    payload = json.loads(content.splitlines()[0].removeprefix("data: "))
+
+    assert "节点 1 缺少有效 id" in payload["error"]
+    assert recorded_messages == []
 
 
 @pytest.mark.parametrize(

--- a/server/apps/opspilot/utils/chat_flow_utils/engine/engine.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/engine/engine.py
@@ -73,9 +73,11 @@ class ChatFlowEngine(FlowGraphMixin, NodeRunnerMixin, SSEResponderMixin):
         # 与写入 execution_contexts，需串行化以避免计数错乱或字典写入竞争。
         self._state_lock = threading.RLock()
 
-        # 解析流程图
-        self.nodes = self._parse_nodes(instance.flow_json)
-        self.edges = self._parse_edges(instance.flow_json)
+        # 先校验并生成仅供本次执行使用的安全结构视图。历史数据保持原样，
+        # 但缺字段/错类型不能在 validate_flow() 之前触发原始 Python 异常。
+        self._flow_structure_errors, execution_flow_json = self._normalize_flow_structure(instance.flow_json)
+        self.nodes = self._parse_nodes(execution_flow_json)
+        self.edges = self._parse_edges(execution_flow_json)
 
         # 构建节点ID到节点的映射字典（用于 O(1) 查找）
         self._node_map: Dict[str, Dict[str, Any]] = {node.get("id"): node for node in self.nodes if node.get("id")}
@@ -93,6 +95,69 @@ class ChatFlowEngine(FlowGraphMixin, NodeRunnerMixin, SSEResponderMixin):
         self.max_parallel_nodes = 5
         self.max_retry_count = 3
         self.execution_timeout = 300  # 5分钟超时
+
+    @staticmethod
+    def _is_valid_graph_id(value: Any) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    @classmethod
+    def _normalize_flow_structure(cls, flow_json: Any) -> tuple[List[str], Dict[str, List[Dict[str, Any]]]]:
+        """返回结构错误和可安全建图的执行视图，不改写持久化配置。"""
+        if not isinstance(flow_json, dict):
+            return ["流程数据必须是对象"], {"nodes": [], "edges": []}
+
+        errors: List[str] = []
+        raw_nodes = flow_json.get("nodes", [])
+        raw_edges = flow_json.get("edges", [])
+
+        if not isinstance(raw_nodes, list):
+            errors.append("nodes 必须是数组")
+            raw_nodes = []
+        if not isinstance(raw_edges, list):
+            errors.append("edges 必须是数组")
+            raw_edges = []
+
+        nodes = []
+        node_ids = set()
+        for index, node in enumerate(raw_nodes, start=1):
+            if not isinstance(node, dict):
+                errors.append(f"节点 {index} 必须是对象")
+                continue
+            node_id = node.get("id")
+            if not cls._is_valid_graph_id(node_id):
+                errors.append(f"节点 {index} 缺少有效 id")
+                continue
+            if not isinstance(node.get("type"), str):
+                errors.append(f"节点 {index} 的 type 必须是字符串")
+                continue
+            if node_id in node_ids:
+                errors.append(f"节点 {index} 的 id 重复: {node_id}")
+                continue
+            node_ids.add(node_id)
+            nodes.append(node)
+
+        edges = []
+        for index, edge in enumerate(raw_edges, start=1):
+            if not isinstance(edge, dict):
+                errors.append(f"边 {index} 必须是对象")
+                continue
+            source = edge.get("source")
+            target = edge.get("target")
+            if not cls._is_valid_graph_id(source):
+                errors.append(f"边 {index} 缺少有效 source")
+                continue
+            if not cls._is_valid_graph_id(target):
+                errors.append(f"边 {index} 缺少有效 target")
+                continue
+            if source not in node_ids:
+                errors.append(f"边 {index} 的 source 未引用现有节点: {source}")
+                continue
+            if target not in node_ids:
+                errors.append(f"边 {index} 的 target 未引用现有节点: {target}")
+                continue
+            edges.append(edge)
+
+        return errors, {"nodes": nodes, "edges": edges}
 
     def _initialize_variables(self, input_data: Dict[str, Any]):
         """初始化变量管理器
@@ -980,7 +1045,9 @@ class ChatFlowEngine(FlowGraphMixin, NodeRunnerMixin, SSEResponderMixin):
         Returns:
             错误列表，空列表表示无错误
         """
-        errors = []
+        errors = list(self._flow_structure_errors)
+        if errors:
+            return errors
 
         # 检查是否有节点
         if not self.nodes:

--- a/server/apps/opspilot/utils/chat_flow_utils/engine/engine.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/engine/engine.py
@@ -96,69 +96,6 @@ class ChatFlowEngine(FlowGraphMixin, NodeRunnerMixin, SSEResponderMixin):
         self.max_retry_count = 3
         self.execution_timeout = 300  # 5分钟超时
 
-    @staticmethod
-    def _is_valid_graph_id(value: Any) -> bool:
-        return isinstance(value, str) and bool(value.strip())
-
-    @classmethod
-    def _normalize_flow_structure(cls, flow_json: Any) -> tuple[List[str], Dict[str, List[Dict[str, Any]]]]:
-        """返回结构错误和可安全建图的执行视图，不改写持久化配置。"""
-        if not isinstance(flow_json, dict):
-            return ["流程数据必须是对象"], {"nodes": [], "edges": []}
-
-        errors: List[str] = []
-        raw_nodes = flow_json.get("nodes", [])
-        raw_edges = flow_json.get("edges", [])
-
-        if not isinstance(raw_nodes, list):
-            errors.append("nodes 必须是数组")
-            raw_nodes = []
-        if not isinstance(raw_edges, list):
-            errors.append("edges 必须是数组")
-            raw_edges = []
-
-        nodes = []
-        node_ids = set()
-        for index, node in enumerate(raw_nodes, start=1):
-            if not isinstance(node, dict):
-                errors.append(f"节点 {index} 必须是对象")
-                continue
-            node_id = node.get("id")
-            if not cls._is_valid_graph_id(node_id):
-                errors.append(f"节点 {index} 缺少有效 id")
-                continue
-            if not isinstance(node.get("type"), str):
-                errors.append(f"节点 {index} 的 type 必须是字符串")
-                continue
-            if node_id in node_ids:
-                errors.append(f"节点 {index} 的 id 重复: {node_id}")
-                continue
-            node_ids.add(node_id)
-            nodes.append(node)
-
-        edges = []
-        for index, edge in enumerate(raw_edges, start=1):
-            if not isinstance(edge, dict):
-                errors.append(f"边 {index} 必须是对象")
-                continue
-            source = edge.get("source")
-            target = edge.get("target")
-            if not cls._is_valid_graph_id(source):
-                errors.append(f"边 {index} 缺少有效 source")
-                continue
-            if not cls._is_valid_graph_id(target):
-                errors.append(f"边 {index} 缺少有效 target")
-                continue
-            if source not in node_ids:
-                errors.append(f"边 {index} 的 source 未引用现有节点: {source}")
-                continue
-            if target not in node_ids:
-                errors.append(f"边 {index} 的 target 未引用现有节点: {target}")
-                continue
-            edges.append(edge)
-
-        return errors, {"nodes": nodes, "edges": edges}
-
     def _initialize_variables(self, input_data: Dict[str, Any]):
         """初始化变量管理器
 
@@ -355,14 +292,15 @@ class ChatFlowEngine(FlowGraphMixin, NodeRunnerMixin, SSEResponderMixin):
         entry_type = input_data.get("entry_type", "openai")
         logger.info(f"[SSE-Engine] 开始执行 - flow_id: {self.instance.id}, user_id: {user_id}, entry_type: {entry_type}, 节点数: {len(self.nodes)}")
 
+        validation_errors = self.validate_flow()
+        if validation_errors:
+            error_message = f"流程验证失败: {'; '.join(validation_errors)}"
+            return None, None, user_id, entry_type, session_id, "", False, False, self._create_error_response(error_message)
+
         self._initialize_variables(input_data)
 
         node_id = input_data.get("node_id", "")
         self._record_conversation_history(user_id, input_message, "user", entry_type, node_id, session_id)
-
-        validation_errors = self.validate_flow()
-        if validation_errors:
-            return None, None, user_id, entry_type, session_id, node_id, False, False, self._create_error_response("流程验证失败")
 
         start_node = self._get_start_node()
         start_node_type = start_node.get("type", "") if start_node else None

--- a/server/apps/opspilot/utils/chat_flow_utils/engine/flow_graph.py
+++ b/server/apps/opspilot/utils/chat_flow_utils/engine/flow_graph.py
@@ -28,6 +28,73 @@ class FlowGraphMixin:
     """
 
     # ---- 解析与拓扑 ----
+    @staticmethod
+    def _is_valid_graph_id(value: Any) -> bool:
+        return isinstance(value, str) and bool(value.strip())
+
+    @classmethod
+    def _normalize_flow_structure(cls, flow_json: Any) -> tuple[List[str], Dict[str, List[Dict[str, Any]]]]:
+        """返回结构错误和可安全建图的执行视图，不改写持久化配置。"""
+        if not isinstance(flow_json, dict):
+            return ["流程数据必须是对象"], {"nodes": [], "edges": []}
+
+        errors: List[str] = []
+        raw_nodes = flow_json.get("nodes", [])
+        raw_edges = flow_json.get("edges", [])
+
+        if not isinstance(raw_nodes, list):
+            errors.append("nodes 必须是数组")
+            raw_nodes = []
+        if not isinstance(raw_edges, list):
+            errors.append("edges 必须是数组")
+            raw_edges = []
+
+        nodes = []
+        node_ids = set()
+        for index, node in enumerate(raw_nodes, start=1):
+            if not isinstance(node, dict):
+                errors.append(f"节点 {index} 必须是对象")
+                continue
+            node_id = node.get("id")
+            if not cls._is_valid_graph_id(node_id):
+                errors.append(f"节点 {index} 缺少有效 id")
+                continue
+            node_type = node.get("type")
+            if not isinstance(node_type, str):
+                errors.append(f"节点 {index} 的 type 必须是字符串")
+                continue
+            if not node_type.strip():
+                errors.append(f"节点 {index} 缺少有效 type")
+                continue
+            if node_id in node_ids:
+                errors.append(f"节点 {index} 的 id 重复: {node_id}")
+                continue
+            node_ids.add(node_id)
+            nodes.append(node)
+
+        edges = []
+        for index, edge in enumerate(raw_edges, start=1):
+            if not isinstance(edge, dict):
+                errors.append(f"边 {index} 必须是对象")
+                continue
+            source = edge.get("source")
+            target = edge.get("target")
+            if not cls._is_valid_graph_id(source):
+                errors.append(f"边 {index} 缺少有效 source")
+                continue
+            if not cls._is_valid_graph_id(target):
+                errors.append(f"边 {index} 缺少有效 target")
+                continue
+            if source not in node_ids:
+                errors.append(f"边 {index} 的 source 未引用现有节点: {source}")
+                continue
+            if target not in node_ids:
+                errors.append(f"边 {index} 的 target 未引用现有节点: {target}")
+                continue
+            edges.append(edge)
+
+        return errors, {"nodes": nodes, "edges": edges}
+
     def _parse_nodes(self, flow_json: Dict[str, Any]) -> List[Dict[str, Any]]:
         """解析节点定义"""
         return flow_json.get("nodes", [])


### PR DESCRIPTION
## 问题

`BotWorkFlow.flow_json` 可以保留历史开放 JSON，但执行引擎此前会在结构校验前解析节点、边并构建拓扑。非对象配置、缺少关键字段、错类型、重复节点 ID 或悬空边因此可能先触发 `AttributeError` / `KeyError` / `TypeError`，或者形成静默路由错误，调用方拿不到一致的工作流验证结果。

## 根因

设计上把“解析和建图”放在了“结构验证”之前。现有 `validate_flow()` 能检查空流程、循环和节点类型，却没有机会处理连安全建图都无法完成的输入。

## 怎么修的

- 在 `ChatFlowEngine` 构造阶段先生成只供本次执行使用的安全结构视图，原 `flow_json` 保持不变。
- 对顶层对象、`nodes/edges` 数组、节点对象、非空字符串 `id/type`、边 `source/target`、重复 ID 和端点引用做最小结构校验。
- 非法项不参与映射和拓扑构建，错误统一交给现有 `validate_flow()` / `execute()` 短路返回。
- 不修改模型字段、保存/导入入口、历史数据、正常响应或权限契约；该提交可独立回滚。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["页面 / NATS / Celery / 聊天渠道\n创建 ChatFlowEngine"]
    end

    subgraph N["核心处理层"]
        N1["_normalize_flow_structure\nengine.py"]
        N2["安全解析与拓扑构建\nengine.py"]
        N3["validate_flow / execute\nengine.py"]
    end

    subgraph C["失败边界"]
        C1["返回可读流程验证错误"]
    end

    T1 --> N1 --> N2 --> N3
    N1 -. "结构非法" .-> C1
```

## 影响范围与兼容性

- 影响限于 OpsPilot 工作流执行引擎，所有既有调用方复用同一门面。
- 合法流程与旧最小节点结构保持原行为；不会写回或迁移存量 JSON。
- 本 PR 是非破坏性运行保护首片。保存/导入时的版本化 schema、历史数据盘点与渐进迁移仍可后续独立治理。

## 验证

- `apps/opspilot/tests/test_workflow_structure_validation.py`：20 passed。
- 回归测试覆盖非对象、容器错类型、缺字段、`type` 错类型、非字符串 ID、重复 ID、悬空端点、旧最小节点和原配置不变。
- 回退实现时，非法列表输入会重新触发构造期 `AttributeError`，证明测试直接覆盖修复点。
- 触及文件的格式、静态检查、迁移检查和依赖检查均通过。

## 三轨门禁

- Standards：PASS，无 P0/P1/P2。
- Spec：PASS，兼容首片覆盖执行前结构安全边界，未冒充完整存量迁移。
- Runtime Contract：PASS，构造与执行真实边界 20 项通过；NATS、Celery、Web/SSE 和聊天渠道继续复用原门面与失败返回路径。
- 质量评分：96/100，`SCORE_PASS`。

关联 Issue #3763。
