### PR TITLE
bugfix:Fixed the issue where the high-risk path rule pop-up sample ar…

### DIFF
--- a/web/src/app/job/(pages)/home/page.tsx
+++ b/web/src/app/job/(pages)/home/page.tsx
@@ -817,7 +817,7 @@ const JobHomePage = () => {
               <ChipIcon>{ICON_EXEC}</ChipIcon>
             </span>
             <span className="text-[13px] text-(--color-text-2) font-medium">{t('job.executionCount')}</span>
-            <span className="ml-auto rounded-md bg-[#eef1f6] px-2 py-0.5 text-[11px] text-(--color-text-3)">{periodLabel}</span>
+            <span className="ml-auto rounded-md bg-[var(--color-fill-1)] px-2 py-0.5 text-[11px] text-(--color-text-3)">{periodLabel}</span>
           </div>
           <div className="flex items-baseline gap-2.5">
             <span className="text-[30px] font-bold leading-none tracking-tight text-(--color-text-1)">{executionTotal}</span>
@@ -833,7 +833,7 @@ const JobHomePage = () => {
               <ChipIcon>{ICON_CHECK}</ChipIcon>
             </span>
             <span className="text-[13px] text-(--color-text-2) font-medium">{t('job.successRate')}</span>
-            <span className="ml-auto rounded-md bg-[#eef1f6] px-2 py-0.5 text-[11px] text-(--color-text-3)">{periodLabel}</span>
+            <span className="ml-auto rounded-md bg-[var(--color-fill-1)] px-2 py-0.5 text-[11px] text-(--color-text-3)">{periodLabel}</span>
           </div>
           <div className="flex items-baseline gap-2.5">
             <span className="text-[30px] font-bold leading-none tracking-tight text-[#19b87a]">{formatPercent(successRate)}</span>

--- a/web/src/app/job/components/dangerous-rule-page/index.tsx
+++ b/web/src/app/job/components/dangerous-rule-page/index.tsx
@@ -552,7 +552,7 @@ const JobDangerousRulePage: React.FC<JobDangerousRulePageProps> = ({
             {resolvedPatternHelp}
           </div>
           <div
-            className="mb-6 rounded-md bg-[#f5f7fa] px-4 py-3 text-xs leading-relaxed"
+            className="mb-6 rounded-md bg-[var(--color-fill-1)] px-4 py-3 text-xs leading-relaxed"
             style={{ color: 'var(--color-text-2)' }}
           >
             <div className="mb-1 font-medium">


### PR DESCRIPTION
…ea and homepage time label on the homework platform were not visible under dark themes, and uniformly switched to bright and dark theme semantic colors.