### PR TITLE
bugfix(k8s-collector): 集群级 RBAC 加 bk-lite- 前缀，避免覆盖集群自带监控栈

### DIFF
--- a/agents/webhookd/bk-lite-log-collector.yaml
+++ b/agents/webhookd/bk-lite-log-collector.yaml
@@ -84,7 +84,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -96,11 +96,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 subjects:
   - kind: ServiceAccount
     name: vector-daemonset

--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -98,8 +98,7 @@ automountServiceAccountToken: false
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -228,8 +227,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -237,7 +235,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: bk-lite-kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
@@ -500,8 +498,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vmagent-role
-  namespace: bk-lite-collector
+  name: bk-lite-vmagent
 rules:
 - apiGroups: [""]
   resources:
@@ -517,12 +514,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vmagent-role-binding
-  namespace: bk-lite-collector
+  name: bk-lite-vmagent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vmagent-role
+  name: bk-lite-vmagent
 subjects:
 - kind: ServiceAccount
   name: vmagent

--- a/agents/webhookd/bk-lite-resource-collector.yaml
+++ b/agents/webhookd/bk-lite-resource-collector.yaml
@@ -98,8 +98,7 @@ automountServiceAccountToken: false
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -228,8 +227,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -237,7 +235,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: bk-lite-kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics

--- a/agents/webhookd/infra/tests/test_k8s_manifest_contract.py
+++ b/agents/webhookd/infra/tests/test_k8s_manifest_contract.py
@@ -1,0 +1,127 @@
+"""K8S 采集器 manifest 的集群级资源命名契约。
+
+集群级资源（ClusterRole / ClusterRoleBinding）在整个集群内唯一，`kubectl apply`
+遇到同名对象会整份覆盖而不是合并。裸名 `kube-state-metrics` / `vmagent-role` /
+`vector-daemonset` 会与集群自带的监控栈（kube-prometheus、KubeSphere 等）撞名，
+静默夺走对方的权限。因此 BK-Lite 下发的集群级资源必须带 `bk-lite-` 前缀。
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WEBHOOKD_DIR = Path(__file__).resolve().parents[2]
+REPO_ROOT = WEBHOOKD_DIR.parents[1]
+DIST_DIR = REPO_ROOT / "deploy" / "dist" / "bk-lite-kubernetes-collector"
+
+MANIFEST_PATHS = [
+    WEBHOOKD_DIR / "bk-lite-metric-collector.yaml",
+    WEBHOOKD_DIR / "bk-lite-resource-collector.yaml",
+    WEBHOOKD_DIR / "bk-lite-log-collector.yaml",
+    DIST_DIR / "bk-lite-metric-collector.yaml",
+    DIST_DIR / "bk-lite-log-collector.yaml",
+]
+
+CLUSTER_SCOPED_KINDS = ("ClusterRole", "ClusterRoleBinding")
+CLUSTER_SCOPED_PREFIX = "bk-lite-"
+
+# 渲染前的模板占位符，独占整行，解析前剔除
+LINE_PLACEHOLDERS = (
+    "__LOG_VOLUME_MOUNTS__",
+    "__LOG_VOLUMES__",
+    "__INCLUDE_PATHS_GLOB_PATTERNS__",
+)
+
+
+def _load_documents(path):
+    text = "\n".join(line for line in path.read_text(encoding="utf-8").splitlines() if line.strip() not in LINE_PLACEHOLDERS)
+    return [document for document in yaml.safe_load_all(text) if document]
+
+
+@pytest.mark.parametrize("path", MANIFEST_PATHS, ids=lambda path: path.name)
+def test_cluster_scoped_resources_are_namespaced_by_name(path):
+    """集群级资源必须带 bk-lite- 前缀，避免与集群自带监控栈撞名。"""
+    for document in _load_documents(path):
+        if document["kind"] not in CLUSTER_SCOPED_KINDS:
+            continue
+        name = document["metadata"]["name"]
+        assert name.startswith(CLUSTER_SCOPED_PREFIX), (
+            f"{path.name}: {document['kind']} `{name}` 缺少 `{CLUSTER_SCOPED_PREFIX}` 前缀，" "会与集群内同名的集群级资源互相覆盖"
+        )
+
+
+@pytest.mark.parametrize("path", MANIFEST_PATHS, ids=lambda path: path.name)
+def test_cluster_scoped_resources_carry_no_namespace_field(path):
+    """集群级资源上的 namespace 字段会被 API Server 忽略，不得出现。"""
+    for document in _load_documents(path):
+        if document["kind"] not in CLUSTER_SCOPED_KINDS:
+            continue
+        metadata = document["metadata"]
+        assert "namespace" not in metadata, f"{path.name}: {document['kind']} `{metadata['name']}` 带了 namespace 字段，" "集群级资源没有命名空间归属"
+
+
+@pytest.mark.parametrize("path", MANIFEST_PATHS, ids=lambda path: path.name)
+def test_cluster_role_binding_role_ref_resolves_within_manifest(path):
+    """改名后 ClusterRoleBinding 的 roleRef 必须仍指向同一份 manifest 里的 ClusterRole。"""
+    documents = _load_documents(path)
+    cluster_roles = {document["metadata"]["name"] for document in documents if document["kind"] == "ClusterRole"}
+    for document in documents:
+        if document["kind"] != "ClusterRoleBinding":
+            continue
+        role_ref = document["roleRef"]
+        assert role_ref["kind"] == "ClusterRole"
+        assert role_ref["name"] in cluster_roles, (
+            f"{path.name}: ClusterRoleBinding `{document['metadata']['name']}` 的 roleRef " f"`{role_ref['name']}` 在本 manifest 中没有对应的 ClusterRole"
+        )
+
+
+@pytest.mark.parametrize("path", MANIFEST_PATHS, ids=lambda path: path.name)
+def test_cluster_role_binding_subjects_stay_in_bk_lite_namespace(path):
+    """ServiceAccount 是命名空间内资源，主体必须仍绑定 BK-Lite 自己的命名空间。"""
+    for document in _load_documents(path):
+        if document["kind"] != "ClusterRoleBinding":
+            continue
+        for subject in document["subjects"]:
+            assert subject["kind"] == "ServiceAccount"
+            assert subject["namespace"].startswith("bk-lite-"), (
+                f"{path.name}: ClusterRoleBinding `{document['metadata']['name']}` " f"绑定了非 BK-Lite 命名空间 `{subject['namespace']}`"
+            )
+
+
+def test_metric_and_resource_collector_share_identical_cluster_rbac():
+    """两份 manifest 共用同一套集群级 RBAC，先后 apply 必须幂等。"""
+
+    def cluster_rbac(path):
+        return {
+            (document["kind"], document["metadata"]["name"]): document
+            for document in _load_documents(path)
+            if document["kind"] in CLUSTER_SCOPED_KINDS
+        }
+
+    metric = cluster_rbac(WEBHOOKD_DIR / "bk-lite-metric-collector.yaml")
+    resource = cluster_rbac(WEBHOOKD_DIR / "bk-lite-resource-collector.yaml")
+
+    shared = set(metric) & set(resource)
+    assert ("ClusterRole", "bk-lite-kube-state-metrics") in shared
+    assert ("ClusterRoleBinding", "bk-lite-kube-state-metrics") in shared
+    for identity in shared:
+        assert metric[identity] == resource[identity], f"{identity} 在 metric 与 resource 采集器中定义不一致，" "后 apply 的一份会覆盖前一份"
+
+
+def test_dist_and_webhookd_metric_manifests_share_cluster_rbac():
+    """手动部署包与 webhookd 渲染模板的集群级 RBAC 必须同名同权限。"""
+
+    def cluster_rbac(path):
+        return {
+            (document["kind"], document["metadata"]["name"]): document
+            for document in _load_documents(path)
+            if document["kind"] in CLUSTER_SCOPED_KINDS
+        }
+
+    template = cluster_rbac(WEBHOOKD_DIR / "bk-lite-metric-collector.yaml")
+    dist = cluster_rbac(DIST_DIR / "bk-lite-metric-collector.yaml")
+
+    assert set(template) == set(dist)
+    for identity in template:
+        assert template[identity] == dist[identity], f"{identity} 在 webhookd 模板与 deploy/dist 部署包中不一致"

--- a/deploy/dist/bk-lite-kubernetes-collector/Readme.md
+++ b/deploy/dist/bk-lite-kubernetes-collector/Readme.md
@@ -128,11 +128,52 @@ kubectl logs -n bk-lite-collector -l app=telegraf
 - cadvisor 服务监听端口：8080
 - kube-state-metrics 服务监听端口：8080, 8081
 
-## 卸载
+## 从旧版本升级（重要）
+
+早期版本下发的集群级资源使用了通用名字（ClusterRole / ClusterRoleBinding
+`kube-state-metrics`、`vmagent-role`、`vmagent-role-binding`、`vector-daemonset`）。
+这些名字与集群自带监控栈（kube-prometheus、KubeSphere 等）的默认命名相同，
+`kubectl apply` 会整份覆盖对方而不是合并，导致对方的 kube-state-metrics 丢失
+权限、监控页面无数据。
+
+当前版本已把全部集群级资源改名为 `bk-lite-` 前缀。**改名后旧对象不会被自动
+回收**，从旧版本升级时需要手动清理，否则它们会继续占用集群自带监控栈的名字。
 
 ```bash
-# 删除所有资源
-kubectl delete -f bk-lite-collector.yaml
+# 1. 先确认这些对象确实属于 BK-Lite，再删除
+#    subjects 指向 bk-lite-collector 命名空间的才是 BK-Lite 下发的
+kubectl get clusterrolebinding kube-state-metrics -o yaml
+kubectl get clusterrolebinding vmagent-role-binding -o yaml
+kubectl get clusterrolebinding vector-daemonset -o yaml
+```
+
+```bash
+# 2. 确认无误后删除旧的集群级资源
+kubectl delete clusterrolebinding kube-state-metrics vmagent-role-binding vector-daemonset --ignore-not-found
+kubectl delete clusterrole kube-state-metrics vmagent-role vector-daemonset --ignore-not-found
+```
+
+```bash
+# 3. 应用新版本 manifest
+kubectl apply -f bk-lite-metric-collector.yaml
+kubectl apply -f bk-lite-log-collector.yaml
+```
+
+如果集群里原本就有自己的监控栈，第 2 步删除后需要重新应用该监控栈的 RBAC，
+把被覆盖掉的 ClusterRole / ClusterRoleBinding 恢复回它自己的定义。
+
+## 卸载
+
+集群级资源不属于任何命名空间，删除 namespace 不会连带回收，必须显式删除。
+
+```bash
+# 删除命名空间内的全部资源
+kubectl delete -f bk-lite-metric-collector.yaml --ignore-not-found
+kubectl delete -f bk-lite-log-collector.yaml --ignore-not-found
+
+# 删除集群级资源
+kubectl delete clusterrolebinding bk-lite-kube-state-metrics bk-lite-vmagent bk-lite-vector-daemonset --ignore-not-found
+kubectl delete clusterrole bk-lite-kube-state-metrics bk-lite-vmagent bk-lite-vector-daemonset --ignore-not-found
 
 # 删除 namespace（可选）
 kubectl delete ns bk-lite-collector

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
@@ -96,7 +96,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 rules:
   - apiGroups: [""]
     resources: ["pods", "namespaces", "nodes"]
@@ -108,11 +108,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vector-daemonset
+  name: bk-lite-vector-daemonset
 subjects:
   - kind: ServiceAccount
     name: vector-daemonset

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -313,8 +313,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -322,7 +321,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kube-state-metrics
+  name: bk-lite-kube-state-metrics
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
@@ -332,8 +331,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kube-state-metrics
-  namespace: bk-lite-collector
+  name: bk-lite-kube-state-metrics
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
@@ -482,8 +480,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: vmagent-role
-  namespace: bk-lite-collector
+  name: bk-lite-vmagent
 rules:
 - apiGroups: [""]
   resources:
@@ -499,12 +496,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: vmagent-role-binding
-  namespace: bk-lite-collector
+  name: bk-lite-vmagent
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: vmagent-role
+  name: bk-lite-vmagent
 subjects:
 - kind: ServiceAccount
   name: vmagent

--- a/server/apps/monitor/tests/test_k8s_collector_template_contract.py
+++ b/server/apps/monitor/tests/test_k8s_collector_template_contract.py
@@ -79,8 +79,7 @@ def test_webhookd_vmagent_scrapes_kube_state_metrics():
     """webhookd 下发版 vmagent 必须包含 KSM 抓取 job，否则监控 K8s 对象实例发现断供。"""
     jobs = vmagent_scrape_jobs(WEBHOOKD_METRIC)
     assert KSM_JOB_NAME in jobs, (
-        f"webhookd 版 vmagent-config 缺少 '{KSM_JOB_NAME}' 抓取 job：监控链路将没有 "
-        f"{REMOTE_WRITE_PREFIX}kube_* 指标，Pod/Node 等监控实例无法被发现"
+        f"webhookd 版 vmagent-config 缺少 '{KSM_JOB_NAME}' 抓取 job：监控链路将没有 " f"{REMOTE_WRITE_PREFIX}kube_* 指标，Pod/Node 等监控实例无法被发现"
     )
 
 
@@ -145,11 +144,18 @@ def test_vmagent_ksm_discovery_matches_ksm_pod_metadata():
 
 
 def test_ksm_stack_present_in_all_ksm_templates():
-    """三份模板都必须自带完整 KSM 资源栈：metric-only / resource-only / 双装任意组合都功能完整。"""
+    """三份模板都必须自带完整 KSM 资源栈：metric-only / resource-only / 双装任意组合都功能完整。
+
+    命名空间内资源沿用 kube-state-metrics；集群级资源（ClusterRole/ClusterRoleBinding）
+    全集群唯一，必须带 bk-lite- 前缀，否则会与集群自带监控栈同名对象互相覆盖。
+    """
     for template in KSM_TEMPLATES:
         docs = load_docs(template)
-        for kind in ("Deployment", "Service", "ServiceAccount", "ClusterRole", "ClusterRoleBinding"):
+        for kind in ("Deployment", "Service", "ServiceAccount"):
             assert find_docs(docs, kind, "kube-state-metrics"), f"{template} 缺少 kube-state-metrics {kind}"
+        for kind in ("ClusterRole", "ClusterRoleBinding"):
+            assert find_docs(docs, kind, "bk-lite-kube-state-metrics"), f"{template} 缺少 bk-lite-kube-state-metrics {kind}"
+            assert not find_docs(docs, kind, "kube-state-metrics"), f"{template} 的 {kind} 使用了会与集群自带监控栈撞名的裸名"
 
 
 def test_ksm_args_identical_across_templates():

--- a/specs/capabilities/resource-collector-template.md
+++ b/specs/capabilities/resource-collector-template.md
@@ -5,7 +5,7 @@
 
 #### Scenario: kube-state-metrics resources present
 - **WHEN** the resource collector template is rendered
-- **THEN** the output YAML contains Deployment `kube-state-metrics`, Service `kube-state-metrics`, ClusterRole `kube-state-metrics`, ClusterRoleBinding `kube-state-metrics`, ServiceAccount `kube-state-metrics` in namespace `bk-lite-collector`
+- **THEN** the output YAML contains Deployment `kube-state-metrics`, Service `kube-state-metrics`, ServiceAccount `kube-state-metrics` in namespace `bk-lite-collector`, plus cluster-scoped ClusterRole `bk-lite-kube-state-metrics` and ClusterRoleBinding `bk-lite-kube-state-metrics`
 
 ### Requirement: Resource collector template contains independent telegraf-resource data path
 `bk-lite-resource-collector.yaml` SHALL contain a Deployment `telegraf-resource` that uses `inputs.prometheus` to scrape `kube-state-metrics:8080/metrics`, and `outputs.nats` to send data to NATS (subject `metrics.cloud`).
@@ -45,7 +45,7 @@ All resource-specific components (telegraf, ConfigMap) SHALL use `-resource` suf
 
 #### Scenario: KSM present in metric template
 - **WHEN** the metric collector template is rendered
-- **THEN** the output YAML contains Deployment, Service, ClusterRole, ClusterRoleBinding, ServiceAccount named `kube-state-metrics` in namespace `bk-lite-collector`
+- **THEN** the output YAML contains Deployment, Service, ServiceAccount named `kube-state-metrics` in namespace `bk-lite-collector`, plus cluster-scoped ClusterRole and ClusterRoleBinding named `bk-lite-kube-state-metrics`
 - **THEN** the vmagent-config ConfigMap contains both the `kubernetes-cadvisor` and `kubernetes-kube-state-metrics` scrape jobs
 
 #### Scenario: metric collector deployed alone is fully functional
@@ -55,4 +55,25 @@ All resource-specific components (telegraf, ConfigMap) SHALL use `-resource` suf
 
 #### Scenario: both collectors applied to the same cluster in any order
 - **WHEN** both the metric and resource collector templates are applied to the same cluster, in any order
-- **THEN** the shared KSM (`bk-lite-collector/kube-state-metrics`) carries identical args in every template, so the last-applied copy is equivalent and both pipelines keep working
+- **THEN** the shared KSM (`bk-lite-collector/kube-state-metrics`) and its cluster-scoped RBAC (`bk-lite-kube-state-metrics`) carry identical definitions in every template, so the last-applied copy is equivalent and both pipelines keep working
+
+### Requirement: Cluster-scoped resources are namespaced by name
+Cluster-scoped objects are unique per cluster and `kubectl apply` replaces a
+same-named object wholesale instead of merging it. Every ClusterRole and
+ClusterRoleBinding shipped by `bk-lite-metric-collector.yaml`,
+`bk-lite-resource-collector.yaml`, `bk-lite-log-collector.yaml` and the
+manually-applied copies under `deploy/dist/bk-lite-kubernetes-collector/` SHALL
+be named with a `bk-lite-` prefix, and SHALL NOT carry a `metadata.namespace`
+field. Generic names such as `kube-state-metrics`, `vmagent-role` or
+`vector-daemonset` collide with the monitoring stacks clusters already run
+(kube-prometheus, KubeSphere), silently stripping their permissions.
+
+#### Scenario: BK-Lite collector applied to a cluster that already runs kube-prometheus
+- **WHEN** any K8S collector manifest is applied to a cluster whose own monitoring stack owns ClusterRole/ClusterRoleBinding `kube-state-metrics`
+- **THEN** no BK-Lite object shares a name with it, so the existing binding keeps its subjects and the existing role keeps its rules
+- **THEN** BK-Lite's own RBAC is named `bk-lite-kube-state-metrics`, `bk-lite-vmagent` and `bk-lite-vector-daemonset`
+
+#### Scenario: ClusterRoleBinding subjects stay inside BK-Lite namespaces
+- **WHEN** a BK-Lite ClusterRoleBinding is rendered
+- **THEN** its `roleRef` resolves to a ClusterRole declared in the same manifest
+- **THEN** every subject is a ServiceAccount in a `bk-lite-` prefixed namespace


### PR DESCRIPTION
## 问题

K8S 采集器下发的 ClusterRole / ClusterRoleBinding 用了通用名字：`kube-state-metrics`、`vmagent-role` / `vmagent-role-binding`、`vector-daemonset`。

集群级资源在整个集群内唯一，`kubectl apply` 遇到同名对象会**整份覆盖而不是合并**。这些名字与集群自带监控栈（kube-prometheus、KubeSphere 等）的默认命名相同，用户按 Readme 或平台生成的命令 apply 之后：

- 两边 `roleRef` 相同（都是 `ClusterRole/kube-state-metrics`）→ apply 成功，对方 ClusterRoleBinding 的 `subjects` 被整份替换，ClusterRole 的 `rules` 一并被换掉，对方 kube-state-metrics **静默丢权限**，监控页无数据；
- `roleRef` 不同 → `roleRef` 是 immutable 字段，apply 直接报错，BK-Lite 采集器起不来。

一个佐证：这些集群级资源的 `metadata` 上还写着 `namespace: bk-lite-collector` —— 该字段在集群级资源上会被 API Server 忽略，说明写 manifest 时是当成命名空间内资源看的。

K3S 采集器（`bk-lite-k3s-metric-collector.yaml`）已经做过这项隔离，有 `bk-lite-k3s-` 前缀和两处契约测试。本 PR 把同一治理回灌到 K8S 侧。

## 修复方式

**1. 集群级资源统一加 `bk-lite-` 前缀**

| 旧名（集群唯一） | 新名 | 涉及文件 |
|---|---|---|
| ClusterRole/Binding `kube-state-metrics` | `bk-lite-kube-state-metrics` | metric、resource、dist/metric |
| ClusterRole `vmagent-role` / Binding `vmagent-role-binding` | `bk-lite-vmagent` | metric、dist/metric |
| ClusterRole/Binding `vector-daemonset` | `bk-lite-vector-daemonset` | log、dist/log |

同时删掉集群级资源上无意义的 `metadata.namespace` 字段。

**命名空间内资源（ServiceAccount / Deployment / Service / ConfigMap）和全部 label 一律未改** —— 它们本就不跨命名空间冲突，改动反而会打断 Service selector 和 `kubectl logs -n bk-lite-collector -l app=vector-daemonset` 这类既有文案。这也让存量集群可以直接 apply 原地滚动更新，不必重建 Secret。

**2. 新增契约测试** `agents/webhookd/infra/tests/test_k8s_manifest_contract.py`，6 组共 22 个用例覆盖 5 份 manifest：

- 集群级资源必须带 `bk-lite-` 前缀
- 集群级资源不得带 `metadata.namespace`
- ClusterRoleBinding 的 `roleRef` 能在同一份 manifest 内解析到 ClusterRole
- subjects 仍绑定 `bk-lite-` 前缀的命名空间
- metric 与 resource 采集器共用的集群级 RBAC 定义完全一致（两者同 ns 同 SA，先后 apply 必须幂等）
- webhookd 模板与 `deploy/dist` 手动部署包的集群级 RBAC 一致

**3. 文档**

- `specs/capabilities/resource-collector-template.md`：修正三处旧名描述，新增 "Cluster-scoped resources are namespaced by name" 需求与两个场景
- `deploy/dist/bk-lite-kubernetes-collector/Readme.md`：新增「从旧版本升级」章节；修正卸载章节（原文引用的 `bk-lite-collector.yaml` 并不存在，且未说明集群级资源不随 namespace 回收）

## 升级注意事项（需要人工判断，无法自动化）

**改名不会回收旧对象。** 升级后集群里会同时存在裸名和 `bk-lite-` 名两套 RBAC，裸名那份仍占着集群自带监控栈的名字。**删除 namespace 也清不掉** —— 集群级资源不属于任何命名空间。

清理前必须先确认裸名对象此刻归谁所有：

```bash
kubectl get clusterrolebinding kube-state-metrics -o jsonpath='{.subjects}'
```

- subjects 指向 `bk-lite-collector` → 已被 BK-Lite 覆盖，可以删除；删除后还需**重新应用对方监控栈自己的 RBAC**，把被覆盖掉的定义放回去（本 PR 无法代劳，取决于对方部署方式）
- subjects 指向对方命名空间（如 `kubesphere-monitoring-system`）→ 尚未被覆盖或已被对方抢回，不要动它，直接 apply 新版 manifest 即可，此后两边各用各的名字

## 本次未处理

只做了命名隔离，**没有收敛权限**。BK-Lite 这份 ClusterRole 的 rules 覆盖面较宽（含 `secrets`、`serviceaccounts`），而 K3S 那份只要 `nodes/pods` + `apps` 三种。收窄有可能打断某些指标采集，需要先核实 vmagent 的 scrape job 实际依赖哪些资源，未做该验证故未改动，建议单独跟进。

## 验证

```bash
python3 -m pytest agents/webhookd/infra/tests/ -q
```

43 passed（含既有 k3s 契约、render、证书、sidecar 测试）。web 侧 `npx tsx scripts/k3s-monitoring-isolation-test.ts` 输出 `K3S isolation contract passed`。

做过反向验证：将 `bk-lite-kube-state-metrics` 手工改回裸名，3 个用例立即失败，还原后恢复全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
