### PR TITLE
fix(监控): 防止磁盘过滤字段写回污染 inputs.disk

### DIFF
--- a/server/apps/monitor/services/node_mgmt.py
+++ b/server/apps/monitor/services/node_mgmt.py
@@ -302,8 +302,11 @@ class InstanceConfigService:
             if config_obj.file_type == "toml":
                 raw_content = config[content_key]
                 config["content"] = ConfigFormat.toml_to_dict(raw_content)
+                from apps.monitor.utils.disk_fstype_filters import expose_disk_fstype_filters_for_edit
                 from apps.monitor.utils.snmp_ifmib_capability import is_interface_filter_capable_plugin
 
+                # 磁盘 fstype 过滤在 starlark.constants；表单只绑 content.config，需投影回显。
+                config["content"] = expose_disk_fstype_filters_for_edit(config["content"])
                 if (config_obj.collect_type or "").startswith("snmp") and is_interface_filter_capable_plugin(
                     getattr(config_obj, "monitor_plugin", None)
                 ):
@@ -1048,6 +1051,10 @@ class InstanceConfigService:
                     extract_group_metrics_timeout_from_env(env_config),
                     child_interval,
                 )
+            from apps.monitor.utils.disk_fstype_filters import sync_disk_fstype_filters_on_writeback
+
+            # 表单把 disk_*_fstypes 写在 content.config；Telegraf inputs.* 不认，必须挪回 starlark。
+            child_info["content"] = sync_disk_fstype_filters_on_writeback(child_info.get("content"))
             content = ConfigFormat.json_to_toml(child_info["content"]) if child_info else None
             if ifmib_capable and content is not None:
                 from apps.monitor.utils.snmp_interface_template import (

--- a/server/apps/monitor/utils/disk_fstype_filters.py
+++ b/server/apps/monitor/utils/disk_fstype_filters.py
@@ -1,0 +1,101 @@
+"""Host Telegraf disk 文件系统过滤字段的读写投影。
+
+BK-Lite 用自定义字段 disk_include_fstypes / disk_exclude_fstypes，经
+[[processors.starlark]] constants 过滤；Telegraf 1.29.5 的 [[inputs.disk]]
+只认 ignore_fs / mount_points / ignore_mount_opts，不认这两个字段。
+
+编辑表单绑定 child.content.config.*，json_to_toml 会把 content.config 整段
+写回 inputs.<plugin>[0]。若不投影，保存后会把非法字段塞进 inputs.disk，
+Telegraf 拒载并报 “fields were not used”。
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+DISK_FSTYPE_FILTER_KEYS = ("disk_include_fstypes", "disk_exclude_fstypes")
+
+
+def _iter_starlark_processors(document: dict[str, Any]) -> list[dict[str, Any]]:
+    processors = document.get("processors")
+    if not isinstance(processors, dict):
+        return []
+    starlark = processors.get("starlark")
+    if isinstance(starlark, list):
+        return [item for item in starlark if isinstance(item, dict)]
+    if isinstance(starlark, dict):
+        return [starlark]
+    return []
+
+
+def _namepass_includes_disk(processor: dict[str, Any]) -> bool:
+    namepass = processor.get("namepass")
+    if isinstance(namepass, list):
+        return any(str(item) == "disk" for item in namepass)
+    if isinstance(namepass, str):
+        return namepass == "disk"
+    return False
+
+
+def _disk_filter_starlark(document: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(document, dict):
+        return None
+    for processor in _iter_starlark_processors(document):
+        if not _namepass_includes_disk(processor):
+            continue
+        constants = processor.get("constants")
+        if isinstance(constants, dict):
+            return constants
+        constants = {}
+        processor["constants"] = constants
+        return constants
+    return None
+
+
+def expose_disk_fstype_filters_for_edit(content: dict | None) -> dict | None:
+    """把 starlark.constants 中的磁盘过滤投影到 content.config，供表单回显。"""
+    if not isinstance(content, dict):
+        return content
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return content
+
+    constants = _disk_filter_starlark(content.get("_toml_document"))
+    if constants is None:
+        return content
+
+    projected = deepcopy(config)
+    for key in DISK_FSTYPE_FILTER_KEYS:
+        if key in constants:
+            projected[key] = deepcopy(constants[key])
+        else:
+            projected.pop(key, None)
+    content["config"] = projected
+    return content
+
+
+def sync_disk_fstype_filters_on_writeback(content: dict | None) -> dict | None:
+    """把表单写入 content.config 的磁盘过滤挪回 starlark.constants，并清掉 input 上的非法字段。"""
+    if not isinstance(content, dict):
+        return content
+    config = content.get("config")
+    if not isinstance(config, dict):
+        return content
+
+    pending = {
+        key: deepcopy(config.pop(key))
+        for key in DISK_FSTYPE_FILTER_KEYS
+        if key in config
+    }
+    if not pending:
+        return content
+
+    constants = _disk_filter_starlark(content.get("_toml_document"))
+    if constants is None:
+        # 无 starlark 段时至少不要把非法字段写进 inputs.*，避免 Telegraf 拒载。
+        return content
+
+    for key, value in pending.items():
+        constants[key] = value
+    return content


### PR DESCRIPTION
## Summary
- 修复主机磁盘采集编辑保存后，`disk_include_fstypes` / `disk_exclude_fstypes` 被写进 `[[inputs.disk]]`，Telegraf（1.29.5）拒载并报 `fields were not used` 的问题。
- 读取时从 `[processors.starlark.constants]` 投影到表单；写回时挪回 starlark，并从 input 段剥离非法字段。
- 已损坏配置通过监控侧「编辑保存」路径可自愈。

## Test plan
- [ ] 新建主机磁盘采集，确认生成配置中过滤字段仅在 `processors.starlark.constants`
- [ ] 编辑并修改磁盘黑/白名单后保存，确认 `[[inputs.disk]]` 不再出现 `disk_*_fstypes`，Telegraf 可正常启动
- [ ] 对已损坏配置（`inputs.disk` 上已有非法字段）再保存一次，确认恢复正常
- [ ] 本地已验证 expose→sync→json_to_toml 往返（测试文件按仓库约定未纳入本 PR）

## Review notes
- 对照 `tencent-upstream/master` 做过 Standards/Spec/bug 复核：主路径无实质功能 bug。
- 提交范围已检查：仅 2 个生产文件；测试与无关工作区改动未纳入。