### PR TITLE
fix(opspilot): 渠道/悬浮对话不再把规划 CUSTOM 事件渲成气泡

### DIFF
--- a/server/apps/opspilot/services/history_service.py
+++ b/server/apps/opspilot/services/history_service.py
@@ -47,11 +47,13 @@ class HistoryService:
         processed_history = []
         role_map = {"assistant": "bot"}
         for user_msg in chat_history[num:]:
-            message = user_msg.get("message", user_msg.get("text", ""))
-            if user_msg["event"] == "user" and isinstance(message, list):
+            event = str(user_msg.get("event") or user_msg.get("role") or "").strip().lower()
+            event = role_map.get(event, event or "user")
+            message = user_msg.get("message", user_msg.get("text", user_msg.get("content", "")))
+            if event == "user" and isinstance(message, list):
                 image_list = []
                 msg = ""
-                for item in user_msg["message"]:
+                for item in message:
                     if item["type"] == "image_url":
                         image_url = item.get("image_url", item.get("url"))
                         if isinstance(image_url, dict):
@@ -62,12 +64,12 @@ class HistoryService:
                         msg = item.get("text", "") or item.get("message", "")
                 processed_history.append({"event": "user", "message": msg, "image_data": image_list})
             else:
-                txt = user_msg.get("message", user_msg.get("text", ""))
+                txt = message
                 if isinstance(txt, list):
                     txt = "\n".join([i.get("message", i.get("text")) for i in txt])
                 processed_history.append(
                     {
-                        "event": role_map.get(user_msg["event"], user_msg["event"]),
+                        "event": event,
                         "message": txt,
                     }
                 )

--- a/server/apps/opspilot/services/skill_channel_chat_service.py
+++ b/server/apps/opspilot/services/skill_channel_chat_service.py
@@ -16,9 +16,10 @@ from apps.opspilot.models import LLMSkill, SkillChannel, SkillConversation, Skil
 from apps.opspilot.services.caller_identity import CALLER_IDENTITY_CONFIG_KEY, CallerIdentityError, capture_caller_identity
 from apps.opspilot.services.skill_channel_service import channel_allows_team, resolve_ops_pilot_guest_id
 from apps.opspilot.services.skill_package.runtime import build_skill_package_prompt, build_skill_package_strategy, hydrate_skill_packages
+from apps.opspilot.utils.agui_chat import stream_agui_chat
 from apps.opspilot.utils.prompt_utils import merge_skill_params
 from apps.opspilot.utils.skill_execution_params import resolve_request_tools
-from apps.opspilot.utils.sse_chat import create_error_stream_response, stream_chat
+from apps.opspilot.utils.sse_chat import create_error_stream_response
 
 
 class SkillChannelChatError(Exception):
@@ -201,13 +202,98 @@ def build_skill_chat_params(skill: LLMSkill, user_message: str, request_user, ex
     return params
 
 
+def parse_sse_json_payloads(text: str) -> list[dict]:
+    """从 SSE 分片中解析 data: JSON 行。"""
+    events = []
+    for line in text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        payload = line[6:].strip()
+        if not payload or payload == "[DONE]":
+            continue
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(data, dict):
+            events.append(data)
+    return events
+
+
+def assemble_assistant_persist_content(events: list[dict]) -> str:
+    """助手落库：有 AG-UI type 时存事件数组，供前端分步回放；否则拼 OpenAI 正文。"""
+    typed = [item for item in events if item.get("type")]
+    if typed:
+        return json.dumps(typed, ensure_ascii=False)
+    parts = []
+    for data in events:
+        delta = (((data.get("choices") or [{}])[0]).get("delta") or {}).get("content")
+        if delta:
+            parts.append(str(delta))
+        elif data.get("content") and "choices" not in data:
+            parts.append(str(data["content"]))
+    return "".join(parts).strip()
+
+
+def _looks_like_planned_execution_delta(delta: str) -> bool:
+    """TEXT_MESSAGE_CONTENT 误带规划 JSON 时不当成可见正文。"""
+    stripped = (delta or "").strip()
+    if not stripped.startswith("{"):
+        return False
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    phase = payload.get("phase")
+    return phase in {"planning", "planned", "replanning", "idle", "start", "end"}
+
+
+def visible_assistant_text(content: str) -> str:
+    """给模型的上下文只用可见正文，丢掉计划/工具等 AG-UI 事件。"""
+    if not content:
+        return ""
+    stripped = content.strip()
+    if not stripped.startswith("["):
+        return content
+    try:
+        events = json.loads(stripped)
+    except json.JSONDecodeError:
+        return content
+    if not (isinstance(events, list) and events and isinstance(events[0], dict) and events[0].get("type")):
+        return content
+    parts = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != "TEXT_MESSAGE_CONTENT":
+            continue
+        delta = event.get("delta") or ""
+        if delta and _looks_like_planned_execution_delta(str(delta)):
+            continue
+        if delta:
+            parts.append(str(delta))
+    return "".join(parts).strip()
+
+
 def _history_from_conversation(conversation: SkillConversation, window: int) -> list[dict]:
+    """从落库会话取出上下文，转成 chat_service 使用的 {event, message}。
+
+    当前用户话已作为 user_message 单独传入，最后一条 user 不重复进历史。
+    助手 AG-UI 事件数组会先抽成可见正文，避免计划/工具日志进入模型上下文。
+    """
     qs = conversation.messages.order_by("-created_at", "-id")[: max(window, 0) * 2]
     items = list(reversed(list(qs)))
-    history = []
+    if items and items[-1].role == SkillConversationMessage.ROLE_USER:
+        items = items[:-1]
+    raw = []
     for msg in items:
-        history.append({"role": msg.role if msg.role != "assistant" else "assistant", "content": msg.content})
-    return history
+        content = msg.content
+        if msg.role == SkillConversationMessage.ROLE_ASSISTANT:
+            content = visible_assistant_text(content)
+        raw.append({"role": msg.role, "content": content})
+    return normalize_client_chat_history(raw)
 
 
 def normalize_client_chat_history(raw) -> list[dict]:
@@ -305,6 +391,7 @@ def stream_skill_channel_chat(
     user = identity_user or request.user
     params = build_skill_chat_params(skill, user_message, user)
     params["chat_history"] = _history_from_conversation(conversation, skill.conversation_window_size or 10)
+    params["browser_use_force_task"] = True
     try:
         params[CALLER_IDENTITY_CONFIG_KEY] = capture_caller_identity(request, user)
     except CallerIdentityError as e:
@@ -316,7 +403,7 @@ def stream_skill_channel_chat(
     else:
         current_ip = request.META.get("REMOTE_ADDR", "")
 
-    base_response = stream_chat(params, skill.name, {}, current_ip, user_message)
+    base_response = stream_agui_chat(params, skill.name, {}, current_ip, user_message, skill_id=skill.id)
     return _wrap_stream_persist_assistant(base_response, conversation.id)
 
 
@@ -331,33 +418,19 @@ async def _aiter_stream(iterable):
 
 
 def _wrap_stream_persist_assistant(response: StreamingHttpResponse, conversation_id: int) -> StreamingHttpResponse:
-    """包装 SSE：尽量从 delta 拼出助手回复并落库。失败不影响流式输出。"""
+    """包装 SSE：落库 AG-UI 事件数组（或 OpenAI 正文）。失败不影响流式输出。"""
 
     original = response.streaming_content
 
     async def generator():
-        chunks: list[str] = []
+        events: list[dict] = []
         try:
             async for piece in _aiter_stream(original):
                 text = piece.decode("utf-8") if isinstance(piece, (bytes, bytearray)) else str(piece)
                 yield piece
-                for line in text.splitlines():
-                    if not line.startswith("data: "):
-                        continue
-                    payload = line[6:].strip()
-                    if payload == "[DONE]":
-                        continue
-                    try:
-                        data = json.loads(payload)
-                    except json.JSONDecodeError:
-                        continue
-                    delta = (((data.get("choices") or [{}])[0]).get("delta") or {}).get("content")
-                    if delta:
-                        chunks.append(delta)
-                    elif data.get("content"):
-                        chunks.append(str(data["content"]))
+                events.extend(parse_sse_json_payloads(text))
         finally:
-            content = "".join(chunks).strip()
+            content = assemble_assistant_persist_content(events)
             if content:
                 try:
                     await sync_to_async(append_message)(

--- a/server/apps/opspilot/tests/test_skill_channel_publish.py
+++ b/server/apps/opspilot/tests/test_skill_channel_publish.py
@@ -278,7 +278,7 @@ class TestPlatformListAndEmbeddedGate:
             format="json",
             HTTP_API_AUTHORIZATION=plain,
         )
-        with patch("apps.opspilot.services.skill_channel_chat_service.stream_chat") as mock_stream:
+        with patch("apps.opspilot.services.skill_channel_chat_service.stream_agui_chat") as mock_stream:
             from django.http import StreamingHttpResponse
 
             def gen():

--- a/server/apps/opspilot/tests/test_skill_channel_publish_coverage.py
+++ b/server/apps/opspilot/tests/test_skill_channel_publish_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -285,8 +286,15 @@ class TestChatServiceUnit:
         chat_svc.append_message(c1, "assistant", "b")
         c2 = chat_svc.get_or_create_conversation(ch, "u1", session_id="sid-1")
         assert c2.id == c1.id
+        from apps.opspilot.services.history_service import history_service
+
         hist = chat_svc._history_from_conversation(c1, 10)
-        assert hist[-1]["content"] == "b"
+        assert hist[-1]["event"] == "bot"
+        assert hist[-1]["message"] == "b"
+        assert history_service.process_chat_history(hist, 10, [])[-1]["event"] == "bot"
+        chat_svc.append_message(c1, "user", "current-turn")
+        hist2 = chat_svc._history_from_conversation(c1, 10)
+        assert [item["message"] for item in hist2] == ["a", "b"]
 
     def test_build_params_with_tools_and_extra(self):
         skill = _skill(tools=[{"name": "t1"}], skill_prompt="p", team=[1])
@@ -337,7 +345,7 @@ class TestChatServiceUnit:
             yield b'data: {"content":"!"}\n\n'
             yield b"data: [DONE]\n\n"
 
-        with patch("apps.opspilot.services.skill_channel_chat_service.stream_chat") as mock_stream:
+        with patch("apps.opspilot.services.skill_channel_chat_service.stream_agui_chat") as mock_stream:
             mock_stream.return_value = StreamingHttpResponse(gen(), content_type="text/event-stream")
             with patch(
                 "apps.opspilot.services.skill_channel_chat_service.capture_caller_identity",
@@ -378,6 +386,41 @@ class TestChatServiceUnit:
 
         chunks = asyncio.run(consume())
         assert chunks  # 至少透传了流式分片
+
+    def test_agui_persist_helpers_and_history_uses_visible_text(self):
+        events = [
+            {"type": "CUSTOM", "name": "planned_execution_status", "value": {"phase": "planning"}},
+            {
+                "type": "CUSTOM",
+                "name": "planned_execution_step",
+                "value": {
+                    "phase": "start",
+                    "step_index": 1,
+                    "total_steps": 1,
+                    "objective": "查询当前时间",
+                    "tools": ["get_current_time"],
+                },
+            },
+            {"type": "TEXT_MESSAGE_CONTENT", "delta": "现在是下午两点"},
+            {"type": "RUN_FINISHED"},
+        ]
+        sse_text = "".join(f"data: {json.dumps(item, ensure_ascii=False)}\n\n" for item in events) + "data: [DONE]\n\n"
+        parsed = chat_svc.parse_sse_json_payloads(sse_text)
+        assert [item.get("type") for item in parsed] == ["CUSTOM", "CUSTOM", "TEXT_MESSAGE_CONTENT", "RUN_FINISHED"]
+        content = chat_svc.assemble_assistant_persist_content(parsed)
+        assert json.loads(content)[0]["name"] == "planned_execution_status"
+        assert chat_svc.visible_assistant_text(content) == "现在是下午两点"
+        mixed = chat_svc.assemble_assistant_persist_content(events + [{"type": "TEXT_MESSAGE_CONTENT", "delta": '{"phase":"planning"}'}])
+        assert chat_svc.visible_assistant_text(mixed) == "现在是下午两点"
+        assert chat_svc.assemble_assistant_persist_content([{"choices": [{"delta": {"content": "hello"}}]}, {"content": "!"}]) == "hello!"
+
+        skill = _skill()
+        ch = _channel(skill)
+        conv = SkillConversation.objects.create(session_id="s-agui", skill=skill, channel=ch, external_user_id="u")
+        SkillConversationMessage.objects.create(conversation=conv, role="user", content="现在几点了")
+        SkillConversationMessage.objects.create(conversation=conv, role="assistant", content=content)
+        history = chat_svc._history_from_conversation(conv, 10)
+        assert history == [{"event": "user", "message": "现在几点了"}, {"event": "bot", "message": "现在是下午两点"}]
 
     def test_wrap_persist_swallows_db_error(self):
         skill = _skill()

--- a/server/apps/opspilot/tests/test_slice_opbiz_history_service.py
+++ b/server/apps/opspilot/tests/test_slice_opbiz_history_service.py
@@ -7,7 +7,6 @@ import pydantic.root_model  # noqa
 
 from apps.opspilot.services.history_service import HistoryService, history_service
 
-
 # ---------------------------------------------------------------------------
 # process_user_message_and_images
 # ---------------------------------------------------------------------------
@@ -118,6 +117,14 @@ class TestProcessChatHistory:
         history = [{"event": "user", "message": "上一句"}]
         out = HistoryService.process_chat_history(history, window_size=10, image_data=["new_img"])
         assert out[-1] == {"event": "user", "message": "", "image_data": ["new_img"]}
+
+    def test_role_content_openai_shape_accepted(self):
+        history = [
+            {"role": "user", "content": "问"},
+            {"role": "assistant", "content": "答"},
+        ]
+        out = HistoryService.process_chat_history(history, window_size=10, image_data=[])
+        assert out == [{"event": "user", "message": "问"}, {"event": "bot", "message": "答"}]
 
     def test_text_key_fallback_for_user(self):
         history = [{"event": "user", "text": "用 text 键"}]

--- a/web/scripts/opspilot-planned-execution-step-test.ts
+++ b/web/scripts/opspilot-planned-execution-step-test.ts
@@ -132,14 +132,71 @@ assert.equal(history.plannedExecutionSteps?.[0].status, 'done');
 assert.equal(history.isStreamingTools, false);
 assert.equal(history.toolCalls?.find((t) => t.id === 'tc-1')?.name, 'list_namespaces');
 
+const dumped = processHistoryMessageWithExtras(
+  JSON.stringify({ phase: 'start', step_index: 1, total_steps: 1, objective: '查询当前时间', tools: ['get_current_time'] }),
+  'bot'
+);
+assert.equal(dumped.content.includes('phase'), false);
+assert.equal(dumped.plannedExecutionSteps?.[0].objective, '查询当前时间');
+
+const wikiHistory = processHistoryMessageWithExtras(
+  [
+    { type: 'RUN_STARTED' },
+    {
+      type: 'CUSTOM',
+      name: 'wiki_citations',
+      value: { citations: [{ n: 1, kb_id: 1, kind: 'page', id: 9, title: '蓝鲸平台' }] },
+    },
+    { type: 'TEXT_MESSAGE_CONTENT', delta: '{"phase":"planning"}' },
+    { type: 'TEXT_MESSAGE_CONTENT', delta: '蓝鲸是腾讯蓝鲸智云。[1]' },
+    { type: 'RUN_FINISHED' },
+  ],
+  'bot'
+);
+assert.equal(wikiHistory.content.includes('蓝鲸是腾讯蓝鲸智云。[1]'), true);
+assert.equal(wikiHistory.content.includes('planning'), false);
+assert.equal(wikiHistory.wikiCitations?.[0].title, '蓝鲸平台');
+
+const stringCustom = processHistoryMessageWithExtras(
+  [
+    {
+      type: 'CUSTOM',
+      name: 'planned_execution_step',
+      value: JSON.stringify({ phase: 'start', step_index: 1, total_steps: 1, objective: '查询当前时间', tools: ['get_current_time'] }),
+    },
+    { type: 'TEXT_MESSAGE_CONTENT', delta: '现在下午两点' },
+  ],
+  'assistant'
+);
+assert.equal(stringCustom.content, '现在下午两点');
+assert.equal(stringCustom.plannedExecutionSteps?.[0].objective, '查询当前时间');
+
+import {
+  looksLikePlannedExecutionPayload,
+  stripPlannedExecutionDumps,
+  unwrapCustomValue,
+} from '../src/app/opspilot/components/custom-chat-sse/plannedExecutionPayload';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+
+assert.equal(looksLikePlannedExecutionPayload({ phase: 'planning' }), 'status');
+assert.equal(looksLikePlannedExecutionPayload({ phase: 'start', step_index: 1, objective: '查询当前时间' }), 'step');
+assert.equal(
+  looksLikePlannedExecutionPayload(unwrapCustomValue('{"phase":"planned","step_count":1,"goal":"获取当前时间"}')),
+  'status'
+);
+assert.equal(
+  stripPlannedExecutionDumps('{"phase":"planning"}\n\n现在是下午两点\n\n{"phase":"end","step_index":1,"total_steps":1,"objective":"查询时间"}'),
+  '现在是下午两点'
+);
 
 const root = join(process.cwd(), 'src/app/opspilot/components/custom-chat-sse');
 const handler = readFileSync(join(root, 'aguiMessageHandler.ts'), 'utf8');
 const ui = readFileSync(join(root, 'index.tsx'), 'utf8');
 assert.match(handler, /planned_execution_step/);
 assert.match(handler, /handlePlannedExecutionStep/);
+assert.match(handler, /applyPlannedExecutionText/);
 assert.match(ui, /PlannedExecutionSteps/);
+assert.match(ui, /stripPlannedExecutionDumps/);
 
 console.log('planned execution step state tests passed');

--- a/web/src/app/opspilot/(pages)/skill/chat/page.tsx
+++ b/web/src/app/opspilot/(pages)/skill/chat/page.tsx
@@ -167,7 +167,7 @@ const SkillWebChatPage: React.FC = () => {
       const data = await fetchSkillSessionMessages(id);
       const messages = (data || []).map((row: any) => {
         const role = row.conversation_role === 'user' ? 'user' : 'bot';
-        const processed = processHistoryMessageWithExtras(row.conversation_content, row.conversation_role);
+        const processed = processHistoryMessageWithExtras(row.conversation_content, role);
         return {
           id: String(row.id),
           role,
@@ -178,6 +178,7 @@ const SkillWebChatPage: React.FC = () => {
           browserStepsHistory: processed.browserStepsHistory ?? null,
           agentStepProgress: processed.agentStepProgress,
           plannedExecutionSteps: processed.plannedExecutionSteps,
+          wikiCitations: processed.wikiCitations,
           toolCalls: processed.toolCalls,
           isStreamingTools: false,
           configDiffReports: processed.configDiffReports,
@@ -266,6 +267,11 @@ const SkillWebChatPage: React.FC = () => {
     return {
       url,
       payload: { message, session_id: sessionId },
+      interruptRequest: {
+        enabled: true,
+        url: '/api/proxy/opspilot/bot_mgmt/interrupt_chat_flow_execution/',
+        reason: 'user_manual',
+      },
     };
   };
 

--- a/web/src/app/opspilot/(pages)/skill/detail/channel/page.tsx
+++ b/web/src/app/opspilot/(pages)/skill/detail/channel/page.tsx
@@ -255,7 +255,7 @@ const SkillChannelPage: React.FC = () => {
         ),
       },
       {
-        title: t('skill.channel.status', '状态'),
+        title: t('skill.channel.status', '启停'),
         dataIndex: 'enabled',
         key: 'enabled',
         width: 88,
@@ -267,7 +267,6 @@ const SkillChannelPage: React.FC = () => {
         title: t('common.action') || '操作',
         key: 'action',
         width: 220,
-        align: 'right' as const,
         render: (_: unknown, item: SkillChannelItem) => (
           <Space size="small">
             {item.channel_type === 'web_chat' ? (

--- a/web/src/app/opspilot/(pages)/studio/chat/page.tsx
+++ b/web/src/app/opspilot/(pages)/studio/chat/page.tsx
@@ -152,6 +152,7 @@ const StudioChatPage: React.FC = () => {
           browserStepsHistory: processed.browserStepsHistory ?? null,
           agentStepProgress: processed.agentStepProgress,
           plannedExecutionSteps: processed.plannedExecutionSteps,
+          wikiCitations: processed.wikiCitations,
           toolCalls: processed.toolCalls,
           isStreamingTools: false,
           configDiffReports: processed.configDiffReports,

--- a/web/src/app/opspilot/components/custom-chat-sse/aguiMessageHandler.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/aguiMessageHandler.ts
@@ -56,6 +56,11 @@ import {
   PlannedExecutionState,
 } from './plannedExecutionState';
 import type { PlannedExecutionStatusValue, PlannedExecutionStepValue } from '@/app/opspilot/types/chat';
+import {
+  looksLikePlannedExecutionPayload,
+  unwrapCustomValue,
+  tryParseJsonValue,
+} from './plannedExecutionPayload';
 import { isToolResultErrorContent } from './toolResultStatus';
 
 export { isToolResultErrorContent } from './toolResultStatus';
@@ -313,6 +318,9 @@ export class AGUIMessageHandler {
     for (const block of this.contentBlocks) {
       if (block.type === 'text') {
         // 遇到文本块，先输出累积的工具调用
+        if (looksLikePlannedExecutionPayload(tryParseJsonValue(block.content))) {
+          continue;
+        }
         flushToolCalls();
         if (parts.length > 0) {
           parts.push('\n\n' + block.content);
@@ -360,7 +368,7 @@ export class AGUIMessageHandler {
     flushToolCalls();
 
     // 添加当前正在累积的文本
-    if (this.currentTextBlock) {
+    if (this.currentTextBlock && !looksLikePlannedExecutionPayload(tryParseJsonValue(this.currentTextBlock))) {
       if (parts.length > 0 && lastBlockType !== 'text') {
         parts.push('\n\n' + this.currentTextBlock);
       } else if (parts.length > 0) {
@@ -389,10 +397,45 @@ export class AGUIMessageHandler {
    * 提交当前文本块
    */
   private flushCurrentTextBlock() {
-    if (this.currentTextBlock) {
-      this.contentBlocks.push({ type: 'text', content: this.currentTextBlock });
-      this.currentTextBlock = '';
+    if (!this.currentTextBlock) {
+      return;
     }
+    const pending = this.currentTextBlock;
+    this.currentTextBlock = '';
+    if (this.applyPlannedExecutionText(pending)) {
+      return;
+    }
+    this.contentBlocks.push({ type: 'text', content: pending });
+  }
+
+  private applyPlannedExecutionText(raw: string): boolean {
+    const parsed = unwrapCustomValue(tryParseJsonValue(raw));
+    const kind = looksLikePlannedExecutionPayload(parsed);
+    if (!kind || !parsed || typeof parsed !== 'object') {
+      return false;
+    }
+    if (kind === 'status') {
+      const value = parsed as PlannedExecutionStatusValue;
+      this.plannedExecutionStatus = {
+        phase: String(value.phase || ''),
+        step_count: value.step_count,
+        goal: value.goal,
+        replan_count: value.replan_count,
+        reason: value.reason,
+      };
+      return true;
+    }
+    this.plannedExecutionState = applyPlannedExecutionStep(
+      this.plannedExecutionState,
+      parsed as PlannedExecutionStepValue
+    );
+    if (this.plannedExecutionStatus) {
+      this.plannedExecutionStatus = {
+        ...this.plannedExecutionStatus,
+        phase: 'idle',
+      };
+    }
+    return true;
   }
 
   /**
@@ -432,7 +475,14 @@ export class AGUIMessageHandler {
    */
   handleTextContent(delta: string) {
     this.stopThinking();
+    if (this.applyPlannedExecutionText(delta)) {
+      this.updateMessageContent(this.getFullContent(), undefined, undefined, this.thinkingContent, this.isThinking);
+      return;
+    }
     this.currentTextBlock += delta;
+    if (this.applyPlannedExecutionText(this.currentTextBlock)) {
+      this.currentTextBlock = '';
+    }
     this.updateMessageContent(this.getFullContent(), undefined, undefined, this.thinkingContent, this.isThinking);
   }
 
@@ -952,26 +1002,36 @@ export class AGUIMessageHandler {
         this.updateMessageContent(this.getFullContent(), undefined, undefined, this.thinkingContent, this.isThinking);
         return false;
 
-      case 'TOOL_CALL_START':
-        if (aguiData.toolCallId && aguiData.toolCallName) {
-          this.handleToolCallStart(aguiData.toolCallId, aguiData.toolCallName);
+      case 'TOOL_CALL_START': {
+        const snake = aguiData as unknown as { tool_call_id?: string; tool_call_name?: string };
+        const toolCallId = aguiData.toolCallId || snake.tool_call_id;
+        const toolCallName = aguiData.toolCallName || snake.tool_call_name;
+        if (toolCallId && toolCallName) {
+          this.handleToolCallStart(toolCallId, toolCallName);
         }
         return false;
+      }
 
-      case 'TOOL_CALL_ARGS':
-        if (aguiData.toolCallId && aguiData.delta) {
-          this.handleToolCallArgs(aguiData.toolCallId, aguiData.delta);
+      case 'TOOL_CALL_ARGS': {
+        const toolCallId = aguiData.toolCallId
+          || (aguiData as unknown as { tool_call_id?: string }).tool_call_id;
+        if (toolCallId && aguiData.delta) {
+          this.handleToolCallArgs(toolCallId, aguiData.delta);
         }
         return false;
+      }
 
       case 'TOOL_CALL_END':
         return false;
 
-      case 'TOOL_CALL_RESULT':
-        if (aguiData.toolCallId && aguiData.content !== undefined) {
-          this.handleToolCallResult(aguiData.toolCallId, aguiData.content);
+      case 'TOOL_CALL_RESULT': {
+        const toolCallId = aguiData.toolCallId
+          || (aguiData as unknown as { tool_call_id?: string }).tool_call_id;
+        if (toolCallId && aguiData.content !== undefined) {
+          this.handleToolCallResult(toolCallId, aguiData.content);
         }
         return false;
+      }
 
       case 'ERROR':
         if (aguiData.error) {
@@ -999,41 +1059,47 @@ export class AGUIMessageHandler {
         this.updateMessageContent(this.getFullContent(), undefined, undefined, this.thinkingContent, false);
         return true;
 
-      case 'CUSTOM':
-        if (aguiData.name === 'browser_step_progress' && aguiData.value) {
-          this.handleBrowserStepProgress(aguiData.value as BrowserStepProgressValue);
-        } else if (aguiData.name === 'browser_task_received' && aguiData.value) {
-          this.handleBrowserTaskReceived(aguiData.value as BrowserTaskReceivedValue);
-        } else if (aguiData.name === 'approval_request' && aguiData.value) {
-          this.handleApprovalRequest(aguiData.value as ApprovalRequestValue);
-        } else if (aguiData.name === 'user_choice_request' && aguiData.value) {
-          this.handleUserChoiceRequest(aguiData.value as UserChoiceRequestValue);
-        } else if (aguiData.name === 'user_choice_result' && aguiData.value) {
-          this.handleUserChoiceResult(aguiData.value as { choice_id: string; selected: string[]; source: string });
-        } else if (aguiData.name === 'repair_diff_report' && aguiData.value) {
-          this.handleConfigDiffReport(aguiData.value as unknown as ConfigDiffReportValue);
-        } else if (aguiData.name === 'config_analysis_report' && aguiData.value) {
-          this.handleConfigAnalysisReport(aguiData.value as ConfigAnalysisReportValue);
-        } else if (aguiData.name === 'report_file_download' && aguiData.value) {
-          this.handleReportFileDownload(aguiData.value as unknown as ReportFileDownloadValue);
-        } else if (aguiData.name === 'repair_commands' && aguiData.value) {
-          this.handleRepairCommands(aguiData.value as unknown as RepairCommandsValue);
-        } else if (aguiData.name === 'agent_step_progress' && aguiData.value) {
-          this.handleAgentStepProgress(aguiData.value as AgentStepProgressValue);
-        } else if (aguiData.name === 'sub_agent_progress' && aguiData.value) {
-          this.handleSubAgentProgress(aguiData.value as SubAgentProgressValue);
-        } else if (aguiData.name === 'skill_view' && aguiData.value) {
-          this.handleSkillView(aguiData.value as SkillViewValue);
-        } else if (aguiData.name === 'wiki_citations' && aguiData.value) {
-          this.handleWikiCitations(aguiData.value as { citations?: WikiCitation[] });
-        } else if (aguiData.name === 'planned_execution_step' && aguiData.value) {
-          this.handlePlannedExecutionStep(aguiData.value as PlannedExecutionStepValue);
-        } else if (aguiData.name === 'planned_execution_status' && aguiData.value) {
-          this.handlePlannedExecutionStatus(aguiData.value as PlannedExecutionStatusValue);
-        } else if (aguiData.name === 'assistant_text_retract') {
+      case 'CUSTOM': {
+        const customValue = unwrapCustomValue(aguiData.value);
+        const customName = aguiData.name || (typeof customValue === 'object' && customValue && 'name' in customValue
+          ? String((customValue as { name?: string }).name || '')
+          : '');
+        const plannedKind = looksLikePlannedExecutionPayload(customValue);
+        if (customName === 'browser_step_progress' && customValue) {
+          this.handleBrowserStepProgress(customValue as BrowserStepProgressValue);
+        } else if (customName === 'browser_task_received' && customValue) {
+          this.handleBrowserTaskReceived(customValue as BrowserTaskReceivedValue);
+        } else if (customName === 'approval_request' && customValue) {
+          this.handleApprovalRequest(customValue as ApprovalRequestValue);
+        } else if (customName === 'user_choice_request' && customValue) {
+          this.handleUserChoiceRequest(customValue as UserChoiceRequestValue);
+        } else if (customName === 'user_choice_result' && customValue) {
+          this.handleUserChoiceResult(customValue as { choice_id: string; selected: string[]; source: string });
+        } else if (customName === 'repair_diff_report' && customValue) {
+          this.handleConfigDiffReport(customValue as unknown as ConfigDiffReportValue);
+        } else if (customName === 'config_analysis_report' && customValue) {
+          this.handleConfigAnalysisReport(customValue as ConfigAnalysisReportValue);
+        } else if (customName === 'report_file_download' && customValue) {
+          this.handleReportFileDownload(customValue as unknown as ReportFileDownloadValue);
+        } else if (customName === 'repair_commands' && customValue) {
+          this.handleRepairCommands(customValue as unknown as RepairCommandsValue);
+        } else if (customName === 'agent_step_progress' && customValue) {
+          this.handleAgentStepProgress(customValue as AgentStepProgressValue);
+        } else if (customName === 'sub_agent_progress' && customValue) {
+          this.handleSubAgentProgress(customValue as SubAgentProgressValue);
+        } else if (customName === 'skill_view' && customValue) {
+          this.handleSkillView(customValue as SkillViewValue);
+        } else if (customName === 'wiki_citations' && customValue) {
+          this.handleWikiCitations(customValue as { citations?: WikiCitation[] });
+        } else if (customName === 'planned_execution_step' || plannedKind === 'step') {
+          this.handlePlannedExecutionStep(customValue as PlannedExecutionStepValue);
+        } else if (customName === 'planned_execution_status' || plannedKind === 'status') {
+          this.handlePlannedExecutionStatus(customValue as PlannedExecutionStatusValue);
+        } else if (customName === 'assistant_text_retract') {
           this.handleAssistantTextRetract();
         }
         return false;
+      }
 
       default:
         console.warn('[AG-UI] Unknown message type:', aguiData.type);

--- a/web/src/app/opspilot/components/custom-chat-sse/historyMessageProcessor.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/historyMessageProcessor.ts
@@ -14,6 +14,7 @@ import {
   RepairCommands,
   ReportFileDownload,
   UserChoiceRequest,
+  WikiCitation,
 } from '@/app/opspilot/types/global';
 import { initToolCallTooltips, renderErrorMessage, ToolCallInfo } from './toolCallRenderer';
 import {
@@ -26,6 +27,7 @@ import {
 } from './plannedExecutionState';
 import { isToolResultErrorContent } from './toolResultStatus';
 import type { PlannedExecutionStepValue } from '@/app/opspilot/types/chat';
+import { isRecord, looksLikePlannedExecutionPayload, unwrapCustomValue } from './plannedExecutionPayload';
 
 const escapeNewlinesInStrings = (raw: string) => {
   let result = '';
@@ -288,10 +290,14 @@ const parseJsonArray = (raw: string): any[] | null => {
   };
 
   const extractArraySlice = (value: string) => {
-    const start = value.indexOf('[');
-    const end = value.lastIndexOf(']');
-    if (start >= 0 && end > start) {
-      return value.slice(start, end + 1);
+    // 只裁顶层数组。对象里的 tools: [...] 不能当成事件列表，否则规划 JSON 会被解析成 ["get_current_time"]。
+    const trimmed = value.trim();
+    if (!trimmed.startsWith('[')) {
+      return value;
+    }
+    const end = trimmed.lastIndexOf(']');
+    if (end > 0) {
+      return trimmed.slice(0, end + 1);
     }
     return value;
   };
@@ -350,6 +356,7 @@ const buildFromEvents = (events: any[], finalize = true) => {
   let lastStep: BrowserStepProgressData | null = null;
   const pendingToolIds: string[] = [];
   let plannedExecutionState = createPlannedExecutionState();
+  const wikiCitations: WikiCitation[] = [];
 
   const flushToolCalls = () => {
     if (pendingToolIds.length > 0) {
@@ -402,6 +409,20 @@ const buildFromEvents = (events: any[], finalize = true) => {
 
       case 'TEXT_MESSAGE_CONTENT':
         isThinking = false;
+        {
+          const plannedPayload = unwrapCustomValue(msg.delta);
+          const plannedKind = looksLikePlannedExecutionPayload(plannedPayload);
+          if (plannedKind === 'step') {
+            plannedExecutionState = applyPlannedExecutionStep(
+              plannedExecutionState,
+              plannedPayload as PlannedExecutionStepValue
+            );
+            break;
+          }
+          if (plannedKind === 'status') {
+            break;
+          }
+        }
         // If pending tool calls exist and this is the start of new text, flush them
         if (pendingToolIds.length > 0 && !currentText) {
           flushToolCalls();
@@ -494,66 +515,79 @@ const buildFromEvents = (events: any[], finalize = true) => {
 
       case 'CUSTOM':
         isThinking = false;
-        if (msg.name === 'browser_step_progress' && msg.value) {
-          upsertStep(msg.value as BrowserStepProgressData);
-        } else if (msg.name === 'browser_task_received' && msg.value) {
-          const browserTaskReceived = msg.value as BrowserTaskReceivedData;
-          const toolCallId = findLatestCallingToolCallId(typeof browserTaskReceived.tool === 'string' ? browserTaskReceived.tool : undefined);
-          if (toolCallId) {
-            const tool = toolCalls.get(toolCallId);
-            if (tool) {
-              tool.browserTaskReceived = browserTaskReceived;
-            }
-          }
-        } else if (msg.name === 'agent_step_progress' && msg.value) {
-          const data = msg.value as any;
-          const key = `${data.agent_name || 'main'}_${data.step}`;
-          const existingIdx = agentSteps.findIndex(
-            (d: any) => `${d.agent_name || 'main'}_${d.step}` === key
-          );
-          if (existingIdx >= 0) {
-            agentSteps[existingIdx] = data;
-          } else {
-            agentSteps.push(data);
-          }
-        } else if (msg.name === 'sub_agent_progress' && msg.value) {
-          const data = msg.value as any;
-          const newStep = {
-            agent_name: data.agent_name,
-            step: 0,
-            max_steps: 0,
-            status: data.status,
-            description: data.description,
-          };
-          const existingIdx = agentSteps.findIndex(
-            (d: any) => d.agent_name === data.agent_name && (d.status === 'started' || d.status === 'running')
-          );
-          if (existingIdx >= 0 && (data.status === 'completed' || data.status === 'error')) {
-            agentSteps[existingIdx] = newStep;
-          } else {
-            agentSteps.push(newStep);
-          }
-        } else if (msg.name === 'skill_view' && msg.value && Array.isArray(msg.value.items)) {
-          skillViews.splice(0, skillViews.length, ...msg.value.items.filter((item: any) => item?.name));
-        } else if (msg.name === 'planned_execution_step' && msg.value) {
-          plannedExecutionState = applyPlannedExecutionStep(
-            plannedExecutionState,
-            msg.value as PlannedExecutionStepValue
-          );
-          const stepValue = msg.value as PlannedExecutionStepValue;
-          if (stepValue.phase === 'end' && isFailedPlannedStepStatus(stepValue.status)) {
-            const step = plannedExecutionState.steps.find(
-              (item) => item.step_index === Number(stepValue.step_index)
-            );
-            const errorText =
-              (typeof stepValue.error === 'string' && stepValue.error.trim()) ||
-              step?.error ||
-              '步骤因凭据、权限或配置失败已中止';
-            for (const toolCallId of step?.toolCallIds || []) {
+        {
+          const customValue = unwrapCustomValue(msg.value);
+          const customName = msg.name || (isRecord(customValue) ? String(customValue.name || '') : '');
+          const plannedKind = looksLikePlannedExecutionPayload(customValue);
+          if (customName === 'browser_step_progress' && customValue) {
+            upsertStep(customValue as BrowserStepProgressData);
+          } else if (customName === 'browser_task_received' && customValue) {
+            const browserTaskReceived = customValue as BrowserTaskReceivedData;
+            const toolCallId = findLatestCallingToolCallId(typeof browserTaskReceived.tool === 'string' ? browserTaskReceived.tool : undefined);
+            if (toolCallId) {
               const tool = toolCalls.get(toolCallId);
-              if (!tool || tool.status !== 'calling') continue;
-              tool.status = 'error';
-              tool.result = errorText;
+              if (tool) {
+                tool.browserTaskReceived = browserTaskReceived;
+              }
+            }
+          } else if (customName === 'agent_step_progress' && customValue) {
+            const data = customValue as any;
+            const key = `${data.agent_name || 'main'}_${data.step}`;
+            const existingIdx = agentSteps.findIndex(
+              (d: any) => `${d.agent_name || 'main'}_${d.step}` === key
+            );
+            if (existingIdx >= 0) {
+              agentSteps[existingIdx] = data;
+            } else {
+              agentSteps.push(data);
+            }
+          } else if (customName === 'sub_agent_progress' && customValue) {
+            const data = customValue as any;
+            const newStep = {
+              agent_name: data.agent_name,
+              step: 0,
+              max_steps: 0,
+              status: data.status,
+              description: data.description,
+            };
+            const existingIdx = agentSteps.findIndex(
+              (d: any) => d.agent_name === data.agent_name && (d.status === 'started' || d.status === 'running')
+            );
+            if (existingIdx >= 0 && (data.status === 'completed' || data.status === 'error')) {
+              agentSteps[existingIdx] = newStep;
+            } else {
+              agentSteps.push(newStep);
+            }
+          } else if (customName === 'skill_view' && customValue && Array.isArray((customValue as any).items)) {
+            skillViews.splice(0, skillViews.length, ...(customValue as any).items.filter((item: any) => item?.name));
+          } else if (customName === 'wiki_citations' && customValue) {
+            const items = Array.isArray((customValue as { citations?: WikiCitation[] }).citations)
+              ? (customValue as { citations: WikiCitation[] }).citations
+              : Array.isArray(customValue)
+                ? customValue
+                : [];
+            for (const item of items) {
+              if (item && typeof item.n === 'number' && item.id) {
+                wikiCitations.push(item);
+              }
+            }
+          } else if (customName === 'planned_execution_step' || plannedKind === 'step') {
+            const stepValue = customValue as PlannedExecutionStepValue;
+            plannedExecutionState = applyPlannedExecutionStep(plannedExecutionState, stepValue);
+            if (stepValue?.phase === 'end' && isFailedPlannedStepStatus(stepValue.status)) {
+              const step = plannedExecutionState.steps.find(
+                (item) => item.step_index === Number(stepValue.step_index)
+              );
+              const errorText =
+                (typeof stepValue.error === 'string' && stepValue.error.trim()) ||
+                step?.error ||
+                '步骤因凭据、权限或配置失败已中止';
+              for (const toolCallId of step?.toolCallIds || []) {
+                const tool = toolCalls.get(toolCallId);
+                if (!tool || tool.status !== 'calling') continue;
+                tool.status = 'error';
+                tool.result = errorText;
+              }
             }
           }
         }
@@ -567,15 +601,23 @@ const buildFromEvents = (events: any[], finalize = true) => {
         plannedExecutionState = finalizePlannedExecutionSteps(plannedExecutionState);
         break;
 
-      default:
+      default: {
+        const plannedKind = looksLikePlannedExecutionPayload(msg);
+        if (plannedKind === 'step') {
+          plannedExecutionState = applyPlannedExecutionStep(
+            plannedExecutionState,
+            msg as PlannedExecutionStepValue
+          );
+        }
         break;
+      }
     }
   });
 
   // 输出剩余的工具调用占位
   flushToolCalls();
 
-  if (currentText) {
+  if (currentText && !looksLikePlannedExecutionPayload(currentText)) {
     if (parts.length > 0 && lastBlockType !== 'text') {
       parts.push('\n\n' + currentText);
     } else {
@@ -613,6 +655,7 @@ const buildFromEvents = (events: any[], finalize = true) => {
     agentStepProgress: agentSteps.length > 0 ? agentSteps : undefined,
     skillViews: skillViews.length > 0 ? skillViews : undefined,
     reportFileDownloads: reportFileDownloads.length > 0 ? reportFileDownloads : undefined,
+    wikiCitations: wikiCitations.length > 0 ? wikiCitations : undefined,
     plannedExecutionSteps,
     isStreamingTools: finalize ? false : Boolean(plannedExecutionSteps?.some((s) => s.status === 'running')),
     toolCalls: toolCalls.size > 0 ? Array.from(toolCalls.entries()).map(([id, info]) => ({
@@ -635,7 +678,7 @@ export const processHistoryMessageContent = (content: string, role: string): str
   }
 
   // 非 bot 消息直接返回
-  if (role !== 'bot') return typeof content === 'string' ? content : String(content ?? '');
+  if (role !== 'bot' && role !== 'assistant') return typeof content === 'string' ? content : String(content ?? '');
 
   if (Array.isArray(content)) {
     return buildFromEvents(content, true).content;
@@ -677,10 +720,11 @@ export const processHistoryMessageWithExtras = (
   repairCommands?: RepairCommands[];
   reportFileDownloads?: ReportFileDownload[];
   plannedExecutionSteps?: PlannedExecutionStepView[];
+  wikiCitations?: WikiCitation[];
   isStreamingTools?: boolean;
   toolCalls?: Array<{ id: string; name: string; args: string; status: 'calling' | 'completed' | 'error'; result?: string }>;
 } => {
-  if (role !== 'bot') {
+  if (role !== 'bot' && role !== 'assistant') {
     return {
       content: typeof content === 'string' ? content : String(content ?? ''),
       thinking: '',
@@ -693,6 +737,10 @@ export const processHistoryMessageWithExtras = (
 
   if (Array.isArray(content)) {
     return buildFromEvents(content, true);
+  }
+
+  if (content && typeof content === 'object') {
+    return buildFromEvents([content], true);
   }
 
   if (typeof content !== 'string') {
@@ -716,6 +764,14 @@ export const processHistoryMessageWithExtras = (
       browserStepsHistory: null,
       reportFileDownloads: undefined,
     };
+  }
+
+  if (
+    parsedContent.length > 0
+    && parsedContent.every((item) => typeof item === 'string')
+    && looksLikePlannedExecutionPayload(content)
+  ) {
+    return buildFromEvents([unwrapCustomValue(content)], true);
   }
 
   return buildFromEvents(parsedContent, true);

--- a/web/src/app/opspilot/components/custom-chat-sse/index.tsx
+++ b/web/src/app/opspilot/components/custom-chat-sse/index.tsx
@@ -33,6 +33,7 @@ import {CustomChatSSEProps, GuideParseResult} from '@/app/opspilot/types/chat';
 import {useSSEStream} from './hooks/useSSEStream';
 import {useSendMessage} from './hooks/useSendMessage';
 import {initToolCallTooltips} from './toolCallRenderer';
+import { stripPlannedExecutionDumps } from './plannedExecutionPayload';
 
 const normalizeThinkingText = (value?: string) => {
   if (!value) return '';
@@ -617,7 +618,7 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
       ? reportFileDownloads.filter(isRenderableReportDownload)
       : [];
 
-    let replacedContent = parseReferenceLinks(content || '');
+    let replacedContent = parseReferenceLinks(stripPlannedExecutionDumps(content || ''));
     replacedContent = parseSuggestionLinks(replacedContent);
     replacedContent = rewriteAttachmentDownloadMentions(replacedContent, reportFileDownloads);
 
@@ -629,18 +630,21 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
       const hasMarkers = markerPattern.test(replacedContent);
 
       if (!hasMarkers) {
-        // No markers — render as single block with fallback positions
-        const html = sanitizeHtml(hydrateGeneratedFileLinks(sanitizeHtml(md.render(replacedContent)), reportFileDownloads));
+        const html = replacedContent.trim()
+          ? sanitizeHtml(hydrateGeneratedFileLinks(sanitizeHtml(md.render(replacedContent)), reportFileDownloads))
+          : '';
         return (
           <>
-            <div
-              dangerouslySetInnerHTML={{ __html: html }}
-              className={styles.markdownBody}
-              onClick={e => {
-                handleToolCallClick(e);
-                handleSuggestionClick(e);
-              }}
-            />
+            {html ? (
+              <div
+                dangerouslySetInnerHTML={{ __html: html }}
+                className={styles.markdownBody}
+                onClick={e => {
+                  handleToolCallClick(e);
+                  handleSuggestionClick(e);
+                }}
+              />
+            ) : null}
             {Array.isArray(configDiffReports) && configDiffReports.length > 0 && (
               <div className="mt-2">
                 {[...configDiffReports].sort((a, b) => (a.received_at || 0) - (b.received_at || 0)).map(report => (
@@ -872,7 +876,7 @@ const CustomChatSSE: React.FC<CustomChatSSEProps> = ({
           <BrowserStepProgress history={browserStepsHistory} />
         )}
         {renderContentWithInlineComponents()}
-        {!!msg.wikiCitations?.length && <WikiCitations citations={msg.wikiCitations} content={msg.content} />}
+        {!!msg.wikiCitations?.length && <WikiCitations citations={msg.wikiCitations} content={replacedContent} />}
       </>
     );
   };

--- a/web/src/app/opspilot/components/custom-chat-sse/plannedExecutionPayload.ts
+++ b/web/src/app/opspilot/components/custom-chat-sse/plannedExecutionPayload.ts
@@ -1,0 +1,108 @@
+/**
+ * 识别误入正文的 DeepAgent 规划载荷，避免 CUSTOM 事件被当成聊天气泡。
+ */
+
+export type PlannedExecutionKind = 'status' | 'step';
+
+const STATUS_PHASES = new Set(['planning', 'planned', 'replanning', 'idle']);
+const STEP_PHASES = new Set(['start', 'end']);
+
+export const tryParseJsonValue = (raw: string): unknown => {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+    return null;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+};
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+export const unwrapCustomValue = (value: unknown): unknown => {
+  if (typeof value === 'string') {
+    const parsed = tryParseJsonValue(value);
+    return parsed == null ? value : unwrapCustomValue(parsed);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+  if (isRecord(value.data) && looksLikePlannedExecutionPayload(value.data)) {
+    return value.data;
+  }
+  if (isRecord(value.value) && looksLikePlannedExecutionPayload(value.value)) {
+    return value.value;
+  }
+  return value;
+};
+
+export const looksLikePlannedExecutionPayload = (value: unknown): PlannedExecutionKind | null => {
+  const payload = unwrapCustomValue(value);
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const phase = typeof payload.phase === 'string' ? payload.phase : '';
+  if (STATUS_PHASES.has(phase) && payload.step_index == null) {
+    return 'status';
+  }
+  if (STEP_PHASES.has(phase) && (payload.step_index != null || payload.objective != null || Array.isArray(payload.tools))) {
+    return 'step';
+  }
+  return null;
+};
+
+export const plannedExecutionKindFromText = (raw: string): PlannedExecutionKind | null => {
+  return looksLikePlannedExecutionPayload(tryParseJsonValue(raw));
+};
+
+const extractTopLevelObjects = (value: string): string[] => {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === '{') {
+      if (depth === 0) start = i;
+      depth += 1;
+      continue;
+    }
+    if (ch === '}' && depth > 0) {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        objects.push(value.slice(start, i + 1));
+        start = -1;
+      }
+    }
+  }
+  return objects;
+};
+
+/** 从 Markdown 正文里剔除误入的规划 JSON，只留下最终回答。 */
+export const stripPlannedExecutionDumps = (content: string): string => {
+  if (!content) return '';
+  let result = content.replace(/^\s*planned_execution_(?:status|step)\s+/gm, '');
+  for (const slice of extractTopLevelObjects(result)) {
+    if (looksLikePlannedExecutionPayload(tryParseJsonValue(slice))) {
+      result = result.replace(slice, '');
+    }
+  }
+  return result.replace(/\n{3,}/g, '\n\n').trim();
+};

--- a/web/src/app/opspilot/constants/menu.json
+++ b/web/src/app/opspilot/constants/menu.json
@@ -71,7 +71,7 @@
           "name": "skill_setting"
         },
         {
-          "title": "渠道发布",
+          "title": "发布",
           "url": "/opspilot/skill/detail/channel",
           "icon": "channel1",
           "name": "skill_channel",

--- a/web/src/app/opspilot/locales/en.json
+++ b/web/src/app/opspilot/locales/en.json
@@ -1199,12 +1199,12 @@
       "usageGroup": "Usage Organization",
       "usageGroupTip": "Usage organizations can chat with / call this skill via API; management organizations are auto-included and cannot be removed."
     },
-    "channelPublish": "Channel Publish",
+    "channelPublish": "Publish",
     "channel": {
       "type": "Channel Type",
       "name": "Name",
       "enabled": "Enabled",
-      "status": "Status",
+      "status": "On/Off",
       "types": {
         "platform": "Platform",
         "web_chat": "Web Chat",

--- a/web/src/app/opspilot/locales/zh.json
+++ b/web/src/app/opspilot/locales/zh.json
@@ -1206,12 +1206,12 @@
       "usageGroup": "使用组织",
       "usageGroupTip": "使用组织可调用该智能体进行对话/接口请求；管理组织会自动加入且不可移除"
     },
-    "channelPublish": "渠道发布",
+    "channelPublish": "发布",
     "channel": {
       "type": "渠道类型",
       "name": "名称",
       "enabled": "启用",
-      "status": "状态",
+      "status": "启停",
       "types": {
         "platform": "平台",
         "web_chat": "Web 对话",

--- a/webchat/packages/webchat-core/src/aguiHistoryText.ts
+++ b/webchat/packages/webchat-core/src/aguiHistoryText.ts
@@ -9,8 +9,20 @@ const SKIP_CUSTOM_EVENTS = new Set([
   'browser_step_progress',
   'browser_task_received',
   'planned_execution_step',
+  'planned_execution_status',
   'skill_view',
+  'wiki_citations',
+  'user_choice_result',
+  'assistant_text_retract',
 ]);
+
+/**
+ * 进度/元数据类 CUSTOM 事件：只描述执行过程，不该作为聊天气泡展示。
+ * 实时流与历史回放共用同一份清单，避免规划 JSON 被降级成正文。
+ */
+export function isSilentCustomEvent(name: string): boolean {
+  return SKIP_CUSTOM_EVENTS.has(name);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);

--- a/webchat/packages/webchat-core/src/index.ts
+++ b/webchat/packages/webchat-core/src/index.ts
@@ -9,5 +9,6 @@ export { SessionManager } from './sessionManager';
 export { StateMachine } from './stateMachine';
 export { SSEHandler } from './sse';
 export { SSEStreamParser } from './sseParser';
+export { assembleAguiHistoryText, isSilentCustomEvent } from './aguiHistoryText';
 export * from './utils';
 export * from './platform';

--- a/webchat/packages/webchat-ui/src/Chat.tsx
+++ b/webchat/packages/webchat-ui/src/Chat.tsx
@@ -16,6 +16,7 @@ import {
   MessageContent,
   MessageType,
   generateId,
+  isSilentCustomEvent,
   normalizeWebChatConfig,
 } from '@webchat/core';
 import { AGUIHandler, AGUIEvent, type CustomProtocolEvent } from './agui';
@@ -351,6 +352,10 @@ const ChatInner = React.forwardRef<HTMLDivElement, ChatProps>((props, ref) => {
     onCustomEvent?.(event);
     if (isBlockingHitlEvent(event)) {
       setHitlEvent(event);
+      return;
+    }
+    // 进度/元数据类事件（规划步骤、步骤进度、引用等）不降级成聊天气泡
+    if (isSilentCustomEvent(event.name)) {
       return;
     }
     const degraded = formatDegradedCustomEvent(event);

--- a/webchat/tests/core/platform.test.ts
+++ b/webchat/tests/core/platform.test.ts
@@ -16,6 +16,7 @@ import {
   unwrapPlatformPayload,
   writeDockCollapsed,
 } from '../../packages/webchat-core/src/platform';
+import { isSilentCustomEvent } from '../../packages/webchat-core/src/aguiHistoryText';
 import { normalizeWebChatConfig } from '../../packages/webchat-core/src/config';
 
 const platform = {
@@ -191,6 +192,34 @@ test('drops protocol-only AG-UI dumps and keeps assistant text from mixed dumps'
     },
   ]);
   assert.equal(mixed[0].content, '工作负载正常');
+});
+
+test('planned execution CUSTOM events stay out of chat bubbles', () => {
+  // 实时流（Chat.applyCustomEvent）与历史回放共用同一份静默清单
+  assert.equal(isSilentCustomEvent('planned_execution_status'), true);
+  assert.equal(isSilentCustomEvent('planned_execution_step'), true);
+  assert.equal(isSilentCustomEvent('wiki_citations'), true);
+  assert.equal(isSilentCustomEvent('approval_request'), false);
+  assert.equal(isSilentCustomEvent('config_analysis_report'), false);
+
+  const planned = mapPlatformMessages([
+    {
+      id: 12,
+      conversation_role: 'bot',
+      conversation_content: JSON.stringify([
+        { type: 'RUN_STARTED' },
+        { type: 'CUSTOM', name: 'planned_execution_status', value: { phase: 'planning' } },
+        {
+          type: 'CUSTOM',
+          name: 'planned_execution_step',
+          value: { phase: 'start', step_index: 1, total_steps: 1, objective: '查询当前时间', tools: ['get_current_time'] },
+        },
+        { type: 'TEXT_MESSAGE_CONTENT', delta: '现在是下午两点' },
+        { type: 'RUN_FINISHED' },
+      ]),
+    },
+  ]);
+  assert.equal(planned[0].content, '现在是下午两点');
 });
 
 test('formats session timestamps in Chinese relative units', () => {


### PR DESCRIPTION
技能渠道改走 AG-UI 流并过滤规划 JSON；webchat 静默跳过 planned_execution_* 等进度事件，正文只保留最终回答。