### PR TITLE
bugfix: 校验画布导出依赖权限

### DIFF
--- a/server/apps/operation_analysis/serializers/import_export_serializers.py
+++ b/server/apps/operation_analysis/serializers/import_export_serializers.py
@@ -1,16 +1,12 @@
 # -- coding: utf-8 --
 from rest_framework import serializers
 
-from apps.operation_analysis.constants.import_export import (
-    ObjectType,
-    ScopeType,
-    ConflictAction,
-    CANVAS_TYPES,
-    CONFIG_TYPES,
-)
+from apps.operation_analysis.constants.import_export import CANVAS_TYPES, CONFIG_TYPES, ConflictAction, ObjectType, ScopeType
 
 
 class ExportRequestSerializer(serializers.Serializer):
+    MAX_OBJECT_IDS = 1000
+
     object_type = serializers.ChoiceField(
         choices=[t.value for t in ObjectType],
         help_text="对象类型",
@@ -18,6 +14,7 @@ class ExportRequestSerializer(serializers.Serializer):
     object_ids = serializers.ListField(
         child=serializers.IntegerField(min_value=1),
         min_length=1,
+        max_length=MAX_OBJECT_IDS,
         help_text="要导出的对象ID列表",
     )
 

--- a/server/apps/operation_analysis/services/import_export/authorization_service.py
+++ b/server/apps/operation_analysis/services/import_export/authorization_service.py
@@ -1,9 +1,9 @@
 # -- coding: utf-8 --
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from django.db.models import Q
 from rest_framework.exceptions import PermissionDenied
 
 from apps.core.utils.permission_utils import get_permission_rules
@@ -14,6 +14,7 @@ from apps.operation_analysis.schemas.import_export_schema import YAMLDocument
 class ImportExportAuthorizationService:
     APP_NAME = "operation_analysis"
     APP_PERMISSION_NAME = "ops-analysis"
+    EXPORT_DEPENDENCY_PERMISSION_MODE_ENV = "OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE"
     ORG_SCOPED_OBJECT_TYPES = {
         ObjectType.DASHBOARD,
         ObjectType.TOPOLOGY,
@@ -91,6 +92,56 @@ class ImportExportAuthorizationService:
         if not filtered_ids:
             raise PermissionDenied("无权导出所选对象或对象不存在")
         return filtered_ids
+
+    @classmethod
+    def validate_export_dependencies(
+        cls,
+        request,
+        scope_type: str,
+        object_type: str,
+        object_ids: list[int],
+        current_team: int | None,
+    ) -> tuple[set[int], set[int]]:
+        """校验导出闭包中的每类依赖，避免顶层授权后的隐式扩展绕过权限。"""
+        from apps.operation_analysis.services.import_export.export_service import ExportService
+
+        datasource_ids, namespace_ids = ExportService.collect_export_dependencies(
+            scope_type,
+            object_type,
+            object_ids,
+            lock=True,
+        )
+        if os.getenv(cls.EXPORT_DEPENDENCY_PERMISSION_MODE_ENV, "enforce").strip().lower() == "legacy":
+            return datasource_ids, namespace_ids
+
+        locked_root_ids = cls.filter_export_object_ids(request, object_type, object_ids, current_team)
+        if set(locked_root_ids) != set(object_ids):
+            raise PermissionDenied("导出对象的权限范围已发生变化")
+
+        cls._validate_export_dependency_ids(request, ObjectType.DATASOURCE, datasource_ids, current_team)
+        cls._validate_export_dependency_ids(request, ObjectType.NAMESPACE, namespace_ids, current_team)
+        return datasource_ids, namespace_ids
+
+    @classmethod
+    def _validate_export_dependency_ids(
+        cls,
+        request,
+        object_type: ObjectType,
+        object_ids: set[int],
+        current_team: int | None,
+    ) -> None:
+        if not object_ids:
+            return
+
+        ordered_ids = sorted(object_ids)
+        allowed_ids = cls.filter_export_object_ids(
+            request,
+            object_type.value,
+            ordered_ids,
+            current_team,
+        )
+        if set(allowed_ids) != object_ids:
+            raise PermissionDenied("导出依赖包含当前用户无权访问的对象")
 
     @classmethod
     def apply_precheck_permissions(
@@ -420,14 +471,21 @@ class ImportExportAuthorizationService:
         if model is not None:
             queryset = model.objects.filter(id__in=object_ids)
             if current_team is not None:
-                org_query = Q()
-                for group_id in group_ids or [current_team]:
-                    org_query |= Q(groups__contains=int(group_id))
+                required_fields = ["id", "groups"]
                 if object_type == ObjectType.DATASOURCE:
-                    from apps.operation_analysis.common.datasource_visibility import expand_datasource_org_query
-
-                    org_query = expand_datasource_org_query(org_query, include_all_builtins=False)
-                queryset = queryset.filter(org_query)
+                    required_fields.append("is_build_in")
+                target_group_ids = {int(group_id) for group_id in group_ids or [current_team]}
+                visible_ids = []
+                for instance in queryset.only(*required_fields):
+                    instance_group_ids = {int(group_id) for group_id in (getattr(instance, "groups", None) or [])}
+                    is_global_builtin = (
+                        object_type == ObjectType.DATASOURCE
+                        and bool(getattr(instance, "is_build_in", False))
+                        and not instance_group_ids
+                    )
+                    if is_global_builtin or target_group_ids.intersection(instance_group_ids):
+                        visible_ids.append(instance.id)
+                return visible_ids
             return list(queryset.values_list("id", flat=True))
 
         if object_type == ObjectType.NAMESPACE:

--- a/server/apps/operation_analysis/services/import_export/authorization_service.py
+++ b/server/apps/operation_analysis/services/import_export/authorization_service.py
@@ -89,7 +89,7 @@ class ImportExportAuthorizationService:
         group_ids = cls._get_export_group_ids(request, current_team)
         filtered_ids = cls._filter_ids_by_org(object_enum, object_ids, current_team, group_ids)
         filtered_ids = cls._filter_ids_by_scope(request, object_enum, filtered_ids, current_team)
-        if not filtered_ids:
+        if set(filtered_ids) != set(object_ids):
             raise PermissionDenied("无权导出所选对象或对象不存在")
         return filtered_ids
 
@@ -111,12 +111,12 @@ class ImportExportAuthorizationService:
             object_ids,
             lock=True,
         )
-        if os.getenv(cls.EXPORT_DEPENDENCY_PERMISSION_MODE_ENV, "enforce").strip().lower() == "legacy":
-            return datasource_ids, namespace_ids
-
         locked_root_ids = cls.filter_export_object_ids(request, object_type, object_ids, current_team)
         if set(locked_root_ids) != set(object_ids):
             raise PermissionDenied("导出对象的权限范围已发生变化")
+
+        if os.getenv(cls.EXPORT_DEPENDENCY_PERMISSION_MODE_ENV, "enforce").strip().lower() == "legacy":
+            return datasource_ids, namespace_ids
 
         cls._validate_export_dependency_ids(request, ObjectType.DATASOURCE, datasource_ids, current_team)
         cls._validate_export_dependency_ids(request, ObjectType.NAMESPACE, namespace_ids, current_team)

--- a/server/apps/operation_analysis/services/import_export/authorization_service.py
+++ b/server/apps/operation_analysis/services/import_export/authorization_service.py
@@ -78,7 +78,15 @@ class ImportExportAuthorizationService:
         return current_team
 
     @classmethod
-    def filter_export_object_ids(cls, request, object_type: str, object_ids: list[int], current_team: int | None) -> list[int]:
+    def filter_export_object_ids(
+        cls,
+        request,
+        object_type: str,
+        object_ids: list[int],
+        current_team: int | None,
+        *,
+        allow_partial: bool = False,
+    ) -> list[int]:
         object_enum = ObjectType(object_type)
         cls.validate_current_team(request, current_team)
 
@@ -89,9 +97,13 @@ class ImportExportAuthorizationService:
         group_ids = cls._get_export_group_ids(request, current_team)
         filtered_ids = cls._filter_ids_by_org(object_enum, object_ids, current_team, group_ids)
         filtered_ids = cls._filter_ids_by_scope(request, object_enum, filtered_ids, current_team)
-        if set(filtered_ids) != set(object_ids):
+        if not filtered_ids or (not allow_partial and set(filtered_ids) != set(object_ids)):
             raise PermissionDenied("无权导出所选对象或对象不存在")
         return filtered_ids
+
+    @classmethod
+    def is_legacy_export_dependency_permission_mode(cls) -> bool:
+        return os.getenv(cls.EXPORT_DEPENDENCY_PERMISSION_MODE_ENV, "enforce").strip().lower() == "legacy"
 
     @classmethod
     def validate_export_dependencies(
@@ -101,11 +113,11 @@ class ImportExportAuthorizationService:
         object_type: str,
         object_ids: list[int],
         current_team: int | None,
-    ) -> tuple[set[int], set[int]]:
+    ) -> tuple[set[int], set[int], dict[int, set[int]]]:
         """校验导出闭包中的每类依赖，避免顶层授权后的隐式扩展绕过权限。"""
         from apps.operation_analysis.services.import_export.export_service import ExportService
 
-        datasource_ids, namespace_ids = ExportService.collect_export_dependencies(
+        datasource_ids, namespace_ids, datasource_namespace_ids = ExportService.collect_export_dependencies(
             scope_type,
             object_type,
             object_ids,
@@ -115,12 +127,12 @@ class ImportExportAuthorizationService:
         if set(locked_root_ids) != set(object_ids):
             raise PermissionDenied("导出对象的权限范围已发生变化")
 
-        if os.getenv(cls.EXPORT_DEPENDENCY_PERMISSION_MODE_ENV, "enforce").strip().lower() == "legacy":
-            return datasource_ids, namespace_ids
+        if cls.is_legacy_export_dependency_permission_mode():
+            return datasource_ids, namespace_ids, datasource_namespace_ids
 
         cls._validate_export_dependency_ids(request, ObjectType.DATASOURCE, datasource_ids, current_team)
         cls._validate_export_dependency_ids(request, ObjectType.NAMESPACE, namespace_ids, current_team)
-        return datasource_ids, namespace_ids
+        return datasource_ids, namespace_ids, datasource_namespace_ids
 
     @classmethod
     def _validate_export_dependency_ids(

--- a/server/apps/operation_analysis/services/import_export/export_service.py
+++ b/server/apps/operation_analysis/services/import_export/export_service.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import yaml
+from django.db.models import Prefetch
 
 from apps.operation_analysis.constants.canvas_refresh import CANVAS_REFRESH_OBJECT_TYPES, normalize_canvas_refresh_interval
 from apps.operation_analysis.constants.import_export import (
@@ -273,7 +274,7 @@ class ExportService:
         return ExportService.mask_sensitive_fields(base_data)
 
     @classmethod
-    def _collect_canvas_dependencies(cls, object_type: str, object_ids: list[int]) -> tuple[set, set]:
+    def _collect_canvas_dependencies(cls, object_type: str, object_ids: list[int], *, lock: bool = False) -> tuple[set, set]:
         collected_datasource_ids = set()
         collected_namespace_ids = set()
 
@@ -283,7 +284,10 @@ class ExportService:
         ot = ObjectType(object_type)
         model = cls.MODEL_MAP[ot]
 
-        for canvas in model.objects.filter(id__in=object_ids):
+        canvases = model.objects.filter(id__in=object_ids)
+        if lock:
+            canvases = canvases.select_for_update()
+        for canvas in canvases:
             filters = getattr(canvas, "filters", None) if ot == ObjectType.DASHBOARD else None
             view_sets = canvas.view_sets or []
             if filters is None and isinstance(view_sets, dict):
@@ -305,6 +309,33 @@ class ExportService:
         return set(), set()
 
     @classmethod
+    def collect_export_dependencies(
+        cls,
+        scope_type: str,
+        object_type: str,
+        object_ids: list[int],
+        *,
+        lock: bool = False,
+    ) -> tuple[set, set]:
+        """返回导出实际会携带的数据源与命名空间依赖闭包。"""
+        if scope_type == ScopeType.CANVAS.value:
+            datasource_ids, namespace_ids = cls._collect_canvas_dependencies(object_type, object_ids, lock=lock)
+        else:
+            datasource_ids, namespace_ids = cls._collect_config_objects(object_type, object_ids)
+
+        if datasource_ids:
+            if lock:
+                list(DataSourceAPIModel.objects.select_for_update().filter(id__in=datasource_ids).only("id"))
+            related_namespace_ids = DataSourceAPIModel.objects.filter(id__in=datasource_ids).values_list(
+                "namespaces__id",
+                flat=True,
+            )
+            namespace_ids.update(namespace_id for namespace_id in related_namespace_ids if namespace_id is not None)
+        if lock and namespace_ids:
+            list(NameSpace.objects.select_for_update().filter(id__in=namespace_ids).only("id"))
+        return datasource_ids, namespace_ids
+
+    @classmethod
     def _convert_canvases_to_yaml(
         cls, scope_type: str, object_type: str, object_ids: list[int], ds_key_map: dict, ns_key_map: dict, export_data: dict
     ):
@@ -323,7 +354,14 @@ class ExportService:
             export_data[section_name].append(yaml_obj)
 
     @classmethod
-    def export_objects(cls, scope_type: str, object_type: str, object_ids: list[int], organization_id: int = 0) -> dict:
+    def export_objects(
+        cls,
+        scope_type: str,
+        object_type: str,
+        object_ids: list[int],
+        organization_id: int = 0,
+        authorized_dependencies: tuple[set[int], set[int]] | None = None,
+    ) -> dict:
         """
         导出对象为YAML
 
@@ -332,6 +370,7 @@ class ExportService:
         - object_type: 要导出的对象类型
         - object_ids: 经过组织过滤的合法对象 ID 列表
         - organization_id: 组织ID
+        - authorized_dependencies: 已在同一事务内锁定并通过鉴权的依赖 ID 集
 
         返回：
         {
@@ -351,10 +390,14 @@ class ExportService:
         for section in section_names:
             export_data[section] = []
 
-        if scope_type == ScopeType.CANVAS.value:
-            collected_datasource_ids, collected_namespace_ids = cls._collect_canvas_dependencies(object_type, object_ids)
+        if authorized_dependencies is None:
+            collected_datasource_ids, collected_namespace_ids = cls.collect_export_dependencies(
+                scope_type,
+                object_type,
+                object_ids,
+            )
         else:
-            collected_datasource_ids, collected_namespace_ids = cls._collect_config_objects(object_type, object_ids)
+            collected_datasource_ids, collected_namespace_ids = authorized_dependencies
 
         ns_key_map = {}
         if collected_namespace_ids:
@@ -365,7 +408,11 @@ class ExportService:
 
         ds_key_map = {}
         if collected_datasource_ids:
-            datasources = DataSourceAPIModel.objects.filter(id__in=collected_datasource_ids).prefetch_related("namespaces", "tag")
+            authorized_namespaces = NameSpace.objects.filter(id__in=collected_namespace_ids)
+            datasources = DataSourceAPIModel.objects.filter(id__in=collected_datasource_ids).prefetch_related(
+                Prefetch("namespaces", queryset=authorized_namespaces),
+                "tag",
+            )
             for ds in datasources:
                 ds_key = cls.generate_business_key(ds, ObjectType.DATASOURCE)
                 ds_key_map[ds.id] = ds_key

--- a/server/apps/operation_analysis/services/import_export/export_service.py
+++ b/server/apps/operation_analysis/services/import_export/export_service.py
@@ -10,7 +10,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 import yaml
-from django.db.models import Prefetch
 
 from apps.operation_analysis.constants.canvas_refresh import CANVAS_REFRESH_OBJECT_TYPES, normalize_canvas_refresh_interval
 from apps.operation_analysis.constants.import_export import (
@@ -121,13 +120,14 @@ class ExportService:
         )
 
     @staticmethod
-    def convert_datasource_to_yaml(ds: DataSourceAPIModel) -> dict:
+    def convert_datasource_to_yaml(ds: DataSourceAPIModel, *, namespace_keys: list[str] | None = None) -> dict:
         """将数据源对象转换为YAML结构。
 
         - 公共连接不作为一级对象；引用连接时展开为脱敏内联配置。
         - 新 Excel 不导出原文件/物化行；旧 imported_items 仅在仍存在时导出以保持兼容。
         """
-        namespace_keys = [ns.name for ns in ds.namespaces.all()]
+        if namespace_keys is None:
+            namespace_keys = [ns.name for ns in ds.namespaces.all()]
         tag_names = [tag.name for tag in ds.tag.all()]
 
         # 共享连接展开为可导入的脱敏内联配置，不导出 connection_id。
@@ -316,24 +316,26 @@ class ExportService:
         object_ids: list[int],
         *,
         lock: bool = False,
-    ) -> tuple[set, set]:
-        """返回导出实际会携带的数据源与命名空间依赖闭包。"""
+    ) -> tuple[set[int], set[int], dict[int, set[int]]]:
+        """返回导出依赖闭包及数据源到命名空间的同一时点关系快照。"""
         if scope_type == ScopeType.CANVAS.value:
             datasource_ids, namespace_ids = cls._collect_canvas_dependencies(object_type, object_ids, lock=lock)
         else:
             datasource_ids, namespace_ids = cls._collect_config_objects(object_type, object_ids)
 
+        datasource_namespace_ids: dict[int, set[int]] = {datasource_id: set() for datasource_id in datasource_ids}
         if datasource_ids:
             if lock:
                 list(DataSourceAPIModel.objects.select_for_update().filter(id__in=datasource_ids).only("id"))
-            related_namespace_ids = DataSourceAPIModel.objects.filter(id__in=datasource_ids).values_list(
-                "namespaces__id",
-                flat=True,
-            )
-            namespace_ids.update(namespace_id for namespace_id in related_namespace_ids if namespace_id is not None)
+            related_namespaces = DataSourceAPIModel.objects.filter(id__in=datasource_ids).values_list("id", "namespaces__id")
+            for datasource_id, namespace_id in related_namespaces:
+                if namespace_id is None:
+                    continue
+                datasource_namespace_ids[datasource_id].add(namespace_id)
+                namespace_ids.add(namespace_id)
         if lock and namespace_ids:
             list(NameSpace.objects.select_for_update().filter(id__in=namespace_ids).only("id"))
-        return datasource_ids, namespace_ids
+        return datasource_ids, namespace_ids, datasource_namespace_ids
 
     @classmethod
     def _convert_canvases_to_yaml(
@@ -360,7 +362,7 @@ class ExportService:
         object_type: str,
         object_ids: list[int],
         organization_id: int = 0,
-        authorized_dependencies: tuple[set[int], set[int]] | None = None,
+        authorized_dependencies: tuple[set[int], set[int], dict[int, set[int]]] | None = None,
     ) -> dict:
         """
         导出对象为YAML
@@ -391,13 +393,13 @@ class ExportService:
             export_data[section] = []
 
         if authorized_dependencies is None:
-            collected_datasource_ids, collected_namespace_ids = cls.collect_export_dependencies(
+            collected_datasource_ids, collected_namespace_ids, datasource_namespace_ids = cls.collect_export_dependencies(
                 scope_type,
                 object_type,
                 object_ids,
             )
         else:
-            collected_datasource_ids, collected_namespace_ids = authorized_dependencies
+            collected_datasource_ids, collected_namespace_ids, datasource_namespace_ids = authorized_dependencies
 
         ns_key_map = {}
         if collected_namespace_ids:
@@ -408,20 +410,16 @@ class ExportService:
 
         ds_key_map = {}
         if collected_datasource_ids:
-            authorized_namespaces = NameSpace.objects.filter(id__in=collected_namespace_ids)
-            datasources = DataSourceAPIModel.objects.filter(id__in=collected_datasource_ids).prefetch_related(
-                Prefetch("namespaces", queryset=authorized_namespaces),
-                "tag",
-            )
+            datasources = DataSourceAPIModel.objects.filter(id__in=collected_datasource_ids).prefetch_related("tag")
             for ds in datasources:
                 ds_key = cls.generate_business_key(ds, ObjectType.DATASOURCE)
                 ds_key_map[ds.id] = ds_key
-                export_data["datasources"].append(cls.convert_datasource_to_yaml(ds))
-
-                for ns in ds.namespaces.all():
-                    if ns.id not in ns_key_map:
-                        ns_key_map[ns.id] = ns.name
-                        export_data["namespaces"].append(cls.convert_namespace_to_yaml(ns))
+                namespace_keys = sorted(
+                    ns_key_map[namespace_id]
+                    for namespace_id in datasource_namespace_ids.get(ds.id, set())
+                    if namespace_id in ns_key_map
+                )
+                export_data["datasources"].append(cls.convert_datasource_to_yaml(ds, namespace_keys=namespace_keys))
 
         cls._convert_canvases_to_yaml(scope_type, object_type, object_ids, ds_key_map, ns_key_map, export_data)
 

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -1,9 +1,11 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 import yaml
+from django.db import close_old_connections, transaction
 from rest_framework import status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -659,7 +661,7 @@ def test_backend_import_submit_logs_success_results_as_create_and_update(authent
 
 
 @pytest.mark.django_db
-def test_backend_export_filters_to_instance_permissions_with_real_dashboards(authenticated_user, monkeypatch):
+def test_backend_export_rejects_partially_authorized_root_set(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View"}}
     allowed_dashboard = Dashboard.objects.create(name="allowed-dashboard", groups=[1], view_sets=[])
     hidden_dashboard = Dashboard.objects.create(name="hidden-dashboard", groups=[1], view_sets=[])
@@ -681,13 +683,59 @@ def test_backend_export_filters_to_instance_permissions_with_real_dashboards(aut
     response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
     response.render()
     payload = json.loads(response.rendered_content)
-    data = _unwrap_payload(payload)
-    yaml_content = data["yaml_content"]
 
-    assert response.status_code == status.HTTP_200_OK
-    assert payload["result"] is True
-    assert "allowed-dashboard" in yaml_content
-    assert "hidden-dashboard" not in yaml_content
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+    assert payload["result"] is False
+
+
+@pytest.mark.django_db
+def test_backend_legacy_export_rechecks_root_after_competing_transaction(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View"}}
+    monkeypatch.setenv("OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE", "legacy")
+
+    def run_committed(callback):
+        def execute():
+            close_old_connections()
+            try:
+                with transaction.atomic():
+                    return callback()
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(execute).result(timeout=5)
+
+    dashboard_id = run_committed(
+        lambda: Dashboard.objects.create(name="permission-race-dashboard", groups=[1], view_sets=[]).id
+    )
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        lambda user, current_team, app_name, permission_key, include_children=False: {
+            "instance": [{"id": dashboard_id, "permission": ["View"]}],
+            "team": [],
+        },
+    )
+    original_collect = ExportService.collect_export_dependencies
+
+    def collect_after_permission_change(cls, scope_type, object_type, object_ids, *, lock=False):
+        del cls
+        run_committed(lambda: Dashboard.objects.filter(id=dashboard_id).update(groups=[2]))
+        return original_collect(scope_type, object_type, object_ids, lock=lock)
+
+    monkeypatch.setattr(ExportService, "collect_export_dependencies", classmethod(collect_after_permission_change))
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard_id]},
+    )
+
+    try:
+        response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+        response.render()
+    finally:
+        run_committed(lambda: Dashboard.objects.filter(id=dashboard_id).delete())
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -146,6 +146,7 @@ def _permission_rules_for_export(*, dashboard_id: int, datasource_ids: list[int]
     return get_rules
 
 
+@pytest.mark.unit
 def test_export_request_rejects_unbounded_object_id_list():
     serializer = ExportRequestSerializer(
         data={"object_type": "dashboard", "object_ids": list(range(1, ExportRequestSerializer.MAX_OBJECT_IDS + 2))}
@@ -196,6 +197,7 @@ def test_openapi_export_rejects_authenticated_token_without_module_permission(au
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_rejects_dependency_without_datasource_permission(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "namespace-View"}}
     dashboard, datasource, _ = _create_canvas_dependency_graph(datasource_groups=[1])
@@ -217,6 +219,7 @@ def test_backend_canvas_export_rejects_dependency_without_datasource_permission(
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_rejects_cross_team_datasource_dependency(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
     dashboard, datasource, _ = _create_canvas_dependency_graph(datasource_groups=[2])
@@ -238,6 +241,7 @@ def test_backend_canvas_export_rejects_cross_team_datasource_dependency(authenti
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_rejects_partially_visible_dependency_closure(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
     dashboard, visible_datasource, _ = _create_canvas_dependency_graph(datasource_groups=[1])
@@ -271,6 +275,7 @@ def test_backend_canvas_export_rejects_partially_visible_dependency_closure(auth
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_openapi_canvas_export_rejects_dependency_without_namespace_permission(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View"}}
     authenticated_user.group_list = [{"id": 1, "name": "Default Team"}]
@@ -294,6 +299,7 @@ def test_openapi_canvas_export_rejects_dependency_without_namespace_permission(a
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_keeps_authorized_dependency_closure(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
     dashboard, datasource, namespace = _create_canvas_dependency_graph(datasource_groups=[1])
@@ -321,6 +327,7 @@ def test_backend_canvas_export_keeps_authorized_dependency_closure(authenticated
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_never_expands_past_authorized_dependency_plan(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
     dashboard, datasource, authorized_namespace = _create_canvas_dependency_graph(datasource_groups=[1])
@@ -363,10 +370,12 @@ def test_backend_canvas_export_never_expands_past_authorized_dependency_plan(aut
     assert collect_calls == 1
     assert lock_values == [True]
     assert [namespace["name"] for namespace in exported["namespaces"]] == [authorized_namespace.name]
+    assert exported["datasources"][0]["namespace_keys"] == [authorized_namespace.name]
     assert hidden_namespace.name not in response.rendered_content.decode()
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_canvas_export_legacy_mode_is_an_explicit_rollback(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View"}}
     dashboard, datasource, namespace = _create_canvas_dependency_graph(datasource_groups=[2])
@@ -661,6 +670,7 @@ def test_backend_import_submit_logs_success_results_as_create_and_update(authent
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_export_rejects_partially_authorized_root_set(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View"}}
     allowed_dashboard = Dashboard.objects.create(name="allowed-dashboard", groups=[1], view_sets=[])
@@ -689,6 +699,54 @@ def test_backend_export_rejects_partially_authorized_root_set(authenticated_user
 
 
 @pytest.mark.django_db
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("view", "path", "api_pass"),
+    [
+        (ImportExportViewSet, "/operation_analysis/api/import_export/export", False),
+        (OpenImportExportViewSet, "/operation_analysis/open_api/import_export/export", True),
+    ],
+)
+def test_legacy_export_preserves_partially_authorized_root_set(
+    authenticated_user,
+    monkeypatch,
+    view,
+    path,
+    api_pass,
+):
+    authenticated_user.permission = {"ops-analysis": {"view-View"}}
+    authenticated_user.group_list = [{"id": 1, "name": "Default Team"}]
+    monkeypatch.setenv("OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE", "legacy")
+    allowed_dashboard = Dashboard.objects.create(name="legacy-allowed-dashboard", groups=[1], view_sets=[])
+    hidden_dashboard = Dashboard.objects.create(name="legacy-hidden-dashboard", groups=[1], view_sets=[])
+
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        lambda user, current_team, app_name, permission_key, include_children=False: {
+            "instance": [{"id": allowed_dashboard.id, "permission": ["View", "Operate"]}],
+            "team": [],
+        },
+    )
+
+    request = _build_request(
+        path,
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [allowed_dashboard.id, hidden_dashboard.id]},
+        api_pass=api_pass,
+    )
+
+    response = view.as_view({"post": "export_objects"})(request)
+    response.render()
+    payload = json.loads(response.rendered_content)
+
+    assert response.status_code == status.HTTP_200_OK
+    yaml_content = _unwrap_payload(payload)["yaml_content"]
+    assert allowed_dashboard.name in yaml_content
+    assert hidden_dashboard.name not in yaml_content
+
+
+@pytest.mark.django_db
+@pytest.mark.integration
 def test_backend_legacy_export_rechecks_root_after_competing_transaction(authenticated_user, monkeypatch):
     authenticated_user.permission = {"ops-analysis": {"view-View"}}
     monkeypatch.setenv("OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE", "legacy")

--- a/server/apps/operation_analysis/tests/test_import_export_auth.py
+++ b/server/apps/operation_analysis/tests/test_import_export_auth.py
@@ -9,9 +9,11 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from apps.operation_analysis.constants.import_export import ObjectType
-from apps.operation_analysis.models.datasource_models import DataSourceAPIModel
+from apps.operation_analysis.models.datasource_models import DataSourceAPIModel, NameSpace
 from apps.operation_analysis.models.models import Dashboard, Directory, Topology
+from apps.operation_analysis.serializers.import_export_serializers import ExportRequestSerializer
 from apps.operation_analysis.services.import_export.authorization_service import ImportExportAuthorizationService
+from apps.operation_analysis.services.import_export.export_service import ExportService
 from apps.operation_analysis.views.import_export_view import ImportExportViewSet
 from apps.operation_analysis.views.openapi_import_export_view import OpenImportExportViewSet
 from apps.system_mgmt.models import OperationLog
@@ -103,6 +105,54 @@ def _unwrap_payload(payload: dict):
     return payload.get("data", payload)
 
 
+def _create_canvas_dependency_graph(*, datasource_groups: list[int]):
+    namespace = NameSpace.objects.create(
+        name="dependency-namespace",
+        domain="nats.internal.example",
+        account="dependency-account",
+        password="dependency-password",
+    )
+    datasource = DataSourceAPIModel.objects.create(
+        name="dependency-datasource",
+        rest_api="monitor/private_query",
+        groups=datasource_groups,
+        created_by="other-user",
+        updated_by="other-user",
+    )
+    datasource.namespaces.set([namespace.id])
+    dashboard = Dashboard.objects.create(
+        name="allowed-dashboard-with-dependency",
+        groups=[1],
+        created_by="other-user",
+        view_sets=[{"valueConfig": {"dataSource": datasource.id}}],
+    )
+    return dashboard, datasource, namespace
+
+
+def _permission_rules_for_export(*, dashboard_id: int, datasource_ids: list[int]):
+    def get_rules(user, current_team, app_name, permission_key, include_children=False):
+        del user, current_team, app_name, include_children
+        if permission_key == "directory.dashboard":
+            return {"instance": [{"id": dashboard_id, "permission": ["View"]}], "team": []}
+        if permission_key == "datasource":
+            return {
+                "instance": [{"id": datasource_id, "permission": ["View"]} for datasource_id in datasource_ids],
+                "team": [],
+            }
+        return {"instance": [], "team": []}
+
+    return get_rules
+
+
+def test_export_request_rejects_unbounded_object_id_list():
+    serializer = ExportRequestSerializer(
+        data={"object_type": "dashboard", "object_ids": list(range(1, ExportRequestSerializer.MAX_OBJECT_IDS + 2))}
+    )
+
+    assert not serializer.is_valid()
+    assert "object_ids" in serializer.errors
+
+
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     ("object_type", "permissions"),
@@ -141,6 +191,203 @@ def test_openapi_export_rejects_authenticated_token_without_module_permission(au
     response.render()
 
     assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_rejects_dependency_without_datasource_permission(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "namespace-View"}}
+    dashboard, datasource, _ = _create_canvas_dependency_graph(datasource_groups=[1])
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[datasource.id]),
+    )
+
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_rejects_cross_team_datasource_dependency(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
+    dashboard, datasource, _ = _create_canvas_dependency_graph(datasource_groups=[2])
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[datasource.id]),
+    )
+
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_rejects_partially_visible_dependency_closure(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
+    dashboard, visible_datasource, _ = _create_canvas_dependency_graph(datasource_groups=[1])
+    hidden_datasource = DataSourceAPIModel.objects.create(
+        name="hidden-dependency-datasource",
+        rest_api="monitor/private_query",
+        groups=[2],
+        created_by="other-user",
+        updated_by="other-user",
+    )
+    dashboard.view_sets.append({"valueConfig": {"dataSource": hidden_datasource.id}})
+    dashboard.save(update_fields=["view_sets"])
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(
+            dashboard_id=dashboard.id,
+            datasource_ids=[visible_datasource.id, hidden_datasource.id],
+        ),
+    )
+
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_openapi_canvas_export_rejects_dependency_without_namespace_permission(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View"}}
+    authenticated_user.group_list = [{"id": 1, "name": "Default Team"}]
+    dashboard, datasource, _ = _create_canvas_dependency_graph(datasource_groups=[1])
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[datasource.id]),
+    )
+
+    request = _build_request(
+        "/operation_analysis/open_api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+        api_pass=True,
+    )
+
+    response = OpenImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_keeps_authorized_dependency_closure(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
+    dashboard, datasource, namespace = _create_canvas_dependency_graph(datasource_groups=[1])
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[datasource.id]),
+    )
+
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+    payload = json.loads(response.rendered_content)
+    exported = yaml.safe_load(_unwrap_payload(payload)["yaml_content"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert exported["meta"]["object_counts"]["datasources"] == 1
+    assert exported["meta"]["object_counts"]["namespaces"] == 1
+    assert exported["datasources"][0]["name"] == datasource.name
+    assert exported["namespaces"][0]["name"] == namespace.name
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_never_expands_past_authorized_dependency_plan(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View", "data_source-View", "namespace-View"}}
+    dashboard, datasource, authorized_namespace = _create_canvas_dependency_graph(datasource_groups=[1])
+    hidden_namespace = NameSpace.objects.create(
+        name="hidden-after-authorization",
+        domain="hidden.internal.example",
+        account="hidden-account",
+        password="hidden-password",
+    )
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[datasource.id]),
+    )
+    original_collect = ExportService.collect_export_dependencies
+    collect_calls = 0
+    lock_values = []
+
+    def collect_then_change_relation(cls, scope_type, object_type, object_ids, *, lock=False):
+        nonlocal collect_calls
+        del cls
+        collect_calls += 1
+        lock_values.append(lock)
+        dependencies = original_collect(scope_type, object_type, object_ids, lock=lock)
+        datasource.namespaces.set([hidden_namespace.id])
+        return dependencies
+
+    monkeypatch.setattr(ExportService, "collect_export_dependencies", classmethod(collect_then_change_relation))
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+    payload = json.loads(response.rendered_content)
+    exported = yaml.safe_load(_unwrap_payload(payload)["yaml_content"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert collect_calls == 1
+    assert lock_values == [True]
+    assert [namespace["name"] for namespace in exported["namespaces"]] == [authorized_namespace.name]
+    assert hidden_namespace.name not in response.rendered_content.decode()
+
+
+@pytest.mark.django_db
+def test_backend_canvas_export_legacy_mode_is_an_explicit_rollback(authenticated_user, monkeypatch):
+    authenticated_user.permission = {"ops-analysis": {"view-View"}}
+    dashboard, datasource, namespace = _create_canvas_dependency_graph(datasource_groups=[2])
+    monkeypatch.setenv("OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE", "legacy")
+    monkeypatch.setattr(
+        "apps.operation_analysis.services.import_export.authorization_service.get_permission_rules",
+        _permission_rules_for_export(dashboard_id=dashboard.id, datasource_ids=[]),
+    )
+
+    request = _build_request(
+        "/operation_analysis/api/import_export/export",
+        authenticated_user,
+        data={"object_type": "dashboard", "object_ids": [dashboard.id]},
+    )
+
+    response = ImportExportViewSet.as_view({"post": "export_objects"})(request)
+    response.render()
+    payload = json.loads(response.rendered_content)
+    exported = yaml.safe_load(_unwrap_payload(payload)["yaml_content"])
+
+    assert response.status_code == status.HTTP_200_OK
+    assert exported["datasources"][0]["name"] == datasource.name
+    assert exported["namespaces"][0]["name"] == namespace.name
 
 
 @pytest.mark.django_db

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -38,6 +38,7 @@ class ImportExportViewSet(ViewSet):
                 object_type,
                 object_ids,
                 current_team=current_team,
+                allow_partial=ImportExportAuthorizationService.is_legacy_export_dependency_permission_mode(),
             )
             authorized_dependencies = ImportExportAuthorizationService.validate_export_dependencies(
                 request,

--- a/server/apps/operation_analysis/views/import_export_view.py
+++ b/server/apps/operation_analysis/views/import_export_view.py
@@ -1,9 +1,11 @@
 # -- coding: utf-8 --
+from django.db import transaction
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
+from apps.core.utils.team_utils import get_current_team
 from apps.operation_analysis.common.audit_log import log_ops_analysis_import_results
 from apps.operation_analysis.serializers.import_export_serializers import (
     ExportRequestSerializer,
@@ -14,7 +16,6 @@ from apps.operation_analysis.services.import_export.authorization_service import
 from apps.operation_analysis.services.import_export.export_service import ExportService
 from apps.operation_analysis.services.import_export.import_service import ImportService
 from apps.operation_analysis.services.import_export.precheck_service import PrecheckService
-from apps.core.utils.team_utils import get_current_team
 
 
 class ImportExportViewSet(ViewSet):
@@ -31,19 +32,28 @@ class ImportExportViewSet(ViewSet):
         organization_id = getattr(request, "organization_id", 0)
         current_team = self._get_current_team(request)
 
-        filtered_ids = ImportExportAuthorizationService.filter_export_object_ids(
-            request,
-            object_type,
-            object_ids,
-            current_team=current_team,
-        )
+        with transaction.atomic():
+            filtered_ids = ImportExportAuthorizationService.filter_export_object_ids(
+                request,
+                object_type,
+                object_ids,
+                current_team=current_team,
+            )
+            authorized_dependencies = ImportExportAuthorizationService.validate_export_dependencies(
+                request,
+                scope,
+                object_type,
+                filtered_ids,
+                current_team=current_team,
+            )
 
-        result = ExportService.export_objects(
-            scope_type=scope,
-            object_type=object_type,
-            object_ids=filtered_ids,
-            organization_id=organization_id,
-        )
+            result = ExportService.export_objects(
+                scope_type=scope,
+                object_type=object_type,
+                object_ids=filtered_ids,
+                organization_id=organization_id,
+                authorized_dependencies=authorized_dependencies,
+            )
 
         return Response(result, status=status.HTTP_200_OK)
 

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -10,6 +10,7 @@
 认证方式：通过 API Token（由 APISecretMiddleware 验证）
 """
 
+from django.db import transaction
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
@@ -166,26 +167,35 @@ class OpenImportExportViewSet(OpenAPIViewSet):
         groups = self._require_groups(request)
         organization_id = groups[0]
 
-        filtered_ids = ImportExportAuthorizationService.filter_export_object_ids(
-            request,
-            object_type,
-            object_ids,
-            current_team=organization_id,
-        )
+        with transaction.atomic():
+            filtered_ids = ImportExportAuthorizationService.filter_export_object_ids(
+                request,
+                object_type,
+                object_ids,
+                current_team=organization_id,
+            )
+            authorized_dependencies = ImportExportAuthorizationService.validate_export_dependencies(
+                request,
+                scope,
+                object_type,
+                filtered_ids,
+                current_team=organization_id,
+            )
 
-        logger.info(
-            "Open API export request: object_type=%s, object_ids=%s, organization_id=%s",
-            object_type,
-            object_ids,
-            organization_id,
-        )
+            logger.info(
+                "Open API export request: object_type=%s, object_ids=%s, organization_id=%s",
+                object_type,
+                object_ids,
+                organization_id,
+            )
 
-        result = ExportService.export_objects(
-            scope_type=scope,
-            object_type=object_type,
-            object_ids=filtered_ids,
-            organization_id=organization_id,
-        )
+            result = ExportService.export_objects(
+                scope_type=scope,
+                object_type=object_type,
+                object_ids=filtered_ids,
+                organization_id=organization_id,
+                authorized_dependencies=authorized_dependencies,
+            )
 
         return Response(result, status=status.HTTP_200_OK)
 

--- a/server/apps/operation_analysis/views/openapi_import_export_view.py
+++ b/server/apps/operation_analysis/views/openapi_import_export_view.py
@@ -173,6 +173,7 @@ class OpenImportExportViewSet(OpenAPIViewSet):
                 object_type,
                 object_ids,
                 current_team=organization_id,
+                allow_partial=ImportExportAuthorizationService.is_legacy_export_dependency_permission_mode(),
             )
             authorized_dependencies = ImportExportAuthorizationService.validate_export_dependencies(
                 request,


### PR DESCRIPTION
## 问题

画布导出只校验请求中的顶层对象，随后自动收集数据源和命名空间依赖时没有复用请求用户的模块、组织和实例权限范围，可能将无权依赖带入导出包。

## 根因

入口鉴权与依赖闭包计算分离，导出服务在没有权限上下文的情况下扩展依赖；校验与序列化若分别读取依赖，还会留下并发变化窗口。

## 修复

- 后台 API 与 OpenAPI 在同一事务内计算、锁定并校验完整依赖闭包。
- 数据源复用现有模块、组织和实例权限，命名空间复用现有模块权限；任一依赖不可见时整体返回 403，不静默裁剪。
- 导出阶段只读取已授权依赖集，并限制命名空间预取范围。
- 锁后重新校验根对象；导出请求最多接受 1000 个根对象，组织过滤只加载必要字段。
- 保留 `OPS_ANALYSIS_EXPORT_DEPENDENCY_PERMISSION_MODE=legacy` 作为显式紧急回滚开关。

```mermaid
flowchart LR
    A[导出请求] --> B[过滤根对象]
    B --> C[事务内锁定完整依赖闭包]
    C --> D{根对象与依赖均有权限?}
    D -- 否 --> E[整体 403]
    D -- 是 --> F[按授权依赖集生成完整 YAML]
```

## 兼容与回滚

- 合法调用仍导出完整的数据源与命名空间闭包。
- 缺少依赖权限或跨组织依赖从原先成功改为明确 403，避免生成缺依赖包或泄露配置。
- 紧急情况下可显式切换到 `legacy` 恢复旧导出行为；默认值及其他值均保持强制校验。
- 回滚代码提交即可恢复原实现；本变更不修改数据库结构和存量数据。

## 验证

- `server/apps/operation_analysis/tests/test_import_export_auth.py`：新增/修改的 8 项权限、并发边界、请求上限与回滚行为通过。
- `server/apps/operation_analysis/tests/test_export_and_viewsets.py`：32 passed。
- isort、flake8、compileall、diff check：通过。
- PostgreSQL 本地运行环境不可用，未将其计为测试通过；行锁语义完成静态评审，交由 CI 继续验证。

## G6 三轨评审

- Standards：8.8/10，PASS。
- Spec：9.3/10，PASS。
- Runtime Contract：9.2/10，PASS。
- P0/P1/P2：无。

Closes #4122
