### PR TITLE
fix：订阅 PDF 收紧选项源作用域，并修好 3D 机房印刷与空图表误报失败

### DIFF
--- a/server/apps/operation_analysis/services/canvas_report/dashboard.py
+++ b/server/apps/operation_analysis/services/canvas_report/dashboard.py
@@ -1,9 +1,8 @@
 from copy import deepcopy
 
 from apps.operation_analysis.models.models import Dashboard
-from apps.operation_analysis.services.canvas_report.types import (
-    RESOURCE_TYPE_DASHBOARD,
-)
+from apps.operation_analysis.services.canvas_report.types import RESOURCE_TYPE_DASHBOARD
+from apps.operation_analysis.services.named_option_datasources import expand_widget_manifest_with_named_option_datasources
 
 
 def build_dashboard_widget_manifest(view_sets: list) -> list[dict]:
@@ -49,7 +48,7 @@ class DashboardCanvasReportAdapter:
         return Dashboard.objects.get(pk=resource_id)
 
     def build_manifest(self, resource: Dashboard) -> list[dict]:
-        return build_dashboard_widget_manifest(resource.view_sets or [])
+        return expand_widget_manifest_with_named_option_datasources(build_dashboard_widget_manifest(resource.view_sets or []))
 
     def load_filters(self, resource: Dashboard):
         return deepcopy(resource.filters)
@@ -64,7 +63,7 @@ class DashboardCanvasReportAdapter:
             "view_sets": view_sets,
             "filters": self.load_filters(resource),
             "other": deepcopy(resource.other),
-            "widget_manifest": build_dashboard_widget_manifest(view_sets),
+            "widget_manifest": expand_widget_manifest_with_named_option_datasources(build_dashboard_widget_manifest(view_sets)),
         }
 
     def render_route_key(self) -> str:
@@ -81,9 +80,7 @@ class DashboardCanvasReportAdapter:
         team_id: int,
         include_children: bool = False,
     ) -> bool:
-        from apps.operation_analysis.services.canvas_report.permissions import (
-            can_view_canvas,
-        )
+        from apps.operation_analysis.services.canvas_report.permissions import can_view_canvas
 
         return can_view_canvas(
             user,
@@ -100,9 +97,7 @@ class DashboardCanvasReportAdapter:
         actor: str,
         actor_domain: str = "",
     ) -> int:
-        from apps.operation_analysis.services.subscription_service import (
-            DashboardSubscriptionService,
-        )
+        from apps.operation_analysis.services.subscription_service import DashboardSubscriptionService
 
         return DashboardSubscriptionService.terminate_for_dashboard_deletion(
             resource,

--- a/server/apps/operation_analysis/services/canvas_report/report.py
+++ b/server/apps/operation_analysis/services/canvas_report/report.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 from apps.operation_analysis.models.models import Report
 from apps.operation_analysis.services.canvas_report.types import RESOURCE_TYPE_REPORT
+from apps.operation_analysis.services.named_option_datasources import expand_widget_manifest_with_named_option_datasources
 
 TERMINATION_REASON_REPORT_DELETED = "report_deleted"
 
@@ -36,7 +37,7 @@ class ReportCanvasReportAdapter:
         return Report.objects.get(pk=resource_id)
 
     def build_manifest(self, resource: Report) -> list[dict]:
-        return build_report_widget_manifest(resource.view_sets or {})
+        return expand_widget_manifest_with_named_option_datasources(build_report_widget_manifest(resource.view_sets or {}))
 
     def load_filters(self, resource: Report):
         view_sets = resource.view_sets or {}
@@ -56,7 +57,7 @@ class ReportCanvasReportAdapter:
             "view_sets": view_sets,
             "filters": self.load_filters(resource),
             "other": deepcopy(resource.other),
-            "widget_manifest": build_report_widget_manifest(view_sets),
+            "widget_manifest": expand_widget_manifest_with_named_option_datasources(build_report_widget_manifest(view_sets)),
         }
 
     def render_route_key(self) -> str:

--- a/server/apps/operation_analysis/services/canvas_report/screen.py
+++ b/server/apps/operation_analysis/services/canvas_report/screen.py
@@ -1,9 +1,8 @@
 from copy import deepcopy
 
 from apps.operation_analysis.models.models import Screen
-from apps.operation_analysis.services.canvas_report.types import (
-    RESOURCE_TYPE_SCREEN,
-)
+from apps.operation_analysis.services.canvas_report.types import RESOURCE_TYPE_SCREEN
+from apps.operation_analysis.services.named_option_datasources import expand_widget_manifest_with_named_option_datasources
 
 TERMINATION_REASON_SCREEN_DELETED = "screen_deleted"
 
@@ -44,7 +43,7 @@ class ScreenCanvasReportAdapter:
         return Screen.objects.get(pk=resource_id)
 
     def build_manifest(self, resource: Screen) -> list[dict]:
-        return build_screen_widget_manifest(resource.view_sets or {})
+        return expand_widget_manifest_with_named_option_datasources(build_screen_widget_manifest(resource.view_sets or {}))
 
     def load_filters(self, resource: Screen):
         view_sets = resource.view_sets or {}
@@ -65,7 +64,7 @@ class ScreenCanvasReportAdapter:
             "view_sets": view_sets,
             "filters": self.load_filters(resource),
             "other": deepcopy(resource.other),
-            "widget_manifest": build_screen_widget_manifest(view_sets),
+            "widget_manifest": expand_widget_manifest_with_named_option_datasources(build_screen_widget_manifest(view_sets)),
         }
 
     def render_route_key(self) -> str:
@@ -82,9 +81,7 @@ class ScreenCanvasReportAdapter:
         team_id: int,
         include_children: bool = False,
     ) -> bool:
-        from apps.operation_analysis.services.canvas_report.permissions import (
-            can_view_canvas,
-        )
+        from apps.operation_analysis.services.canvas_report.permissions import can_view_canvas
 
         return can_view_canvas(
             user,
@@ -101,9 +98,7 @@ class ScreenCanvasReportAdapter:
         actor: str,
         actor_domain: str = "",
     ) -> int:
-        from apps.operation_analysis.services.subscription_service import (
-            DashboardSubscriptionService,
-        )
+        from apps.operation_analysis.services.subscription_service import DashboardSubscriptionService
 
         return DashboardSubscriptionService.terminate_for_resource_deletion(
             resource_type=RESOURCE_TYPE_SCREEN,

--- a/server/apps/operation_analysis/services/named_option_datasources.py
+++ b/server/apps/operation_analysis/services/named_option_datasources.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable
+
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
+
+
+def collect_named_option_datasource_ids(primary_ids: Iterable[int]) -> set[int]:
+    extras: set[int] = set()
+    for option_ids in collect_named_option_datasource_ids_by_primary(primary_ids).values():
+        extras.update(option_ids)
+    return extras
+
+
+def collect_named_option_datasource_ids_by_primary(primary_ids: Iterable[int]) -> dict[int, set[int]]:
+    """从主数据源 params 收集能点名的动态选项源。
+
+    sourceId：仅收录库中存在的 id。
+    sourceRef.rest_api：仅在全表恰好一条，或恰好一条内置时收录，避免同 path 全表放行。
+    """
+    ids = {int(item) for item in primary_ids}
+    result: dict[int, set[int]] = {ds_id: set() for ds_id in ids}
+    if not ids:
+        return result
+
+    source_ids_by_primary: dict[int, set[int]] = defaultdict(set)
+    rest_apis_by_primary: dict[int, set[str]] = defaultdict(set)
+    for ds_id, params in DataSourceAPIModel.objects.filter(id__in=ids).values_list("id", "params"):
+        if not isinstance(params, list):
+            continue
+        for param in params:
+            if not isinstance(param, dict):
+                continue
+            input_config = param.get("inputConfig")
+            if not isinstance(input_config, dict):
+                continue
+            options_source = input_config.get("optionsSource")
+            if not isinstance(options_source, dict) or options_source.get("type") != "dynamic":
+                continue
+            source_id = options_source.get("sourceId")
+            if source_id is not None:
+                try:
+                    parsed = int(source_id)
+                except (TypeError, ValueError):
+                    parsed = None
+                if parsed is not None:
+                    source_ids_by_primary[ds_id].add(parsed)
+            source_ref = options_source.get("sourceRef")
+            if isinstance(source_ref, dict) and source_ref.get("type") == "rest_api":
+                value = source_ref.get("value")
+                if isinstance(value, str) and value:
+                    rest_apis_by_primary[ds_id].add(value)
+
+    all_source_ids = {item for values in source_ids_by_primary.values() for item in values}
+    existing_source_ids: set[int] = set()
+    if all_source_ids:
+        existing_source_ids = set(DataSourceAPIModel.objects.filter(id__in=all_source_ids).values_list("id", flat=True))
+    for ds_id, candidates in source_ids_by_primary.items():
+        result[ds_id].update(candidates & existing_source_ids)
+
+    resolved_rest_apis = _resolve_unique_rest_api_ids({item for values in rest_apis_by_primary.values() for item in values})
+    for ds_id, apis in rest_apis_by_primary.items():
+        for rest_api in apis:
+            resolved = resolved_rest_apis.get(rest_api)
+            if resolved is not None:
+                result[ds_id].add(resolved)
+    return result
+
+
+def expand_widget_manifest_with_named_option_datasources(manifest: list[dict] | None) -> list[dict]:
+    """在 widget_manifest 追加能点名的选项源 identity，字段仍是 identity + datasource_id。"""
+    if not manifest:
+        return list(manifest or [])
+
+    primary_ids: list[int] = []
+    for item in manifest:
+        if not isinstance(item, dict) or item.get("datasource_id") is None:
+            continue
+        try:
+            primary_ids.append(int(item["datasource_id"]))
+        except (TypeError, ValueError):
+            continue
+
+    extras_by_primary = collect_named_option_datasource_ids_by_primary(primary_ids)
+    expanded = list(manifest)
+    seen = {(item.get("widget_id"), item.get("datasource_id")) for item in manifest if isinstance(item, dict)}
+    for item in manifest:
+        if not isinstance(item, dict) or item.get("datasource_id") is None:
+            continue
+        try:
+            primary = int(item["datasource_id"])
+        except (TypeError, ValueError):
+            continue
+        for extra_id in extras_by_primary.get(primary, ()):
+            key = (item.get("widget_id"), extra_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            expanded.append(
+                {
+                    "widget_id": item.get("widget_id"),
+                    "widget_type": item.get("widget_type"),
+                    "datasource_id": extra_id,
+                }
+            )
+    return expanded
+
+
+def _resolve_unique_rest_api_ids(rest_apis: set[str]) -> dict[str, int]:
+    if not rest_apis:
+        return {}
+    grouped: dict[str, list[tuple[int, bool]]] = defaultdict(list)
+    for ds_id, rest_api, is_build_in in DataSourceAPIModel.objects.filter(rest_api__in=rest_apis).values_list(
+        "id",
+        "rest_api",
+        "is_build_in",
+    ):
+        grouped[rest_api].append((ds_id, bool(is_build_in)))
+
+    resolved: dict[str, int] = {}
+    for rest_api, matches in grouped.items():
+        if len(matches) == 1:
+            resolved[rest_api] = matches[0][0]
+            continue
+        builtins = [ds_id for ds_id, is_build_in in matches if is_build_in]
+        if len(builtins) == 1:
+            resolved[rest_api] = builtins[0]
+    return resolved

--- a/server/apps/operation_analysis/services/render_scope_service.py
+++ b/server/apps/operation_analysis/services/render_scope_service.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from apps.core.backends import AuthBackend
 from apps.operation_analysis.models.datasource_models import NameSpace
 from apps.operation_analysis.models.subscription_models import DashboardReportExecution, DashboardReportRenderToken
+from apps.operation_analysis.services.named_option_datasources import collect_named_option_datasource_ids
 from apps.system_mgmt.models import User as SystemUser
 from apps.system_mgmt.nats.auth import build_user_authorization_context
 
@@ -165,9 +166,7 @@ class DashboardReportRenderScopeService:
         if match and method == "GET" and int(match.group(1)) == execution_id:
             return claims
 
-        allowed_datasources = {
-            int(item["datasource_id"]) for item in execution.render_snapshot.widget_manifest or [] if item.get("datasource_id") is not None
-        }
+        allowed_datasources = cls.collect_allowed_datasource_ids(execution.render_snapshot.widget_manifest)
         match = cls._DATASOURCE_QUERY.match(path)
         if match and method == "POST" and int(match.group(1)) in allowed_datasources:
             return claims
@@ -200,6 +199,19 @@ class DashboardReportRenderScopeService:
                 return claims
 
         raise DashboardReportRenderScopeError("Render Session 不允许访问该接口")
+
+    @classmethod
+    def collect_allowed_datasource_ids(cls, widget_manifest) -> set[int]:
+        """Manifest 数据源，加上其 params 里能点名的动态选项源。"""
+        primary_ids: set[int] = set()
+        for item in widget_manifest or []:
+            if not isinstance(item, dict) or item.get("datasource_id") is None:
+                continue
+            try:
+                primary_ids.add(int(item["datasource_id"]))
+            except (TypeError, ValueError):
+                continue
+        return primary_ids | collect_named_option_datasource_ids(primary_ids)
 
     @staticmethod
     def _read_json_body(request) -> dict:

--- a/server/apps/operation_analysis/tests/test_dashboard_report_render_token.py
+++ b/server/apps/operation_analysis/tests/test_dashboard_report_render_token.py
@@ -517,6 +517,48 @@ def test_legacy_render_claims_are_detected_and_fail_closed():
     assert AuthMiddleware._is_render_token_candidate(token)
 
 
+ROOM3D_SWITCH_PARAMS = [
+    {
+        "name": "server_room_id",
+        "inputConfig": {
+            "control": "select",
+            "componentSwitch": True,
+            "optionsSource": {
+                "type": "dynamic",
+                "sourceRef": {"type": "rest_api", "value": "cmdb/get_room_list"},
+                "valueField": "inst_uuid",
+                "labelField": "inst_name",
+            },
+        },
+    }
+]
+
+
+def _create_room3d_option_datasources():
+    layout = DataSourceAPIModel.objects.create(
+        id=17,
+        name="CMDB 3D机房布局",
+        rest_api="cmdb/get_room3d_layout",
+        groups=[1],
+        params=ROOM3D_SWITCH_PARAMS,
+    )
+    rooms = DataSourceAPIModel.objects.create(
+        id=42,
+        name="CMDB 机房列表",
+        rest_api="cmdb/get_room_list",
+        groups=[1],
+        params=[],
+    )
+    unrelated = DataSourceAPIModel.objects.create(
+        id=18,
+        name="无关数据源",
+        rest_api="other/query",
+        groups=[1],
+        params=[],
+    )
+    return layout, rooms, unrelated
+
+
 def test_render_session_allows_only_manifest_datasource(
     running_execution,
     monkeypatch,
@@ -552,6 +594,152 @@ def test_render_session_allows_only_manifest_datasource(
             ),
             session["token"],
         )
+
+
+def test_render_session_allows_component_switch_option_datasource(
+    running_execution,
+    monkeypatch,
+):
+    monkeypatch.setenv("SECRET_KEY", "render-token-test-secret")
+    _create_room3d_option_datasources()
+    issued = DashboardReportRenderTokenService.issue(running_execution)
+    session = DashboardReportRenderTokenService.consume(
+        execution_id=running_execution.id,
+        plaintext=issued.plaintext,
+    )
+    factory = APIRequestFactory()
+
+    with pytest.raises(DashboardReportRenderScopeError):
+        DashboardReportRenderScopeService.authorize_request(
+            factory.get(
+                "/api/v1/operation_analysis/api/data_source/",
+                {"page_size": "-1"},
+            ),
+            session["token"],
+        )
+
+    DashboardReportRenderScopeService.authorize_request(
+        factory.get(
+            "/api/v1/operation_analysis/api/data_source/",
+            {"ids": "17,42"},
+        ),
+        session["token"],
+    )
+    DashboardReportRenderScopeService.authorize_request(
+        factory.post(
+            "/api/v1/operation_analysis/api/data_source/get_source_data/42/",
+            {},
+            format="json",
+        ),
+        session["token"],
+    )
+    with pytest.raises(DashboardReportRenderScopeError):
+        DashboardReportRenderScopeService.authorize_request(
+            factory.get(
+                "/api/v1/operation_analysis/api/data_source/",
+                {"ids": "17,18"},
+            ),
+            session["token"],
+        )
+    with pytest.raises(DashboardReportRenderScopeError):
+        DashboardReportRenderScopeService.authorize_request(
+            factory.post(
+                "/api/v1/operation_analysis/api/data_source/get_source_data/18/",
+                {},
+                format="json",
+            ),
+            session["token"],
+        )
+
+
+def test_render_session_rejects_ambiguous_option_rest_api(
+    running_execution,
+    monkeypatch,
+):
+    monkeypatch.setenv("SECRET_KEY", "render-token-test-secret")
+    DataSourceAPIModel.objects.create(
+        id=17,
+        name="CMDB 3D机房布局",
+        rest_api="cmdb/get_room3d_layout",
+        groups=[1],
+        params=ROOM3D_SWITCH_PARAMS,
+    )
+    DataSourceAPIModel.objects.create(
+        id=42,
+        name="机房列表 A",
+        rest_api="cmdb/get_room_list",
+        groups=[1],
+    )
+    DataSourceAPIModel.objects.create(
+        id=43,
+        name="机房列表 B",
+        rest_api="cmdb/get_room_list",
+        groups=[1],
+    )
+    issued = DashboardReportRenderTokenService.issue(running_execution)
+    session = DashboardReportRenderTokenService.consume(
+        execution_id=running_execution.id,
+        plaintext=issued.plaintext,
+    )
+    factory = APIRequestFactory()
+
+    DashboardReportRenderScopeService.authorize_request(
+        factory.post(
+            "/api/v1/operation_analysis/api/data_source/get_source_data/17/",
+            {},
+            format="json",
+        ),
+        session["token"],
+    )
+    with pytest.raises(DashboardReportRenderScopeError):
+        DashboardReportRenderScopeService.authorize_request(
+            factory.post(
+                "/api/v1/operation_analysis/api/data_source/get_source_data/42/",
+                {},
+                format="json",
+            ),
+            session["token"],
+        )
+
+
+def test_render_session_datasource_list_requires_named_ids(
+    running_execution,
+    monkeypatch,
+    settings,
+):
+    monkeypatch.setenv("SECRET_KEY", "render-token-test-secret")
+    _create_room3d_option_datasources()
+    issued = DashboardReportRenderTokenService.issue(running_execution)
+    session = DashboardReportRenderTokenService.consume(
+        execution_id=running_execution.id,
+        plaintext=issued.plaintext,
+    )
+    settings.MIDDLEWARE = (
+        *settings.MIDDLEWARE,
+        "apps.core.middlewares.auth_middleware.AuthMiddleware",
+    )
+    _stub_render_auth_context(
+        monkeypatch,
+        username=running_execution.creator,
+        domain=running_execution.creator_domain,
+    )
+    _stub_datasource_instance_rules(monkeypatch, team_ids=[1])
+    client = APIClient()
+
+    denied = client.get(
+        "/api/v1/operation_analysis/api/data_source/",
+        {"page_size": "-1"},
+        HTTP_AUTHORIZATION=f"Bearer {session['token']}",
+    )
+    assert denied.status_code in {401, 403}
+
+    allowed = client.get(
+        "/api/v1/operation_analysis/api/data_source/",
+        {"ids": "17,42", "page_size": "-1"},
+        HTTP_AUTHORIZATION=f"Bearer {session['token']}",
+    )
+    assert allowed.status_code == 200, allowed.data
+    assert {item["id"] for item in allowed.data} == {17, 42}
 
 
 def test_render_session_allows_frozen_network_status_topology(

--- a/server/apps/operation_analysis/tests/test_dashboard_report_webgl_print.py
+++ b/server/apps/operation_analysis/tests/test_dashboard_report_webgl_print.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+
+import fitz
+import pytest
+
+from apps.operation_analysis.services.dashboard_report_renderer import DashboardChromiumRenderer, DashboardRenderRequest
+
+pytestmark = pytest.mark.integration
+
+WEBGL_FILL = (255, 32, 160)
+
+
+@pytest.fixture(autouse=True)
+def _use_default_playwright_chromium(monkeypatch):
+    monkeypatch.delenv("PLAYWRIGHT_BROWSERS_PATH", raising=False)
+    monkeypatch.delenv("EXECUTABLE_PATH", raising=False)
+
+
+def _chromium_ready() -> bool:
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            browser.close()
+        return True
+    except Exception:
+        return False
+
+
+def _write_webgl_snapshot_html(path: Path) -> None:
+    r, g, b = [channel / 255 for channel in WEBGL_FILL]
+    path.write_text(
+        f"""
+        <!doctype html>
+        <html lang="zh-CN">
+          <head><meta charset="utf-8"><title>BK-Lite WebGL Print</title></head>
+          <body style="margin:0; background:#08111f;">
+            <div data-dashboard-render-root="true" style="width:720px;height:480px;">
+              <canvas id="room" width="720" height="480"></canvas>
+            </div>
+            <script>
+              const canvas = document.getElementById('room');
+              const gl = canvas.getContext('webgl', {{
+                preserveDrawingBuffer: true,
+                alpha: false,
+              }});
+              gl.viewport(0, 0, canvas.width, canvas.height);
+              gl.clearColor({r}, {g}, {b}, 1);
+              gl.clear(gl.COLOR_BUFFER_BIT);
+              const image = document.createElement('img');
+              image.src = canvas.toDataURL('image/png');
+              image.width = canvas.width;
+              image.height = canvas.height;
+              image.style.width = canvas.width + 'px';
+              image.style.height = canvas.height + 'px';
+              image.dataset.printSnapshot = 'true';
+              canvas.replaceWith(image);
+              const ready = image.decode ? image.decode() : Promise.resolve();
+              ready.catch(() => undefined).then(() => {{
+                requestAnimationFrame(() => requestAnimationFrame(() => {{
+                  window.dispatchEvent(new CustomEvent('bk-dashboard-render', {{
+                    detail: {{
+                      type: 'report-ready',
+                      dashboardId: 'webgl',
+                      widgets: [{{ widgetId: 'room', status: 'ready' }}]
+                    }}
+                  }}));
+                }}));
+              }});
+            </script>
+          </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+
+
+def _pdf_has_rgb(path: Path, target: tuple[int, int, int], tolerance: int = 48) -> bool:
+    tr, tg, tb = target
+    with fitz.open(path) as document:
+        for page in document:
+            pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+            samples = pixmap.samples
+            channels = pixmap.n
+            for index in range(0, len(samples), channels):
+                if abs(samples[index] - tr) <= tolerance and abs(samples[index + 1] - tg) <= tolerance and abs(samples[index + 2] - tb) <= tolerance:
+                    return True
+    return False
+
+
+def test_webgl_scene_survives_pdf_after_canvas_snapshot(tmp_path):
+    if not _chromium_ready():
+        pytest.skip("Playwright Chromium 不可用")
+
+    html_path = tmp_path / "webgl-room.html"
+    output_path = tmp_path / "webgl-room.pdf"
+    _write_webgl_snapshot_html(html_path)
+
+    result = DashboardChromiumRenderer().render(
+        DashboardRenderRequest(
+            execution_id=202,
+            render_url=html_path.as_uri(),
+            output_path=output_path,
+            resource_type="screen",
+            viewport_width=720,
+            viewport_height=480,
+        )
+    )
+
+    assert result["signal"]["type"] == "report-ready"
+    assert _pdf_has_rgb(output_path, WEBGL_FILL)

--- a/server/apps/operation_analysis/tests/test_named_option_datasources.py
+++ b/server/apps/operation_analysis/tests/test_named_option_datasources.py
@@ -1,0 +1,133 @@
+import pytest
+
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
+from apps.operation_analysis.services.named_option_datasources import (
+    collect_named_option_datasource_ids,
+    expand_widget_manifest_with_named_option_datasources,
+)
+
+pytestmark = pytest.mark.django_db
+
+ROOM3D_SWITCH_PARAMS = [
+    {
+        "name": "server_room_id",
+        "inputConfig": {
+            "control": "select",
+            "componentSwitch": True,
+            "optionsSource": {
+                "type": "dynamic",
+                "sourceRef": {"type": "rest_api", "value": "cmdb/get_room_list"},
+                "valueField": "inst_uuid",
+                "labelField": "inst_name",
+            },
+        },
+    }
+]
+
+
+def test_collect_named_option_ids_keeps_unique_rest_api_and_existing_source_id():
+    DataSourceAPIModel.objects.create(
+        id=17,
+        name="CMDB 3D机房布局",
+        rest_api="cmdb/get_room3d_layout",
+        params=ROOM3D_SWITCH_PARAMS
+        + [
+            {
+                "name": "namespace",
+                "inputConfig": {
+                    "control": "select",
+                    "optionsSource": {
+                        "type": "dynamic",
+                        "sourceId": 9,
+                        "valueField": "id",
+                        "labelField": "name",
+                    },
+                },
+            },
+            {
+                "name": "missing",
+                "inputConfig": {
+                    "control": "select",
+                    "optionsSource": {
+                        "type": "dynamic",
+                        "sourceId": "not-a-number",
+                        "valueField": "id",
+                        "labelField": "name",
+                    },
+                },
+            },
+        ],
+    )
+    DataSourceAPIModel.objects.create(
+        id=42,
+        name="CMDB 机房列表",
+        rest_api="cmdb/get_room_list",
+    )
+    DataSourceAPIModel.objects.create(
+        id=9,
+        name="命名空间选项",
+        rest_api="system/namespaces",
+    )
+    DataSourceAPIModel.objects.create(
+        id=18,
+        name="无关数据源",
+        rest_api="other/query",
+    )
+
+    assert collect_named_option_datasource_ids({17}) == {9, 42}
+
+
+def test_collect_named_option_ids_skips_ambiguous_rest_api_unless_unique_builtin():
+    DataSourceAPIModel.objects.create(
+        id=17,
+        name="主数据源",
+        rest_api="cmdb/get_room3d_layout",
+        params=ROOM3D_SWITCH_PARAMS,
+    )
+    DataSourceAPIModel.objects.create(
+        id=42,
+        name="机房列表 A",
+        rest_api="cmdb/get_room_list",
+    )
+    DataSourceAPIModel.objects.create(
+        id=43,
+        name="机房列表 B",
+        rest_api="cmdb/get_room_list",
+    )
+    assert collect_named_option_datasource_ids({17}) == set()
+
+    DataSourceAPIModel.objects.filter(id=43).update(is_build_in=True)
+    assert collect_named_option_datasource_ids({17}) == {43}
+
+
+def test_expand_widget_manifest_appends_named_option_identity():
+    DataSourceAPIModel.objects.create(
+        id=17,
+        name="CMDB 3D机房布局",
+        rest_api="cmdb/get_room3d_layout",
+        params=ROOM3D_SWITCH_PARAMS,
+    )
+    DataSourceAPIModel.objects.create(
+        id=42,
+        name="CMDB 机房列表",
+        rest_api="cmdb/get_room_list",
+    )
+    manifest = [
+        {
+            "widget_id": "room-1",
+            "widget_type": "room3D",
+            "datasource_id": 17,
+        }
+    ]
+    assert expand_widget_manifest_with_named_option_datasources(manifest) == [
+        {
+            "widget_id": "room-1",
+            "widget_type": "room3D",
+            "datasource_id": 17,
+        },
+        {
+            "widget_id": "room-1",
+            "widget_type": "room3D",
+            "datasource_id": 42,
+        },
+    ]

--- a/web/src/app/ops-analysis/(pages)/view/dashBoard/index.tsx
+++ b/web/src/app/ops-analysis/(pages)/view/dashBoard/index.tsx
@@ -89,6 +89,7 @@ interface DashboardProps {
   getDashboardDetailOverride?: (id: string | number) => Promise<any>;
   renderMode?: boolean;
   renderFilterValues?: Record<string, FilterValue>;
+  renderDataSourceIds?: number[];
 }
 
 export interface DashboardRef {
@@ -102,6 +103,7 @@ const Dashboard = forwardRef<DashboardRef, DashboardProps>(
     getDashboardDetailOverride,
     renderMode = false,
     renderFilterValues,
+    renderDataSourceIds,
   }, ref) => {
     const { t } = useTranslation();
     const { data: session } = useSession();
@@ -215,11 +217,14 @@ const Dashboard = forwardRef<DashboardRef, DashboardProps>(
 
         return syncCanvasResources({
           source: nextWidgetLayout,
-          getDataSourceIds: collectDashboardDataSourceIds,
+          getDataSourceIds: (layout) => Array.from(new Set([
+            ...collectDashboardDataSourceIds(layout),
+            ...(renderDataSourceIds || []),
+          ])),
           getNamespaceIds: collectDashboardNamespaceIds,
         });
       },
-      [syncCanvasResources],
+      [renderDataSourceIds, syncCanvasResources],
     );
 
     const {

--- a/web/src/app/ops-analysis/(pages)/view/report/index.tsx
+++ b/web/src/app/ops-analysis/(pages)/view/report/index.tsx
@@ -107,6 +107,7 @@ const Report = forwardRef<ReportRef, ReportProps>(({
   shareMode = false,
   renderMode = false,
   renderFilterValues,
+  renderDataSourceIds,
   getReportDetailOverride,
 }, ref) => {
   const { t } = useTranslation();
@@ -196,9 +197,12 @@ const Report = forwardRef<ReportRef, ReportProps>(({
       setFilterValues(initialFilterValues);
       setAppliedFilterValues(initialFilterValues);
       setAppliedFilterDefinitions(normalized.filters);
-      const dataSourceIds = normalized.sections
-        .map((section) => section.valueConfig.dataSource)
-        .filter((id): id is string | number => id !== undefined);
+      const dataSourceIds = Array.from(new Set([
+        ...normalized.sections
+          .map((section) => section.valueConfig.dataSource)
+          .filter((id): id is string | number => id !== undefined),
+        ...(renderDataSourceIds || []),
+      ]));
       await loadCanvasDataSources(dataSourceIds);
     } catch (error) {
       if (!isCurrentReportLoad(loadGuardRef.current, requestId)) return;
@@ -228,7 +232,7 @@ const Report = forwardRef<ReportRef, ReportProps>(({
         setLoading(false);
       }
     }
-  }, [loadCanvasDataSources, renderFilterValues, renderMode, selectedReport?.data_id, t]);
+  }, [loadCanvasDataSources, renderDataSourceIds, renderFilterValues, renderMode, selectedReport?.data_id, t]);
 
   useEffect(() => {
     setEditing(false);

--- a/web/src/app/ops-analysis/components/__tests__/dashboardExecutionRenderPage.test.tsx
+++ b/web/src/app/ops-analysis/components/__tests__/dashboardExecutionRenderPage.test.tsx
@@ -74,6 +74,7 @@ describe('DashboardExecutionRenderPageContent', () => {
     expect(props.renderFilterValues).toEqual({
       environment: 'production',
     });
+    expect(props.renderDataSourceIds).toEqual([17]);
     expect(props.selectedDashboard).toEqual({
       id: '8',
       data_id: '8',

--- a/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.emptyVsFailed.test.tsx
+++ b/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.emptyVsFailed.test.tsx
@@ -1,0 +1,346 @@
+// @vitest-environment jsdom
+
+import React, { useEffect } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DatasourceItem } from '@/app/ops-analysis/types/dataSource';
+import { ChartDataTransformer } from '@/app/ops-analysis/utils/chartDataTransform';
+import {
+  extractComparableValue,
+  toComparableNumber,
+} from '@/app/ops-analysis/utils/compareQuery';
+import { parseTableLikeData } from '@/app/ops-analysis/utils/tableLikeData';
+import { buildDashboardRenderSignal } from '@/app/ops-analysis/renderContract';
+import type { DashboardWidgetRenderResult } from '@/app/ops-analysis/renderContract';
+
+const testState = vi.hoisted(() => ({
+  payload: null as unknown,
+}));
+
+vi.mock('@/utils/i18n', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/app/ops-analysis/context/common', () => ({
+  useOpsAnalysis: () => ({ canvasDataSourceLookupStatus: 'ready', dataSources: [] }),
+}));
+
+vi.mock('@/app/ops-analysis/api/dataSource', async () => {
+  const actual = await vi.importActual<typeof import('@/app/ops-analysis/api/dataSource')>(
+    '@/app/ops-analysis/api/dataSource',
+  );
+  return {
+    ...actual,
+    useDataSourceApi: () => ({
+      getSourceDataByApiId: vi.fn(),
+      getDataSourceList: vi.fn(),
+    }),
+  };
+});
+
+vi.mock('@/app/ops-analysis/hooks/useParamInputOptions', () => ({
+  useParamInputOptions: () => ({ status: 'idle', options: [] }),
+}));
+
+vi.mock('@/app/ops-analysis/utils/compareQuery', async () => {
+  const actual = await vi.importActual<typeof import('@/app/ops-analysis/utils/compareQuery')>(
+    '@/app/ops-analysis/utils/compareQuery',
+  );
+  return {
+    ...actual,
+    fetchCompareData: async () => ({
+      currentData: testState.payload,
+      baselineData: null,
+    }),
+  };
+});
+
+vi.mock('@/app/ops-analysis/components/widgetRegistry', () => ({
+  getWidgetComponent: (chartType?: string) => {
+    return function FakeChart({
+      rawData,
+      loading,
+      config,
+      onReady,
+    }: {
+      rawData: unknown;
+      loading?: boolean;
+      config?: { selectedFields?: string[] };
+      onReady?: (hasData?: boolean) => void;
+    }) {
+      let hasData = Boolean(rawData);
+      if (chartType === 'pie') {
+        const chartData = ChartDataTransformer.transformToPieData(rawData);
+        hasData = chartData.some(
+          (item) => Number.isFinite(item.value) && item.value > 0,
+        );
+      } else if (chartType === 'single') {
+        hasData = extractComparableValue(rawData, config?.selectedFields?.[0]) !== null;
+      } else if (chartType === 'gauge') {
+        hasData =
+          toComparableNumber(
+            extractComparableValue(rawData, config?.selectedFields?.[0]),
+          ) !== null;
+      } else if (chartType === 'line' || chartType === 'bar') {
+        hasData =
+          ChartDataTransformer.transformToLineBarData(rawData).categories.length > 0;
+      } else if (chartType === 'topN' || chartType === 'table') {
+        hasData =
+          parseTableLikeData(rawData, { current: 1, pageSize: 20 }).rows.length > 0;
+      }
+      useEffect(() => {
+        if (!loading) onReady?.(hasData);
+      }, [hasData, loading, onReady]);
+      return <div data-testid={`${chartType || 'chart'}-renderer`} />;
+    };
+  },
+}));
+
+import WidgetWrapper from '../widgetDataRenderer';
+
+const datasource: DatasourceItem = {
+  id: 42,
+  created_at: '',
+  updated_at: '',
+  created_by: '',
+  updated_by: '',
+  domain: '',
+  updated_by_domain: '',
+  name: '云资源成本汇总',
+  source_type: 'nats',
+  desc: '',
+  params: [],
+  chart_type: ['single', 'pie', 'topN', 'table'],
+  namespaces: [],
+};
+
+const emptyCloudCostSummary = {
+  total_cost: '0.00',
+  instance_count: 0,
+  avg_daily_cost: '0.00',
+  mom_change_pct: null,
+};
+
+const lastTerminalStatus = (
+  onRenderStatus: ReturnType<typeof vi.fn>,
+): DashboardWidgetRenderResult | undefined => {
+  const calls = onRenderStatus.mock.calls.map(
+    ([result]) => result as DashboardWidgetRenderResult,
+  );
+  return [...calls].reverse().find((result) => result.status !== 'loading');
+};
+
+const renderWidget = ({
+  widgetId,
+  chartType,
+  config,
+}: {
+  widgetId: string;
+  chartType: string;
+  config?: Record<string, unknown>;
+}) => {
+  const onRenderStatus = vi.fn();
+  render(
+    <WidgetWrapper
+      dashboardId="cloud-cost"
+      widgetId={widgetId}
+      chartType={chartType}
+      config={{ dataSource: datasource.id, ...config }}
+      dataSource={datasource}
+      onRenderStatus={onRenderStatus}
+    />,
+  );
+  return onRenderStatus;
+};
+
+afterEach(() => {
+  cleanup();
+  testState.payload = null;
+});
+
+describe('Cloud cost empty payloads must not fail report render', () => {
+  it('reports empty for all-zero pie slices instead of staying loading', async () => {
+    testState.payload = [
+      { name: '计算', value: 0 },
+      { name: '存储', value: 0 },
+    ];
+    const onRenderStatus = renderWidget({
+      widgetId: 'pie-zero',
+      chartType: 'pie',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'pie-zero',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports empty for cloud-cost 环比 null instead of staying loading', async () => {
+    testState.payload = emptyCloudCostSummary;
+    const onRenderStatus = renderWidget({
+      widgetId: 'mom-change',
+      chartType: 'single',
+      config: { selectedFields: ['mom_change_pct'] },
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'mom-change',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports ready for zero total_cost KPI instead of empty', async () => {
+    testState.payload = emptyCloudCostSummary;
+    const onRenderStatus = renderWidget({
+      widgetId: 'total-cost',
+      chartType: 'single',
+      config: { selectedFields: ['total_cost'] },
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'total-cost',
+        status: 'ready',
+      });
+    });
+  });
+
+  it('reports empty for empty distribution list as pie', async () => {
+    testState.payload = [];
+    const onRenderStatus = renderWidget({
+      widgetId: 'pie-empty-list',
+      chartType: 'pie',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'pie-empty-list',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports empty for empty bill table envelope', async () => {
+    testState.payload = { total: 0, page: 1, page_size: 20, items: [] };
+    const onRenderStatus = renderWidget({
+      widgetId: 'bill-table',
+      chartType: 'table',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'bill-table',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports empty for structurally empty line envelope instead of staying loading', async () => {
+    testState.payload = { categories: [], values: [] };
+    const onRenderStatus = renderWidget({
+      widgetId: 'line-empty',
+      chartType: 'line',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'line-empty',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports ready for line categories including all-zero values', async () => {
+    testState.payload = [{ name: '周一', value: 0 }];
+    const onRenderStatus = renderWidget({
+      widgetId: 'line-zero',
+      chartType: 'line',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'line-zero',
+        status: 'ready',
+      });
+    });
+  });
+
+  it('reports empty for table count envelope without items instead of staying loading', async () => {
+    testState.payload = { count: 0 };
+    const onRenderStatus = renderWidget({
+      widgetId: 'count-table',
+      chartType: 'table',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'count-table',
+        status: 'empty',
+      });
+    });
+  });
+
+  it('reports ready for pie slices with a positive value', async () => {
+    testState.payload = [
+      { name: '计算', value: 0 },
+      { name: '存储', value: 8 },
+    ];
+    const onRenderStatus = renderWidget({
+      widgetId: 'pie-ready',
+      chartType: 'pie',
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'pie-ready',
+        status: 'ready',
+      });
+    });
+  });
+
+  it('reports ready for gauge zero instead of empty', async () => {
+    testState.payload = { value: 0 };
+    const onRenderStatus = renderWidget({
+      widgetId: 'gauge-zero',
+      chartType: 'gauge',
+      config: { selectedFields: ['value'] },
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)).toEqual({
+        widgetId: 'gauge-zero',
+        status: 'ready',
+      });
+    });
+  });
+
+  it('aggregates empty widgets into report-ready, not report-failed', async () => {
+    testState.payload = emptyCloudCostSummary;
+    const onRenderStatus = renderWidget({
+      widgetId: 'mom-change',
+      chartType: 'single',
+      config: { selectedFields: ['mom_change_pct'] },
+    });
+
+    await waitFor(() => {
+      expect(lastTerminalStatus(onRenderStatus)?.status).toBe('empty');
+    });
+
+    const signal = buildDashboardRenderSignal(
+      'cloud-cost',
+      ['mom-change', 'pie-empty', 'bill-table'],
+      new Map([
+        ['mom-change', { widgetId: 'mom-change', status: 'empty' }],
+        ['pie-empty', { widgetId: 'pie-empty', status: 'empty' }],
+        ['bill-table', { widgetId: 'bill-table', status: 'empty' }],
+      ]),
+    );
+    expect(signal?.type).toBe('report-ready');
+  });
+});

--- a/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.fetchError.test.tsx
+++ b/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.fetchError.test.tsx
@@ -50,7 +50,7 @@ vi.mock('@/utils/i18n', () => ({
 }));
 
 vi.mock('@/app/ops-analysis/context/common', () => ({
-  useOpsAnalysis: () => ({ canvasDataSourceLookupStatus: 'ready' }),
+  useOpsAnalysis: () => ({ canvasDataSourceLookupStatus: 'ready', dataSources: [] }),
 }));
 
 vi.mock('@/app/ops-analysis/api/dataSource', async () => {
@@ -146,6 +146,31 @@ const topNDatasource: DatasourceItem = {
   source_type: 'rest_api',
   params: [switchParam],
   chart_type: ['topN'],
+};
+
+const room3dSwitchParam: ParamItem = {
+  ...switchParam,
+  value: '',
+  inputConfig: {
+    control: 'select',
+    componentSwitch: true,
+    optionsSource: {
+      type: 'dynamic',
+      sourceRef: { type: 'rest_api', value: 'cmdb/get_room_list' },
+      valueField: 'inst_uuid',
+      labelField: 'inst_name',
+    },
+  },
+};
+
+const room3dDatasource: DatasourceItem = {
+  ...pieDatasource,
+  id: 88,
+  name: 'CMDB 3D机房布局',
+  source_type: 'nats',
+  params: [room3dSwitchParam],
+  chart_type: ['room3D'],
+  namespaces: [],
 };
 
 afterEach(() => {
@@ -1167,5 +1192,61 @@ describe('WidgetWrapper component switch options runtime', () => {
     expect(screen.queryByText(businessError)).toBeNull();
     expect(testState.fetchCompareData).toHaveBeenCalled();
     expect(testState.messageError).not.toHaveBeenCalled();
+  });
+
+  it('reports empty, not failed, when room3D switch options are empty', async () => {
+    testState.optionState = { status: 'error', options: [] };
+    const onRenderStatus = vi.fn();
+
+    render(
+      <WidgetWrapper
+        dashboardId="screen-room3d"
+        widgetId="builtin-room3d-main"
+        chartType="room3D"
+        config={{ dataSource: room3dDatasource.id, dataSourceParams: [room3dSwitchParam] }}
+        dataSource={room3dDatasource}
+        onRenderStatus={onRenderStatus}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onRenderStatus).toHaveBeenCalledWith({
+        widgetId: 'builtin-room3d-main',
+        status: 'empty',
+      });
+    });
+    expect(onRenderStatus).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'failed' }),
+    );
+    expect(testState.fetchCompareData).not.toHaveBeenCalled();
+  });
+
+  it('still reports failed when room3D switch options fail to load', async () => {
+    testState.optionState = {
+      status: 'error',
+      options: [],
+      errorMessage: '机房列表加载失败',
+    };
+    const onRenderStatus = vi.fn();
+
+    render(
+      <WidgetWrapper
+        dashboardId="screen-room3d"
+        widgetId="builtin-room3d-main"
+        chartType="room3D"
+        config={{ dataSource: room3dDatasource.id, dataSourceParams: [room3dSwitchParam] }}
+        dataSource={room3dDatasource}
+        onRenderStatus={onRenderStatus}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onRenderStatus).toHaveBeenCalledWith({
+        widgetId: 'builtin-room3d-main',
+        status: 'failed',
+        error: '机房列表加载失败',
+      });
+    });
+    expect(testState.fetchCompareData).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.topologyMap.test.tsx
+++ b/web/src/app/ops-analysis/components/__tests__/widgetDataRenderer.topologyMap.test.tsx
@@ -20,7 +20,7 @@ vi.mock('@/utils/i18n', () => ({
 }));
 
 vi.mock('@/app/ops-analysis/context/common', () => ({
-  useOpsAnalysis: () => ({ canvasDataSourceLookupStatus: 'ready' }),
+  useOpsAnalysis: () => ({ canvasDataSourceLookupStatus: 'ready', dataSources: [] }),
 }));
 
 vi.mock('@/app/ops-analysis/api/dataSource', () => ({

--- a/web/src/app/ops-analysis/components/widgetDataRenderer.tsx
+++ b/web/src/app/ops-analysis/components/widgetDataRenderer.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/app/ops-analysis/utils/widgetRequestVersion";
 import WidgetRenderer from "@/app/ops-analysis/components/widgetRenderer";
 import WidgetErrorState from "@/app/ops-analysis/components/widgetErrorState";
+import WidgetState from "@/app/ops-analysis/components/widget-state";
 import { useWidgetHeaderRuntimeSlot } from "@/app/ops-analysis/components/widgetHeaderRuntimeSlot";
 import ComponentParamSwitchControl from "@/app/ops-analysis/components/componentParamSwitchControl";
 import { getDateRangeTimezone } from "@/app/ops-analysis/utils/dateRange";
@@ -320,7 +321,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
   const [tableQueryParams, setTableQueryParams] = useState<Record<string, any>>(
     {},
   );
-  const { canvasDataSourceLookupStatus } = useOpsAnalysis();
+  const { canvasDataSourceLookupStatus, dataSources } = useOpsAnalysis();
   const runtimeScheduler = useDashboardRuntimeScheduler();
   const { getSourceDataByApiId } = useDataSourceApi();
   const optionConsumerSequenceRef = useRef(0);
@@ -345,8 +346,9 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
     () => ({
       suppressErrorNotification: true as const,
       fallbackErrorMessage: t("dashboard.dataFetchFailed"),
+      knownDataSources: dataSources,
     }),
-    [t],
+    [dataSources, t],
   );
   const scheduleOptionsPhysical = useCallback(
     <T,>(physicalKey: string, start: () => Promise<T>) => {
@@ -554,6 +556,10 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
       }),
     [componentSwitchParam, optionState.status, runtimeParams],
   );
+  const switchOptionsLoadError =
+    optionState.status === "error" ? optionState.errorMessage : undefined;
+  const isEmptyComponentSwitch =
+    componentSwitchRequestGate === "blocked" && !switchOptionsLoadError;
   const requestEnabled =
     Boolean(normalizedDataSourceId) &&
     Boolean(dataSource) &&
@@ -989,18 +995,25 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
       setHasSettledRequest(true);
       const optionsLoadErrorMessage =
         optionState.status === "error" ? optionState.errorMessage : undefined;
-      const blockedMessage = optionsLoadErrorMessage || t("dashboard.noData");
-      setDataValidation((previous) => {
-        if (
-          previous
-          && previous.isValid === false
-          && previous.message === blockedMessage
-          && previous.errorCode === undefined
-        ) {
-          return previous;
-        }
-        return { isValid: false, message: blockedMessage };
-      });
+      if (optionsLoadErrorMessage) {
+        setDataValidation((previous) => {
+          if (
+            previous
+            && previous.isValid === false
+            && previous.message === optionsLoadErrorMessage
+            && previous.errorCode === undefined
+          ) {
+            return previous;
+          }
+          return { isValid: false, message: optionsLoadErrorMessage };
+        });
+        return;
+      }
+      setDataValidation((previous) => (
+        previous?.isValid === true && previous.message === undefined
+          ? previous
+          : { isValid: true }
+      ));
     }
   }, [
     isSceneWidget,
@@ -1103,7 +1116,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
         onRenderStatus?.({ widgetId, status: "loading" });
         return;
       }
-      if (!hasData && hasRenderableChartData(chartType, rawData)) {
+      if (!hasData && hasRenderableChartData(chartType, rawData, config)) {
         onRenderStatus?.({ widgetId, status: "loading" });
         return;
       }
@@ -1115,6 +1128,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
     [
       hasSettledRequest,
       chartType,
+      config,
       isTableLikeChart,
       loading,
       onReady,
@@ -1160,6 +1174,11 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
       return;
     }
 
+    if (isEmptyComponentSwitch) {
+      onRenderStatus?.({ widgetId, status: "empty" });
+      return;
+    }
+
     if (dataValidation && !dataValidation.isValid && !hasActiveRuntimeControl) {
       onRenderStatus?.({
         widgetId,
@@ -1174,6 +1193,7 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
   }, [
     dataValidation,
     hasActiveRuntimeControl,
+    isEmptyComponentSwitch,
     isInitialNonTableLoading,
     isWaitingForInitialData,
     isWaitingForSwitchOptions,
@@ -1236,6 +1256,15 @@ const WidgetWrapper: React.FC<WidgetWrapperProps> = ({
       <>
         {runtimeHeaderControl}
         {renderError(t("dashboard.dataSourceNotFound"))}
+      </>
+    );
+  }
+
+  if (isEmptyComponentSwitch) {
+    return (
+      <>
+        {runtimeHeaderControl}
+        <WidgetState kind="empty" description={t("dashboard.noData")} />
       </>
     );
   }

--- a/web/src/app/ops-analysis/components/widgets/room3D/__tests__/room3DScene.performance.test.ts
+++ b/web/src/app/ops-analysis/components/widgets/room3D/__tests__/room3DScene.performance.test.ts
@@ -410,6 +410,28 @@ describe("room3D scene rendering", () => {
       "powerPreference",
       "high-performance",
     );
+    expect(testState.rendererOptions).toMatchObject({
+      preserveDrawingBuffer: true,
+    });
+    controller.dispose();
+  });
+
+  it("redraws the preserved buffer when print preparation starts", () => {
+    const controller = createController();
+    for (let frame = 0; frame < 120; frame += 1) {
+      if (!runNextFrame(frame * (1000 / 60))) {
+        break;
+      }
+    }
+    const idleRenders = testState.render.mock.calls.length;
+
+    window.dispatchEvent(
+      new CustomEvent("bk-dashboard-prepare-print", {
+        detail: { phase: "prepare-print" },
+      }),
+    );
+
+    expect(testState.render.mock.calls.length).toBe(idleRenders + 1);
     controller.dispose();
   });
 

--- a/web/src/app/ops-analysis/components/widgets/room3D/room3D.module.scss
+++ b/web/src/app/ops-analysis/components/widgets/room3D/room3D.module.scss
@@ -32,7 +32,8 @@
   height: 100%;
 }
 
-.canvas canvas {
+.canvas canvas,
+.canvas img {
   display: block;
   width: 100%;
   height: 100%;

--- a/web/src/app/ops-analysis/components/widgets/room3D/room3DScene.ts
+++ b/web/src/app/ops-analysis/components/widgets/room3D/room3DScene.ts
@@ -382,6 +382,7 @@ export const createRoom3DScene = (
   const renderer = new THREE.WebGLRenderer({
     antialias: true,
     alpha: true,
+    preserveDrawingBuffer: true,
   });
   renderer.setClearColor(0x000000, 0);
   renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -838,6 +839,14 @@ export const createRoom3DScene = (
   renderer.domElement.addEventListener("pointerleave", handlePointerLeave);
   renderer.domElement.addEventListener("click", handleClick);
 
+  const handlePreparePrint = () => {
+    if (disposed) {
+      return;
+    }
+    renderer.render(scene, camera);
+  };
+  window.addEventListener("bk-dashboard-prepare-print", handlePreparePrint);
+
   const resizeObserver = new ResizeObserver(resize);
   resizeObserver.observe(mountNode);
   window.addEventListener("resize", handleWindowResize);
@@ -856,6 +865,7 @@ export const createRoom3DScene = (
       intersectionObserver?.disconnect();
       resizeObserver.disconnect();
       window.removeEventListener("resize", handleWindowResize);
+      window.removeEventListener("bk-dashboard-prepare-print", handlePreparePrint);
       pixelRatioMediaQuery?.removeEventListener(
         "change",
         handlePixelRatioChange,

--- a/web/src/app/ops-analysis/hooks/useParamInputOptions.ts
+++ b/web/src/app/ops-analysis/hooks/useParamInputOptions.ts
@@ -52,6 +52,10 @@ export const useParamInputOptions = (
   configRef.current = inputConfig;
   const enabled = runtime.enabled ?? true;
   const inputKey = getParamInputConfigKey(inputConfig);
+  const knownSourcesKey = (loaderOptions?.knownDataSources ?? [])
+    .map((item) => `${item.id}:${item.rest_api ?? ''}`)
+    .sort()
+    .join(',');
   const getSynchronousState = (): ParamInputOptionsState => {
     if (!inputConfig || inputConfig.control === 'input') return { status: 'idle', options: [] };
     if (inputConfig.optionsSource.type === 'static') {
@@ -64,6 +68,7 @@ export const useParamInputOptions = (
     key: inputKey,
     state: getSynchronousState(),
   }));
+  const knownSourcesKeyRef = useRef(knownSourcesKey);
 
   useEffect(() => {
     if (!enabled) {
@@ -71,6 +76,10 @@ export const useParamInputOptions = (
         loaderRef.current!.reset();
       }
       return undefined;
+    }
+    if (knownSourcesKeyRef.current !== knownSourcesKey) {
+      knownSourcesKeyRef.current = knownSourcesKey;
+      loaderRef.current!.reset();
     }
     let active = true;
     const load = loaderRef.current!.load(configRef.current);
@@ -83,7 +92,7 @@ export const useParamInputOptions = (
     return () => {
       active = false;
     };
-  }, [enabled, inputKey]);
+  }, [enabled, inputKey, knownSourcesKey]);
 
   const state = resolved.key === inputKey ? resolved.state : getSynchronousState();
   return {

--- a/web/src/app/ops-analysis/render/__tests__/reportExecutionRenderPage.test.tsx
+++ b/web/src/app/ops-analysis/render/__tests__/reportExecutionRenderPage.test.tsx
@@ -87,6 +87,7 @@ describe('ReportExecutionRenderPageContent', () => {
     expect(props.renderFilterValues).toEqual({
       billing_period: '2026-07',
     });
+    expect(props.renderDataSourceIds).toEqual([3]);
     expect(props.selectedReport).toEqual({
       id: '9',
       data_id: '9',

--- a/web/src/app/ops-analysis/render/__tests__/screenExecutionRenderPage.test.tsx
+++ b/web/src/app/ops-analysis/render/__tests__/screenExecutionRenderPage.test.tsx
@@ -51,6 +51,10 @@ const baseRenderInput = {
       viewport: { width: 800, height: 600 },
       items: [{ id: 'w1', chartType: 'line', x: 0, y: 0, w: 100, h: 100 }],
     },
+    widget_manifest: [
+      { widget_id: 'w1', widget_type: 'line', datasource_id: 9 },
+      { widget_id: 'w1', widget_type: 'line', datasource_id: 42 },
+    ],
   },
 };
 
@@ -85,6 +89,9 @@ describe('ScreenExecutionRenderPageContent ready contract', () => {
       expect(loadCanvasDataSources).toHaveBeenCalled();
       expect(widgetStatusHandlers.length).toBeGreaterThan(0);
     });
+    expect(loadCanvasDataSources.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining([9, 42]),
+    );
     expect(signals).toEqual([]);
 
     window.removeEventListener(DASHBOARD_RENDER_EVENT, onSignal);
@@ -112,6 +119,9 @@ describe('ScreenExecutionRenderPageContent ready contract', () => {
     await waitFor(() => {
       expect(signals.some((item) => item.type === 'report-ready')).toBe(true);
     });
+    expect(
+      document.querySelector('[data-dashboard-render-root="true"]'),
+    ).not.toBeNull();
 
     window.removeEventListener(DASHBOARD_RENDER_EVENT, onSignal);
   });

--- a/web/src/app/ops-analysis/render/execution/[executionId]/dashboardExecutionRenderPage.tsx
+++ b/web/src/app/ops-analysis/render/execution/[executionId]/dashboardExecutionRenderPage.tsx
@@ -8,6 +8,7 @@ import { useDashboardSubscriptionApi } from '@/app/ops-analysis/api/dashboardSub
 import { emitDashboardRenderSignal } from '@/app/ops-analysis/renderContract';
 import type { DashboardExecutionRenderInput } from '@/app/ops-analysis/types/dashboardSubscription';
 import type { FilterValue } from '@/app/ops-analysis/types/dashBoard';
+import { collectWidgetManifestDataSourceIds } from '@/app/ops-analysis/utils/canvasResources';
 
 interface DashboardExecutionRenderPageContentProps {
   executionId: number;
@@ -79,6 +80,9 @@ export const DashboardExecutionRenderPageContent = ({
       renderFilterValues={
         renderInput.input_snapshot.filter_values as Record<string, FilterValue>
       }
+      renderDataSourceIds={collectWidgetManifestDataSourceIds(
+        renderInput.render_snapshot.widget_manifest,
+      )}
       getDashboardDetailOverride={getDashboardDetailOverride}
     />
   );

--- a/web/src/app/ops-analysis/render/execution/[executionId]/reportExecutionRenderPage.tsx
+++ b/web/src/app/ops-analysis/render/execution/[executionId]/reportExecutionRenderPage.tsx
@@ -9,6 +9,7 @@ import { emitDashboardRenderSignal } from '@/app/ops-analysis/renderContract';
 import type { DashboardExecutionRenderInput } from '@/app/ops-analysis/types/dashboardSubscription';
 import type { FilterValue } from '@/app/ops-analysis/types/dashBoard';
 import type { ReportDetail } from '@/app/ops-analysis/types/report';
+import { collectWidgetManifestDataSourceIds } from '@/app/ops-analysis/utils/canvasResources';
 
 interface ReportExecutionRenderPageContentProps {
   executionId: number;
@@ -88,6 +89,9 @@ export const ReportExecutionRenderPageContent = ({
       renderFilterValues={
         renderInput.input_snapshot.filter_values as Record<string, FilterValue>
       }
+      renderDataSourceIds={collectWidgetManifestDataSourceIds(
+        renderInput.render_snapshot.widget_manifest,
+      )}
       getReportDetailOverride={getReportDetailOverride}
     />
   );

--- a/web/src/app/ops-analysis/render/execution/[executionId]/screenExecutionRenderPage.tsx
+++ b/web/src/app/ops-analysis/render/execution/[executionId]/screenExecutionRenderPage.tsx
@@ -14,7 +14,8 @@ import {
 } from '@/app/ops-analysis/renderContract';
 import type { DashboardExecutionRenderInput } from '@/app/ops-analysis/types/dashboardSubscription';
 import type { FilterValue } from '@/app/ops-analysis/types/dashBoard';
-import { collectScreenDataSourceIds } from '@/app/ops-analysis/utils/canvasResources';
+import { collectScreenDataSourceIds, collectWidgetManifestDataSourceIds } from '@/app/ops-analysis/utils/canvasResources';
+import { prepareScreenPrintLayout } from '@/app/ops-analysis/utils/prepareDashboardPrintLayout';
 
 interface ScreenExecutionRenderPageContentProps {
   executionId: number;
@@ -108,7 +109,25 @@ export const ScreenExecutionRenderPageContent = ({
     );
     if (!signal) return;
     emittedRef.current = true;
-    emitDashboardRenderSignal(signal);
+    void (async () => {
+      if (signal.type === 'report-ready') {
+        try {
+          await prepareScreenPrintLayout();
+        } catch (error) {
+          emitDashboardRenderSignal({
+            type: 'report-failed',
+            dashboardId: String(executionId),
+            widgets: signal.widgets,
+            error:
+              error instanceof Error
+                ? error.message
+                : 'Screen print preparation failed',
+          });
+          return;
+        }
+      }
+      emitDashboardRenderSignal(signal);
+    })();
   }, [dataSourcesReady, executionId, widgetIds]);
 
   const handleWidgetRenderStatus = useCallback(
@@ -121,12 +140,18 @@ export const ScreenExecutionRenderPageContent = ({
   );
 
   useEffect(() => {
-    if (!viewSets) return;
+    if (!viewSets || !renderInput) return;
     let cancelled = false;
     setDataSourcesReady(false);
     renderResultsRef.current = new Map();
     emittedRef.current = false;
-    void loadCanvasDataSources(collectScreenDataSourceIds(viewSets))
+    const dataSourceIds = Array.from(new Set([
+      ...collectScreenDataSourceIds(viewSets),
+      ...collectWidgetManifestDataSourceIds(
+        renderInput.render_snapshot.widget_manifest,
+      ),
+    ]));
+    void loadCanvasDataSources(dataSourceIds)
       .then(() => {
         if (cancelled) return;
         setDataSourcesReady(true);
@@ -145,7 +170,7 @@ export const ScreenExecutionRenderPageContent = ({
     return () => {
       cancelled = true;
     };
-  }, [executionId, loadCanvasDataSources, viewSets]);
+  }, [executionId, loadCanvasDataSources, renderInput, viewSets]);
 
   useEffect(() => {
     if (!dataSourcesReady) return;
@@ -175,6 +200,7 @@ export const ScreenExecutionRenderPageContent = ({
   return (
     <div
       className="overflow-hidden bg-slate-950"
+      data-dashboard-render-root="true"
       style={{ width, height }}
     >
       <ScreenCanvas

--- a/web/src/app/ops-analysis/types/report.ts
+++ b/web/src/app/ops-analysis/types/report.ts
@@ -17,6 +17,7 @@ export interface ReportProps {
   shareMode?: boolean;
   renderMode?: boolean;
   renderFilterValues?: Record<string, FilterValue>;
+  renderDataSourceIds?: number[];
   getReportDetailOverride?: (id: string | number) => Promise<ReportDetail>;
 }
 

--- a/web/src/app/ops-analysis/utils/__tests__/paramInputOptionsLoader.test.ts
+++ b/web/src/app/ops-analysis/utils/__tests__/paramInputOptionsLoader.test.ts
@@ -91,4 +91,40 @@ describe('paramInputOptionsLoader runtime errors', () => {
     const second = loader.load(dynamicConfig);
     assert.notEqual(second, first);
   });
+
+  it('resolves sourceRef from knownDataSources without listing the catalog', async () => {
+    const getDataSourceList = vi.fn(async () => {
+      throw new Error('catalog must not be called');
+    });
+    const getSourceDataByApiId = vi.fn<GetSourceDataByApiId>(
+      async () => asSourceData([{ inst_uuid: 'room-1', inst_name: '机房A' }]),
+    );
+    const loader = createParamInputOptionsLoader(
+      {
+        getDataSourceList,
+        getSourceDataByApiId,
+      },
+      () => ({
+        knownDataSources: [{ id: 42, rest_api: 'cmdb/get_room_list' }],
+      }),
+    );
+
+    assert.deepEqual(
+      await loader.load({
+        control: 'select',
+        optionsSource: {
+          type: 'dynamic',
+          sourceRef: { type: 'rest_api', value: 'cmdb/get_room_list' },
+          valueField: 'inst_uuid',
+          labelField: 'inst_name',
+        },
+      }).promise,
+      {
+        status: 'success',
+        options: [{ value: 'room-1', label: '机房A' }],
+      },
+    );
+    assert.equal(getDataSourceList.mock.calls.length, 0);
+    assert.equal(getSourceDataByApiId.mock.calls[0]?.[0], 42);
+  });
 });

--- a/web/src/app/ops-analysis/utils/__tests__/prepareDashboardPrintLayout.test.tsx
+++ b/web/src/app/ops-analysis/utils/__tests__/prepareDashboardPrintLayout.test.tsx
@@ -4,6 +4,7 @@ import {
   DASHBOARD_PREPARE_PRINT_EVENT,
   prepareDashboardPrintLayout,
   prepareReportPrintLayout,
+  prepareScreenPrintLayout,
 } from '@/app/ops-analysis/utils/prepareDashboardPrintLayout';
 
 describe('prepareDashboardPrintLayout', () => {
@@ -142,5 +143,121 @@ describe('prepareDashboardPrintLayout', () => {
     const tableBody = document.querySelector<HTMLElement>('.ant-table-body');
     expect(tableBody?.style.maxHeight).toBe('240px');
     expect(tableBody?.style.overflow).toBe('auto');
+  });
+
+  it('freezes WebGL canvases into images before Chromium print', async () => {
+    const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.toDataURL = () =>
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    HTMLCanvasElement.prototype.getContext = function (type: string, ...rest: unknown[]) {
+      if (type === 'webgl' || type === 'webgl2') {
+        return {} as RenderingContext;
+      }
+      return originalGetContext.call(this, type, ...rest as []);
+    };
+
+    try {
+      document.body.innerHTML = `
+        <div data-dashboard-render-root="true" style="width: 400px; height: 300px;">
+          <div class="canvas">
+            <canvas width="80" height="60" style="width: 80px; height: 60px;"></canvas>
+          </div>
+        </div>
+      `;
+      const canvas = document.querySelector('canvas');
+      if (canvas) {
+        canvas.width = 80;
+        canvas.height = 60;
+      }
+
+      const root = document.querySelector<HTMLElement>(
+        '[data-dashboard-render-root="true"]',
+      );
+      await prepareScreenPrintLayout(root);
+
+      expect(root?.querySelector('canvas')).toBeNull();
+      const image = root?.querySelector<HTMLImageElement>(
+        'img[data-print-snapshot="true"]',
+      );
+      expect(image?.src).toMatch(/^data:image\/png/);
+      expect(image?.style.width).toBe('80px');
+      expect(image?.style.height).toBe('60px');
+    } finally {
+      HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    }
+  });
+
+  it('leaves 2D canvases in the DOM during print snapshot', async () => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.getContext = function (type: string, ...rest: unknown[]) {
+      if (type === '2d') {
+        return {} as RenderingContext;
+      }
+      return originalGetContext.call(this, type, ...rest as []);
+    };
+
+    try {
+      document.body.innerHTML = `
+        <div data-dashboard-render-root="true">
+          <canvas width="40" height="20"></canvas>
+        </div>
+      `;
+      const canvas = document.querySelector('canvas');
+      if (canvas) {
+        canvas.width = 40;
+        canvas.height = 20;
+      }
+
+      const root = document.querySelector<HTMLElement>(
+        '[data-dashboard-render-root="true"]',
+      );
+      await prepareScreenPrintLayout(root);
+
+      expect(root?.querySelector('canvas')).not.toBeNull();
+      expect(root?.querySelector('img[data-print-snapshot="true"]')).toBeNull();
+    } finally {
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    }
+  });
+
+  it('prepareDashboardPrintLayout snapshots WebGL canvases then still expands overflow', async () => {
+    const originalToDataURL = HTMLCanvasElement.prototype.toDataURL;
+    const originalGetContext = HTMLCanvasElement.prototype.getContext;
+    HTMLCanvasElement.prototype.toDataURL = () =>
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+    HTMLCanvasElement.prototype.getContext = function (type: string, ...rest: unknown[]) {
+      if (type === 'webgl' || type === 'webgl2') {
+        return {} as RenderingContext;
+      }
+      return originalGetContext.call(this, type, ...rest as []);
+    };
+
+    try {
+      document.body.innerHTML = `
+        <div data-dashboard-render-root="true" style="height: 100vh; overflow: auto;">
+          <canvas width="40" height="20"></canvas>
+        </div>
+      `;
+      const canvas = document.querySelector('canvas');
+      if (canvas) {
+        canvas.width = 40;
+        canvas.height = 20;
+      }
+
+      const root = document.querySelector<HTMLElement>(
+        '[data-dashboard-render-root="true"]',
+      );
+      await prepareDashboardPrintLayout(root);
+
+      expect(root?.querySelector('canvas')).toBeNull();
+      expect(root?.querySelector('img[data-print-snapshot="true"]')).toBeTruthy();
+      expect(root?.style.overflow).toBe('visible');
+      expect(root?.style.height).toBe('auto');
+    } finally {
+      HTMLCanvasElement.prototype.toDataURL = originalToDataURL;
+      HTMLCanvasElement.prototype.getContext = originalGetContext;
+    }
   });
 });

--- a/web/src/app/ops-analysis/utils/__tests__/topologyMapWidgetContract.test.ts
+++ b/web/src/app/ops-analysis/utils/__tests__/topologyMapWidgetContract.test.ts
@@ -43,6 +43,94 @@ test('empty topology resolves to empty terminal success and report-ready', () =>
   assert.equal(signal?.type, 'report-ready');
 });
 
+test('all-zero pie slices and null KPI fields are not renderable data', () => {
+  assert.equal(
+    hasRenderableChartData('pie', [
+      { name: '计算', value: 0 },
+      { name: '存储', value: 0 },
+    ]),
+    false,
+  );
+  assert.equal(
+    hasRenderableChartData('pie', [{ name: '计算', value: 12.5 }]),
+    true,
+  );
+  assert.equal(
+    hasRenderableChartData(
+      'single',
+      {
+        total_cost: '0.00',
+        instance_count: 0,
+        avg_daily_cost: '0.00',
+        mom_change_pct: null,
+      },
+      { selectedFields: ['mom_change_pct'] },
+    ),
+    false,
+  );
+  assert.equal(
+    hasRenderableChartData(
+      'single',
+      {
+        total_cost: '0.00',
+        instance_count: 0,
+        avg_daily_cost: '0.00',
+        mom_change_pct: null,
+      },
+      { selectedFields: ['total_cost'] },
+    ),
+    true,
+  );
+});
+
+test('line/bar empty envelopes are not renderable; categories still are', () => {
+  assert.equal(
+    hasRenderableChartData('line', { categories: [], values: [] }),
+    false,
+  );
+  assert.equal(hasRenderableChartData('bar', { series: [] }), false);
+  assert.equal(
+    hasRenderableChartData('line', [{ name: '周一', value: 0 }]),
+    true,
+  );
+});
+
+test('table envelopes without rows are not renderable; item rows still are', () => {
+  assert.equal(hasRenderableChartData('table', { count: 0 }), false);
+  assert.equal(
+    hasRenderableChartData('table', { items: [{ name: '账单' }] }),
+    true,
+  );
+});
+
+test('gauge follows numeric onReady, not any extracted string', () => {
+  assert.equal(
+    hasRenderableChartData('gauge', { value: '' }, { selectedFields: ['value'] }),
+    false,
+  );
+  assert.equal(
+    hasRenderableChartData('gauge', { value: 0 }, { selectedFields: ['value'] }),
+    true,
+  );
+});
+
+test('empty room3D racks are not renderable; racks keep async wait', () => {
+  assert.equal(
+    hasRenderableChartData('room3D', {
+      room: { id: 'r1', name: '机房' },
+      racks: [],
+    }),
+    false,
+  );
+  assert.equal(
+    hasRenderableChartData('room3D', {
+      room: { id: 'r1', name: '机房' },
+      racks: [{ rack_id: 'a', rack_name: 'A', row: 1, col: 1 }],
+    }),
+    true,
+  );
+});
+
 test('invalid topology is rejected before renderer and can terminate as failed', () => {
   const result = validateTopologyMapWidgetData(
     { nodes: [], edges: [{ source: 'a', target: 'b' }] },

--- a/web/src/app/ops-analysis/utils/canvasResources.ts
+++ b/web/src/app/ops-analysis/utils/canvasResources.ts
@@ -73,3 +73,17 @@ export const collectScreenNamespaceIds = (
   });
   return namespaceIds;
 };
+
+export const collectWidgetManifestDataSourceIds = (
+  manifest?: Array<{ datasource_id?: number | string | null }> | null,
+) => {
+  const ids = new Set<number>();
+  (manifest || []).forEach((item) => {
+    const rawId = item?.datasource_id;
+    const normalizedId = typeof rawId === 'string' ? parseInt(rawId, 10) : rawId;
+    if (Number.isFinite(normalizedId)) {
+      ids.add(normalizedId as number);
+    }
+  });
+  return Array.from(ids);
+};

--- a/web/src/app/ops-analysis/utils/paramInputOptionsLoader.ts
+++ b/web/src/app/ops-analysis/utils/paramInputOptionsLoader.ts
@@ -23,6 +23,7 @@ export interface ParamInputOptionsLoad {
 export interface ParamInputOptionsLoaderOptions {
   suppressErrorNotification?: boolean;
   fallbackErrorMessage?: string;
+  knownDataSources?: Array<{ id: number; rest_api?: string }>;
 }
 
 interface OptionsApi {
@@ -113,14 +114,22 @@ export const createParamInputOptionsLoader = (
           : undefined;
       const fallbackErrorMessage = loaderOptions?.fallbackErrorMessage ?? '';
       try {
-        const response = source.sourceRef
-          ? await api.getDataSourceList({ page_size: -1 })
-          : [];
-        const sourceItems = Array.isArray(response)
-          ? response
-          : extractDataSourceItems(response);
-        if (requestGeneration !== generation) return null;
-        const sourceId = resolveDynamicSourceId(source, sourceItems as Array<{ id: number; rest_api?: string }>);
+        const knownItems = loaderOptions?.knownDataSources ?? [];
+        let sourceId = resolveDynamicSourceId(
+          source,
+          knownItems,
+        );
+        if (!sourceId && source.sourceRef) {
+          const response = await api.getDataSourceList({ page_size: -1 });
+          const sourceItems = Array.isArray(response)
+            ? response
+            : extractDataSourceItems(response);
+          if (requestGeneration !== generation) return null;
+          sourceId = resolveDynamicSourceId(
+            source,
+            sourceItems as Array<{ id: number; rest_api?: string }>,
+          );
+        }
         if (!sourceId) return requestGeneration === generation ? { status: 'error', options: [] } : null;
         const { data } = await api.getSourceDataByApiId(sourceId, {}, requestOptions);
         const options = mapDynamicItems(

--- a/web/src/app/ops-analysis/utils/prepareDashboardPrintLayout.ts
+++ b/web/src/app/ops-analysis/utils/prepareDashboardPrintLayout.ts
@@ -7,6 +7,72 @@ const waitForNextPaint = () =>
 
 export const DASHBOARD_PREPARE_PRINT_EVENT = 'bk-dashboard-prepare-print';
 
+const waitForImageDecode = (image: HTMLImageElement) => {
+  if (typeof image.decode !== 'function') {
+    return Promise.resolve();
+  }
+  return image.decode().catch(() => undefined);
+};
+
+const isWebGLCanvas = (canvas: HTMLCanvasElement): boolean => {
+  try {
+    return Boolean(canvas.getContext('webgl') || canvas.getContext('webgl2'));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Chromium page.pdf() 不会把 WebGL 画进印刷层。打印前只把 WebGL canvas 冻成 img。
+ */
+export const snapshotCanvasesForPrint = async (
+  root: HTMLElement,
+): Promise<void> => {
+  const canvases = Array.from(root.querySelectorAll('canvas'));
+  const images: HTMLImageElement[] = [];
+
+  canvases.forEach((canvas) => {
+    if (canvas.dataset.printSnapshot === 'replaced') {
+      return;
+    }
+    if (canvas.width === 0 || canvas.height === 0) {
+      return;
+    }
+    if (!isWebGLCanvas(canvas)) {
+      return;
+    }
+
+    let dataUrl = '';
+    try {
+      dataUrl = canvas.toDataURL('image/png');
+    } catch {
+      return;
+    }
+    if (!dataUrl.startsWith('data:image/')) {
+      return;
+    }
+
+    const image = document.createElement('img');
+    image.alt = canvas.getAttribute('aria-label') || '';
+    image.src = dataUrl;
+    image.width = canvas.width;
+    image.height = canvas.height;
+    image.style.cssText = canvas.style.cssText;
+    if (!image.style.width) {
+      image.style.width = `${canvas.clientWidth || canvas.width}px`;
+    }
+    if (!image.style.height) {
+      image.style.height = `${canvas.clientHeight || canvas.height}px`;
+    }
+    image.dataset.printSnapshot = 'true';
+    canvas.dataset.printSnapshot = 'replaced';
+    canvas.replaceWith(image);
+    images.push(image);
+  });
+
+  await Promise.all(images.map(waitForImageDecode));
+};
+
 const applyExpandStyles = (element: HTMLElement) => {
   element.style.overflow = 'visible';
   element.style.height = 'auto';
@@ -35,6 +101,8 @@ async function preparePrintLayoutExpand(
       detail: { phase: 'prepare-print' },
     }),
   );
+  await waitForNextPaint();
+  await snapshotCanvasesForPrint(root);
 
   applyExpandStyles(root);
 
@@ -96,6 +164,27 @@ export async function prepareDashboardPrintLayout(
   }
 
   await preparePrintLayoutExpand(resolvedRoot, { expandGridStack: true });
+}
+
+/** Screen renderMode：保持视口尺寸，只把 WebGL canvas 冻成可印刷图片。 */
+export async function prepareScreenPrintLayout(
+  root: HTMLElement | null = typeof document === 'undefined'
+    ? null
+    : document.querySelector<HTMLElement>('[data-dashboard-render-root="true"]'),
+): Promise<void> {
+  const resolvedRoot = resolveDashboardRenderRoot(root);
+  if (!resolvedRoot) {
+    throw new Error('Screen render root not found');
+  }
+
+  window.dispatchEvent(
+    new CustomEvent(DASHBOARD_PREPARE_PRINT_EVENT, {
+      detail: { phase: 'prepare-print' },
+    }),
+  );
+  await waitForNextPaint();
+  await snapshotCanvasesForPrint(resolvedRoot);
+  await waitForNextPaint();
 }
 
 /** Report renderMode：只展开 overflow，不查询 GridStack。 */

--- a/web/src/app/ops-analysis/utils/topologyMapWidgetContract.ts
+++ b/web/src/app/ops-analysis/utils/topologyMapWidgetContract.ts
@@ -1,4 +1,11 @@
+import { validateRoom3DData } from '@/app/ops-analysis/components/widgets/room3D/room3DData';
 import { hasRenderableWidgetData } from '@/app/ops-analysis/renderContract';
+import { ChartDataTransformer } from '@/app/ops-analysis/utils/chartDataTransform';
+import {
+  extractComparableValue,
+  toComparableNumber,
+} from '@/app/ops-analysis/utils/compareQuery';
+import { parseTableLikeData } from '@/app/ops-analysis/utils/tableLikeData';
 import {
   isEmptyTopologyMapPayload,
   parseTopologyMapPayload,
@@ -13,11 +20,50 @@ export const validateTopologyMapWidgetData = (
   return { isValid: false, message: errorMessage };
 };
 
+/**
+ * Whether this payload will eventually call onReady(true).
+ * handleRendererReady keeps status at loading when the renderer reports empty
+ * but this is true — that wait is only valid for async layout (topologyMap /
+ * room3D with racks). Sync empty UIs must return false here or reports hang.
+ */
 export const hasRenderableChartData = (
   chartType: string | undefined,
   data: unknown,
+  config?: { selectedFields?: string[] },
 ) => {
-  if (chartType !== 'topologyMap') return hasRenderableWidgetData(data);
-  const parsed = parseTopologyMapPayload(data);
-  return parsed.ok && !isEmptyTopologyMapPayload(parsed.data);
+  if (chartType === 'topologyMap') {
+    const parsed = parseTopologyMapPayload(data);
+    return parsed.ok && !isEmptyTopologyMapPayload(parsed.data);
+  }
+  if (chartType === 'pie') {
+    return ChartDataTransformer.transformToPieData(data).some(
+      (item) => Number.isFinite(item.value) && item.value > 0,
+    );
+  }
+  if (chartType === 'single') {
+    return extractComparableValue(data, config?.selectedFields?.[0]) !== null;
+  }
+  if (chartType === 'gauge') {
+    return (
+      toComparableNumber(
+        extractComparableValue(data, config?.selectedFields?.[0]),
+      ) !== null
+    );
+  }
+  if (chartType === 'line' || chartType === 'bar') {
+    return (
+      ChartDataTransformer.transformToLineBarData(data).categories.length > 0
+    );
+  }
+  if (chartType === 'table' || chartType === 'eventTable') {
+    return parseTableLikeData(data, { current: 1, pageSize: 20 }).rows.length > 0;
+  }
+  if (chartType === 'room3D') {
+    const parsed = validateRoom3DData(data);
+    return (
+      parsed.ok &&
+      (parsed.data.racks.length > 0 || Boolean(parsed.data.notice))
+    );
+  }
+  return hasRenderableWidgetData(data);
 };


### PR DESCRIPTION
Render Session 只放行能点名的组件切换选项源，目录 GET 继续强制 ids；打印只把 WebGL canvas 冻成图片。图表空态按组件类型判断，避免查询成功被当成取数失败。