### PR TITLE
fix(openapi): 渲染器省略空小节，修复 Traefik 拒绝整份动态配置

### DIFF
--- a/server/apps/core/openapi/renderer.py
+++ b/server/apps/core/openapi/renderer.py
@@ -170,7 +170,7 @@ def render_traefik_config(entries: dict, internal_services=()):
         logger.warning("OPENAPI_AUTH_ADDRESS 未配置，不渲染任何外部服务路由（fail-closed）")
         for name in entries:
             report["skipped"][name] = "auth address unconfigured"
-        return {"http": {"routers": {}, "middlewares": {}, "services": {}}}, report
+        return _pack({}, {}, {}), report
 
     # 全局中间件：入站身份头清除（红线 1）与 ForwardAuth
     middlewares["openapi-clear-headers"] = {
@@ -247,8 +247,28 @@ def render_traefik_config(entries: dict, internal_services=()):
             }
         report["rendered"].append(name)
 
-    config = {"http": {"routers": routers, "middlewares": middlewares, "services": services}}
-    return config, report
+    return _pack(routers, middlewares, services), report
+
+
+def _pack(routers, middlewares, services):
+    """组装动态配置，省略空小节。
+
+    Traefik 的动态配置解码器不接受空 map：整份配置里出现 "routers": {} 会以
+    `routers cannot be a standalone element` 整份拒绝（连同其中合法的
+    middlewares 一起失效）。未注册任何外部服务是常态（首次部署即如此），
+    因此空小节必须省略而非置空；三者皆空时返回 {"http": {}}。
+    真机验证：.149 HA 栈曾因此让 http provider 配置持续被拒。
+    """
+    if not routers:
+        # 无路由时全局中间件没有任何引用方，整份省略；避免下发只含孤立
+        # 中间件的配置，也规避空 map 触发的解码拒绝
+        return {"http": {}}
+    http = {"routers": routers}
+    if middlewares:
+        http["middlewares"] = middlewares
+    if services:
+        http["services"] = services
+    return {"http": http}
 
 
 def refresh_snapshot(internal_services=()):
@@ -258,7 +278,7 @@ def refresh_snapshot(internal_services=()):
         if entries is None:
             if _snapshot["config"] is None:
                 logger.warning("openapi_registry 不可达且无历史快照，返回空配置")
-                return {"http": {"routers": {}, "middlewares": {}, "services": {}}}
+                return _pack({}, {}, {})
             logger.warning("openapi_registry 不可达，沿用最近一次成功快照")
             return _snapshot["config"]
 

--- a/server/apps/core/openapi/tests/test_renderer.py
+++ b/server/apps/core/openapi/tests/test_renderer.py
@@ -115,7 +115,7 @@ def test_bad_entries_skipped(env, mutation, reason_part):
     config, report = render_one(entry)
     assert report["rendered"] == []
     assert reason_part in report["skipped"]["itsm"]
-    assert config["http"]["routers"] == {}
+    assert "routers" not in config["http"]
 
 
 def test_disabled_entry_skipped_quietly(env):
@@ -167,8 +167,24 @@ def test_missing_allowlist_rejects_everything(env, monkeypatch):
 def test_missing_auth_address_renders_nothing(env, monkeypatch):
     monkeypatch.delenv("OPENAPI_AUTH_ADDRESS")
     config, report = render_one(dict(GOOD))
-    assert config["http"]["routers"] == {}
+    assert "routers" not in config["http"]
     assert report["skipped"]["itsm"] == "auth address unconfigured"
+
+
+def test_empty_sections_are_omitted_not_empty_maps(env):
+    """Traefik 解码器拒绝空 map：出现 "routers": {} 会整份配置被拒
+    （`routers cannot be a standalone element`），连合法的 middlewares 一起失效。
+    未注册外部服务是常态，故空小节必须省略。回归自 .149 HA 真机验证。
+    """
+    config, report = renderer.render_traefik_config({}, ())
+    assert report["rendered"] == []
+    assert config == {"http": {}}
+    for section in ("routers", "middlewares", "services"):
+        assert section not in config["http"], f"{section} 为空时必须省略而非置为 {{}}"
+
+    # 有条目被跳过时同样不得残留空 map
+    skipped_config, _ = render_one(dict(GOOD, enabled=False))
+    assert skipped_config == {"http": {}}
 
 
 def test_gateway_versions_default_active(env):

--- a/specs/changes/openapi-unified-gateway/m4-notes.md
+++ b/specs/changes/openapi-unified-gateway/m4-notes.md
@@ -72,3 +72,51 @@ commit `8c054cc`（分支 claude/webhookd-traefik-openapi-gateway-14ea9d）。
 - `OPENAPI_INVOKE_TIMEOUT` 生产未配置且 settings 未接入该 env（README 列为运行期配置但当前为空操作）；开启后线程池 worker 的 DB 连接不随请求周期回收。试点为分页轻查询，发版前处理。
 - 试点端点未声明 `permission`（团队决策：维持现状，team 组织自域约束已在）。
 - `_me`/`_docs`/`_auth` 未捕获异常经 AppExceptionMiddleware 输出无 `code` 的 500；参数位置混用被静默忽略而非 `SCHEMA_INVALID`；`wxc openapi list` 将服务端会丢弃的条目显示为 ok。
+
+## .149 HA 真机端到端验证（2026-08-18）
+
+镜像：WeOpsx #295（checkout `1568377e` = PR #4864 合并提交），企业版 overlay 后含完整 openapi 包。
+
+验证矩阵（全部经 Traefik 公网入口，HA 栈 bk-primary）：
+
+| # | 场景 | 结果 |
+| --- | --- | --- |
+| 1 | 无凭据 → 401 `AUTH_INVALID` | ✅ |
+| 2 | 错误令牌 → 401 | ✅ |
+| 3 | `_me` 结构（user/domain/credential_type/groups/anchor_scopes/roles/services） | ✅ |
+| 4 | 本组织 patch-mgmt 调用 → 200 + 真实数据（2 台主机） | ✅ |
+| 5 | 越权他组织 → 403 `TEAM_OUT_OF_SCOPE` | ✅（C1 修复生效） |
+| 6 | 伪造 `X-BK-User`/`X-BK-Team` → 仍按凭据判定，403 | ✅（红线 1/2） |
+| 7 | 未注册端点 → 404 `NOT_FOUND` | ✅ |
+| 8 | schema 未知字段 → 400 `SCHEMA_INVALID` | ✅ |
+| 9 | `_docs` 聚合（cmdb/patch-mgmt 各 1 端点） | ✅ |
+| 10 | `_provider` 经公网入口 → 404（已排除） | ✅（A4 修复生效） |
+| 11 | `_provider` 内网：无令牌 401 / 有令牌 200 | ✅ |
+| 12 | wxc `validate`/`register`/`list` 写 KV | ✅ |
+| 13 | 未配置 secret 的条目被 fail-closed 跳过 | ✅ |
+| 14 | 配置 secret 后渲染出 router/service/4 中间件 | ✅ |
+| 15 | Traefik 消费动态路由（`openapi-v1-itsm@http` enabled） | ✅ |
+| 16 | 端到端调外部服务：无凭据 401 / 有凭据穿透 200 | ✅ |
+
+## 真机验证发现并修复的缺陷
+
+**Traefik 拒绝空 map 导致 http provider 配置整份失效**（renderer.py）：
+未注册任何外部服务时渲染器输出 `{"http": {"routers": {}, ...}}`，Traefik 报
+`cannot decode configuration data: routers cannot be a standalone element`
+并**拒绝整份配置**——连同其中合法的全局中间件一起失效（traefik API 确认
+只剩 docker provider 条目）。未注册外部服务是首次部署的常态，故该缺陷在
+任何新环境上线即触发，且仅表现为 traefik 日志告警。
+
+修复：空小节一律省略；无路由时全局中间件无引用方，整份返回 `{"http": {}}`。
+补专项回归测试（`test_empty_sections_are_omitted_not_empty_maps`）。测试 80 项全过。
+
+## 验证环境遗留（需清理/注意）
+
+- `.149` 的 `server:latest` 现指向验证 tag `openapi-gw-verify` 的镜像；registry
+  `latest` 的解析在验证期间仍返回旧 digest（`f0e00057`，疑似 CDN/复制延迟），
+  待其收敛后按常规流程重新 `docker pull` 即可。
+- `.149` 上遗留：KV 中 `itsm` 测试条目（指向 stargazer）、`.env` 的
+  `OPENAPI_BASEURL_ALLOWLIST=stargazer` 与 `ITSM_GW_SECRET`、
+  `compose/server.yaml` 的 `ITSM_GW_SECRET` 透传行、验证用户 `gwverify` 及其令牌。
+  正式使用前应清理或替换为真实 ITSM 配置。
+- registry 中新增 tag `bklite/weopsx/server:openapi-gw-verify`（验证用，可删）。


### PR DESCRIPTION
## 问题

.149 HA 栈真机端到端验证（WeOpsx #295 镜像）发现：**未注册任何外部服务时**，渲染器输出

```json
{"http": {"routers": {}, "middlewares": {...}, "services": {}}}
```

Traefik 报错并**拒绝整份配置**：

```
cannot decode configuration data: routers cannot be a standalone element (type map[string]*dynamic.Router)
```

后果：连同配置中合法的全局中间件（`openapi-clear-headers` / `openapi-auth`）一起失效——经 traefik API 确认，此时只剩 docker provider 的条目，http provider 全军覆没。**未注册外部服务是首次部署的常态**，因此该缺陷在任何新环境上线即触发，且仅表现为 traefik 日志告警，不易察觉。

## 修复

- 空小节一律省略，不再下发空 map；
- 无路由时全局中间件没有任何引用方，整份返回 `{"http": {}}`；
- 三处返回点（正常渲染 / auth 地址未配置 / KV 不可达且无快照）统一走 `_pack`；
- 新增专项回归测试 `test_empty_sections_are_omitted_not_empty_maps`，更新两处空结构断言。

## 验证

- 单元/集成测试 **80 项全过**；
- 修复前后在 .149 实测：注册外部服务后 Traefik 正确消费动态路由（`openapi-v1-itsm@http` status=enabled），端到端调用穿透成功（无凭据 401 / 有凭据 200）。

同时补充 `m4-notes.md`：16 项 HA 真机端到端验证矩阵（认证契约、越权 403 TEAM_OUT_OF_SCOPE、伪造头防护、_docs、provider 端点收敛、wxc KV 注册、动态路由生效）与验证环境遗留清理清单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)