### PR TITLE
fix(monitor): K8S Pod/Node 过滤与仪表盘不再展示 uuid 拼接名

### DIFF
--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -148,7 +148,7 @@ class InstanceSearch:
             instance_id_strs = [str(iid) for iid in instance_ids]
             node_id_strs = [str(nid) for nid in node_ids]
 
-            # 从数据库查询 Cluster 和 Node 实例名称
+            # 从数据库查询 Cluster / Node 实例名称
             instance_name_map = {}
             node_name_map = {}
 
@@ -158,7 +158,6 @@ class InstanceSearch:
                 instance_name_map = {inst["id"]: inst["name"] for inst in cluster_instances}
 
             if node_id_strs:
-                # 查询 Node 实例名称
                 node_instances = MonitorInstance.objects.filter(id__in=node_id_strs).values("id", "name")
                 node_name_map = {inst["id"]: inst["name"] for inst in node_instances}
 
@@ -171,13 +170,19 @@ class InstanceSearch:
                 for iid in instance_ids
             ]
 
-            node_list = [
-                {
-                    "id": nid[-1],  # 原始 node 维度值（如 "worker-node-1"）
-                    "name": node_name_map.get(str(nid), nid[-1]),  # Node 名称
-                }
-                for nid in node_ids
-            ]
+            # 节点过滤：保留手动改名；仅当库内名等于自动发现拼接名（uuid__hostname）
+            # 时改展示 kube 节点名，避免 240px 下拉被截成一串 id。
+            seen_nodes = set()
+            node_list = []
+            for nid in node_ids:
+                node = nid[-1]
+                if node in seen_nodes:
+                    continue
+                seen_nodes.add(node)
+                db_name = node_name_map.get(str(nid))
+                auto_joined = "__".join(str(part) for part in nid)
+                display_name = node if (not db_name or db_name == auto_joined) else db_name
+                node_list.append({"id": node, "name": display_name})
             return {"cluster": instance_list, "node": node_list}
         elif monitor_obj_name == "Node":
             query = "count(prometheus_remote_write_kube_node_info) by (instance_id)"

--- a/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
+++ b/web/src/app/monitor/dashboards/objects/common/simple-dashboard-core.tsx
@@ -337,8 +337,10 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   // so we must ref-stabilize them to prevent useCallback deps from constantly changing.
   const getInstanceQueryRef = useRef(viewApi.getInstanceQuery);
   const getInstanceListRef = useRef(monitorApi.getInstanceList);
+  const getInstanceQueryParamsRef = useRef(viewApi.getInstanceQueryParams);
   useEffect(() => { getInstanceQueryRef.current = viewApi.getInstanceQuery; });
   useEffect(() => { getInstanceListRef.current = monitorApi.getInstanceList; });
+  useEffect(() => { getInstanceQueryParamsRef.current = viewApi.getInstanceQueryParams; });
 
   const getInstanceQuery = useCallback(
     (...args: Parameters<typeof viewApi.getInstanceQuery>) => getInstanceQueryRef.current(...args),
@@ -346,6 +348,11 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   );
   const getInstanceList = useCallback(
     (...args: Parameters<typeof monitorApi.getInstanceList>) => getInstanceListRef.current(...args),
+    []
+  );
+  const getInstanceQueryParams = useCallback(
+    (...args: Parameters<typeof viewApi.getInstanceQueryParams>) =>
+      getInstanceQueryParamsRef.current(...args),
     []
   );
   const searchParams = useSearchParams();
@@ -364,6 +371,7 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const [queryTimeRange, setQueryTimeRange] = useState<{ startMs: number; endMs: number } | null>(null);
   const [instanceOptions, setInstanceOptions] = useState<InstanceOption[]>([]);
   const [instanceLoading, setInstanceLoading] = useState(false);
+  const [clusterNameById, setClusterNameById] = useState<Record<string, string>>({});
   const [metricsRefreshSignal, setMetricsRefreshSignal] = useState(0);
   // 每次 loadMetrics(含静默自动刷新)递增,供 bespoke 取数面板(如 ES/PG 的 TopN)
   // 与核心盘同步刷新——核心盘重载即 bespoke 面板重载,而非各自维护定时器。
@@ -438,6 +446,37 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
     };
   }, [getInstanceList, monitorObjectId]);
 
+  useEffect(() => {
+    if (!config.clusterFilter || !monitorObjectName) {
+      setClusterNameById({});
+      return;
+    }
+    let active = true;
+    const loadClusterNames = async () => {
+      try {
+        const enumData = await getInstanceQueryParams(monitorObjectName, {
+          monitor_object_id: monitorObjectId || undefined
+        });
+        if (!active) return;
+        const clusters = Array.isArray(enumData?.cluster) ? enumData.cluster : [];
+        const next: Record<string, string> = {};
+        clusters.forEach((item: { id?: unknown; name?: unknown }) => {
+          const id = String(item?.id ?? '').trim();
+          if (!id) return;
+          const name = String(item?.name ?? '').trim();
+          next[id] = name || id;
+        });
+        setClusterNameById(next);
+      } catch {
+        if (active) setClusterNameById({});
+      }
+    };
+    loadClusterNames();
+    return () => {
+      active = false;
+    };
+  }, [config.clusterFilter, getInstanceQueryParams, monitorObjectId, monitorObjectName]);
+
   const idValuesKey = useMemo(() => JSON.stringify(idValues), [idValues]);
   const currentInstanceCandidates = useMemo(
     () => instanceOptions.filter((item) => isInstanceOptionForIdentity(item, instanceId, idValues)),
@@ -457,8 +496,11 @@ export function useSimpleDashboardData(config: SimpleDashboardConfig) {
   const clusterFilterEnabled = Boolean(config.clusterFilter);
   const activeCluster = clusterFilterEnabled ? (idValues[0] ? String(idValues[0]) : undefined) : undefined;
   const clusterFilterOptions = useMemo(
-    () => (clusterFilterEnabled ? buildClusterFilterOptions(instanceOptions) : []),
-    [clusterFilterEnabled, instanceOptions]
+    () =>
+      clusterFilterEnabled
+        ? buildClusterFilterOptions(instanceOptions, clusterNameById)
+        : [],
+    [clusterFilterEnabled, clusterNameById, instanceOptions]
   );
   const instanceSelectOptions = useMemo(() => {
     const options = filterInstanceOptionsByCluster(instanceOptions, activeCluster);

--- a/web/src/app/monitor/dashboards/shared/utils/instance.ts
+++ b/web/src/app/monitor/dashboards/shared/utils/instance.ts
@@ -40,12 +40,26 @@ const resolveInstanceIdValues = (item: any): string[] => {
   return parsePythonTupleString(String(item?.instance_id || '')) || [];
 };
 
+/** 自动发现实例名：`instance_id_keys` 各维用 `__` 拼接（见 SyncInstance）。 */
+export const isAutoDiscoveryJoinedName = (
+  name: unknown,
+  idValues: readonly string[]
+) => {
+  if (idValues.length < 2 || name == null) return false;
+  const trimmed = String(name).trim();
+  return Boolean(trimmed) && trimmed === idValues.map(String).join('__');
+};
+
 export const buildInstanceDisplayName = (item: any) => {
   const idValues = resolveInstanceIdValues(item);
   const identityLeaf = idValues.length > 1 ? normalizeDisplayText(idValues[idValues.length - 1]) : '';
+  // K8S 等衍生对象自动发现名为 "集群uuid__pod/node"，下拉里会被截成一串 id；优先展示末段。
+  const rawName = item.instance_name ?? item.name;
+  const usableRawName = isAutoDiscoveryJoinedName(rawName, idValues)
+    ? ''
+    : normalizeDisplayText(rawName);
   const primaryName =
-    normalizeDisplayText(item.instance_name) ||
-    normalizeDisplayText(item.name) ||
+    usableRawName ||
     normalizeDisplayText(item.process_name) ||
     identityLeaf;
   const hostPort = normalizeDisplayText(item.host && item.port ? `${item.host}:${item.port}` : '');
@@ -97,12 +111,27 @@ export interface DashboardInstanceOption {
   interval?: number;
 }
 
-export const buildClusterFilterOptions = (options: readonly DashboardInstanceOption[]) => {
+export const buildClusterFilterOptions = (
+  options: readonly DashboardInstanceOption[],
+  clusterNameById?: ReadonlyMap<string, string> | Record<string, string>
+) => {
+  const resolveLabel = (clusterId: string) => {
+    if (!clusterNameById) return clusterId;
+    if (clusterNameById instanceof Map) {
+      return clusterNameById.get(clusterId) || clusterId;
+    }
+    return clusterNameById[clusterId] || clusterId;
+  };
   const seen = new Map<string, { label: string; value: string; searchTokens: string[] }>();
   options.forEach((item) => {
     const cluster = item.instanceIdValues[0];
     if (cluster && !seen.has(cluster)) {
-      seen.set(cluster, { label: cluster, value: cluster, searchTokens: [cluster] });
+      const label = resolveLabel(cluster);
+      seen.set(cluster, {
+        label,
+        value: cluster,
+        searchTokens: Array.from(new Set([label, cluster].filter(Boolean)))
+      });
     }
   });
   return Array.from(seen.values());


### PR DESCRIPTION
## Summary
- Pod 列表「节点」过滤项改为直接展示 kube 节点名，避免自动发现名 `集群uuid__节点` 在窄下拉中被截成一串 id
- 专业仪表盘实例选择器跳过自动发现拼接名，展示身份末段（Pod/Node 名）
- 仪表盘「集群」下拉通过 `query_params_enum` 映射为集群友好名

## Test plan
- [ ] 生产/含 uuid.hex 集群 id 的环境：打开 K8S Pod 列表，「节点」过滤应显示主机名而非 `4695e12d...`
- [ ] 打开 Pod/Node 专业仪表盘，「实例」下拉与标题显示可读名
- [ ] 「集群」下拉显示接入时填写的集群名，而非 uuid
- [ ] 切换集群/实例后指标查询仍正常
- [ ] 本地可读 cluster id（如 `mac`）场景行为与改前一致

## 提交范围说明
仅包含上述 3 个生产文件；相关单测留在工作区未提交。