### PR TITLE
fix(monitor): 修复批量导入地址正则误判与空占位行残留

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automatic.tsx
@@ -54,7 +54,10 @@ import {
   getIfmibDeploymentPatch
 } from './ifmibDeploymentState';
 import { getSnmpInterfaceFilterModePatch } from '@/app/monitor/hooks/integration/snmpInterfaceFilterMode';
-import { countAccessAssets } from './automaticAssetCount';
+import {
+  countAccessAssets,
+  mergeImportedAssetRows
+} from './automaticAssetCount';
 const { confirm } = Modal;
 
 interface CollectDetectState {
@@ -800,7 +803,14 @@ const AutomaticConfiguration: React.FC<IntegrationAccessProps> = ({}) => {
       key: uuidv4(),
       group_ids: row.group_ids || groupId
     }));
-    setDataSource([...dataSource, ...newRows]);
+    setDataSource(
+      mergeImportedAssetRows(
+        dataSource,
+        newRows,
+        visibleTableColumns,
+        initTableItems
+      )
+    );
   };
 
   const batchMenuItems: MenuProps['items'] = [

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/automaticAssetCount.ts
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/automaticAssetCount.ts
@@ -69,6 +69,15 @@ const areComparableValuesEqual = (left: unknown, right: unknown): boolean => {
 export const hasAssetValue = (value: unknown): boolean =>
   normalizeComparableValue(value) !== undefined;
 
+const getRelevantAssetColumns = (
+  visibleColumns: AssetCountColumn[]
+): AssetCountColumn[] => {
+  const submissionColumns = visibleColumns.filter(
+    (column) => column.required || column.is_only
+  );
+  return submissionColumns.length ? submissionColumns : visibleColumns;
+};
+
 export const isCountedAssetRow = (
   row: AssetRow,
   visibleColumns: AssetCountColumn[],
@@ -76,12 +85,7 @@ export const isCountedAssetRow = (
 ): boolean => {
   if (!visibleColumns.length) return false;
 
-  const submissionColumns = visibleColumns.filter(
-    (column) => column.required || column.is_only
-  );
-  const relevantColumns = submissionColumns.length
-    ? submissionColumns
-    : visibleColumns;
+  const relevantColumns = getRelevantAssetColumns(visibleColumns);
 
   const isComplete = relevantColumns.every((column) =>
     hasAssetValue(row[column.name])
@@ -95,6 +99,35 @@ export const isCountedAssetRow = (
         placeholderRow[column.name]
       )
   );
+};
+
+/** 仍为初始化默认值/空值的占位行，导入时应剔除，避免空行压在导入数据上方。 */
+export const isPlaceholderAssetRow = (
+  row: AssetRow,
+  visibleColumns: AssetCountColumn[],
+  placeholderRow: AssetRow = {}
+): boolean => {
+  if (!visibleColumns.length) return true;
+
+  const relevantColumns = getRelevantAssetColumns(visibleColumns);
+  return relevantColumns.every(
+    (column) =>
+      !hasAssetValue(row[column.name]) ||
+      areComparableValuesEqual(row[column.name], placeholderRow[column.name])
+  );
+};
+
+/** 保留已填写行，去掉空占位行后追加导入数据。 */
+export const mergeImportedAssetRows = <T extends AssetRow>(
+  existingRows: T[],
+  importedRows: T[],
+  visibleColumns: AssetCountColumn[],
+  placeholderRow: AssetRow = {}
+): T[] => {
+  const retainedRows = existingRows.filter(
+    (row) => !isPlaceholderAssetRow(row, visibleColumns, placeholderRow)
+  );
+  return [...retainedRows, ...importedRows];
 };
 
 export const countAccessAssets = (

--- a/web/src/app/monitor/(pages)/integration/list/detail/configure/excelImportModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/configure/excelImportModal.tsx
@@ -231,7 +231,8 @@ const ExcelImportModal = forwardRef<ExcelImportModalRef, ExcelImportModalProps>(
             for (const rule of rules) {
               if (rule.type === 'pattern') {
                 if (value !== undefined && value !== null && value !== '') {
-                  const stringValue = String(value?.text || '').trim();
+                  // Excel 普通文本是 string；超链接单元格才是 { text }。须回退到 value 本身。
+                  const stringValue = String(value?.text || value || '').trim();
                   const regex = new RegExp(rule.pattern);
                   if (!regex.test(stringValue)) {
                     return {


### PR DESCRIPTION
## Summary
- 修复 Excel 批量导入 `pattern` 校验误读 `value?.text`：普通文本地址（如 `10.90.40.2`）被当成空串导致误报无效
- 导入成功后剔除仍为默认值的空占位行再追加导入数据，避免「只导 1 条却多出一行空行」
- 抽取 `mergeImportedAssetRows` / `isPlaceholderAssetRow`，与接入资产计数的占位语义对齐

## Test plan
- [ ] TCP(Telegraf) 等带主机/目标地址 pattern 的接入页：Excel 填合法 IPv4（如 `10.90.40.2`）导入应通过校验
- [ ] 空表（仅默认空行）导入 1 条后，表格只显示 1 行，接入资产数=1
- [ ] 表中已有已填写行时再导入：保留已有行，导入行追加在后
- [ ] 半填行（仅改了部分必填）再导入：半填行不被误删

## Notes
- 本地验证了 `automaticAssetCount` 相关单测；按仓库约定测试文件未纳入本 PR
- 审查范围已核对：仅 3 个生产文件，未包含测试/图标/本地无关改动