### PR TITLE
fix(日志): 稳定 Server Core 日志模板

### DIFF
--- a/server/apps/core/db_patches/dameng.py
+++ b/server/apps/core/db_patches/dameng.py
@@ -167,27 +167,47 @@ def _patch_cursor_execute_with_lock():
         # 这解决了达梦驱动使用 GBK 编码时的 UnicodeEncodeError 问题
         sanitized_params = _sanitize_unicode_for_gbk(params) if params else params
 
-        logger.debug(f"[DAMENG_LOCK] Thread={current_thread.name}({current_thread.ident}) WAITING for lock, sql={sql_preview}")
+        logger.debug(
+            "[DAMENG_LOCK] Thread=%s(%s) WAITING for lock, sql=%s",
+            current_thread.name,
+            current_thread.ident,
+            sql_preview,
+        )
 
         try:
             lock_acquired = _dameng_global_lock.acquire(blocking=True, timeout=60.0)
 
             if not lock_acquired:
-                logger.error(f"[DAMENG_LOCK] Thread={current_thread.name}({current_thread.ident}) TIMEOUT after 60s, sql={sql_preview}")
+                logger.error(
+                    "[DAMENG_LOCK] Thread=%s(%s) TIMEOUT after 60s, sql=%s",
+                    current_thread.name,
+                    current_thread.ident,
+                    sql_preview,
+                )
                 raise TimeoutError("Failed to acquire database lock within 60 seconds")
 
             wait_time = time.time() - start_time
             logger.debug(
-                f"[DAMENG_LOCK] Thread={current_thread.name}({current_thread.ident}) ACQUIRED lock after {wait_time:.3f}s, sql={sql_preview}"
+                "[DAMENG_LOCK] Thread=%s(%s) ACQUIRED lock after %.3fs, sql=%s",
+                current_thread.name,
+                current_thread.ident,
+                wait_time,
+                sql_preview,
             )
             if wait_time > _LOCK_WAIT_WARNING_THRESHOLD:
-                logger.warning(f"[DAMENG_LOCK] Lock wait time {wait_time:.2f}s exceeded threshold")
+                logger.warning("[DAMENG_LOCK] Lock wait time %.2fs exceeded threshold", wait_time)
 
             try:
                 exec_start = time.time()
                 result = base_execute(self, sql, sanitized_params)
                 exec_time = time.time() - exec_start
-                logger.debug(f"[DAMENG_LOCK] Thread={current_thread.name}({current_thread.ident}) EXECUTED in {exec_time:.3f}s, sql={sql_preview}")
+                logger.debug(
+                    "[DAMENG_LOCK] Thread=%s(%s) EXECUTED in %.3fs, sql=%s",
+                    current_thread.name,
+                    current_thread.ident,
+                    exec_time,
+                    sql_preview,
+                )
                 return result
 
             except dmPython.DatabaseError as e:
@@ -214,7 +234,12 @@ def _patch_cursor_execute_with_lock():
         finally:
             if lock_acquired:
                 _dameng_global_lock.release()
-                logger.debug(f"[DAMENG_LOCK] Thread={current_thread.name}({current_thread.ident}) RELEASED lock, sql={sql_preview}")
+                logger.debug(
+                    "[DAMENG_LOCK] Thread=%s(%s) RELEASED lock, sql=%s",
+                    current_thread.name,
+                    current_thread.ident,
+                    sql_preview,
+                )
 
     CursorWrapper.execute = locked_execute
     logger.info("[DAMENG_LOCK] cursor.execute patched with global lock for ASGI concurrency safety")

--- a/server/apps/core/decorators/api_permission.py
+++ b/server/apps/core/decorators/api_permission.py
@@ -82,7 +82,7 @@ class HasRole(object):
                 if role in self.roles:
                     return task_definition(*args, **kwargs)
 
-            logger.warning(f"Access denied. Required roles: {self.roles}, user roles: {user_roles}")
+            logger.warning("Access denied. Required roles: %s, user roles: %s", self.roles, user_roles)
             loader = _get_loader(request)
             return WebUtils.response_403(loader.get("error.insufficient_permissions", "Insufficient permissions"))
 
@@ -148,7 +148,12 @@ class HasPermission(object):
             if self.permission & user_permissions:
                 return task_definition(*args, **kwargs)
 
-            logger.warning(f"Access denied. App: {app_name}," f" Required permissions: {self.permission}," f"user permissions: {user_permissions}")
+            logger.warning(
+                "Access denied. App: %s, Required permissions: %s,user permissions: %s",
+                app_name,
+                self.permission,
+                user_permissions,
+            )
             loader = _get_loader(request)
             return WebUtils.response_403(loader.get("error.insufficient_permissions", "Insufficient permissions"))
 

--- a/server/apps/core/fields/s3_json_field.py
+++ b/server/apps/core/fields/s3_json_field.py
@@ -165,7 +165,7 @@ class S3JSONField(models.CharField):
                 setattr(model_instance, self.attname, uploaded_path)
                 self._register_cleanup_task(model_instance, previous_path, uploaded_path)
 
-                logger.debug(f"S3JSONField uploaded: {uploaded_path}")
+                logger.debug("S3JSONField uploaded: %s", uploaded_path)
                 return uploaded_path
 
             except Exception as e:
@@ -292,10 +292,10 @@ class S3JSONField(models.CharField):
         Returns:
             Python 对象（list 或 dict）
         """
-        logger.info(f"[S3JSONField] Loading from S3: {file_path}")
+        logger.info("[S3JSONField] Loading from S3: %s", file_path)
 
         if not file_path:
-            logger.warning(f"[S3JSONField] Empty file_path, returning None")
+            logger.warning("[S3JSONField] Empty file_path, returning None")
             return None
 
         try:
@@ -303,21 +303,21 @@ class S3JSONField(models.CharField):
             with self.storage.open(file_path, "rb") as f:
                 content_bytes = f.read()
 
-            logger.info(f"[S3JSONField] Read {len(content_bytes)} bytes from S3")
+            logger.info("[S3JSONField] Read %s bytes from S3", len(content_bytes))
 
             if not content_bytes:
-                logger.warning(f"S3 file is empty: {file_path}")
+                logger.warning("S3 file is empty: %s", file_path)
                 return None
 
             # 解压（智能检测）
             try:
                 # 尝试解压
                 json_bytes = gzip.decompress(content_bytes)
-                logger.info(f"[S3JSONField] Decompressed {len(content_bytes)} -> {len(json_bytes)} bytes")
+                logger.info("[S3JSONField] Decompressed %s -> %s bytes", len(content_bytes), len(json_bytes))
             except gzip.BadGzipFile:
                 # 不是 gzip 文件，使用原始内容
                 json_bytes = content_bytes
-                logger.info(f"[S3JSONField] Not gzipped, using raw content")
+                logger.info("[S3JSONField] Not gzipped, using raw content")
 
             # 解析 JSON
             json_str = json_bytes.decode("utf-8")
@@ -332,7 +332,7 @@ class S3JSONField(models.CharField):
             logger.error(f"Invalid JSON in S3 file {file_path}: {e}")
             return None
         except Exception as e:
-            logger.error(f"Failed to load from S3 {file_path}: {e}", exc_info=True)
+            logger.error("Failed to load from S3 %s: %s", file_path, e, exc_info=True)
             return None
 
     def get_prep_value(self, value):
@@ -432,7 +432,7 @@ class S3JSONFieldDescriptor:
             loaded_value = self.field._load_from_s3(value)
             if loaded_value is None:
                 # S3 加载失败时保留路径，避免后续 save 把 DB 中的引用清空
-                logger.warning(f"[S3JSONField] Load failed for {value}, preserving path reference")
+                logger.warning("[S3JSONField] Load failed for %s, preserving path reference", value)
                 return None
             instance.__dict__[self.field.attname] = loaded_value
             return loaded_value

--- a/server/apps/core/middlewares/request_timing_middleware.py
+++ b/server/apps/core/middlewares/request_timing_middleware.py
@@ -87,7 +87,7 @@ class RequestTimingMiddleware(MiddlewareMixin):
 
         # 根据耗时和状态码选择日志级别
         if elapsed_time_ms > self.SLOW_REQUEST_THRESHOLD_MS:
-            logger.warning(f"Slow {log_message} (threshold: {self.SLOW_REQUEST_THRESHOLD_MS}ms)")
+            logger.warning("Slow %s (threshold: %sms)", log_message, self.SLOW_REQUEST_THRESHOLD_MS)
         elif status_code >= 500:
             logger.error(log_message)
         elif status_code >= 400:

--- a/server/apps/core/mixinx.py
+++ b/server/apps/core/mixinx.py
@@ -112,7 +112,7 @@ class PeriodicTaskUtils:
                 "enabled": True,
             },
         )
-        logger.info(f"已创建周期任务: {task_name}, 执行时间: {sync_time}")
+        logger.info("已创建周期任务: %s, 执行时间: %s", task_name, sync_time)
 
     @staticmethod
     def create_periodic_task_from_spec(schedule_spec, task_name, task_args, task_path):
@@ -140,11 +140,11 @@ class PeriodicTaskUtils:
                 "enabled": True,
             },
         )
-        logger.info(f"已创建周期任务: {task_name}, 调度配置: {schedule_spec}")
+        logger.info("已创建周期任务: %s, 调度配置: %s", task_name, schedule_spec)
 
     @staticmethod
     def delete_periodic_task(task_name):
         from django_celery_beat.models import PeriodicTask
 
         PeriodicTask.objects.filter(name=task_name).delete()
-        logger.info(f"已删除周期任务: {task_name}")
+        logger.info("已删除周期任务: %s", task_name)

--- a/server/apps/core/tests/test_celery_utils_service.py
+++ b/server/apps/core/tests/test_celery_utils_service.py
@@ -8,9 +8,7 @@ from django_celery_beat.models import CrontabSchedule, IntervalSchedule, Periodi
 from apps.core.utils import celery_utils as celery_utils_module
 from apps.core.utils.celery_utils import CeleryUtils, crontab_format
 
-pytestmark = pytest.mark.django_db
-
-
+@pytest.mark.unit
 class TestCrontabFormat:
     def test_cycle(self):
         assert crontab_format("cycle", "5") == (True, "*/5 * * * *")
@@ -30,6 +28,8 @@ class TestCrontabFormat:
             crontab_format("nope", "1")
 
 
+@pytest.mark.integration
+@pytest.mark.django_db
 class TestGetOrCreateCrontabSchedule:
     def test_creates_and_reuses(self):
         s1 = CeleryUtils.get_or_create_crontab_schedule("0", "1", "*", "*", "*")
@@ -46,6 +46,8 @@ class TestGetOrCreateCrontabSchedule:
         assert result.id == sched.id
 
 
+@pytest.mark.integration
+@pytest.mark.django_db
 class TestPeriodicTaskCRUD:
     def test_create_with_crontab(self, mocker):
         info = mocker.patch.object(celery_utils_module.logger, "info")

--- a/server/apps/core/tests/test_celery_utils_service.py
+++ b/server/apps/core/tests/test_celery_utils_service.py
@@ -5,6 +5,7 @@ import json
 import pytest
 from django_celery_beat.models import CrontabSchedule, IntervalSchedule, PeriodicTask
 
+from apps.core.utils import celery_utils as celery_utils_module
 from apps.core.utils.celery_utils import CeleryUtils, crontab_format
 
 pytestmark = pytest.mark.django_db
@@ -46,14 +47,30 @@ class TestGetOrCreateCrontabSchedule:
 
 
 class TestPeriodicTaskCRUD:
-    def test_create_with_crontab(self):
+    def test_create_with_crontab(self, mocker):
+        info = mocker.patch.object(celery_utils_module.logger, "info")
+
         task = CeleryUtils.create_or_update_periodic_task(
             name="t_cron", crontab="*/10 * * * *", task="apps.x.task", args=[1], kwargs={"a": 1}
         )
+
         assert task.crontab is not None
         assert task.interval is None
         assert json.loads(task.args) == [1]
         assert json.loads(task.kwargs) == {"a": 1}
+        info.assert_has_calls(
+            [
+                mocker.call(
+                    "创建或更新周期任务: name=%s, crontab=%s, interval=%s, task=%s, enabled=%s",
+                    "t_cron",
+                    "*/10 * * * *",
+                    None,
+                    "apps.x.task",
+                    True,
+                ),
+                mocker.call("%s周期任务成功: %s", "创建", "t_cron"),
+            ]
+        )
 
     def test_create_with_interval(self):
         task = CeleryUtils.create_or_update_periodic_task(name="t_int", interval=30, task="apps.x.task")

--- a/server/apps/core/tests/test_middlewares_exception_timing_service.py
+++ b/server/apps/core/tests/test_middlewares_exception_timing_service.py
@@ -173,7 +173,11 @@ class TestRequestTimingMiddleware:
 
         warn = mocker.patch.object(mod.logger, "warning")
         self.mw._log_request(_Req(path="/api/slow"), _Resp(200), elapsed_time_ms=99999)
-        warn.assert_called_once()
+        warn.assert_called_once_with(
+            "Slow %s (threshold: %sms)",
+            "Request: GET /api/slow - 200 - 99999.00ms",
+            self.mw.SLOW_REQUEST_THRESHOLD_MS,
+        )
 
     def test_log_request_500_error(self, mocker):
         from apps.core.middlewares import request_timing_middleware as mod

--- a/server/apps/core/tests/test_s3_json_field_service.py
+++ b/server/apps/core/tests/test_s3_json_field_service.py
@@ -108,10 +108,19 @@ class TestUploadAndLoadRoundTrip:
         assert json.loads(raw.decode("utf-8")) == data
         assert field._load_from_s3(path) == data
 
-    def test_load_non_gzip_raw_json(self):
+    def test_load_non_gzip_raw_json(self, mocker):
         field = _make_field(compressed=True)
         field.storage.objects["p.json"] = b'{"plain": true}'
+        info = mocker.patch.object(mod.logger, "info")
+
         assert field._load_from_s3("p.json") == {"plain": True}
+        info.assert_has_calls(
+            [
+                mocker.call("[S3JSONField] Loading from S3: %s", "p.json"),
+                mocker.call("[S3JSONField] Read %s bytes from S3", 15),
+                mocker.call("[S3JSONField] Not gzipped, using raw content"),
+            ]
+        )
 
 
 class TestLoadFromS3EdgeCases:

--- a/server/apps/core/tests/utils/test_ssrf_validator.py
+++ b/server/apps/core/tests/utils/test_ssrf_validator.py
@@ -17,6 +17,8 @@ import pytest
 from apps.core.utils import ssrf_validator as ssrf_validator_module
 from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 
+pytestmark = pytest.mark.unit
+
 # ===========================================================================
 # validate() 严格模式测试
 # ===========================================================================

--- a/server/apps/core/tests/utils/test_ssrf_validator.py
+++ b/server/apps/core/tests/utils/test_ssrf_validator.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import pytest
 
+from apps.core.utils import ssrf_validator as ssrf_validator_module
 from apps.core.utils.ssrf_validator import SSRFError, SSRFValidator
 
 # ===========================================================================
@@ -98,10 +99,17 @@ class TestSSRFValidatorStrictMode:
     # 协议阻断测试
     # -------------------------------------------------------------------------
 
-    def test_blocks_file_protocol(self):
+    def test_blocks_file_protocol(self, mocker):
         """阻断 file:// 协议"""
+        warning = mocker.patch.object(ssrf_validator_module.logger, "warning")
+
         with pytest.raises(SSRFError, match="不允许的协议"):
             SSRFValidator.validate("file:///etc/passwd")
+        warning.assert_called_once_with(
+            "[SSRF] 阻断非法协议: url=%s, scheme=%s",
+            "file:///etc/passwd",
+            "file",
+        )
 
     def test_blocks_ftp_protocol(self):
         """阻断 ftp:// 协议"""

--- a/server/apps/core/utils/celery_utils.py
+++ b/server/apps/core/utils/celery_utils.py
@@ -53,7 +53,14 @@ class CeleryUtils:
         """
         创建或更新周期任务
         """
-        logger.info(f"创建或更新周期任务: name={name}, crontab={crontab}, interval={interval}, task={task}, enabled={enabled}")
+        logger.info(
+            "创建或更新周期任务: name=%s, crontab=%s, interval=%s, task=%s, enabled=%s",
+            name,
+            crontab,
+            interval,
+            task,
+            enabled,
+        )
 
         if crontab:
             minute, hour, day_of_month, month_of_year, day_of_week = crontab.split()
@@ -95,7 +102,7 @@ class CeleryUtils:
         task_obj, task_created = PeriodicTask.objects.update_or_create(name=name, defaults=defaults)
 
         action = "创建" if task_created else "更新"
-        logger.info(f"{action}周期任务成功: {name}")
+        logger.info("%s周期任务成功: %s", action, name)
 
         return task_obj
 
@@ -107,9 +114,9 @@ class CeleryUtils:
         try:
             deleted_count, _ = PeriodicTask.objects.filter(name=name).delete()
             if deleted_count > 0:
-                logger.info(f"删除周期任务成功: {name}")
+                logger.info("删除周期任务成功: %s", name)
             else:
-                logger.warning(f"未找到要删除的周期任务: {name}")
+                logger.warning("未找到要删除的周期任务: %s", name)
             return deleted_count
         except Exception as e:
             logger.error(f"删除周期任务失败: {name}, 错误: {str(e)}")
@@ -145,7 +152,7 @@ class CeleryUtils:
             task = PeriodicTask.objects.get(name=name)
             task.enabled = True
             task.save()
-            logger.info(f"启用周期任务成功: {name}")
+            logger.info("启用周期任务成功: %s", name)
             return True
         except PeriodicTask.DoesNotExist:
             logger.warning(f"要启用的周期任务不存在: {name}")
@@ -164,7 +171,7 @@ class CeleryUtils:
             task = PeriodicTask.objects.get(name=name)
             task.enabled = False
             task.save()
-            logger.info(f"禁用周期任务成功: {name}")
+            logger.info("禁用周期任务成功: %s", name)
             return True
         except PeriodicTask.DoesNotExist:
             logger.warning(f"要禁用的周期任务不存在: {name}")

--- a/server/apps/core/utils/crypto/rsa_crypto.py
+++ b/server/apps/core/utils/crypto/rsa_crypto.py
@@ -18,7 +18,7 @@ class RSACryptor:
             self.key = RSA.generate(bits)
             self.private_key = self.key.export_key()
             self.public_key = self.key.publickey().export_key()
-            logger.info(f"RSA 密钥对生成成功，长度: {bits} 位")
+            logger.info("RSA 密钥对生成成功，长度: %s 位", bits)
         except Exception as e:
             logger.error(f"RSA 密钥生成失败: {e}")
             raise

--- a/server/apps/core/utils/group_query_mixin.py
+++ b/server/apps/core/utils/group_query_mixin.py
@@ -71,7 +71,7 @@ class GroupQueryMixin:
         )
 
         if not query_groups:
-            logger.warning(f"用户对组织 {current_team} 没有权限或该组织不存在")
+            logger.warning("用户对组织 %s 没有权限或该组织不存在", current_team)
 
         return query_groups
 
@@ -94,7 +94,7 @@ class GroupQueryMixin:
                 return []
             return list(GroupUtils.active_queryset(id__in=group_ids).values_list("id", flat=True))
 
-        logger.warning(f"无法获取用户 {request.user.username} 的组织列表")
+        logger.warning("无法获取用户 %s 的组织列表", request.user.username)
         return []
 
     def filter_by_groups(self, queryset, request):

--- a/server/apps/core/utils/loader.py
+++ b/server/apps/core/utils/loader.py
@@ -125,7 +125,7 @@ class LanguageLoader:
                         continue
                     lang_file = os.path.join(os.path.dirname(metrics_path), "language", f"{lang}.yaml")
                     if not os.path.isfile(lang_file):
-                        logger.warning(f"Plugin language missing: {lang_file}")
+                        logger.warning("Plugin language missing: %s", lang_file)
                         continue
                     try:
                         with open(lang_file, "r", encoding="utf-8") as f:
@@ -214,7 +214,7 @@ class LanguageLoader:
         result = self._deep_merge(result, enterprise)
 
         if not result:
-            logger.warning(f"No translations loaded for app={self.app} lang={lang}")
+            logger.warning("No translations loaded for app=%s lang=%s", self.app, lang)
         return result
 
     def _deep_merge(self, base: dict, override: dict) -> dict:
@@ -335,9 +335,9 @@ def preload_language_cache(apps: Optional[List[str]] = None, languages: Optional
                 logger.error(f"Failed to preload language cache {app}/{lang}: {e}")
 
     logger.info(
-        f"Language cache preload complete: "
-        f"{len(result['loaded'])} loaded, "
-        f"{len(result['skipped'])} skipped, "
-        f"{len(result['failed'])} failed"
+        "Language cache preload complete: %s loaded, %s skipped, %s failed",
+        len(result["loaded"]),
+        len(result["skipped"]),
+        len(result["failed"]),
     )
     return result

--- a/server/apps/core/utils/permission_cache.py
+++ b/server/apps/core/utils/permission_cache.py
@@ -287,7 +287,7 @@ def get_cached_permission_rules(
     )
     cached = cache.get(cache_key)
     if cached is not None and get_user_permission_version(username, domain) == permission_version:
-        logger.debug(f"Permission rules cache hit: {username}@{app_name}/{permission_key}")
+        logger.debug("Permission rules cache hit: %s@%s/%s", username, app_name, permission_key)
         return cached
     return None
 
@@ -345,7 +345,13 @@ def set_cached_permission_rules(
         existing_keys.add(cache_key)
         cache.set(user_keys_index, existing_keys, PERMISSION_CACHE_TTL + 60)
 
-    logger.debug(f"Permission rules cached: {username}@{app_name}/{permission_key}, TTL={PERMISSION_CACHE_TTL}s")
+    logger.debug(
+        "Permission rules cached: %s@%s/%s, TTL=%ss",
+        username,
+        app_name,
+        permission_key,
+        PERMISSION_CACHE_TTL,
+    )
     return get_user_permission_version(username, domain) == permission_version
 
 
@@ -356,7 +362,7 @@ def _clear_user_permission_cache_entries(username: str, domain: str) -> None:
             user_prefix = _get_user_perm_prefix(username, domain)
             try:
                 cache.delete_pattern(f"{user_prefix}*")
-                logger.info(f"Cleared permission cache (pattern) for user: {username}")
+                logger.info("Cleared permission cache (pattern) for user: %s", username)
             except Exception as e:
                 logger.warning(
                     "Failed to clear permission cache by pattern for %s, falling back to index: %s",
@@ -393,9 +399,9 @@ def _clear_user_cache_by_index(username: str, domain: str) -> None:
     if cached_keys:
         cache.delete_many(list(cached_keys))
         cache.delete(user_keys_index)
-        logger.info(f"Cleared {len(cached_keys)} permission cache entries (index) for user: {username}")
+        logger.info("Cleared %s permission cache entries (index) for user: %s", len(cached_keys), username)
     else:
-        logger.debug(f"No permission cache index found for user: {username}")
+        logger.debug("No permission cache index found for user: %s", username)
 
 
 def clear_users_permission_cache(users: List[Dict]) -> None:

--- a/server/apps/core/utils/safe_requests.py
+++ b/server/apps/core/utils/safe_requests.py
@@ -201,7 +201,11 @@ def safe_request(
 
         while response.is_redirect and redirect_count < max_redirects:
             if not allow_redirects:
-                logger.warning(f"[SafeRequests] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                logger.warning(
+                    "[SafeRequests] 禁止重定向: url=%s, location=%s",
+                    url,
+                    response.headers.get("Location"),
+                )
                 response.close()
                 raise SSRFError("不允许重定向")
 
@@ -310,7 +314,11 @@ def safe_request_llm_endpoint(
 
         while response.is_redirect and redirect_count < max_redirects:
             if not allow_redirects:
-                logger.warning(f"[SafeRequests-LLM] 禁止重定向: url={url}, location={response.headers.get('Location')}")
+                logger.warning(
+                    "[SafeRequests-LLM] 禁止重定向: url=%s, location=%s",
+                    url,
+                    response.headers.get("Location"),
+                )
                 response.close()
                 raise SSRFError("不允许重定向")
 

--- a/server/apps/core/utils/safe_template.py
+++ b/server/apps/core/utils/safe_template.py
@@ -126,14 +126,14 @@ def check_dangerous_patterns(template_str: str) -> None:
 
     description = _find_dangerous_pattern(template_lower, GLOBAL_DANGEROUS_PATTERNS)
     if description:
-        logger.warning(f"[SSTI] 检测到危险模式: {description}, template={template_str[:100]}...")
+        logger.warning("[SSTI] 检测到危险模式: %s, template=%s...", description, template_str[:100])
         raise TemplateSecurityError(f"模板包含禁止的模式: {description}")
 
     # 仅在真正的 Jinja2 表达式内部检查高危替代，避免将普通文本字符误判为 SSTI。
     for expression in JINJA_EXPRESSION_PATTERN.findall(template_lower):
         description = _find_dangerous_pattern(expression, EXPRESSION_DANGEROUS_PATTERNS)
         if description:
-            logger.warning(f"[SSTI] 检测到危险模式: {description}, template={template_str[:100]}...")
+            logger.warning("[SSTI] 检测到危险模式: %s, template=%s...", description, template_str[:100])
             raise TemplateSecurityError(f"模板包含禁止的模式: {description}")
 
 

--- a/server/apps/core/utils/ssrf_validator.py
+++ b/server/apps/core/utils/ssrf_validator.py
@@ -294,7 +294,7 @@ class SSRFValidator:
         # 1. 协议校验
         scheme = parsed.scheme.lower()
         if scheme not in cls.ALLOWED_SCHEMES:
-            logger.warning(f"[SSRF] 阻断非法协议: url={url}, scheme={scheme}")
+            logger.warning("[SSRF] 阻断非法协议: url=%s, scheme=%s", url, scheme)
             raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
 
         # 2. 主机校验
@@ -312,15 +312,15 @@ class SSRFValidator:
 
         # 3. 固定危险 / 云元数据主机名
         if hostname in cls.CLOUD_METADATA_HOSTS:
-            logger.warning(f"[SSRF] 阻断云元数据主机: url={url}")
+            logger.warning("[SSRF] 阻断云元数据主机: url=%s", url)
             raise SSRFError(f"禁止访问云元数据地址: {hostname}", code="CONNECTION_TARGET_FORBIDDEN")
         if hostname in cls.DANGEROUS_HOSTNAMES:
-            logger.warning(f"[SSRF] 阻断危险主机: url={url}")
+            logger.warning("[SSRF] 阻断危险主机: url=%s", url)
             raise SSRFError(f"禁止访问危险主机名: {hostname}", code="CONNECTION_TARGET_FORBIDDEN")
 
         # 4. 调用方额外域名限制（旧 allowlist 参数语义）
         if allowlist is not None and hostname not in {h.lower() for h in allowlist}:
-            logger.warning(f"[SSRF] 主机不在允许列表: url={url}, allowlist={allowlist}")
+            logger.warning("[SSRF] 主机不在允许列表: url=%s, allowlist=%s", url, allowlist)
             raise SSRFError(f"主机 {hostname} 不在允许列表中")
 
         allowed_networks = cls._get_allowed_networks()
@@ -395,7 +395,7 @@ class SSRFValidator:
         # 1. 协议校验
         scheme = parsed.scheme.lower()
         if scheme not in cls.ALLOWED_SCHEMES:
-            logger.warning(f"[SSRF-llm] 阻断非法协议: url={url}, scheme={scheme}")
+            logger.warning("[SSRF-llm] 阻断非法协议: url=%s, scheme=%s", url, scheme)
             raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
 
         # 2. 主机校验
@@ -406,7 +406,7 @@ class SSRFValidator:
 
         # 3. 云元数据主机名直接阻断
         if hostname in cls.CLOUD_METADATA_HOSTS:
-            logger.warning(f"[SSRF-llm] 阻断云元数据主机: url={url}")
+            logger.warning("[SSRF-llm] 阻断云元数据主机: url=%s", url)
             raise SSRFError(f"禁止访问云元数据地址: {hostname}")
 
         # 4. DNS 解析并校验云元数据 IP
@@ -429,7 +429,7 @@ class SSRFValidator:
             for network in cls.LLM_ENDPOINT_BLOCKED_NETWORKS:
                 try:
                     if ip in network:
-                        logger.warning(f"[SSRF-llm] 阻断云元数据 IP: url={url}, ip={ip_str}")
+                        logger.warning("[SSRF-llm] 阻断云元数据 IP: url=%s, ip=%s", url, ip_str)
                         raise SSRFError(f"禁止访问云元数据地址: {ip_str}")
                 except TypeError:
                     continue
@@ -466,7 +466,7 @@ class SSRFValidator:
         # 1. 协议校验
         scheme = parsed.scheme.lower()
         if scheme not in cls.ALLOWED_SCHEMES:
-            logger.warning(f"[SSRF-callback] 阻断非法协议: url={url}, scheme={scheme}")
+            logger.warning("[SSRF-callback] 阻断非法协议: url=%s, scheme=%s", url, scheme)
             raise SSRFError(f"不允许的协议: {scheme}，仅支持 http/https")
 
         # 2. 主机校验
@@ -477,7 +477,7 @@ class SSRFValidator:
 
         # 3. 云元数据主机名直接阻断
         if hostname in cls.CLOUD_METADATA_HOSTS:
-            logger.warning(f"[SSRF-callback] 阻断云元数据主机: url={url}")
+            logger.warning("[SSRF-callback] 阻断云元数据主机: url=%s", url)
             raise SSRFError(f"禁止访问云元数据地址: {hostname}")
 
         # 4. DNS 解析并校验阻断列表
@@ -501,10 +501,10 @@ class SSRFValidator:
                 try:
                     if ip in network:
                         if network == ipaddress.ip_network("127.0.0.0/8") or network == ipaddress.ip_network("::1/128"):
-                            logger.warning(f"[SSRF-callback] 阻断 localhost: url={url}, ip={ip_str}")
+                            logger.warning("[SSRF-callback] 阻断 localhost: url=%s, ip=%s", url, ip_str)
                             raise SSRFError(f"禁止访问 localhost: {ip_str}")
                         else:
-                            logger.warning(f"[SSRF-callback] 阻断云元数据 IP: url={url}, ip={ip_str}")
+                            logger.warning("[SSRF-callback] 阻断云元数据 IP: url=%s, ip=%s", url, ip_str)
                             raise SSRFError(f"禁止访问云元数据地址: {ip_str}")
                 except TypeError:
                     continue


### PR DESCRIPTION
Closes #4947

## 问题

Server Core 的部分日志在调用前通过 f-string 完成插值。业务行为虽然正确，但动态值被固化进 message，采集端难以按稳定模板聚合；即使对应级别被过滤，插值也已经发生。

## 根因

这些调用没有沿用 stdlib logging 的“稳定模板 + 独立参数”边界，将日志事件描述和运行时字段提前合并。本轮只修正该调用契约，不同时调整日志等级、字段内容、logger 来源或业务控制流。

## 怎么修的

- 将 Server Core 13 个文件中的 53 个独立 L001 动态日志模板改为 stdlib logging 稳定模板与惰性参数；
- 保留所有日志等级、渲染文案、动态参数内容和异常上下文；
- 保留 S3 上传压缩率 `:.1%` 候选，未触碰登录鉴权入口、异常所有权或其他扫描规则；
- 为 Celery 周期任务、S3 加载、慢请求和 SSRF 拒绝增加代表性日志调用契约测试。

## 调用链

```mermaid
flowchart LR
    subgraph B["业务调用层"]
        B1["Core 任务、存储与安全校验\n13 个生产文件"]
    end
    subgraph L["日志处理层"]
        L1["logger.<level>\n稳定模板 + 独立参数"]
        L2["LogRecord.getMessage\n仅在输出时完成渲染"]
    end
    subgraph O["输出层"]
        O1["现有 formatter / handler\n渲染文案保持不变"]
    end
    B1 --> L1 --> L2 --> O1
    L1 -. "级别被过滤" .-> D1["跳过字符串插值"]
```

## 影响范围

- 返回值、异常传播、ORM/缓存副作用、周期任务状态和 SSRF/SSTI 拒绝逻辑均未改变；
- 无接口、配置、数据库迁移或依赖变化；
- 使用 Server 当前 stdlib `logging` 的 `%` 参数机制，与现有 formatter 兼容；
- AST 契约对比逐项验证 53 个调用：旧 f-string 的文字片段、插值表达式、精度和 keyword 参数与新调用一一对应；
- 没有新增、删除、截断日志参数，也没有扩大敏感值或无界对象的输出范围。

## TDD 与审查

- 红：4 个代表性测试均因旧调用已提前渲染为单字符串而失败；
- 绿：同 4 个测试在实现后全部通过，并继续断言原业务结果或拒绝异常；
- Standards：PASS。模板、惰性参数和最小 diff 符合本轮范围；触及文件的存量 logger 来源、S3 INFO 噪声、日志内容风险与测试命名债务已记录到 Issue 后续项，本轮不混改等级、字段或 logger 绑定；
- Spec：PASS。53 个转换与模块分布符合 Issue，渲染、异常、返回、ORM、缓存和安全判断不变；
- Runtime Contract：PASS。新增断言在旧实现下会失败，53/53 渲染契约等价，相关 Core 测试通过；达梦真实驱动、真实 MinIO 和网络重定向未实测，因控制流未改记为非阻塞缺口；
- 质量评分：95/100（SCORE_PASS）。

## 验证

```text
Core 相关 17 个测试文件：349 passed
涉及 13 个生产模块总体覆盖率：77%
diff coverage：84%（51 行中 43 行）
py_compile（13 个生产文件）：passed
git diff --check：passed
flake8 E9/F63/F7/F82（17 个文件）：passed
日志扫描：total 148 → 95，L001 81 → 28，独立 L001 54 → 1
其他规则：L003/L004/L005/L006/L007/L009 数量完全不变
扫描 parse errors：0
渲染契约 AST 对比：53/53 passed
GitHub import-check：passed
GitHub 开源扫描：passed
```

唯一保留的独立 L001 是 `S3JSONField` 上传压缩率 `:.1%`；它已按 Issue 明确排除。

## 门禁限制

- `make test-app APP=core` 在测试执行前受基线环境阻断：最小 app 集缺少 `log` model 注册；默认 app 集缺少 `mcp.shared.session` 依赖。定向 349 项均已正常执行并通过；
- 仓库固定版本 Black 对 5 个触及文件报告存量非本轮格式偏好，hunk 均不在本次修改行；
- 仓库固定版本 isort 对 5 个触及文件报告存量 import 布局，hunk 均不在本次修改行；
- 为保持日志 PR 最小 diff，没有夹带全文件格式化或 import 重排。
- CLA 仍为 pending，需由外部签署状态解除。

## 回滚

无数据和配置变化；如日志采集兼容性异常，可直接回滚本提交。
