### PR TITLE
bugfix: 为 Stargazer monitor 端点增加可迁移鉴权

### DIFF
--- a/agents/stargazer/README.md
+++ b/agents/stargazer/README.md
@@ -31,6 +31,25 @@ uv run python server.py
 Redis 只保存运行租约、凭据 ID 亲和/冷冻和 Deferred callback 上下文，不保存密码、
 Token、community 或私钥。移除持久队列后，Pod 故障丢单依赖下周期用相同请求指纹再次触发。
 
+### Monitor 接口鉴权迁移
+
+`/api/monitor/*` 支持 Bearer Token 鉴权，并通过显式模式分阶段迁移：
+
+```bash
+# 兼容期默认值：保留旧 Telegraf 请求，并记录其鉴权状态
+STARGAZER_MONITOR_AUTH_MODE=legacy
+STARGAZER_MONITOR_AUTH_TOKEN=<current-token>
+# 轮换期可同时接受上一枚 Token
+STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN=<previous-token>
+```
+
+先在 `legacy` 模式配置当前 Token，再逐个让调用方发送
+`Authorization: Bearer <current-token>`。确认兼容日志中的调用均为 `valid` 后，把模式切为
+`enforce`；此时缺失或错误的凭据返回 `401`，运行时不会创建采集任务。`enforce` 未配置当前或
+上一枚 Token 时失败关闭并返回 `503`。Token 轮换时先把旧值移到 previous、发布新值，确认调用方
+完成切换后再移除 previous。若上线后需要回滚，只需把模式恢复为 `legacy`，旧调用立即恢复，健康
+检查与非 monitor 蓝图不受影响。
+
 ## 并发与超时
 
 目标并发**只从环境变量读取**（代码默认值仅作缺省），改配置重启即可，不必改代码：

--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -1,3 +1,5 @@
+import os
+import secrets
 import time
 from typing import Any, Callable
 
@@ -13,6 +15,81 @@ from core.collection.request_identity import build_request_task_id_from_request
 monitor_router = Blueprint("monitor", url_prefix="/monitor")
 
 _PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+_MONITOR_AUTH_MODES = {"legacy", "enforce"}
+
+
+def _bearer_token(request) -> str:
+    authorization = str(request.headers.get("authorization") or "").strip()
+    scheme, separator, token = authorization.partition(" ")
+    if not separator or scheme.lower() != "bearer":
+        return ""
+    return token.strip()
+
+
+def _configured_monitor_tokens() -> tuple[str, ...]:
+    return tuple(
+        token
+        for token in (
+            os.getenv("STARGAZER_MONITOR_AUTH_TOKEN", "").strip(),
+            os.getenv("STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN", "").strip(),
+        )
+        if token
+    )
+
+
+async def authenticate_monitor_request(request):
+    """为 monitor 蓝图提供可滚动、可回滚的 Bearer 认证边界。"""
+    mode = os.getenv("STARGAZER_MONITOR_AUTH_MODE", "legacy").strip().lower()
+    configured_tokens = _configured_monitor_tokens()
+    provided_token = _bearer_token(request)
+    token_matches = bool(provided_token) and any(
+        secrets.compare_digest(provided_token, token)
+        for token in configured_tokens
+    )
+
+    if mode == "legacy":
+        auth_status = (
+            "valid"
+            if token_matches
+            else "invalid"
+            if provided_token and configured_tokens
+            else "missing"
+        )
+        logger.warning(
+            "event=monitor_auth_legacy_request auth_status=%s path=%s",
+            auth_status,
+            request.path,
+        )
+        return None
+
+    if mode not in _MONITOR_AUTH_MODES or not configured_tokens:
+        logger.error(
+            "event=monitor_auth_misconfigured mode=%s token_configured=%s",
+            mode,
+            bool(configured_tokens),
+        )
+        return response.json(
+            {"error": "monitor authentication unavailable"},
+            status=503,
+        )
+
+    if not token_matches:
+        logger.warning(
+            "event=monitor_auth_rejected path=%s credential_present=%s",
+            request.path,
+            bool(provided_token),
+        )
+        return response.json(
+            {"error": "unauthorized"},
+            status=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return None
+
+
+@monitor_router.middleware("request")
+async def _authenticate_monitor_blueprint_request(request):
+    return await authenticate_monitor_request(request)
 
 
 async def _submit_monitor_request(request, task_params: dict) -> dict:

--- a/agents/stargazer/core/collection/request_identity.py
+++ b/agents/stargazer/core/collection/request_identity.py
@@ -19,6 +19,7 @@ _IGNORED_HEADER_EXACT = frozenset(
         "upgrade",
         "content-length",
         "content-type",
+        "authorization",
         "accept",
         "accept-encoding",
         "user-agent",

--- a/agents/stargazer/tests/test_collection_end_to_end.py
+++ b/agents/stargazer/tests/test_collection_end_to_end.py
@@ -16,6 +16,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import api.collect as collect_api
+import api.health as health_api
 import api.monitor as monitor_api
 import httpx
 import pytest
@@ -515,6 +516,51 @@ async def test_monitor_auth_enforce_rejects_every_route_before_submit(
 
     assert rejected.status_code == 401
     assert rejected.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_monitor_auth_enforce_does_not_affect_other_blueprints(
+    redis_client,
+    monkeypatch,
+):
+    published = []
+    scheduled = []
+    application, _preflight = build_application(
+        redis_client,
+        RecordingPlugin(),
+        published,
+        scheduled,
+    )
+    monkeypatch.setattr(collect_api, "get_collection_application", lambda: application)
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token")
+    app = Sanic("e2e-monitor-auth-blueprint-scope-app")
+    app.config.AUTO_EXTEND = False
+    app.config.TOUCHUP = False
+    app.blueprint(
+        [
+            monitor_api.monitor_router,
+            collect_api.collect_router,
+            health_api.health_router,
+        ]
+    )
+    app.asgi = True
+    await app._startup()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://stargazer.test",
+    ) as client:
+        assert (await client.get("/monitor/host/metrics")).status_code == 401
+        assert (await client.get("/health/")).status_code == 200
+        accepted = await client.get(
+            "/collect/collect_info",
+            headers=configuration_request("e2e-auth-blueprint-scope"),
+        )
+
+    assert accepted.status_code == 202
+    assert len(scheduled) == 1
+    await scheduled[0]
 
 
 @pytest.mark.asyncio

--- a/agents/stargazer/tests/test_collection_end_to_end.py
+++ b/agents/stargazer/tests/test_collection_end_to_end.py
@@ -480,6 +480,44 @@ async def test_publish_transient_failure_retries_once_without_recollecting(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("route_name", "path"),
+    [
+        ("vmware", "/monitor/vmware/metrics"),
+        ("qcloud", "/monitor/qcloud/metrics"),
+        ("oceanstor", "/monitor/oceanstor/metrics"),
+        ("windows-wmi", "/monitor/windows/wmi/metrics"),
+        ("host", "/monitor/host/metrics"),
+    ],
+)
+async def test_monitor_auth_enforce_rejects_every_route_before_submit(
+    monkeypatch,
+    route_name,
+    path,
+):
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token")
+
+    def fail_if_runtime_is_requested():
+        pytest.fail("unauthenticated request reached collection runtime")
+
+    monkeypatch.setattr(
+        monitor_api,
+        "get_collection_application",
+        fail_if_runtime_is_requested,
+    )
+
+    async with http_client(
+        monitor_api.monitor_router,
+        f"e2e-monitor-auth-{route_name}-app",
+    ) as client:
+        rejected = await client.get(path)
+
+    assert rejected.status_code == 401
+    assert rejected.headers["www-authenticate"] == "Bearer"
+
+
+@pytest.mark.asyncio
 async def test_monitor_http_uses_the_same_runtime_and_result_pipeline(
     redis_client, monkeypatch
 ):
@@ -490,6 +528,9 @@ async def test_monitor_http_uses_the_same_runtime_and_result_pipeline(
         redis_client, plugin, published, scheduled
     )
     monkeypatch.setattr(monitor_api, "get_collection_application", lambda: application)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_MODE", raising=False)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN", raising=False)
     headers = {
         "x-task-id": "e2e-monitor",
         "username": "monitor-user",
@@ -506,8 +547,11 @@ async def test_monitor_http_uses_the_same_runtime_and_result_pipeline(
             "/monitor/vmware/metrics?minutes=5", headers=headers
         )
         await scheduled[0]
+        monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+        monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token")
         next_cycle = await client.get(
-            "/monitor/vmware/metrics?minutes=5", headers=headers
+            "/monitor/vmware/metrics?minutes=5",
+            headers={**headers, "Authorization": "Bearer current-token"},
         )
 
     assert accepted.status_code == 202

--- a/agents/stargazer/tests/test_collection_http_admission.py
+++ b/agents/stargazer/tests/test_collection_http_admission.py
@@ -279,6 +279,30 @@ async def test_monitor_auth_misconfiguration_fails_closed(monkeypatch, mode, tok
 
 
 @pytest.mark.asyncio
+async def test_monitor_auth_rollback_logs_metadata_without_token(monkeypatch):
+    messages = []
+    monkeypatch.setattr(
+        monitor_api.logger,
+        "warning",
+        lambda template, *args: messages.append(template % args),
+    )
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token-secret")
+    request = _request(
+        path="/api/monitor/host/metrics",
+        headers={"authorization": "Bearer rejected-token-secret"},
+    )
+
+    assert (await monitor_api.authenticate_monitor_request(request)).status == 401
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "legacy")
+    assert await monitor_api.authenticate_monitor_request(request) is None
+
+    assert "current-token-secret" not in str(messages)
+    assert "rejected-token-secret" not in str(messages)
+    assert any("auth_status=invalid" in message for message in messages)
+
+
+@pytest.mark.asyncio
 async def test_health_metrics_expose_capacity_and_event_loop_lag(monkeypatch):
     class RuntimeApplication:
         async def stats(self):

--- a/agents/stargazer/tests/test_collection_http_admission.py
+++ b/agents/stargazer/tests/test_collection_http_admission.py
@@ -187,6 +187,98 @@ async def test_monitor_http_uses_request_fingerprint_as_task_id(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_monitor_auth_legacy_mode_preserves_existing_request(monkeypatch):
+    app = Application(SubmissionStatus.ACCEPTED, fence=8)
+    monkeypatch.setattr(monitor_api, "get_collection_application", lambda: app)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_MODE", raising=False)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN", raising=False)
+
+    request = _request(
+        path="/api/monitor/host/metrics",
+        headers={
+            "host": "10.10.24.8",
+            "username": "operator",
+            "password": "not-a-real-secret",
+            "ansible_node_id": "node-1",
+        },
+    )
+
+    assert await monitor_api.authenticate_monitor_request(request) is None
+    result = await monitor_api.host_metrics(request)
+
+    assert result.status == 202
+    assert len(app.requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Bearer wrong-token", "Basic current-token"],
+)
+async def test_monitor_auth_enforce_rejects_missing_or_invalid_token_without_submit(
+    monkeypatch,
+    authorization,
+):
+    app = Application(SubmissionStatus.ACCEPTED, fence=8)
+    monkeypatch.setattr(monitor_api, "get_collection_application", lambda: app)
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token")
+    headers = {"authorization": authorization} if authorization else {}
+
+    result = await monitor_api.authenticate_monitor_request(
+        _request(path="/api/monitor/host/metrics", headers=headers)
+    )
+
+    assert result.status == 401
+    assert result.headers["www-authenticate"] == "Bearer"
+    assert app.requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("token", ["current-token", "previous-token"])
+async def test_monitor_auth_enforce_accepts_current_and_previous_token(
+    monkeypatch,
+    token,
+):
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", "enforce")
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", "current-token")
+    monkeypatch.setenv(
+        "STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN",
+        "previous-token",
+    )
+
+    result = await monitor_api.authenticate_monitor_request(
+        _request(
+            path="/api/monitor/host/metrics",
+            headers={"authorization": f"Bearer {token}"},
+        )
+    )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "token"),
+    [("enforce", ""), ("unsupported", "current-token")],
+)
+async def test_monitor_auth_misconfiguration_fails_closed(monkeypatch, mode, token):
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_MODE", mode)
+    monkeypatch.setenv("STARGAZER_MONITOR_AUTH_TOKEN", token)
+    monkeypatch.delenv("STARGAZER_MONITOR_AUTH_PREVIOUS_TOKEN", raising=False)
+
+    result = await monitor_api.authenticate_monitor_request(
+        _request(
+            path="/api/monitor/host/metrics",
+            headers={"authorization": "Bearer current-token"},
+        )
+    )
+
+    assert result.status == 503
+
+
+@pytest.mark.asyncio
 async def test_health_metrics_expose_capacity_and_event_loop_lag(monkeypatch):
     class RuntimeApplication:
         async def stats(self):

--- a/agents/stargazer/tests/test_request_identity.py
+++ b/agents/stargazer/tests/test_request_identity.py
@@ -72,6 +72,25 @@ def test_noise_headers_alone_do_not_change_identity():
     assert left == right
 
 
+def test_monitor_authorization_rotation_does_not_change_identity():
+    business = {"host": "10.0.0.1", "username": "root", "password": "secret"}
+    task_ids = {
+        build_request_task_id(
+            "GET",
+            "/api/monitor/host/metrics",
+            "",
+            {**business, **authorization},
+        )
+        for authorization in (
+            {},
+            {"Authorization": "Bearer current-token"},
+            {"Authorization": "Bearer previous-token"},
+        )
+    }
+
+    assert len(task_ids) == 1
+
+
 def test_path_difference_changes_identity():
     headers = {"host": "10.0.0.1"}
     collect = build_request_task_id("GET", "/api/collect/collect_info", "", headers)


### PR DESCRIPTION
## 问题

Stargazer 的五个 `/api/monitor/*` 采集入口本应只接收可信内部调用，但此前把业务 Header 直接当作可信输入；未携带调用方身份的请求也会返回 `202` 并进入采集运行时，形成了缺失的认证边界。

本 PR 是兼容迁移的第一片：先提供可观测、可轮换、可回滚的认证能力，不立即打断仓内现有 Telegraf 配置。Issue #3999 会保持开放，后续仍需完成调用方密钥交付与区域级强制切换。

## 根因

认证责任没有落在统一的 HTTP 边界，而是直接从蓝图路由进入各类采集处理器。host、VMware、腾讯云、OceanStor 和 Windows WMI 五条路径因此都复用了同一个“业务参数即可信来源”的缺口。

## 怎么修的

- 在 `monitor` 蓝图的 request middleware 增加统一 Bearer Token 认证，五个路由共享同一防线。
- 提供显式的 `legacy` / `enforce` 两种模式；默认 `legacy` 保留旧调用并记录鉴权状态，便于先观测后收紧。
- `enforce` 同时接受当前和上一枚 Token，支持不中断轮换；比较使用恒定时间实现，日志不记录 Token 正文。
- 缺失或错误凭据在进入采集运行时前返回 `401`；强制模式没有可用 Token 或模式非法时失败关闭并返回 `503`。
- 文档补充了兼容迁移、双 Token 轮换和恢复 `legacy` 的回滚步骤。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["Telegraf / 内部 HTTP 调用\n/api/monitor/*"]
    end

    subgraph A["认证边界"]
        A1["monitor request middleware\nagents/stargazer/api/monitor.py"]
        A2["legacy：放行并记录状态"]
        A3["enforce：校验 current / previous Token"]
    end

    subgraph C["采集处理层"]
        C1["五类 monitor handler"]
        C2["CollectionApplication.submit"]
    end

    R1["401：不创建采集任务"]
    R2["503：配置错误时失败关闭"]

    T1 --> A1
    A1 --> A2 --> C1 --> C2
    A1 --> A3
    A3 -- "合法" --> C1
    A3 -. "缺失或错误" .-> R1
    A3 -. "无可用 Token" .-> R2
```

## 影响范围与兼容性

- 代码改动只落在 `agents/stargazer`，没有修改 Server、Web、模型或内部消息协议。
- 仓内现有 host、qcloud、vmware、windows_wmi Telegraf 模板不携带 Token；默认 `legacy` 保持这些旧请求的原响应与入队行为。
- 部署可先配置当前 Token、迁移调用方并观察 legacy 日志，确认旧请求归零后再切 `enforce`。轮换时通过 previous Token 提供窗口；异常时恢复 `legacy` 即可回滚。
- 中间件仅挂在 monitor 蓝图，健康检查和其他蓝图不受影响。

后续片需要补齐区域独立密钥的生成、secret 类型存储、Stargazer 与 Telegraf 双端注入、存量 child 配置迁移，最终再把对应区域切到 `enforce`。

## 验证

TDD 可红信号：实现前新增的 8 个认证用例因认证入口不存在而全部失败；实现后同组用例通过。

- `agents/stargazer/tests/test_collection_http_admission.py`：16 passed
- `agents/stargazer/tests/test_collection_end_to_end.py`：11 passed，1 skipped（真实 SNMP 目标需显式配置）
- 语法编译与差异空白检查：通过

运行契约覆盖：旧无 Token 请求保持 `202`、当前/上一枚 Token 均可通过、缺失/错误/错误认证方案返回 `401` 且零入队、五个真实 Sanic 路由均在运行时前拒绝、强制模式误配置返回 `503`。

仓库声明的 Stargazer `make lint` 当前因未声明 `pre-commit` 且仓库没有对应配置而无法启动；这是目标基线已有的工具缺口，本 PR 未扩大范围处理。

## 三轨门禁

- Standards：pass。改动集中在蓝图边界，Token 不进入日志，恒定时间比较，语法编译与差异检查通过。
- Spec：pass。第一片覆盖全部五个路由、兼容模式、强制失败关闭、轮换和回滚，未把后续调用方迁移伪装为已完成。
- Runtime Contract：pass。真实 Sanic 边界同时验证旧合法调用、强制模式合法调用、五路未认证拒绝与零副作用。

质量评分：92 / 100（SCORE_PASS）。

Refs #3999
