### PR TITLE
fix(日志): 补齐采集执行与配置回调终态

### DIFF
--- a/server/apps/cmdb/nats/nats.py
+++ b/server/apps/cmdb/nats/nats.py
@@ -921,20 +921,34 @@ def delete_instance_association(params):
 @nats_client.register
 def receive_config_file_result(data: dict):
     """接收 Stargazer 回传的配置文件采集结果并落库。"""
-    logger.info("==[ConfigFileCollect] 接收配置文件采集结果")
     result = ConfigFileService.process_collect_result(data)
-    logger.info(
-        "==[ConfigFileCollect] 处理配置文件采集结果完成",
-    )
+    payload = ConfigFileService._normalize_collect_payload(data)
     error_lines = str(result.get("error") or "").splitlines()
     error = (error_lines[0] if error_lines else "")[:500]
-    return {
+    response = {
         "result": True,
         "processed": not bool(error),
         "error": error,
         "changed": bool(result.get("changed", False)),
         "task_updated": bool(result.get("task_updated", False)),
     }
+    callback_status = str(payload.get("status") or "error").lower()
+    if callback_status not in ConfigFileService.STATUS_MAP:
+        callback_status = "unknown"
+    execution_id = str(payload.get("execution_id") or "-").replace("\r", "\\r").replace("\n", "\\n")[:64]
+    callback_failed = callback_status != "success"
+    log_terminal = logger.warning if error or callback_failed else logger.info
+    log_terminal(
+        "event=config_file_callback_finished task_id=%s execution_id=%s " "callback_status=%s processed=%s changed=%s task_updated=%s stale=%s",
+        payload.get("collect_task_id") or payload.get("task_id") or "-",
+        execution_id,
+        callback_status,
+        response["processed"],
+        response["changed"],
+        response["task_updated"],
+        bool(result.get("stale", False)),
+    )
+    return response
 
 
 def _manual_config_file_already_exists(instance_uuid, file_path) -> bool:

--- a/server/apps/cmdb/tasks/celery_tasks.py
+++ b/server/apps/cmdb/tasks/celery_tasks.py
@@ -32,6 +32,22 @@ _COLLECT_TERMINAL_STATUSES = (
     CollectRunStatusType.FORCE_STOP,
     CollectRunStatusType.PARTIAL_SUCCESS,
 )
+_COLLECT_STATUS_LOG_NAMES = {
+    CollectRunStatusType.NOT_START: "NOT_START",
+    CollectRunStatusType.RUNNING: "RUNNING",
+    CollectRunStatusType.SUCCESS: "SUCCESS",
+    CollectRunStatusType.ERROR: "ERROR",
+    CollectRunStatusType.TIME_OUT: "TIME_OUT",
+    CollectRunStatusType.WRITING: "WRITING",
+    CollectRunStatusType.FORCE_STOP: "FORCE_STOP",
+    CollectRunStatusType.PARTIAL_SUCCESS: "PARTIAL_SUCCESS",
+}
+_COLLECT_WARNING_LOG_STATUSES = {
+    CollectRunStatusType.ERROR,
+    CollectRunStatusType.TIME_OUT,
+    CollectRunStatusType.FORCE_STOP,
+    CollectRunStatusType.PARTIAL_SUCCESS,
+}
 _NODE_MGMT_RAW_DATA_MAX_ROWS = 50_000
 _NODE_MGMT_RAW_DATA_MAX_BYTES = 64 * 1024 * 1024
 _NODE_MGMT_RAW_METRIC_TYPES = {
@@ -455,7 +471,7 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
     """
     同步采集任务
     """
-    logger.info("[CollectTask] 开始采集任务 task_id=%s", instance_id)
+    run_started_at = time.monotonic()
     start_time = now()
     execution_id = execution_id or self.request.id or str(uuid4())
     if not _node_mgmt_collect_version_allowed(
@@ -476,6 +492,11 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
         return
     execution_id = instance.task_id
     claim_token = instance.claim_token
+    logger.info(
+        "event=collect_task_execution_started task_id=%s execution_id=%s",
+        instance_id,
+        execution_id,
+    )
     from apps.cmdb.services.collect_service import CollectModelService
 
     exec_error_message = ""
@@ -483,6 +504,8 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
     exec_traceback_location = ""
     task_exec_status = CollectRunStatusType.SUCCESS
     config_file_pending = False
+    failed_stage = "-"
+    result_persisted = False
     try:
         CollectModelService.repair_host_cloud_snapshot(instance)
         if CollectDispatchService.should_dispatch(instance):
@@ -505,10 +528,13 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
         import traceback
 
         traceback_text = traceback.format_exc()
-        logger.error(
-            "[CollectTask] 同步采集数据失败 task_id=%s, error=%s",
+        failed_stage = "collection"
+        logger.exception(
+            "event=collect_task_stage_failed task_id=%s execution_id=%s " "failed_stage=%s error_type=%s",
             instance_id,
-            traceback_text,
+            execution_id,
+            failed_stage,
+            type(err).__name__,
         )
         exec_error_message = "采集任务执行失败（task_id={}）：{}".format(instance_id, _build_safe_error_message(err))
         exec_traceback_excerpt = _build_traceback_excerpt(traceback_text)
@@ -600,6 +626,7 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
             claim_token,
             update_values,
         )
+        result_persisted = updated
         if not updated:
             logger.info(
                 "[CollectTask] 忽略旧执行结果 stale_execution_result " "task_id=%s, execution_id=%s",
@@ -607,14 +634,15 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
                 execution_id,
             )
     except Exception as err:
-        import traceback
-
-        logger.error(
-            "[CollectTask] 保存采集结果失败 task_id=%s, error=%s",
+        failed_stage = "result_persistence"
+        logger.exception(
+            "event=collect_task_stage_failed task_id=%s execution_id=%s " "failed_stage=%s error_type=%s",
             instance_id,
-            traceback.format_exc(),
+            execution_id,
+            failed_stage,
+            type(err).__name__,
         )
-        _save_collect_result_if_current(
+        result_persisted = _save_collect_result_if_current(
             instance_id,
             execution_id,
             claim_token,
@@ -630,7 +658,19 @@ def sync_collect_task(self, instance_id, execution_id=None, node_config_id=None,
             },
         )
 
-    logger.info("[CollectTask] 采集任务执行结束 task_id=%s", instance_id)
+    terminal_status = CollectRunStatusType.ERROR if failed_stage == "result_persistence" else instance.exec_status
+    log_terminal = logger.warning if terminal_status in _COLLECT_WARNING_LOG_STATUSES else logger.info
+    log_terminal(
+        "event=collect_task_execution_finished task_id=%s execution_id=%s "
+        "status=%s failed_stage=%s result_persisted=%s callback_pending=%s duration_ms=%.2f",
+        instance_id,
+        execution_id,
+        _COLLECT_STATUS_LOG_NAMES.get(terminal_status, str(terminal_status)),
+        failed_stage,
+        result_persisted,
+        config_file_pending,
+        (time.monotonic() - run_started_at) * 1000,
+    )
 
 
 @shared_task

--- a/server/apps/cmdb/tests/test_collect_task_diagnosability_service.py
+++ b/server/apps/cmdb/tests/test_collect_task_diagnosability_service.py
@@ -1,0 +1,156 @@
+import logging
+
+import pytest
+
+from apps.cmdb.constants.constants import CollectDriverTypes, CollectPluginTypes, CollectRunStatusType
+from apps.cmdb.models.collect_model import CollectModels
+from apps.cmdb.tasks import celery_tasks as collect_tasks
+
+pytestmark = pytest.mark.integration
+
+
+def _create_protocol_task(name: str) -> CollectModels:
+    return CollectModels.objects.create(
+        name=name,
+        task_type=CollectPluginTypes.PROTOCOL,
+        model_id="mysql",
+        driver_type="protocol",
+        cycle_value_type="cycle",
+        team=[1],
+        instances=[{"_id": "instance-1", "model_id": "mysql", "inst_name": "db-1"}],
+    )
+
+
+def _create_config_file_task(name: str) -> CollectModels:
+    return CollectModels.objects.create(
+        name=name,
+        task_type=CollectPluginTypes.CONFIG_FILE,
+        driver_type=CollectDriverTypes.JOB,
+        model_id="host",
+        cycle_value_type="cycle",
+        credential={"credential_id": "credential-1"},
+        instances=[{"_id": "host-1", "model_id": "host", "inst_name": "host-1"}],
+    )
+
+
+@pytest.mark.django_db
+def test_collect_execution_failure_has_owned_error_and_correlated_terminal_summary(monkeypatch, caplog):
+    task = _create_protocol_task("diagnosability-execution-failure")
+    monkeypatch.setattr(
+        collect_tasks.CollectDispatchService,
+        "should_dispatch",
+        staticmethod(lambda _task: False),
+    )
+
+    class FailingProtocolCollect:
+        def __init__(self, task):
+            self.task = task
+
+        def main(self):
+            raise RuntimeError("collector unavailable")
+
+    monkeypatch.setattr(collect_tasks, "ProtocolCollect", FailingProtocolCollect)
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    collect_tasks.sync_collect_task(task.id, execution_id="execution-log-1")
+
+    task.refresh_from_db()
+    assert task.exec_status == CollectRunStatusType.ERROR
+    assert "collector unavailable" in task.collect_digest["message"]
+
+    owned_errors = [record for record in caplog.records if "event=collect_task_stage_failed" in record.getMessage()]
+    assert len(owned_errors) == 1
+    assert owned_errors[0].levelno == logging.ERROR
+    assert owned_errors[0].exc_info is not None
+    assert owned_errors[0].exc_info[0] is RuntimeError
+    assert f"task_id={task.id}" in owned_errors[0].getMessage()
+    assert "execution_id=execution-log-1" in owned_errors[0].getMessage()
+    assert "failed_stage=collection" in owned_errors[0].getMessage()
+    assert "error_type=RuntimeError" in owned_errors[0].getMessage()
+
+    summaries = [record for record in caplog.records if "event=collect_task_execution_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert f"task_id={task.id}" in summaries[0].getMessage()
+    assert "execution_id=execution-log-1" in summaries[0].getMessage()
+    assert "status=ERROR" in summaries[0].getMessage()
+    assert "failed_stage=collection" in summaries[0].getMessage()
+
+
+@pytest.mark.django_db
+def test_collect_result_persistence_failure_identifies_stage_and_preserves_error_state(monkeypatch, caplog):
+    task = _create_protocol_task("diagnosability-persistence-failure")
+    monkeypatch.setattr(
+        collect_tasks.CollectDispatchService,
+        "should_dispatch",
+        staticmethod(lambda _task: False),
+    )
+
+    class MalformedProtocolCollect:
+        def __init__(self, task):
+            self.task = task
+
+        def main(self):
+            return {}, {
+                "add": [],
+                "update": [],
+                "delete": [],
+                "association": [],
+                "__raw_data__": [None],
+            }
+
+    monkeypatch.setattr(collect_tasks, "ProtocolCollect", MalformedProtocolCollect)
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    collect_tasks.sync_collect_task(task.id, execution_id="execution-log-2")
+
+    task.refresh_from_db()
+    assert task.exec_status == CollectRunStatusType.ERROR
+    assert "采集结果写入失败" in task.collect_digest["message"]
+
+    owned_errors = [record for record in caplog.records if "event=collect_task_stage_failed" in record.getMessage()]
+    assert len(owned_errors) == 1
+    assert owned_errors[0].levelno == logging.ERROR
+    assert owned_errors[0].exc_info is not None
+    assert owned_errors[0].exc_info[0] is AttributeError
+    assert f"task_id={task.id}" in owned_errors[0].getMessage()
+    assert "execution_id=execution-log-2" in owned_errors[0].getMessage()
+    assert "failed_stage=result_persistence" in owned_errors[0].getMessage()
+    assert "error_type=AttributeError" in owned_errors[0].getMessage()
+
+    summaries = [record for record in caplog.records if "event=collect_task_execution_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert "status=ERROR" in summaries[0].getMessage()
+    assert "failed_stage=result_persistence" in summaries[0].getMessage()
+    assert "result_persisted=True" in summaries[0].getMessage()
+
+
+@pytest.mark.django_db
+def test_collect_config_callback_pending_is_an_info_outcome(monkeypatch, caplog):
+    task = _create_config_file_task("diagnosability-callback-pending")
+    monkeypatch.setattr(
+        collect_tasks.CollectDispatchService,
+        "should_dispatch",
+        staticmethod(lambda _task: False),
+    )
+
+    class PendingConfigFileCollect:
+        def __init__(self, task):
+            self.task = task
+
+        def main(self):
+            return {"config_file": {"status": "pending"}}, {}
+
+    monkeypatch.setattr(collect_tasks, "JobCollect", PendingConfigFileCollect)
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    collect_tasks.sync_collect_task(task.id, execution_id="execution-log-3")
+
+    task.refresh_from_db()
+    assert task.exec_status == CollectRunStatusType.RUNNING
+    summaries = [record for record in caplog.records if "event=collect_task_execution_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.INFO
+    assert "status=RUNNING" in summaries[0].getMessage()
+    assert "callback_pending=True" in summaries[0].getMessage()

--- a/server/apps/cmdb/tests/test_config_file_callback_diagnosability_service.py
+++ b/server/apps/cmdb/tests/test_config_file_callback_diagnosability_service.py
@@ -1,0 +1,197 @@
+import logging
+
+import pytest
+
+from apps.cmdb.nats import nats as cmdb_nats
+
+pytestmark = pytest.mark.unit
+
+
+def test_config_file_callback_business_failure_has_correlated_terminal_summary(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": None,
+            "changed": False,
+            "task_updated": True,
+            "stale": False,
+            "error": "配置文件采集回调缺少目标实例标识\ninternal detail",
+        },
+    )
+    payload = {
+        "collect_task_id": 42,
+        "execution_id": "execution-callback-1",
+        "status": "error",
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    response = cmdb_nats.receive_config_file_result(payload)
+
+    assert response == {
+        "result": True,
+        "processed": False,
+        "error": "配置文件采集回调缺少目标实例标识",
+        "changed": False,
+        "task_updated": True,
+    }
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert "task_id=42" in summaries[0].getMessage()
+    assert "execution_id=execution-callback-1" in summaries[0].getMessage()
+    assert "callback_status=error" in summaries[0].getMessage()
+    assert "processed=False" in summaries[0].getMessage()
+    assert "changed=False" in summaries[0].getMessage()
+    assert "task_updated=True" in summaries[0].getMessage()
+    assert "stale=False" in summaries[0].getMessage()
+    assert "internal detail" not in summaries[0].getMessage()
+
+
+def test_config_file_callback_success_preserves_ack_and_uses_info(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": object(),
+            "changed": True,
+            "task_updated": True,
+        },
+    )
+    payload = {
+        "collect_task_id": 43,
+        "execution_id": "execution-callback-2",
+        "status": "success",
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    response = cmdb_nats.receive_config_file_result(payload)
+
+    assert response == {
+        "result": True,
+        "processed": True,
+        "error": "",
+        "changed": True,
+        "task_updated": True,
+    }
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.INFO
+    assert "task_id=43" in summaries[0].getMessage()
+    assert "execution_id=execution-callback-2" in summaries[0].getMessage()
+    assert "callback_status=success" in summaries[0].getMessage()
+    assert "processed=True" in summaries[0].getMessage()
+    assert "changed=True" in summaries[0].getMessage()
+    assert "task_updated=True" in summaries[0].getMessage()
+
+
+def test_config_file_callback_reported_failure_uses_warning_when_processing_completed(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": None,
+            "changed": False,
+            "task_updated": True,
+        },
+    )
+    payload = {
+        "collect_task_id": 44,
+        "execution_id": "execution-callback-3",
+        "status": "permission_denied",
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    response = cmdb_nats.receive_config_file_result(payload)
+
+    assert response["processed"] is True
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert "callback_status=permission_denied" in summaries[0].getMessage()
+
+
+def test_config_file_callback_noncanonical_status_uses_warning(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": None,
+            "changed": False,
+            "task_updated": True,
+        },
+    )
+    payload = {
+        "collect_task_id": 45,
+        "execution_id": "execution-callback-4",
+        "status": " success ",
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    cmdb_nats.receive_config_file_result(payload)
+
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert "callback_status=unknown" in summaries[0].getMessage()
+
+
+def test_config_file_callback_log_uses_normalized_nested_payload(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": None,
+            "changed": False,
+            "task_updated": True,
+        },
+    )
+    payload = {
+        "collect_task_id": 47,
+        "execution_id": "execution-top-level",
+        "status": "success",
+        "collect_result": {
+            "collect_task_id": 48,
+            "execution_id": "execution-nested",
+            "status": "error",
+        },
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    cmdb_nats.receive_config_file_result(payload)
+
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    assert summaries[0].levelno == logging.WARNING
+    assert "task_id=48" in summaries[0].getMessage()
+    assert "execution_id=execution-nested" in summaries[0].getMessage()
+    assert "callback_status=error" in summaries[0].getMessage()
+
+
+def test_config_file_callback_bounds_and_escapes_execution_id(monkeypatch, caplog):
+    monkeypatch.setattr(
+        cmdb_nats.ConfigFileService,
+        "process_collect_result",
+        lambda _data: {
+            "version_obj": None,
+            "changed": False,
+            "task_updated": False,
+            "stale": True,
+            "error": "非当前执行",
+        },
+    )
+    payload = {
+        "collect_task_id": 46,
+        "execution_id": "execution\n" + "x" * 100,
+        "status": "success",
+    }
+    caplog.set_level(logging.INFO, logger="cmdb")
+
+    cmdb_nats.receive_config_file_result(payload)
+
+    summaries = [record for record in caplog.records if "event=config_file_callback_finished" in record.getMessage()]
+    assert len(summaries) == 1
+    execution_id = summaries[0].args[1]
+    assert len(execution_id) == 64
+    assert "\n" not in execution_id
+    assert "\\n" in execution_id


### PR DESCRIPTION
## 问题

CMDB 采集执行和配置文件回调本应提供一条可串联、可判断成败的终态证据。现状却把 traceback 手工拼进模糊 ERROR，并在失败后继续输出泛化 INFO；配置回调前后两条 INFO 既没有任务/执行 ID，也无法区分采集失败、回调处理失败和成功。

Closes #4956

## 根因（设计层）

异步边界没有明确日志所有者，也没有把“执行结果”“结果持久化”“等待回调”“回调处理结果”建模为不同的诊断阶段。日志因此依赖自由文本和调用顺序，无法按稳定事件聚合；回调日志还旁路了服务层既有的 payload 规范化规则，嵌套兼容 payload 可能出现假成功。

## 怎么修的

- `sync_collect_task` 在领取执行权后记录稳定开始事件；采集与结果持久化异常由任务边界各自以同一个 `collect_task_stage_failed` 事件持有 traceback，并用 `failed_stage` 区分；
- 每次已领取的执行只输出一条 `collect_task_execution_finished`，包含状态、持久化结果、回调等待状态和耗时；失败/部分成功为 WARNING，成功及正常等待回调为 INFO；
- `receive_config_file_result` 删除两条泛化 INFO，改为一条 `config_file_callback_finished`；日志视图复用服务层 payload 规范化，正确处理嵌套字段和非 canonical 状态；
- 外部 `execution_id` 仅在日志副本中转义 CR/LF 并按模型 64 字符上限截断；不记录 payload、配置内容或错误全文。

## 调用链

```mermaid
flowchart TD
    C["Celery sync_collect_task"] --> O["领取 task_id + execution_id"]
    O --> E["本地采集或派发 Stargazer"]
    E --> P["归一化并持久化结果"]
    P -->|普通任务| T["执行终态汇总"]
    P -->|配置文件 pending| S["Stargazer 采集配置文件"]
    S --> N["NATS receive_config_file_result"]
    N --> F["ConfigFileService.process_collect_result"]
    F --> A["ACK 信封 + 回调终态汇总"]
```

## 影响范围与兼容性

- 仅修改 CMDB Celery 采集任务和既有配置文件 NATS handler，并新增两个分层测试文件；
- 不修改 NATS subject、payload、ACK schema、数据库字段、状态机、执行权、重试、超时和 Stargazer publish；
- 服务仍只接收一次原始 payload；二次规范化仅生成无副作用日志视图，服务异常仍由 listener 边界接收；
- 原任务错误摘要与 traceback excerpt 继续按既有契约持久化。

## 验证

- 新增日志契约：9 passed；回退生产日志改动后，稳定事件数量/等级断言会失败；
- 相关 CMDB 采集、single-flight、配置服务、DB 与 NATS handler E2E：154 passed；
- Black（新增测试）、isort、flake8 致命规则、`py_compile`、`git diff --check` 通过；
- 目标代码不再把 `traceback.format_exc()` 作为日志参数，旧泛化完成文案已移除。

## 三轨门禁

- Standards：PASS。失败状态、嵌套 payload、关联 ID 边界和测试 marker 均符合仓库规范；
- Spec：PASS。三个 Celery 场景及回调成功/失败契约完整，无范围扩张；
- Runtime Contract：PASS。真实 SQLite 状态、digest、真实 `exc_info`、ACK 和异常传播均保持兼容；未启动真实 broker/Stargazer 不阻塞，因为 subject、注册、序列化和 schema 未改。

## 质量评分

97/100，SCORE_PASS。

- 漏洞修复完整性：30/30
- 修复方案设计：19/20
- 向后兼容性：15/15
- 测试覆盖质量：19/20
- 风险评估准确性：14/15

## 回滚

无迁移、配置或协议变化；如日志采集兼容性异常，可直接回滚本 PR。
