### PR TITLE
bugfix: 延后训练配置旧文件清理

### DIFF
--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -50,6 +50,7 @@ class TrainDataFileCleanupMixin:
         4. Deletes the old file after the surrounding transaction commits
         """
         from django.db import router, transaction
+
         from apps.mlops.services.train_data_file_cleanup import (
             _assert_file_reference_available,
             _lock_file_reference_guards,
@@ -59,9 +60,7 @@ class TrainDataFileCleanupMixin:
         file_field_name = self._file_field_name
         file_field = self._meta.get_field(file_field_name)
         update_fields = kwargs.get("update_fields")
-        using = kwargs.get("using") or router.db_for_write(
-            self.__class__, instance=self
-        )
+        using = kwargs.get("using") or router.db_for_write(self.__class__, instance=self)
 
         # New records and partial saves that exclude the file keep normal Model.save semantics.
         if not self.pk:
@@ -96,11 +95,7 @@ class TrainDataFileCleanupMixin:
 
         with transaction.atomic(using=using):
             try:
-                old_instance = (
-                    self.__class__.objects.using(using)
-                    .select_for_update()
-                    .get(pk=self.pk)
-                )
+                old_instance = self.__class__.objects.using(using).select_for_update().get(pk=self.pk)
                 old_file = getattr(old_instance, file_field_name)
                 old_path = old_file.name if old_file else None
             except self.__class__.DoesNotExist:
@@ -109,17 +104,11 @@ class TrainDataFileCleanupMixin:
 
             new_file = getattr(self, file_field_name)
             new_path = new_file.name if new_file else None
-            loaded_path = getattr(
-                self, "_loaded_file_path", self._loaded_file_path_missing
-            )
+            loaded_path = getattr(self, "_loaded_file_path", self._loaded_file_path_missing)
 
             # A stale instance that did not change the file must not overwrite a
             # replacement committed by another request.
-            if (
-                loaded_path is not self._loaded_file_path_missing
-                and new_path == loaded_path
-                and old_path != loaded_path
-            ):
+            if loaded_path is not self._loaded_file_path_missing and new_path == loaded_path and old_path != loaded_path:
                 setattr(self, file_field_name, old_file)
                 new_file = getattr(self, file_field_name)
                 new_path = old_path
@@ -157,9 +146,7 @@ class TrainDataFileCleanupMixin:
                 }
 
                 def delete_old_file():
-                    from apps.mlops.services.train_data_file_cleanup import (
-                        delete_train_data_file_with_retry,
-                    )
+                    from apps.mlops.services.train_data_file_cleanup import delete_train_data_file_with_retry
 
                     delete_train_data_file_with_retry(**cleanup_kwargs)
 
@@ -221,64 +208,98 @@ class TrainJobConfigSyncMixin:
         Raises:
             ConfigSyncError: If MinIO sync fails, the entire save is rolled back.
         """
-        from django.db import transaction
+        from django.db import router, transaction
+
         from apps.core.logger import mlops_logger as logger
 
         # If only updating non-config fields, skip file sync
         update_fields = kwargs.get("update_fields")
 
-        if update_fields and not any(
-            field in self._config_related_fields for field in update_fields
-        ):
+        if update_fields and not any(field in self._config_related_fields for field in update_fields):
             super().save(*args, **kwargs)
             return
 
+        using = kwargs.get("using") or router.db_for_write(self.__class__, instance=self)
+        old_file_name = self.config_url.name if self.config_url else None
+        uploaded_file_name = None
+
         # Wrap in transaction so DB changes roll back if MinIO sync fails
-        with transaction.atomic():
+        with transaction.atomic(using=using):
             # 1. Save to database first to get pk
             super().save(*args, **kwargs)
 
             # 2. Sync file to MinIO based on pk
             config_updated = False
 
-            if self.hyperopt_config:
-                # Has config → complete and upload to MinIO
-                # Raises ConfigSyncError on failure → transaction rolls back
-                self._sync_config_to_minio()
-                config_updated = True
-            elif self.config_url:
-                # Config is empty → delete MinIO file
-                # Failure propagates → transaction rolls back
-                self.config_url.delete(save=False)
-                logger.info(
-                    f"Deleted config file (empty config) for TrainJob {self.pk}"
-                )
-                self.config_url = None
-                config_updated = True
+            try:
+                if self.hyperopt_config:
+                    # Has config → complete and upload to MinIO
+                    # Raises ConfigSyncError on failure → transaction rolls back
+                    self._sync_config_to_minio()
+                    uploaded_file_name = self.config_url.name
+                    config_updated = True
+                elif self.config_url:
+                    # Config is empty → clear the database pointer first. The old
+                    # object is deleted only after the outermost transaction commits.
+                    self.config_url = None
+                    config_updated = True
 
-            # 3. If config_url changed, update database (use queryset.update to avoid recursive save)
-            if config_updated:
-                self.__class__.objects.filter(pk=self.pk).update(
-                    config_url=self.config_url
+                # 3. If config_url changed, update database (use queryset.update to avoid recursive save)
+                if config_updated:
+                    updated = self.__class__.objects.using(using).filter(pk=self.pk).update(config_url=self.config_url)
+                    if updated != 1:
+                        raise ConfigSyncError(f"训练配置数据库指针更新失败: TrainJob {self.pk} 不存在")
+            except Exception:
+                if uploaded_file_name and uploaded_file_name != old_file_name:
+                    try:
+                        self._meta.get_field("config_url").storage.delete(uploaded_file_name)
+                        logger.info(f"Deleted unreferenced config upload after database failure for TrainJob {self.pk}: {uploaded_file_name}")
+                    except Exception as cleanup_error:
+                        logger.warning(f"Failed to delete unreferenced config upload '{uploaded_file_name}': {cleanup_error}")
+                self.config_url = old_file_name
+                raise
+
+            new_file_name = self.config_url.name if self.config_url else None
+            if old_file_name and old_file_name != new_file_name:
+                self._delete_config_file_on_commit(
+                    file_name=old_file_name,
+                    using=using,
                 )
+
+    def _delete_config_file_on_commit(self, *, file_name, using):
+        """Delete an obsolete config only after the outer DB transaction commits."""
+        from django.db import transaction
+
+        from apps.core.logger import mlops_logger as logger
+
+        storage = self._meta.get_field("config_url").storage
+        train_job_pk = self.pk
+
+        def delete_old_file():
+            try:
+                storage.delete(file_name)
+                logger.info(f"Deleted old config file after commit for TrainJob {train_job_pk}: {file_name}")
+            except Exception as cleanup_error:
+                logger.warning(f"Failed to delete old config file '{file_name}': {cleanup_error}")
+
+        transaction.on_commit(delete_old_file, using=using)
 
     def _sync_config_to_minio(self):
         """Sync hyperopt_config to MinIO (auto-complete model and mlflow config).
 
-        Upload new config file first, then clean up old file. This ordering
-        ensures that if the upload fails, the old file is still intact and
-        the transaction rollback leaves everything consistent.
+        Upload a new config file without deleting the previous object. The
+        caller updates the database pointer and schedules old-object deletion
+        after the outermost database transaction commits.
 
         Raises:
             ConfigSyncError: If the new config file cannot be uploaded.
         """
-        from django.core.files.base import ContentFile
         import json
         import uuid
-        from apps.core.logger import mlops_logger as logger
 
-        # Capture old file path before overwriting
-        old_file_name = self.config_url.name if self.config_url else None
+        from django.core.files.base import ContentFile
+
+        from apps.core.logger import mlops_logger as logger
 
         # Build and upload new config file — failure MUST propagate
         try:
@@ -295,21 +316,7 @@ class TrainJobConfigSyncMixin:
             logger.info(f"Synced config to MinIO for TrainJob {self.pk}: {filename}")
         except Exception as e:
             logger.error(f"Failed to sync config to MinIO: {e}", exc_info=True)
-            raise ConfigSyncError(
-                f"训练配置同步到 MinIO 失败，数据库变更已回滚: {e}"
-            ) from e
-
-        # Clean up old file after successful upload (best-effort)
-        if old_file_name and old_file_name != self.config_url.name:
-            try:
-                self.config_url.storage.delete(old_file_name)
-                logger.info(
-                    f"Deleted old config file for TrainJob {self.pk}: {old_file_name}"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Failed to delete old config file '{old_file_name}': {e}"
-                )
+            raise ConfigSyncError(f"训练配置同步到 MinIO 失败，数据库变更已回滚: {e}") from e
 
     def _build_complete_config(self):
         """Build complete config file (add model, mlflow, and max_evals sections)."""

--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -220,11 +220,19 @@ class TrainJobConfigSyncMixin:
             return
 
         using = kwargs.get("using") or router.db_for_write(self.__class__, instance=self)
-        old_file_name = self.config_url.name if self.config_url else None
+        old_file_name = None
         uploaded_file_name = None
 
         # Wrap in transaction so DB changes roll back if MinIO sync fails
         with transaction.atomic(using=using):
+            if self.pk:
+                try:
+                    persisted = self.__class__.objects.using(using).select_for_update().only("config_url").get(pk=self.pk)
+                except self.__class__.DoesNotExist:
+                    pass
+                else:
+                    old_file_name = persisted.config_url.name if persisted.config_url else None
+
             # 1. Save to database first to get pk
             super().save(*args, **kwargs)
 

--- a/server/apps/mlops/models/mixins.py
+++ b/server/apps/mlops/models/mixins.py
@@ -50,7 +50,6 @@ class TrainDataFileCleanupMixin:
         4. Deletes the old file after the surrounding transaction commits
         """
         from django.db import router, transaction
-
         from apps.mlops.services.train_data_file_cleanup import (
             _assert_file_reference_available,
             _lock_file_reference_guards,
@@ -60,7 +59,9 @@ class TrainDataFileCleanupMixin:
         file_field_name = self._file_field_name
         file_field = self._meta.get_field(file_field_name)
         update_fields = kwargs.get("update_fields")
-        using = kwargs.get("using") or router.db_for_write(self.__class__, instance=self)
+        using = kwargs.get("using") or router.db_for_write(
+            self.__class__, instance=self
+        )
 
         # New records and partial saves that exclude the file keep normal Model.save semantics.
         if not self.pk:
@@ -95,7 +96,11 @@ class TrainDataFileCleanupMixin:
 
         with transaction.atomic(using=using):
             try:
-                old_instance = self.__class__.objects.using(using).select_for_update().get(pk=self.pk)
+                old_instance = (
+                    self.__class__.objects.using(using)
+                    .select_for_update()
+                    .get(pk=self.pk)
+                )
                 old_file = getattr(old_instance, file_field_name)
                 old_path = old_file.name if old_file else None
             except self.__class__.DoesNotExist:
@@ -104,11 +109,17 @@ class TrainDataFileCleanupMixin:
 
             new_file = getattr(self, file_field_name)
             new_path = new_file.name if new_file else None
-            loaded_path = getattr(self, "_loaded_file_path", self._loaded_file_path_missing)
+            loaded_path = getattr(
+                self, "_loaded_file_path", self._loaded_file_path_missing
+            )
 
             # A stale instance that did not change the file must not overwrite a
             # replacement committed by another request.
-            if loaded_path is not self._loaded_file_path_missing and new_path == loaded_path and old_path != loaded_path:
+            if (
+                loaded_path is not self._loaded_file_path_missing
+                and new_path == loaded_path
+                and old_path != loaded_path
+            ):
                 setattr(self, file_field_name, old_file)
                 new_file = getattr(self, file_field_name)
                 new_path = old_path
@@ -146,7 +157,9 @@ class TrainDataFileCleanupMixin:
                 }
 
                 def delete_old_file():
-                    from apps.mlops.services.train_data_file_cleanup import delete_train_data_file_with_retry
+                    from apps.mlops.services.train_data_file_cleanup import (
+                        delete_train_data_file_with_retry,
+                    )
 
                     delete_train_data_file_with_retry(**cleanup_kwargs)
 
@@ -227,7 +240,12 @@ class TrainJobConfigSyncMixin:
         with transaction.atomic(using=using):
             if self.pk:
                 try:
-                    persisted = self.__class__.objects.using(using).select_for_update().only("config_url").get(pk=self.pk)
+                    persisted = (
+                        self.__class__.objects.select_for_update()
+                        .only("config_url")
+                        .using(using)
+                        .get(pk=self.pk)
+                    )
                 except self.__class__.DoesNotExist:
                     pass
                 else:
@@ -254,7 +272,11 @@ class TrainJobConfigSyncMixin:
 
                 # 3. If config_url changed, update database (use queryset.update to avoid recursive save)
                 if config_updated:
-                    updated = self.__class__.objects.using(using).filter(pk=self.pk).update(config_url=self.config_url)
+                    updated = (
+                        self.__class__.objects.filter(pk=self.pk)
+                        .using(using)
+                        .update(config_url=self.config_url)
+                    )
                     if updated != 1:
                         raise ConfigSyncError(f"训练配置数据库指针更新失败: TrainJob {self.pk} 不存在")
             except Exception:

--- a/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
@@ -70,6 +70,23 @@ def test_clearing_config_keeps_old_object_until_outer_transaction_commits(
     assert deleted == []
 
 
+def test_replacing_config_locks_and_cleans_current_database_pointer(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    stale_job = _create_job_with_config_path("configs/stale.json")
+    deleted = _mock_config_storage(monkeypatch, stale_job)
+    ObjectDetectionTrainJob.objects.filter(pk=stale_job.pk).update(config_url="configs/current.json")
+
+    with django_capture_on_commit_callbacks(execute=True):
+        stale_job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+        stale_job.save()
+
+    stale_job.refresh_from_db()
+    assert stale_job.config_url.name.startswith("uploaded/config_")
+    assert deleted == ["configs/current.json"]
+
+
 def test_replacing_config_deletes_old_object_after_commit(
     monkeypatch,
     django_capture_on_commit_callbacks,

--- a/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
@@ -1,0 +1,230 @@
+import pytest
+from django.db import transaction
+from django.db.models.query import QuerySet
+
+from apps.mlops.models.mixins import ConfigSyncError
+from apps.mlops.models.object_detection import ObjectDetectionTrainJob
+
+pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+
+
+def _create_job_with_config_path(path="configs/old.json"):
+    job = ObjectDetectionTrainJob.objects.create(
+        name="config-sync-job",
+        team=[1],
+        algorithm="yolo11",
+        max_evals=12,
+        hyperopt_config={},
+    )
+    ObjectDetectionTrainJob.objects.filter(pk=job.pk).update(config_url=path)
+    job.refresh_from_db()
+    return job
+
+
+def _mock_config_storage(monkeypatch, job):
+    field = job.config_url
+    deleted = []
+
+    def save(field_file, filename, _content, save=False):
+        assert save is False
+        field_file.name = f"uploaded/{filename}"
+
+    monkeypatch.setattr(type(field), "save", save)
+    monkeypatch.setattr(field.storage, "delete", deleted.append)
+    return deleted
+
+
+def test_replacing_config_keeps_old_object_until_outer_transaction_commits(
+    monkeypatch,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+
+    with pytest.raises(RuntimeError, match="outer rollback"):
+        with transaction.atomic():
+            job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+            job.save()
+            assert deleted == []
+            raise RuntimeError("outer rollback")
+
+    job.refresh_from_db()
+    assert job.config_url.name == "configs/old.json"
+    assert deleted == []
+
+
+def test_clearing_config_keeps_old_object_until_outer_transaction_commits(
+    monkeypatch,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+
+    with pytest.raises(RuntimeError, match="outer rollback"):
+        with transaction.atomic():
+            job.hyperopt_config = {}
+            job.save()
+            assert deleted == []
+            raise RuntimeError("outer rollback")
+
+    job.refresh_from_db()
+    assert job.config_url.name == "configs/old.json"
+    assert deleted == []
+
+
+def test_replacing_config_deletes_old_object_after_commit(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+        job.save()
+        assert deleted == []
+
+    job.refresh_from_db()
+    assert job.config_url.name.startswith("uploaded/config_")
+    assert deleted == ["configs/old.json"]
+
+
+def test_clearing_config_deletes_old_object_after_commit(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        job.hyperopt_config = {}
+        job.save()
+        assert deleted == []
+
+    job.refresh_from_db()
+    assert not job.config_url
+    assert deleted == ["configs/old.json"]
+
+
+def test_database_pointer_failure_cleans_new_upload_without_deleting_old(
+    monkeypatch,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+    real_update = QuerySet.update
+
+    def fail_config_pointer_update(queryset, **kwargs):
+        if set(kwargs) == {"config_url"}:
+            raise RuntimeError("pointer update failed")
+        return real_update(queryset, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+
+    job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+    with pytest.raises(RuntimeError, match="pointer update failed"):
+        job.save()
+
+    job.refresh_from_db()
+    assert job.config_url.name == "configs/old.json"
+    assert len(deleted) == 1
+    assert deleted[0].startswith("uploaded/config_")
+
+
+def test_initial_create_pointer_failure_rolls_back_row_and_cleans_upload(
+    monkeypatch,
+):
+    job = ObjectDetectionTrainJob(
+        name="new-config-sync-job",
+        team=[1],
+        algorithm="yolo11",
+        max_evals=12,
+        hyperopt_config={"hyperparams": {"epochs": 3}},
+    )
+    deleted = _mock_config_storage(monkeypatch, job)
+    real_update = QuerySet.update
+
+    def fail_config_pointer_update(queryset, **kwargs):
+        if set(kwargs) == {"config_url"}:
+            raise RuntimeError("pointer update failed")
+        return real_update(queryset, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+
+    with pytest.raises(RuntimeError, match="pointer update failed"):
+        job.save()
+
+    assert not ObjectDetectionTrainJob.objects.filter(pk=job.pk).exists()
+    assert not job.config_url
+    assert len(deleted) == 1
+    assert deleted[0].startswith("uploaded/config_")
+
+
+def test_clearing_pointer_failure_preserves_old_object_and_pointer(
+    monkeypatch,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+    real_update = QuerySet.update
+
+    def fail_config_pointer_update(queryset, **kwargs):
+        if set(kwargs) == {"config_url"}:
+            raise RuntimeError("pointer update failed")
+        return real_update(queryset, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+
+    job.hyperopt_config = {}
+    with pytest.raises(RuntimeError, match="pointer update failed"):
+        job.save()
+
+    job.refresh_from_db()
+    assert job.config_url.name == "configs/old.json"
+    assert deleted == []
+
+
+def test_missing_database_row_cleans_new_upload_without_deleting_old(
+    monkeypatch,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+    real_update = QuerySet.update
+
+    def miss_config_pointer_update(queryset, **kwargs):
+        if set(kwargs) == {"config_url"}:
+            return 0
+        return real_update(queryset, **kwargs)
+
+    monkeypatch.setattr(QuerySet, "update", miss_config_pointer_update)
+
+    job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+    with pytest.raises(ConfigSyncError, match="数据库指针更新失败"):
+        job.save()
+
+    job.refresh_from_db()
+    assert job.config_url.name == "configs/old.json"
+    assert len(deleted) == 1
+    assert deleted[0].startswith("uploaded/config_")
+
+
+def test_old_object_cleanup_failure_does_not_roll_back_committed_pointer(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    job = _create_job_with_config_path()
+    field = job.config_url
+
+    def save(field_file, filename, _content, save=False):
+        assert save is False
+        field_file.name = f"uploaded/{filename}"
+
+    monkeypatch.setattr(type(field), "save", save)
+    monkeypatch.setattr(
+        field.storage,
+        "delete",
+        lambda _path: (_ for _ in ()).throw(OSError("cleanup failed")),
+    )
+
+    with django_capture_on_commit_callbacks(execute=True):
+        job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+        job.save()
+
+    job.refresh_from_db()
+    assert job.config_url.name.startswith("uploaded/config_")

--- a/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
@@ -34,6 +34,19 @@ def _mock_config_storage(monkeypatch, job):
     return deleted
 
 
+def _mock_config_pointer_update(monkeypatch, outcome):
+    real_update = QuerySet.update
+
+    def update_config_pointer(queryset, **kwargs):
+        if set(kwargs) != {"config_url"}:
+            return real_update(queryset, **kwargs)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(QuerySet, "update", update_config_pointer)
+
+
 def test_replacing_config_keeps_old_object_until_outer_transaction_commits(
     monkeypatch,
 ):
@@ -126,14 +139,7 @@ def test_database_pointer_failure_cleans_new_upload_without_deleting_old(
 ):
     job = _create_job_with_config_path()
     deleted = _mock_config_storage(monkeypatch, job)
-    real_update = QuerySet.update
-
-    def fail_config_pointer_update(queryset, **kwargs):
-        if set(kwargs) == {"config_url"}:
-            raise RuntimeError("pointer update failed")
-        return real_update(queryset, **kwargs)
-
-    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+    _mock_config_pointer_update(monkeypatch, RuntimeError("pointer update failed"))
 
     job.hyperopt_config = {"hyperparams": {"epochs": 3}}
     with pytest.raises(RuntimeError, match="pointer update failed"):
@@ -156,14 +162,7 @@ def test_initial_create_pointer_failure_rolls_back_row_and_cleans_upload(
         hyperopt_config={"hyperparams": {"epochs": 3}},
     )
     deleted = _mock_config_storage(monkeypatch, job)
-    real_update = QuerySet.update
-
-    def fail_config_pointer_update(queryset, **kwargs):
-        if set(kwargs) == {"config_url"}:
-            raise RuntimeError("pointer update failed")
-        return real_update(queryset, **kwargs)
-
-    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+    _mock_config_pointer_update(monkeypatch, RuntimeError("pointer update failed"))
 
     with pytest.raises(RuntimeError, match="pointer update failed"):
         job.save()
@@ -179,14 +178,7 @@ def test_clearing_pointer_failure_preserves_old_object_and_pointer(
 ):
     job = _create_job_with_config_path()
     deleted = _mock_config_storage(monkeypatch, job)
-    real_update = QuerySet.update
-
-    def fail_config_pointer_update(queryset, **kwargs):
-        if set(kwargs) == {"config_url"}:
-            raise RuntimeError("pointer update failed")
-        return real_update(queryset, **kwargs)
-
-    monkeypatch.setattr(QuerySet, "update", fail_config_pointer_update)
+    _mock_config_pointer_update(monkeypatch, RuntimeError("pointer update failed"))
 
     job.hyperopt_config = {}
     with pytest.raises(RuntimeError, match="pointer update failed"):
@@ -202,14 +194,7 @@ def test_missing_database_row_cleans_new_upload_without_deleting_old(
 ):
     job = _create_job_with_config_path()
     deleted = _mock_config_storage(monkeypatch, job)
-    real_update = QuerySet.update
-
-    def miss_config_pointer_update(queryset, **kwargs):
-        if set(kwargs) == {"config_url"}:
-            return 0
-        return real_update(queryset, **kwargs)
-
-    monkeypatch.setattr(QuerySet, "update", miss_config_pointer_update)
+    _mock_config_pointer_update(monkeypatch, 0)
 
     job.hyperopt_config = {"hyperparams": {"epochs": 3}}
     with pytest.raises(ConfigSyncError, match="数据库指针更新失败"):
@@ -227,29 +212,53 @@ def test_config_sync_uses_explicit_database_alias_for_update_and_cleanup(
 ):
     job = _create_job_with_config_path()
     deleted = _mock_config_storage(monkeypatch, job)
+    locked_read_aliases = []
     update_aliases = []
-    cleanup_aliases = []
+    atomic_aliases = []
+    on_commit_aliases = []
+    real_using = QuerySet.using
+    real_get = QuerySet.get
     real_update = QuerySet.update
-    real_schedule = type(job)._delete_config_file_on_commit
+    real_atomic = transaction.atomic
+    real_on_commit = transaction.on_commit
+
+    def record_using(queryset, alias):
+        clone = real_using(queryset, alias)
+        clone._explicit_config_alias = alias
+        return clone
+
+    def record_get(queryset, *args, **kwargs):
+        if queryset.model is type(job) and kwargs == {"pk": job.pk}:
+            locked_read_aliases.append(getattr(queryset, "_explicit_config_alias", None))
+        return real_get(queryset, *args, **kwargs)
 
     def record_update(queryset, **kwargs):
         if set(kwargs) == {"config_url"}:
-            update_aliases.append(queryset.db)
+            update_aliases.append(getattr(queryset, "_explicit_config_alias", None))
         return real_update(queryset, **kwargs)
 
-    def record_schedule(instance, *, file_name, using):
-        cleanup_aliases.append(using)
-        return real_schedule(instance, file_name=file_name, using=using)
+    def record_atomic(using=None, savepoint=True, durable=False):
+        atomic_aliases.append(using)
+        return real_atomic(using=using, savepoint=savepoint, durable=durable)
 
+    def record_on_commit(func, using=None, robust=False):
+        on_commit_aliases.append(using)
+        return real_on_commit(func, using=using, robust=robust)
+
+    monkeypatch.setattr(QuerySet, "using", record_using)
+    monkeypatch.setattr(QuerySet, "get", record_get)
     monkeypatch.setattr(QuerySet, "update", record_update)
-    monkeypatch.setattr(type(job), "_delete_config_file_on_commit", record_schedule)
+    monkeypatch.setattr(transaction, "atomic", record_atomic)
+    monkeypatch.setattr(transaction, "on_commit", record_on_commit)
 
     with django_capture_on_commit_callbacks(execute=True):
         job.hyperopt_config = {"hyperparams": {"epochs": 3}}
         job.save(using="default")
 
+    assert locked_read_aliases == ["default"]
     assert update_aliases == ["default"]
-    assert cleanup_aliases == ["default"]
+    assert atomic_aliases == ["default"]
+    assert on_commit_aliases == ["default"]
     assert deleted == ["configs/old.json"]
 
 

--- a/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
@@ -221,6 +221,38 @@ def test_missing_database_row_cleans_new_upload_without_deleting_old(
     assert deleted[0].startswith("uploaded/config_")
 
 
+def test_config_sync_uses_explicit_database_alias_for_update_and_cleanup(
+    monkeypatch,
+    django_capture_on_commit_callbacks,
+):
+    job = _create_job_with_config_path()
+    deleted = _mock_config_storage(monkeypatch, job)
+    update_aliases = []
+    cleanup_aliases = []
+    real_update = QuerySet.update
+    real_schedule = type(job)._delete_config_file_on_commit
+
+    def record_update(queryset, **kwargs):
+        if set(kwargs) == {"config_url"}:
+            update_aliases.append(queryset.db)
+        return real_update(queryset, **kwargs)
+
+    def record_schedule(instance, *, file_name, using):
+        cleanup_aliases.append(using)
+        return real_schedule(instance, file_name=file_name, using=using)
+
+    monkeypatch.setattr(QuerySet, "update", record_update)
+    monkeypatch.setattr(type(job), "_delete_config_file_on_commit", record_schedule)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        job.hyperopt_config = {"hyperparams": {"epochs": 3}}
+        job.save(using="default")
+
+    assert update_aliases == ["default"]
+    assert cleanup_aliases == ["default"]
+    assert deleted == ["configs/old.json"]
+
+
 def test_old_object_cleanup_failure_does_not_roll_back_committed_pointer(
     monkeypatch,
     django_capture_on_commit_callbacks,

--- a/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
+++ b/server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py
@@ -5,7 +5,7 @@ from django.db.models.query import QuerySet
 from apps.mlops.models.mixins import ConfigSyncError
 from apps.mlops.models.object_detection import ObjectDetectionTrainJob
 
-pytestmark = [pytest.mark.unit, pytest.mark.django_db]
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
 
 
 def _create_job_with_config_path(path="configs/old.json"):

--- a/server/apps/mlops/tests/test_uncovered_runtime_contracts.py
+++ b/server/apps/mlops/tests/test_uncovered_runtime_contracts.py
@@ -11,9 +11,13 @@ from rest_framework.response import Response
 from apps.mlops.management.commands.init_algorithm_config import Command
 from apps.mlops.models.mixins import ConfigSyncError
 from apps.mlops.models.object_detection import ObjectDetectionTrainJob
-from apps.mlops.utils.webhook_client import WebhookConnectionError, WebhookError
+from apps.mlops.utils.webhook_client import (
+    WebhookConnectionError,
+    WebhookError,
+)
 from apps.mlops.views import base as base_views
 from apps.mlops.views.base import TeamModelViewSet
+
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
@@ -103,9 +107,13 @@ def test_config_sync_wraps_upload_failure_and_preserves_old_file(monkeypatch):
     monkeypatch.setattr(
         type(field),
         "save",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("storage offline")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("storage offline")
+        ),
     )
-    monkeypatch.setattr(field.storage, "delete", lambda path: deleted.append(path))
+    monkeypatch.setattr(
+        field.storage, "delete", lambda path: deleted.append(path)
+    )
 
     with pytest.raises(ConfigSyncError, match="storage offline"):
         job._sync_config_to_minio()
@@ -183,7 +191,9 @@ def test_authorized_object_or_none_maps_http404():
         ({}, "训练任务关联的数据集版本无权访问"),
     ],
 )
-def test_dataset_scope_error_is_flattened_for_api_clients(monkeypatch, detail, expected):
+def test_dataset_scope_error_is_flattened_for_api_clients(
+    monkeypatch, detail, expected
+):
     def reject(*_args):
         raise serializers.ValidationError(detail)
 
@@ -201,7 +211,9 @@ def test_destroy_train_job_stops_on_first_runtime_cleanup_error():
     blocked = Response({"error": "cleanup failed"}, status=500)
     job = SimpleNamespace(
         id=4,
-        servings=SimpleNamespace(all=lambda: [SimpleNamespace(id=1), SimpleNamespace(id=2)]),
+        servings=SimpleNamespace(
+            all=lambda: [SimpleNamespace(id=1), SimpleNamespace(id=2)]
+        ),
     )
     view.get_object = lambda: job
     calls = []
@@ -262,7 +274,9 @@ def _valid_algorithm_payload(name):
         ),
     ],
 )
-def test_algorithm_config_file_validation_reports_specific_reason(tmp_path, content, filename, reason):
+def test_algorithm_config_file_validation_reports_specific_reason(
+    tmp_path, content, filename, reason
+):
     path = tmp_path / filename
     path.write_text(content, encoding="utf-8")
     valid, payload, actual_reason = Command()._load_and_validate_file(path)

--- a/server/apps/mlops/tests/test_uncovered_runtime_contracts.py
+++ b/server/apps/mlops/tests/test_uncovered_runtime_contracts.py
@@ -11,13 +11,9 @@ from rest_framework.response import Response
 from apps.mlops.management.commands.init_algorithm_config import Command
 from apps.mlops.models.mixins import ConfigSyncError
 from apps.mlops.models.object_detection import ObjectDetectionTrainJob
-from apps.mlops.utils.webhook_client import (
-    WebhookConnectionError,
-    WebhookError,
-)
+from apps.mlops.utils.webhook_client import WebhookConnectionError, WebhookError
 from apps.mlops.views import base as base_views
 from apps.mlops.views.base import TeamModelViewSet
-
 
 pytestmark = [pytest.mark.unit, pytest.mark.django_db]
 
@@ -55,7 +51,7 @@ def test_train_job_complete_config_creates_missing_hyperparams():
     assert job._build_complete_config()["hyperparams"] == {"max_evals": 5}
 
 
-def test_config_sync_uploads_complete_json_before_deleting_old_file(
+def test_config_sync_uploads_complete_json_without_deleting_old_file(
     monkeypatch,
 ):
     job = ObjectDetectionTrainJob(
@@ -91,7 +87,7 @@ def test_config_sync_uploads_complete_json_before_deleting_old_file(
     assert calls[0][0] == "save"
     assert calls[0][2]["hyperparams"] == {"epochs": 3, "max_evals": 12}
     assert calls[0][3] is False
-    assert calls[1] == ("delete", "configs/old.json")
+    assert len(calls) == 1
 
 
 def test_config_sync_wraps_upload_failure_and_preserves_old_file(monkeypatch):
@@ -107,13 +103,9 @@ def test_config_sync_wraps_upload_failure_and_preserves_old_file(monkeypatch):
     monkeypatch.setattr(
         type(field),
         "save",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            OSError("storage offline")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("storage offline")),
     )
-    monkeypatch.setattr(
-        field.storage, "delete", lambda path: deleted.append(path)
-    )
+    monkeypatch.setattr(field.storage, "delete", lambda path: deleted.append(path))
 
     with pytest.raises(ConfigSyncError, match="storage offline"):
         job._sync_config_to_minio()
@@ -121,7 +113,7 @@ def test_config_sync_wraps_upload_failure_and_preserves_old_file(monkeypatch):
     assert job.config_url.name == "configs/old.json"
 
 
-def test_config_sync_tolerates_old_file_cleanup_failure(monkeypatch):
+def test_config_sync_leaves_old_file_cleanup_to_save_commit_boundary(monkeypatch):
     job = ObjectDetectionTrainJob(
         id=42,
         algorithm="yolo11",
@@ -138,7 +130,7 @@ def test_config_sync_tolerates_old_file_cleanup_failure(monkeypatch):
     monkeypatch.setattr(
         field.storage,
         "delete",
-        lambda _path: (_ for _ in ()).throw(OSError("cleanup failed")),
+        lambda _path: (_ for _ in ()).throw(AssertionError("old file must not be deleted during upload")),
     )
 
     job._sync_config_to_minio()
@@ -191,9 +183,7 @@ def test_authorized_object_or_none_maps_http404():
         ({}, "训练任务关联的数据集版本无权访问"),
     ],
 )
-def test_dataset_scope_error_is_flattened_for_api_clients(
-    monkeypatch, detail, expected
-):
+def test_dataset_scope_error_is_flattened_for_api_clients(monkeypatch, detail, expected):
     def reject(*_args):
         raise serializers.ValidationError(detail)
 
@@ -211,9 +201,7 @@ def test_destroy_train_job_stops_on_first_runtime_cleanup_error():
     blocked = Response({"error": "cleanup failed"}, status=500)
     job = SimpleNamespace(
         id=4,
-        servings=SimpleNamespace(
-            all=lambda: [SimpleNamespace(id=1), SimpleNamespace(id=2)]
-        ),
+        servings=SimpleNamespace(all=lambda: [SimpleNamespace(id=1), SimpleNamespace(id=2)]),
     )
     view.get_object = lambda: job
     calls = []
@@ -274,9 +262,7 @@ def _valid_algorithm_payload(name):
         ),
     ],
 )
-def test_algorithm_config_file_validation_reports_specific_reason(
-    tmp_path, content, filename, reason
-):
+def test_algorithm_config_file_validation_reports_specific_reason(tmp_path, content, filename, reason):
     path = tmp_path / filename
     path.write_text(content, encoding="utf-8")
     valid, payload, actual_reason = Command()._load_and_validate_file(path)


### PR DESCRIPTION
## 问题

六类训练任务共用同一套配置同步逻辑。此前替换或清空训练配置时，旧 MinIO 对象会在数据库最外层事务提交前被删除；一旦后续数据库操作或外层事务回滚，数据库会恢复旧指针，但旧对象已经不存在，训练入口随后读取到失效配置。

## 根因（设计层）

原实现把“数据库保存、MinIO 上传、MinIO 删除”放在同一段同步流程中，却没有区分可回滚的数据库状态与不可回滚的对象存储副作用。上传失败回滚数据库是合理防线，但提交前执行破坏性删除越过了数据库提交边界。

## 怎么修的

- 新配置仍先上传，随后在数据库事务内更新 `config_url`，保持上传失败时数据库回滚的既有语义。
- 旧配置删除改为 `transaction.on_commit()`，并绑定实际数据库别名；只有最外层事务成功提交后才执行。
- 数据库指针更新抛错或返回 0 行时，尽力删除本次新上传对象，恢复内存实例的旧指针后继续抛出原错误。
- 提交后旧对象删除失败仍只记录告警，不回滚已经有效的数据库指针，保持现有接口成功语义。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["六类 TrainJob save\nmodels/mixins.py"]
    end

    U["上传新配置\nMinIO"]

    subgraph D["数据库提交层"]
        D1["保存 TrainJob"]
        D2["更新 config_url"]
    end

    subgraph C["提交后清理层"]
        C1["on_commit 删除旧对象"]
        C2["指针失败时回收新上传"]
    end

    T1 --> D1 --> U --> D2 --> C1
    D2 -. "失败" .-> C2
```

## 影响范围与兼容性

- 影响 `anomaly_detection`、`classification`、`image_classification`、`log_clustering`、`object_detection`、`timeseries_predict` 六类 TrainJob 的共享保存逻辑。
- 不修改字段、迁移、REST/NATS 契约、前端请求或训练入口；仓库内没有 Agent 侧配置写入调用方。
- 回滚只需回退本提交，不涉及数据迁移。
- 本首片消除“事务回滚后旧指针失效”的正确性故障，并回收本层数据库失败产生的新上传。调用方外层事务回滚后的孤儿新对象仍需后续通过 staging 标记、保留期与六表引用对账治理；本片不引入可能误删并发对象的无界扫描。

## 验证

- `server/apps/mlops/tests/test_train_job_config_sync_mixin_service.py`、`server/apps/mlops/tests/test_uncovered_runtime_contracts.py`：32 passed。
- 回归用例在修复前能稳定命中“外层事务尚未提交即删除旧对象”，修复后覆盖首次创建、替换、清空、上传失败、数据库指针失败、0 行更新、外层回滚、提交成功及提交后删除失败。
- Black、isort、flake8 与 `git diff --check` 均通过。

## 三轨门禁

- Standards：PASS。无原生 SQL、无迁移、无密钥与无关重构。
- Spec：PASS。共享 mixin 覆盖六类模型，原始首片场景与兼容失败方式均有测试。
- Runtime Contract：PASS。数据库提交边界、MinIO 上传/删除顺序、异常传播与既有调用方响应格式已复核。

评分：91/100，`SCORE_PASS`。

关联 Issue #4242。
