### PR TITLE
bugfix: Log 通知通道查询按授权范围收口（#3982）

### DIFF
--- a/server/apps/log/tests/test_search_system_mgmt_views.py
+++ b/server/apps/log/tests/test_search_system_mgmt_views.py
@@ -12,8 +12,9 @@ import json
 import pytest
 from rest_framework.parsers import JSONParser
 from rest_framework.request import Request
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIClient, APIRequestFactory
 
+from apps.core.exceptions.base_app_exception import ValidationAppException
 from apps.log.models.log_group import SearchCondition
 from apps.log.services.access_scope import LogAccessScope
 from apps.log.utils import system_mgmt as log_system_mgmt
@@ -28,6 +29,12 @@ factory = APIRequestFactory()
 class _User:
     username = "tester"
     is_authenticated = True
+
+
+class _ScopedUser(_User):
+    domain = "domain.com"
+    is_superuser = True
+    group_list = [{"id": "8"}, {"id": 9}, {"id": "invalid"}]
 
 
 def _drf(wsgi_request, cookies=None, user=None):
@@ -554,24 +561,72 @@ def test_get_users_by_organizations_intersects_assignable(monkeypatch):
     assert [item["id"] for item in users] == [user_a.id]
 
 
-def test_search_channel_list_builds_teams_from_team_cookie(mocker):
+def test_search_channel_list_uses_scoped_rpc_with_authenticated_actor(mocker):
     rpc = mocker.patch("apps.log.views.system_mgmt.SystemMgmt")
+    rpc.return_value.search_channel_list_scoped.return_value = {"data": [{"id": "ch"}]}
     rpc.return_value.search_channel_list.return_value = {"data": [{"id": "ch"}]}
 
-    request = get_req({"channel_type": "email"}, cookies={"current_team": "8"})
+    request = get_req(
+        {"channel_type": "email"},
+        cookies={"current_team": "8", "include_children": "1"},
+        user=_ScopedUser(),
+    )
     response = SystemMgmtView().search_channel_list(request)
 
     assert response.status_code == 200
     assert _json(response)["data"] == [{"id": "ch"}]
-    rpc.return_value.search_channel_list.assert_called_once_with(
-        channel_type="email", teams=[8], include_children=False
+    rpc.return_value.search_channel_list_scoped.assert_called_once_with(
+        {
+            "username": "tester",
+            "domain": "domain.com",
+            "current_team": 8,
+            "include_children": True,
+            "is_superuser": True,
+            "group_list": [8, 9],
+        },
+        channel_type="email",
+        teams=None,
+        include_children=True,
     )
+    rpc.return_value.search_channel_list.assert_not_called()
 
 
-def test_search_channel_list_teams_none_without_team_cookie(mocker):
+def test_search_channel_list_missing_team_fails_closed(mocker):
     rpc = mocker.patch("apps.log.views.system_mgmt.SystemMgmt")
-    rpc.return_value.search_channel_list.return_value = {"data": []}
 
-    SystemMgmtView().search_channel_list(get_req())
+    response = SystemMgmtView().search_channel_list(get_req(user=_User()))
 
-    assert rpc.return_value.search_channel_list.call_args.kwargs["teams"] is None
+    assert response.status_code == 200
+    assert _json(response)["data"] == []
+    rpc.return_value.search_channel_list.assert_not_called()
+    rpc.return_value.search_channel_list_scoped.assert_not_called()
+
+
+def test_search_channel_list_invalid_team_fails_closed(mocker):
+    rpc = mocker.patch("apps.log.views.system_mgmt.SystemMgmt")
+    client = APIClient()
+    client.force_authenticate(user=_User())
+    client.cookies["current_team"] = "invalid"
+
+    response = client.get("/api/v1/log/system_mgmt/search_channel_list/")
+
+    assert response.status_code == ValidationAppException.STATUS_CODE
+    assert _json(response)["message"] == "current_team 参数非法"
+    rpc.return_value.search_channel_list.assert_not_called()
+    rpc.return_value.search_channel_list_scoped.assert_not_called()
+
+
+def test_search_channel_list_preserves_scoped_failure_message(mocker):
+    rpc = mocker.patch("apps.log.views.system_mgmt.SystemMgmt")
+    rpc.return_value.search_channel_list_scoped.return_value = {
+        "result": False,
+        "message": "current_team 对应组织已归档或不存在",
+    }
+    client = APIClient()
+    client.force_authenticate(user=_ScopedUser())
+    client.cookies["current_team"] = "8"
+
+    response = client.get("/api/v1/log/system_mgmt/search_channel_list/")
+
+    assert response.status_code == 403
+    assert _json(response)["message"] == "current_team 对应组织已归档或不存在"

--- a/server/apps/log/views/system_mgmt.py
+++ b/server/apps/log/views/system_mgmt.py
@@ -1,21 +1,27 @@
 from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.viewsets import ViewSet
 
+from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
+from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.user_group import normalize_user_group_ids
 from apps.core.utils.web_utils import WebUtils
 from apps.log.utils.system_mgmt import SystemMgmtUtils
 from apps.rpc.system_mgmt import SystemMgmt
-from apps.core.utils.team_utils import get_current_team
 
 
-def _build_actor_context(request):
+def _build_actor_context(request, *, require_current_team=False):
     current_team = get_current_team(request)
     if current_team not in (None, ""):
         try:
             current_team = int(current_team)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
+            if require_current_team:
+                raise ValidationAppException("current_team 参数非法") from exc
             current_team = None
     else:
+        if require_current_team:
+            return None
         current_team = None
 
     user = getattr(request, "user", None)
@@ -49,8 +55,18 @@ class SystemMgmtView(ViewSet):
     @action(methods=["get"], detail=False, url_path="search_channel_list")
     def search_channel_list(self, request):
         channel_type = request.GET.get("channel_type", "")
-        current_team = get_current_team(request)
-        include_children = request.COOKIES.get("include_children", "0") == "1"
-        teams = [int(current_team)] if current_team else None
-        result = SystemMgmt().search_channel_list(channel_type=channel_type, teams=teams, include_children=include_children)
-        return WebUtils.response_success(result["data"])
+        actor_context = _build_actor_context(request, require_current_team=True)
+        if actor_context is None:
+            return WebUtils.response_success([])
+
+        result = SystemMgmt().search_channel_list_scoped(
+            actor_context,
+            channel_type=channel_type,
+            teams=None,
+            include_children=actor_context["include_children"],
+        )
+        if not isinstance(result, dict):
+            raise BaseAppException("通知通道查询失败")
+        if result.get("result") is False:
+            raise PermissionDenied(result.get("message") or "通知通道查询失败")
+        return WebUtils.response_success(result.get("data") or [])

--- a/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
+++ b/server/apps/system_mgmt/tests/test_nats_api_handlers_service.py
@@ -448,6 +448,105 @@ def test_search_channel_list_filters_by_team_and_type():
     assert "c1" in names and "c2" not in names
 
 
+def test_search_channel_list_scoped_without_actor_returns_empty():
+    Channel.objects.create(
+        name="hidden-without-actor",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="d",
+        team=[7],
+    )
+
+    result = nats_api.search_channel_list_scoped(None, teams=[7])
+
+    assert result == {"result": True, "data": []}
+
+
+def test_search_channel_list_scoped_intersects_requested_teams_with_persisted_user_scope():
+    allowed_group = Group.objects.create(name="channel-scope-allowed", parent_id=0)
+    forbidden_group = Group.objects.create(name="channel-scope-forbidden", parent_id=0)
+    actor = User.objects.create(
+        username="channel-scope-user",
+        domain="domain.com",
+        password="x",
+        group_list=[allowed_group.id],
+    )
+    Channel.objects.create(
+        name="allowed-channel",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="allowed",
+        team=[allowed_group.id],
+    )
+    Channel.objects.create(
+        name="forbidden-channel",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="forbidden",
+        team=[forbidden_group.id],
+    )
+
+    result = nats_api.search_channel_list_scoped(
+        {
+            "username": actor.username,
+            "domain": actor.domain,
+            "current_team": allowed_group.id,
+            "is_superuser": True,
+        },
+        teams=[allowed_group.id, forbidden_group.id],
+    )
+
+    assert [channel["name"] for channel in result["data"]] == ["allowed-channel"]
+
+
+def test_search_channel_list_scoped_include_children_returns_only_authorized_descendants():
+    parent = Group.objects.create(name="channel-scope-parent", parent_id=0)
+    authorized_child = Group.objects.create(name="channel-scope-authorized-child", parent_id=parent.id)
+    unauthorized_child = Group.objects.create(name="channel-scope-unauthorized-child", parent_id=parent.id)
+    actor = User.objects.create(
+        username="channel-scope-child-user",
+        domain="domain.com",
+        password="x",
+        group_list=[parent.id, authorized_child.id],
+    )
+    Channel.objects.create(
+        name="parent-channel",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="parent",
+        team=[parent.id],
+    )
+    Channel.objects.create(
+        name="authorized-child-channel",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="authorized-child",
+        team=[authorized_child.id],
+    )
+    Channel.objects.create(
+        name="unauthorized-child-channel",
+        channel_type=ChannelChoices.EMAIL,
+        config={},
+        description="unauthorized-child",
+        team=[unauthorized_child.id],
+    )
+
+    result = nats_api.search_channel_list_scoped(
+        {
+            "username": actor.username,
+            "domain": actor.domain,
+            "current_team": parent.id,
+        },
+        teams=None,
+        include_children=True,
+    )
+
+    assert {channel["name"] for channel in result["data"]} == {
+        "parent-channel",
+        "authorized-child-channel",
+    }
+
+
 @pytest.mark.skipif(
     connection.vendor == "sqlite",
     reason="现有 Channel.team JSON contains 查询只支持生产 PostgreSQL",


### PR DESCRIPTION
## 问题

Log 的通知通道列表是登录用户入口，但此前把 cookie 中的组织 ID 直接传给无作用域的 legacy NATS 查询。该查询不绑定用户身份，调用方可自报 `teams` 获取其他组织的通道元数据。

本 PR 是 Issue #3982 分阶段迁移的安全首片：先消除 Log 用户入口对 legacy 查询的依赖，不在本阶段删除 legacy subject。

## 根因（设计层）

用户认证边界与数据范围校验分离：HTTP 层知道登录用户，legacy NATS 查询却只收到调用方自报的组织列表。与此同时，仓库已有基于持久化用户和组织关系计算范围的 scoped 查询，但 Log 入口尚未迁移，导致同一数据存在安全语义不同的两条路径。

## 怎么修的

- Log 视图在 HTTP 鉴权边界构造用户上下文，改调 `search_channel_list_scoped`。
- 不传请求 `teams`，由 scoped handler 使用当前用户完整授权组织集合，保留授权子组织语义并排除未授权兄弟组织。
- 缺少当前组织时保留原有 `200 + []`；非法组织失败关闭；scoped 标准失败响应保留原 message，不再退化为 `KeyError`。
- 补齐无身份、跨组织、授权子组织、legacy 未调用和失败响应合同测试。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Log 通知通道 GET\nserver/apps/log/views/system_mgmt.py"]
    end

    C1["构造 actor context\n登录用户与当前组织"]
    R1["search_channel_list_scoped\nserver/apps/rpc/system_mgmt.py"]

    subgraph N["授权处理层"]
        N1["scoped NATS handler\nsystem_mgmt/nats/channels.py"]
        DB["读取持久化用户与组织\n计算授权组织交集"]
        N2["查询授权范围内通道\n仅返回元数据字段"]
    end

    subgraph E["失败与兼容层"]
        E1["缺组织返回空列表\n非法或归档保留明确消息"]
    end

    T1 --> C1 --> R1 --> N1 --> DB --> N2
    C1 -. "缺少当前组织" .-> E1
    N1 -. "范围解析失败" .-> E1
```

## 影响范围与兼容性

- 仅修改 Log 用户入口及 System Mgmt 合同测试；HTTP URL、`channel_type`、成功响应字段保持不变。
- 普通用户按持久化组织范围查询；超管身份仍由持久化角色决定，消息体声明不能提权。
- legacy NATS handler 与 RPC 包装器保持不变，Alerts、Agents、Web 和后台调用方不受本首片影响。
- 单 commit 可回滚到原 Log 调用；回滚会重新暴露已确认的无作用域风险，只应用于受控应急窗口。
- 剩余治理是可信服务身份、最小 subject ACL、仓外调用观测和 legacy 最终退役，本 PR 不宣称这些工作已经完成。

## 验证

- `server/apps/log/tests/test_search_system_mgmt_views.py`：36 passed。
- `server/apps/system_mgmt/tests/test_nats_api_handlers_service.py`：48 passed。
- `server/apps/rpc/tests/test_system_mgmt_forwarding.py`：45 passed。
- 合计 129 passed；临时撤回生产修复后，目标回归测试因 scoped RPC 未调用而失败，恢复后全绿。

## 三轨门禁

- Standards：PASS。第 2 轮确认子组织兼容与失败响应问题已闭环，无新增 P0/P1/P2。
- Spec：PASS。保留缺组织空结果、授权子组织、HTTP/响应与 legacy 迁移窗口契约。
- Runtime Contract：PASS。覆盖正常用户、无身份、跨组织、授权子组织、非法/归档组织、RPC 转发与响应格式。
- G6：96/100，`SCORE_PASS`。

关联 Issue #3982。
