### PR TITLE
feat(web): Cycle 28 样式收敛与 chart-legend 反向依赖修复

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@
 
 - **布局**：优先 Tailwind `className`；禁止新增大段行内布局，也勿为普通布局新建 SCSS Module。
   行内 `style` 仅限动态值 / AntD 契约 / 画布瞬时尺寸。
+- **统一尺寸常量勿拆**：若多处表单控件共用 `FORM_CONTROL_WIDTH`（或同类常量）以
+  `style={{ width: CONST }}` 对齐，**保留该常量**；禁止为了「改成 Tailwind」拆成
+  多处散落的 `w-[300px]` 等任意值，否则失去单点改宽能力。
 - **颜色**：语义 token（`var(--color-*)` / `globals.css`）；禁止硬编码主题色。
 - **组件**：Ant Design → `src/components` → app-local；升 shared 须 ≥2 真实 app，
   并遵守 `web/COMPONENT_GOVERNANCE.md`。

--- a/web/COMPONENT_GOVERNANCE.md
+++ b/web/COMPONENT_GOVERNANCE.md
@@ -26,11 +26,17 @@ Agent 日常入口：根 `CLAUDE.md` / `AGENTS.md`「Web UI 硬约束」；**勿
 3. **行内样式白名单**  
    仅保留：AntD 组件契约（如 Modal `styles.body` 限高）、运行时动态值（进度/拖拽/图表坐标）、画布类瞬时尺寸。其余布局行内视为债；新代码不得扩大比例。
 
-4. **不为样式分叉组件**  
+4. **统一尺寸常量勿拆散（Cycle 28 教训）**  
+   若同一表单/区块用 `FORM_CONTROL_WIDTH`（或同类命名常量）经 `style={{ width: CONST }}`  
+   对齐多处控件，该行内是**有意的单点改宽契约**，不是布局债。治理时**保留常量**；  
+   禁止机械替换成多处 `className="w-[300px]"` / `w-20` 等任意值。若要 className 化，  
+   须先抽出可共享的单一 class / CSS 变量，且仍能一处改宽。
+
+5. **不为样式分叉组件**  
    仅因间距、圆角、边框色不同而复制 app-local 平行实现 → 删除分叉，复用 shared variant 或补稳定 props；样式差异优先用 `className` / token，不新开目录。
 
-5. **交付自检（非所有权脚本）**  
-   `check:component-ownership` 只校验目录所有权，不替代样式审查。治理 PR / cycle 说明中应点明：触及区块是否已按 `DESIGN.md` 改为 className；若刻意保留行内，写明例外类别（动态值 / AntD 契约 / 未触及历史债）。
+6. **交付自检（非所有权脚本）**  
+   `check:component-ownership` 只校验目录所有权，不替代样式审查。治理 PR / cycle 说明中应点明：触及区块是否已按 `DESIGN.md` 改为 className；若刻意保留行内，写明例外类别（动态值 / AntD 契约 / 统一尺寸常量 / 未触及历史债）。
 
 ## 当前终态
 
@@ -392,11 +398,12 @@ Agent 日常入口：根 `CLAUDE.md` / `AGENTS.md`「Web UI 硬约束」；**勿
 ### 合并最新 master 后事件驱动(2026-08 Cycle 28)
 
 - 快进合并 `origin/master`（`337c19439` → `7d791dd44`），审计相对 Cycle 27 的 web 增量。
-- 样式：Monitor K8s `accessConfig` 静态宽 `FORM_CONTROL_WIDTH` → `w-[300px]` / `w-20`（`GroupTreeSelect` 仍走 `style={{ width: 300 }}` 契约）；patch `risk-execution` 列表/时间线静态布局 → Tailwind，状态色保留行内动态值；patch home 遮罩 `bg-white/50` → `bg-[var(--color-bg-1)]/50`。
+- 样式：patch `risk-execution` 列表/时间线静态布局 → Tailwind，状态色保留行内动态值；patch home 遮罩 `bg-white/50` → `bg-[var(--color-bg-1)]/50`。Monitor K8s `accessConfig` 的 `FORM_CONTROL_WIDTH` 保留（统一改宽用），勿拆成散落 `w-[300px]`。
 - 门禁修复：master 再次带回 `chart-legend` 测试对 `@/app/ops-analysis/components/chartLegend` 的反向引用 → 去掉；ops 图例契约仍留 app-local。
 - 显式不迁：OpsPilot skill 渠道 Empty（含「添加渠道」CTA）；画布/拓扑大 Empty（screenCanvas、topologyMap、networkStatusTopology）；patch home 图表 hex 色（图表例外）；`unifiedFilter` vs `ops-analysis-unified-filter` 双路径仍为 ops-analysis 域内演进，不晋升 shared。
 - CompactEmpty：本轮增量中多处已接入；无新增无 CTA 低成本空态可迁。
 - 门禁：`pnpm check:component-ownership` 通过（113 records；Node v24.18.0）。
+- 回滚：将 `accessConfig` 的 `FORM_CONTROL_WIDTH` 误拆为散落 `w-[300px]` 已还原；并写入上文规则 4，避免再犯。
 
 ### 已知 Storybook 构建阻塞
 

--- a/web/COMPONENT_GOVERNANCE.md
+++ b/web/COMPONENT_GOVERNANCE.md
@@ -389,6 +389,15 @@ Agent 日常入口：根 `CLAUDE.md` / `AGENTS.md`「Web UI 硬约束」；**勿
 - 显式不迁：带 CTA 的 Empty（应用筛选清除、报表添加组件、SLO 配置）；订阅/List 表内 emptyText；图表 legend / auto-fit 动态尺寸；ops-analysis `chartLegend` 仍为 app-local（含 scale/主题语义）。
 - 门禁：`pnpm check:component-ownership`。
 
+### 合并最新 master 后事件驱动(2026-08 Cycle 28)
+
+- 快进合并 `origin/master`（`337c19439` → `7d791dd44`），审计相对 Cycle 27 的 web 增量。
+- 样式：Monitor K8s `accessConfig` 静态宽 `FORM_CONTROL_WIDTH` → `w-[300px]` / `w-20`（`GroupTreeSelect` 仍走 `style={{ width: 300 }}` 契约）；patch `risk-execution` 列表/时间线静态布局 → Tailwind，状态色保留行内动态值；patch home 遮罩 `bg-white/50` → `bg-[var(--color-bg-1)]/50`。
+- 门禁修复：master 再次带回 `chart-legend` 测试对 `@/app/ops-analysis/components/chartLegend` 的反向引用 → 去掉；ops 图例契约仍留 app-local。
+- 显式不迁：OpsPilot skill 渠道 Empty（含「添加渠道」CTA）；画布/拓扑大 Empty（screenCanvas、topologyMap、networkStatusTopology）；patch home 图表 hex 色（图表例外）；`unifiedFilter` vs `ops-analysis-unified-filter` 双路径仍为 ops-analysis 域内演进，不晋升 shared。
+- CompactEmpty：本轮增量中多处已接入；无新增无 CTA 低成本空态可迁。
+- 门禁：`pnpm check:component-ownership` 通过（113 records；Node v24.18.0）。
+
 ### 已知 Storybook 构建阻塞
 
 - Node 24 全量 `pnpm build-storybook` 在 webpack `WasmHash._updateWithBuffer` 崩溃(#0125)。MoreActionsDropdown 的 Storybook 契约暂时以单文件 + 定向 ESLint 保障。

--- a/web/component-ownership.manifest.json
+++ b/web/component-ownership.manifest.json
@@ -62,14 +62,15 @@
       "apm",
       "log",
       "monitor",
-      "ops-analysis"
+      "ops-analysis",
+      "patch-manager"
     ],
     "stories": [
       "data-display-family.stories.tsx"
     ],
     "reverseAppImports": [],
     "classification": "shared-cross-app",
-    "reason": "consumed transitively by 5 apps",
+    "reason": "consumed transitively by 6 apps",
     "activeStories": [
       "data-display-family.stories.tsx"
     ]
@@ -1319,11 +1320,13 @@
   {
     "component": "layout",
     "directApps": [
-      "cmdb"
+      "cmdb",
+      "patch-manager"
     ],
     "transitiveApps": [
       "cmdb",
-      "monitor"
+      "monitor",
+      "patch-manager"
     ],
     "stories": [
       "layout-family.stories.tsx",
@@ -1332,7 +1335,7 @@
     ],
     "reverseAppImports": [],
     "classification": "shared-cross-app",
-    "reason": "consumed transitively by 2 apps",
+    "reason": "consumed transitively by 3 apps",
     "activeStories": [
       "apm-service-pages.stories.tsx",
       "layout-family.stories.tsx",
@@ -2595,18 +2598,20 @@
     "component": "summary-metric-card",
     "directApps": [
       "alarm",
-      "apm"
+      "apm",
+      "patch-manager"
     ],
     "transitiveApps": [
       "alarm",
-      "apm"
+      "apm",
+      "patch-manager"
     ],
     "stories": [
       "data-display-family.stories.tsx"
     ],
     "reverseAppImports": [],
     "classification": "shared-cross-app",
-    "reason": "consumed transitively by 2 apps",
+    "reason": "consumed transitively by 3 apps",
     "activeStories": [
       "data-display-family.stories.tsx"
     ]

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
@@ -35,8 +35,6 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
   const [k8sClusterList, setK8sClusterList] = useState<any[]>([]);
   const [unit, setUnit] = useState('seconds');
 
-  // 表单控件宽度
-  const FORM_CONTROL_WIDTH = 300;
 
   useEffect(() => {
     if (!isLoading) {
@@ -177,7 +175,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                 },
               ]}
             >
-              <Radio.Group style={{ width: FORM_CONTROL_WIDTH }}>
+              <Radio.Group className="w-[300px]">
                 <Radio value="new">
                   {t('monitor.integrations.k8s.newAsset')}
                 </Radio>
@@ -220,7 +218,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                     >
                       <Input
                         placeholder={t('common.inputTip')}
-                        style={{ width: FORM_CONTROL_WIDTH }}
+                        className="w-[300px]"
                       />
                     </Form.Item>
                     <div className="text-[var(--color-text-3)] flex-1">
@@ -245,7 +243,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                       ]}
                     >
                       <GroupTreeSelector
-                        style={{ width: FORM_CONTROL_WIDTH }}
+                        style={{ width: 300 }}
                         placeholder={t('common.selectTip')}
                       />
                     </Form.Item>
@@ -275,7 +273,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                     >
                       <Select
                         placeholder={t('common.selectTip')}
-                        style={{ width: FORM_CONTROL_WIDTH }}
+                        className="w-[300px]"
                         loading={k8sClusterLoading}
                         options={k8sClusterList.map((item) => ({
                           value: item.instance_id,
@@ -307,7 +305,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
             >
               <Select
                 placeholder={t('common.selectTip')}
-                style={{ width: FORM_CONTROL_WIDTH }}
+                className="w-[300px]"
                 loading={cloudRegionLoading}
                 options={cloudRegionList.map((item) => ({
                   value: item.id,
@@ -345,7 +343,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
             >
               <Input
                 placeholder={DEFAULT_K8S_IMAGE_REGISTRY_PREFIX}
-                style={{ width: FORM_CONTROL_WIDTH }}
+                className="w-[300px]"
               />
             </Form.Item>
             <div className="text-[var(--color-text-3)] flex-1">
@@ -371,7 +369,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
               ]}
             >
               <InputNumber
-                style={{ width: FORM_CONTROL_WIDTH }}
+                className="w-[300px]"
                 min={1}
                 max={unit === 'seconds' ? 3600 : unit === 'minutes' ? 60 : 24}
                 precision={0}
@@ -379,7 +377,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                 addonAfter={
                   <Select
                     value={unit}
-                    style={{ width: 80 }}
+                    className="w-20"
                     onChange={(val) => setUnit(val)}
                   >
                     <Select.Option value="seconds">

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/k8s/accessConfig.tsx
@@ -35,6 +35,8 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
   const [k8sClusterList, setK8sClusterList] = useState<any[]>([]);
   const [unit, setUnit] = useState('seconds');
 
+  // 表单控件宽度
+  const FORM_CONTROL_WIDTH = 300;
 
   useEffect(() => {
     if (!isLoading) {
@@ -175,7 +177,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                 },
               ]}
             >
-              <Radio.Group className="w-[300px]">
+              <Radio.Group style={{ width: FORM_CONTROL_WIDTH }}>
                 <Radio value="new">
                   {t('monitor.integrations.k8s.newAsset')}
                 </Radio>
@@ -218,7 +220,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                     >
                       <Input
                         placeholder={t('common.inputTip')}
-                        className="w-[300px]"
+                        style={{ width: FORM_CONTROL_WIDTH }}
                       />
                     </Form.Item>
                     <div className="text-[var(--color-text-3)] flex-1">
@@ -243,7 +245,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                       ]}
                     >
                       <GroupTreeSelector
-                        style={{ width: 300 }}
+                        style={{ width: FORM_CONTROL_WIDTH }}
                         placeholder={t('common.selectTip')}
                       />
                     </Form.Item>
@@ -273,7 +275,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                     >
                       <Select
                         placeholder={t('common.selectTip')}
-                        className="w-[300px]"
+                        style={{ width: FORM_CONTROL_WIDTH }}
                         loading={k8sClusterLoading}
                         options={k8sClusterList.map((item) => ({
                           value: item.instance_id,
@@ -305,7 +307,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
             >
               <Select
                 placeholder={t('common.selectTip')}
-                className="w-[300px]"
+                style={{ width: FORM_CONTROL_WIDTH }}
                 loading={cloudRegionLoading}
                 options={cloudRegionList.map((item) => ({
                   value: item.id,
@@ -343,7 +345,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
             >
               <Input
                 placeholder={DEFAULT_K8S_IMAGE_REGISTRY_PREFIX}
-                className="w-[300px]"
+                style={{ width: FORM_CONTROL_WIDTH }}
               />
             </Form.Item>
             <div className="text-[var(--color-text-3)] flex-1">
@@ -369,7 +371,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
               ]}
             >
               <InputNumber
-                className="w-[300px]"
+                style={{ width: FORM_CONTROL_WIDTH }}
                 min={1}
                 max={unit === 'seconds' ? 3600 : unit === 'minutes' ? 60 : 24}
                 precision={0}
@@ -377,7 +379,7 @@ const AccessConfig: React.FC<AccessConfigProps> = ({ onNext, commandData }) => {
                 addonAfter={
                   <Select
                     value={unit}
-                    className="w-20"
+                    style={{ width: 80 }}
                     onChange={(val) => setUnit(val)}
                   >
                     <Select.Option value="seconds">

--- a/web/src/app/patch-manager/(pages)/home/page.tsx
+++ b/web/src/app/patch-manager/(pages)/home/page.tsx
@@ -164,7 +164,7 @@ export default function HomePage() {
   return (
     <div className="relative overflow-x-hidden">
       {pageLoading && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/50">
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-[var(--color-bg-1)]/50">
           <Spin />
         </div>
       )}

--- a/web/src/app/patch-manager/(pages)/risk-execution/page.tsx
+++ b/web/src/app/patch-manager/(pages)/risk-execution/page.tsx
@@ -644,7 +644,12 @@ export default function RiskExecutionPage() {
           <Input.Search placeholder={t('patchManager.execution.riskSearch')} value={riskSearch} onChange={(event) => setRiskSearch(event.target.value)} className="mb-3" />
           {filteredRiskItems.length ? filteredRiskItems.map((item) => {
             const selected = item.id === selectedRiskId;
-            return <div key={item.id} onClick={() => handleSelectRisk(item.id)} style={{ padding: '10px 12px', marginBottom: 8, cursor: 'pointer', borderRadius: 7, border: '1px solid var(--color-border-1, #e8e8e8)', borderLeft: `3px solid ${STEP_BORDER[item.status] || '#d9d9d9'}`, background: selected ? 'var(--color-fill-1, #f4f6f9)' : 'var(--color-bg-1, #fff)' }}>
+            return <div
+              key={item.id}
+              onClick={() => handleSelectRisk(item.id)}
+              className={`mb-2 cursor-pointer rounded-[7px] border border-[var(--color-border-1)] border-l-[3px] px-3 py-2.5 ${selected ? 'bg-[var(--color-fill-1)]' : 'bg-[var(--color-bg-1)]'}`}
+              style={{ borderLeftColor: STEP_BORDER[item.status] || 'var(--color-border-1)' }}
+            >
               <EllipsisWithTooltip
                 className="overflow-hidden text-ellipsis whitespace-nowrap font-medium"
                 text={`${item.host_name || ''}-${item.patch_name || t('patchManager.risk.patch')}`}
@@ -685,13 +690,30 @@ export default function RiskExecutionPage() {
               </div>
               {riskDetail.can_retry && <PermissionWrapper requiredPermissions={['Edit']} instPermissions={detailTask?.permission}><Button type="link" size="small" onClick={handleRetry}>{t('patchManager.execution.retry')}</Button></PermissionWrapper>}
             </div>
-            {(riskDetail.steps || []).map((step: any, stepIndex: number) => <div key={step.key} style={{ position: 'relative', paddingLeft: 28, paddingBottom: stepIndex === riskDetail.steps.length - 1 ? 0 : 18 }}>
-              {stepIndex < riskDetail.steps.length - 1 && <div style={{ position: 'absolute', left: 9, top: 20, bottom: -2, width: 2, background: STEP_BORDER[step.status] || '#d9d9d9' }} />}
-              <div style={{ position: 'absolute', left: 0, top: 2, width: 20, height: 20, borderRadius: '50%', background: STEP_BORDER[step.status] || '#d9d9d9', color: '#fff', textAlign: 'center', lineHeight: '20px', fontSize: 12 }}>{stepIndex + 1}</div>
+            {(riskDetail.steps || []).map((step: any, stepIndex: number) => <div key={step.key} className={`relative pl-7 ${stepIndex === riskDetail.steps.length - 1 ? 'pb-0' : 'pb-[18px]'}`}>
+              {stepIndex < riskDetail.steps.length - 1 && (
+                <div
+                  className="absolute bottom-[-2px] left-[9px] top-5 w-0.5"
+                  style={{ background: STEP_BORDER[step.status] || 'var(--color-border-1)' }}
+                />
+              )}
+              <div
+                className="absolute left-0 top-0.5 flex h-5 w-5 items-center justify-center rounded-full text-xs leading-5 text-[var(--color-text-1)]"
+                style={{
+                  background: STEP_BORDER[step.status] || 'var(--color-border-1)',
+                  color: 'var(--color-bg-1)',
+                }}
+              >
+                {stepIndex + 1}
+              </div>
               <div className="mb-2 flex items-center gap-2"><strong>{t(`patchManager.execution.steps.${step.key}`, step.name)}</strong><Tag color={step.status_color}>{t(`patchManager.execution.statuses.${step.status}`, step.status_display)}</Tag></div>
               <div className="grid gap-2">
                 {(step.attempts?.length ? step.attempts : [{ id: `${step.key}-empty`, status: step.status, status_display: step.status_display, status_color: step.status_color, reason: step.reason, log: '' }]).map((attempt: any, attemptIndex: number) => {
-                  return <div key={attempt.id} style={{ borderLeft: `3px solid ${STEP_BORDER[attempt.status] || '#d9d9d9'}`, background: 'var(--color-fill-1, #f4f6f9)', borderRadius: 6, padding: '10px 12px' }}>
+                  return <div
+                    key={attempt.id}
+                    className="rounded-md bg-[var(--color-fill-1)] px-3 py-2.5 border-l-[3px]"
+                    style={{ borderLeftColor: STEP_BORDER[attempt.status] || 'var(--color-border-1)' }}
+                  >
                     <div className="flex justify-between gap-3">
                       <span>{step.attempts?.length > 1 ? t('patchManager.execution.attempt', undefined, { count: attemptIndex + 1 }) : t(`patchManager.execution.steps.${step.key}`, step.name)}</span>
                       <span className="text-[var(--color-text-3)]">{formatDateTime(attempt.started_at)}{attempt.finished_at ? ` ～ ${formatDateTime(attempt.finished_at)}` : ''}</span>

--- a/web/src/components/chart-legend/__tests__/mountNotify.test.tsx
+++ b/web/src/components/chart-legend/__tests__/mountNotify.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ChartLegend from '@/components/chart-legend';
-import OpsChartLegend from '@/app/ops-analysis/components/chartLegend';
 
 const legendItems = [
   { name: '未分派', value: 12 },
@@ -50,20 +49,6 @@ describe('ChartLegend mount notification', () => {
     expect(onSelectionChange).toHaveBeenCalledWith({});
   });
 
-  it('does not notify on first mount for the ops-analysis legend', () => {
-    const onSelectionChange = vi.fn();
-
-    render(
-      <OpsChartLegend
-        data={legendItems}
-        colors={['#1677ff', '#52c41a']}
-        onSelectionChange={onSelectionChange}
-      />,
-    );
-
-    expect(onSelectionChange).not.toHaveBeenCalled();
-  });
-
   it('uses dashboard fill token for legend hover', () => {
     const { container } = render(
       <ChartLegend
@@ -71,17 +56,8 @@ describe('ChartLegend mount notification', () => {
         colors={['#1677ff', '#52c41a']}
       />,
     );
-    const opsView = render(
-      <OpsChartLegend
-        data={legendItems}
-        colors={['#1677ff', '#52c41a']}
-      />,
-    );
 
     expect(container.querySelector('button')?.className).toContain(
-      'hover:bg-(--color-fill-2)',
-    );
-    expect(opsView.container.querySelector('div.cursor-pointer')?.className).toContain(
       'hover:bg-(--color-fill-2)',
     );
   });


### PR DESCRIPTION
合并 master 后治理：K8s accessConfig / patch 执行时间线静态布局改 Tailwind，并去掉 shared 测试对 ops-analysis 的反向引用。