### PR TITLE
refactor(k8s-collector): 容忍策略收敛为 DaemonSet 专属的精确清单渲染参数

### DIFF
--- a/.github/workflows/webhookd-infra-tests.yml
+++ b/.github/workflows/webhookd-infra-tests.yml
@@ -1,0 +1,45 @@
+name: Webhookd Infra Tests
+
+# K8s 采集器渲染脚本与 manifest 合约测试。渲染测试会真实执行
+# agents/webhookd/infra/kubernetes.sh（依赖 bash + jq + python3 + pyyaml），
+# 合约测试静态解析模板/dist YAML。此前这些测试没有任何 CI 入口，
+# 容忍策略等渲染契约的回归只能靠本地手跑发现。
+on:
+  pull_request:
+    paths:
+      - 'agents/webhookd/**'
+      - 'deploy/dist/bk-lite-kubernetes-collector/**'
+      - '.github/workflows/webhookd-infra-tests.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'agents/webhookd/**'
+      - 'deploy/dist/bk-lite-kubernetes-collector/**'
+  workflow_dispatch:
+
+jobs:
+  infra-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agents/webhookd/infra
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # kubernetes.sh 内部以裸 `python` 调用解释器（与 python:3.12 运行镜像一致），
+      # CI runner 上需保证 python 可用
+      - name: Ensure python alias
+        run: python --version || sudo ln -s "$(command -v python3)" /usr/local/bin/python
+
+      - name: Install test dependencies
+        run: pip install pytest pyyaml
+
+      - name: Run webhookd infra tests
+        run: python3 -m pytest tests/ -q

--- a/.github/workflows/webhookd-infra-tests.yml
+++ b/.github/workflows/webhookd-infra-tests.yml
@@ -4,6 +4,9 @@ name: Webhookd Infra Tests
 # agents/webhookd/infra/kubernetes.sh（依赖 bash + jq + python3 + pyyaml），
 # 合约测试静态解析模板/dist YAML。此前这些测试没有任何 CI 入口，
 # 容忍策略等渲染契约的回归只能靠本地手跑发现。
+permissions:
+  contents: read
+
 on:
   pull_request:
     paths:
@@ -39,7 +42,7 @@ jobs:
         run: python --version || sudo ln -s "$(command -v python3)" /usr/local/bin/python
 
       - name: Install test dependencies
-        run: pip install pytest pyyaml
+        run: pip install pytest pyyaml cryptography
 
       - name: Run webhookd infra tests
         run: python3 -m pytest tests/ -q

--- a/agents/webhookd/bk-lite-log-collector.yaml
+++ b/agents/webhookd/bk-lite-log-collector.yaml
@@ -20,10 +20,7 @@ spec:
         bklite.io/log-collect-config: "__LOG_COLLECT_CONFIG_HASH__"
     spec:
       serviceAccount: vector-daemonset
-      # 控制平面默认 NoSchedule；不上这台节点则该节点日志采不到
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
+__DS_TOLERATIONS__
       containers:
         - name: vector
           image: __IMAGE_REGISTRY_PREFIX__/vector:0.39.0-debian

--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -83,10 +83,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics
-      # 控制平面默认 NoSchedule；单节点集群否则采集 Pod 全部 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -287,10 +283,7 @@ spec:
         prometheus.io/path: '/metrics'
     spec:
       serviceAccountName: cadvisor
-      # 控制平面默认 NoSchedule；不上这台节点则该节点 cadvisor 指标为空
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
+__DS_TOLERATIONS__
       containers:
       - name: cadvisor
         image: __IMAGE_REGISTRY_PREFIX__/cadvisor:0.56.2
@@ -364,10 +357,7 @@ spec:
       labels:
         app: telegraf-daemonset
     spec:
-      # 控制平面默认 NoSchedule；不上这台节点则该节点主机指标为空
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
+__DS_TOLERATIONS__
       containers:
         - name: telegraf
           image: __IMAGE_REGISTRY_PREFIX__/telegraf:1.29.5
@@ -420,10 +410,6 @@ spec:
       labels:
         app: telegraf
     spec:
-      # 控制平面默认 NoSchedule；单节点集群否则 remote_write 接收端 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
       containers:
         - name: telegraf
           image: __IMAGE_REGISTRY_PREFIX__/telegraf:1.29.5
@@ -479,10 +465,6 @@ spec:
         app: vmagent
     spec:
       serviceAccountName: vmagent
-      # 控制平面默认 NoSchedule；单节点集群否则 vmagent Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
       containers:
         - name: vmagent
           image: __IMAGE_REGISTRY_PREFIX__/vmagent

--- a/agents/webhookd/bk-lite-resource-collector.yaml
+++ b/agents/webhookd/bk-lite-resource-collector.yaml
@@ -83,10 +83,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics
-      # 控制平面默认 NoSchedule；单节点集群否则采集 Pod 全部 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -281,10 +277,6 @@ spec:
       labels:
         app: telegraf-resource
     spec:
-      # 控制平面默认 NoSchedule；单节点集群否则 CMDB 资源采集 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
       containers:
         - name: telegraf
           image: __IMAGE_REGISTRY_PREFIX__/telegraf:1.29.5

--- a/agents/webhookd/infra/API.md
+++ b/agents/webhookd/infra/API.md
@@ -81,7 +81,7 @@ Content-Type: application/json
 | docker_container_log_path | string | 否 | Docker 容器原始日志目录绝对路径。仅当节点仍使用 Docker 且需要额外挂载容器原始日志目录时填写，常见值为 `/var/lib/docker/containers` |
 | namespace_patterns | string[] | 否 | 仅 `type=log` 时生效。采集 Namespace 通配列表，语法为 glob（`*` / `?`），仅允许小写字母、数字、`-`、`.`、`*`、`?`。留空或省略表示全部 Namespace |
 | pod_patterns | string[] | 否 | 仅 `type=log` 时生效。采集 Pod 名称通配列表，规则同 `namespace_patterns`。与 Namespace 为「且」关系；两者都空时不下发 `include_paths_glob_patterns`，保持全量采集 |
-| tolerations | object[] | 否 | DaemonSet 的污点容忍清单，仅注入节点级 DaemonSet，Deployment 一律遵循集群默认调度。每项仅允许 `key`（必填，K8s qualified name）、`effect`（必填，`NoSchedule` 或 `NoExecute`）、`value`（可选：提供渲染为 `operator: Equal`，省略渲染为限定 key 的 `operator: Exists`）；最多 16 项，不允许无 key 的通配容忍，非法输入整单拒绝。省略时默认注入 `node-role.kubernetes.io/control-plane:NoSchedule` 与 `node-role.kubernetes.io/master:NoSchedule` 两条精确容忍；显式 `[]` 表示不容忍任何污点。单节点集群保留 control-plane 污点时中心组件会 Pending——按 Kubernetes 管理实践应由管理员移除该污点 |
+| tolerations | object[] | 否 | DaemonSet 的污点容忍清单，仅注入节点级 DaemonSet，Deployment 一律遵循集群默认调度。每项仅允许 `key`（必填，K8s qualified name）、`effect`（必填，`NoSchedule` 或 `NoExecute`）、`value`（可选：提供渲染为 `operator: Equal`，省略渲染为限定 key 的 `operator: Exists`）；最多 16 项，不允许无 key 的通配容忍，非法输入整单拒绝。省略或显式 `null` 时默认注入 `node-role.kubernetes.io/control-plane:NoSchedule` 与 `node-role.kubernetes.io/master:NoSchedule` 两条精确容忍；显式 `[]` 表示不容忍任何污点。`value` 为空串表示精确匹配空值污点（渲染为 `operator: Equal, value: ""`）。`key`/`value` 中不允许出现 `__`（模板占位符保留字）。注意：`type=resource` 模板没有 DaemonSet，清单照常校验但不会落地到任何 workload。单节点集群保留 control-plane 污点时中心组件会 Pending——按 Kubernetes 管理实践应由管理员移除该污点 |
 
 **成功响应**:
 ```json

--- a/agents/webhookd/infra/API.md
+++ b/agents/webhookd/infra/API.md
@@ -57,7 +57,11 @@ Content-Type: application/json
   "image_registry_prefix": "bk-lite.tencentcloudcr.com/bklite",
   "runtime_profile": "standard",
   "host_log_path": "/var/log/pods",
-  "docker_container_log_path": "/var/lib/docker/containers"
+  "docker_container_log_path": "/var/lib/docker/containers",
+  "tolerations": [
+    {"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"},
+    {"key": "dedicated", "value": "edge", "effect": "NoSchedule"}
+  ]
 }
 ```
 
@@ -77,6 +81,7 @@ Content-Type: application/json
 | docker_container_log_path | string | 否 | Docker 容器原始日志目录绝对路径。仅当节点仍使用 Docker 且需要额外挂载容器原始日志目录时填写，常见值为 `/var/lib/docker/containers` |
 | namespace_patterns | string[] | 否 | 仅 `type=log` 时生效。采集 Namespace 通配列表，语法为 glob（`*` / `?`），仅允许小写字母、数字、`-`、`.`、`*`、`?`。留空或省略表示全部 Namespace |
 | pod_patterns | string[] | 否 | 仅 `type=log` 时生效。采集 Pod 名称通配列表，规则同 `namespace_patterns`。与 Namespace 为「且」关系；两者都空时不下发 `include_paths_glob_patterns`，保持全量采集 |
+| tolerations | object[] | 否 | DaemonSet 的污点容忍清单，仅注入节点级 DaemonSet，Deployment 一律遵循集群默认调度。每项仅允许 `key`（必填，K8s qualified name）、`effect`（必填，`NoSchedule` 或 `NoExecute`）、`value`（可选：提供渲染为 `operator: Equal`，省略渲染为限定 key 的 `operator: Exists`）；最多 16 项，不允许无 key 的通配容忍，非法输入整单拒绝。省略时默认注入 `node-role.kubernetes.io/control-plane:NoSchedule` 与 `node-role.kubernetes.io/master:NoSchedule` 两条精确容忍；显式 `[]` 表示不容忍任何污点。单节点集群保留 control-plane 污点时中心组件会 Pending——按 Kubernetes 管理实践应由管理员移除该污点 |
 
 **成功响应**:
 ```json

--- a/agents/webhookd/infra/kubernetes.sh
+++ b/agents/webhookd/infra/kubernetes.sh
@@ -2,6 +2,8 @@
 
 # webhookd infra render script
 # 接收 JSON: {"cluster_name": "xxx", "type": "metric|log|resource", "nats_url": "nats://x.x.x.x:4222", "nats_username": "user", "nats_password": "pass", "nats_ca": "...", "image_registry_prefix": "bk-lite.tencentcloudcr.com/bklite", "runtime_profile": "standard|docker|custom", "host_log_path": "/var/log/pods", "docker_container_log_path": "/var/lib/docker/containers", "namespace_patterns": [], "pod_patterns": []}
+# 可选 "tolerations": [{"key": "...", "effect": "NoSchedule|NoExecute", "value": "可选"}]，仅注入 DaemonSet；
+#   缺省时注入 control-plane/master 两条精确容忍，显式 [] 表示不容忍任何污点；不允许无 key 的通配容忍
 # 渲染出 K8s 配置 YAML
 set -euo pipefail
 
@@ -84,6 +86,8 @@ DOCKER_CONTAINER_LOG_PATH=$(echo "$JSON_DATA" | jq -r '.docker_container_log_pat
 NAMESPACE_PATTERNS=$(echo "$JSON_DATA" | jq -c '.namespace_patterns // []')
 POD_PATTERNS=$(echo "$JSON_DATA" | jq -c '.pod_patterns // []')
 IMAGE_REGISTRY_PREFIX=$(echo "$JSON_DATA" | jq -r '.image_registry_prefix // "bk-lite.tencentcloudcr.com/bklite"')
+# 空串=未提供(渲染默认容忍)；显式 [] 会保留为 []（渲染为不容忍任何污点）
+TOLERATIONS_JSON=$(echo "$JSON_DATA" | jq -c 'if has("tolerations") then .tolerations else empty end')
 
 # 验证必填字段
 validate_cluster_name() {
@@ -241,6 +245,98 @@ print(json.dumps({"include_yaml": include_yaml, "config_hash": config_hash}))
 '
 }
 
+# 校验容忍清单并生成 DaemonSet 的 tolerations YAML 块。
+# 受限 schema：每项仅允许 key(必填, K8s qualified name)/effect(必填, NoSchedule|NoExecute)/value(可选)；
+# 结构上无法表达无 key 的通配容忍。Deployment 一律不注入，遵循集群默认调度。
+build_ds_tolerations_block() {
+    TOLERATIONS_INPUT="$1" python -c '
+import json
+import os
+import re
+import sys
+
+MAX_ITEMS = 16
+ALLOWED_EFFECTS = {"NoSchedule", "NoExecute"}
+ALLOWED_FIELDS = {"key", "effect", "value"}
+NAME_RE = re.compile(r"^[A-Za-z0-9]([A-Za-z0-9._-]{0,61}[A-Za-z0-9])?$")
+DNS_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+DEFAULT_TOLERATIONS = [
+    {"key": "node-role.kubernetes.io/control-plane", "effect": "NoSchedule"},
+    {"key": "node-role.kubernetes.io/master", "effect": "NoSchedule"},
+]
+
+
+def fail(message):
+    print(message, file=sys.stderr)
+    sys.exit(1)
+
+
+def validate_key(key):
+    if not isinstance(key, str) or not key:
+        fail("Invalid tolerations: key is required and must be a non-empty string")
+    if key.count("/") > 1:
+        fail("Invalid tolerations: key has more than one /")
+    if "/" in key:
+        prefix, name = key.split("/")
+        if len(prefix) > 253 or not all(DNS_LABEL_RE.fullmatch(part) for part in prefix.split(".")):
+            fail(f"Invalid tolerations: key prefix {prefix!r} is not a DNS subdomain")
+    else:
+        name = key
+    if not NAME_RE.fullmatch(name):
+        fail(f"Invalid tolerations: key name {name!r} violates Kubernetes qualified-name rules")
+
+
+raw = os.environ["TOLERATIONS_INPUT"]
+if raw == "":
+    items = DEFAULT_TOLERATIONS
+else:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        fail("Invalid tolerations: must be a JSON array")
+    if not isinstance(parsed, list):
+        fail("Invalid tolerations: must be a JSON array")
+    if len(parsed) > MAX_ITEMS:
+        fail(f"Invalid tolerations: at most {MAX_ITEMS} items")
+    items = []
+    for entry in parsed:
+        if not isinstance(entry, dict):
+            fail("Invalid tolerations: items must be objects")
+        unknown = sorted(set(entry) - ALLOWED_FIELDS)
+        if unknown:
+            fail(f"Invalid tolerations: unknown fields {unknown} (wildcard tolerations are not allowed)")
+        validate_key(entry.get("key"))
+        effect = entry.get("effect")
+        if effect not in ALLOWED_EFFECTS:
+            fail("Invalid tolerations: effect must be NoSchedule or NoExecute")
+        value = entry.get("value")
+        if value is not None:
+            if not isinstance(value, str):
+                fail("Invalid tolerations: value must be a string")
+            if value and not NAME_RE.fullmatch(value):
+                fail(f"Invalid tolerations: value {value!r} violates Kubernetes label-value rules")
+        items.append({"key": entry["key"], "effect": effect, "value": value})
+
+if not items:
+    sys.exit(0)
+
+lines = ["      tolerations:"]
+for item in items:
+    key = item["key"]
+    effect = item["effect"]
+    value = item.get("value")
+    lines.append(f"        - key: {key}")
+    if value is None:
+        lines.append("          operator: Exists")
+    else:
+        lines.append("          operator: Equal")
+        quoted = json.dumps(value)
+        lines.append(f"          value: {quoted}")
+    lines.append(f"          effect: {effect}")
+print(chr(10).join(lines))
+'
+}
+
 require_field() {
     local field="$1" value="$2"
     if [ -z "$value" ]; then
@@ -270,6 +366,11 @@ if [ "$TYPE" == "log" ] && [ "$RUNTIME_PROFILE" == "custom" ]; then
     if [ -n "$DOCKER_CONTAINER_LOG_PATH" ]; then
         validate_absolute_path "$DOCKER_CONTAINER_LOG_PATH" || { json_error "$CLUSTER_NAME" "Invalid docker_container_log_path: must be an absolute path"; exit 1; }
     fi
+fi
+
+if ! DS_TOLERATIONS_YAML=$(build_ds_tolerations_block "$TOLERATIONS_JSON" 2>&1); then
+    json_error "$CLUSTER_NAME" "$DS_TOLERATIONS_YAML"
+    exit 1
 fi
 
 INCLUDE_PATHS_YAML=""
@@ -394,6 +495,7 @@ render_k8s_config() {
     local include_paths_yaml="${10}"
     local config_hash="${11}"
     local image_registry_prefix="${12}"
+    local ds_tolerations_yaml="${13}"
     
     # 根据类型选择模板
     local template
@@ -406,6 +508,8 @@ render_k8s_config() {
     fi
 
     template=$(replace_placeholder "$template" "__IMAGE_REGISTRY_PREFIX__" "$image_registry_prefix")
+    # DaemonSet 容忍策略统一注入（resource 模板无 DaemonSet、无占位符，替换为 no-op）
+    template=$(replace_placeholder "$template" "__DS_TOLERATIONS__" "$ds_tolerations_yaml")
 
     if [ "$type" == "log" ]; then
         local log_mounts
@@ -439,7 +543,7 @@ render_k8s_config() {
 }
 
 # 执行渲染
-K8S_CONFIG=$(render_k8s_config "$CLUSTER_NAME" "$NATS_URL" "$NATS_USERNAME" "$NATS_PASSWORD" "$NATS_CA" "$TYPE" "$RUNTIME_PROFILE" "$HOST_LOG_PATH" "$DOCKER_CONTAINER_LOG_PATH" "$INCLUDE_PATHS_YAML" "$CONFIG_HASH" "$IMAGE_REGISTRY_PREFIX")
+K8S_CONFIG=$(render_k8s_config "$CLUSTER_NAME" "$NATS_URL" "$NATS_USERNAME" "$NATS_PASSWORD" "$NATS_CA" "$TYPE" "$RUNTIME_PROFILE" "$HOST_LOG_PATH" "$DOCKER_CONTAINER_LOG_PATH" "$INCLUDE_PATHS_YAML" "$CONFIG_HASH" "$IMAGE_REGISTRY_PREFIX" "$DS_TOLERATIONS_YAML")
 
 # 返回成功响应，YAML 内容放在 yaml 字段中
 json_success "$CLUSTER_NAME" "K8s configuration rendered successfully" "yaml" "$K8S_CONFIG"

--- a/agents/webhookd/infra/kubernetes.sh
+++ b/agents/webhookd/infra/kubernetes.sh
@@ -274,6 +274,8 @@ def fail(message):
 def validate_key(key):
     if not isinstance(key, str) or not key:
         fail("Invalid tolerations: key is required and must be a non-empty string")
+    if "__" in key:
+        fail("Invalid tolerations: __ is reserved for template placeholders")
     if key.count("/") > 1:
         fail("Invalid tolerations: key has more than one /")
     if "/" in key:
@@ -287,7 +289,8 @@ def validate_key(key):
 
 
 raw = os.environ["TOLERATIONS_INPUT"]
-if raw == "":
+# 显式 null 与缺省等价（上游可选字段序列化为 null 是常态）；显式 [] 才是"不容忍任何污点"
+if raw in ("", "null"):
     items = DEFAULT_TOLERATIONS
 else:
     try:
@@ -315,6 +318,8 @@ else:
                 fail("Invalid tolerations: value must be a string")
             if value and not NAME_RE.fullmatch(value):
                 fail(f"Invalid tolerations: value {value!r} violates Kubernetes label-value rules")
+            if value is not None and "__" in value:
+                fail("Invalid tolerations: __ is reserved for template placeholders")
         items.append({"key": entry["key"], "effect": effect, "value": value})
 
 if not items:
@@ -325,7 +330,10 @@ for item in items:
     key = item["key"]
     effect = item["effect"]
     value = item.get("value")
-    lines.append(f"        - key: {key}")
+    # key 必须引号化输出：裸拼时 "null" 会被 YAML 解析为空 key（= 通配容忍），
+    # "on"/"123" 等会被隐式转型；json.dumps 保证永远是显式字符串标量
+    quoted_key = json.dumps(key)
+    lines.append(f"        - key: {quoted_key}")
     if value is None:
         lines.append("          operator: Exists")
     else:
@@ -508,8 +516,6 @@ render_k8s_config() {
     fi
 
     template=$(replace_placeholder "$template" "__IMAGE_REGISTRY_PREFIX__" "$image_registry_prefix")
-    # DaemonSet 容忍策略统一注入（resource 模板无 DaemonSet、无占位符，替换为 no-op）
-    template=$(replace_placeholder "$template" "__DS_TOLERATIONS__" "$ds_tolerations_yaml")
 
     if [ "$type" == "log" ]; then
         local log_mounts
@@ -521,6 +527,10 @@ render_k8s_config() {
         template=$(replace_placeholder "$template" "__INCLUDE_PATHS_GLOB_PATTERNS__" "$include_paths_yaml")
         template=$(replace_placeholder "$template" "__LOG_COLLECT_CONFIG_HASH__" "$config_hash")
     fi
+
+    # DaemonSet 容忍策略注入必须放在所有占位符替换的最后：
+    # 注入内容含用户输入，先注入会被后续替换二次展开（resource 模板无占位符，此处为 no-op）
+    template=$(replace_placeholder "$template" "__DS_TOLERATIONS__" "$ds_tolerations_yaml")
     
     # Base64 编码
     local cluster_name_b64=$(echo -n "$cluster_name" | base64 | tr -d '\n')

--- a/agents/webhookd/infra/tests/test_k8s_manifest_contract.py
+++ b/agents/webhookd/infra/tests/test_k8s_manifest_contract.py
@@ -25,11 +25,19 @@ MANIFEST_PATHS = [
 
 CLUSTER_SCOPED_KINDS = ("ClusterRole", "ClusterRoleBinding")
 CLUSTER_SCOPED_PREFIX = "bk-lite-"
-CONTROL_PLANE_NOSCHEDULE_TOLERATION = {"operator": "Exists", "effect": "NoSchedule"}
-WORKLOAD_MANIFEST_PATHS = [
+# DaemonSet 容忍策略：模板经 __DS_TOLERATIONS__ 占位符由渲染脚本注入（默认两条精确容忍），
+# dist 静态部署包写死同样的默认值；Deployment 一律不带 tolerations，遵循集群默认调度。
+DS_TOLERATIONS_PLACEHOLDER = "__DS_TOLERATIONS__"
+DEFAULT_DS_TOLERATIONS = [
+    {"key": "node-role.kubernetes.io/control-plane", "operator": "Exists", "effect": "NoSchedule"},
+    {"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"},
+]
+TEMPLATE_MANIFEST_PATHS = [
     WEBHOOKD_DIR / "bk-lite-metric-collector.yaml",
     WEBHOOKD_DIR / "bk-lite-resource-collector.yaml",
     WEBHOOKD_DIR / "bk-lite-log-collector.yaml",
+]
+DIST_MANIFEST_PATHS = [
     DIST_DIR / "bk-lite-metric-collector.yaml",
     DIST_DIR / "bk-lite-log-collector.yaml",
 ]
@@ -39,6 +47,7 @@ LINE_PLACEHOLDERS = (
     "__LOG_VOLUME_MOUNTS__",
     "__LOG_VOLUMES__",
     "__INCLUDE_PATHS_GLOB_PATTERNS__",
+    "__DS_TOLERATIONS__",
 )
 
 
@@ -135,13 +144,44 @@ def test_dist_and_webhookd_metric_manifests_share_cluster_rbac():
         assert template[identity] == dist[identity], f"{identity} 在 webhookd 模板与 deploy/dist 部署包中不一致"
 
 
-@pytest.mark.parametrize("path", WORKLOAD_MANIFEST_PATHS, ids=lambda path: path.name)
-def test_workloads_tolerate_control_plane_noschedule(path):
-    """采集器必须能调度到 control-plane:NoSchedule，否则单节点/污点节点没有采集 Pod。"""
-    workloads = [document for document in _load_documents(path) if document["kind"] in ("Deployment", "DaemonSet")]
-    assert workloads, f"{path} 没有 Deployment/DaemonSet"
-    for document in workloads:
-        tolerations = document["spec"]["template"]["spec"].get("tolerations") or []
-        assert CONTROL_PLANE_NOSCHEDULE_TOLERATION in tolerations, (
-            f"{path.name}: {document['kind']} `{document['metadata']['name']}` " "缺少 operator=Exists effect=NoSchedule，无法调度到控制平面污点节点"
+@pytest.mark.parametrize("path", TEMPLATE_MANIFEST_PATHS + DIST_MANIFEST_PATHS, ids=lambda path: str(path.relative_to(REPO_ROOT)))
+def test_deployments_carry_no_tolerations(path):
+    """Deployment 是中心组件，只需要集群里有地方跑；容忍污点会穿透 cordon/专用池等
+    管理员隔离语义，一律遵循集群默认调度。单节点集群的 control-plane 污点由管理员
+    按 Kubernetes 管理实践自行移除。"""
+    for document in _load_documents(path):
+        if document["kind"] != "Deployment":
+            continue
+        pod_spec = document["spec"]["template"]["spec"]
+        assert "tolerations" not in pod_spec, (
+            f"{path.name}: Deployment `{document['metadata']['name']}` 不得携带 tolerations，" "中心组件必须遵循集群默认调度语义"
+        )
+
+
+@pytest.mark.parametrize("path", TEMPLATE_MANIFEST_PATHS, ids=lambda path: path.name)
+def test_template_daemonsets_use_tolerations_placeholder(path):
+    """模板 DaemonSet 的容忍策略由渲染脚本注入：每个 DaemonSet 对应一个
+    __DS_TOLERATIONS__ 占位行，模板自身不得硬编码 tolerations。"""
+    documents = _load_documents(path)
+    daemonsets = [document for document in documents if document["kind"] == "DaemonSet"]
+    for document in daemonsets:
+        assert "tolerations" not in document["spec"]["template"]["spec"], (
+            f"{path.name}: DaemonSet `{document['metadata']['name']}` 硬编码了 tolerations，" "容忍策略必须经渲染参数注入"
+        )
+    placeholder_count = sum(1 for line in path.read_text(encoding="utf-8").splitlines() if line.strip() == DS_TOLERATIONS_PLACEHOLDER)
+    assert placeholder_count == len(daemonsets), (
+        f"{path.name}: __DS_TOLERATIONS__ 占位行数量 ({placeholder_count}) 与 DaemonSet 数量 ({len(daemonsets)}) 不一致"
+    )
+
+
+@pytest.mark.parametrize("path", DIST_MANIFEST_PATHS, ids=lambda path: path.name)
+def test_dist_daemonsets_carry_exact_default_tolerations(path):
+    """手动部署包无渲染环节，DaemonSet 写死与渲染默认值一致的两条精确容忍；
+    禁止无 key 的通配容忍（会穿透 cordon 与专用节点隔离）。"""
+    daemonsets = [document for document in _load_documents(path) if document["kind"] == "DaemonSet"]
+    assert daemonsets, f"{path} 没有 DaemonSet"
+    for document in daemonsets:
+        tolerations = document["spec"]["template"]["spec"].get("tolerations")
+        assert tolerations == DEFAULT_DS_TOLERATIONS, (
+            f"{path.name}: DaemonSet `{document['metadata']['name']}` 的 tolerations 必须恰好是 " "control-plane/master 两条精确容忍"
         )

--- a/agents/webhookd/infra/tests/test_kubernetes_tolerations_render.py
+++ b/agents/webhookd/infra/tests/test_kubernetes_tolerations_render.py
@@ -1,0 +1,122 @@
+"""K8S 采集器容忍策略的渲染契约。
+
+污点是集群管理员的调度主权声明。容忍清单是接入时的显式输入（受限 schema），
+仅注入节点级 DaemonSet；缺省注入 control-plane/master 两条精确容忍，
+显式空数组表示不容忍任何污点。Deployment 一律不注入，遵循集群默认调度。
+无 key 的通配容忍（会穿透 cordon 与专用节点隔离）在 schema 上不可表达。
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+WEBHOOKD_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = WEBHOOKD_ROOT / "infra/kubernetes.sh"
+VALID_REQUEST = {
+    "cluster_name": "prod-k8s",
+    "nats_url": "tls://nats.internal:4222",
+    "nats_username": "collector",
+    "nats_password": "secret",
+    "nats_ca": "test-ca",
+}
+DEFAULT_DS_TOLERATIONS = [
+    {"key": "node-role.kubernetes.io/control-plane", "operator": "Exists", "effect": "NoSchedule"},
+    {"key": "node-role.kubernetes.io/master", "operator": "Exists", "effect": "NoSchedule"},
+]
+
+
+def _render(config_type, **extra):
+    payload = {**VALID_REQUEST, "type": config_type, **extra}
+    result = subprocess.run(
+        ["bash", str(SCRIPT), json.dumps(payload)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result, json.loads(result.stdout)
+
+
+def _workload_tolerations(yaml_content):
+    tolerations = {}
+    for document in yaml.safe_load_all(yaml_content):
+        if isinstance(document, dict) and document.get("kind") in {"Deployment", "DaemonSet"}:
+            key = f"{document['kind']}/{document['metadata']['name']}"
+            tolerations[key] = document["spec"]["template"]["spec"].get("tolerations")
+    return tolerations
+
+
+@pytest.mark.parametrize("config_type", ["metric", "log", "resource"])
+def test_default_render_gives_daemonsets_exact_control_plane_tolerations(config_type):
+    """缺省渲染：DaemonSet 恰好两条精确容忍，Deployment 一律没有，占位符不残留。"""
+    result, response = _render(config_type)
+
+    assert result.returncode == 0, result.stderr
+    assert response["status"] == "success"
+    assert "__DS_TOLERATIONS__" not in response["yaml"]
+
+    tolerations = _workload_tolerations(response["yaml"])
+    assert tolerations
+    for workload, value in tolerations.items():
+        if workload.startswith("DaemonSet/"):
+            assert value == DEFAULT_DS_TOLERATIONS, f"{workload} 缺省容忍不符: {value}"
+        else:
+            assert value is None, f"{workload} 是 Deployment，不得携带 tolerations: {value}"
+
+
+def test_custom_tolerations_only_reach_daemonsets():
+    """显式清单注入 DaemonSet（无 value 渲染为 Exists，有 value 渲染为 Equal），Deployment 不受影响。"""
+    requested = [
+        {"key": "dedicated", "value": "edge", "effect": "NoSchedule"},
+        {"key": "CriticalAddonsOnly", "effect": "NoExecute"},
+    ]
+    result, response = _render("metric", tolerations=requested)
+
+    assert result.returncode == 0, result.stderr
+    assert response["status"] == "success"
+
+    tolerations = _workload_tolerations(response["yaml"])
+    expected = [
+        {"key": "dedicated", "operator": "Equal", "value": "edge", "effect": "NoSchedule"},
+        {"key": "CriticalAddonsOnly", "operator": "Exists", "effect": "NoExecute"},
+    ]
+    for workload, value in tolerations.items():
+        if workload.startswith("DaemonSet/"):
+            assert value == expected, f"{workload} 清单渲染不符: {value}"
+        else:
+            assert value is None
+
+
+def test_explicit_empty_list_means_no_tolerations_at_all():
+    """显式 [] 是管理员"任何采集组件都不容忍污点"的决定，与缺省(默认容忍)必须可区分。"""
+    result, response = _render("metric", tolerations=[])
+
+    assert result.returncode == 0, result.stderr
+    assert response["status"] == "success"
+    tolerations = _workload_tolerations(response["yaml"])
+    assert tolerations
+    assert all(value is None for value in tolerations.values())
+
+
+@pytest.mark.parametrize(
+    ("case", "tolerations"),
+    [
+        ("wildcard-without-key", [{"operator": "Exists", "effect": "NoSchedule"}]),
+        ("empty-key", [{"key": "", "effect": "NoSchedule"}]),
+        ("missing-effect", [{"key": "dedicated"}]),
+        ("prefer-no-schedule", [{"key": "dedicated", "effect": "PreferNoSchedule"}]),
+        ("not-a-list", {"key": "dedicated", "effect": "NoSchedule"}),
+        ("toleration-seconds", [{"key": "a", "effect": "NoExecute", "tolerationSeconds": 30}]),
+        ("yaml-injection-in-key", [{"key": "a\nevil: true", "effect": "NoSchedule"}]),
+        ("yaml-injection-in-value", [{"key": "a", "value": "x\"\nevil: true", "effect": "NoSchedule"}]),
+        ("double-slash-key", [{"key": "a/b/c", "effect": "NoSchedule"}]),
+        ("too-many-items", [{"key": f"k{i}", "effect": "NoSchedule"} for i in range(17)]),
+    ],
+)
+def test_invalid_tolerations_are_rejected(case, tolerations):
+    """受限 schema：非法输入必须整单拒绝，而不是丢弃或静默修正。"""
+    result, response = _render("metric", tolerations=tolerations)
+
+    assert response["status"] == "error", f"{case} 应被拒绝: {response}"

--- a/agents/webhookd/infra/tests/test_kubernetes_tolerations_render.py
+++ b/agents/webhookd/infra/tests/test_kubernetes_tolerations_render.py
@@ -66,13 +66,15 @@ def test_default_render_gives_daemonsets_exact_control_plane_tolerations(config_
             assert value is None, f"{workload} 是 Deployment，不得携带 tolerations: {value}"
 
 
-def test_custom_tolerations_only_reach_daemonsets():
-    """显式清单注入 DaemonSet（无 value 渲染为 Exists，有 value 渲染为 Equal），Deployment 不受影响。"""
+@pytest.mark.parametrize("config_type", ["metric", "log"])
+def test_custom_tolerations_only_reach_daemonsets(config_type):
+    """显式清单注入 DaemonSet（无 value 渲染为 Exists，有 value 渲染为 Equal），Deployment 不受影响。
+    log 类型同时护住「容忍注入必须是最后一个占位符替换」的顺序回归。"""
     requested = [
         {"key": "dedicated", "value": "edge", "effect": "NoSchedule"},
         {"key": "CriticalAddonsOnly", "effect": "NoExecute"},
     ]
-    result, response = _render("metric", tolerations=requested)
+    result, response = _render(config_type, tolerations=requested)
 
     assert result.returncode == 0, result.stderr
     assert response["status"] == "success"
@@ -101,22 +103,126 @@ def test_explicit_empty_list_means_no_tolerations_at_all():
 
 
 @pytest.mark.parametrize(
-    ("case", "tolerations"),
+    ("case", "tolerations", "expected_message"),
     [
-        ("wildcard-without-key", [{"operator": "Exists", "effect": "NoSchedule"}]),
-        ("empty-key", [{"key": "", "effect": "NoSchedule"}]),
-        ("missing-effect", [{"key": "dedicated"}]),
-        ("prefer-no-schedule", [{"key": "dedicated", "effect": "PreferNoSchedule"}]),
-        ("not-a-list", {"key": "dedicated", "effect": "NoSchedule"}),
-        ("toleration-seconds", [{"key": "a", "effect": "NoExecute", "tolerationSeconds": 30}]),
-        ("yaml-injection-in-key", [{"key": "a\nevil: true", "effect": "NoSchedule"}]),
-        ("yaml-injection-in-value", [{"key": "a", "value": "x\"\nevil: true", "effect": "NoSchedule"}]),
-        ("double-slash-key", [{"key": "a/b/c", "effect": "NoSchedule"}]),
-        ("too-many-items", [{"key": f"k{i}", "effect": "NoSchedule"} for i in range(17)]),
+        ("wildcard-without-key", [{"operator": "Exists", "effect": "NoSchedule"}], "wildcard tolerations are not allowed"),
+        ("empty-key", [{"key": "", "effect": "NoSchedule"}], "key is required"),
+        ("non-string-key", [{"key": 123, "effect": "NoSchedule"}], "key is required"),
+        ("missing-effect", [{"key": "dedicated"}], "effect must be NoSchedule or NoExecute"),
+        ("prefer-no-schedule", [{"key": "dedicated", "effect": "PreferNoSchedule"}], "effect must be NoSchedule or NoExecute"),
+        ("not-a-list", {"key": "dedicated", "effect": "NoSchedule"}, "must be a JSON array"),
+        ("toleration-seconds", [{"key": "a", "effect": "NoExecute", "tolerationSeconds": 30}], "unknown fields"),
+        ("yaml-injection-in-key", [{"key": "a\nevil: true", "effect": "NoSchedule"}], "qualified-name"),
+        ("yaml-injection-in-value", [{"key": "a", "value": "x\"\nevil: true", "effect": "NoSchedule"}], "label-value"),
+        ("double-slash-key", [{"key": "a/b/c", "effect": "NoSchedule"}], "more than one /"),
+        ("bad-dns-prefix-uppercase", [{"key": "Example.COM/dedicated", "effect": "NoSchedule"}], "not a DNS subdomain"),
+        ("bad-dns-prefix-empty-label", [{"key": "a..b/dedicated", "effect": "NoSchedule"}], "not a DNS subdomain"),
+        ("placeholder-in-key", [{"key": "X__LOG_VOLUME_MOUNTS__X", "effect": "NoSchedule"}], "reserved for template placeholders"),
+        ("placeholder-in-value", [{"key": "a", "value": "X__DS_TOLERATIONS__X", "effect": "NoSchedule"}], "reserved for template placeholders"),
+        ("too-many-items", [{"key": f"k{i}", "effect": "NoSchedule"} for i in range(17)], "at most 16 items"),
     ],
 )
-def test_invalid_tolerations_are_rejected(case, tolerations):
-    """受限 schema：非法输入必须整单拒绝，而不是丢弃或静默修正。"""
+def test_invalid_tolerations_are_rejected(case, tolerations, expected_message):
+    """受限 schema：非法输入必须整单拒绝，且给出干净的校验消息而非内部异常。"""
     result, response = _render("metric", tolerations=tolerations)
 
     assert response["status"] == "error", f"{case} 应被拒绝: {response}"
+    assert expected_message in response.get("message", ""), f"{case} 拒绝原因不符: {response}"
+    assert "Traceback" not in response.get("message", ""), f"{case} 泄漏了内部异常: {response}"
+
+
+@pytest.mark.parametrize("ambiguous_key", ["null", "true", "false", "on", "off", "yes", "no", "123456", "0x1A", "1.5"])
+def test_yaml_ambiguous_keys_render_as_strings(ambiguous_key):
+    """YAML 1.1 隐式标量形态的合法 key 必须引号化输出：裸拼时 "null" 会解析成空 key
+    （= 无 key 通配容忍，正是本设计要消灭的），"on"/"0x1A" 会被静默改名。"""
+    result, response = _render("metric", tolerations=[{"key": ambiguous_key, "effect": "NoSchedule"}])
+
+    assert result.returncode == 0, result.stderr
+    assert response["status"] == "success"
+    for workload, value in _workload_tolerations(response["yaml"]).items():
+        if workload.startswith("DaemonSet/"):
+            rendered_key = value[0]["key"]
+            assert isinstance(rendered_key, str), f"{workload} 的 key 被 YAML 隐式转型: {rendered_key!r}"
+            assert rendered_key == ambiguous_key, f"{workload} 的 key 被改写: {rendered_key!r}"
+
+
+def test_toleration_value_is_quoted_in_raw_yaml():
+    """value 的引号必须锁在原始文本层面：round-trip 比较会被解析器抵消，测不出引号丢失。"""
+    result, response = _render("metric", tolerations=[{"key": "dedicated", "value": "true", "effect": "NoSchedule"}])
+
+    assert response["status"] == "success"
+    assert 'value: "true"' in response["yaml"]
+    assert 'key: "dedicated"' in response["yaml"]
+
+
+def test_null_tolerations_equals_omitted():
+    """显式 null 与缺省等价（上游可选字段序列化为 null 是常态），区别于显式 [] 的零容忍。"""
+    result, response = _render("metric", tolerations=None)
+
+    assert result.returncode == 0, result.stderr
+    assert response["status"] == "success"
+    for workload, value in _workload_tolerations(response["yaml"]).items():
+        if workload.startswith("DaemonSet/"):
+            assert value == DEFAULT_DS_TOLERATIONS
+
+
+def test_dns_prefixed_key_is_accepted():
+    """带 DNS 前缀的 key（nvidia.com/gpu 形态）是真实场景最常见形态，正例必须钉住。"""
+    result, response = _render("metric", tolerations=[{"key": "example.com/dedicated", "effect": "NoSchedule"}])
+
+    assert response["status"] == "success"
+    for workload, value in _workload_tolerations(response["yaml"]).items():
+        if workload.startswith("DaemonSet/"):
+            assert value[0]["key"] == "example.com/dedicated"
+
+
+def test_boundary_sizes_are_accepted():
+    """界内边界必须成功：name 63 字符、prefix 253 字符、恰好 16 项。"""
+    name_63 = "a" * 63
+    prefix_253 = ".".join(["a" * 61, "b" * 61, "c" * 61, "d" * 61, "e" * 5])
+    assert len(prefix_253) == 253
+    sixteen = [{"key": f"k{i}", "effect": "NoSchedule"} for i in range(16)]
+
+    for tolerations in ([{"key": name_63, "effect": "NoSchedule"}], [{"key": f"{prefix_253}/x", "effect": "NoSchedule"}], sixteen):
+        result, response = _render("metric", tolerations=tolerations)
+        assert response["status"] == "success", response
+
+
+def test_empty_string_value_renders_equal_with_empty_value():
+    """value 为空串是合法输入：渲染为 operator Equal + value ""，用于精确匹配空值污点。"""
+    result, response = _render("metric", tolerations=[{"key": "dedicated", "value": "", "effect": "NoSchedule"}])
+
+    assert response["status"] == "success"
+    for workload, value in _workload_tolerations(response["yaml"]).items():
+        if workload.startswith("DaemonSet/"):
+            assert value == [{"key": "dedicated", "operator": "Equal", "value": "", "effect": "NoSchedule"}]
+
+
+def test_resource_type_silently_ignores_tolerations():
+    """resource 模板没有 DaemonSet：清单照常校验但不落地（钉住该行为，API 文档已注明）。"""
+    result, response = _render("resource", tolerations=[{"key": "dedicated", "effect": "NoSchedule"}])
+
+    assert response["status"] == "success"
+    assert "dedicated" not in response["yaml"]
+    assert all(value is None for value in _workload_tolerations(response["yaml"]).values())
+
+
+def test_render_default_matches_dist_static_default():
+    """跨真值一致性锁：webhookd 渲染默认与 dist 静态包写死的默认必须逐字段相等。
+    两条生产路径各自有测试比对各自的常量，缺这条锁时可以分叉而全部测试仍然全绿。"""
+    dist_dir = WEBHOOKD_ROOT.parents[1] / "deploy" / "dist" / "bk-lite-kubernetes-collector"
+    checks = [("metric", dist_dir / "bk-lite-metric-collector.yaml"), ("log", dist_dir / "bk-lite-log-collector.yaml")]
+    for config_type, dist_path in checks:
+        _, response = _render(config_type)
+        rendered = {
+            workload: value
+            for workload, value in _workload_tolerations(response["yaml"]).items()
+            if workload.startswith("DaemonSet/")
+        }
+        dist_docs = [document for document in yaml.safe_load_all(dist_path.read_text(encoding="utf-8")) if document]
+        dist = {
+            f"DaemonSet/{document['metadata']['name']}": document["spec"]["template"]["spec"].get("tolerations")
+            for document in dist_docs
+            if document.get("kind") == "DaemonSet"
+        }
+        assert rendered == dist, f"{config_type}: 渲染默认与 dist 静态默认漂移\n渲染={rendered}\ndist={dist}"

--- a/deploy/dist/bk-lite-kubernetes-collector/Readme.md
+++ b/deploy/dist/bk-lite-kubernetes-collector/Readme.md
@@ -27,6 +27,19 @@
 - Kubernetes 集群版本 >= 1.16
 - 集群节点需要有足够的资源（CPU、内存）
 - 已部署 bk-lite 监控平台或具备 NATS 消息队列服务
+- **单节点集群 / 控制平面跑业务的集群**：本包中的 Deployment（kube-state-metrics、
+  telegraf-deployment、vmagent）不携带任何污点容忍，遵循集群默认调度语义。若集群
+  唯一可调度节点仍保留 `node-role.kubernetes.io/control-plane:NoSchedule` 污点，
+  这些组件会 Pending——请按 Kubernetes 标准实践先移除该污点：
+
+  ```bash
+  kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+  ```
+
+  DaemonSet（cadvisor、telegraf-daemonset、vector-daemonset）已内置
+  control-plane/master 两条精确容忍，无需处理；如集群还有其他自定义污点节点需要
+  纳入节点级采集，请在各 DaemonSet 的 `tolerations` 处按注释追加**精确**容忍项，
+  不要使用无 key 的通配容忍（会穿透 cordon 与专用节点隔离）
 
 ## 安装部署
 

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-log-collector.yaml
@@ -22,9 +22,14 @@ spec:
         bklite.io/log-collect-config: "default"
     spec:
       serviceAccount: vector-daemonset
-      # 控制平面默认 NoSchedule；不上这台节点则该节点日志采不到
+      # 默认容忍 control-plane/master 污点：控制平面节点也需要节点级采集；
+      # 如需覆盖其他带自定义污点的节点，请在此追加精确容忍项（禁止无 key 的通配容忍）
       tolerations:
-        - operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
       containers:
         - name: vector

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -24,9 +24,14 @@ spec:
         prometheus.io/path: '/metrics'
     spec:
       serviceAccountName: cadvisor
-      # 控制平面默认 NoSchedule；不上这台节点则该节点 cadvisor 指标为空
+      # 默认容忍 control-plane/master 污点：控制平面节点也需要节点级采集；
+      # 如需覆盖其他带自定义污点的节点，请在此追加精确容忍项（禁止无 key 的通配容忍）
       tolerations:
-        - operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
       containers:
       - name: cadvisor
@@ -100,9 +105,14 @@ spec:
       labels:
         app: telegraf-daemonset
     spec:
-      # 控制平面默认 NoSchedule；不上这台节点则该节点主机指标为空
+      # 默认容忍 control-plane/master 污点：控制平面节点也需要节点级采集；
+      # 如需覆盖其他带自定义污点的节点，请在此追加精确容忍项（禁止无 key 的通配容忍）
       tolerations:
-        - operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Exists
           effect: NoSchedule
       containers:
         - name: telegraf
@@ -221,10 +231,6 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics
-      # 控制平面默认 NoSchedule；单节点集群否则采集 Pod 全部 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
 
 ---
 apiVersion: apps/v1
@@ -242,10 +248,6 @@ spec:
       labels:
         app: telegraf
     spec:    
-      # 控制平面默认 NoSchedule；单节点集群否则 remote_write 接收端 Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
       containers:
         - name: telegraf
           image: bk-lite.tencentcloudcr.com/bklite/telegraf:1.29.5
@@ -301,10 +303,6 @@ spec:
         app: vmagent
     spec:
       serviceAccountName: vmagent    
-      # 控制平面默认 NoSchedule；单节点集群否则 vmagent Pending
-      tolerations:
-        - operator: Exists
-          effect: NoSchedule
       containers:
         - name: vmagent
           image: bk-lite.tencentcloudcr.com/bklite/vmagent

--- a/specs/capabilities/resource-collector-template.md
+++ b/specs/capabilities/resource-collector-template.md
@@ -78,18 +78,51 @@ field. Generic names such as `kube-state-metrics`, `vmagent-role` or
 - **THEN** its `roleRef` resolves to a ClusterRole declared in the same manifest
 - **THEN** every subject is a ServiceAccount in a `bk-lite-` prefixed namespace
 
-### Requirement: Collector workloads tolerate control-plane NoSchedule
-DaemonSets and Deployments in `bk-lite-metric-collector.yaml`,
-`bk-lite-resource-collector.yaml`, `bk-lite-log-collector.yaml`, the dist
-copies, and the K3S metric manifest SHALL include a toleration
-`{operator: Exists, effect: NoSchedule}`. Control-plane nodes (and single-node
-clusters) default to `node-role.kubernetes.io/control-plane:NoSchedule`;
-without this toleration the collectors stay Pending and metrics or logs for
-those nodes are empty.
+### Requirement: DaemonSet tolerations are an explicit, precise admission input
+Taints are the cluster administrator's scheduling declaration; the collector
+SHALL NOT override them wholesale. For `bk-lite-metric-collector.yaml`,
+`bk-lite-resource-collector.yaml`, `bk-lite-log-collector.yaml` and the dist
+copies under `deploy/dist/bk-lite-kubernetes-collector/`:
 
-#### Scenario: Apply onto a tainted control-plane node
-- **WHEN** the collector is applied to a cluster whose schedulable node has
+- Node-level DaemonSets receive tolerations from the webhookd render parameter
+  `tolerations` through the `__DS_TOLERATIONS__` line placeholder; templates
+  SHALL NOT hardcode tolerations.
+- Each list item is restricted to `key` (required, a Kubernetes qualified
+  name), `effect` (required, `NoSchedule` or `NoExecute`) and an optional
+  `value` (present renders `operator: Equal`, absent renders
+  `operator: Exists` scoped to that key). A key-less wildcard toleration is
+  not expressible; invalid input SHALL reject the whole render request.
+- When the parameter is omitted, the render SHALL inject exactly
+  `node-role.kubernetes.io/control-plane:NoSchedule` and
+  `node-role.kubernetes.io/master:NoSchedule`. An explicit empty list SHALL
+  render no tolerations.
+- Deployments SHALL NOT carry tolerations: central components follow the
+  cluster's default scheduling semantics. A single-node cluster that keeps the
+  control-plane taint is the administrator's call — removing the taint is the
+  standard Kubernetes practice and a documented onboarding precondition, not
+  something the product works around.
+- The dist manifests have no render step: their DaemonSets SHALL carry exactly
+  the two default tolerations, statically.
+- Scope: K8S main-path templates and dist copies only. The K3S manifest's
+  toleration policy is maintained separately and is not covered here.
+
+#### Scenario: Default render onto a tainted control-plane node
+- **WHEN** the collector is rendered without a `tolerations` parameter and
+  applied to a cluster whose node carries
   `node-role.kubernetes.io/control-plane:NoSchedule`
-- **THEN** cadvisor, telegraf-daemonset, kube-state-metrics, vmagent,
-  telegraf-deployment, telegraf-resource and vector-daemonset are not left
-  Pending due to an untolerated taint
+- **THEN** cadvisor, telegraf-daemonset and vector-daemonset schedule onto
+  that node with exactly the two default precise tolerations
+- **THEN** kube-state-metrics, vmagent, telegraf-deployment and
+  telegraf-resource carry no tolerations and follow default scheduling
+
+#### Scenario: Administrator supplies a custom toleration list
+- **WHEN** the render request carries
+  `tolerations: [{"key": "dedicated", "value": "edge", "effect": "NoSchedule"}]`
+- **THEN** only DaemonSets receive that toleration (rendered as
+  `operator: Equal`), and no Deployment receives any toleration
+
+#### Scenario: Wildcard toleration is rejected
+- **WHEN** the render request carries a toleration item without a `key`, or
+  with any field outside `key`/`value`/`effect`
+- **THEN** the render request fails with an error instead of producing a
+  manifest that bypasses cordon or dedicated-node isolation

--- a/specs/capabilities/resource-collector-template.md
+++ b/specs/capabilities/resource-collector-template.md
@@ -92,10 +92,15 @@ copies under `deploy/dist/bk-lite-kubernetes-collector/`:
   `value` (present renders `operator: Equal`, absent renders
   `operator: Exists` scoped to that key). A key-less wildcard toleration is
   not expressible; invalid input SHALL reject the whole render request.
-- When the parameter is omitted, the render SHALL inject exactly
-  `node-role.kubernetes.io/control-plane:NoSchedule` and
+- When the parameter is omitted or explicitly `null`, the render SHALL
+  inject exactly `node-role.kubernetes.io/control-plane:NoSchedule` and
   `node-role.kubernetes.io/master:NoSchedule`. An explicit empty list SHALL
   render no tolerations.
+- Rendered `key` and `value` scalars SHALL be quoted so YAML implicit typing
+  can never reinterpret them (`"null"` as a bare key parses to an empty key —
+  a wildcard toleration). `__` is rejected in `key`/`value` (template
+  placeholder reserved token), and the toleration injection SHALL be the last
+  placeholder substitution of the render.
 - Deployments SHALL NOT carry tolerations: central components follow the
   cluster's default scheduling semantics. A single-node cluster that keeps the
   control-plane taint is the administrator's call — removing the taint is the


### PR DESCRIPTION
## 背景与动机

#4919 为修复「control-plane 污点节点无采集 Pod / 单节点集群采集全 Pending」，给全部采集器 workload（含中心 Deployment）硬编码了**无 key 的通配容忍** `{operator: Exists, effect: NoSchedule}`，并把该行为固化进了 spec 与合约测试。

无 key 的 Exists 会容忍**一切** NoSchedule 污点，这带来两类运维语义破坏：

- **cordon/drain 穿透**：cordon 节点携带 `node.kubernetes.io/unschedulable:NoSchedule` 虚拟污点。DaemonSet 本就由 DS controller 注入该容忍，但 vmagent/kube-state-metrics/telegraf 等 Deployment 被赋予通配容忍后，维护窗口 drain 时副本可能被调度器调回正在维护的节点；
- **专用池穿透**：`dedicated=xxx:NoSchedule`、GPU 池等管理员自定义隔离对中心 Deployment 全部失效。

污点是集群管理员的调度主权声明，交付型产品不应替客户管理员整体绕过（安装方式是 `curl webhookd | kubectl apply -f -`，客户对 yaml 内容无感知）。

## 设计（经评审讨论确定）

容忍策略 = **DaemonSet 专属的、接入时可显式提供的精确清单**：

| 规则 | 说明 |
|---|---|
| 渲染参数 | webhookd `/infra/kubernetes` 新增可选 `tolerations` 数组，仅注入节点级 DaemonSet（经 `__DS_TOLERATIONS__` 占位符） |
| 受限 schema | 每项仅 `key`（必填，K8s qualified name）/ `effect`（必填，`NoSchedule\|NoExecute`）/ `value`（可选：提供→`Equal`，省略→限定 key 的 `Exists`）；≤16 项；未知字段（含 `operator`、`tolerationSeconds`）、空 key、注入字符**整单拒绝**——无 key 通配在结构上不可表达 |
| 默认值 | 缺省注入 `node-role.kubernetes.io/control-plane:NoSchedule` + `node-role.kubernetes.io/master:NoSchedule` 两条精确容忍（保住 #4919 的 DS 修复目标，不穿透任何自定义隔离）；显式 `[]` = 不容忍任何污点 |
| Deployment | 一律不带 tolerations，遵循集群默认调度。单节点集群保留 control-plane 污点时中心组件 Pending 属预期——按 Kubernetes 管理实践由管理员移除污点，为接入前置条件 |
| dist 静态包 | 无渲染环节，DaemonSet 写死同样的默认两条并注释追加方式 |
| K3S | 容忍策略单独维护，本次不改动（其 manifest 与合约测试保持现状） |

## 改动内容

- `agents/webhookd/infra/kubernetes.sh`：`tolerations` 参数提取（`jq has()` 区分缺省与显式 `[]`）、`build_ds_tolerations_block` 校验+YAML 生成、占位符统一替换
- 三份模板：DS 的硬编码宽容忍 → `__DS_TOLERATIONS__` 占位行；5 处 Deployment 宽容忍删除
- `deploy/dist/bk-lite-kubernetes-collector/`：DS 静态默认两条，Deployment 删除
- `specs/capabilities/resource-collector-template.md`：原宽容忍 Requirement 改写为上述契约
- `test_k8s_manifest_contract.py`：宽容忍断言 → Deployment 禁带 tolerations / 模板 DS 占位符数量=DS 数量 / dist DS 恰好默认两条
- 新增 `test_kubernetes_tolerations_render.py`：默认、自定义（Equal/Exists/NoExecute）、空清单、10 类非法输入拒绝
- `agents/webhookd/infra/API.md`：参数文档与示例

## 验证

- `agents/webhookd/infra/tests/` 全量 **81 passed**（含未改动的 k3s 合约测试）
- 端到端冒烟：metric/log/resource × 默认/自定义/空/非法输入，逐 workload 断言渲染产物

## 现网影响

manifest 为接入时一次性 `kubectl apply` 下发，无自动重下发：存量集群不受本次合并影响；新接入集群与 re-apply 的集群按新契约生效。相对 #4919 合并后的状态，Deployment 回归集群默认调度语义。

## 后续（不在本 PR）

- monitor/log/cmdb 三模块的 token 透传 + 共享安装表单的清单编辑（可照抄 `image_registry_prefix` 的透传模式），让管理员在接入页显式维护清单
- K3S manifest 遗留的 4 处宽容忍单独立项收敛（注意 k3s 官方推荐的 `CriticalAddonsOnly` 污点是 NoExecute）

🤖 Generated with [Claude Code](https://claude.com/claude-code)