### PR TITLE
bugfix: Fixed the issue of timed timeout inspection incorrectly marki…

### DIFF
--- a/server/apps/patch_mgmt/tasks.py
+++ b/server/apps/patch_mgmt/tasks.py
@@ -635,10 +635,11 @@ def watch_governance_timeouts() -> None:
     for task in GovernanceTask.objects.filter(pk__in=changed_task_ids):
         _finalize_task_status(task)
 
-    # 独立收敛父任务与子任务的终态不一致；没有子结果的刚启动任务不在此误收口。
+    # 只收敛已被父 worker 领取的任务；PENDING -> RUNNING 只能由父任务入口完成，
+    # 否则巡检会让仍在 Celery 队列中的父任务误以为已启动并跳过子任务派发。
     inconsistent_tasks = (
         GovernanceTask.objects.filter(
-            status__in=GovernanceTaskStatus.ACTIVE_STATES,
+            status=GovernanceTaskStatus.RUNNING,
             host_results__isnull=False,
         )
         .distinct()

--- a/server/apps/patch_mgmt/tests/test_governance_timeout.py
+++ b/server/apps/patch_mgmt/tests/test_governance_timeout.py
@@ -126,6 +126,37 @@ def test_watchdog_finalizes_active_parent_when_all_children_are_terminal():
 
 
 @pytest.mark.django_db
+def test_watchdog_does_not_preempt_pending_parent_before_it_dispatches(monkeypatch):
+    target = PatchTarget.objects.create(name="queued-host", ip="10.0.0.10", os_type=OSType.WINDOWS)
+    task = GovernanceTask.objects.create(
+        name="queued-parent",
+        task_type=GovernanceTaskType.ASSESS,
+        status=GovernanceTaskStatus.PENDING,
+        target_list=[target.id],
+    )
+    GovernanceTaskHost.objects.create(
+        task=task,
+        target_id=target.id,
+        target_name=target.name,
+        target_ip=target.ip,
+        stage="waiting",
+    )
+    dispatched = []
+    monkeypatch.setattr(
+        patch_tasks.execute_governance_host,
+        "apply_async",
+        lambda **kwargs: dispatched.append(kwargs),
+    )
+
+    patch_tasks.watch_governance_timeouts()
+    patch_tasks.execute_governance_task(task.id)
+
+    task.refresh_from_db()
+    assert task.status == GovernanceTaskStatus.RUNNING
+    assert [call["args"] for call in dispatched] == [[task.id, target.id]]
+
+
+@pytest.mark.django_db
 def test_late_worker_cannot_overwrite_watchdog_terminal_state():
     task = GovernanceTask.objects.create(
         name="late-worker",


### PR DESCRIPTION
…ng pending tasks still in the Celery queue as running in advance, which resulted in skipping host dispatch after the task was actually collected and subsequently misjudging timeout.