### PR TITLE
fix(monitor): 优化策略模版卡片内置/自定义标签布局

### DIFF
--- a/web/src/app/monitor/(pages)/event/template/index.module.scss
+++ b/web/src/app/monitor/(pages)/event/template/index.module.scss
@@ -240,6 +240,20 @@
 }
 
 .cardTitle {
+    padding-right: 28px;
+    min-width: 0;
+}
+
+.cardTitleInner {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 100%;
+    vertical-align: top;
+}
+
+.cardTitleText {
+    min-width: 0;
     color: var(--color-text-1);
     font-size: 14px;
     font-weight: 700;
@@ -247,6 +261,29 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.cardTypeBadge {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 7px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 18px;
+    white-space: nowrap;
+}
+
+.cardBuiltinBadge {
+    color: var(--color-text-2);
+    background: var(--color-fill-2);
+}
+
+.cardCustomBadge {
+    color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
 }
 
 .cardMetric {
@@ -259,43 +296,9 @@
     white-space: nowrap;
 }
 
-.cardMeta {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 8px;
-    min-height: 22px;
-
-    :global(.ant-tag) {
-        margin-inline-end: 0;
-    }
-}
-
-.cardTag {
-    max-width: 100%;
-    margin: 0;
-    border: 0;
-    border-radius: 4px;
-    color: var(--color-primary);
-    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
-    font-size: 12px;
-    font-weight: 600;
-    line-height: 20px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.cardTypeTag {
-    margin: 0;
-    flex-shrink: 0;
-    font-size: 12px;
-    line-height: 20px;
-}
-
 .cardDescription {
     display: -webkit-box;
-    margin-top: 18px;
+    margin-top: 8px;
     color: var(--color-text-2);
     font-size: 12px;
     line-height: 19px;

--- a/web/src/app/monitor/(pages)/event/template/page.tsx
+++ b/web/src/app/monitor/(pages)/event/template/page.tsx
@@ -327,22 +327,27 @@ const Template: React.FC = () => {
           />
         </div>
         <div className={templateStyle.cardBody}>
-          <div className={templateStyle.cardTitle} title={item.name || '--'}>
-            {item.name || '--'}
+          <div className={templateStyle.cardTitle}>
+            <Tooltip title={item.name || '--'} mouseEnterDelay={0.3}>
+              <span className={templateStyle.cardTitleInner}>
+                <span className={templateStyle.cardTitleText}>{item.name || '--'}</span>
+                <span
+                  className={`${templateStyle.cardTypeBadge} ${
+                    item.template_type === 'custom'
+                      ? templateStyle.cardCustomBadge
+                      : templateStyle.cardBuiltinBadge
+                  }`}
+                >
+                  {item.template_type === 'custom' ? '自定义' : '内置'}
+                </span>
+              </span>
+            </Tooltip>
           </div>
           {metricName ? (
             <div className={templateStyle.cardMetric} title={metricName}>
               {metricName}
             </div>
           ) : null}
-          <div className={templateStyle.cardMeta}>
-            <Tag
-              className={templateStyle.cardTypeTag}
-              color={item.template_type === 'custom' ? 'blue' : 'default'}
-            >
-              {item.template_type === 'custom' ? '自定义' : '内置'}
-            </Tag>
-          </div>
           <div className={templateStyle.cardDescription} title={item.description || '--'}>
             {item.description || '--'}
           </div>


### PR DESCRIPTION
## Summary

- 将「内置 / 自定义」标签改为标题旁的胶囊样式，内置与自定义视觉一致
- 指标名单独占一行，避免标签挤压英文指标名
- 收紧描述与指标名间距（18px → 8px），长标题支持截断并通过 Tooltip 展示全文

## Test plan

- [x] 本地页面确认内置/自定义标签位置与样式一致
- [x] 确认指标名左对齐、描述不再过度下沉
- [x] 确认长标题截断与 Tooltip 正常
- [ ] CI 通过

## 提交范围说明

仅包含 2 个文件：
- `web/src/app/monitor/(pages)/event/template/page.tsx`
- `web/src/app/monitor/(pages)/event/template/index.module.scss`

未纳入无关图标资源、测试文件及本地 `next-env.d.ts` 变更。