### PR TITLE
fix(monitor): 避免对象树 URL 回写打断插件列表请求

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/page.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/page.tsx
@@ -131,21 +131,22 @@ const Integration = () => {
   };
 
   const handleObjectChange = async (id: string) => {
+    const nextObjectType =
+      id && id !== 'all' && isTypeNodeKey(String(id)) ? String(id) : '';
+    const nextObjectId = !id || id === 'all' || nextObjectType ? '' : id;
+    // URL 回写同一节点时不要 abort 刚发出的插件列表请求，否则右侧会停在上一对象。
+    if (
+      String(objectId) === String(nextObjectId) &&
+      String(objectType) === String(nextObjectType)
+    ) {
+      syncObjectId(id || 'all');
+      return;
+    }
     cancelAllRequests();
     setPagination((prev) => ({ ...prev, current: 1 }));
     syncObjectId(id || 'all');
-    if (id === 'all' || !id) {
-      setObjectId('');
-      setObjectType('');
-      return;
-    }
-    if (isTypeNodeKey(String(id))) {
-      setObjectId('');
-      setObjectType(String(id));
-      return;
-    }
-    setObjectType('');
-    setObjectId(id);
+    setObjectId(nextObjectId);
+    setObjectType(nextObjectType);
   };
 
   const getPluginList = async (
@@ -201,6 +202,10 @@ const Integration = () => {
         current: page,
         total: count
       }));
+    } catch (error: any) {
+      if (error?.name === 'CanceledError' || error?.code === 'ERR_CANCELED') {
+        return;
+      }
     } finally {
       if (currentRequestId === pluginRequestIdRef.current) {
         setPageLoading(false);

--- a/web/src/app/monitor/components/treeSelector/__tests__/selectionNotify.component.test.tsx
+++ b/web/src/app/monitor/components/treeSelector/__tests__/selectionNotify.component.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import TreeSelector from '../index';
+
+vi.mock('@/utils/i18n', () => ({
+  useTranslation: () => ({ t: (key: string) => key })
+}));
+
+vi.mock('../index.module.scss', () => ({
+  default: {
+    treeWrap: 'treeWrap',
+    node: 'node',
+    icon: 'icon',
+    label: 'label',
+    ellipsis: 'ellipsis',
+    count: 'count'
+  }
+}));
+
+const treeData = [
+  { title: '全部', key: 'all', children: [] },
+  {
+    title: '网络',
+    key: 'web',
+    children: [
+      { title: 'Ping', key: '22', children: [] },
+      { title: 'TCP', key: '35', children: [] }
+    ]
+  }
+];
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('TreeSelector 选中回写', () => {
+  it('用户点选后 URL 回写同一节点时不再次 onNodeSelect', async () => {
+    const onNodeSelect = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <TreeSelector
+        showAllMenu
+        allowParentSelect
+        data={treeData}
+        defaultSelectedKey="22"
+        onNodeSelect={onNodeSelect}
+      />
+    );
+
+    expect(onNodeSelect).toHaveBeenCalledTimes(1);
+    expect(onNodeSelect).toHaveBeenCalledWith('22');
+
+    await user.click(screen.getByText('TCP'));
+    expect(onNodeSelect).toHaveBeenCalledWith('35');
+    expect(onNodeSelect).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <TreeSelector
+        showAllMenu
+        allowParentSelect
+        data={treeData}
+        defaultSelectedKey="35"
+        onNodeSelect={onNodeSelect}
+      />
+    );
+
+    expect(onNodeSelect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/app/monitor/components/treeSelector/__tests__/selectionNotify.test.ts
+++ b/web/src/app/monitor/components/treeSelector/__tests__/selectionNotify.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldNotifyTreeNodeSelect } from '../selectionNotify';
+
+describe('shouldNotifyTreeNodeSelect', () => {
+  it('首次选中节点时通知父页面', () => {
+    expect(shouldNotifyTreeNodeSelect('', '22')).toBe(true);
+  });
+
+  it('用户改选另一节点时通知父页面', () => {
+    expect(shouldNotifyTreeNodeSelect('22', '35')).toBe(true);
+  });
+
+  it('URL 回写同一节点时不再通知，避免父页面 abort 进行中的插件列表请求', () => {
+    expect(shouldNotifyTreeNodeSelect('35', '35')).toBe(false);
+    expect(shouldNotifyTreeNodeSelect('35', 35)).toBe(false);
+  });
+
+  it('浏览器后退到上一节点时仍要通知', () => {
+    expect(shouldNotifyTreeNodeSelect('35', '22')).toBe(true);
+  });
+
+  it('空 key 不通知', () => {
+    expect(shouldNotifyTreeNodeSelect('35', '')).toBe(false);
+    expect(shouldNotifyTreeNodeSelect('35', null)).toBe(false);
+  });
+});

--- a/web/src/app/monitor/components/treeSelector/index.tsx
+++ b/web/src/app/monitor/components/treeSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Tree, Spin, Input, Empty } from 'antd';
 import { TreeItem, TableDataItem, TreeSortData } from '@/app/monitor/types';
 import { useTranslation } from '@/utils/i18n';
@@ -7,6 +7,7 @@ import { cloneDeep } from 'lodash';
 import ObjectIcon from '@/app/monitor/components/objectIcon';
 import EllipsisWithTooltip from '@/components/ellipsis-with-tooltip';
 import styles from './index.module.scss';
+import { shouldNotifyTreeNodeSelect } from './selectionNotify';
 
 const { Search } = Input;
 
@@ -38,12 +39,20 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
   const [treeSearchValue, setTreeSearchValue] = useState<string>('');
   const [originalTreeData, setOriginalTreeData] = useState<TreeItem[]>([]);
   const [treeData, setTreeData] = useState<TreeItem[]>([]);
+  const lastNotifiedKeyRef = useRef('');
+
+  const notifyNodeSelect = (key: React.Key) => {
+    if (!shouldNotifyTreeNodeSelect(lastNotifiedKeyRef.current, key)) {
+      return;
+    }
+    lastNotifiedKeyRef.current = String(key);
+    onNodeSelect?.(String(key));
+  };
 
   useEffect(() => {
-    if (defaultSelectedKey) {
-      setSelectedKeys([defaultSelectedKey]);
-      onNodeSelect?.(defaultSelectedKey as string);
-    }
+    if (!defaultSelectedKey) return;
+    setSelectedKeys([defaultSelectedKey]);
+    notifyNodeSelect(defaultSelectedKey);
   }, [defaultSelectedKey]);
 
   useEffect(() => {
@@ -68,7 +77,7 @@ const TreeComponent: React.FC<TreeComponentProps> = ({
     // 默认仅叶子可选；allowParentSelect 时一级分类也可选（如点「数据库」看该类全部能力）
     if ((!hasChildren || allowParentSelect) && selectedKeys?.length) {
       setSelectedKeys(selectedKeys);
-      onNodeSelect?.(selectedKeys[0] as string);
+      notifyNodeSelect(selectedKeys[0]);
     }
   };
 

--- a/web/src/app/monitor/components/treeSelector/selectionNotify.ts
+++ b/web/src/app/monitor/components/treeSelector/selectionNotify.ts
@@ -1,0 +1,15 @@
+/**
+ * 对象树是否需要把选中节点通知给父页面。
+ *
+ * 点击叶子后父页面会把 objId 写回 URL，TreeSelector 再收到同一个
+ * defaultSelectedKey。若此时再次 onNodeSelect，父页面会 abort 刚发出的
+ * 列表请求，右侧插件/资产停在上一份数据。
+ */
+export const shouldNotifyTreeNodeSelect = (
+  lastNotifiedKey: string,
+  nextKey: unknown
+): boolean => {
+  const normalized = String(nextKey ?? '').trim();
+  if (!normalized) return false;
+  return lastNotifiedKey !== normalized;
+};


### PR DESCRIPTION
选择对象后 defaultSelectedKey 回写会再次 onNodeSelect，把刚发出的插件列表请求 abort 掉，右侧停在上一对象。