### PR TITLE
fix(monitor): 去掉合入冲突留下的重复模板字段声明

### DIFF
--- a/web/src/app/monitor/(pages)/event/template/templateBulkUtils.ts
+++ b/web/src/app/monitor/(pages)/event/template/templateBulkUtils.ts
@@ -31,12 +31,6 @@ export interface PolicyTemplateItem {
   plugin_name?: string;
   template_type?: 'builtin' | 'custom';
   deletable?: boolean;
-  threshold_unit?: string;
-  calculation_unit?: string;
-  metric_unit?: string;
-  trigger_count?: number;
-  group_algorithm?: string;
-  algorithm?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
PolicyTemplateItem 合并时两端都保留了 unit/algorithm 字段，导致 TS2300 构建失败。