### PR TITLE
fix(日志): 收敛 CMDB/Stargazer 采集扇出 INFO

### DIFF
--- a/agents/stargazer/core/collection/executor.py
+++ b/agents/stargazer/core/collection/executor.py
@@ -214,7 +214,7 @@ class TargetCollectionExecutor:
                     target = targets[index]
                     target_started_at = time.monotonic()
                     active_targets.add(target)
-                    logger.info(
+                    logger.debug(
                         "event=target_collection_started instance_id=%s "
                         "plugin_ref=%s plugin_name=%s model_id=%s target=%s",
                         instance_id,
@@ -236,7 +236,7 @@ class TargetCollectionExecutor:
                             plugin_name=request.params.get("plugin_name"),
                         ):
                             duration_ms = round((time.monotonic() - target_started_at) * 1000, 2)
-                            logger.info(
+                            logger.debug(
                                 "event=target_collection_succeeded %s "
                                 "plugin_ref=%s plugin_name=%s model_id=%s target=%s "
                                 "credential_id=%s duration_ms=%s | SNMP采集成功 IP=%s 耗时=%sms",

--- a/agents/stargazer/tests/test_target_collection_executor.py
+++ b/agents/stargazer/tests/test_target_collection_executor.py
@@ -939,13 +939,18 @@ async def test_single_snmp_no_response_is_visible_as_timeout_without_plugin_trac
 
 
 @pytest.mark.asyncio
-async def test_collection_progress_is_bounded_and_shows_plugin_and_targets(monkeypatch):
+async def test_collection_info_is_bounded_and_target_details_are_debug(monkeypatch):
     info_logs = []
+    debug_logs = []
 
     def capture_info(message, *args):
         info_logs.append(message % args if args else message)
 
+    def capture_debug(message, *args):
+        debug_logs.append(message % args if args else message)
+
     monkeypatch.setattr("core.collection.executor.logger.info", capture_info)
+    monkeypatch.setattr("core.collection.executor.logger.debug", capture_debug)
     executor = TargetCollectionExecutor(
         preflight=ReachablePreflight(),
         plugin=RecordingPlugin(),
@@ -968,9 +973,11 @@ async def test_collection_progress_is_bounded_and_shows_plugin_and_targets(monke
     await executor.execute(request, lease)
 
     progress = [item for item in info_logs if "event=collection_progress" in item]
-    starts = [item for item in info_logs if "event=target_collection_started" in item]
-    successes = [item for item in info_logs if "event=target_collection_succeeded" in item]
+    summaries = [item for item in info_logs if "event=collection_run_summary" in item]
     assert 2 <= len(progress) <= 12
+    assert len(summaries) == 1
+    assert not any("event=target_collection_started" in item for item in info_logs)
+    assert not any("event=target_collection_succeeded" in item for item in info_logs)
     assert "plugin_ref=network.config" in progress[0]
     assert "plugin_name=snmp_facts" in progress[0]
     assert "instance_id=cmdb-network-1" in progress[0]
@@ -979,6 +986,8 @@ async def test_collection_progress_is_bounded_and_shows_plugin_and_targets(monke
     assert "当前目标样本=" in progress[0]
     assert "已完成=25/25" in progress[-1]
     assert "最近结果=成功" in progress[-1]
+    starts = [item for item in debug_logs if "event=target_collection_started" in item]
+    successes = [item for item in debug_logs if "event=target_collection_succeeded" in item]
     assert len(starts) == 25
     assert all("plugin_name=snmp_facts" in item for item in starts)
     assert all("target=" in item for item in starts)

--- a/server/apps/cmdb/services/collect_dispatch_service.py
+++ b/server/apps/cmdb/services/collect_dispatch_service.py
@@ -86,7 +86,7 @@ class CollectDispatchService:
                     target = target_map[attempt.object_key]
                     snapshot = CollectTargetService.build_target_snapshot(target)
                     if attempt.success:
-                        logger.info(
+                        logger.debug(
                             "[CollectDispatch] 凭据尝试成功 task_id=%s object_key=%s credential_id=%s",
                             task.id,
                             attempt.object_key,
@@ -128,7 +128,17 @@ class CollectDispatchService:
 
             pending_object_keys = list(dict.fromkeys(next_pending))
 
-        return cls.merge_attempt_results(task, attempts)
+        success_count = sum(attempt.success for attempt in attempts)
+        merged_result = cls.merge_attempt_results(task, attempts)
+        logger.info(
+            "[CollectDispatch] 任务派发完成 task_id=%s target_count=%s attempt_count=%s success_count=%s failure_count=%s",
+            task.id,
+            len(targets),
+            len(attempts),
+            success_count,
+            len(attempts) - success_count,
+        )
+        return merged_result
 
     @classmethod
     def plan_dispatch(cls, task, targets, pool, states) -> dict[str, list[CanonicalCollectTarget]]:

--- a/server/apps/cmdb/services/collect_target_service.py
+++ b/server/apps/cmdb/services/collect_target_service.py
@@ -57,12 +57,18 @@ class CollectTargetService:
                 )
 
         for target in targets:
-            logger.info(
+            logger.debug(
                 "[CollectTarget] build object key task_id=%s object_key=%s model_id=%s",
                 task.id,
                 CollectTargetService.build_object_key(target),
                 target.model_id,
             )
+        logger.info(
+            "[CollectTarget] 目标构建完成 task_id=%s target_count=%s model_count=%s",
+            task.id,
+            len(targets),
+            len({target.model_id for target in targets}),
+        )
         return targets
 
     @staticmethod

--- a/server/apps/cmdb/tests/test_collect_dispatch_service.py
+++ b/server/apps/cmdb/tests/test_collect_dispatch_service.py
@@ -25,7 +25,13 @@ def _create_task(task_type=CollectPluginTypes.HOST, driver_type=CollectDriverTyp
             {"credential_id": "cred-2", "username": "ops", "password": "plain-2", "port": 22},
         ],
         instances=[
-            {"_id": "host-1", "model_id": "host", "inst_name": "10.0.0.1", "ip": "10.0.0.1"},
+            {
+                "_id": "host-1",
+                "inst_uuid": "9696c7b8-78ab-4778-91d9-7e7fe38ac256",
+                "model_id": "host",
+                "inst_name": "10.0.0.1",
+                "ip": "10.0.0.1",
+            },
         ],
     )
 
@@ -79,6 +85,8 @@ def test_collect_dispatch_plan_prefers_success_state_and_skips_cooldown():
 @pytest.mark.django_db
 def test_collect_dispatch_execute_task_falls_back_to_next_credential(monkeypatch):
     task = _create_task()
+    logger = MagicMock()
+    monkeypatch.setattr("apps.cmdb.services.collect_dispatch_service.logger", logger)
 
     def fake_run_job_batch(inner_task, credential, targets):
         target = targets[0]
@@ -125,6 +133,39 @@ def test_collect_dispatch_execute_task_falls_back_to_next_credential(monkeypatch
     second_state = CollectTaskCredentialHit.objects.get(task=task, credential_id="cred-2")
     assert first_state.status == CollectTaskCredentialHit.STATUS_KNOWN_FAILED
     assert second_state.status == CollectTaskCredentialHit.STATUS_SUCCESS
+    assert logger.warning.call_count == 1
+    assert logger.info.call_count == 1
+    info_args = logger.info.call_args.args
+    assert "任务派发完成" in info_args[0]
+    assert info_args[1:] == (task.id, 1, 2, 1, 1)
+    assert logger.debug.call_count == 1
+    assert "凭据尝试成功" in logger.debug.call_args.args[0]
+
+
+@pytest.mark.django_db
+def test_collect_dispatch_does_not_log_completed_when_result_merge_fails(monkeypatch):
+    task = _create_task()
+    logger = MagicMock()
+    monkeypatch.setattr("apps.cmdb.services.collect_dispatch_service.logger", logger)
+
+    def fake_run_job_batch(inner_task, credential, targets):
+        target = targets[0]
+        return [
+            DispatchAttemptResult(
+                object_key=CollectTargetService.build_object_key(target),
+                credential_id=credential["credential_id"],
+                success=True,
+                failure_kind="",
+                raw_payload={"format_data": {"add": None}},
+            )
+        ]
+
+    monkeypatch.setattr(CollectDispatchService, "run_job_batch", staticmethod(fake_run_job_batch))
+
+    with pytest.raises(TypeError):
+        CollectDispatchService.execute_task(task)
+
+    assert not any("任务派发完成" in call.args[0] for call in logger.info.call_args_list)
 
 
 @pytest.mark.parametrize(

--- a/server/apps/cmdb/tests/test_collect_target_uuid_contract.py
+++ b/server/apps/cmdb/tests/test_collect_target_uuid_contract.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from apps.cmdb.constants.constants import CollectPluginTypes
 from apps.cmdb.services.collect_target_service import CollectTargetService
 
 HOST_UUID = "63e4a531-b6bb-43cc-9eae-8eb8a09f795e"
+SECOND_HOST_UUID = "4c6643d2-4dc5-4a2a-8f24-3af72f33f7bc"
 
 
 def _task(instances):
@@ -48,3 +50,25 @@ def test_collect_target_skips_legacy_snapshot_without_uuid():
     targets = CollectTargetService.build_targets(_task([{"_id": 7, "model_id": "host", "ip_addr": "10.0.0.8"}]))
 
     assert targets == []
+
+
+def test_collect_target_logs_one_info_summary_and_keeps_details_at_debug(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr("apps.cmdb.services.collect_target_service.logger", logger)
+
+    targets = CollectTargetService.build_targets(
+        _task(
+            [
+                {"inst_uuid": HOST_UUID, "model_id": "host", "ip_addr": "10.0.0.8"},
+                {"inst_uuid": SECOND_HOST_UUID, "model_id": "host", "ip_addr": "10.0.0.9"},
+            ]
+        )
+    )
+
+    assert [target.host for target in targets] == ["10.0.0.8", "10.0.0.9"]
+    assert logger.info.call_count == 1
+    info_args = logger.info.call_args.args
+    assert "目标构建完成" in info_args[0]
+    assert info_args[1:] == (42, 2, 1)
+    assert logger.debug.call_count == 2
+    assert all("build object key" in call.args[0] for call in logger.debug.call_args_list)


### PR DESCRIPTION
> Closes #4944；隶属 #4930
> 建议审查人：Stargazer 采集运行与 Server/CMDB 模块维护者

## 概要

第二轮第一批收敛采集扇出链路中的逐目标/逐凭据成功 INFO，同时保留 DEBUG 细节、有界进度、失败证据和每任务终态汇总。

## 变更

### Stargazer

- `target_collection_started` 和 SNMP `target_collection_succeeded` 从 INFO 降为 DEBUG；
- `collection_progress` 继续按首项、末项和约 10% 步长输出 INFO；
- `collection_run_summary` 继续作为一次运行的 INFO/WARNING 终态。

25 个成功 SNMP 目标由至少 50 条逐目标 INFO，收敛为 2–12 条有界进度 INFO 和 1 条终态汇总；逐目标字段仍可在 DEBUG 获取。

### CMDB

- 目标构建：逐目标 object key 从 INFO 降为 DEBUG，每次调用新增 1 条 `task_id/target_count/model_count` 汇总；
- 凭据派发：逐次成功从 INFO 降为 DEBUG，每个任务新增 1 条 `target_count/attempt_count/success_count/failure_count` 终态汇总；
- 单次失败 WARNING 保持不变；
- 先成功合并结果，再记录“任务派发完成”，避免异常退出时产生假终态日志。

## 兼容性

- `TargetCollectionExecutor.execute()` 返回的 `RunSummary`、发布、重试和失败采样不变；
- `CollectTargetService.build_targets()` 返回目标、UUID 约束和 object key 规则不变；
- `CollectDispatchService.execute_task()` 返回数据、凭据轮换、命中状态写入及异常传播不变；
- 无数据库迁移、配置或外部依赖变化。

## TDD 与审查

- 三个公开方法均先添加/修改行为测试并观察旧实现失败，再做最小实现；
- 双轴审查各发现 1 项相同的 P1：结果合并前记录完成会产生假终态；已补“合并失败不记录完成”回归测试并修复；
- 未发现其余规范违规、范围扩张或 Fowler smell。

## 验证

```text
Stargazer 执行器测试：46 passed
Stargazer 执行器文件覆盖率：89%
CMDB 相关测试：17 passed
三个生产文件 py_compile：通过
flake8 致命错误规则（E9/F63/F7/F82）：通过
git diff --check：通过
触及文件 L007 重扫：2 → 0，无解析错误
```

门禁限制：

- `agents/stargazer make lint`：本地缺少 `pre-commit` 可执行文件；
- CMDB 全量 4,399 项：收集阶段因缺少企业模块 `apps.cmdb_enterprise`，以及精简测试环境未加载 Monitor 模型而中止；
- Black check 仅报告 `collect_dispatch_service.py` 一处上游已有的相邻字符串格式，不属于本次 diff。

## 回滚

直接回滚本提交即可；回滚只会恢复逐项 INFO 噪声，不涉及数据或协议回退。
