### PR TITLE
fix(monitor): 复合对象指标页签按插件家族分组

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/page.tsx
@@ -33,7 +33,7 @@ import { useSearchParams } from 'next/navigation';
 import Permission from '@/components/permission';
 import {
   needsTagsEntry,
-  getObjectTypeByName
+  getPluginFamilyObjects
 } from '@/app/monitor/utils/monitorObject';
 import { cloneDeep } from 'lodash';
 import { buildIfmibMetricView, getDefaultMetricGroupOpenState } from './ifmibMetricView';
@@ -223,10 +223,7 @@ const Configure = () => {
       const data = await getMonitorObject();
       if (templateType !== 'pull' && needsTagsEntry(groupName, data)) {
         setShowTabs(true);
-        const objectType = getObjectTypeByName(groupName, data);
-        const _items = data
-          .filter((item: ObjectItem) => item.type === objectType)
-          .sort((a: ObjectItem, b: ObjectItem) => a.id - b.id)
+        const _items = getPluginFamilyObjects(groupName, data)
           .map((item: ObjectItem) => {
             const name = item.display_name || item.name;
             return {

--- a/web/src/app/monitor/(pages)/view/viewList.tsx
+++ b/web/src/app/monitor/(pages)/view/viewList.tsx
@@ -35,7 +35,10 @@ import { OBJECT_DEFAULT_ICON } from '@/app/monitor/constants';
 import { getProfessionalDashboardUrl } from '@/app/monitor/dashboards/registry';
 import { withDashboardReturnContext } from '@/app/monitor/dashboards/shared/utils';
 import { encodeInstanceIdValuesParam } from '@/app/monitor/dashboards/shared/utils/instance';
-import { getDerivativeObjectNames } from '@/app/monitor/utils/monitorObject';
+import {
+  getBaseObject,
+  getDerivativeObjectNames
+} from '@/app/monitor/utils/monitorObject';
 import { findByMonitorId, sameMonitorId } from '@/app/monitor/utils/monitorIds';
 import { cloneDeep } from 'lodash';
 import {
@@ -231,13 +234,11 @@ const ViewList: React.FC<ViewListProps> = ({
   }, [objects, objectId]);
 
   const instNamePlaceholder = useMemo(() => {
-    const type = findByMonitorId(objects, objectId)?.type || '';
-    const baseTarget = objects
-      .filter((item) => item.type === type)
-      .find((item) => item.level === 'base');
+    const current = findByMonitorId(objects, objectId);
+    const baseTarget = current ? getBaseObject(current, objects) : undefined;
     const title: string = baseTarget?.display_name || t('monitor.source');
     return title;
-  }, [objects, objectId]);
+  }, [objects, objectId, t]);
 
   const isPod = useMemo(() => {
     return currentObjectName === 'Pod';

--- a/web/src/app/monitor/types/index.ts
+++ b/web/src/app/monitor/types/index.ts
@@ -222,6 +222,7 @@ export interface ObjectItem {
   is_custom?: boolean;
   is_visible?: boolean;
   parent?: number | null;
+  level?: 'base' | 'derivative';
   type: string;
   plugin_name?: string;
   plugin_id?: number;

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -20,7 +20,10 @@ import {
   APPOINT_METRIC_IDS,
   OBJECT_DEFAULT_ICON
 } from '@/app/monitor/constants';
-import { isDerivativeObject } from '@/app/monitor/utils/monitorObject';
+import {
+  getBaseObject,
+  isDerivativeObject
+} from '@/app/monitor/utils/monitorObject';
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import dayjs from 'dayjs';
@@ -496,9 +499,7 @@ export const getBaseInstanceColumn = (config: {
   queryData?: any[];
   ipFilterOptions?: string[];
 }) => {
-  const baseTarget = config.objects
-    .filter((item) => item.type === config.row?.type)
-    .find((item) => item.level === 'base');
+  const baseTarget = getBaseObject(config.row, config.objects);
   const title = baseTarget?.display_name || config.t('monitor.source');
   const isDerivative = isDerivativeObject(config.row, config.objects);
   const renderAssetText = (value: unknown) => (

--- a/web/src/app/monitor/utils/monitorObject.ts
+++ b/web/src/app/monitor/utils/monitorObject.ts
@@ -7,9 +7,41 @@
  * - level: 'base' | 'derivative' - 基础对象或派生对象
  * - type: string - 对象类型分组（如 'Container Management', 'K8S', 'VMWare'）
  * - parent: number | null - 派生对象的父对象 ID
+ *
+ * 复合对象页签按插件家族（parent）划分，而不是按 type。
+ * type 只表示侧边栏分类；多个平台可以共用同一个 type（如 Cloud）。
  */
 
 import { ObjectItem } from '@/app/monitor/types';
+
+const objectLevel = (obj: ObjectItem): 'base' | 'derivative' =>
+  obj.level === 'derivative' ? 'derivative' : 'base';
+
+const resolveObject = (
+  objectOrName: ObjectItem | string,
+  objects: ObjectItem[]
+): ObjectItem | undefined => {
+  if (typeof objectOrName === 'string') {
+    return objects.find((obj) => obj.name === objectOrName);
+  }
+  return objectOrName;
+};
+
+const baseObjectsOfType = (type: string, objects: ObjectItem[]): ObjectItem[] =>
+  objects.filter((obj) => obj.type === type && objectLevel(obj) === 'base');
+
+const sortPluginFamily = (family: ObjectItem[]): ObjectItem[] =>
+  [...family].sort((left, right) => {
+    const leftRank = objectLevel(left) === 'base' ? 0 : 1;
+    const rightRank = objectLevel(right) === 'base' ? 0 : 1;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return left.id - right.id;
+  });
+
+const familyRootId = (target: ObjectItem): number =>
+  objectLevel(target) === 'base' || target.parent == null
+    ? target.id
+    : target.parent;
 
 /**
  * 判断对象是否为派生对象（level === 'derivative'）
@@ -27,7 +59,7 @@ export const isDerivativeObject = (
 ): boolean => {
   if (typeof objectOrName === 'string') {
     if (!objects) return false;
-    const obj = objects.find((o) => o.name === objectOrName);
+    const obj = objects.find((item) => item.name === objectOrName);
     return obj?.level === 'derivative';
   }
   return objectOrName?.level === 'derivative';
@@ -38,16 +70,16 @@ export const isDerivativeObject = (
  */
 export const getDerivativeObjectNames = (objects: ObjectItem[]): string[] => {
   return objects
-    .filter((obj) => obj.level === 'derivative')
+    .filter((obj) => objectLevel(obj) === 'derivative')
     .map((obj) => obj.name);
 };
 
 /**
- * 判断对象是否需要标签入口（即基础对象，且有派生对象）
+ * 判断对象是否需要标签入口（即基础对象，且有本插件家族的派生对象）
  *
  * 需要标签入口的对象特点：
  * - level === 'base'
- * - 存在同 type 的派生对象
+ * - 存在 parent 指向它的派生对象；若 parent 未写入，仅当该 type 只有一个基础对象时回退到同 type
  *
  * 例如：Docker, Cluster, vCenter, TCP, SangforSCP
  * 这些对象的指标页面需要显示 Segmented tabs 来切换不同子对象
@@ -56,21 +88,22 @@ export const needsTagsEntry = (
   objectOrName: ObjectItem | string,
   objects: ObjectItem[]
 ): boolean => {
-  let targetObj: ObjectItem | undefined;
+  const targetObj = resolveObject(objectOrName, objects);
 
-  if (typeof objectOrName === 'string') {
-    targetObj = objects.find((o) => o.name === objectOrName);
-  } else {
-    targetObj = objectOrName;
-  }
-
-  if (!targetObj || targetObj.level !== 'base') {
+  if (!targetObj || objectLevel(targetObj) !== 'base') {
     return false;
   }
 
-  // 检查是否有同 type 的派生对象
+  if (objects.some((obj) => obj.parent === targetObj.id)) {
+    return true;
+  }
+
+  if (baseObjectsOfType(targetObj.type, objects).length !== 1) {
+    return false;
+  }
+
   return objects.some(
-    (obj) => obj.type === targetObj!.type && obj.level === 'derivative'
+    (obj) => obj.type === targetObj.type && objectLevel(obj) === 'derivative'
   );
 };
 
@@ -106,32 +139,60 @@ export const getObjectsByType = (
 };
 
 /**
+ * 获取某个对象所属插件家族（基础对象 + 其子对象）。
+ *
+ * 优先用 parent；parent 缺失时，仅当该 type 只有一个基础对象才按 type 回退。
+ * 多个平台共用 type（如 Cloud 下的 SangforSCP 与 CNware）时不会混在一起。
+ */
+export const getPluginFamilyObjects = (
+  objectOrName: ObjectItem | string,
+  objects: ObjectItem[]
+): ObjectItem[] => {
+  const target = resolveObject(objectOrName, objects);
+  if (!target) return [];
+
+  const rootId = familyRootId(target);
+  const familyByParent = objects.filter(
+    (obj) => obj.id === rootId || obj.parent === rootId
+  );
+  if (
+    familyByParent.length > 1 ||
+    objects.some((obj) => obj.parent === rootId)
+  ) {
+    return sortPluginFamily(familyByParent);
+  }
+
+  if (baseObjectsOfType(target.type, objects).length === 1) {
+    return sortPluginFamily(objects.filter((obj) => obj.type === target.type));
+  }
+
+  return [target];
+};
+
+/**
  * 获取某个对象的基础对象（父对象）
  *
  * 如果对象本身是 base 类型，返回自身
- * 如果对象是 derivative 类型，返回同 type 的 base 对象
+ * 如果对象是 derivative 类型，返回 parent 指向的基础对象
  */
 export const getBaseObject = (
   objectOrName: ObjectItem | string,
   objects: ObjectItem[]
 ): ObjectItem | undefined => {
-  let targetObj: ObjectItem | undefined;
-
-  if (typeof objectOrName === 'string') {
-    targetObj = objects.find((o) => o.name === objectOrName);
-  } else {
-    targetObj = objectOrName;
-  }
+  const targetObj = resolveObject(objectOrName, objects);
 
   if (!targetObj) return undefined;
 
-  if (targetObj.level === 'base') {
+  if (objectLevel(targetObj) === 'base') {
     return targetObj;
   }
 
-  return objects.find(
-    (obj) => obj.type === targetObj!.type && obj.level === 'base'
-  );
+  if (targetObj.parent != null) {
+    return objects.find((obj) => obj.id === targetObj.parent);
+  }
+
+  const bases = baseObjectsOfType(targetObj.type, objects);
+  return bases.length === 1 ? bases[0] : undefined;
 };
 
 /**
@@ -141,18 +202,21 @@ export const getDerivativeObjects = (
   baseObjectOrName: ObjectItem | string,
   objects: ObjectItem[]
 ): ObjectItem[] => {
-  let baseObj: ObjectItem | undefined;
-
-  if (typeof baseObjectOrName === 'string') {
-    baseObj = objects.find((o) => o.name === baseObjectOrName);
-  } else {
-    baseObj = baseObjectOrName;
-  }
+  const baseObj = resolveObject(baseObjectOrName, objects);
 
   if (!baseObj) return [];
 
+  const children = objects.filter((obj) => obj.parent === baseObj.id);
+  if (children.length) {
+    return children;
+  }
+
+  if (baseObjectsOfType(baseObj.type, objects).length !== 1) {
+    return [];
+  }
+
   return objects.filter(
-    (obj) => obj.type === baseObj!.type && obj.level === 'derivative'
+    (obj) => obj.type === baseObj.type && objectLevel(obj) === 'derivative'
   );
 };
 


### PR DESCRIPTION
## Summary
- 集成指标页不再按共享的 `Cloud` type 列出对象页签，改为按插件家族（`parent`）分组，避免深信服 SCP 与云宏 CNware 混在同一页。
- 视图列表和实例列的基础对象查询同步改为按 `parent` 解析，避免取到同 type 下另一个平台的基础对象。
- 阿里云等「一个 type 只有一个基础对象」的插件仍可在缺少 `parent` 时按 type 回退。

## Test plan
- [ ] 打开 集成 → 深信服 SCP 云平台 → 指标，页签只有 SCP 基础 / 物理主机 / 云主机，没有 CNware。
- [ ] 打开 集成 → 云宏 CNware 云平台 → 指标，页签没有 SCP 对象。
- [ ] 打开 集成 → 阿里云 → 指标，复合对象页签仍可切换 ECS 等子对象。
- [ ] 打开 CNware 宿主机视图列表，来源列/占位文案指向云宏而不是深信服。

提交范围已核对：仅 5 个生产文件。测试文件、本地图标、`next-env.d.ts` 留在工作区未提交。