### PR TITLE
fix: 节点推送监控改为本进程写入，避免嵌套 NATS 与 Node 行锁自死锁

### DIFF
--- a/server/apps/cmdb/display_field/cache.py
+++ b/server/apps/cmdb/display_field/cache.py
@@ -5,19 +5,20 @@
 职责：
 1. 项目启动时读取所有模型的 organization/user/enum 类型字段
 2. 缓存到 Redis，TTL 为 1 小时
-3. 模型字段变更时动态更新缓存
+3. 模型字段变更时失效该模型 attrs 缓存，下次按 model_id 回源查询
 4. 为全文检索提供需要排除的字段列表
 
 缓存策略：
 - 缓存key: cmdb:exclude_fields:all
 - TTL: 3600秒（1小时）
 - 数据格式: ["organization", "created_by", "status", ...]
-- 更新时机: 启动时初始化 + 模型字段变更时
+- 预热时机: 启动时若全局缓存缺失则加载一次
+- 模型字段变更: 只失效该 model 的 attrs 缓存，下次 get_model_attrs 按 model_id 回源查询；不拉全量模型预热
 
 设计原则：
-- 单次查询：所有缓存数据来自同一次模型查询，避免重复DB访问
-- 统一管理：初始化/更新/清空/刷新使用统一的内部逻辑
-- 按需构建：根据 cache_key 选择对应的数据构建策略
+- 单次查询：启动预热时所有缓存数据来自同一次模型查询，避免重复DB访问
+- 统一管理：初始化/清空/手动刷新使用统一的内部逻辑
+- 按需构建：根据 cache_key 选择对应的数据构建策略；单模型失效后按需回源
 """
 
 from typing import Any, Dict, List, Set
@@ -42,7 +43,7 @@ class ExcludeFieldsCache:
     """
     排除字段缓存管理器
     管理全文检索时需要排除的原始字段列表（organization/user/enum类型）
-    使用 Redis 缓存，定期刷新，支持统一的缓存管理逻辑
+    使用 Redis 缓存；启动可预热，模型变更只失效对应 attrs，读取未命中时回源查询
 
     常量说明:
     - EXCLUDE_FIELDS_KEY: 缓存 key（从 constants 导入）
@@ -112,7 +113,8 @@ class ExcludeFieldsCache:
         项目启动时预热缓存。
 
         启动路径以“可用即跳过”为主，避免每次进程启动都清缓存、查图库。
-        模型字段变更和手动刷新仍然使用 initialize_all/refresh_cache 的强制刷新语义。
+        手动刷新仍使用 initialize_all/refresh_cache 的强制刷新语义；
+        模型字段变更只失效对应 model 的 attrs，不在变更路径全量预热。
         """
         try:
             if cls._global_caches_ready():
@@ -213,7 +215,10 @@ class ExcludeFieldsCache:
     @classmethod
     def update_on_model_change(cls, model_id: str) -> bool:
         """
-        模型字段变更时更新所有缓存
+        模型字段变更时失效该模型的 attrs 缓存。
+
+        模型变更低频，不在这里拉全量模型预热。下次 get_model_attrs(model_id)
+        缓存未命中时按该模型回源查询。
 
         使用场景：
         - 模型新增字段
@@ -224,28 +229,17 @@ class ExcludeFieldsCache:
             model_id: 发生变更的模型ID
 
         Returns:
-            更新是否成功
+            失效是否成功
         """
-        logger.info(f"[ExcludeFieldsCache] 模型变更触发缓存更新, 模型: {model_id}")
+        logger.info(f"[ExcludeFieldsCache] 模型变更失效 attrs 缓存, 模型: {model_id}")
 
         try:
-            # P2-2.6: 精准删该 model 的 attrs 缓存后再全量刷新,避免在
-            # _refresh_all_caches 重建之前读到陈旧数据(极端时序)。
             cls._purge_model_attrs_cache(model_id)
-
-            # 全量刷新所有缓存（确保完整性）
-            success = cls._refresh_all_caches()
-
-            if success:
-                logger.info(f"[ExcludeFieldsCache] 缓存更新成功, 模型: {model_id}")
-            else:
-                logger.error(f"[ExcludeFieldsCache] 缓存更新失败, 模型: {model_id}")
-
-            return success
-
+            logger.info(f"[ExcludeFieldsCache] 已失效模型 attrs 缓存, 模型: {model_id}")
+            return True
         except Exception as e:
             logger.error(
-                f"[ExcludeFieldsCache] 缓存更新异常, 模型: {model_id}, 错误: {e}",
+                f"[ExcludeFieldsCache] 失效模型 attrs 缓存异常, 模型: {model_id}, 错误: {e}",
                 exc_info=True,
             )
             return False
@@ -498,8 +492,8 @@ class ExcludeFieldsCache:
 
             try:
                 # 延迟导入避免循环依赖
-                from apps.cmdb.services.model import ModelManage
                 from apps.cmdb.model_ops.extensions import is_file_attr_type
+                from apps.cmdb.services.model import ModelManage
 
                 attrs = ModelManage.parse_attrs(attrs_json)
 
@@ -510,11 +504,7 @@ class ExcludeFieldsCache:
                     # 展示型字段（有 _display 冗余）+ 文件型字段（附件/图片，值为元数据 JSON）
                     # + 敏感型字段（pwd，密文）都排除出全文检索；
                     # 缺企业版时 is_file_attr_type 恒 False，社区行为不变。
-                    if (
-                        attr_type in cls.EXCLUDE_FIELD_TYPES
-                        or attr_type in SENSITIVE_FIELD_TYPES
-                        or is_file_attr_type(attr_type)
-                    ):
+                    if attr_type in cls.EXCLUDE_FIELD_TYPES or attr_type in SENSITIVE_FIELD_TYPES or is_file_attr_type(attr_type):
                         all_exclude_fields.add(attr_id)
 
             except Exception as e:

--- a/server/apps/cmdb/tests/test_migrate_display_slice.py
+++ b/server/apps/cmdb/tests/test_migrate_display_slice.py
@@ -11,14 +11,13 @@ system_mgmt Group/User(真实ORM) / FieldGroup·PublicEnumLibrary(真实Postgres
 断言真实输出、DB副作用、异常契约、入参契约。
 """
 
-import pydantic.root_model  # noqa: F401  预热避免 cov 竞态
-
 import io
 import json
 import sys
 from collections import defaultdict
 
 import pandas as pd
+import pydantic.root_model  # noqa: F401  预热避免 cov 竞态
 import pytest
 
 from apps.cmdb.constants.field_constraints import (
@@ -398,11 +397,7 @@ class TestModelMigrateWithDB:
             created_by="system",
             updated_by="system",
         )
-        cfg = {
-            "public_enum_libraries": [
-                {"library_id": "os_type", "name": "新名", "team": "[]", "options": "[{'id':'a','name':'A'}]"}
-            ]
-        }
+        cfg = {"public_enum_libraries": [{"library_id": "os_type", "name": "新名", "team": "[]", "options": "[{'id':'a','name':'A'}]"}]}
         m, mod = self._make(monkeypatch, cfg)
         refreshed = []
         monkeypatch.setattr(mod, "enqueue_library_snapshot_refresh", lambda lib_id, **k: refreshed.append(lib_id))
@@ -432,11 +427,7 @@ class TestModelMigrateWithDB:
 
     def test_validate_public_library_references_missing_raises(self, monkeypatch):
         m, _ = self._make(monkeypatch, {})
-        attrs = {
-            "host": [
-                {"attr_id": "os", "attr_type": "enum", "enum_rule_type": "public_library", "public_library_id": "nope"}
-            ]
-        }
+        attrs = {"host": [{"attr_id": "os", "attr_type": "enum", "enum_rule_type": "public_library", "public_library_id": "nope"}]}
         with pytest.raises(BaseAppException):
             m._validate_public_library_references(attrs)
 
@@ -445,11 +436,7 @@ class TestModelMigrateWithDB:
 
         PublicEnumLibrary.objects.create(library_id="exists", name="n", team=[], options=[], created_by="x", updated_by="x")
         m, _ = self._make(monkeypatch, {})
-        attrs = {
-            "host": [
-                {"attr_id": "os", "attr_type": "enum", "enum_rule_type": "public_library", "public_library_id": "exists"}
-            ]
-        }
+        attrs = {"host": [{"attr_id": "os", "attr_type": "enum", "enum_rule_type": "public_library", "public_library_id": "exists"}]}
         # 不抛异常即通过
         m._validate_public_library_references(attrs)
 
@@ -504,9 +491,7 @@ class TestModelMigrateWithDB:
 
         ag = FakeGraph()
         existing_attrs = [{"attr_id": "ip", "attr_type": "str", "attr_name": "旧"}]
-        existing_model_map = {
-            "host": {"_id": "n1", "model_id": "host", "attrs": json.dumps(existing_attrs)}
-        }
+        existing_model_map = {"host": {"_id": "n1", "model_id": "host", "attrs": json.dumps(existing_attrs)}}
         attrs_by_model = {"host": [{"attr_id": "ip", "attr_type": "str", "attr_name": "新名"}]}
         res = m._sync_added_attrs_to_existing_models(ag, attrs_by_model, existing_model_map)
         assert res["updated_attr_count"] == 1
@@ -523,9 +508,7 @@ class TestModelMigrateWithDB:
         from apps.cmdb.models.field_group import FieldGroup
 
         m, _ = self._make(monkeypatch, {})
-        existing = FieldGroup.objects.create(
-            model_id="host", group_name="网络", order=1, is_collapsed=False, attr_orders=["ip"], created_by="system"
-        )
+        existing = FieldGroup.objects.create(model_id="host", group_name="网络", order=1, is_collapsed=False, attr_orders=["ip"], created_by="system")
         field_group_map = {("host", "网络"): existing}
         max_order = defaultdict(int)
         max_order["host"] = 1
@@ -574,9 +557,7 @@ class TestModelMigrateWithDB:
     def test_migrate_associations_builds_edges(self, monkeypatch):
         cfg = {
             "models": [{"model_id": "host"}],
-            "asso-host": [
-                {"src_model_id": "host", "dst_model_id": "switch", "asst_id": "connect", "asst_name": "连接"}
-            ],
+            "asso-host": [{"src_model_id": "host", "dst_model_id": "switch", "asst_id": "connect", "asst_name": "连接"}],
         }
         m, mod = self._make(monkeypatch, cfg)
         fake = _patch_graph(
@@ -761,9 +742,7 @@ class TestDisplayFieldInitializer:
         models = [
             {
                 "model_id": "host",
-                "attrs": json.dumps(
-                    [{"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行中"}]}]
-                ),
+                "attrs": json.dumps([{"attr_id": "status", "attr_type": "enum", "option": [{"id": "1", "name": "运行中"}]}]),
             }
         ]
         init._preload_mappings(models)
@@ -1005,8 +984,9 @@ class TestExcludeFieldsCache:
         assert "org" in ExcludeFieldsCache.get_exclude_fields()
 
     def test_get_model_attrs_cache_hit_and_miss(self, monkeypatch):
-        from apps.cmdb.display_field.cache import ExcludeFieldsCache
         from django.core.cache import cache as dj_cache
+
+        from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
         # miss -> 调用 ModelManage.search_model_attr 并缓存
         monkeypatch.setattr(
@@ -1026,10 +1006,17 @@ class TestExcludeFieldsCache:
         assert ExcludeFieldsCache.get_model_attrs("host") == [{"attr_id": "x"}]
 
     def test_update_on_model_change(self, monkeypatch):
+        from django.core.cache import cache as dj_cache
+
         from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
-        _patch_graph(monkeypatch, "apps.cmdb.display_field.cache", query_entity=([], 0))
+        host_key = f"{ExcludeFieldsCache.MODEL_ATTRS_KEY_PREFIX}host"
+        dj_cache.set(host_key, [{"attr_id": "stale"}])
+        fake = _patch_graph(monkeypatch, "apps.cmdb.display_field.cache", query_entity=([], 0))
+
         assert ExcludeFieldsCache.update_on_model_change("host") is True
+        assert dj_cache.get(host_key) is None
+        assert fake.calls == []
 
     # -----------------------------------------------------------------
     # P2-2.6 — clear_cache 必须真的清掉 model attrs 缓存,不能只 log 一句 warning
@@ -1043,8 +1030,9 @@ class TestExcludeFieldsCache:
 
         修复:_build_and_cache_model_attrs 维护 model_id 索引,refresh 时比对新旧
         索引,删掉已下线的 model 的 attrs 缓存键。"""
-        from apps.cmdb.display_field.cache import ExcludeFieldsCache
         from django.core.cache import cache as dj_cache
+
+        from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
         # 模拟生产路径:第一次 build 含 host / switch,索引写入这两个 model
         models_v1 = [
@@ -1064,40 +1052,49 @@ class TestExcludeFieldsCache:
         assert ExcludeFieldsCache.refresh_cache() is True
 
         # host 的 attrs 缓存键必须被精准删(否则会留 1h TTL 持续返回陈旧数据)
-        assert dj_cache.get(host_key) is None, (
-            f"{host_key} 必须被精准清掉,实际保留说明模型被删后缓存未同步"
-        )
+        assert dj_cache.get(host_key) is None, f"{host_key} 必须被精准清掉,实际保留说明模型被删后缓存未同步"
 
     def test_update_on_model_change_purges_only_target_model_attrs(self, monkeypatch):
-        """P2-2.6 附加:update_on_model_change(model_id) 应精准清掉该 model 的 attrs
-        缓存,其他 model 的 attrs 不受影响(避免误清 + 减少缓存抖动)。"""
-        from apps.cmdb.display_field.cache import ExcludeFieldsCache
+        """模型变更只失效该 model 的 attrs 缓存，不拉全量模型预热。下次读取回源查询。"""
         from django.core.cache import cache as dj_cache
+
+        from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
         target_key = f"{ExcludeFieldsCache.MODEL_ATTRS_KEY_PREFIX}host"
         other_key = f"{ExcludeFieldsCache.MODEL_ATTRS_KEY_PREFIX}switch"
         dj_cache.set(target_key, [{"stale": True}])
         dj_cache.set(other_key, [{"stale": True}])
+        dj_cache.set(ExcludeFieldsCache.EXCLUDE_FIELDS_KEY, ["organization"])
+        dj_cache.set(ExcludeFieldsCache.MODEL_FIELDS_MAPPING_KEY, {"host": {"organization": ["organization"]}})
 
-        # mock 图查询返空(只关心缓存清理,不需要刷数据)
-        _patch_graph(monkeypatch, "apps.cmdb.display_field.cache", query_entity=([], 0))
+        fake = _patch_graph(monkeypatch, "apps.cmdb.display_field.cache", query_entity=([], 0))
         ExcludeFieldsCache.update_on_model_change("host")
 
         assert dj_cache.get(target_key) is None, "目标 model 的 attrs 缓存必须被清掉"
-        # other_key 不一定要保留(update_on_model_change 整体刷会重建),
-        # 但至少不应抛错
+        assert dj_cache.get(other_key) == [{"stale": True}]
+        assert dj_cache.get(ExcludeFieldsCache.EXCLUDE_FIELDS_KEY) == ["organization"]
+        assert dj_cache.get(ExcludeFieldsCache.MODEL_FIELDS_MAPPING_KEY) == {"host": {"organization": ["organization"]}}
+        assert fake.calls == []
+
+        monkeypatch.setattr(
+            "apps.cmdb.services.model.ModelManage.search_model_attr",
+            staticmethod(lambda model_id, *a, **k: [{"attr_id": "ip_addr"}]),
+        )
+        assert ExcludeFieldsCache.get_model_attrs("host") == [{"attr_id": "ip_addr"}]
 
     def test_clear_cache(self, monkeypatch):
-        from apps.cmdb.display_field.cache import ExcludeFieldsCache
         from django.core.cache import cache as dj_cache
+
+        from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
         dj_cache.set(ExcludeFieldsCache.EXCLUDE_FIELDS_KEY, ["a"])
         assert ExcludeFieldsCache.clear_cache() is True
         assert dj_cache.get(ExcludeFieldsCache.EXCLUDE_FIELDS_KEY) is None
 
     def test_get_cache_info(self, monkeypatch):
-        from apps.cmdb.display_field.cache import ExcludeFieldsCache
         from django.core.cache import cache as dj_cache
+
+        from apps.cmdb.display_field.cache import ExcludeFieldsCache
 
         dj_cache.set(ExcludeFieldsCache.EXCLUDE_FIELDS_KEY, ["organization", "pwd"])
         dj_cache.set(ExcludeFieldsCache.MODEL_FIELDS_MAPPING_KEY, {"host": {}})
@@ -1195,8 +1192,9 @@ class TestExcludeFieldsCache:
 @pytest.mark.django_db
 class TestMigrateFieldConstraintsCommand:
     def _run(self, monkeypatch, models, **opts):
-        from django.core.management import call_command
         from io import StringIO
+
+        from django.core.management import call_command
 
         _patch_graph(
             monkeypatch,
@@ -1221,7 +1219,6 @@ class TestMigrateFieldConstraintsCommand:
                 "attrs": json.dumps([{"attr_id": "ip", "attr_type": "str", "option": {}}]),
             }
         ]
-        captured = {}
 
         from apps.cmdb.management.commands import migrate_field_constraints as cmd_mod
 
@@ -1231,8 +1228,9 @@ class TestMigrateFieldConstraintsCommand:
             "apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change",
             classmethod(lambda cls, model_id: True),
         )
-        from django.core.management import call_command
         from io import StringIO
+
+        from django.core.management import call_command
 
         out = StringIO()
         call_command("migrate_field_constraints", "--dry-run", stdout=out, stderr=out)
@@ -1264,8 +1262,9 @@ class TestMigrateFieldConstraintsCommand:
             "apps.cmdb.display_field.ExcludeFieldsCache.update_on_model_change",
             classmethod(lambda cls, model_id: refreshed.append(model_id) or True),
         )
-        from django.core.management import call_command
         from io import StringIO
+
+        from django.core.management import call_command
 
         out = StringIO()
         call_command("migrate_field_constraints", stdout=out, stderr=out)
@@ -1339,9 +1338,11 @@ class TestMigrateFieldConstraintsCommand:
     def test_per_model_error_counted(self, monkeypatch):
         # attrs 无法解析 -> _migrate_model 抛错 -> errors+1，命令不崩溃
         models = [{"_id": "n1", "model_id": "host", "attrs": "not-json"}]
-        from apps.cmdb.management.commands import migrate_field_constraints as cmd_mod
-        from django.core.management import call_command
         from io import StringIO
+
+        from django.core.management import call_command
+
+        from apps.cmdb.management.commands import migrate_field_constraints as cmd_mod
 
         fake = FakeGraph(query_entity=(models, 1))
         monkeypatch.setattr(cmd_mod, "GraphClient", lambda *a, **k: fake)
@@ -1352,13 +1353,16 @@ class TestMigrateFieldConstraintsCommand:
         assert "1 个错误" in text
 
     def test_outer_query_error_handled(self, monkeypatch):
-        from apps.cmdb.management.commands import migrate_field_constraints as cmd_mod
-        from django.core.management import call_command
         from io import StringIO
+
+        from django.core.management import call_command
+
+        from apps.cmdb.management.commands import migrate_field_constraints as cmd_mod
 
         class _Boom(FakeGraph):
             def __getattr__(self, name):
                 if name == "query_entity":
+
                     def _q(*a, **k):
                         raise RuntimeError("connection refused")
 

--- a/server/apps/monitor/tests/test_plugin_controller.py
+++ b/server/apps/monitor/tests/test_plugin_controller.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.monitor.models import MonitorInstance, MonitorObject
 from apps.monitor.models.plugin import MonitorPlugin, MonitorPluginConfigTemplate
 from apps.monitor.utils import plugin_controller as pc
 from apps.monitor.utils.plugin_controller import Controller
@@ -113,10 +114,7 @@ class TestRenderTemplate:
 
     def test_host_os_disk_template_uses_defaults_when_fstype_config_is_missing(self):
         """回归：Host/OS 磁盘模板缺省文件系统过滤配置时仍可通过 default 渲染。"""
-        template_path = (
-            Path(__file__).resolve().parents[1]
-            / "support-files/plugins/Telegraf/host/os/disk.child.toml.j2"
-        )
+        template_path = Path(__file__).resolve().parents[1] / "support-files/plugins/Telegraf/host/os/disk.child.toml.j2"
         template_content = template_path.read_text()
 
         out = Controller({}).render_template(
@@ -136,13 +134,24 @@ class TestRenderTemplate:
 class TestGetTemplatesByCollector:
     def test_groups_by_type(self):
         plugin = MonitorPlugin.objects.create(
-            name="PCPlugin", collector="Telegraf", collect_type="snmp", template_type="builtin",
+            name="PCPlugin",
+            collector="Telegraf",
+            collect_type="snmp",
+            template_type="builtin",
         )
         MonitorPluginConfigTemplate.objects.create(
-            plugin=plugin, type="base", config_type="base", file_type="toml", content="a",
+            plugin=plugin,
+            type="base",
+            config_type="base",
+            file_type="toml",
+            content="a",
         )
         MonitorPluginConfigTemplate.objects.create(
-            plugin=plugin, type="child", config_type="child", file_type="toml", content="b",
+            plugin=plugin,
+            type="child",
+            config_type="child",
+            file_type="toml",
+            content="b",
         )
         ctrl = Controller({"monitor_plugin_id": plugin.id})
         out = ctrl.get_templates_by_collector("Telegraf", "snmp")
@@ -151,11 +160,74 @@ class TestGetTemplatesByCollector:
 
     def test_filters_by_collector_when_no_plugin_id(self):
         plugin = MonitorPlugin.objects.create(
-            name="PCPlugin2", collector="Exporter", collect_type="http", template_type="builtin",
+            name="PCPlugin2",
+            collector="Exporter",
+            collect_type="http",
+            template_type="builtin",
         )
         MonitorPluginConfigTemplate.objects.create(
-            plugin=plugin, type="base", config_type="base", file_type="yaml", content="c",
+            plugin=plugin,
+            type="base",
+            config_type="base",
+            file_type="yaml",
+            content="c",
         )
         ctrl = Controller({})
         out = ctrl.get_templates_by_collector("Exporter", "http")
         assert "base" in out
+
+
+@pytest.mark.django_db
+def test_controller_writes_node_configs_via_local_node_mgmt(mocker):
+    """采集配置必须本进程写入 NodeMgmt。
+
+    节点→监控 ingest 会在同一事务里更新 Node.monitor_id；若 Controller 再 NATS
+    到另一连接写 NodeCollectorConfiguration，InnoDB 外键会等待父行锁，调用方超时后记 skipped。
+    """
+    constructed = {}
+
+    class FakeNodeMgmt:
+        def __init__(self, is_local_client=False):
+            constructed["is_local_client"] = is_local_client
+
+        def batch_create_configs_and_child_configs(self, configs, child_configs):
+            constructed["called"] = True
+            constructed["configs"] = configs
+            constructed["child_configs"] = child_configs
+
+    mocker.patch("apps.monitor.utils.plugin_controller.NodeMgmt", FakeNodeMgmt)
+
+    host = MonitorObject.objects.create(name="Host", display_name="主机", level="base")
+    MonitorInstance.objects.create(id="('h1',)", name="h1", monitor_object=host)
+    plugin = MonitorPlugin.objects.create(name="Host", collector="Telegraf", collect_type="host")
+    plugin.monitor_object.add(host)
+    MonitorPluginConfigTemplate.objects.create(
+        plugin=plugin,
+        type="cpu",
+        config_type="child",
+        file_type="toml",
+        content='instance = "{{ instance_id }}"',
+    )
+
+    Controller(
+        {
+            "monitor_object_id": host.id,
+            "collector": "Telegraf",
+            "collect_type": "host",
+            "monitor_plugin_id": plugin.id,
+            "configs": [{"type": "cpu", "interval": 60}],
+            "instances": [
+                {
+                    "instance_id": "('h1',)",
+                    "instance_name": "h1",
+                    "node_ids": ["n-local-1"],
+                    "group_ids": [1],
+                    "instance_type": "os",
+                }
+            ],
+        }
+    ).controller()
+
+    assert constructed.get("is_local_client") is True
+    assert constructed.get("called") is True
+    assert constructed.get("child_configs")

--- a/server/apps/monitor/utils/plugin_controller.py
+++ b/server/apps/monitor/utils/plugin_controller.py
@@ -4,19 +4,13 @@ from jinja2 import BaseLoader, DebugUndefined
 from jinja2.defaults import DEFAULT_FILTERS
 
 from apps.core.exceptions.base_app_exception import BaseAppException, ValidationAppException
-from apps.core.utils.safe_template import (
-    TemplateSecurityError,
-    build_sandboxed_env,
-    sanitize_template_context,
-    validate_template_variables,
-)
 from apps.core.logger import monitor_logger as logger
+from apps.core.utils.safe_template import TemplateSecurityError, build_sandboxed_env, sanitize_template_context, validate_template_variables
 from apps.monitor.constants.database import DatabaseConstants
 from apps.monitor.models import CollectConfig, MonitorPlugin, MonitorPluginConfigTemplate
 from apps.monitor.services.website_config import normalize_website_request_config
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.rpc.node_mgmt import NodeMgmt
-
 
 _MONITOR_TEMPLATE_ALLOWED_FILTERS = (
     "default",
@@ -116,13 +110,7 @@ _MONITOR_TEMPLATE_ALLOWED_VARIABLES = {
 def _escape_toml_string(value):
     if not isinstance(value, str):
         value = str(value)
-    return (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-        .replace("\t", "\\t")
-    )
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
 
 
 def to_toml_dict(d):
@@ -142,9 +130,7 @@ def to_toml_str_array(value):
 
 def normalize_filter_list(value):
     """兼容旧导入路径；实现见 snmp_interface_filters.normalize_filter_list。"""
-    from apps.monitor.utils.snmp_interface_filters import (
-        normalize_filter_list as _normalize_filter_list,
-    )
+    from apps.monitor.utils.snmp_interface_filters import normalize_filter_list as _normalize_filter_list
 
     return _normalize_filter_list(value)
 
@@ -192,20 +178,10 @@ class Controller:
                     "to_toml_str_array": to_toml_str_array,
                 },
             )
-            missing_filters = [
-                name
-                for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
-                if name not in DEFAULT_FILTERS and name not in env.filters
-            ]
+            missing_filters = [name for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS if name not in DEFAULT_FILTERS and name not in env.filters]
             if missing_filters:
                 raise BaseAppException(f"Missing default Jinja filters: {', '.join(missing_filters)}")
-            env.filters.update(
-                {
-                    name: DEFAULT_FILTERS[name]
-                    for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS
-                    if name in DEFAULT_FILTERS
-                }
-            )
+            env.filters.update({name: DEFAULT_FILTERS[name] for name in _MONITOR_TEMPLATE_ALLOWED_FILTERS if name in DEFAULT_FILTERS})
             self._jinja_env = env
         return self._jinja_env
 
@@ -287,9 +263,7 @@ class Controller:
         template_content = ensure_core_network_ifmib_jinja(template_content, _context)
         # 接口过滤与公共 IF-MIB 同能力边界：非 Network Device（如 hardware_server）
         # 即使模板含 ifDescr，也不得静默注入默认 ifType 排除。
-        if is_ifmib_capable_render_context(_context) and needs_snmp_interface_filter_jinja(
-            template_content
-        ):
+        if is_ifmib_capable_render_context(_context) and needs_snmp_interface_filter_jinja(template_content):
             template_content = ensure_snmp_interface_filter_jinja(template_content)
 
         safe_context = sanitize_template_context(_context)
@@ -355,7 +329,7 @@ class Controller:
 
         return configs
 
-    def controller(self):
+    def controller(self):  # noqa: C901
         """
         创建采集配置的控制器方法
 
@@ -449,24 +423,15 @@ class Controller:
                     # 与 IF-MIB 能力判定一致：覆盖 snmp / snmp_h3c 等厂商 collect_type。
                     snmp_collect = str(collect_type or "").startswith("snmp")
                     if snmp_collect and is_child:
-                        from apps.monitor.utils.snmp_interface_filters import (
-                            assert_snmp_interface_filter_mutex_from_values,
-                        )
+                        from apps.monitor.utils.snmp_interface_filters import assert_snmp_interface_filter_mutex_from_values
 
                         # 互斥校验放在模板渲染前，避免被包装成「渲染采集模板失败」
                         assert_snmp_interface_filter_mutex_from_values(render_context)
-                    if (
-                        is_child
-                        and str(collect_type or "") == "exporter"
-                        and str(type_name or "").lower() == "kafka"
-                    ):
-                        from apps.monitor.utils.kafka_collect_timeouts import (
-                            assert_kafka_group_metrics_timeout_lt_interval,
-                        )
+                    if is_child and str(collect_type or "") == "exporter" and str(type_name or "").lower() == "kafka":
+                        from apps.monitor.utils.kafka_collect_timeouts import assert_kafka_group_metrics_timeout_lt_interval
 
                         assert_kafka_group_metrics_timeout_lt_interval(
-                            config_info.get("ENV_GROUP_METRICS_TIMEOUT")
-                            or env_config.get("GROUP_METRICS_TIMEOUT"),
+                            config_info.get("ENV_GROUP_METRICS_TIMEOUT") or env_config.get("GROUP_METRICS_TIMEOUT"),
                             config_info.get("interval"),
                         )
                     template_config = self.render_template(
@@ -480,9 +445,7 @@ class Controller:
                     raw_id = config_info.get("instance_id")
                     logical_id = config_info.get("logical_instance_value")
                     storage_id = config_info.get("storage_instance_key")
-                    logger.error(
-                        f"实例识别失败：type={type_name}, raw={raw_id}, logical={logical_id}, storage={storage_id}, 错误: {e}"
-                    )
+                    logger.error(f"实例识别失败：type={type_name}, raw={raw_id}, logical={logical_id}, storage={storage_id}, 错误: {e}")
                     raise BaseAppException(f"实例识别失败：type={type_name}, instance_id={raw_id}") from e
                 except Exception as e:
                     logger.error(f"渲染模板失败：type={type_name}, config_id={config_id}, instance_id={config_info.get('instance_id')}, 错误: {e}")
@@ -538,13 +501,14 @@ class Controller:
             logger.error(f"批量创建 CollectConfig 失败：{e}")
             raise
 
-        # 步骤3：原子性创建配置和子配置（RPC调用，底层有事务保护，失败会抛异常）
+        # 必须本进程写入：Controller 常处于外层 atomic（节点推送还会锁 Node 行）。
+        # 再 NATS 到另一连接写 NodeCollectorConfiguration 会与父行锁自死锁。
         if node_configs or node_child_configs:
             try:
-                NodeMgmt().batch_create_configs_and_child_configs(node_configs, node_child_configs)
+                NodeMgmt(is_local_client=True).batch_create_configs_and_child_configs(node_configs, node_child_configs)
                 logger.info(f"创建配置成功，node_config={len(node_configs)}个，child_config={len(node_child_configs)}个")
             except Exception as e:
-                logger.error(f"RPC 调用失败，配置创建失败：node_configs={len(node_configs)}, child_configs={len(node_child_configs)}, 错误: {e}")
+                logger.error(f"本进程写入采集配置失败：node_configs={len(node_configs)}, child_configs={len(node_child_configs)}, 错误: {e}")
                 raise
 
         logger.info(f"创建采集配置成功，共{len(collect_configs)}个配置")

--- a/server/apps/node_mgmt/services/module_push.py
+++ b/server/apps/node_mgmt/services/module_push.py
@@ -9,21 +9,16 @@ from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import node_logger as logger
 from apps.core.utils.current_team_scope import resolve_current_team_data_scope
 from apps.node_mgmt.models.sidecar import Node, NodeOrganization
-from apps.node_mgmt.services.module_push_contract import (
-    EVENT_LIFECYCLE,
-    EVENT_UPSERT,
-    IngestEnvelope,
-    PushTargetStatus,
-)
+from apps.node_mgmt.services.module_push_contract import EVENT_LIFECYCLE, EVENT_UPSERT, IngestEnvelope, PushTargetStatus
 from apps.rpc.cmdb import CMDB
 from apps.rpc.monitor import Monitor
 
 
 class MonitorLinkage:
-    """监控联动客户端：转发至 Monitor.ingest_from_source（NATS）。"""
+    """监控联动客户端：本进程执行 Monitor ingest，避免 NATS handler 再嵌套调 NodeMgmt。"""
 
     def ingest_from_source(self, **kwargs):
-        return Monitor().ingest_from_source(**kwargs)
+        return Monitor(is_local_client=True).ingest_from_source(**kwargs)
 
 
 def build_module_push_actor_scope(request) -> dict[str, Any]:
@@ -273,9 +268,7 @@ class ModulePushService:
 
     @classmethod
     def _build_envelope(cls, node: Node) -> dict[str, Any]:
-        org_ids = list(
-            NodeOrganization.objects.filter(node=node).values_list("organization", flat=True)
-        )
+        org_ids = list(NodeOrganization.objects.filter(node=node).values_list("organization", flat=True))
         cloud_region = node.cloud_region
         raw: dict[str, Any] = {
             "ip": node.ip,

--- a/server/apps/node_mgmt/tests/test_module_push_service.py
+++ b/server/apps/node_mgmt/tests/test_module_push_service.py
@@ -21,6 +21,22 @@ def node(db):
     return n
 
 
+def test_monitor_linkage_uses_local_ingest_client(mocker):
+    """节点推送已在 server 进程内，监控 ingest 必须本进程执行。
+
+    走真 NATS 时 handler 会再调 NodeMgmt 写采集配置，形成嵌套 RPC + Node 行锁自死锁，
+    调用方超时三次后把 push_status 记为 skipped。
+    """
+    monitor_cls = mocker.patch("apps.node_mgmt.services.module_push.Monitor")
+    monitor_cls.return_value.ingest_from_source.return_value = {"id": "mon-1", "created": True}
+    from apps.node_mgmt.services.module_push import MonitorLinkage
+
+    result = MonitorLinkage().ingest_from_source(source_module="node_mgmt")
+
+    monitor_cls.assert_called_once_with(is_local_client=True)
+    assert result["id"] == "mon-1"
+
+
 @pytest.mark.django_db
 def test_push_cmdb_only_does_not_call_monitor(mocker, node):
     cmdb = mocker.patch("apps.node_mgmt.services.module_push.CMDB")

--- a/specs/changes/node-cmdb-monitor-push-linkage/spec.md
+++ b/specs/changes/node-cmdb-monitor-push-linkage/spec.md
@@ -135,4 +135,6 @@ Status: ready
     - 各模块**自己创建主机后** best-effort 通知另外两边（钩子）；NATS 失败可回退本地 node ingest；回声/causation 防环。
     - 创建钩子通知 ≠ 暗建资产：监控侧无凭据不得新建。
   - 遗留：公开 CMDB `push_instance` 信封仍不携带凭据；扫描等特权路径经 `push_with_credential` 写入 `raw.credential` 并置 `allow_credential_create`，全局 `CMDB_CREDENTIAL_CREATE_ENABLED` 仍默认 False。
+  - **2026-08-19 修订**：CMDB 资产页无凭据「同步」改为探测建链，命中只写关联 ID、不覆盖监控业务字段、不新建。见 [`cmdb-monitor-probe-link`](../cmdb-monitor-probe-link/spec.md)。
+  - **2026-08-20 修订**：节点→监控推送在 server 进程内本进程执行 ingest；`Controller` 写采集配置走 `NodeMgmt(is_local_client=True)`。禁止 ingest 事务锁住 Node 行后再 NATS 写 `NodeCollectorConfiguration`（InnoDB 外键自死锁，调用方超时三次后 `skipped`）。
   - ~~CMDB/监控 → 节点自动关联~~：已收敛为节点对称 ingest + 创建钩子通知。


### PR DESCRIPTION
ingest 再经 NATS 写采集配置会与已锁的 Node 行形成 InnoDB 外键等待，调用方超时三次后记 skipped；模型字段变更也不再全量预热 CMDB 缓存。