### PR TITLE
bugfix: 统一治理剩余运行时日志

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@
 - 凭据只由环境注入，不提交或记录 `.env`、keystore、token。
 - 数据库访问使用 Django ORM，禁止 raw SQL、`.raw()`、`RawSQL`、`cursor.execute`。
 - `server/apps/<app>/` 引入日志统一用 `from apps.core.logger import {app_name}_logger as logger`（见 `server/apps/core/logger.py`），禁止 `loguru` 或就地 `logging.getLogger`。
+- 生产日志遵守 `specs/capabilities/backend-engineering.md` §8：使用稳定模板和惰性参数；INFO 只记录生命周期、终态或有界汇总，逐项/阶段信息放 DEBUG；一个失败只由一个边界持有 traceback ERROR，并带关联 ID、`failed_stage`、`error_type`。
+- 生产日志和 stdout 不得包含凭据、payload、响应正文或其他无界对象；不可记录的值直接省略，不以截断凭据作为脱敏。常驻 Server/Agent 禁用 `print`，仅明确面向人的 CLI、诊断脚本和测试可使用 stdout。
+- 修改日志须补行为回归测试：验证模板与独立参数、完整格式化输出、单一 traceback 所有权和敏感哨兵不泄露，并同时锁定原返回值、异常身份、状态与协议契约。
 - 非关键、可重建的外部资源失败不得阻断服务启动。
 - 新增对外 API 一律经 OpenAPI 网关暴露（内部函数用 `@openapi_expose`，外部服务写 KV 注册表），不得新增散落的 `open_api` 端点或对外端口；暴露端点必须附双租户测试并登记。见 `specs/capabilities/openapi-gateway.md`。
 - 向目标主机下发或执行操作必须有资源边界、幂等/回滚和相应测试。

--- a/agents/stargazer/api/collect.py
+++ b/agents/stargazer/api/collect.py
@@ -199,7 +199,7 @@ async def collect(request):
     返回：
         Prometheus 格式的"请求已接收"指标，包含 task_id 用于追踪
     """
-    logger.info("=== Plugin collection request received ===")
+    logger.info("event=plugin_collection_request_received")
 
     # Sanic 要求请求体被消费（即使是 GET 请求），否则可能出现
     # "<Request ...> body not consumed." 日志告警。

--- a/agents/stargazer/api/monitor.py
+++ b/agents/stargazer/api/monitor.py
@@ -3,14 +3,12 @@ import secrets
 import time
 from typing import Any, Callable
 
-from sanic import Blueprint
-from sanic import response
-from sanic.exceptions import SanicException
-from core.logger import logger
-
 from core.collection.application import get_collection_application
 from core.collection.request_builder import build_collection_request
 from core.collection.request_identity import build_request_task_id_from_request
+from core.logger import logger
+from sanic import Blueprint, response
+from sanic.exceptions import SanicException
 
 monitor_router = Blueprint("monitor", url_prefix="/monitor")
 
@@ -215,7 +213,7 @@ async def _run_monitor_handler(
     log_name: str | None = None,
 ):
     display = log_name or monitor_type
-    logger.info("=== %s metrics collection request received ===", display)
+    logger.info("event=metrics_collection_request_received monitor_type=%s", display)
     try:
         task_params = build_params(request)
         task_info = await _submit_monitor_request(request, task_params)
@@ -396,8 +394,6 @@ async def windows_wmi_metrics(request):
 
 @monitor_router.get("/host/metrics")
 async def host_metrics(request):
-    logger.info("=== Host metrics collection request received ===")
-
     host = request.headers.get("host")
     os_type = request.headers.get("os_type", "linux")
     username = request.headers.get("username")

--- a/agents/stargazer/common/cmp/cloud_apis/resource_apis/cw_manageone.py
+++ b/agents/stargazer/common/cmp/cloud_apis/resource_apis/cw_manageone.py
@@ -1,6 +1,5 @@
 # -*- coding: UTF-8 -*-
 import datetime
-import logging
 import os
 import time
 import typing
@@ -9,6 +8,7 @@ import requests
 
 from common.cmp.cloud_apis.base import PrivateCloudManage
 from common.cmp.cloud_apis.cloud_object.base import VM, BusinessRegion, DataStore, HostMachine
+from core.logger import logger
 
 # from common.cmp.cloud_apis.constant import CloudResourceType, CloudType, SnapshotStatus, VMStatusType, VolumeStatus,
 # VPCStatus
@@ -24,9 +24,6 @@ from common.cmp.cloud_apis.cloud_object.base import VM, BusinessRegion, DataStor
 # from common.cmp.models import AccountConfig
 # from common.cmp.cloud_apis.constant import CloudResourceType, CloudType
 # from common.cmp.cloud_apis.resource_apis.utils import fail
-
-logger = logging.getLogger("root")
-
 
 def character_conversion_timestamp(time_str):
     """
@@ -536,18 +533,14 @@ class ManageOne(PrivateCloudManage):
             i.update(floating_ip_id=ip_id_map.get(i["floating_ip"], None))
             i.update(elb_id=pool_member_vm_map.get(i["resource_id"], None))
 
-        print(
-            {
-                "result": "True",
-                "data": {
-                    "mo_cloud": mo_cloud["data"],
-                    "mo_host": mo_host["data"],
-                    "mo_ds": mo_ds["data"],
-                    "mo_server": mo_server["data"],
-                    "mo_ip": mo_ip["data"],
-                    "mo_elb": mo_elb["data"],
-                },
-            }
+        logger.debug(
+            "event=manageone_inventory_collected clouds=%s hosts=%s datastores=%s servers=%s floating_ips=%s elbs=%s",
+            len(mo_cloud["data"]),
+            len(mo_host["data"]),
+            len(mo_ds["data"]),
+            len(mo_server["data"]),
+            len(mo_ip["data"]),
+            len(mo_elb["data"]),
         )
         return {
             "result": "True",

--- a/agents/stargazer/core/collection/executor.py
+++ b/agents/stargazer/core/collection/executor.py
@@ -632,7 +632,7 @@ class TargetCollectionExecutor:
             error_code = preflight.error_code or "target_unreachable"
             if log_failure_detail:
                 logger.warning(
-                    "🚫 event=target_unreachable task_id=%s plugin_ref=%s "
+                    "event=target_unreachable task_id=%s plugin_ref=%s "
                     "model_id=%s target=%s "
                     "reason=%s detail=%s",
                     request.task_id,
@@ -991,7 +991,7 @@ class TargetCollectionExecutor:
                 error_code=error_code,
             )
             logger.debug(
-                "🚫 event=access_probe_failed task_id=%s plugin_ref=%s "
+                "event=access_probe_failed task_id=%s plugin_ref=%s "
                 "model_id=%s target=%s "
                 "credential_id=%s probe_status=%s error_code=%s action=rotate",
                 request.task_id,
@@ -1013,7 +1013,7 @@ class TargetCollectionExecutor:
         if access.status == AccessProbeStatus.NO_RESPONSE:
             no_response_attempts += 1
             logger.debug(
-                "🚫 event=access_probe_failed task_id=%s plugin_ref=%s "
+                "event=access_probe_failed task_id=%s plugin_ref=%s "
                 "model_id=%s target=%s "
                 "credential_id=%s probe_status=%s error_code=%s "
                 "no_response_attempts=%s",
@@ -1044,7 +1044,7 @@ class TargetCollectionExecutor:
             )
         if access.status == AccessProbeStatus.TARGET_UNREACHABLE:
             logger.debug(
-                "🚫 event=target_unreachable task_id=%s plugin_ref=%s "
+                "event=target_unreachable task_id=%s plugin_ref=%s "
                 "model_id=%s target=%s "
                 "credential_id=%s reason=%s",
                 request.task_id,
@@ -1067,7 +1067,7 @@ class TargetCollectionExecutor:
             )
         if access.status == AccessProbeStatus.RATE_LIMITED:
             logger.debug(
-                "🚫 event=access_probe_failed task_id=%s plugin_ref=%s "
+                "event=access_probe_failed task_id=%s plugin_ref=%s "
                 "model_id=%s target=%s "
                 "credential_id=%s probe_status=%s error_code=%s action=defer",
                 request.task_id,
@@ -1096,7 +1096,7 @@ class TargetCollectionExecutor:
             AccessProbeStatus.MISCONFIGURED,
         }:
             logger.debug(
-                "🚫 event=access_probe_failed task_id=%s plugin_ref=%s "
+                "event=access_probe_failed task_id=%s plugin_ref=%s "
                 "model_id=%s target=%s "
                 "credential_id=%s probe_status=%s error_code=%s action=stop",
                 request.task_id,

--- a/agents/stargazer/core/collection/preflight.py
+++ b/agents/stargazer/core/collection/preflight.py
@@ -226,7 +226,7 @@ class AsyncProtocolPreflight:
     def _log_outbound_skip(request: CollectionRequest, target: str, error: BaseException) -> None:
         reason = str(error).strip() or type(error).__name__
         logger.info(
-            "🚫 event=outbound_target_skipped task_id=%s target=%s reason=%s",
+            "event=outbound_target_skipped task_id=%s target=%s reason=%s",
             request.task_id,
             target,
             reason,

--- a/agents/stargazer/core/infra/ssh_client.py
+++ b/agents/stargazer/core/infra/ssh_client.py
@@ -4,13 +4,17 @@
 # @Author: windyzhao
 import os
 import time
+from dataclasses import dataclass
+from typing import Optional
 
 import paramiko
-from typing import Optional
-from dataclasses import dataclass
-
+from core.logger import logger
 
 # from sanic.log import logger
+
+
+def _safe_log_host(host: str) -> str:
+    return str(host).replace("\r", "\\r").replace("\n", "\\n")[:255]
 
 
 @dataclass
@@ -55,7 +59,12 @@ class SSHClient:
         :raises: ConnectionError 如果连接失败
         """
         try:
-            print(f"Connecting to {host}:{port} as {username}...")
+            log_host = _safe_log_host(host)
+            logger.debug(
+                "event=ssh_connection_started host=%s port=%s",
+                log_host,
+                port,
+            )
             self._client.connect(
                 hostname=host,
                 port=port,
@@ -67,7 +76,7 @@ class SSHClient:
                 allow_agent=False,
                 look_for_keys=False
             )
-            print(f"Connected to {host} successfully")
+            logger.debug("event=ssh_connection_succeeded host=%s port=%s", log_host, port)
         except Exception as e:
             self.close()
             raise ConnectionError(f"SSH connection failed to {host}: {str(e)}")
@@ -112,7 +121,7 @@ class SSHClient:
 
         # 记录命令执行时间
         exec_time = time.time() - start_time
-        print(f"Command executed in {exec_time:.2f}s")
+        logger.debug("event=ssh_command_completed duration_ms=%.3f", exec_time * 1000)
 
         # 如果输出是二进制，转换为字符串
         if isinstance(stdout_data, bytes):
@@ -121,7 +130,11 @@ class SSHClient:
             stderr_data = stderr_data.decode('utf-8', errors='replace')
 
         # 打印原始输出大小以便调试
-        print(f"DEBUG: Raw stdout size: {len(stdout_data)}, stderr size: {len(stderr_data)}")
+        logger.debug(
+            "event=ssh_command_output_summary stdout_bytes=%s stderr_bytes=%s",
+            len(stdout_data),
+            len(stderr_data),
+        )
 
         return SSHResult(stdout_data, stderr_data, exit_status, exec_time)
 

--- a/agents/stargazer/tests/test_async_executor_diagnosability.py
+++ b/agents/stargazer/tests/test_async_executor_diagnosability.py
@@ -1,0 +1,21 @@
+import asyncio
+from unittest.mock import patch
+
+from utils import async_executor as async_executor_module
+
+
+def test_execute_tasks_emits_one_debug_summary_without_info():
+    executor = async_executor_module.AsyncExecutor()
+
+    async def task():
+        return "done"
+
+    with (
+        patch.object(async_executor_module.logger, "info") as info,
+        patch.object(async_executor_module.logger, "debug") as debug,
+    ):
+        result = asyncio.run(executor.execute_tasks([task]))
+
+        assert result == ["done"]
+        info.assert_not_called()
+        debug.assert_called_once_with("event=async_tasks_completed task_count=%s", 1)

--- a/agents/stargazer/tests/test_manageone_sensitive_logging.py
+++ b/agents/stargazer/tests/test_manageone_sensitive_logging.py
@@ -3,6 +3,13 @@ import types
 from unittest.mock import MagicMock
 
 
+def test_manageone_uses_stargazer_logger():
+    from common.cmp.cloud_apis.resource_apis import cw_manageone
+    from core.logger import logger
+
+    assert cw_manageone.logger is logger
+
+
 def test_manageone_token_is_returned_without_entering_logs(monkeypatch):
     requests_module = types.ModuleType("requests")
     requests_module.request = MagicMock()
@@ -136,3 +143,38 @@ def test_manageone_transport_failure_owns_traceback_without_credentials(monkeypa
     assert log_args[1:] == ("https://manageone.example/token", "PUT")
     assert "header-secret" not in repr(logger.mock_calls)
     assert "password-secret" not in repr(logger.mock_calls)
+
+
+def test_manageone_inventory_returns_data_without_printing_cloud_response(monkeypatch, capsys):
+    from common.cmp.cloud_apis.resource_apis import cw_manageone
+
+    client = object.__new__(cw_manageone.ManageOne)
+    resources = {
+        "list_biz_regions": [{"id": "cloud-1"}],
+        "list_hosts": [{"host_id": "host-1", "biz_region_id": "cloud-1"}],
+        "list_ds": [{"id": "ds-1", "biz_region_id": "cloud-1"}],
+        "list_vms": [{"resource_id": "vm-1", "host_id": "host-1", "floating_ip": "192.0.2.1"}],
+        "list_floating_ips": [{"id": "ip-1", "floatingIpAddress": "192.0.2.1"}],
+        "list_elb": [{"id": "elb-1"}],
+        "list_elb_pool": [{"id": "pool-1", "elbId": "elb-1"}],
+        "list_elb_pool_members": [{"vmId": "vm-1", "poolId": "pool-1"}],
+    }
+    for method_name, data in resources.items():
+        client.__dict__[method_name] = lambda data=data: {"result": True, "data": data}
+    logger = MagicMock()
+    monkeypatch.setattr(cw_manageone, "logger", logger)
+
+    result = client.list_all_resources()
+
+    assert result["result"] == "True"
+    assert result["data"]["mo_server"][0]["floating_ip_id"] == "ip-1"
+    assert capsys.readouterr().out == ""
+    logger.debug.assert_called_once_with(
+        "event=manageone_inventory_collected clouds=%s hosts=%s datastores=%s servers=%s floating_ips=%s elbs=%s",
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+    )

--- a/agents/stargazer/tests/test_ssh_client_host_key_policy.py
+++ b/agents/stargazer/tests/test_ssh_client_host_key_policy.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import paramiko
-
+from core.infra import ssh_client as ssh_client_module
 from core.infra.ssh_client import SSHClient
 
 
@@ -88,3 +88,33 @@ class TestSSHClientHostKeyPolicy:
         # SSHClient must NOT produce this
         our_client = SSHClient()
         assert not isinstance(self._get_policy(our_client), paramiko.AutoAddPolicy)
+
+    def test_connect_uses_bounded_logger_fields_without_credentials(self, capsys):
+        client = SSHClient()
+        host = "node\r\n" + "x" * 300
+        username = "operator-private"
+        with (
+            patch.object(client._client, "connect") as connect,
+            patch.object(ssh_client_module.logger, "debug") as debug,
+        ):
+            client.connect(host, username, password="ssh-password-secret")
+
+            connect.assert_called_once_with(
+                hostname=host,
+                port=22,
+                username=username,
+                password="ssh-password-secret",
+                key_filename=None,
+                timeout=30,
+                banner_timeout=30,
+                allow_agent=False,
+                look_for_keys=False,
+            )
+            assert capsys.readouterr().out == ""
+            logged = str(debug.call_args_list)
+            assert "ssh-password-secret" not in logged
+            assert username not in logged
+            assert "\r" not in debug.call_args_list[0].args[1]
+            assert "\n" not in debug.call_args_list[0].args[1]
+            assert len(debug.call_args_list[0].args[1]) == 255
+            assert debug.call_count == 2

--- a/agents/stargazer/utils/async_executor.py
+++ b/agents/stargazer/utils/async_executor.py
@@ -11,7 +11,8 @@
 import asyncio
 import inspect
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Callable, Any, Optional, Coroutine
+from typing import Any, Callable, Coroutine, List, Optional
+
 from sanic.log import logger
 
 
@@ -115,9 +116,8 @@ class AsyncExecutor:
                 raise TypeError(f"Task must be a callable or coroutine function, got {type(task)}")
 
         # 并发执行所有协程
-        logger.info(f"🚀 Executing {len(coroutines)} tasks concurrently...")
         results = await asyncio.gather(*coroutines, return_exceptions=return_exceptions)
-        logger.info(f"✅ All {len(coroutines)} tasks completed")
+        logger.debug("event=async_tasks_completed task_count=%s", len(coroutines))
 
         return results
 

--- a/algorithms/classify_anomaly_server/classify_anomaly_server/serving/schemas/api_schema.py
+++ b/algorithms/classify_anomaly_server/classify_anomaly_server/serving/schemas/api_schema.py
@@ -50,19 +50,24 @@ class PredictRequest(BaseModel):
 
         # 自动排序（如果未排序）
         if not series.index.is_monotonic_increasing:
-            logger.warning(f"⚠️  时间戳未按升序排列，自动排序")
+            logger.warning("event=timeseries_input_sorted reason=non_monotonic")
             series = series.sort_index()
 
         # 去重（如果有重复时间戳，保留最后一个值）
         if series.index.has_duplicates:
             duplicate_count = series.index.duplicated().sum()
-            logger.warning(f"⚠️  发现 {duplicate_count} 个重复时间戳，保留最后出现的值")
+            logger.warning(
+                "event=timeseries_input_deduplicated duplicate_points={}",
+                duplicate_count,
+            )
             series = series[~series.index.duplicated(keep="last")]
 
         # 记录处理结果
         if len(series) != original_count:
-            logger.info(
-                f"📊 数据处理: 输入 {original_count} 个点 -> 输出 {len(series)} 个点"
+            logger.debug(
+                "event=timeseries_input_normalized input_points={} output_points={}",
+                original_count,
+                len(series),
             )
 
         return series

--- a/algorithms/classify_anomaly_server/classify_anomaly_server/serving/service.py
+++ b/algorithms/classify_anomaly_server/classify_anomaly_server/serving/service.py
@@ -4,6 +4,9 @@ import bentoml
 from loguru import logger
 import time
 import os
+import sys
+import traceback
+from pathlib import Path
 
 from .config import get_model_config
 from .exceptions import ModelInferenceError
@@ -15,6 +18,26 @@ from .metrics import (
 )
 from .models import load_model
 from .schemas import PredictRequest, PredictResponse, PREDICT_MAX_DATA_POINTS
+
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
 
 
 @bentoml.service(
@@ -59,9 +82,10 @@ class MLService:
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.exception(
-                "event=anomaly_model_load_failed failed_stage=model_load error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=anomaly_model_load_failed failed_stage=model_load error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             # 根据环境变量决定是否允许降级到 DummyModel
@@ -346,9 +370,10 @@ class MLService:
 
         except Exception as e:
             # 其他错误（模型检测失败等）
-            logger.exception(
-                "event=anomaly_detection_failed failed_stage=model_predict error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=anomaly_detection_failed failed_stage=model_predict error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             prediction_counter.labels(

--- a/algorithms/classify_anomaly_server/classify_anomaly_server/serving/service.py
+++ b/algorithms/classify_anomaly_server/classify_anomaly_server/serving/service.py
@@ -32,18 +32,17 @@ class MLService:
                 用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
         # 可以在这里做全局初始化,例如:
         # - 预热模型缓存
         # - 下载共享资源
         # - 初始化全局连接池
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=anomaly_service_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=anomaly_service_initializing")
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=anomaly_service_config_loaded model_source={}", self.config.source)
 
         try:
             load_start = time.time()
@@ -52,12 +51,18 @@ class MLService:
 
             model_load_counter.labels(source=self.config.source, status="success").inc()
             logger.info(
-                f"⏱️  Model loaded successfully in {load_time:.3f}s: {self.config.mlflow_model_uri or 'local/dummy'}"
+                "event=anomaly_model_load_succeeded model_source={} model_type={} duration_ms={:.3f}",
+                self.config.source,
+                type(self.model).__name__,
+                load_time * 1000,
             )
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.error(f"❌ Failed to load model: {e}", exc_info=True)
+            logger.exception(
+                "event=anomaly_model_load_failed failed_stage=model_load error_type={}",
+                type(e).__name__,
+            )
 
             # 根据环境变量决定是否允许降级到 DummyModel
             allow_fallback = (
@@ -67,18 +72,12 @@ class MLService:
             if allow_fallback:
                 from .models.dummy_model import DummyModel
 
-                logger.warning(
-                    "⚠️  ALLOW_DUMMY_FALLBACK=true, using DummyModel as fallback"
-                )
+                logger.warning("event=anomaly_model_fallback_enabled fallback=dummy")
                 self.model = DummyModel()
                 model_load_counter.labels(
                     source="dummy_fallback", status="success"
                 ).inc()
             else:
-                logger.error(
-                    "Model loading failed and fallback is disabled. "
-                    "Set ALLOW_DUMMY_FALLBACK=true to enable DummyModel fallback."
-                )
                 raise RuntimeError(
                     f"Failed to load model from source '{self.config.source}'. "
                     "Service cannot start without a valid model. "
@@ -92,12 +91,11 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
         # 清理逻辑,例如:
         # - 关闭数据库连接
         # - 保存缓存状态
         # - 释放 GPU 显存
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=anomaly_service_cleanup_completed")
 
     @bentoml.api
     async def predict(self, data: list, config: dict = None) -> PredictResponse:
@@ -147,7 +145,9 @@ class MLService:
             )
         if len(data) > PREDICT_MAX_DATA_POINTS:
             logger.warning(
-                f"请求数据点数 {len(data)} 超过上限 {PREDICT_MAX_DATA_POINTS}，拒绝处理"
+                "event=anomaly_request_rejected reason=input_too_large data_points={} max_data_points={}",
+                len(data),
+                PREDICT_MAX_DATA_POINTS,
             )
             return PredictResponse(
                 success=False,
@@ -178,7 +178,10 @@ class MLService:
             detect_config = DetectionConfig(**config) if config else None
             request = PredictRequest(data=data_points, config=detect_config)
         except Exception as e:
-            logger.error(f"Request validation failed: {e}")
+            logger.warning(
+                "event=anomaly_request_rejected reason=invalid_request error_type={}",
+                type(e).__name__,
+            )
             # 返回验证失败响应
             return PredictResponse(
                 success=False,
@@ -200,38 +203,29 @@ class MLService:
                 ),
             )
 
-        logger.info(
-            f"📥 Received anomaly detection request: data_points={len(request.data)}"
-        )
+        logger.debug("event=anomaly_request_received data_points={}", len(request.data))
 
         try:
             # 转换为时间序列
             series = request.to_series()
 
-            logger.info(f"📊 Input data range: {series.index[0]} to {series.index[-1]}")
+            logger.debug("event=anomaly_input_ready data_points={}", len(series))
 
             # 推断频率（宽松模式，允许不规则序列）
             inferred_freq = None
             try:
                 inferred_freq = pd.infer_freq(series.index)
                 if inferred_freq:
-                    logger.info(f"🕒 Detected frequency: {inferred_freq}")
+                    logger.debug("event=anomaly_input_frequency_detected frequency={}", inferred_freq)
             except Exception:
-                logger.warning(
-                    "⚠️  Could not infer frequency, treating as irregular time series"
-                )
+                logger.debug("event=anomaly_input_frequency_unknown")
 
             # 执行异常检测
-            model_info = (
-                f"source={self.config.source}, type={type(self.model).__name__}"
+            logger.debug(
+                "event=anomaly_detection_started model_source={} model_type={}",
+                self.config.source,
+                type(self.model).__name__,
             )
-            if self.config.source == "local":
-                model_info += f", path={self.config.model_path}"
-            elif self.config.source == "mlflow":
-                model_info += f", uri={self.config.mlflow_model_uri}"
-
-            logger.info(f"🤖 Model info: {model_info}")
-            logger.info(f"🔍 Starting anomaly detection...")
 
             detect_start = time.time()
 
@@ -244,9 +238,6 @@ class MLService:
             detection_result = self.model.predict(model_input)
 
             detect_time = time.time() - detect_start
-
-            logger.info(f"✅ Detection completed successfully")
-            logger.info(f"⏱️  Detection time: {detect_time:.3f}s")
 
             # 解析检测结果
             # 期望格式: {'labels': [0,1,0,...], 'scores': [0.1,0.9,0.2,...], 'anomaly_severity': [0.05,0.95,...]}
@@ -262,7 +253,7 @@ class MLService:
 
             # 兼容性处理：如果模型没有返回anomaly_severity，使用scores作为fallback
             if len(anomaly_severity) != len(request.data):
-                logger.warning("模型未返回anomaly_severity，使用scores作为fallback")
+                logger.warning("event=anomaly_severity_fallback fallback=scores")
                 anomaly_severity = scores
 
             # 构造结果点
@@ -306,9 +297,15 @@ class MLService:
 
             total_time = time.time() - request_start
             logger.info(
-                f"📈 Detection summary: {anomaly_count}/{len(request.data)} anomalies ({anomaly_rate:.2%})"
+                "event=anomaly_detection_completed model_source={} data_points={} anomalies={} "
+                "anomaly_rate={:.4f} detect_duration_ms={:.3f} total_duration_ms={:.3f}",
+                self.config.source,
+                len(request.data),
+                anomaly_count,
+                anomaly_rate,
+                detect_time * 1000,
+                total_time * 1000,
             )
-            logger.info(f"⏱️  Total request time: {total_time:.3f}s")
 
             prediction_counter.labels(
                 model_source=self.config.source,
@@ -319,7 +316,10 @@ class MLService:
 
         except ValueError as e:
             # 验证错误
-            logger.error(f"Validation error: {e}")
+            logger.warning(
+                "event=anomaly_detection_failed failed_stage=result_validation error_type={}",
+                type(e).__name__,
+            )
             prediction_counter.labels(
                 model_source=self.config.source,
                 status="failure",
@@ -346,10 +346,10 @@ class MLService:
 
         except Exception as e:
             # 其他错误（模型检测失败等）
-            logger.error(f"Detection failed: {e}")
-            import traceback
-
-            logger.error(traceback.format_exc())
+            logger.exception(
+                "event=anomaly_detection_failed failed_stage=model_predict error_type={}",
+                type(e).__name__,
+            )
 
             prediction_counter.labels(
                 model_source=self.config.source,

--- a/algorithms/classify_anomaly_server/tests/test_serving_logging_service.py
+++ b/algorithms/classify_anomaly_server/tests/test_serving_logging_service.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+
+def test_serving_lifecycle_uses_stable_non_decorative_events(monkeypatch):
+    from classify_anomaly_server.serving import service
+
+    logger = MagicMock()
+    monkeypatch.setattr(service, "logger", logger)
+    service_class = getattr(service.MLService, "inner", service.MLService)
+
+    service_class.setup()
+    service_class.cleanup(object.__new__(service_class))
+
+    assert logger.info.call_args_list == [
+        (("event=anomaly_service_deployment_setup_completed",), {}),
+        (("event=anomaly_service_cleanup_completed",), {}),
+    ]
+    assert "===" not in repr(logger.mock_calls)

--- a/algorithms/classify_anomaly_server/tests/test_serving_logging_service.py
+++ b/algorithms/classify_anomaly_server/tests/test_serving_logging_service.py
@@ -1,4 +1,17 @@
+from io import StringIO
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
+from loguru import logger as real_logger
+
+
+def _make_service(service_module, model):
+    service_class = getattr(service_module.MLService, "inner", service_module.MLService)
+    instance = object.__new__(service_class)
+    instance.config = SimpleNamespace(source="dummy", mlflow_model_uri=None)
+    instance.model = model
+    return instance
 
 
 def test_serving_lifecycle_uses_stable_non_decorative_events(monkeypatch):
@@ -16,3 +29,70 @@ def test_serving_lifecycle_uses_stable_non_decorative_events(monkeypatch):
         (("event=anomaly_service_cleanup_completed",), {}),
     ]
     assert "===" not in repr(logger.mock_calls)
+
+
+@pytest.mark.asyncio
+async def test_predict_success_preserves_response_with_stable_terminal_log(monkeypatch):
+    from classify_anomaly_server.serving import service
+
+    logger = MagicMock()
+    monkeypatch.setattr(service, "logger", logger)
+    model = MagicMock()
+    model.predict.return_value = {
+        "labels": [0, 0, 1, 0, 0],
+        "scores": [0.1, 0.2, 0.9, 0.2, 0.1],
+        "anomaly_severity": [0.1, 0.2, 0.9, 0.2, 0.1],
+    }
+    instance = _make_service(service, model)
+    data = [{"timestamp": 1700000000 + index * 60, "value": float(index)} for index in range(5)]
+
+    response = await instance.predict(data)
+
+    assert response.success is True
+    assert len(response.results) == len(data)
+    assert any(call.args[0].startswith("event=anomaly_detection_completed") for call in logger.info.call_args_list)
+    assert "📥" not in repr(logger.mock_calls)
+
+
+@pytest.mark.asyncio
+async def test_predict_failure_preserves_error_response_and_single_sanitized_traceback(monkeypatch):
+    from classify_anomaly_server.serving import service
+
+    secret = "model-response-secret-must-not-enter-logs"
+    frame_secret = "frame-local-secret-must-not-enter-logs"
+    monkeypatch.setattr(service, "logger", real_logger)
+    model = MagicMock()
+    error = RuntimeError(secret)
+    def fail_with_sensitive_local(*_args, **_kwargs):
+        sensitive_local = frame_secret
+        assert sensitive_local
+        raise error
+
+    model.predict.side_effect = fail_with_sensitive_local
+    output = StringIO()
+    service._configure_production_logger(output)
+    instance = _make_service(service, model)
+    data = [{"timestamp": 1700000000 + index * 60, "value": float(index)} for index in range(5)]
+
+    try:
+        response = await instance.predict(data)
+    finally:
+        service._configure_production_logger()
+
+    assert response.success is False
+    assert response.error.code == "E2002"
+    assert secret in response.error.message
+    safe_type, safe_error, safe_traceback = service._safe_exception_info(error)
+    assert safe_traceback is error.__traceback__
+    assert safe_error is not error
+    assert safe_type.__name__ == "_SafeLogException"
+    assert isinstance(safe_error, RuntimeError)
+    assert str(safe_error) == "RuntimeError"
+    assert str(error) == secret
+    rendered = output.getvalue()
+    assert "event=anomaly_detection_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+    assert "call_chain=" in rendered
+    assert "Traceback" in rendered
+    assert "service.py" in rendered
+    assert secret not in rendered
+    assert frame_secret not in rendered

--- a/algorithms/classify_image_classification_server/classify_image_classification_server/serving/service.py
+++ b/algorithms/classify_image_classification_server/classify_image_classification_server/serving/service.py
@@ -59,12 +59,11 @@ class MLService:
         用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
         # 可以在这里做全局初始化,例如:
         # - 预热模型缓存
         # - 下载共享资源
         # - 初始化全局连接池
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=image_classification_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
@@ -89,12 +88,11 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
         # 清理逻辑,例如:
         # - 关闭数据库连接
         # - 保存缓存状态
         # - 释放 GPU 显存
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=image_classification_cleanup_completed")
 
     def _decode_base64_image(
         self, img_data: str, remaining_pixels: int | None = None
@@ -234,10 +232,19 @@ class MLService:
                 images.append(image)
                 decode_times.append((time.time() - img_decode_start) * 1000)
                 decode_errors.append(None)
-                logger.debug(f"✅ Image {idx} decoded: {image.size}, {image.mode}")
+                logger.debug(
+                    "event=image_decode_succeeded image_index={} size={} mode={}",
+                    idx,
+                    image.size,
+                    image.mode,
+                )
 
             except Exception as e:
-                logger.warning(f"⚠️  Image {idx} decode failed: {e}")
+                logger.warning(
+                    "event=image_decode_failed image_index={} error_type={}",
+                    idx,
+                    type(e).__name__,
+                )
                 images.append(None)
                 decode_times.append((time.time() - img_decode_start) * 1000)
                 decode_errors.append(str(e))
@@ -252,13 +259,16 @@ class MLService:
         valid_count = len(valid_images)
         failure_count = batch_size - valid_count
 
-        logger.info(
-            f"📊 Decode completed: success={valid_count}, failed={failure_count}, time={total_decode_time:.3f}s"
+        logger.debug(
+            "event=image_decode_completed success={} failed={} duration_ms={:.3f}",
+            valid_count,
+            failure_count,
+            total_decode_time * 1000,
         )
 
         # 全部解码失败，提前返回
         if not valid_images:
-            logger.error(f"❌ All images decode failed")
+            logger.error("event=image_batch_decode_failed reason=all_images_failed")
             return PredictResponse(
                 results=[
                     ImageResult(
@@ -291,8 +301,10 @@ class MLService:
             )
 
         # ========== 阶段2：批量预测 ==========
-        logger.info(
-            f"🤖 Starting prediction: {valid_count} valid images, model_source={self.config.source}"
+        logger.debug(
+            "event=image_prediction_started valid_images={} model_source={}",
+            valid_count,
+            self.config.source,
         )
 
         predict_start = time.time()
@@ -308,9 +320,10 @@ class MLService:
             )
             image_process_peak_rss.observe(_process_peak_rss_bytes())
 
-            logger.info(f"✅ Prediction completed successfully")
-            logger.info(
-                f"⏱️  Prediction time: {predict_time:.3f}s, {valid_count} images, {predict_time / valid_count:.3f}s per image"
+            logger.debug(
+                "event=image_prediction_completed images={} duration_ms={:.3f}",
+                valid_count,
+                predict_time * 1000,
             )
 
         except Exception as e:
@@ -321,7 +334,10 @@ class MLService:
             image_process_peak_rss.observe(_process_peak_rss_bytes())
             predict_error = str(e)
 
-            logger.error(f"❌ Prediction failed: {e}", exc_info=True)
+            logger.exception(
+                "event=image_prediction_failed failed_stage=model_predict error_type={}",
+                type(e).__name__,
+            )
 
             # 预测失败，标记所有有效图片为失败
             return PredictResponse(
@@ -429,7 +445,11 @@ class MLService:
             ).inc(failure_count)
 
         logger.info(
-            f"✅ Request completed: success={success_count}/{batch_size} ({metadata.success_rate:.1%}), total_time={total_time:.3f}s"
+            "event=image_classification_request_completed success={} batch_size={} success_rate={:.4f} duration_ms={:.3f}",
+            success_count,
+            batch_size,
+            metadata.success_rate,
+            total_time * 1000,
         )
 
         return PredictResponse(

--- a/algorithms/classify_image_classification_server/classify_image_classification_server/serving/service.py
+++ b/algorithms/classify_image_classification_server/classify_image_classification_server/serving/service.py
@@ -5,7 +5,9 @@ import os
 import resource
 import sys
 import time
+import traceback
 from io import BytesIO
+from pathlib import Path
 
 import bentoml
 from loguru import logger
@@ -37,6 +39,26 @@ from .schemas.api_schema import (
     validate_image_budget_config,
 )
 
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
+
 
 def _process_peak_rss_bytes() -> int:
     """返回进程峰值 RSS；macOS 以字节、Linux 以 KiB 报告。"""
@@ -67,18 +89,22 @@ class MLService:
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=image_classification_service_initializing")
         validate_image_budget_config()
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=image_classification_config_loaded model_source={}", self.config.source)
 
         try:
             self.model = load_model(self.config)
             model_load_counter.labels(source=self.config.source, status="success").inc()
-            logger.info("Model loaded successfully")
+            logger.info("event=image_classification_model_load_succeeded model_source={}", self.config.source)
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.error(f"Failed to load model: {e}")
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=image_classification_model_load_failed failed_stage=model_load error_type={} call_chain={}",
+                type(e).__name__,
+                _safe_exception_call_chain(e),
+            )
             raise
 
     @bentoml.on_shutdown
@@ -183,7 +209,10 @@ class MLService:
             predict_config = PredictConfig(**config) if config else PredictConfig()
             request = PredictRequest(images=images, config=predict_config)
         except Exception as e:
-            logger.error(f"Request validation failed: {e}")
+            logger.warning(
+                "event=image_classification_request_rejected reason=invalid_request error_type={}",
+                type(e).__name__,
+            )
             return PredictResponse(
                 results=[],
                 metadata=PredictionMetadata(
@@ -209,8 +238,10 @@ class MLService:
 
         batch_size = len(request.images)
 
-        logger.info(
-            f"📥 Received prediction request: batch_size={batch_size}, top_k={request.config.top_k}"
+        logger.debug(
+            "event=image_classification_request_received batch_size={} top_k={}",
+            batch_size,
+            request.config.top_k,
         )
 
         # ========== 阶段1：批量解码 ==========
@@ -268,7 +299,7 @@ class MLService:
 
         # 全部解码失败，提前返回
         if not valid_images:
-            logger.error("event=image_batch_decode_failed reason=all_images_failed")
+            logger.warning("event=image_batch_decode_failed reason=all_images_failed")
             return PredictResponse(
                 results=[
                     ImageResult(
@@ -334,9 +365,10 @@ class MLService:
             image_process_peak_rss.observe(_process_peak_rss_bytes())
             predict_error = str(e)
 
-            logger.exception(
-                "event=image_prediction_failed failed_stage=model_predict error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=image_prediction_failed failed_stage=model_predict error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             # 预测失败，标记所有有效图片为失败

--- a/algorithms/classify_image_classification_server/tests/test_issue_3852_image_budget.py
+++ b/algorithms/classify_image_classification_server/tests/test_issue_3852_image_budget.py
@@ -1,11 +1,12 @@
 """Issue #3852：图片分类 serving 必须在解码前后限制请求资源成本。"""
 
 import base64
-from io import BytesIO
+from io import BytesIO, StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger as real_logger
 from PIL import Image
 from pydantic import ValidationError
 
@@ -13,6 +14,7 @@ from classify_image_classification_server.serving.schemas import (
     PredictRequest,
     api_schema,
 )
+from classify_image_classification_server.serving import service as service_module
 from classify_image_classification_server.serving.service import MLService
 
 
@@ -251,14 +253,60 @@ async def test_observe_mode_preserves_legacy_public_predict(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_public_predict_returns_e1001_when_all_images_fail_to_decode():
+async def test_public_predict_returns_e1001_when_all_images_fail_to_decode(monkeypatch):
     service = _make_service()
     payload = base64.b64encode(b"x" * 75).decode("ascii")
+    logger = MagicMock()
+    monkeypatch.setattr(service_module, "logger", logger)
 
     response = await service.predict([payload])
 
     assert response.success is False
     assert response.error.code == "E1001"
+    logger.warning.assert_any_call("event=image_batch_decode_failed reason=all_images_failed")
+    assert not logger.error.called
+
+
+@pytest.mark.asyncio
+async def test_model_failure_keeps_response_error_without_leaking_formatter_output(monkeypatch):
+    payload, decoded_bytes = _encode_png()
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", str(len(payload)))
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_BYTES", str(decoded_bytes))
+    service = _make_service()
+    secret = "model-response-secret-must-not-enter-logs"
+    frame_secret = "frame-local-secret-must-not-enter-logs"
+    error = RuntimeError(secret)
+    def fail_with_sensitive_local(*_args, **_kwargs):
+        sensitive_local = frame_secret
+        assert sensitive_local
+        raise error
+
+    service.model.predict.side_effect = fail_with_sensitive_local
+    output = StringIO()
+    service_module._configure_production_logger(output)
+    monkeypatch.setattr(service_module, "logger", real_logger)
+
+    try:
+        response = await service.predict([payload])
+    finally:
+        service_module._configure_production_logger()
+
+    assert response.success is False
+    assert response.results[0].error == secret
+    safe_type, safe_error, safe_traceback = service_module._safe_exception_info(error)
+    assert safe_traceback is error.__traceback__
+    assert safe_error is not error
+    assert safe_type.__name__ == "_SafeLogException"
+    assert isinstance(safe_error, RuntimeError)
+    assert str(safe_error) == "RuntimeError"
+    assert str(error) == secret
+    rendered = output.getvalue()
+    assert "event=image_prediction_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+    assert "call_chain=" in rendered
+    assert "Traceback" in rendered
+    assert "service.py" in rendered
+    assert secret not in rendered
+    assert frame_secret not in rendered
 
 
 @pytest.mark.asyncio
@@ -268,9 +316,18 @@ async def test_service_allows_legacy_batch_when_pixel_budget_is_raised(monkeypat
     monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_BYTES", str(decoded_bytes * 2))
     monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_PIXELS", "8")
     service = _make_service()
+    logger = MagicMock()
+    monkeypatch.setattr(service_module, "logger", logger)
 
     response = await service.predict([payload, payload])
 
     assert response.success is True
     assert [result.success for result in response.results] == [True, True]
     assert len(service.model.predict.call_args.args[0]) == 2
+    logger.debug.assert_any_call(
+        "event=image_classification_request_received batch_size={} top_k={}",
+        2,
+        5,
+    )
+    assert any(call.args[0].startswith("event=image_classification_request_completed") for call in logger.info.call_args_list)
+    assert "📥" not in repr(logger.mock_calls)

--- a/algorithms/classify_log_server/classify_log_server/serving/service.py
+++ b/algorithms/classify_log_server/classify_log_server/serving/service.py
@@ -2,7 +2,10 @@
 
 import time
 import os
+import sys
+import traceback
 from collections import Counter
+from pathlib import Path
 
 import bentoml
 from loguru import logger
@@ -23,6 +26,26 @@ from .schemas import (
     LogClusterResult,
     TemplateGroup,
 )
+
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
 
 
 @bentoml.service(
@@ -48,19 +71,23 @@ class MLService:
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=log_classification_service_initializing")
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=log_classification_config_loaded model_source={}", self.config.source)
 
         try:
             self.model = load_model(self.config)
             model_load_counter.labels(
                 source=self.config.source, status="success").inc()
-            logger.info("Model loaded successfully")
+            logger.info("event=log_classification_model_load_succeeded model_source={}", self.config.source)
         except Exception as e:
             model_load_counter.labels(
                 source=self.config.source, status="failure").inc()
-            logger.error(f"Failed to load model: {e}")
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=log_classification_model_load_failed failed_stage=model_load error_type={} call_chain={}",
+                type(e).__name__,
+                _safe_exception_call_chain(e),
+            )
             raise
 
     @bentoml.on_shutdown
@@ -103,9 +130,11 @@ class MLService:
         req_config = request.config
         
         start_time = time.time()
-        logger.info(
-            f"收到日志聚类请求: {len(data)} 条日志, "
-            f"return_details={req_config.return_details}, sort_by={req_config.sort_by}"
+        logger.debug(
+            "event=log_classification_request_received logs={} return_details={} sort_by={}",
+            len(data),
+            req_config.return_details,
+            req_config.sort_by,
         )
 
         try:
@@ -223,17 +252,24 @@ class MLService:
             ).inc()
             
             logger.info(
-                f"聚类完成: {summary.num_templates} 个模板, "
-                f"覆盖率 {summary.coverage_rate:.2%}, "
-                f"未知日志 {summary.unknown_logs} 条, "
-                f"耗时 {total_time:.0f}ms (预测={predict_time:.0f}ms, 聚合={aggregate_time:.0f}ms)"
+                "event=log_classification_completed templates={} coverage_rate={:.4f} unknown_logs={} "
+                "duration_ms={:.3f} predict_duration_ms={:.3f} aggregate_duration_ms={:.3f}",
+                summary.num_templates,
+                summary.coverage_rate,
+                summary.unknown_logs,
+                total_time,
+                predict_time,
+                aggregate_time,
             )
             
             return response
             
         except ValueError as e:
             # 输入验证错误
-            logger.error(f"输入验证失败: {e}")
+            logger.warning(
+                "event=log_classification_failed failed_stage=input_validation error_type={}",
+                type(e).__name__,
+            )
             prediction_counter.labels(
                 model_source=self.config.source,
                 status="failure",
@@ -246,7 +282,11 @@ class MLService:
                 model_source=self.config.source,
                 status="failure",
             ).inc()
-            logger.error(f"日志聚类失败: {type(e).__name__}: {e}")
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=log_classification_failed failed_stage=model_predict error_type={} call_chain={}",
+                type(e).__name__,
+                _safe_exception_call_chain(e),
+            )
             raise ModelInferenceError(f"Log clustering failed: {str(e)}") from e
 
     @bentoml.api

--- a/algorithms/classify_log_server/classify_log_server/serving/service.py
+++ b/algorithms/classify_log_server/classify_log_server/serving/service.py
@@ -40,12 +40,11 @@ class MLService:
         用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
         # 可以在这里做全局初始化,例如:
         # - 预热模型缓存
         # - 下载共享资源
         # - 初始化全局连接池
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=log_classification_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
@@ -71,12 +70,11 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
         # 清理逻辑,例如:
         # - 关闭数据库连接
         # - 保存缓存状态
         # - 释放 GPU 显存
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=log_classification_cleanup_completed")
 
     @bentoml.api
     async def predict(self, request: LogClusterRequest) -> LogClusterResponseV2:

--- a/algorithms/classify_log_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_log_server/tests/test_schema_and_predict.py
@@ -8,9 +8,11 @@
 
 import sys
 import types
+from io import StringIO
 from unittest.mock import MagicMock, patch  # noqa: F401
 
 import pytest
+from loguru import logger as real_logger
 from pydantic import ValidationError
 
 
@@ -315,9 +317,54 @@ class TestMLServicePredict:
             "DB timeout after 10s",
         ]
         mock_model = self._make_mock_model(data, [0, 1], ["User login *", "DB timeout *"])
+        from classify_log_server.serving import service as service_module
+
         svc = self._make_service(mock_model)
-        response = await svc.predict(LogClusterRequest(data=data))
+        logger = MagicMock()
+        with patch.object(service_module, "logger", logger):
+            response = await svc.predict(LogClusterRequest(data=data))
         assert response.summary.total_logs == 2
+        assert any(call.args[0].startswith("event=log_classification_completed") for call in logger.info.call_args_list)
+        assert "聚类完成" not in repr(logger.mock_calls)
+
+    @pytest.mark.asyncio
+    async def test_predict_failure_preserves_exception_contract_and_single_traceback(self):
+        from classify_log_server.serving import service as service_module
+        from classify_log_server.serving.exceptions import ModelInferenceError
+
+        secret = "cluster-response-secret-must-not-enter-logs"
+        frame_secret = "frame-local-secret-must-not-enter-logs"
+        mock_model = MagicMock()
+        error = RuntimeError(secret)
+        def fail_with_sensitive_local(*_args, **_kwargs):
+            sensitive_local = frame_secret
+            assert sensitive_local
+            raise error
+
+        mock_model.predict.side_effect = fail_with_sensitive_local
+        svc = self._make_service(mock_model)
+        output = StringIO()
+        service_module._configure_production_logger(output)
+        try:
+            with patch.object(service_module, "logger", real_logger), pytest.raises(ModelInferenceError, match=secret):
+                await svc.predict(LogClusterRequest(data=["safe input"]))
+        finally:
+            service_module._configure_production_logger()
+
+        rendered = output.getvalue()
+        safe_type, safe_error, safe_traceback = service_module._safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "_SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "RuntimeError"
+        assert str(error) == secret
+        assert "event=log_classification_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "service.py" in rendered
+        assert secret not in rendered
+        assert frame_secret not in rendered
 
     @pytest.mark.asyncio
     async def test_predict_coverage_rate_in_unit_interval(self):

--- a/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
+++ b/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
@@ -61,12 +61,11 @@ class MLService:
         用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
         # 可以在这里做全局初始化,例如:
         # - 预热模型缓存
         # - 下载共享资源
         # - 初始化全局连接池
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=object_detection_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
@@ -91,12 +90,11 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
         # 清理逻辑,例如:
         # - 关闭数据库连接
         # - 保存缓存状态
         # - 释放 GPU 显存
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=object_detection_cleanup_completed")
 
     def _decode_base64_image(
         self, img_data: str, remaining_pixels: int | None = None
@@ -239,10 +237,19 @@ class MLService:
                 decoded_images.append(image)
                 decode_times.append((time.time() - img_decode_start) * 1000)
                 decode_errors.append(None)
-                logger.debug(f"✅ Image {idx} decoded: {image.size}, {image.mode}")
+                logger.debug(
+                    "event=image_decode_succeeded image_index={} size={} mode={}",
+                    idx,
+                    image.size,
+                    image.mode,
+                )
 
             except Exception as e:
-                logger.warning(f"⚠️  Image {idx} decode failed: {e}")
+                logger.warning(
+                    "event=image_decode_failed image_index={} error_type={}",
+                    idx,
+                    type(e).__name__,
+                )
                 decoded_images.append(None)
                 decode_times.append((time.time() - img_decode_start) * 1000)
                 decode_errors.append(str(e))
@@ -257,14 +264,16 @@ class MLService:
         valid_count = len(valid_images)
         failure_count = batch_size - valid_count
 
-        logger.info(
-            f"📊 Decode completed: success={valid_count}, "
-            f"failed={failure_count}, time={total_decode_time:.3f}s"
+        logger.debug(
+            "event=image_decode_completed success={} failed={} duration_ms={:.3f}",
+            valid_count,
+            failure_count,
+            total_decode_time * 1000,
         )
 
         # 全部解码失败，提前返回
         if not valid_images:
-            logger.error("❌ All images decode failed")
+            logger.error("event=image_batch_decode_failed reason=all_images_failed")
             return PredictResponse(
                 results=[
                     ImageResult(
@@ -299,9 +308,10 @@ class MLService:
             )
 
         # ========== 阶段2：批量预测 ==========
-        logger.info(
-            f"🤖 Starting detection: {valid_count} valid images, "
-            f"model_source={self.config.source}"
+        logger.debug(
+            "event=object_detection_started valid_images={} model_source={}",
+            valid_count,
+            self.config.source,
         )
 
         predict_start = time.time()
@@ -325,10 +335,10 @@ class MLService:
             )
             image_process_peak_rss.observe(_process_peak_rss_bytes())
 
-            logger.info("✅ Detection completed successfully")
-            logger.info(
-                f"⏱️  Detection time: {predict_time:.3f}s, {valid_count} images, "
-                f"{predict_time / valid_count:.3f}s per image"
+            logger.debug(
+                "event=object_detection_completed images={} duration_ms={:.3f}",
+                valid_count,
+                predict_time * 1000,
             )
 
         except Exception as e:
@@ -339,7 +349,10 @@ class MLService:
             image_process_peak_rss.observe(_process_peak_rss_bytes())
             predict_error = str(e)
 
-            logger.error(f"❌ Detection failed: {e}", exc_info=True)
+            logger.exception(
+                "event=object_detection_failed failed_stage=model_predict error_type={}",
+                type(e).__name__,
+            )
 
             # 预测失败，标记所有有效图片为失败
             return PredictResponse(
@@ -468,9 +481,13 @@ class MLService:
             ).inc(failure_count)
 
         logger.info(
-            f"✅ Request completed: success={success_count}/{batch_size} "
-            f"({metadata.success_rate:.1%}), total_detections={total_detections}, "
-            f"total_time={total_time:.3f}s"
+            "event=object_detection_request_completed success={} batch_size={} success_rate={:.4f} "
+            "detections={} duration_ms={:.3f}",
+            success_count,
+            batch_size,
+            metadata.success_rate,
+            total_detections,
+            total_time * 1000,
         )
 
         return PredictResponse(

--- a/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
+++ b/algorithms/classify_object_detection_server/classify_object_detection_server/serving/service.py
@@ -5,7 +5,9 @@ import os
 import resource
 import sys
 import time
+import traceback
 from io import BytesIO
+from pathlib import Path
 
 import bentoml
 from loguru import logger
@@ -39,6 +41,26 @@ from .schemas.api_schema import (
     validate_image_budget_config,
 )
 
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
+
 
 def _process_peak_rss_bytes() -> int:
     """返回进程峰值 RSS；macOS 以字节、Linux 以 KiB 报告。"""
@@ -69,18 +91,22 @@ class MLService:
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=object_detection_service_initializing")
         validate_image_budget_config()
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=object_detection_config_loaded model_source={}", self.config.source)
 
         try:
             self.model = load_model(self.config)
             model_load_counter.labels(source=self.config.source, status="success").inc()
-            logger.info("Model loaded successfully")
+            logger.info("event=object_detection_model_load_succeeded model_source={}", self.config.source)
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.error(f"Failed to load model: {e}")
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=object_detection_model_load_failed failed_stage=model_load error_type={} call_chain={}",
+                type(e).__name__,
+                _safe_exception_call_chain(e),
+            )
             raise
 
     @bentoml.on_shutdown
@@ -185,7 +211,10 @@ class MLService:
             predict_config = PredictConfig(**config) if config else PredictConfig()
             request = PredictRequest(images=images, config=predict_config)
         except Exception as e:
-            logger.error(f"Request validation failed: {e}")
+            logger.warning(
+                "event=object_detection_request_rejected reason=invalid_request error_type={}",
+                type(e).__name__,
+            )
             return PredictResponse(
                 results=[],
                 metadata=PredictionMetadata(
@@ -213,9 +242,11 @@ class MLService:
 
         batch_size = len(request.images)
 
-        logger.info(
-            f"📥 Received detection request: batch_size={batch_size}, "
-            f"conf={request.config.conf_threshold}, iou={request.config.iou_threshold}"
+        logger.debug(
+            "event=object_detection_request_received batch_size={} conf={} iou={}",
+            batch_size,
+            request.config.conf_threshold,
+            request.config.iou_threshold,
         )
 
         # ========== 阶段1：批量解码 ==========
@@ -273,7 +304,7 @@ class MLService:
 
         # 全部解码失败，提前返回
         if not valid_images:
-            logger.error("event=image_batch_decode_failed reason=all_images_failed")
+            logger.warning("event=image_batch_decode_failed reason=all_images_failed")
             return PredictResponse(
                 results=[
                     ImageResult(
@@ -349,9 +380,10 @@ class MLService:
             image_process_peak_rss.observe(_process_peak_rss_bytes())
             predict_error = str(e)
 
-            logger.exception(
-                "event=object_detection_failed failed_stage=model_predict error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=object_detection_failed failed_stage=model_predict error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             # 预测失败，标记所有有效图片为失败

--- a/algorithms/classify_object_detection_server/tests/test_issue_3852_image_budget.py
+++ b/algorithms/classify_object_detection_server/tests/test_issue_3852_image_budget.py
@@ -1,15 +1,17 @@
 """Issue #3852：目标检测 serving 必须在解码前后限制请求资源成本。"""
 
 import base64
-from io import BytesIO
+from io import BytesIO, StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from loguru import logger as real_logger
 from PIL import Image
 from pydantic import ValidationError
 
 from classify_object_detection_server.serving.schemas import PredictRequest, api_schema
+from classify_object_detection_server.serving import service as service_module
 from classify_object_detection_server.serving.service import MLService
 
 EMPTY_PREDICTION = {
@@ -255,14 +257,60 @@ async def test_observe_mode_preserves_legacy_public_predict(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_public_predict_returns_e1001_when_all_images_fail_to_decode():
+async def test_public_predict_returns_e1001_when_all_images_fail_to_decode(monkeypatch):
     service = _make_service()
     payload = base64.b64encode(b"x" * 75).decode("ascii")
+    logger = MagicMock()
+    monkeypatch.setattr(service_module, "logger", logger)
 
     response = await service.predict([payload])
 
     assert response.success is False
     assert response.error.code == "E1001"
+    logger.warning.assert_any_call("event=image_batch_decode_failed reason=all_images_failed")
+    assert not logger.error.called
+
+
+@pytest.mark.asyncio
+async def test_model_failure_keeps_response_error_without_leaking_formatter_output(monkeypatch):
+    payload, decoded_bytes = _encode_png()
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BYTES", str(len(payload)))
+    monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_BYTES", str(decoded_bytes))
+    service = _make_service()
+    secret = "model-response-secret-must-not-enter-logs"
+    frame_secret = "frame-local-secret-must-not-enter-logs"
+    error = RuntimeError(secret)
+    def fail_with_sensitive_local(*_args, **_kwargs):
+        sensitive_local = frame_secret
+        assert sensitive_local
+        raise error
+
+    service.model.predict.side_effect = fail_with_sensitive_local
+    output = StringIO()
+    service_module._configure_production_logger(output)
+    monkeypatch.setattr(service_module, "logger", real_logger)
+
+    try:
+        response = await service.predict([payload])
+    finally:
+        service_module._configure_production_logger()
+
+    assert response.success is False
+    assert response.results[0].error == secret
+    safe_type, safe_error, safe_traceback = service_module._safe_exception_info(error)
+    assert safe_traceback is error.__traceback__
+    assert safe_error is not error
+    assert safe_type.__name__ == "_SafeLogException"
+    assert isinstance(safe_error, RuntimeError)
+    assert str(safe_error) == "RuntimeError"
+    assert str(error) == secret
+    rendered = output.getvalue()
+    assert "event=object_detection_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+    assert "call_chain=" in rendered
+    assert "Traceback" in rendered
+    assert "service.py" in rendered
+    assert secret not in rendered
+    assert frame_secret not in rendered
 
 
 @pytest.mark.asyncio
@@ -272,9 +320,19 @@ async def test_service_allows_legacy_batch_when_pixel_budget_is_raised(monkeypat
     monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_BYTES", str(decoded_bytes * 2))
     monkeypatch.setenv("MLOPS_PREDICT_MAX_IMAGE_BATCH_PIXELS", "8")
     service = _make_service()
+    logger = MagicMock()
+    monkeypatch.setattr(service_module, "logger", logger)
 
     response = await service.predict([payload, payload])
 
     assert response.success is True
     assert [result.success for result in response.results] == [True, True]
     assert len(service.model.predict.call_args.args[0]["images"]) == 2
+    logger.debug.assert_any_call(
+        "event=object_detection_request_received batch_size={} conf={} iou={}",
+        2,
+        0.25,
+        0.45,
+    )
+    assert any(call.args[0].startswith("event=object_detection_request_completed") for call in logger.info.call_args_list)
+    assert "📥" not in repr(logger.mock_calls)

--- a/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
+++ b/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
@@ -53,8 +53,7 @@ class MLService:
         用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=text_classification_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
@@ -68,11 +67,18 @@ class MLService:
             load_time = time.time() - load_start
 
             model_load_counter.labels(source=self.config.source, status="success").inc()
-            logger.info(f"⏱️  Model loaded successfully in {load_time:.3f}s")
+            logger.info(
+                "event=text_classification_model_load_succeeded model_source={} duration_ms={:.3f}",
+                self.config.source,
+                load_time * 1000,
+            )
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.error(f"❌ Failed to load model: {e}", exc_info=True)
+            logger.exception(
+                "event=text_classification_model_load_failed failed_stage=model_load error_type={}",
+                type(e).__name__,
+            )
             raise RuntimeError(
                 f"Failed to load model from source '{self.config.source}'. "
                 "Service cannot start without a valid model."
@@ -85,8 +91,7 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=text_classification_cleanup_completed")
 
     @bentoml.api
     async def predict(self, texts: list[str], config: dict = None) -> PredictResponse:
@@ -128,7 +133,7 @@ class MLService:
                 execution_time_ms=(time.time() - request_start) * 1000,
             )
 
-        logger.info(f"📥 Received classification request: {len(request.texts)} texts")
+        logger.debug("event=text_classification_request_received texts={}", len(request.texts))
 
         # 2. 文本预处理（截断处理）
         processed_texts, text_warnings = self._preprocess_texts(request.texts)
@@ -154,7 +159,10 @@ class MLService:
                 model_output = self.model.predict(processed_texts)
 
                 predict_time = (time.time() - predict_start) * 1000
-                logger.info(f"⏱️  Model prediction completed in {predict_time:.1f}ms")
+                logger.debug(
+                    "event=text_classification_model_predict_completed duration_ms={:.1f}",
+                    predict_time,
+                )
 
             # 4. 解析模型输出并构造结果
             results = self._build_results(
@@ -183,9 +191,10 @@ class MLService:
             ).inc()
 
             logger.info(
-                f"✅ Classification completed: {summary.total_samples} texts, "
-                f"avg_probability={summary.avg_probability:.4f}, "
-                f"time={summary.processing_time_ms:.1f}ms"
+                "event=text_classification_completed texts={} avg_probability={:.4f} duration_ms={:.1f}",
+                summary.total_samples,
+                summary.avg_probability,
+                summary.processing_time_ms,
             )
 
             return PredictResponse(
@@ -197,7 +206,10 @@ class MLService:
             )
 
         except Exception as e:
-            logger.error(f"❌ Prediction failed: {e}", exc_info=True)
+            logger.exception(
+                "event=text_classification_failed failed_stage=model_predict error_type={}",
+                type(e).__name__,
+            )
 
             prediction_counter.labels(
                 model_source=self.config.source, status="failure"

--- a/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
+++ b/algorithms/classify_text_classification_server/classify_text_classification_server/serving/service.py
@@ -2,7 +2,10 @@
 
 import time
 import os
+import sys
+import traceback
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 import numpy as np
 import pandas as pd
@@ -32,6 +35,26 @@ from .schemas import (
     ErrorDetail,
 )
 
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
+
 
 # 常量定义
 MAX_TEXT_LENGTH = 5000
@@ -57,9 +80,9 @@ class MLService:
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=text_classification_service_initializing")
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=text_classification_config_loaded model_source={}", self.config.source)
 
         try:
             load_start = time.time()
@@ -75,9 +98,10 @@ class MLService:
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.exception(
-                "event=text_classification_model_load_failed failed_stage=model_load error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=text_classification_model_load_failed failed_stage=model_load error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
             raise RuntimeError(
                 f"Failed to load model from source '{self.config.source}'. "
@@ -121,7 +145,10 @@ class MLService:
             request = PredictRequest(texts=texts, config=pred_config)
 
         except Exception as e:
-            logger.error(f"Request validation failed: {e}")
+            logger.warning(
+                "event=text_classification_request_rejected reason=invalid_request error_type={}",
+                type(e).__name__,
+            )
             return self._create_error_response(
                 code="E1000",
                 message=f"请求验证失败: {str(e)}",
@@ -140,9 +167,10 @@ class MLService:
         text_batch_summary = self._summarize_text_batch(
             processed_texts, text_warnings
         )
-        logger.debug(f"Preprocessed text summary: {text_batch_summary}")
         logger.debug(
-            f"Processed texts type: {type(processed_texts)}, length: {len(processed_texts) if processed_texts else 0}"
+            "event=text_classification_preprocessed texts={} truncated={}",
+            text_batch_summary["count"],
+            text_batch_summary["truncated_count"],
         )
 
         try:
@@ -154,7 +182,9 @@ class MLService:
                 # MLflow加载后的模型使用标准接口：predict(data)
                 # MLflow内部会自动将data传递给自定义包装器的model_input参数
                 logger.debug(
-                    f"Calling model.predict with text summary: {text_batch_summary}"
+                    "event=text_classification_model_predict_started texts={} truncated={}",
+                    text_batch_summary["count"],
+                    text_batch_summary["truncated_count"],
                 )
                 model_output = self.model.predict(processed_texts)
 
@@ -206,9 +236,10 @@ class MLService:
             )
 
         except Exception as e:
-            logger.exception(
-                "event=text_classification_failed failed_stage=model_predict error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=text_classification_failed failed_stage=model_predict error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             prediction_counter.labels(
@@ -257,7 +288,9 @@ class MLService:
                     )
                 )
                 logger.warning(
-                    f"Text truncated: {len(text)} -> {MAX_TEXT_LENGTH} chars"
+                    "event=text_classification_input_truncated original_length={} truncated_length={}",
+                    len(text),
+                    MAX_TEXT_LENGTH,
                 )
 
             processed_texts.append(processed_text)
@@ -478,7 +511,10 @@ class MLService:
             return features
 
         except Exception as e:
-            logger.warning(f"Failed to extract real feature importance: {e}; returning None")
+            logger.warning(
+                "event=text_feature_importance_unavailable error_type={}",
+                type(e).__name__,
+            )
             return None
 
     def _compute_summary(

--- a/algorithms/classify_text_classification_server/tests/test_service_logging_privacy.py
+++ b/algorithms/classify_text_classification_server/tests/test_service_logging_privacy.py
@@ -1,9 +1,11 @@
 """Regression tests for predict debug logging privacy (Issue #3853)."""
 
 import asyncio
-from unittest.mock import MagicMock
+from io import StringIO
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
+from loguru import logger as real_logger
 
 from tests.test_feature_importance import _load_service_module, _make_service
 
@@ -11,8 +13,7 @@ from tests.test_feature_importance import _load_service_module, _make_service
 def test_predict_debug_logs_do_not_include_request_texts():
     """predict() should log metadata only, never raw or processed request text."""
     service_mod = _load_service_module()
-    logger = service_mod.logger
-    logger.reset_mock()
+    logger = MagicMock()
 
     sensitive_text = "user=jane ip=10.0.0.8 token=secret-alert-text"
     oversized_text = "A" * (service_mod.MAX_TEXT_LENGTH + 3)
@@ -37,12 +38,13 @@ def test_predict_debug_logs_do_not_include_request_texts():
     svc = _make_service(model=model)
     svc.config.source = "dummy"
 
-    response = asyncio.run(
-        svc.predict(
-            [sensitive_text, oversized_text],
-            config={"return_feature_importance": False},
+    with patch.dict(svc.predict.__func__.__globals__, {"logger": logger}):
+        response = asyncio.run(
+            svc.predict(
+                [sensitive_text, oversized_text],
+                config={"return_feature_importance": False},
+            )
         )
-    )
 
     assert response.success is True
     model.predict.assert_called_once()
@@ -53,7 +55,51 @@ def test_predict_debug_logs_do_not_include_request_texts():
     assert sensitive_text not in debug_output
     assert "secret-alert-text" not in debug_output
     assert oversized_text[:120] not in debug_output
-    assert "Preprocessed text summary" in debug_output
-    assert "Calling model.predict with text summary" in debug_output
-    assert "'count': 2" in debug_output
-    assert "'truncated_count': 1" in debug_output
+    assert "event=text_classification_preprocessed texts={} truncated={}" in debug_output
+    assert "event=text_classification_model_predict_started texts={} truncated={}" in debug_output
+    assert "call('event=text_classification_preprocessed texts={} truncated={}', 2, 1)" in debug_output
+    assert any(call.args[0].startswith("event=text_classification_completed") for call in logger.info.call_args_list)
+
+
+def test_predict_failure_keeps_error_response_and_uses_one_sanitized_traceback():
+    _load_service_module()
+    secret = "model-response-secret-must-not-enter-logs"
+    frame_secret = "frame-local-secret-must-not-enter-logs"
+    model = MagicMock()
+    error = RuntimeError(secret)
+    def fail_with_sensitive_local(*_args, **_kwargs):
+        sensitive_local = frame_secret
+        assert sensitive_local
+        raise error
+
+    model.predict.side_effect = fail_with_sensitive_local
+    svc = _make_service(model=model)
+    svc.config.source = "dummy"
+    output = StringIO()
+    configure_logger = svc.predict.__func__.__globals__["_configure_production_logger"]
+    configure_logger(output)
+
+    try:
+        with patch.dict(svc.predict.__func__.__globals__, {"logger": real_logger}):
+            response = asyncio.run(svc.predict(["safe input"]))
+    finally:
+        configure_logger()
+
+    assert response.success is False
+    assert response.error.code == "E2001"
+    assert secret in response.error.message
+    safe_exception_info = svc.predict.__func__.__globals__["_safe_exception_info"]
+    safe_type, safe_error, safe_traceback = safe_exception_info(error)
+    assert safe_traceback is error.__traceback__
+    assert safe_error is not error
+    assert safe_type.__name__ == "_SafeLogException"
+    assert isinstance(safe_error, RuntimeError)
+    assert str(safe_error) == "RuntimeError"
+    assert str(error) == secret
+    rendered = output.getvalue()
+    assert "event=text_classification_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+    assert "call_chain=" in rendered
+    assert "Traceback" in rendered
+    assert "service.py" in rendered
+    assert secret not in rendered
+    assert frame_secret not in rendered

--- a/algorithms/classify_timeseries_server/classify_timeseries_server/serving/service.py
+++ b/algorithms/classify_timeseries_server/classify_timeseries_server/serving/service.py
@@ -4,7 +4,10 @@ import bentoml
 from loguru import logger
 import mlflow
 import os
+import sys
 import time
+import traceback
+from pathlib import Path
 
 import mlflow.sklearn
 
@@ -26,6 +29,26 @@ from .schemas.api_schema import MAX_INPUT_DATA_POINTS, MAX_PREDICTION_STEPS, Pre
 
 
 MAX_TIMESERIES_PREDICT_TIMEOUT_SECONDS = 290
+
+def _configure_production_logger(sink=sys.stderr) -> None:
+    logger.configure(handlers=[{"sink": sink, "diagnose": False, "backtrace": True}])
+
+
+_configure_production_logger()
+
+
+def _safe_exception_call_chain(error: BaseException, max_frames: int = 12) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    return ">".join(f"{Path(frame.filename).name}:{frame.lineno}:{frame.name}" for frame in frames[-max_frames:]) or "-"
+
+
+class _SafeLogException(RuntimeError):
+    pass
+
+
+def _safe_exception_info(error: BaseException):
+    safe_error = _SafeLogException(type(error).__name__)
+    return _SafeLogException, safe_error, error.__traceback__
 
 
 def get_timeseries_predict_timeout_seconds() -> int:
@@ -68,9 +91,9 @@ class MLService:
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
-        logger.info("Service instance initializing...")
+        logger.debug("event=timeseries_service_initializing")
         self.config = get_model_config()
-        logger.info(f"Config loaded: {self.config}")
+        logger.debug("event=timeseries_config_loaded model_source={}", self.config.source)
 
         # 配置验证与模型加载使用同一个显式降级策略：生产默认快速失败，
         # 仅开发/测试明确设置 ALLOW_DUMMY_FALLBACK=true 时降级。
@@ -90,9 +113,10 @@ class MLService:
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.exception(
-                "event=timeseries_model_load_failed failed_stage=model_load error_type={}",
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=timeseries_model_load_failed failed_stage=model_load error_type={} call_chain={}",
                 type(e).__name__,
+                _safe_exception_call_chain(e),
             )
 
             # 根据环境变量决定是否允许降级到 DummyModel
@@ -109,10 +133,6 @@ class MLService:
                     source="dummy_fallback", status="success"
                 ).inc()
             else:
-                logger.error(
-                    "Model loading failed and fallback is disabled. "
-                    "Set ALLOW_DUMMY_FALLBACK=true to enable DummyModel fallback."
-                )
                 raise RuntimeError(
                     f"Failed to load model from source '{self.config.source}'. "
                     "Service cannot start without a valid model. "
@@ -123,7 +143,7 @@ class MLService:
         """验证模型配置（启动时快速检查）."""
         from pathlib import Path
 
-        logger.info("Validating model configuration...")
+        logger.debug("event=timeseries_model_config_validation_started")
 
         if self.config.source == "local":
             # 本地模式：检查路径和关键文件
@@ -217,7 +237,10 @@ class MLService:
             pred_config = PredictionConfig(**config)
             request = PredictRequest(data=data_points, config=pred_config)
         except Exception as e:
-            logger.error(f"Request validation failed: {e}")
+            logger.warning(
+                "event=timeseries_request_rejected reason=invalid_request error_type={}",
+                type(e).__name__,
+            )
             # 返回验证失败响应
             return PredictResponse(
                 success=False,
@@ -237,8 +260,10 @@ class MLService:
                 ),
             )
 
-        logger.info(
-            f"📥 Received prediction request: steps={request.config.steps}, data_points={len(request.data)}"
+        logger.debug(
+            "event=timeseries_request_received steps={} data_points={}",
+            request.config.steps,
+            len(request.data),
         )
 
         try:
@@ -329,7 +354,10 @@ class MLService:
 
         except ValueError as e:
             # 验证错误（频率推断失败等）
-            logger.error(f"Validation error: {e}")
+            logger.warning(
+                "event=timeseries_prediction_failed failed_stage=result_validation error_type={}",
+                type(e).__name__,
+            )
             return PredictResponse(
                 success=False,
                 history=None,
@@ -368,10 +396,11 @@ class MLService:
 
         except Exception as e:
             # 其他错误（模型预测失败等）
-            logger.error(f"Prediction failed: {e}")
-            import traceback
-
-            logger.error(traceback.format_exc())
+            logger.opt(exception=_safe_exception_info(e)).error(
+                "event=timeseries_prediction_failed failed_stage=model_predict error_type={} call_chain={}",
+                type(e).__name__,
+                _safe_exception_call_chain(e),
+            )
             return PredictResponse(
                 success=False,
                 history=None,

--- a/algorithms/classify_timeseries_server/classify_timeseries_server/serving/service.py
+++ b/algorithms/classify_timeseries_server/classify_timeseries_server/serving/service.py
@@ -60,12 +60,11 @@ class MLService:
         用于预热缓存、下载资源等全局操作.
         不接收 self 参数,类似静态方法.
         """
-        logger.info("=== Deployment setup started ===")
         # 可以在这里做全局初始化,例如:
         # - 预热模型缓存
         # - 下载共享资源
         # - 初始化全局连接池
-        logger.info("=== Deployment setup completed ===")
+        logger.info("event=timeseries_deployment_setup_completed")
 
     def __init__(self) -> None:
         """初始化服务,加载配置和模型."""
@@ -83,12 +82,18 @@ class MLService:
 
             model_load_counter.labels(source=self.config.source, status="success").inc()
             logger.info(
-                f"⏱️  Model loaded successfully in {load_time:.3f}s: {self.config.mlflow_model_uri or 'local/dummy'}"
+                "event=timeseries_model_load_succeeded model_source={} model_type={} duration_ms={:.3f}",
+                self.config.source,
+                type(self.model).__name__,
+                load_time * 1000,
             )
 
         except Exception as e:
             model_load_counter.labels(source=self.config.source, status="failure").inc()
-            logger.error(f"❌ Failed to load model: {e}", exc_info=True)
+            logger.exception(
+                "event=timeseries_model_load_failed failed_stage=model_load error_type={}",
+                type(e).__name__,
+            )
 
             # 根据环境变量决定是否允许降级到 DummyModel
             allow_fallback = (
@@ -98,9 +103,7 @@ class MLService:
             if allow_fallback:
                 from .models.dummy_model import DummyModel
 
-                logger.warning(
-                    "⚠️  ALLOW_DUMMY_FALLBACK=true, using DummyModel as fallback"
-                )
+                logger.warning("event=timeseries_model_fallback_enabled fallback=dummy")
                 self.model = DummyModel()
                 model_load_counter.labels(
                     source="dummy_fallback", status="success"
@@ -150,7 +153,7 @@ class MLService:
                     "Ensure the path points to a valid MLflow model directory containing MLmodel file."
                 )
 
-            logger.info(f"✅ Local model config validated: {model_path}")
+            logger.info("event=timeseries_model_config_validated model_source=local")
 
         elif self.config.source == "mlflow":
             # MLflow Registry 模式：检查 URI
@@ -160,16 +163,15 @@ class MLService:
                     "Example: models:/model_name/version or models:/model_name/Production"
                 )
 
-            logger.info(
-                f"✅ MLflow model config validated: {self.config.mlflow_model_uri}"
-            )
+            logger.info("event=timeseries_model_config_validated model_source=mlflow")
 
         elif self.config.source == "dummy":
-            logger.info("✅ Using dummy model (no validation needed)")
+            logger.info("event=timeseries_model_config_validated model_source=dummy")
 
         else:
             logger.warning(
-                f"⚠️  Unknown model source: {self.config.source}, will attempt to load"
+                "event=timeseries_model_source_unknown model_source={}",
+                self.config.source,
             )
 
     @bentoml.on_shutdown
@@ -179,12 +181,11 @@ class MLService:
 
         用于释放资源、关闭连接等.
         """
-        logger.info("=== Service shutdown: cleaning up resources ===")
         # 清理逻辑,例如:
         # - 关闭数据库连接
         # - 保存缓存状态
         # - 释放 GPU 显存
-        logger.info("=== Cleanup completed ===")
+        logger.info("event=timeseries_cleanup_completed")
 
     @bentoml.api
     async def predict(self, data: list, config: dict) -> PredictResponse:
@@ -250,28 +251,22 @@ class MLService:
                     f"输入数据点数 {len(request.data)} 超过上限 {MAX_INPUT_DATA_POINTS}"
                 )
 
-            logger.info(
-                f"📊 Input data range: {history.index[0]} to {history.index[-1]}"
-            )
+            logger.debug("event=timeseries_input_ready data_points={}", len(history))
 
             # 推断频率（严格验证）
             inferred_freq = pd.infer_freq(history.index)
             if inferred_freq is None:
                 raise ValueError("无法推断输入数据的时间频率，请检查时间戳是否规则")
 
-            logger.info(f"🕒 Detected frequency: {inferred_freq}")
+            logger.debug("event=timeseries_input_frequency_detected frequency={}", inferred_freq)
 
             # 执行预测（添加模型来源信息）
-            model_info = (
-                f"source={self.config.source}, type={type(self.model).__name__}"
+            logger.debug(
+                "event=timeseries_prediction_started model_source={} model_type={} steps={}",
+                self.config.source,
+                type(self.model).__name__,
+                steps,
             )
-            if self.config.source == "local":
-                model_info += f", path={self.config.model_path}"
-            elif self.config.source == "mlflow":
-                model_info += f", uri={self.config.mlflow_model_uri}"
-
-            logger.info(f"🤖 Model info: {model_info}")
-            logger.info(f"🔮 Starting recursive prediction: steps={steps}")
 
             enforce_recursive_feature_engineering_budget(
                 self.model,
@@ -284,9 +279,10 @@ class MLService:
             prediction_values = self.model.predict({"history": history, "steps": steps})
             predict_time = time.time() - predict_start
 
-            logger.info(f"✅ Prediction completed successfully")
-            logger.info(
-                f"⏱️  Prediction time: {predict_time:.3f}s, returned {len(prediction_values)} values"
+            logger.debug(
+                "event=timeseries_model_predict_completed predictions={} duration_ms={:.3f}",
+                len(prediction_values),
+                predict_time * 1000,
             )
 
             # 生成预测时间戳
@@ -320,7 +316,14 @@ class MLService:
             )
 
             total_time = time.time() - request_start
-            logger.info(f"⏱️  Total request time: {total_time:.3f}s")
+            logger.info(
+                "event=timeseries_prediction_completed model_source={} input_points={} prediction_points={} "
+                "duration_ms={:.3f}",
+                self.config.source,
+                len(request.data),
+                len(predicted_points),
+                total_time * 1000,
+            )
 
             return response
 

--- a/algorithms/classify_timeseries_server/tests/test_schema_and_predict.py
+++ b/algorithms/classify_timeseries_server/tests/test_schema_and_predict.py
@@ -12,9 +12,11 @@ import importlib
 import sys
 import time
 import types
+from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
+from loguru import logger as real_logger
 from pydantic import ValidationError
 
 
@@ -284,13 +286,63 @@ class TestMLServicePredict:
         """
         steps = 3
         svc = self._make_service(steps=steps)
+        logger = MagicMock()
         # 规则间隔 60 秒，可以被 infer_freq 识别为 "min"
         data = [{"timestamp": 1700000000 + i * 60, "value": float(i)} for i in range(5)]
         config = {"steps": steps}
-        response = await svc.predict(data, config)
+        with patch.dict(svc.predict.__func__.__globals__, {"logger": logger}):
+            response = await svc.predict(data, config)
         assert response.success is True
         assert response.prediction is not None
         assert len(response.prediction) == steps
+        logger.debug.assert_any_call(
+            "event=timeseries_request_received steps={} data_points={}",
+            steps,
+            len(data),
+        )
+        assert any(call.args[0].startswith("event=timeseries_prediction_completed") for call in logger.info.call_args_list)
+        assert "📥" not in repr(logger.mock_calls)
+
+    @pytest.mark.asyncio
+    async def test_predict_failure_keeps_response_and_owns_one_traceback(self):
+        secret = "model-response-secret-must-not-enter-logs"
+        frame_secret = "frame-local-secret-must-not-enter-logs"
+        svc = self._make_service(steps=3)
+        error = RuntimeError(secret)
+        def fail_with_sensitive_local(*_args, **_kwargs):
+            sensitive_local = frame_secret
+            assert sensitive_local
+            raise error
+
+        svc.model.predict.side_effect = fail_with_sensitive_local
+        data = [{"timestamp": 1700000000 + i * 60, "value": float(i)} for i in range(5)]
+        output = StringIO()
+        configure_logger = svc.predict.__func__.__globals__["_configure_production_logger"]
+        configure_logger(output)
+        try:
+            with patch.dict(svc.predict.__func__.__globals__, {"logger": real_logger}):
+                response = await svc.predict(data, {"steps": 3})
+        finally:
+            configure_logger()
+
+        assert response.success is False
+        assert response.error.code == "E2002"
+        assert secret in response.error.message
+        safe_exception_info = svc.predict.__func__.__globals__["_safe_exception_info"]
+        safe_type, safe_error, safe_traceback = safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "_SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "RuntimeError"
+        assert str(error) == secret
+        rendered = output.getvalue()
+        assert "event=timeseries_prediction_failed failed_stage=model_predict error_type=RuntimeError" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "service.py" in rendered
+        assert secret not in rendered
+        assert frame_secret not in rendered
 
     @pytest.mark.asyncio
     async def test_max_steps_completes_within_scaled_service_budget(self):

--- a/docs/reviews/log-diagnosability-remediation/round-06-issue.md
+++ b/docs/reviews/log-diagnosability-remediation/round-06-issue.md
@@ -1,0 +1,62 @@
+# 日志可诊断性第六轮：清理剩余运行时噪声
+
+## 背景
+
+前五轮已经处理完整凭据、采集循环 INFO、Server Core 简单动态模板，以及 Server/Stargazer 异步失败所有权。最新 master 全量重扫仍有 6,463 个静态候选：P0 4、P1 1,846、P2 4,481、P3 132。这些数字包含误报、CLI 输出和历史兼容代码，不能机械清零，但当前仍有一批可确认、可由自动测试约束的生产问题：
+
+- S3 JSON 字段一次正常读取输出 4～5 条阶段性 INFO；
+- `server/apps` 中仍有模块绕过统一 app logger，就地调用 `logging.getLogger`；
+- 运行时路径仍有 `print` 绕过日志系统，个别位置会打印完整消息或云接口响应；
+- 部分常驻服务日志包含装饰符、分隔线和逐请求成功文案，难以稳定聚合；
+- 微信失败响应和补丁执行 fencing token 被直接写入日志。
+
+## 本轮目标
+
+本轮作为统一治理轮，在一个 Issue/PR 内处理以下五类工作：
+
+1. **日志噪声**：正常 S3 读取不再输出逐阶段 INFO，改为一个 DEBUG 终态摘要；保留失败 WARNING/ERROR。
+2. **logger 来源**：将 `server/apps` 的活跃生产代码统一迁移到 `apps.core.logger` 对应 app logger；保留 `apps/core/logger.py` 本身和确需动态 logger 的异常封装。
+3. **装饰性日志**：清理常驻服务路径中的 emoji、分隔线和无稳定事件的逐请求成功日志；不改面向人的离线训练 CLI 输出。
+4. **print 绕过**：生产运行时不再用 `print` 输出消息体、云响应或异常；显式命令行工具、生成脚本和测试脚本继续使用 stdout/stderr。
+5. **低风险敏感片段**：微信 token 交换失败不记录完整响应；补丁执行过期结果不记录 fencing token；已经过专用 sanitizer 的 NATS 错误不按机械候选误删。
+
+同时把稳定模板、日志等级、异常所有权、关联字段、安全容量和生产 stdout 边界沉淀到长期工程规范，并在 `AGENTS.md` 提供执行短清单。
+
+## 复现场景
+
+### S3 读取噪声
+
+通过 Django 字段公开读取接口读取一条未压缩 JSON 对象。实际返回正确数据，但产生 Loading、Read、Not gzipped、Successfully loaded 等多条 INFO。预期返回值不变，INFO 为 0，仅保留一个有界 DEBUG 摘要。
+
+### print 绕过
+
+让 NATS listener 收到带 payload 的消息或让云插件请求失败。实际内容直接进入 stdout，无法按 logger、级别、event 和关联 ID 治理。预期生产路径统一走 logger，且不记录完整 payload/响应。
+
+## 影响范围
+
+- Server Core、实际命中的业务 app 与 NATS listener；
+- Stargazer 活跃运行时与少量云插件边界；
+- 算法在线 serving 的装饰性运行日志。
+
+这是跨模块工程治理，风险档为中，人工决策闸为 `automated_deep_review`：不改 API/NATS schema、数据库、任务状态、返回值或异常传播；按模块分别测试，并执行三轨审查。PR 以一个干净提交交付，避免把本地诊断工具或中间治理历史带入远端。
+
+## 明确排除
+
+- 不批量修改 3,684 个 L001 或 1,846 个 P1 机械候选；
+- 不把 CLI、管理命令、诊断脚本、测试脚本的必要 stdout 一律改成 logger；
+- 不删除失败 ERROR、traceback、重试终态或 Run 汇总；
+- 不修改云 SDK 请求参数、响应解析、重试和资源操作；
+- 不以截断 token 作为安全方案：不可记录的值直接省略，需关联时使用非凭据 ID。
+
+## 验收条件
+
+- [ ] S3 正常读取返回值不变、零 INFO、一个 DEBUG 终态；失败日志与缓存语义保持；
+- [ ] 本轮覆盖的 `server/apps` 文件不再就地创建 logger，日志路由到正确 app；
+- [ ] 本轮覆盖的生产 `print` 和装饰性运行日志消失，CLI stdout 保持；
+- [ ] 微信响应、补丁 fencing token、payload 和云原始响应不进入日志；
+- [ ] 长期工程规范与 `AGENTS.md` 已覆盖本轮共同日志契约；
+- [ ] 各模块行为测试先红后绿，相关回归、全量重扫和三轨审查通过。
+
+## 回滚
+
+无数据迁移和协议变化，可通过 `git revert` 整体回滚。

--- a/server/apps/alerts/action/engine.py
+++ b/server/apps/alerts/action/engine.py
@@ -1,13 +1,11 @@
-import logging
-from django.db import IntegrityError, transaction
-from apps.alerts.models.action import ActionRule, ActionExecution
+from apps.alerts.action.handlers.registry import get_handler
 from apps.alerts.action.matcher import event_matches
 from apps.alerts.action.payload import build_match_payload
-from apps.alerts.action.handlers.registry import get_handler
 from apps.alerts.constants.constants import LogAction, LogTargetType
+from apps.alerts.models.action import ActionExecution, ActionRule
 from apps.alerts.utils.operator_log import record_operator_log
-
-logger = logging.getLogger(__name__)
+from apps.core.logger import alert_logger as logger
+from django.db import IntegrityError, transaction
 
 
 class ActionEngine:

--- a/server/apps/alerts/action/handlers/job.py
+++ b/server/apps/alerts/action/handlers/job.py
@@ -1,13 +1,11 @@
-import logging
-from django.conf import settings
-from apps.rpc.job_mgmt import JobMgmt
+from apps.alerts.action.exceptions import ConfigError
 from apps.alerts.action.handlers.base import ActionHandler
 from apps.alerts.action.payload import build_match_payload, resolve_field
 from apps.alerts.action.resolver import resolve_params
 from apps.alerts.action.target_resolver import resolve_effective_team, resolve_node_target
-from apps.alerts.action.exceptions import ConfigError
-
-logger = logging.getLogger(__name__)
+from apps.core.logger import alert_logger as logger
+from apps.rpc.job_mgmt import JobMgmt
+from django.conf import settings
 
 
 class JobActionHandler(ActionHandler):

--- a/server/apps/alerts/enrichment/engine.py
+++ b/server/apps/alerts/enrichment/engine.py
@@ -1,16 +1,13 @@
 import hashlib
 import json
-import logging
 from typing import Dict, List, Optional
 
-from django.core.cache import cache
-
-from apps.alerts.enrichment.keys import resolve_binding, build_binding_key
+from apps.alerts.enrichment.keys import build_binding_key, resolve_binding
 from apps.alerts.enrichment.matcher import event_matches
 from apps.alerts.enrichment.projection import project
 from apps.alerts.enrichment.providers.base import get_provider
-
-logger = logging.getLogger(__name__)
+from apps.core.logger import alert_logger as logger
+from django.core.cache import cache
 
 MAX_KEYS_PER_BATCH = 500
 CACHE_TTL_SECONDS = 60

--- a/server/apps/alerts/enrichment/matcher.py
+++ b/server/apps/alerts/enrichment/matcher.py
@@ -1,8 +1,7 @@
-import logging
 import re as _re
 from typing import Dict, List
 
-logger = logging.getLogger(__name__)
+from apps.core.logger import alert_logger as logger
 
 
 def _cmp(actual, operator: str, expected) -> bool:

--- a/server/apps/alerts/enrichment/providers/cmdb.py
+++ b/server/apps/alerts/enrichment/providers/cmdb.py
@@ -1,11 +1,9 @@
-import logging
 from collections import defaultdict
 from typing import Dict, List
 
 from apps.alerts.enrichment.providers.base import EnrichmentProvider, register_provider
+from apps.core.logger import alert_logger as logger
 from apps.rpc.cmdb import CMDB
-
-logger = logging.getLogger(__name__)
 
 
 @register_provider

--- a/server/apps/alerts/tests/test_alert_util_logging_pure.py
+++ b/server/apps/alerts/tests/test_alert_util_logging_pure.py
@@ -1,0 +1,18 @@
+import pytest
+
+from apps.alerts.utils import util
+
+pytestmark = pytest.mark.unit
+
+
+def test_str_to_md5_encoding_failure_uses_logger_without_stdout(mocker, capsys):
+    warning = mocker.patch.object(util.logger, "warning")
+
+    assert util.str_to_md5("\udcff") == ""
+
+    assert capsys.readouterr().out == ""
+    warning.assert_called_once_with(
+        "event=string_hash_encoding_failed encoding=%s error_type=%s",
+        "utf-8",
+        "UnicodeEncodeError",
+    )

--- a/server/apps/alerts/tests/test_utils.py
+++ b/server/apps/alerts/tests/test_utils.py
@@ -6,11 +6,10 @@
 import datetime
 
 import pytest
-from django.utils import timezone
-
 from apps.alerts.utils import util
 from apps.alerts.utils.rule_matcher import RuleMatcher, filter_by_rules
 from apps.alerts.utils.time_range_checker import TimeRangeChecker, check_time_range
+from django.utils import timezone
 
 # --------------------------------------------------------------------------
 # util.py 纯函数

--- a/server/apps/alerts/utils/util.py
+++ b/server/apps/alerts/utils/util.py
@@ -2,20 +2,17 @@
 # @File: util.py
 # @Time: 2025/5/14 13:44
 # @Author: windyzhao
+import base64
 import hashlib
 import json
 import os
-import base64
-from typing import Dict, Any, List, Optional, Tuple
-
-from cryptography.fernet import InvalidToken
 from functools import wraps
-
-from django.utils.crypto import get_random_string
+from typing import Any, Dict, List, Optional, Tuple
 
 from apps.cmdb.utils.credential import Credential
 from apps.core.logger import alert_logger as logger
-
+from cryptography.fernet import InvalidToken
+from django.utils.crypto import get_random_string
 
 DEFAULT_AGGREGATION_WINDOW_SIZE_MINUTES = 10
 MAX_AGGREGATION_WINDOW_SIZE_MINUTES = 1440
@@ -193,7 +190,11 @@ def str_to_md5(input_str: str, encoding: str = 'utf-8') -> str:
         md5_hex = md5_obj.hexdigest()
         return md5_hex
     except UnicodeEncodeError as e:
-        print(f"编码错误：{e}")
+        logger.warning(
+            "event=string_hash_encoding_failed encoding=%s error_type=%s",
+            encoding,
+            type(e).__name__,
+        )
         return ""
 
 def window_size_to_int(window_size: str) -> int:

--- a/server/apps/alerts/views/action.py
+++ b/server/apps/alerts/views/action.py
@@ -6,14 +6,6 @@ ActionRuleViewSet: ActionRule 的 CRUD REST 视图集。
 """
 
 import hashlib
-import logging
-
-from django.db import transaction
-from rest_framework import status, viewsets
-from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from apps.alerts.action.handlers.registry import get_handler
 from apps.alerts.constants.constants import LogAction, LogTargetType
@@ -28,11 +20,16 @@ from apps.alerts.utils.permission_scope import (
     get_current_team_from_request,
 )
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.logger import alert_logger as logger
 from apps.job_mgmt.utils.callback_signer import verify_callback_signature
 from apps.rpc.job_mgmt import JobMgmt
 from config.drf.viewsets import ModelViewSet
-
-logger = logging.getLogger(__name__)
+from django.db import transaction
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 
 def verify_job_signature(request) -> bool:

--- a/server/apps/cmdb/collection/collect_plugin/host.py
+++ b/server/apps/cmdb/collection/collect_plugin/host.py
@@ -4,12 +4,14 @@
 # @Author: windyzhao
 import json
 import re
+
 from apps.cmdb.collection.collect_plugin.base import CollectBase
 from apps.cmdb.collection.collect_util import timestamp_gt_one_day_ago
 from apps.cmdb.collection.plugins import get_collection_plugin
 from apps.cmdb.collection.plugins.base import bind_collection_mapping
 from apps.cmdb.constants.constants import CollectPluginTypes
 from apps.core.logger import cmdb_logger as logger
+
 
 class HostCollectMetrics(CollectBase):
     def __init__(self, inst_name, inst_id, task_id, *args, **kwargs):
@@ -334,4 +336,8 @@ class HostCollectMetrics(CollectBase):
                 if data:
                     result.append(data)
             self.result[model_id] = result
-        print(json.dumps(self.result, indent=4))
+        logger.debug(
+            "event=host_metrics_formatted model_count=%s item_count=%s",
+            len(self.result),
+            sum(len(items) for items in self.result.values()),
+        )

--- a/server/apps/cmdb/services/cloud_cost/orm.py
+++ b/server/apps/cmdb/services/cloud_cost/orm.py
@@ -13,12 +13,10 @@
 - bill 维度走「先按 bill 维度筛 resource_bill → 图关联(instance_association_map)查 transaction_log」路径
 - transaction_log 实例上无 _bill_id,归属关系由本层从关联结果反哺
 """
-import logging
 from datetime import date
 
 from apps.cmdb.services.instance import InstanceManage
-
-logger = logging.getLogger("cmdb")
+from apps.core.logger import cmdb_logger as logger
 
 RESOURCE_BILL_MODEL = "resource_bill"
 TRANSACTION_LOG_MODEL = "transaction_log"
@@ -32,8 +30,8 @@ def _perm(user_info: dict, model_id: str):
     生成 InstanceManage.instance_list 需要的 permission_map。
     返回 None 表示无权限/身份缺失,调用方必须短路返回空,禁止越权返回全量。
     """
-    from apps.cmdb.nats.nats import _build_nats_permission_map
     from apps.cmdb.constants.constants import PERMISSION_INSTANCES
+    from apps.cmdb.nats.nats import _build_nats_permission_map
 
     return _build_nats_permission_map(
         user_info or {}, model_id=model_id, permission_type=PERMISSION_INSTANCES

--- a/server/apps/cmdb/tests/test_host_collect_format_pure.py
+++ b/server/apps/cmdb/tests/test_host_collect_format_pure.py
@@ -5,12 +5,14 @@
 断言指标分流（host_proc 聚合 / 失败状态过滤 / 过期时间戳熔断）、字段映射
 转换（int 转换 / MAC 规范化 / CPU 架构 / OS 类型 / 进程 JSON）后的真实输出。
 """
-import pydantic.root_model  # noqa: F401  预热
 import time
 
+import pydantic.root_model  # noqa: F401  预热
 import pytest
-
+from apps.cmdb.collection.collect_plugin import host as host_module
 from apps.cmdb.collection.collect_plugin.host import HostCollectMetrics
+
+pytestmark = pytest.mark.unit
 
 
 class _FakeTask:
@@ -99,7 +101,8 @@ def test_format_data_breaks_on_stale_timestamp(runner):
 # ---------------------------------------------------------------------------
 
 
-def test_format_metrics_full_field_mapping(runner):
+def test_format_metrics_full_field_mapping(runner, mocker, capsys):
+    debug = mocker.patch.object(host_module.logger, "debug")
     runner.host_proc_map = {}
     index = {
         "index_key": "host_info_gauge",
@@ -133,6 +136,12 @@ def test_format_metrics_full_field_mapping(runner):
     assert item["proc"] == "[]"  # 无聚合进程，get_host_proc 返回空列表 JSON
     assert item["cloud"] == "vpc-1"  # 来自快照 instance 的 cloud
     assert item["inst_name"] == "10.0.0.9[生产云]"  # ip[云标签]
+    assert capsys.readouterr().out == ""
+    debug.assert_called_once_with(
+        "event=host_metrics_formatted model_count=%s item_count=%s",
+        1,
+        1,
+    )
 
 
 def test_format_metrics_tuple_missing_field_defaults(runner):

--- a/server/apps/console_mgmt/management/commands/init_guest_role.py
+++ b/server/apps/console_mgmt/management/commands/init_guest_role.py
@@ -1,11 +1,7 @@
-import logging
-
-from django.core.management import BaseCommand
-
+from apps.core.logger import console_mgmt_logger as logger
 from apps.rpc.opspilot import OpsPilot
 from apps.rpc.system_mgmt import SystemMgmt
-
-logger = logging.getLogger(__name__)
+from django.core.management import BaseCommand
 
 
 class Command(BaseCommand):

--- a/server/apps/core/apps.py
+++ b/server/apps/core/apps.py
@@ -1,8 +1,5 @@
-import logging
-
+from apps.core.logger import logger
 from django.apps import AppConfig
-
-logger = logging.getLogger(__name__)
 
 
 class CoreConfig(AppConfig):

--- a/server/apps/core/db_patches/__init__.py
+++ b/server/apps/core/db_patches/__init__.py
@@ -8,11 +8,8 @@
     在 CoreConfig.ready() 中调用 apply_patches() 即可。
 """
 
-import logging
-
+from apps.core.logger import logger
 from django.conf import settings
-
-logger = logging.getLogger(__name__)
 
 # 引擎关键字 → 补丁模块映射
 # 新增数据库引擎时，只需在此处添加映射并创建对应的 .py 文件

--- a/server/apps/core/db_patches/dameng.py
+++ b/server/apps/core/db_patches/dameng.py
@@ -20,15 +20,13 @@
 """
 
 import json
-import logging
 import threading
 import time
 
+from apps.core.logger import logger
 from django.db import IntegrityError
 from django.db.models import Q, QuerySet
 from django.db.models.fields.json import JSONField
-
-logger = logging.getLogger(__name__)
 
 # 标记早期补丁是否已应用，避免重复
 _early_patches_applied = False

--- a/server/apps/core/db_patches/gaussdb.py
+++ b/server/apps/core/db_patches/gaussdb.py
@@ -15,9 +15,7 @@ Migration 补丁：
 - 主要用于跳过不兼容的索引创建（GinIndex/BTreeIndex on JSONField）
 """
 
-import logging
-
-logger = logging.getLogger(__name__)
+from apps.core.logger import logger
 
 
 def patch():

--- a/server/apps/core/db_patches/goldendb.py
+++ b/server/apps/core/db_patches/goldendb.py
@@ -16,9 +16,8 @@ Migration 补丁：
 """
 
 import json
-import logging
 
-logger = logging.getLogger(__name__)
+from apps.core.logger import logger
 
 
 def patch():

--- a/server/apps/core/db_patches/kingbase.py
+++ b/server/apps/core/db_patches/kingbase.py
@@ -41,9 +41,7 @@ JSONB、数组、GIN 索引、``ON CONFLICT``、正则 ``~`` 等），运行期�
 必须在真实 Kingbase MySQL 环境回归验证，按需在本模块继续补充。
 """
 
-import logging
-
-logger = logging.getLogger(__name__)
+from apps.core.logger import logger
 
 # 标记补丁是否已应用，避免重复
 _patches_applied = False

--- a/server/apps/core/db_patches/mysql.py
+++ b/server/apps/core/db_patches/mysql.py
@@ -16,9 +16,8 @@ Migration 补丁：
 """
 
 import json
-import logging
 
-logger = logging.getLogger(__name__)
+from apps.core.logger import logger
 
 
 def patch():

--- a/server/apps/core/db_patches/oceanbase.py
+++ b/server/apps/core/db_patches/oceanbase.py
@@ -16,9 +16,8 @@ Migration 补丁：
 """
 
 import json
-import logging
 
-logger = logging.getLogger(__name__)
+from apps.core.logger import logger
 
 
 def patch():

--- a/server/apps/core/decorators/api_permission.py
+++ b/server/apps/core/decorators/api_permission.py
@@ -1,14 +1,11 @@
-import logging
 import os
 from functools import wraps
 from typing import Any, Callable, List, Set, Union
 
-from django.views.generic.base import View
-
+from apps.core.logger import logger
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.web_utils import WebUtils
-
-logger = logging.getLogger("app")
+from django.views.generic.base import View
 
 
 def _get_loader(request) -> LanguageLoader:

--- a/server/apps/core/fields/s3_json_field.py
+++ b/server/apps/core/fields/s3_json_field.py
@@ -14,12 +14,17 @@ import json
 import uuid
 from typing import Any, Optional
 
+from apps.core.logger import logger
 from django.core.files.base import ContentFile
 from django.db import models, transaction
 from django.db.models.signals import post_save
 from django_minio_backend import MinioBackend
 
-from apps.core.logger import logger
+LOG_PATH_MAX_LENGTH = 500
+
+
+def _safe_log_path(path):
+    return str(path).replace("\r", "\\r").replace("\n", "\\n")[:LOG_PATH_MAX_LENGTH]
 
 
 def s3_json_upload_path(instance, filename):
@@ -165,7 +170,6 @@ class S3JSONField(models.CharField):
                 setattr(model_instance, self.attname, uploaded_path)
                 self._register_cleanup_task(model_instance, previous_path, uploaded_path)
 
-                logger.debug("S3JSONField uploaded: %s", uploaded_path)
                 return uploaded_path
 
             except Exception as e:
@@ -248,11 +252,13 @@ class S3JSONField(models.CharField):
         # 上传到 S3
         saved_path = self.storage.save(filename, content)
 
-        logger.info(
-            f"Uploaded to S3: {saved_path}, "
-            f"original={len(json_bytes)} bytes, "
-            f"compressed={len(content_bytes)} bytes, "
-            f"ratio={len(content_bytes) / len(json_bytes):.1%}"
+        logger.debug(
+            "event=s3_json_upload_succeeded path=%s compressed=%s "
+            "original_bytes=%s stored_bytes=%s",
+            _safe_log_path(saved_path),
+            self.compressed,
+            len(json_bytes),
+            len(content_bytes),
         )
 
         return saved_path
@@ -292,8 +298,6 @@ class S3JSONField(models.CharField):
         Returns:
             Python 对象（list 或 dict）
         """
-        logger.info("[S3JSONField] Loading from S3: %s", file_path)
-
         if not file_path:
             logger.warning("[S3JSONField] Empty file_path, returning None")
             return None
@@ -303,8 +307,6 @@ class S3JSONField(models.CharField):
             with self.storage.open(file_path, "rb") as f:
                 content_bytes = f.read()
 
-            logger.info("[S3JSONField] Read %s bytes from S3", len(content_bytes))
-
             if not content_bytes:
                 logger.warning("S3 file is empty: %s", file_path)
                 return None
@@ -313,18 +315,25 @@ class S3JSONField(models.CharField):
             try:
                 # 尝试解压
                 json_bytes = gzip.decompress(content_bytes)
-                logger.info("[S3JSONField] Decompressed %s -> %s bytes", len(content_bytes), len(json_bytes))
+                was_compressed = True
             except gzip.BadGzipFile:
                 # 不是 gzip 文件，使用原始内容
                 json_bytes = content_bytes
-                logger.info("[S3JSONField] Not gzipped, using raw content")
+                was_compressed = False
 
             # 解析 JSON
             json_str = json_bytes.decode("utf-8")
             data = json.loads(json_str)
 
-            logger.info(
-                f"[S3JSONField] Successfully loaded from S3: {file_path}, type: {type(data)}, items: {len(data) if isinstance(data, (list, dict)) else 'N/A'}"
+            logger.debug(
+                "event=s3_json_load_succeeded path=%s compressed=%s "
+                "stored_bytes=%s decoded_bytes=%s value_type=%s item_count=%s",
+                _safe_log_path(file_path),
+                was_compressed,
+                len(content_bytes),
+                len(json_bytes),
+                type(data).__name__,
+                len(data) if isinstance(data, (list, dict)) else "-",
             )
             return data
 

--- a/server/apps/core/fields/s3_json_field.py
+++ b/server/apps/core/fields/s3_json_field.py
@@ -14,7 +14,7 @@ import json
 import uuid
 from typing import Any, Optional
 
-from apps.core.logger import logger
+from apps.core.logger import logger, safe_exception_call_chain, safe_exception_info, safe_log_value
 from django.core.files.base import ContentFile
 from django.db import models, transaction
 from django.db.models.signals import post_save
@@ -24,7 +24,7 @@ LOG_PATH_MAX_LENGTH = 500
 
 
 def _safe_log_path(path):
-    return str(path).replace("\r", "\\r").replace("\n", "\\n")[:LOG_PATH_MAX_LENGTH]
+    return safe_log_value(path, max_length=LOG_PATH_MAX_LENGTH)
 
 
 def s3_json_upload_path(instance, filename):
@@ -173,7 +173,12 @@ class S3JSONField(models.CharField):
                 return uploaded_path
 
             except Exception as e:
-                logger.error(f"Failed to upload JSON to S3: {e}", exc_info=True)
+                logger.error(
+                    "event=s3_json_upload_failed failed_stage=storage_write error_type=%s call_chain=%s",
+                    type(e).__name__,
+                    safe_exception_call_chain(e),
+                    exc_info=safe_exception_info(e),
+                )
                 raise
 
         # 其他情况（如 FieldFile 对象）调用父类方法
@@ -299,7 +304,7 @@ class S3JSONField(models.CharField):
             Python 对象（list 或 dict）
         """
         if not file_path:
-            logger.warning("[S3JSONField] Empty file_path, returning None")
+            logger.warning("event=s3_json_load_skipped reason=empty_path")
             return None
 
         try:
@@ -308,7 +313,10 @@ class S3JSONField(models.CharField):
                 content_bytes = f.read()
 
             if not content_bytes:
-                logger.warning("S3 file is empty: %s", file_path)
+                logger.warning(
+                    "event=s3_json_load_skipped reason=empty_object path=%s",
+                    _safe_log_path(file_path),
+                )
                 return None
 
             # 解压（智能检测）
@@ -338,10 +346,22 @@ class S3JSONField(models.CharField):
             return data
 
         except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON in S3 file {file_path}: {e}")
+            logger.error(
+                "event=s3_json_load_failed path=%s failed_stage=json_decode error_type=%s call_chain=%s",
+                _safe_log_path(file_path),
+                type(e).__name__,
+                safe_exception_call_chain(e),
+                exc_info=safe_exception_info(e),
+            )
             return None
         except Exception as e:
-            logger.error("Failed to load from S3 %s: %s", file_path, e, exc_info=True)
+            logger.error(
+                "event=s3_json_load_failed path=%s failed_stage=storage_or_decode error_type=%s call_chain=%s",
+                _safe_log_path(file_path),
+                type(e).__name__,
+                safe_exception_call_chain(e),
+                exc_info=safe_exception_info(e),
+            )
             return None
 
     def get_prep_value(self, value):
@@ -441,7 +461,11 @@ class S3JSONFieldDescriptor:
             loaded_value = self.field._load_from_s3(value)
             if loaded_value is None:
                 # S3 加载失败时保留路径，避免后续 save 把 DB 中的引用清空
-                logger.warning("[S3JSONField] Load failed for %s, preserving path reference", value)
+                logger.warning(
+                    "event=s3_json_descriptor_load_failed failed_stage=descriptor_load error_type=load_returned_none "
+                    "path=%s action=preserve_reference",
+                    _safe_log_path(value),
+                )
                 return None
             instance.__dict__[self.field.attname] = loaded_value
             return loaded_value
@@ -484,19 +508,22 @@ def _handle_s3jsonfield_post_save_cleanup(sender, instance, **kwargs):
             try:
                 storage.delete(old_path)
                 logger.info(
-                    "Deleted previous S3JSONField object for %s(%s): %s -> %s",
-                    model_label,
+                    "event=s3_json_previous_object_deleted model=%s object_id=%s old_path=%s new_path=%s",
+                    safe_log_value(model_label),
                     pk,
-                    old_path,
-                    new_path,
+                    _safe_log_path(old_path),
+                    _safe_log_path(new_path),
                 )
             except Exception as exc:
-                logger.warning(
-                    "Failed to delete previous S3JSONField object for %s(%s): %s, error=%s",
-                    model_label,
+                logger.error(
+                    "event=s3_json_previous_object_delete_failed failed_stage=cleanup model=%s object_id=%s old_path=%s "
+                    "error_type=%s call_chain=%s",
+                    safe_log_value(model_label),
                     pk,
-                    old_path,
-                    exc,
+                    _safe_log_path(old_path),
+                    type(exc).__name__,
+                    safe_exception_call_chain(exc),
+                    exc_info=safe_exception_info(exc),
                 )
 
         transaction.on_commit(_cleanup_old_object, using=using)

--- a/server/apps/core/logger.py
+++ b/server/apps/core/logger.py
@@ -1,4 +1,34 @@
 import logging
+import traceback
+from pathlib import Path
+
+SAFE_EXCEPTION_MAX_FRAMES = 12
+
+
+class SafeLogException(RuntimeError):
+    """Controlled exception proxy used only for traceback rendering."""
+
+
+def safe_log_value(value, *, max_length=160) -> str:
+    """Return a bounded single-line copy for logs without changing the business value."""
+    return str(value or "").replace("\r", "\\r").replace("\n", "\\n")[:max_length]
+
+
+def safe_exception_call_chain(error: BaseException, *, max_frames=SAFE_EXCEPTION_MAX_FRAMES) -> str:
+    """Keep bounded traceback ownership without formatting exception text or frame locals."""
+    frames = traceback.extract_tb(error.__traceback__)
+    if not frames:
+        return "-"
+    return ">".join(
+        f"{safe_log_value(Path(frame.filename).name)}:{frame.lineno}:{safe_log_value(frame.name)}"
+        for frame in frames[-max_frames:]
+    )
+
+
+def safe_exception_info(error: BaseException):
+    """Preserve traceback frames while replacing the exception body with a controlled message."""
+    safe_error = SafeLogException(type(error).__name__)
+    return SafeLogException, safe_error, error.__traceback__
 
 logger = logging.getLogger("app")
 cmdb_logger = logging.getLogger("cmdb")

--- a/server/apps/core/management/commands/batch_init.py
+++ b/server/apps/core/management/commands/batch_init.py
@@ -3,18 +3,16 @@
 避免多次启动 Python 进程，大幅提升启动速度
 """
 
-import logging
 import os
 from pathlib import Path
 
+from apps.core.logger import logger
+from apps.core.utils.loader import preload_language_cache
 from django.apps import apps as django_apps
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
-from apps.core.utils.loader import preload_language_cache
-
-logger = logging.getLogger("app")
 _ADMIN_PASSWORD_FILE_MAX_CHARS = 4096
 
 

--- a/server/apps/core/middlewares/api_middleware.py
+++ b/server/apps/core/middlewares/api_middleware.py
@@ -1,15 +1,11 @@
-import logging
-
+from apps.core.logger import logger
+from apps.core.utils.loader import LanguageLoader
+from apps.core.utils.web_utils import WebUtils
 from django.conf import settings
 from django.contrib import auth
 from django.utils.deprecation import MiddlewareMixin
 from ipware import get_client_ip
 from rest_framework import status
-
-from apps.core.utils.loader import LanguageLoader
-from apps.core.utils.web_utils import WebUtils
-
-logger = logging.getLogger(__name__)
 
 
 class APISecretMiddleware(MiddlewareMixin):

--- a/server/apps/core/middlewares/app_exception_middleware.py
+++ b/server/apps/core/middlewares/app_exception_middleware.py
@@ -1,15 +1,12 @@
-import logging
 from typing import Optional
 
+from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import logger
+from apps.core.utils.web_utils import WebUtils
 from django.http import HttpRequest, HttpResponse
 from django.utils.deprecation import MiddlewareMixin
 from ipware import get_client_ip
 from rest_framework.exceptions import APIException
-
-from apps.core.exceptions.base_app_exception import BaseAppException
-from apps.core.utils.web_utils import WebUtils
-
-logger = logging.getLogger("app")
 
 
 class AppExceptionMiddleware(MiddlewareMixin):

--- a/server/apps/core/middlewares/auth_middleware.py
+++ b/server/apps/core/middlewares/auth_middleware.py
@@ -1,16 +1,11 @@
-import logging
-
 import jwt
-
-from django.conf import settings
-from django.contrib import auth
-from django.utils.deprecation import MiddlewareMixin
-
+from apps.core.logger import logger
 from apps.core.utils.custom_error import DoesNotExist
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.web_utils import WebUtils
-
-logger = logging.getLogger(__name__)
+from django.conf import settings
+from django.contrib import auth
+from django.utils.deprecation import MiddlewareMixin
 
 
 class AuthMiddleware(MiddlewareMixin):

--- a/server/apps/core/middlewares/dameng_connection_middleware.py
+++ b/server/apps/core/middlewares/dameng_connection_middleware.py
@@ -14,13 +14,11 @@
 3. 配合 CONN_MAX_AGE=0 使用，确保不复用连接
 """
 
-import logging
 import os
 import threading
 
+from apps.core.logger import logger
 from django.db import connections
-
-logger = logging.getLogger(__name__)
 
 # 只在达梦数据库环境下启用
 _IS_DAMENG = os.getenv("DB_ENGINE", "").lower() == "dameng"

--- a/server/apps/core/middlewares/request_timing_middleware.py
+++ b/server/apps/core/middlewares/request_timing_middleware.py
@@ -2,13 +2,11 @@
 请求耗时记录中间件
 记录每个请求的处理时间，并可选记录慢请求
 """
-import logging
 import time
 
+from apps.core.logger import logger
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
-
-logger = logging.getLogger("app")
 
 
 class RequestTimingMiddleware(MiddlewareMixin):

--- a/server/apps/core/mixinx.py
+++ b/server/apps/core/mixinx.py
@@ -1,12 +1,10 @@
 import base64
 import hashlib
-import logging
 from typing import Any, Dict, Optional
 
+from apps.core.logger import logger
 from cryptography.fernet import Fernet, InvalidToken
 from django.conf import settings
-
-logger = logging.getLogger(__name__)
 
 
 class EncryptMixin:

--- a/server/apps/core/services/user_group.py
+++ b/server/apps/core/services/user_group.py
@@ -1,10 +1,8 @@
-import logging
-from typing import Dict, Any, Optional, List, Union
+from typing import Any, Dict, List, Optional, Union
 
+from apps.core.logger import logger
 from apps.core.utils.user_group import Group
 from apps.rpc.system_mgmt import SystemMgmt
-
-logger = logging.getLogger(__name__)
 
 
 class UserGroup:

--- a/server/apps/core/tests/test_logger_source_contract_pure.py
+++ b/server/apps/core/tests/test_logger_source_contract_pure.py
@@ -10,6 +10,23 @@ ALLOWED_GETLOGGER = {
     "core/logger.py",
     "core/exceptions/base_app_exception.py",
 }
+EXPECTED_APP_LOGGERS = {
+    "apm": {"apm_logger", "celery_logger"},
+    "alerts": {"alert_logger"},
+    "cmdb": {"cmdb_logger"},
+    "console_mgmt": {"console_mgmt_logger", "opspilot_logger"},
+    "core": {"logger", "celery_logger", "nats_logger", "openapi_logger", "opspilot_logger"},
+    "job_mgmt": {"job_logger"},
+    "log": {"log_logger", "celery_logger", "logger"},
+    "mlops": {"mlops_logger"},
+    "monitor": {"monitor_logger", "celery_logger", "nats_logger"},
+    "node_mgmt": {"node_logger", "celery_logger", "logger"},
+    "operation_analysis": {"operation_analysis_logger"},
+    "opspilot": {"opspilot_logger", "cmdb_logger", "logger"},
+    "patch_mgmt": {"patch_mgmt_logger", "logger"},
+    "rpc": {"logger"},
+    "system_mgmt": {"system_mgmt_logger", "logger"},
+}
 
 
 def test_server_apps_production_uses_central_logger_sources():
@@ -31,3 +48,21 @@ def test_core_celery_utils_does_not_route_logs_to_another_app():
 
     assert "from apps.core.logger import logger" in source
     assert "opspilot_logger" not in source
+
+
+def test_central_logger_aliases_match_the_owning_app():
+    violations = []
+    for path in SERVER_APPS.rglob("*.py"):
+        relative = path.relative_to(SERVER_APPS)
+        if "tests" in relative.parts or relative.parts[0] not in EXPECTED_APP_LOGGERS:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(relative))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module != "apps.core.logger":
+                continue
+            for name in node.names:
+                routes_as_logger = name.asname == "logger" or (name.name == "logger" and name.asname is None)
+                if routes_as_logger and name.name not in EXPECTED_APP_LOGGERS[relative.parts[0]]:
+                    violations.append(f"{relative.as_posix()}:{node.lineno}:{name.name}")
+
+    assert violations == []

--- a/server/apps/core/tests/test_logger_source_contract_pure.py
+++ b/server/apps/core/tests/test_logger_source_contract_pure.py
@@ -1,0 +1,33 @@
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SERVER_APPS = Path(__file__).resolve().parents[2]
+ALLOWED_GETLOGGER = {
+    "core/logger.py",
+    "core/exceptions/base_app_exception.py",
+}
+
+
+def test_server_apps_production_uses_central_logger_sources():
+    violations = []
+    for path in SERVER_APPS.rglob("*.py"):
+        relative = path.relative_to(SERVER_APPS).as_posix()
+        if "/tests/" in f"/{relative}" or relative in ALLOWED_GETLOGGER:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "getLogger":
+                violations.append(f"{relative}:{node.lineno}")
+
+    assert violations == []
+
+
+def test_core_celery_utils_does_not_route_logs_to_another_app():
+    source = (SERVER_APPS / "core/utils/celery_utils.py").read_text(encoding="utf-8")
+
+    assert "from apps.core.logger import logger" in source
+    assert "opspilot_logger" not in source

--- a/server/apps/core/tests/test_s3_json_field_service.py
+++ b/server/apps/core/tests/test_s3_json_field_service.py
@@ -11,7 +11,6 @@ import io
 import json
 
 import pytest
-
 from apps.core.fields import s3_json_field as mod
 from apps.core.fields.s3_json_field import (
     S3JSONField,
@@ -108,19 +107,37 @@ class TestUploadAndLoadRoundTrip:
         assert json.loads(raw.decode("utf-8")) == data
         assert field._load_from_s3(path) == data
 
-    def test_load_non_gzip_raw_json(self, mocker):
+    def test_load_non_gzip_raw_json_has_debug_summary_without_info(self, mocker):
         field = _make_field(compressed=True)
         field.storage.objects["p.json"] = b'{"plain": true}'
         info = mocker.patch.object(mod.logger, "info")
+        debug = mocker.patch.object(mod.logger, "debug")
 
-        assert field._load_from_s3("p.json") == {"plain": True}
-        info.assert_has_calls(
-            [
-                mocker.call("[S3JSONField] Loading from S3: %s", "p.json"),
-                mocker.call("[S3JSONField] Read %s bytes from S3", 15),
-                mocker.call("[S3JSONField] Not gzipped, using raw content"),
-            ]
+        assert field.to_python("p.json") == {"plain": True}
+        info.assert_not_called()
+        debug.assert_called_once_with(
+            "event=s3_json_load_succeeded path=%s compressed=%s "
+            "stored_bytes=%s decoded_bytes=%s value_type=%s item_count=%s",
+            "p.json",
+            False,
+            15,
+            15,
+            "dict",
+            1,
         )
+
+    def test_load_debug_path_is_bounded_and_single_line(self, mocker):
+        field = _make_field(compressed=True)
+        path = "folder\r\n" + "x" * 600
+        field.storage.objects[path] = b"[]"
+        debug = mocker.patch.object(mod.logger, "debug")
+
+        assert field.to_python(path) == []
+
+        logged_path = debug.call_args.args[1]
+        assert len(logged_path) == 500
+        assert "\r" not in logged_path
+        assert "\n" not in logged_path
 
 
 class TestLoadFromS3EdgeCases:
@@ -202,14 +219,27 @@ class TestPreSave:
         inst.__dict__["data"] = None
         assert field.pre_save(inst, add=True) == ""
 
-    def test_pre_save_object_uploads_and_sets_path(self):
+    def test_pre_save_object_uploads_without_info_noise(self, mocker):
         field = _make_field()
         inst = _Instance()
         inst.__dict__["data"] = [{"k": 1}]
+        info = mocker.patch.object(mod.logger, "info")
+        debug = mocker.patch.object(mod.logger, "debug")
+
         path = field.pre_save(inst, add=True)
+
         assert path in field.storage.objects
         # 实例字段被改写为路径
         assert inst.__dict__["data"] == path
+        info.assert_not_called()
+        debug.assert_called_once_with(
+            "event=s3_json_upload_succeeded path=%s compressed=%s "
+            "original_bytes=%s stored_bytes=%s",
+            path,
+            True,
+            10,
+            30,
+        )
 
     def test_pre_save_promotes_pending_value(self):
         field = _make_field()

--- a/server/apps/core/tests/test_s3_json_field_service.py
+++ b/server/apps/core/tests/test_s3_json_field_service.py
@@ -9,6 +9,9 @@ descriptor 读写拦截、pre_save/get_prep_value 类型分支、deconstruct 迁
 import gzip
 import io
 import json
+import logging
+from contextlib import contextmanager
+from types import SimpleNamespace
 
 import pytest
 from apps.core.fields import s3_json_field as mod
@@ -17,6 +20,18 @@ from apps.core.fields.s3_json_field import (
     S3JSONFieldDescriptor,
     s3_json_upload_path,
 )
+
+
+@contextmanager
+def _capture_real_logger():
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+    mod.logger.addHandler(handler)
+    try:
+        yield output
+    finally:
+        mod.logger.removeHandler(handler)
 
 pytestmark = pytest.mark.unit
 
@@ -161,15 +176,49 @@ class TestLoadFromS3EdgeCases:
         field.storage.objects["empty"] = b""
         assert field._load_from_s3("empty") is None
 
-    def test_invalid_json_returns_none(self):
+    def test_invalid_json_returns_none_without_logging_raw_path_or_content(self):
         field = _make_field()
-        field.storage.objects["bad"] = b"{not valid json"
-        assert field._load_from_s3("bad") is None
+        path = "bad\r\n" + "x" * 600
+        payload = b"{s3-json-secret-must-not-enter-logs"
+        field.storage.objects[path] = payload
+        with _capture_real_logger() as output:
+            assert field._load_from_s3(path) is None
 
-    def test_storage_error_returns_none(self, mocker):
+        rendered = output.getvalue().rstrip("\n")
+        message = rendered.splitlines()[0]
+        assert "s3-json-secret-must-not-enter-logs" not in rendered
+        assert "\r" not in message
+        assert "\n" not in message
+        assert "bad\\r\\n" in message
+        assert "x" * 501 not in message
+        assert "failed_stage=json_decode" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "_load_from_s3" in rendered
+
+    def test_storage_error_returns_none_without_logging_exception_body(self, mocker):
         field = _make_field()
-        mocker.patch.object(field.storage, "open", side_effect=RuntimeError("s3 down"))
-        assert field._load_from_s3("x") is None
+        secret = "storage-response-secret-must-not-enter-logs"
+        error = RuntimeError(secret)
+        mocker.patch.object(field.storage, "open", side_effect=error)
+
+        with _capture_real_logger() as output:
+            assert field._load_from_s3("x") is None
+
+        rendered = output.getvalue().rstrip("\n")
+        safe_type, safe_error, safe_traceback = mod.safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "RuntimeError"
+        assert str(error) == secret
+        assert secret not in rendered
+        assert "failed_stage=storage_or_decode" in rendered
+        assert "error_type=RuntimeError" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "_load_from_s3" in rendered
 
 
 class TestToPythonAndPrep:
@@ -204,6 +253,49 @@ class TestToPythonAndPrep:
 
     def test_get_internal_type(self):
         assert _make_field().get_internal_type() == "CharField"
+
+
+def test_post_save_cleanup_failure_keeps_original_delete_path_without_leaking_log(mocker):
+    old_path = "old\r\n" + "x" * 600
+    new_path = "new.json"
+    secret = "delete-response-secret-must-not-enter-logs"
+    storage = mocker.Mock()
+    error = RuntimeError(secret)
+    storage.delete.side_effect = error
+    instance = SimpleNamespace(pk=42)
+    setattr(
+        instance,
+        S3JSONField.CLEANUP_TASKS_ATTR,
+        [{"old_path": old_path, "new_path": new_path, "storage": storage, "using": "default"}],
+    )
+    sender = SimpleNamespace(_meta=SimpleNamespace(label="app.Model"))
+    mocker.patch.object(mod.transaction, "on_commit", side_effect=lambda callback, using: callback())
+
+    with _capture_real_logger() as output:
+        mod._handle_s3jsonfield_post_save_cleanup(sender, instance)
+
+    storage.delete.assert_called_once_with(old_path)
+    assert getattr(instance, S3JSONField.CLEANUP_TASKS_ATTR) == []
+    rendered = output.getvalue().rstrip("\n")
+    message = rendered.splitlines()[0]
+    safe_type, safe_error, safe_traceback = mod.safe_exception_info(error)
+    assert safe_traceback is error.__traceback__
+    assert safe_error is not error
+    assert safe_type.__name__ == "SafeLogException"
+    assert isinstance(safe_error, RuntimeError)
+    assert str(safe_error) == "RuntimeError"
+    assert str(error) == secret
+    assert "event=s3_json_previous_object_delete_failed" in rendered
+    assert rendered.startswith("ERROR ")
+    assert "failed_stage=cleanup" in rendered
+    assert "error_type=RuntimeError" in rendered
+    assert "call_chain=" in rendered
+    assert "Traceback" in rendered
+    assert "_cleanup_old_object" in rendered
+    assert secret not in rendered
+    assert "\r" not in message
+    assert "\n" not in message
+    assert "old\\r\\n" in message
 
 
 class TestPreSave:
@@ -253,9 +345,26 @@ class TestPreSave:
         field = _make_field()
         inst = _Instance()
         inst.__dict__["data"] = [{"k": 1}]
-        mocker.patch.object(field.storage, "save", side_effect=RuntimeError("upload fail"))
-        with pytest.raises(RuntimeError):
+        secret = "upload-response-secret-must-not-enter-logs"
+        error = RuntimeError(secret)
+        mocker.patch.object(field.storage, "save", side_effect=error)
+        with _capture_real_logger() as output, pytest.raises(RuntimeError) as caught:
             field.pre_save(inst, add=True)
+
+        assert caught.value is error
+        safe_type, safe_error, safe_traceback = mod.safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "RuntimeError"
+        assert str(error) == secret
+        rendered = output.getvalue()
+        assert "event=s3_json_upload_failed failed_stage=storage_write error_type=RuntimeError" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "pre_save" in rendered
+        assert secret not in rendered
 
     def test_previous_path_is_loaded_through_model_manager(self, mocker):
         field = S3JSONField(bucket_name="b1", delete_previous_on_update=True)

--- a/server/apps/core/tests/views/test_wechat_login.py
+++ b/server/apps/core/tests/views/test_wechat_login.py
@@ -45,7 +45,7 @@ class TestVerifyWechatCode:
     @patch("apps.core.views.index_view.LoginModule")
     def test_returns_error_on_token_exchange_failure(self, mock_login_module, mock_requests):
         """Should return error when WeChat token exchange fails."""
-        from apps.core.views.index_view import verify_wechat_code
+        from apps.core.views import index_view
 
         mock_module = MagicMock()
         mock_module.app_id = "test_app"
@@ -53,13 +53,26 @@ class TestVerifyWechatCode:
         mock_login_module.objects.filter.return_value.first.return_value = mock_module
 
         mock_response = MagicMock()
-        mock_response.json.return_value = {"errcode": 40029, "errmsg": "invalid code"}
+        mock_response.status_code = 400
+        mock_response.json.return_value = {
+            "errcode": 40029,
+            "errmsg": "invalid code",
+            "access_token": "wechat-token-must-not-enter-logs",
+        }
         mock_requests.get.return_value = mock_response
 
-        result = verify_wechat_code("test_code")
+        with patch.object(index_view.logger, "warning") as warning:
+            result = index_view.verify_wechat_code("test_code")
 
         assert result["success"] is False
         assert result["errcode"] == 40029
+        warning.assert_called_once_with(
+            "event=wechat_token_exchange_failed http_status=%s errcode=%s error_type=%s",
+            400,
+            40029,
+            "wechat_api_error",
+        )
+        assert "wechat-token-must-not-enter-logs" not in str(warning.call_args)
 
     @patch("apps.core.views.index_view.requests")
     @patch("apps.core.views.index_view.LoginModule")
@@ -94,7 +107,6 @@ class TestVerifyWechatCode:
     def test_handles_timeout(self, mock_login_module, mock_requests):
         """Should handle timeout gracefully."""
         import requests as real_requests
-
         from apps.core.views.index_view import verify_wechat_code
 
         mock_module = MagicMock()
@@ -114,7 +126,7 @@ class TestVerifyWechatCode:
     @patch("apps.core.views.index_view.LoginModule")
     def test_returns_error_on_userinfo_failure(self, mock_login_module, mock_requests):
         """Should return error when userinfo fetch fails."""
-        from apps.core.views.index_view import verify_wechat_code
+        from apps.core.views import index_view
 
         mock_module = MagicMock()
         mock_module.app_id = "test_app"
@@ -127,14 +139,27 @@ class TestVerifyWechatCode:
 
         # Second call: userinfo failure
         userinfo_response = MagicMock()
-        userinfo_response.json.return_value = {"errcode": 40003, "errmsg": "invalid openid"}
+        userinfo_response.status_code = 400
+        userinfo_response.json.return_value = {
+            "errcode": 40003,
+            "errmsg": "invalid openid",
+            "openid": "openid-must-not-enter-logs",
+        }
 
         mock_requests.get.side_effect = [token_response, userinfo_response]
 
-        result = verify_wechat_code("test_code")
+        with patch.object(index_view.logger, "warning") as warning:
+            result = index_view.verify_wechat_code("test_code")
 
         assert result["success"] is False
         assert result["errcode"] == 40003
+        warning.assert_called_once_with(
+            "event=wechat_userinfo_fetch_failed http_status=%s errcode=%s error_type=%s",
+            400,
+            40003,
+            "wechat_api_error",
+        )
+        assert "openid-must-not-enter-logs" not in str(warning.call_args)
 
 
 @pytest.mark.unit

--- a/server/apps/core/tests/views/test_wechat_login.py
+++ b/server/apps/core/tests/views/test_wechat_login.py
@@ -7,6 +7,8 @@ Tests cover:
 """
 
 import json
+import io
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,12 +69,15 @@ class TestVerifyWechatCode:
         assert result["success"] is False
         assert result["errcode"] == 40029
         warning.assert_called_once_with(
-            "event=wechat_token_exchange_failed http_status=%s errcode=%s error_type=%s",
+            "event=wechat_token_exchange_failed failed_stage=token_exchange "
+            "http_status=%s errcode=%s error_type=%s",
             400,
             40029,
             "wechat_api_error",
         )
-        assert "wechat-token-must-not-enter-logs" not in str(warning.call_args)
+        rendered = warning.call_args.args[0] % warning.call_args.args[1:]
+        assert "wechat-token-must-not-enter-logs" not in rendered
+        assert result["error"] == "invalid code"
 
     @patch("apps.core.views.index_view.requests")
     @patch("apps.core.views.index_view.LoginModule")
@@ -124,6 +129,43 @@ class TestVerifyWechatCode:
 
     @patch("apps.core.views.index_view.requests")
     @patch("apps.core.views.index_view.LoginModule")
+    def test_unexpected_response_error_keeps_return_without_leaking_log(self, mock_login_module, mock_requests):
+        import requests as real_requests
+
+        from apps.core.views import index_view
+
+        secret = "wechat-response-secret-must-not-enter-logs"
+        mock_module = MagicMock(app_id="test_app", decrypted_app_secret="test_secret")
+        mock_login_module.objects.filter.return_value.first.return_value = mock_module
+        error = RuntimeError(secret)
+        mock_requests.get.return_value.json.side_effect = error
+        mock_requests.Timeout = real_requests.Timeout
+        output = io.StringIO()
+        handler = logging.StreamHandler(output)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        index_view.logger.addHandler(handler)
+        try:
+            result = index_view.verify_wechat_code("test_code")
+        finally:
+            index_view.logger.removeHandler(handler)
+
+        assert result == {"success": False, "error": secret}
+        safe_type, safe_error, safe_traceback = index_view.safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "RuntimeError"
+        assert str(error) == secret
+        rendered = output.getvalue()
+        assert "event=wechat_verification_failed failed_stage=verification error_type=RuntimeError" in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "verify_wechat_code" in rendered
+        assert secret not in rendered
+
+    @patch("apps.core.views.index_view.requests")
+    @patch("apps.core.views.index_view.LoginModule")
     def test_returns_error_on_userinfo_failure(self, mock_login_module, mock_requests):
         """Should return error when userinfo fetch fails."""
         from apps.core.views import index_view
@@ -154,12 +196,15 @@ class TestVerifyWechatCode:
         assert result["success"] is False
         assert result["errcode"] == 40003
         warning.assert_called_once_with(
-            "event=wechat_userinfo_fetch_failed http_status=%s errcode=%s error_type=%s",
+            "event=wechat_userinfo_fetch_failed failed_stage=userinfo_fetch "
+            "http_status=%s errcode=%s error_type=%s",
             400,
             40003,
             "wechat_api_error",
         )
-        assert "openid-must-not-enter-logs" not in str(warning.call_args)
+        rendered = warning.call_args.args[0] % warning.call_args.args[1:]
+        assert "openid-must-not-enter-logs" not in rendered
+        assert result["error"] == "invalid openid"
 
 
 @pytest.mark.unit

--- a/server/apps/core/utils/celery_utils.py
+++ b/server/apps/core/utils/celery_utils.py
@@ -4,7 +4,7 @@ from django.core.exceptions import MultipleObjectsReturned
 from django.utils import timezone
 from django_celery_beat.models import CrontabSchedule, IntervalSchedule, PeriodicTask
 
-from apps.core.logger import opspilot_logger as logger
+from apps.core.logger import logger
 
 
 def crontab_format(value_type: str, value: str):

--- a/server/apps/core/utils/crypto/aes_crypto.py
+++ b/server/apps/core/utils/crypto/aes_crypto.py
@@ -1,11 +1,10 @@
 import hashlib
-import logging
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+
+from apps.core.logger import logger
+from config.components.base import SECRET_KEY
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad, unpad
-from base64 import urlsafe_b64decode, urlsafe_b64encode
-from config.components.base import SECRET_KEY
-
-logger = logging.getLogger(__name__)
 
 
 class AESCryptor:

--- a/server/apps/core/utils/crypto/rsa_crypto.py
+++ b/server/apps/core/utils/crypto/rsa_crypto.py
@@ -1,9 +1,8 @@
 import base64
-import logging
+
+from apps.core.logger import logger
 from Crypto.Cipher import PKCS1_OAEP
 from Crypto.PublicKey import RSA
-
-logger = logging.getLogger(__name__)
 
 
 class RSACryptor:

--- a/server/apps/core/utils/open_base.py
+++ b/server/apps/core/utils/open_base.py
@@ -1,12 +1,10 @@
-import logging
-from typing import Callable, Any, Optional
 from functools import wraps
+from typing import Any, Callable, Optional
 
+from apps.core.logger import logger
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import ViewSet
-
-logger = logging.getLogger(__name__)
 
 LOGIN_EXEMPT_ATTR = 'login_exempt'
 

--- a/server/apps/core/utils/user_group.py
+++ b/server/apps/core/utils/user_group.py
@@ -1,7 +1,5 @@
-import logging
+from apps.core.logger import logger
 from apps.rpc.system_mgmt import SystemMgmt
-
-logger = logging.getLogger(__name__)
 
 
 def normalize_user_group_ids(group_list):

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -3,7 +3,7 @@ import os
 from urllib.parse import urlencode, urlparse
 
 import requests
-from apps.core.logger import logger
+from apps.core.logger import logger, safe_exception_call_chain, safe_exception_info
 from apps.core.services.login_auth_request_service import (
     AUTH_REQUEST_TTL,
     build_auth_request_state,
@@ -207,7 +207,8 @@ def verify_wechat_code(code: str) -> dict:
 
         if "errcode" in token_data:
             logger.warning(
-                "event=wechat_token_exchange_failed http_status=%s errcode=%s error_type=%s",
+                "event=wechat_token_exchange_failed failed_stage=token_exchange "
+                "http_status=%s errcode=%s error_type=%s",
                 token_resp.status_code,
                 token_data.get("errcode"),
                 "wechat_api_error",
@@ -228,7 +229,8 @@ def verify_wechat_code(code: str) -> dict:
 
         if "errcode" in userinfo_data:
             logger.warning(
-                "event=wechat_userinfo_fetch_failed http_status=%s errcode=%s error_type=%s",
+                "event=wechat_userinfo_fetch_failed failed_stage=userinfo_fetch "
+                "http_status=%s errcode=%s error_type=%s",
                 userinfo_resp.status_code,
                 userinfo_data.get("errcode"),
                 "wechat_api_error",
@@ -251,7 +253,12 @@ def verify_wechat_code(code: str) -> dict:
         logger.error("WeChat API timeout")
         return {"success": False, "error": "WeChat API timeout"}
     except Exception as e:
-        logger.exception("event=wechat_verification_failed error_type=%s", type(e).__name__)
+        logger.error(
+            "event=wechat_verification_failed failed_stage=verification error_type=%s call_chain=%s",
+            type(e).__name__,
+            safe_exception_call_chain(e),
+            exc_info=safe_exception_info(e),
+        )
         return {"success": False, "error": str(e)}
 
 

--- a/server/apps/core/views/index_view.py
+++ b/server/apps/core/views/index_view.py
@@ -3,12 +3,6 @@ import os
 from urllib.parse import urlencode, urlparse
 
 import requests
-from django.conf import settings as django_settings
-from django.core.cache import cache
-from django.http import HttpResponseRedirect, JsonResponse
-from django.shortcuts import render
-from rest_framework.decorators import api_view
-
 from apps.core.logger import logger
 from apps.core.services.login_auth_request_service import (
     AUTH_REQUEST_TTL,
@@ -30,9 +24,14 @@ from apps.rpc.base import RpcClient
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import UserLoginLog
 from apps.system_mgmt.models.login_module import LoginModule
-from apps.system_mgmt.services.login_auth_binding_service import build_login_auth_redirect, get_active_login_auth_bindings
 from apps.system_mgmt.models.system_settings import SystemSettings
+from apps.system_mgmt.services.login_auth_binding_service import build_login_auth_redirect, get_active_login_auth_bindings
 from apps.system_mgmt.utils.login_log_utils import log_user_login_from_request
+from django.conf import settings as django_settings
+from django.core.cache import cache
+from django.http import HttpResponseRedirect, JsonResponse
+from django.shortcuts import render
+from rest_framework.decorators import api_view
 
 PORTAL_BRANDING_KEYS = ("portal_name", "portal_logo_url", "portal_favicon_url", "watermark_enabled", "watermark_text")
 LOGIN_AUTH_BINDINGS_RATE_LIMIT = 60
@@ -207,7 +206,12 @@ def verify_wechat_code(code: str) -> dict:
         token_data = token_resp.json()
 
         if "errcode" in token_data:
-            logger.warning(f"WeChat token exchange failed: {token_data}")
+            logger.warning(
+                "event=wechat_token_exchange_failed http_status=%s errcode=%s error_type=%s",
+                token_resp.status_code,
+                token_data.get("errcode"),
+                "wechat_api_error",
+            )
             return {
                 "success": False,
                 "error": token_data.get("errmsg", "Unknown error"),
@@ -223,7 +227,12 @@ def verify_wechat_code(code: str) -> dict:
         userinfo_data = userinfo_resp.json()
 
         if "errcode" in userinfo_data:
-            logger.warning(f"WeChat userinfo fetch failed: {userinfo_data}")
+            logger.warning(
+                "event=wechat_userinfo_fetch_failed http_status=%s errcode=%s error_type=%s",
+                userinfo_resp.status_code,
+                userinfo_data.get("errcode"),
+                "wechat_api_error",
+            )
             return {
                 "success": False,
                 "error": userinfo_data.get("errmsg", "Unknown error"),
@@ -242,7 +251,7 @@ def verify_wechat_code(code: str) -> dict:
         logger.error("WeChat API timeout")
         return {"success": False, "error": "WeChat API timeout"}
     except Exception as e:
-        logger.exception(f"WeChat verification error: {e}")
+        logger.exception("event=wechat_verification_failed error_type=%s", type(e).__name__)
         return {"success": False, "error": str(e)}
 
 

--- a/server/apps/core/views/user_group.py
+++ b/server/apps/core/views/user_group.py
@@ -1,12 +1,9 @@
-import logging
-from rest_framework import viewsets
-from rest_framework.decorators import action
-
+from apps.core.logger import logger
 from apps.core.services.user_group import UserGroup
 from apps.core.utils.web_utils import WebUtils
 from apps.rpc.system_mgmt import SystemMgmt
-
-logger = logging.getLogger(__name__)
+from rest_framework import viewsets
+from rest_framework.decorators import action
 
 
 class UserGroupViewSet(viewsets.ViewSet):

--- a/server/apps/mlops/utils/group_scope.py
+++ b/server/apps/mlops/utils/group_scope.py
@@ -9,14 +9,11 @@ so that mlops-specific code does not depend on the core ViewSet class hierarchy.
 
 from types import SimpleNamespace
 
-import logging
-
-from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
+from apps.core.logger import mlops_logger as logger
 from apps.core.utils.team_utils import get_current_team as _get_current_team_str
 from apps.mlops.utils.i18n import mlops_message
-
-logger = logging.getLogger(__name__)
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 
 def get_current_team(request, default=0):

--- a/server/apps/monitor/serializers/monitor_policy.py
+++ b/server/apps/monitor/serializers/monitor_policy.py
@@ -1,14 +1,11 @@
-import logging
 import math
 import re
 
-from rest_framework import serializers
-
+from apps.core.logger import monitor_logger as logger
 from apps.monitor.constants.alert_policy import AlertConstants
 from apps.monitor.models.monitor_policy import MonitorPolicy
 from apps.monitor.utils.unit_converter import UnitConverter
-
-logger = logging.getLogger(__name__)
+from rest_framework import serializers
 
 # 阈值条件合法等级 —— 取自 MonitorPolicy.LEVEL_CHOICES 的用户可选档（排除系统在无数据时自动生成的 no_data）
 _VALID_THRESHOLD_LEVELS = {"info", "warning", "error", "critical"}

--- a/server/apps/node_mgmt/services/sidecar_config.py
+++ b/server/apps/node_mgmt/services/sidecar_config.py
@@ -1,15 +1,12 @@
 import base64
-import logging
 import shlex
 
 import yaml
-
+from apps.core.logger import node_logger as logger
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.node import NodeConstants
 from apps.node_mgmt.models.sidecar import Node
 from apps.rpc.executor import Executor
-
-logger = logging.getLogger("node_mgmt")
 
 
 class SidecarConfigService:

--- a/server/apps/node_mgmt/tasks/installer.py
+++ b/server/apps/node_mgmt/tasks/installer.py
@@ -1,57 +1,40 @@
 import hashlib
 import json
-import logging
 import queue
 import threading
 import time
 import uuid
 
-from celery import shared_task
-from django.db import transaction
-from django.db.models import Q
-from django.utils import timezone
-
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.core.logger import node_logger as logger
 from apps.core.utils.crypto.aes_crypto import AESCryptor
 from apps.node_mgmt.constants.collector import CollectorConstants
 from apps.node_mgmt.constants.controller import ControllerConstants
 from apps.node_mgmt.constants.installer import InstallerConstants
 from apps.node_mgmt.constants.node import NodeConstants
-
 from apps.node_mgmt.models import (
-    ControllerTask,
     CollectorTask,
-    PackageVersion,
+    ControllerTask,
+    ControllerTaskNode,
     Node,
     NodeCollectorInstallStatus,
-)
-from apps.node_mgmt.models import ControllerTaskNode
-
-from apps.node_mgmt.utils.installer import (
-    exec_command_to_remote,
-    exec_command_to_remote_stream,
-    download_to_local,
-    exec_command_to_local,
-    get_uninstall_command,
-    unzip_file,
+    PackageVersion,
 )
 from apps.node_mgmt.services.installer import InstallerService
-from apps.node_mgmt.utils.winrm import default_winrm_port, winrm_profile_error
 from apps.node_mgmt.services.package import PackageService
 from apps.node_mgmt.services.windows_remote_bootstrap import (
     WindowsBootstrapTarget,
     WindowsRemoteBootstrapService,
 )
+from apps.node_mgmt.tasks.version_discovery import discover_node_versions
 from apps.node_mgmt.utils.architecture import normalize_cpu_architecture
-from apps.node_mgmt.utils.step_tracker import (
-    advance_step,
-    append_step,
-    append_steps,
-    build_step,
-    clone_steps,
-    now_iso,
-    update_latest_step_by_action,
-    update_last_running_step,
+from apps.node_mgmt.utils.installer import (
+    download_to_local,
+    exec_command_to_local,
+    exec_command_to_remote,
+    exec_command_to_remote_stream,
+    get_uninstall_command,
+    unzip_file,
 )
 from apps.node_mgmt.utils.installer_schema import (
     build_installer_event_record,
@@ -59,16 +42,28 @@ from apps.node_mgmt.utils.installer_schema import (
     normalize_overall_status,
     summarize_installer_progress,
 )
+from apps.node_mgmt.utils.step_tracker import (
+    advance_step,
+    append_step,
+    append_steps,
+    build_step,
+    clone_steps,
+    now_iso,
+    update_last_running_step,
+    update_latest_step_by_action,
+)
 from apps.node_mgmt.utils.task_result_schema import (
     _extract_latest_failure_from_steps,
     _extract_latest_installer_failure_from_steps,
     apply_result_envelope,
 )
-from apps.node_mgmt.tasks.version_discovery import discover_node_versions
+from apps.node_mgmt.utils.winrm import default_winrm_port, winrm_profile_error
+from celery import shared_task
 from config.components.nats import NATS_NAMESPACE
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
 from nats_client.clients import subscribe_lines_sync
-
-logger = logging.getLogger(__name__)
 
 CONTROLLER_INSTALL_TASK_TIMEOUT_SECONDS = InstallerConstants.CONTROLLER_INSTALL_TASK_TIMEOUT_SECONDS
 

--- a/server/apps/operation_analysis/services/delivery_service.py
+++ b/server/apps/operation_analysis/services/delivery_service.py
@@ -1,7 +1,7 @@
-import logging
 import re
 import smtplib
 
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
     DashboardReportExecutionSnapshot,
@@ -20,8 +20,6 @@ from apps.operation_analysis.services.execution_service import (
 from apps.operation_analysis.services.report_render_service import (
     DashboardReportRenderService,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class DashboardReportDeliveryError(RuntimeError):

--- a/server/apps/operation_analysis/services/due_subscription_scanner.py
+++ b/server/apps/operation_analysis/services/due_subscription_scanner.py
@@ -7,20 +7,17 @@ catch_up 计划点由 create_scheduled 锁内计算。
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import datetime
 
-from django.utils import timezone
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportSubscription,
 )
 from apps.operation_analysis.services.execution_service import (
     DashboardReportExecutionService,
 )
-
-logger = logging.getLogger(__name__)
+from django.utils import timezone
 
 DEFAULT_SCAN_BATCH_SIZE = 50
 

--- a/server/apps/operation_analysis/services/execution_orchestrator.py
+++ b/server/apps/operation_analysis/services/execution_orchestrator.py
@@ -1,9 +1,7 @@
-import logging
 from enum import StrEnum
 
-from django.core.exceptions import ValidationError
-
 from apps.base.models import User
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
     DashboardReportExecutionSnapshot,
@@ -18,6 +16,9 @@ from apps.operation_analysis.services.delivery_service import (
 )
 from apps.operation_analysis.services.execution_service import (
     DashboardReportExecutionService,
+)
+from apps.operation_analysis.services.execution_timeout_checker import (
+    ExecutionTimeoutChecker,
 )
 from apps.operation_analysis.services.render_snapshot_service import (
     DashboardReportRenderSnapshotService,
@@ -37,11 +38,7 @@ from apps.operation_analysis.services.retry_types import (
     ClassifierDecisionKind,
     ResumeClass,
 )
-from apps.operation_analysis.services.execution_timeout_checker import (
-    ExecutionTimeoutChecker,
-)
-
-logger = logging.getLogger(__name__)
+from django.core.exceptions import ValidationError
 
 
 class ExecutionStepResult(StrEnum):
@@ -150,8 +147,8 @@ class PermissionStep:
             else execution.dashboard_id
         )
         from apps.operation_analysis.services.canvas_report.permissions import (
-            canvas_resource_exists,
             can_view_canvas,
+            canvas_resource_exists,
         )
 
         live_missing = resource_id is None or not canvas_resource_exists(

--- a/server/apps/operation_analysis/services/execution_retention_cleanup_service.py
+++ b/server/apps/operation_analysis/services/execution_retention_cleanup_service.py
@@ -13,23 +13,20 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import shutil
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-from django.db.models.functions import Coalesce
-from django.utils import timezone
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
 )
 from apps.operation_analysis.services.report_render_service import (
     DashboardReportRenderService,
 )
-
-logger = logging.getLogger(__name__)
+from django.db.models.functions import Coalesce
+from django.utils import timezone
 
 DEFAULT_EXECUTION_RETENTION_DAYS = 180
 DEFAULT_EXECUTION_CLEANUP_BATCH_SIZE = 200

--- a/server/apps/operation_analysis/services/execution_service.py
+++ b/server/apps/operation_analysis/services/execution_service.py
@@ -1,14 +1,8 @@
-import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 
-from django.core.exceptions import ValidationError
-from django.db import IntegrityError, transaction
-from django.utils import timezone
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.exceptions import ValidationError as DRFValidationError
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
     DashboardReportExecutionSnapshot,
@@ -25,8 +19,11 @@ from apps.operation_analysis.services.schedule_calculator import (
 from apps.operation_analysis.services.subscription_service import (
     DashboardSubscriptionService,
 )
-
-logger = logging.getLogger(__name__)
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
 IN_FLIGHT_STATUSES = (
     DashboardReportExecution.Status.PENDING,

--- a/server/apps/operation_analysis/services/execution_timeout_checker.py
+++ b/server/apps/operation_analysis/services/execution_timeout_checker.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import logging
 import os
 from dataclasses import dataclass
 from datetime import timedelta
 
-from django.db.models import Q
-from django.utils import timezone
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
 )
@@ -17,8 +14,8 @@ from apps.operation_analysis.services.execution_service import (
 from apps.operation_analysis.services.resource_state import (
     observe_resource_state,
 )
-
-logger = logging.getLogger(__name__)
+from django.db.models import Q
+from django.utils import timezone
 
 # 三次 Chromium 渲染每次最多 120 秒；额外一分钟留给 Snapshot、PDF 与投递。
 # 显式环境配置仍可按部署规模覆盖该默认值。

--- a/server/apps/operation_analysis/services/network_topology/weops_adapter.py
+++ b/server/apps/operation_analysis/services/network_topology/weops_adapter.py
@@ -25,15 +25,13 @@ so the test suite can run without a live WeOps service.
 from __future__ import annotations
 
 import json
-import logging
 import uuid
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable
 from urllib.parse import quote, urljoin
 
-logger = logging.getLogger(__name__)
-
+from apps.core.logger import operation_analysis_logger as logger
 
 # --------------------------------------------------------------------------- #
 # Errors                                                                       #

--- a/server/apps/operation_analysis/services/pdf_artifact_cleanup_service.py
+++ b/server/apps/operation_analysis/services/pdf_artifact_cleanup_service.py
@@ -10,12 +10,10 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from datetime import datetime
 
-from django.utils import timezone
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
     DashboardReportPdfArtifact,
@@ -23,8 +21,7 @@ from apps.operation_analysis.models.subscription_models import (
 from apps.operation_analysis.services.report_render_service import (
     DashboardReportRenderService,
 )
-
-logger = logging.getLogger(__name__)
+from django.utils import timezone
 
 DEFAULT_ARTIFACT_CLEANUP_BATCH_SIZE = 200
 

--- a/server/apps/operation_analysis/services/report_render_service.py
+++ b/server/apps/operation_analysis/services/report_render_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import logging
 import os
 import re
 import tempfile
@@ -9,10 +8,7 @@ from datetime import timedelta
 from pathlib import Path
 from uuid import uuid4
 
-from django.conf import settings
-from django.db import transaction
-from django.utils import timezone
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.operation_analysis.models.subscription_models import (
     DashboardReportExecution,
     DashboardReportExecutionSnapshot,
@@ -27,8 +23,9 @@ from apps.operation_analysis.services.dashboard_report_renderer import (
 from apps.operation_analysis.services.render_token_service import (
     DashboardReportRenderTokenService,
 )
-
-logger = logging.getLogger(__name__)
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
 
 
 class DashboardReportRenderService:

--- a/server/apps/operation_analysis/services/subscription_service.py
+++ b/server/apps/operation_analysis/services/subscription_service.py
@@ -1,20 +1,17 @@
-import logging
 from copy import deepcopy
 
-from django.db import DatabaseError, OperationalError, transaction
-from django.db.models import F
-from django.utils import timezone
-from rest_framework import status
-from rest_framework.exceptions import APIException, PermissionDenied, ValidationError
-
+from apps.core.logger import operation_analysis_logger as logger
 from apps.core.utils.team_utils import get_current_team
 from apps.operation_analysis.models.models import Dashboard
 from apps.operation_analysis.models.subscription_models import DashboardReportExecution, DashboardReportSubscription
 from apps.operation_analysis.services.filter_snapshot import normalize_applied_filter_values
 from apps.operation_analysis.services.schedule_calculator import ScheduleSpec, next_run, validate_iana_timezone
 from apps.system_mgmt.models import Channel
-
-logger = logging.getLogger(__name__)
+from django.db import DatabaseError, OperationalError, transaction
+from django.db.models import F
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.exceptions import APIException, PermissionDenied, ValidationError
 
 SCHEDULE_FIELDS = frozenset(
     {

--- a/server/apps/operation_analysis/views/network_topology_view.py
+++ b/server/apps/operation_analysis/views/network_topology_view.py
@@ -31,15 +31,9 @@ request to the upstream WeOps service configured on the canvas.
 from __future__ import annotations
 
 import json
-import logging
-
-from django.core.exceptions import ValidationError as DjangoValidationError
-from rest_framework import permissions, status
-from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied, ValidationError as DRFValidationError
-from rest_framework.response import Response
 
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.logger import operation_analysis_logger as logger
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.operation_analysis.models.models import NetworkTopology
 from apps.operation_analysis.serializers.network_topology_serializers import (
@@ -51,9 +45,12 @@ from apps.operation_analysis.services.network_topology import canvas_config
 from apps.operation_analysis.services.network_topology.runtime import NetworkTopologyRuntimeService
 from apps.operation_analysis.services.network_topology.weops_adapter import WeOpsTopologyAdapter, WeOpsTopologyAdapterError
 from apps.operation_analysis.views.view import BuiltinVisibleMixin, _create_canvas_share_response
-
-logger = logging.getLogger("apps.operation_analysis.network_topology")
-
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import permissions, status
+from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from rest_framework.response import Response
 
 # --------------------------------------------------------------------------- #
 # Adapter factory                                                               #

--- a/server/apps/opspilot/memory/engines/base.py
+++ b/server/apps/opspilot/memory/engines/base.py
@@ -1,11 +1,10 @@
 """Base Memory Engine - Abstract base class for all memory engines."""
 
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-logger = logging.getLogger(__name__)
+from apps.core.logger import opspilot_logger as logger
 
 
 @dataclass

--- a/server/apps/opspilot/memory/engines/local_engine.py
+++ b/server/apps/opspilot/memory/engines/local_engine.py
@@ -1,11 +1,9 @@
 """Local Memory Engine - Uses PostgreSQL database for memory storage."""
 
-import logging
 from typing import Any, Dict, List, Optional
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.memory.engines.base import BaseMemoryEngine, MemoryEntity, MemoryReadResult, MemoryWriteResult
-
-logger = logging.getLogger(__name__)
 
 
 class LocalMemoryEngine(BaseMemoryEngine):

--- a/server/apps/opspilot/memory/engines/registry.py
+++ b/server/apps/opspilot/memory/engines/registry.py
@@ -1,11 +1,9 @@
 """Memory Engine Registry - Central registry for memory engines."""
 
-import logging
 from typing import Dict, List, Type
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.memory.engines.base import BaseMemoryEngine
-
-logger = logging.getLogger(__name__)
 
 
 def check_sdk_availability() -> Dict[str, bool]:

--- a/server/apps/opspilot/metis/llm/backends/minio_backend.py
+++ b/server/apps/opspilot/metis/llm/backends/minio_backend.py
@@ -16,11 +16,11 @@
 """
 
 import base64
-import logging
 from io import BytesIO
 from pathlib import PurePosixPath
 from typing import Any, Optional
 
+from apps.core.logger import opspilot_logger as logger
 from deepagents.backends.protocol import (
     FILE_NOT_FOUND,
     BackendProtocol,
@@ -43,8 +43,6 @@ from deepagents.backends.utils import (
     slice_read_response,
     update_file_data,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class MinIOBackend(BackendProtocol):

--- a/server/apps/opspilot/metis/ocr/olm_ocr.py
+++ b/server/apps/opspilot/metis/ocr/olm_ocr.py
@@ -1,13 +1,10 @@
 import base64
 import io
-import logging
 
+from apps.core.logger import opspilot_logger as logger
+from apps.core.utils.ssrf_validator import SSRFValidator
 from openai import OpenAI
 from PIL import Image
-
-from apps.core.utils.ssrf_validator import SSRFValidator
-
-logger = logging.getLogger(__name__)
 
 
 class OlmOcr:

--- a/server/apps/opspilot/metis/ocr/rapid_ocr.py
+++ b/server/apps/opspilot/metis/ocr/rapid_ocr.py
@@ -1,8 +1,5 @@
-import logging
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.ocr.base_ocr import BaseOCR
-
-logger = logging.getLogger(__name__)
 
 
 class RapidOCR(BaseOCR):

--- a/server/apps/opspilot/metis/ocr/tesseract_ocr.py
+++ b/server/apps/opspilot/metis/ocr/tesseract_ocr.py
@@ -1,8 +1,5 @@
-import logging
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.ocr.base_ocr import BaseOCR
-
-logger = logging.getLogger(__name__)
 
 
 class TesseractOCR(BaseOCR):

--- a/server/apps/opspilot/services/skill_package/importer.py
+++ b/server/apps/opspilot/services/skill_package/importer.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import re
 import shutil
@@ -8,9 +7,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
-
-logger = logging.getLogger("apps.opspilot.skill_package.importer")
-
+from apps.core.logger import opspilot_logger as logger
 
 DEFAULT_SKILL_PACKAGE_ROOT = Path(__file__).resolve().parents[4] / ".skill" / "packages"
 

--- a/server/apps/opspilot/services/wiki/embedding_service.py
+++ b/server/apps/opspilot/services/wiki/embedding_service.py
@@ -7,16 +7,13 @@ RRF 融合关键词序与语义序。只需对小候选集调用嵌入服务,无
 嵌入调用走 EmbedProvider(OpenAI 兼容);cosine / rrf_fuse 为纯函数,便于测试。
 """
 
-import logging
 import math
 import re
 
+from apps.core.logger import opspilot_logger as logger
+from apps.opspilot.models import KnowledgePage, PageChunk, PageVersion
 from django.db import transaction
 from openai import OpenAI
-
-from apps.opspilot.models import KnowledgePage, PageChunk, PageVersion
-
-logger = logging.getLogger("opspilot")
 
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
 

--- a/server/apps/opspilot/services/wiki/parsed_storage_service.py
+++ b/server/apps/opspilot/services/wiki/parsed_storage_service.py
@@ -1,10 +1,7 @@
 """Wiki parsed markdown 对象存储清理。"""
 
-import logging
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.services.wiki import material_service
-
-logger = logging.getLogger("opspilot")
 
 
 def _parsed_markdown_prefix_for_knowledge_base(knowledge_base_id):

--- a/server/apps/opspilot/services/wiki/purpose_schema_service.py
+++ b/server/apps/opspilot/services/wiki/purpose_schema_service.py
@@ -5,14 +5,12 @@ Purpose 描述目标/范围/关键问题/成功标准；结构化模板定义知
 + 用户描述生成说明草稿，失败时回退到模板骨架。
 """
 
-import logging
 from copy import deepcopy
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.llm.chain.entity import BasicLLMRequest
 from apps.opspilot.metis.llm.common.llm_client_factory import LLMClientFactory
 from apps.opspilot.models import LLMModel
-
-logger = logging.getLogger("opspilot")
 
 
 def _directory(key, name, page_type, description):

--- a/server/apps/opspilot/services/wiki/retrieval_service.py
+++ b/server/apps/opspilot/services/wiki/retrieval_service.py
@@ -7,11 +7,9 @@ pgvector 语义检索为后期可选增强(P6),不在此处。
 
 import hashlib
 import json
-import logging
 import re
 
-from django.core.cache import cache
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.llm.chain.entity import BasicLLMRequest
 from apps.opspilot.metis.llm.common.llm_client_factory import LLMClientFactory
 from apps.opspilot.models import LLMModel, Material, PageVersion, WikiGenerationIndexEntry
@@ -24,8 +22,7 @@ from apps.opspilot.services.wiki.active_generation_query_service import (
 )
 from apps.opspilot.services.wiki.embedding_service import cosine, embed_texts, rrf_fuse
 from apps.opspilot.services.wiki.title_service import title_identity_key
-
-logger = logging.getLogger("opspilot")
+from django.core.cache import cache
 
 
 def _has_cjk(text):

--- a/server/apps/opspilot/services/wiki/wikilink_enrichment_service.py
+++ b/server/apps/opspilot/services/wiki/wikilink_enrichment_service.py
@@ -1,11 +1,9 @@
 import json
-import logging
 import re
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.models import KnowledgePage, PageVersion
 from apps.opspilot.services.wiki.relation_service import normalize_wikilink_key
-
-logger = logging.getLogger("opspilot")
 
 JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*|\s*```$", re.IGNORECASE)
 WIKILINK_RE = re.compile(r"\[\[[^\]\n]+?\]\]")

--- a/server/apps/opspilot/signals/wiki_material_signal.py
+++ b/server/apps/opspilot/signals/wiki_material_signal.py
@@ -10,17 +10,13 @@ MaterialVersion 也会被级联删除,因此在 MaterialVersion 的 post_delete 
 wiki/media/<kb>/<material>/ 下的解析嵌入图片在 Material post_delete 中一并清理。
 """
 
-import logging
-
-from django.db import transaction
-from django.db.models.signals import post_delete
-from django.dispatch import receiver
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.models import Material, MaterialVersion
 from apps.opspilot.services.wiki.material_service import delete_parsed_markdown, is_parsed_markdown_locator_for_material
 from apps.opspilot.services.wiki.parsed_media_service import delete_material_media
-
-logger = logging.getLogger("opspilot")
+from django.db import transaction
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 
 
 @receiver(post_delete, sender=Material, dispatch_uid="wiki_material_delete_minio_file")

--- a/server/apps/opspilot/utils/enterprise_wechat_aibot_chat_flow_utils.py
+++ b/server/apps/opspilot/utils/enterprise_wechat_aibot_chat_flow_utils.py
@@ -1,18 +1,15 @@
 import json
-import logging
 import re
 from typing import Any
 
 import requests
-from django.http import HttpRequest, HttpResponse
-
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.models import Bot, BotWorkFlow
 from apps.opspilot.utils.base_chat_flow_utils import BaseChatFlowUtils
 from apps.opspilot.utils.chat_flow_utils.engine.factory import create_chat_flow_engine
 from apps.opspilot.utils.enterprise_wechat_aibot_crypto import EnterpriseWechatAibotCrypto, EnterpriseWechatAibotCryptoError
 from apps.opspilot.utils.workflow_sensitive_config import decrypt_workflow_sensitive_config
-
-logger = logging.getLogger(__name__)
+from django.http import HttpRequest, HttpResponse
 
 
 class EnterpriseWechatAibotChatFlowUtils(BaseChatFlowUtils):

--- a/server/apps/opspilot/utils/prompt_utils.py
+++ b/server/apps/opspilot/utils/prompt_utils.py
@@ -1,9 +1,7 @@
 import copy
-import logging
 
+from apps.core.logger import opspilot_logger as logger
 from apps.core.mixinx import EncryptMixin
-
-logger = logging.getLogger(__name__)
 
 MASK_VALUE = "******"
 

--- a/server/apps/opspilot/utils/rollback.py
+++ b/server/apps/opspilot/utils/rollback.py
@@ -12,12 +12,10 @@
 3. ROLLBACK_REGISTRY（代码级默认映射）
 """
 
-import logging
 from typing import Any, Dict, List, Optional
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.llm.chain.entity import RollbackConfig, ToolRollbackSpec
-
-logger = logging.getLogger("opspilot")
 
 # ---------------------------------------------------------------------------
 # 全局回滚注册表（代码级默认映射）

--- a/server/apps/opspilot/utils/verification.py
+++ b/server/apps/opspilot/utils/verification.py
@@ -12,12 +12,10 @@
 """
 
 import asyncio
-import logging
 from typing import Any, Dict, List, Optional
 
+from apps.core.logger import opspilot_logger as logger
 from apps.opspilot.metis.llm.chain.entity import ToolVerificationSpec, VerificationConfig
-
-logger = logging.getLogger("opspilot")
 
 # ---------------------------------------------------------------------------
 # 全局验证注册表（代码级默认映射）

--- a/server/apps/patch_mgmt/services/apt_sync.py
+++ b/server/apps/patch_mgmt/services/apt_sync.py
@@ -16,11 +16,10 @@ Description，按空行分割。该文件中的每个包都是安全更新，但
 """
 
 import gzip
-import logging
 from typing import List, Optional
 
 import requests
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.constants import PatchSourceType
 from apps.patch_mgmt.models import PatchSource
 from apps.patch_mgmt.services.linux_repo_sync import (
@@ -29,8 +28,6 @@ from apps.patch_mgmt.services.linux_repo_sync import (
     RepoSyncError,
 )
 from apps.patch_mgmt.utils.architecture import X86_64, normalize_architecture, repository_architecture
-
-logger = logging.getLogger("app")
 
 USN_API_URL = "https://ubuntu.com/security/notices.json"
 USN_FETCH_TIMEOUT = (5, 30)

--- a/server/apps/patch_mgmt/services/connectivity_prober.py
+++ b/server/apps/patch_mgmt/services/connectivity_prober.py
@@ -15,17 +15,14 @@
 无 URL 的源（如未填 URL 的 WSUS）无法探测，返回 None（调用方保持 UNKNOWN）。
 """
 
-import logging
 from dataclasses import dataclass
 from typing import Optional
 
 import requests
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.constants import PatchSourceType
 from apps.patch_mgmt.models import PatchSource
 from apps.patch_mgmt.utils.architecture import X86_64, repository_architecture
-
-logger = logging.getLogger("app")
 
 # (连接超时, 读取超时) —— 硬封顶，避免探测无限阻塞请求/worker。
 PROBE_CONNECT_TIMEOUT = 5

--- a/server/apps/patch_mgmt/services/linux_repo_sync.py
+++ b/server/apps/patch_mgmt/services/linux_repo_sync.py
@@ -17,13 +17,12 @@
 """
 
 import gzip
-import logging
 from dataclasses import dataclass, field
 from typing import List, Optional
 from xml.etree import ElementTree as ET
 
 import requests
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.constants import PatchSourceType
 from apps.patch_mgmt.models import PatchSource
 from apps.patch_mgmt.utils.architecture import (
@@ -31,8 +30,6 @@ from apps.patch_mgmt.utils.architecture import (
     normalize_architecture,
     repository_package_applies,
 )
-
-logger = logging.getLogger("app")
 
 FETCH_TIMEOUT = (5, 30)  # (连接, 读取) 秒
 

--- a/server/apps/patch_mgmt/services/patch_execution_service.py
+++ b/server/apps/patch_mgmt/services/patch_execution_service.py
@@ -19,12 +19,6 @@ import uuid
 from datetime import timedelta
 from typing import Any, Optional
 
-from asgiref.sync import async_to_sync
-from celery.exceptions import SoftTimeLimitExceeded
-from django.conf import settings
-from django.db import transaction
-from django.utils import timezone
-
 from apps.core.logger import patch_mgmt_logger as logger
 from apps.core.mixinx import EncryptMixin
 from apps.node_mgmt.utils.s3 import delete_s3_file, upload_file_to_s3
@@ -55,7 +49,12 @@ from apps.patch_mgmt.services.target_execution_route import (
 from apps.patch_mgmt.services.target_node_context import is_container_target
 from apps.rpc.ansible import AnsibleExecutor
 from apps.rpc.executor import Executor
+from asgiref.sync import async_to_sync
+from celery.exceptions import SoftTimeLimitExceeded
 from config.components.nats import NATS_NAMESPACE
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
 
 DEFAULT_TIMEOUT = 3600
 WINDOWS_PATCH_STAGE_DIR = 'C:/Windows/Temp/bk-lite-patches'
@@ -1029,10 +1028,9 @@ def _record_host_result(
     host.refresh_from_db()
     if not updated:
         logger.warning(
-            "忽略过期执行结果 task=%s target=%s token=%s current_stage=%s",
+            "event=patch_execution_stale_result_ignored task_id=%s target_id=%s current_stage=%s",
             host.task_id,
             host.target_id,
-            host.execution_token,
             host.stage,
         )
     return bool(updated)

--- a/server/apps/patch_mgmt/services/patch_source_service.py
+++ b/server/apps/patch_mgmt/services/patch_source_service.py
@@ -1,14 +1,11 @@
 """补丁源域服务"""
 
-import logging
 from typing import Optional
 
-from django.utils import timezone
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.constants import ConnectivityStatus, OSType, PatchSourceType
 from apps.patch_mgmt.models import PatchSource
-
-logger = logging.getLogger("app")
+from django.utils import timezone
 
 
 class PatchSourceService:

--- a/server/apps/patch_mgmt/services/risk_service.py
+++ b/server/apps/patch_mgmt/services/risk_service.py
@@ -5,11 +5,11 @@
 合规状态统一按缺失评估；治理状态由 GovernanceTask 推断。
 """
 
-import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any
 
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.constants import (
     ComplianceStatus,
     GovernanceTaskStatus,
@@ -27,8 +27,6 @@ from apps.patch_mgmt.models import (
     Patch,
     PatchTarget,
 )
-
-logger = logging.getLogger("app")
 
 
 @dataclass

--- a/server/apps/patch_mgmt/services/windows_package.py
+++ b/server/apps/patch_mgmt/services/windows_package.py
@@ -1,23 +1,20 @@
 """手工 Windows 补丁包校验与私有存储。"""
 
 import hashlib
-import logging
 from dataclasses import dataclass
 from datetime import timedelta
 from pathlib import Path
 
-from django.db import transaction
-from django.db.models import Q
-from django.utils import timezone
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.config import (
     PATCH_MGMT_MAX_PACKAGE_SIZE_MB,
     PATCH_MGMT_PACKAGE_UPLOAD_TIMEOUT,
 )
 from apps.patch_mgmt.constants import OSType, PackageStatus
 from apps.patch_mgmt.models import Patch, WindowsPatchDetail
-
-logger = logging.getLogger("app")
+from django.db import transaction
+from django.db.models import Q
+from django.utils import timezone
 
 
 class WindowsPackageError(ValueError):

--- a/server/apps/patch_mgmt/services/wsus_sync.py
+++ b/server/apps/patch_mgmt/services/wsus_sync.py
@@ -13,19 +13,16 @@
 """
 
 import json
-import logging
 import re
 from dataclasses import dataclass, field
 from typing import List, Optional
 from urllib.parse import urlparse
 
 import winrm
-from django.utils import timezone
-
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.patch_mgmt.models import PatchSource
 from apps.patch_mgmt.utils.architecture import X86_64
-
-logger = logging.getLogger("app")
+from django.utils import timezone
 
 WINRM_PORT = 5985
 DEFAULT_WSUS_PORT = 8530

--- a/server/apps/patch_mgmt/tests/test_patch_execution_service.py
+++ b/server/apps/patch_mgmt/tests/test_patch_execution_service.py
@@ -54,6 +54,47 @@ def test_reboot_command():
     assert pes._reboot_command(OSType.LINUX).startswith('nohup')
 
 
+@pytest.mark.unit
+def test_stale_result_uses_execution_token_for_fencing_without_logging_it(mocker):
+    execution_token = "execution-token-must-not-enter-logs"
+    host = SimpleNamespace(
+        pk=11,
+        stage="running",
+        execution_token=execution_token,
+        task_id=22,
+        target_id=33,
+        refresh_from_db=mocker.Mock(),
+    )
+    queryset = mocker.Mock()
+    queryset.update.return_value = 0
+    filter_hosts = mocker.patch.object(
+        pes.GovernanceTaskHost.objects,
+        "filter",
+        return_value=queryset,
+    )
+    warning = mocker.patch.object(pes.logger, "warning")
+
+    updated = pes._record_host_result(
+        host,
+        stage="failed",
+        stage_color="failed",
+    )
+
+    assert updated is False
+    filter_hosts.assert_called_once_with(
+        pk=11,
+        stage="running",
+        execution_token=execution_token,
+    )
+    warning.assert_called_once_with(
+        "event=patch_execution_stale_result_ignored task_id=%s target_id=%s current_stage=%s",
+        22,
+        33,
+        "running",
+    )
+    assert execution_token not in str(warning.call_args)
+
+
 @pytest.mark.django_db
 def test_install_commands_linux():
     """Linux 安装命令只使用预先识别出的原生包管理器。"""

--- a/server/apps/patch_mgmt/views/patch_source.py
+++ b/server/apps/patch_mgmt/views/patch_source.py
@@ -1,15 +1,7 @@
 """补丁源视图"""
 
-import logging
-
-from django.db import transaction
-from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
-
-logger = logging.getLogger(__name__)
-
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.patch_mgmt.filters.patch_source import PatchSourceFilter
 from apps.patch_mgmt.models import PatchSource
@@ -22,6 +14,10 @@ from apps.patch_mgmt.services.patch_origin import snapshot_deleted_source
 from apps.patch_mgmt.services.target_access import GlobalSharedResourceMixin
 from apps.patch_mgmt.utils.i18n import patch_message
 from apps.patch_mgmt.utils.operation_log import log_source_changed
+from django.db import transaction
+from rest_framework.decorators import action
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
 
 
 class PatchSourceViewSet(GlobalSharedResourceMixin, AuthViewSet):
@@ -214,13 +210,12 @@ class PatchSourceViewSet(GlobalSharedResourceMixin, AuthViewSet):
 
         同步执行，返回 {total, created, updated, ...}。
         """
-        from rest_framework import status as drf_status
-
         from apps.patch_mgmt.services.linux_repo_sync import RepoSyncError
         from apps.patch_mgmt.services.source_sync_service import (
             SourceSyncError,
             SourceSyncService,
         )
+        from rest_framework import status as drf_status
 
         source = self.get_object()
         if source.is_builtin:
@@ -267,10 +262,9 @@ class PatchSourceViewSet(GlobalSharedResourceMixin, AuthViewSet):
         请求体: {"search": "openssl", "page": 1, "page_size": 20}
         返回: {"items": [...], "total": N, "page": 1, "page_size": 20}
         """
-        from rest_framework import status as drf_status
-
         from apps.patch_mgmt.services.linux_repo_sync import RepoSyncError
         from apps.patch_mgmt.services.source_sync_service import SourceSyncError, SourceSyncService
+        from rest_framework import status as drf_status
 
         source = self.get_object()
         search = (request.data.get("search") or "").strip().lower()
@@ -318,12 +312,11 @@ class PatchSourceViewSet(GlobalSharedResourceMixin, AuthViewSet):
 
         请求体: {"keys": ["ALSA-2023:6595", "ALSA-2023:6593"]}
         """
-        from rest_framework import status as drf_status
-        from rest_framework.exceptions import ValidationError as DRFValidationError
-
         from apps.patch_mgmt.services.linux_repo_sync import RepoSyncError
         from apps.patch_mgmt.services.source_sync_service import SourceSyncError, SourceSyncService
         from apps.patch_mgmt.tasks import ingest_patch_source
+        from rest_framework import status as drf_status
+        from rest_framework.exceptions import ValidationError as DRFValidationError
 
         source = self.get_object()
         current_team = self._validate_current_team_permission(request)
@@ -413,10 +406,9 @@ class PatchSourceViewSet(GlobalSharedResourceMixin, AuthViewSet):
         请求体：{ "source_ids": [1, 2, 3] }
         返回：[{ "source_id": 1, "connectivity_status": "connected", ... }, ...]
         """
+        from apps.patch_mgmt.tasks import check_patch_source_connectivity
         from rest_framework import status as drf_status
         from rest_framework.exceptions import ValidationError as DRFValidationError
-
-        from apps.patch_mgmt.tasks import check_patch_source_connectivity
 
         self._validate_current_team_permission(request)
 

--- a/server/apps/patch_mgmt/views/patch_target.py
+++ b/server/apps/patch_mgmt/views/patch_target.py
@@ -1,14 +1,7 @@
 """补丁管理目标视图"""
 
-import logging
-
-from django.db import transaction
-from rest_framework import status
-from rest_framework.decorators import action
-from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
-from rest_framework.response import Response
-
 from apps.core.decorators.api_permission import HasPermission
+from apps.core.logger import patch_mgmt_logger as logger
 from apps.core.utils.viewset_utils import AuthViewSet
 from apps.patch_mgmt.constants import GovernanceTaskStatus
 from apps.patch_mgmt.filters.patch_target import PatchTargetFilter
@@ -19,8 +12,11 @@ from apps.patch_mgmt.services.target_connectivity import probe_target_data, targ
 from apps.patch_mgmt.services.target_deletion import purge_target_governance_history
 from apps.patch_mgmt.utils.i18n import patch_message
 from apps.patch_mgmt.utils.operation_log import log_target_created, log_target_purged, log_target_updated
-
-logger = logging.getLogger("app")
+from django.db import transaction
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.response import Response
 
 
 class PatchTargetViewSet(TargetRootedResourceMixin, AuthViewSet):
@@ -233,10 +229,9 @@ class PatchTargetViewSet(TargetRootedResourceMixin, AuthViewSet):
     @HasPermission("patch_target-Edit")
     def check_connectivity(self, request, pk=None):
         """执行真实 SSH/WinRM 认证探测并写回结果。"""
-        from django.utils import timezone
-
         from apps.patch_mgmt.constants import ConnectivityStatus
         from apps.patch_mgmt.services.target_connectivity import probe_target
+        from django.utils import timezone
 
         target = self.get_object()
         require_target_ids(request, [target.id], "Operate")

--- a/server/apps/rpc/tests/test_nats_listener_backpressure_service.py
+++ b/server/apps/rpc/tests/test_nats_listener_backpressure_service.py
@@ -1,4 +1,6 @@
 import asyncio
+import io
+import logging
 from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -65,7 +67,8 @@ async def _start_listener(monkeypatch, settings, *, handler, nats, name, js, con
 async def test_jetstream_fetch_logs_subject_without_payload(monkeypatch, mocker):
     command = nats_listener.Command()
     secret = "payload-secret-must-not-enter-logs"
-    message = SimpleNamespace(data=secret.encode(), subject="bklite.js.collect")
+    subject = "bklite.js.collect\r\n" + "x" * 300
+    message = SimpleNamespace(data=secret.encode(), subject=subject)
 
     class OneMessageSubscription:
         async def fetch(self, timeout):
@@ -78,13 +81,18 @@ async def test_jetstream_fetch_logs_subject_without_payload(monkeypatch, mocker)
 
     await command._fetch(OneMessageSubscription(), progress_interval=10)
 
-    enqueue.assert_awaited_once_with(message, secret, "bklite.js.collect", 10)
+    enqueue.assert_awaited_once_with(message, secret, subject, 10)
+    logged_subject = debug.call_args.args[1]
     debug.assert_called_once_with(
         "event=nats_jetstream_message_received subject=%s payload_bytes=%s",
-        "bklite.js.collect",
+        logged_subject,
         len(message.data),
     )
-    assert secret not in str(debug.call_args)
+    rendered = debug.call_args.args[0] % debug.call_args.args[1:]
+    assert secret not in rendered
+    assert "\r" not in logged_subject
+    assert "\n" not in logged_subject
+    assert len(logged_subject) == nats_listener.LOG_SUBJECT_MAX_LENGTH
 
 
 @pytest.mark.parametrize("registered_js", [False, True])
@@ -551,7 +559,9 @@ async def test_core_worker_preserves_success_and_failure_reply_envelopes(monkeyp
         async def publish(self, reply, payload):
             published.append((reply, payload))
 
-    dispatch = AsyncMock(side_effect=[{"value": 1}, ValueError("invalid payload")])
+    secret = "payload-error-secret-must-not-enter-logs"
+    error = ValueError(secret)
+    dispatch = AsyncMock(side_effect=[{"value": 1}, error])
     monkeypatch.setattr(nats_listener, "nats_handler", dispatch)
     settings.NATS_HANDLER_CONCURRENCY = 1
     settings.NATS_HANDLER_QUEUE_SIZE = 2
@@ -559,9 +569,16 @@ async def test_core_worker_preserves_success_and_failure_reply_envelopes(monkeyp
     command = nats_listener.Command()
     command.nats = FakeNats()
     command._start_workers()
-    await command._enqueue("bklite.success", '{"args": [], "kwargs": {}}', reply="_INBOX.success")
-    await command._enqueue("bklite.failure", '{"args": [], "kwargs": {}}', reply="_INBOX.failure")
-    await asyncio.wait_for(command._message_queue.join(), timeout=1)
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    nats_listener.logger.addHandler(handler)
+    try:
+        await command._enqueue("bklite.success", '{"args": [], "kwargs": {}}', reply="_INBOX.success")
+        await command._enqueue("bklite.failure", '{"args": [], "kwargs": {}}', reply="_INBOX.failure")
+        await asyncio.wait_for(command._message_queue.join(), timeout=1)
+    finally:
+        nats_listener.logger.removeHandler(handler)
 
     try:
         success = nats_listener.json.loads(published[0][1])
@@ -571,7 +588,23 @@ async def test_core_worker_preserves_success_and_failure_reply_envelopes(monkeyp
         assert published[1][0] == "_INBOX.failure"
         assert failure["success"] is False
         assert failure["error"] == "ValueError"
-        assert failure["message"] == "invalid payload"
+        assert failure["message"] == secret
+        safe_type, safe_error, safe_traceback = nats_listener.safe_exception_info(error)
+        assert safe_traceback is error.__traceback__
+        assert safe_error is not error
+        assert safe_type.__name__ == "SafeLogException"
+        assert isinstance(safe_error, RuntimeError)
+        assert str(safe_error) == "ValueError"
+        assert str(error) == secret
+        rendered = output.getvalue()
+        assert (
+            "event=nats_handler_failed failed_stage=handler_dispatch transport=core "
+            "subject=bklite.failure error_type=ValueError"
+        ) in rendered
+        assert "call_chain=" in rendered
+        assert "Traceback" in rendered
+        assert "handler" in rendered
+        assert secret not in rendered
     finally:
         await command.shutdown()
         await cancel_tasks_created_after(existing_tasks)

--- a/server/apps/rpc/tests/test_nats_listener_backpressure_service.py
+++ b/server/apps/rpc/tests/test_nats_listener_backpressure_service.py
@@ -4,7 +4,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-
 from nats_client.management.commands import nats_listener
 
 from .nats_listener_test_utils import cancel_tasks_created_after
@@ -63,7 +62,83 @@ async def _start_listener(monkeypatch, settings, *, handler, nats, name, js, con
     return command
 
 
-async def test_core_listener_bounds_slow_handlers_and_backpressures_callback(monkeypatch, settings):
+async def test_jetstream_fetch_logs_subject_without_payload(monkeypatch, mocker):
+    command = nats_listener.Command()
+    secret = "payload-secret-must-not-enter-logs"
+    message = SimpleNamespace(data=secret.encode(), subject="bklite.js.collect")
+
+    class OneMessageSubscription:
+        async def fetch(self, timeout):
+            command._stopping = True
+            return [message]
+
+    enqueue = AsyncMock()
+    monkeypatch.setattr(command, "_enqueue_jetstream", enqueue)
+    debug = mocker.patch.object(nats_listener.logger, "debug")
+
+    await command._fetch(OneMessageSubscription(), progress_interval=10)
+
+    enqueue.assert_awaited_once_with(message, secret, "bklite.js.collect", 10)
+    debug.assert_called_once_with(
+        "event=nats_jetstream_message_received subject=%s payload_bytes=%s",
+        "bklite.js.collect",
+        len(message.data),
+    )
+    assert secret not in str(debug.call_args)
+
+
+@pytest.mark.parametrize("registered_js", [False, True])
+async def test_listener_does_not_report_ready_without_an_active_subscription(
+    monkeypatch,
+    settings,
+    mocker,
+    registered_js,
+):
+    class FakeNats:
+        async def subscribe(self, *args, **kwargs):
+            return None
+
+    monkeypatch.setattr(nats_listener, "get_nc_client", _fake_get_nc_client)
+    monkeypatch.setattr(
+        nats_listener.default_registry,
+        "registry",
+        {
+            "bklite.inactive": {
+                "func": AsyncMock(),
+                "namespace": "bklite",
+                "name": "inactive",
+                "js": registered_js,
+            }
+        },
+    )
+    settings.NATS_JETSTREAM_ENABLED = False
+    settings.NATS_JETSTREAM_CRATE_STREAM = False
+    settings.NATS_CORE_PENDING_MSGS_LIMIT = 7
+    settings.NATS_CORE_PENDING_BYTES_LIMIT = 4096
+    command = nats_listener.Command()
+    command.nats = FakeNats()
+    mocker.patch.object(command, "_start_workers")
+    info = mocker.patch.object(nats_listener.logger, "info")
+    warning = mocker.patch.object(nats_listener.logger, "warning")
+    debug = mocker.patch.object(nats_listener.logger, "debug")
+
+    await command.nats_coroutine()
+
+    assert not any(
+        call.args[0].startswith("event=nats_listener_ready")
+        for call in info.call_args_list
+    )
+    warning.assert_called_once_with(
+        "event=nats_listener_no_active_subscriptions configured_subscriptions=%s",
+        1,
+    )
+    assert not any(
+        call.args[0].startswith("event=nats_listener_subscription_ready")
+        for call in debug.call_args_list
+    )
+
+
+async def test_core_listener_bounds_slow_handlers_and_backpressures_callback(monkeypatch, settings, mocker, capsys):
     existing_tasks = set(asyncio.all_tasks())
     callbacks = {}
     subscription_options = {}
@@ -71,11 +146,13 @@ async def test_core_listener_bounds_slow_handlers_and_backpressures_callback(mon
     active = 0
     max_active = 0
     completed = 0
+    debug = mocker.patch.object(nats_listener.logger, "debug")
 
     class FakeNats:
         async def subscribe(self, subject, queue, cb, **kwargs):
             callbacks[subject] = cb
             subscription_options.update(kwargs)
+            return SimpleNamespace(drain=AsyncMock())
 
     async def slow_handler(_func_name, _data, reply=None):
         nonlocal active, max_active, completed
@@ -131,6 +208,14 @@ async def test_core_listener_bounds_slow_handlers_and_backpressures_callback(mon
 
         assert completed == 6
         assert max_active == 2
+        assert capsys.readouterr().out == ""
+        assert debug.call_args_list.count(
+            mocker.call(
+                "event=nats_core_message_received subject=%s payload_bytes=%s",
+                "bklite.slow_handler",
+                len(_message("bklite.slow_handler").data),
+            )
+        ) == 6
     finally:
         release.set()
         with suppress(asyncio.CancelledError):

--- a/server/apps/rpc/tests/test_nats_listener_queue_service.py
+++ b/server/apps/rpc/tests/test_nats_listener_queue_service.py
@@ -74,7 +74,7 @@ def test_invalid_numeric_config_falls_back_without_blocking_startup(monkeypatch,
     assert nats_config._read_number("NATS_HANDLER_CONCURRENCY", 64, int, 1) == expected
 
 
-async def test_core_queue_overload_returns_failure_reply(monkeypatch, settings):
+async def test_core_queue_overload_returns_failure_reply(monkeypatch, settings, mocker):
     callbacks = {}
     published = []
     release = asyncio.Event()
@@ -114,6 +114,7 @@ async def test_core_queue_overload_returns_failure_reply(monkeypatch, settings):
     command = nats_listener.Command()
     command.nats = FakeNats()
     command.handler = handler
+    warning = mocker.patch.object(nats_listener.logger, "warning")
     await command.nats_coroutine()
     callback = callbacks["bklite.overload"]
 
@@ -125,6 +126,12 @@ async def test_core_queue_overload_returns_failure_reply(monkeypatch, settings):
         assert published[0][0] == "reply-3"
         assert published[0][1]["success"] is False
         assert published[0][1]["error"] == "_ListenerOverloadedError"
+        expected_warning = mocker.call(
+            "event=nats_handler_rejected failed_stage=enqueue subject=%s error_type=%s reason=queue_full",
+            "bklite.overload",
+            "_ListenerOverloadedError",
+        )
+        assert warning.call_args_list.count(expected_warning) == 1
     finally:
         release.set()
         await command.shutdown()

--- a/server/apps/system_mgmt/management/commands/clean_group_data.py
+++ b/server/apps/system_mgmt/management/commands/clean_group_data.py
@@ -1,12 +1,8 @@
-import logging
-
-from django.core.management import BaseCommand
-from django.db import transaction
-
+from apps.core.logger import system_mgmt_logger as logger
 from apps.core.utils.permission_cache import clear_users_permission_cache
 from apps.system_mgmt.models import Group, User
-
-logger = logging.getLogger(__name__)
+from django.core.management import BaseCommand
+from django.db import transaction
 
 
 class Command(BaseCommand):

--- a/server/apps/system_mgmt/management/commands/create_user.py
+++ b/server/apps/system_mgmt/management/commands/create_user.py
@@ -1,13 +1,10 @@
-import logging
 import uuid
 
+from apps.core.logger import system_mgmt_logger as logger
+from apps.system_mgmt.models import Group, Role, User
 from django.contrib.auth.hashers import check_password, make_password
 from django.core.management import BaseCommand, CommandError
 from django.db import IntegrityError, transaction
-
-from apps.system_mgmt.models import Group, Role, User
-
-logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):

--- a/server/apps/system_mgmt/management/commands/init_custom_menu.py
+++ b/server/apps/system_mgmt/management/commands/init_custom_menu.py
@@ -1,11 +1,7 @@
-import logging
-
+from apps.core.logger import system_mgmt_logger as logger
+from apps.system_mgmt.models import App, CustomMenuGroup
 from django.core.management import BaseCommand
 from django.db import transaction
-
-from apps.system_mgmt.models import App, CustomMenuGroup
-
-logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):

--- a/server/apps/system_mgmt/management/commands/init_realm_resource.py
+++ b/server/apps/system_mgmt/management/commands/init_realm_resource.py
@@ -1,16 +1,13 @@
 import json
-import logging
 import os
 from copy import deepcopy
 
-from django.core.management import BaseCommand
-from django.db import transaction
-
+from apps.core.logger import system_mgmt_logger as logger
 from apps.core.utils.permission_cache import clear_all_permission_cache
 from apps.system_mgmt.management.commands._install_apps import get_install_apps
 from apps.system_mgmt.models import App, Group, Menu, Role
-
-logger = logging.getLogger(__name__)
+from django.core.management import BaseCommand
+from django.db import transaction
 
 
 class Command(BaseCommand):

--- a/server/apps/system_mgmt/utils/group_utils.py
+++ b/server/apps/system_mgmt/utils/group_utils.py
@@ -1,8 +1,5 @@
-import logging
 
 from apps.system_mgmt.models import Group
-
-_logger = logging.getLogger("system_mgmt")
 
 
 class GroupUtils(object):

--- a/server/apps/system_mgmt/utils/login_log_utils.py
+++ b/server/apps/system_mgmt/utils/login_log_utils.py
@@ -4,15 +4,12 @@
 提供登录日志记录功能
 """
 
-import logging
 import re
 
 import httpx
-from ipware import get_client_ip
-
+from apps.core.logger import system_mgmt_logger as logger
 from apps.system_mgmt.models import UserLoginLog
-
-logger = logging.getLogger(__name__)
+from ipware import get_client_ip
 
 
 def parse_user_agent(user_agent):

--- a/server/nats_client/management/commands/nats_listener.py
+++ b/server/nats_client/management/commands/nats_listener.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import jsonpickle
 import nats.errors
+from apps.core.logger import nats_logger as logger
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management import BaseCommand
@@ -12,8 +13,6 @@ from django.utils import autoreload
 from nats.aio.client import Client
 from nats.aio.errors import ErrNoServers, ErrTimeout
 from nats.aio.msg import Msg
-
-from apps.core.logger import nats_logger as logger
 
 from ...clients import get_nc_client
 from ...handlers import nats_handler
@@ -58,14 +57,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         reload = options.get("reload", False)
-        print("** Starting NATS listener" + (" with reload enabled" if reload else ""))
+        logger.info("event=nats_listener_starting reload=%s", reload)
         if reload:
             autoreload.run_with_reloader(self.inner_run, *args, **options)
         else:
             self.inner_run(*args, **options)
 
     def inner_run(self, *args, **options):
-        print("** Initializing Loop")
+        logger.debug("event=nats_listener_event_loop_initializing")
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
@@ -205,7 +204,11 @@ class Command(BaseCommand):
             for msg in msgs:
                 data = msg.data.decode()
                 func_name = msg.subject
-                print(f"Received a message on JetStream function `{func_name}`: {data}")
+                logger.debug(
+                    "event=nats_jetstream_message_received subject=%s payload_bytes=%s",
+                    func_name,
+                    len(msg.data),
+                )
                 await self._enqueue_jetstream(msg, data, func_name, progress_interval)
 
     async def _jetstream_progress_interval(self, psub, subject):
@@ -297,20 +300,20 @@ class Command(BaseCommand):
 
         try:
             await get_nc_client(self.nats)
-            print("** Connected to NATS server")
+            logger.info("event=nats_listener_connected")
 
             if getattr(settings, "NATS_JETSTREAM_ENABLED", True):
                 self.js = self.nats.jetstream()
-                print("** Initialized JetStream")
+                logger.info("event=nats_jetstream_initialized")
         except (ErrNoServers, ErrTimeout) as e:
             raise e
 
         if not default_registry.registry:
-            print("** No function found!")
+            logger.warning("event=nats_listener_no_handlers")
             return
 
         if self.js is not None and create_stream:
-            print("** Creating stream")
+            logger.info("event=nats_jetstream_creation_started namespace=%s", namespace)
             stream_config.pop("name", None)
             stream_config.pop("subjects", None)
             await self.js.add_stream(
@@ -325,7 +328,11 @@ class Command(BaseCommand):
             data = msg.data.decode()
             reply = msg.reply
             func_name = msg.subject
-            print(f"Received a message on function `{func_name}`")
+            logger.debug(
+                "event=nats_core_message_received subject=%s payload_bytes=%s",
+                func_name,
+                len(msg.data),
+            )
             try:
                 await asyncio.wait_for(
                     self._enqueue(func_name, data, reply=reply),
@@ -337,8 +344,10 @@ class Command(BaseCommand):
                 if reply:
                     await self._publish_failure(reply, error)
 
-        print("** Listened on:")
+        core_subscription_count = 0
+        jetstream_subscription_count = 0
         for data in default_registry.registry.values():
+            subscription_ready = False
             if data["js"]:
                 full_name = f'{data["namespace"]}.js.{data["name"]}'
                 if self.js is None:
@@ -355,6 +364,8 @@ class Command(BaseCommand):
                     self._fetch_tasks,
                     f"JetStream fetch {full_name}",
                 )
+                jetstream_subscription_count += 1
+                subscription_ready = True
             else:
                 full_name = f'{data["namespace"]}.{data["name"]}'
 
@@ -368,7 +379,27 @@ class Command(BaseCommand):
                 )
                 if subscription is not None:
                     self._core_subscriptions.append(subscription)
-            print(f"     - {full_name}" + (" (JetStream)" if data["js"] else ""))
+                    core_subscription_count += 1
+                    subscription_ready = True
+            if subscription_ready:
+                logger.debug(
+                    "event=nats_listener_subscription_ready subject=%s transport=%s",
+                    full_name,
+                    "jetstream" if data["js"] else "core",
+                )
+        subscription_count = core_subscription_count + jetstream_subscription_count
+        if subscription_count:
+            logger.info(
+                "event=nats_listener_ready subscriptions=%s core_subscriptions=%s jetstream_subscriptions=%s",
+                subscription_count,
+                core_subscription_count,
+                jetstream_subscription_count,
+            )
+        else:
+            logger.warning(
+                "event=nats_listener_no_active_subscriptions configured_subscriptions=%s",
+                len(default_registry.registry),
+            )
 
     async def handler(self, func_name: str, body, reply=None):
         try:

--- a/server/nats_client/management/commands/nats_listener.py
+++ b/server/nats_client/management/commands/nats_listener.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import jsonpickle
 import nats.errors
 from apps.core.logger import nats_logger as logger
+from apps.core.logger import safe_exception_call_chain, safe_exception_info, safe_log_value
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management import BaseCommand
@@ -17,6 +18,12 @@ from nats.aio.msg import Msg
 from ...clients import get_nc_client
 from ...handlers import nats_handler
 from ...registry import default_registry
+
+LOG_SUBJECT_MAX_LENGTH = 255
+
+
+def _safe_log_subject(subject) -> str:
+    return safe_log_value(subject, max_length=LOG_SUBJECT_MAX_LENGTH)
 
 
 @dataclass
@@ -87,8 +94,10 @@ class Command(BaseCommand):
             error = completed_task.exception()
             if error is not None:
                 logger.error(
-                    "NATS listener setup failed",
-                    exc_info=(type(error), error, error.__traceback__),
+                    "event=nats_listener_setup_failed failed_stage=setup error_type=%s call_chain=%s",
+                    type(error).__name__,
+                    safe_exception_call_chain(error),
+                    exc_info=safe_exception_info(error),
                 )
                 loop.stop()
 
@@ -106,9 +115,11 @@ class Command(BaseCommand):
             error = completed_task.exception()
             if error is not None:
                 logger.error(
-                    "NATS %s task stopped unexpectedly",
-                    description,
-                    exc_info=(type(error), error, error.__traceback__),
+                    "event=nats_listener_task_failed failed_stage=background_task task=%s error_type=%s call_chain=%s",
+                    _safe_log_subject(description),
+                    type(error).__name__,
+                    safe_exception_call_chain(error),
+                    exc_info=safe_exception_info(error),
                 )
 
         task.add_done_callback(task_done)
@@ -131,17 +142,37 @@ class Command(BaseCommand):
                 await self.handler(message.func_name, message.data, reply=message.reply)
             except asyncio.CancelledError:
                 raise
-            except Exception:  # pylint: disable=broad-except
+            except Exception as error:  # pylint: disable=broad-except
                 if message.jetstream_message is not None:
-                    logger.exception("JetStream handler failed; message left unacked: %s", message.func_name)
+                    logger.error(
+                        "event=nats_handler_failed failed_stage=handler_dispatch transport=jetstream "
+                        "subject=%s error_type=%s call_chain=%s",
+                        _safe_log_subject(message.func_name),
+                        type(error).__name__,
+                        safe_exception_call_chain(error),
+                        exc_info=safe_exception_info(error),
+                    )
                 else:
-                    logger.exception("NATS handler failed: %s", message.func_name)
+                    logger.error(
+                        "event=nats_handler_failed failed_stage=handler_dispatch transport=core "
+                        "subject=%s error_type=%s call_chain=%s",
+                        _safe_log_subject(message.func_name),
+                        type(error).__name__,
+                        safe_exception_call_chain(error),
+                        exc_info=safe_exception_info(error),
+                    )
             else:
                 if message.jetstream_message is not None:
                     try:
                         await message.jetstream_message.ack()
-                    except Exception:  # pylint: disable=broad-except
-                        logger.exception("JetStream ack failed; message will be redelivered: %s", message.func_name)
+                    except Exception as error:  # pylint: disable=broad-except
+                        logger.error(
+                            "event=nats_ack_failed failed_stage=ack subject=%s error_type=%s call_chain=%s",
+                            _safe_log_subject(message.func_name),
+                            type(error).__name__,
+                            safe_exception_call_chain(error),
+                            exc_info=safe_exception_info(error),
+                        )
             finally:
                 if message.progress_task is not None:
                     message.progress_task.cancel()
@@ -165,8 +196,14 @@ class Command(BaseCommand):
                 await message.in_progress()
             except asyncio.CancelledError:
                 raise
-            except Exception:  # pylint: disable=broad-except
-                logger.exception("JetStream in-progress heartbeat failed: %s", message.subject)
+            except Exception as error:  # pylint: disable=broad-except
+                logger.error(
+                    "event=nats_in_progress_failed failed_stage=heartbeat subject=%s error_type=%s call_chain=%s",
+                    _safe_log_subject(message.subject),
+                    type(error).__name__,
+                    safe_exception_call_chain(error),
+                    exc_info=safe_exception_info(error),
+                )
             await asyncio.sleep(interval)
 
     async def _enqueue_jetstream(self, message, data, func_name, progress_interval):
@@ -196,8 +233,13 @@ class Command(BaseCommand):
                 raise
             except nats.errors.TimeoutError:
                 continue
-            except Exception:  # pylint: disable=broad-except
-                logger.exception("JetStream fetch failed; retrying")
+            except Exception as error:  # pylint: disable=broad-except
+                logger.error(
+                    "event=nats_jetstream_fetch_failed failed_stage=fetch action=retry error_type=%s call_chain=%s",
+                    type(error).__name__,
+                    safe_exception_call_chain(error),
+                    exc_info=safe_exception_info(error),
+                )
                 await asyncio.sleep(retry_delay)
                 continue
 
@@ -206,7 +248,7 @@ class Command(BaseCommand):
                 func_name = msg.subject
                 logger.debug(
                     "event=nats_jetstream_message_received subject=%s payload_bytes=%s",
-                    func_name,
+                    _safe_log_subject(func_name),
                     len(msg.data),
                 )
                 await self._enqueue_jetstream(msg, data, func_name, progress_interval)
@@ -217,8 +259,14 @@ class Command(BaseCommand):
             consumer_info = await psub.consumer_info()
         except AttributeError:
             return configured_interval
-        except Exception:  # pylint: disable=broad-except
-            logger.exception("Unable to read JetStream consumer ack_wait: %s", subject)
+        except Exception as error:  # pylint: disable=broad-except
+            logger.error(
+                "event=nats_consumer_info_failed failed_stage=consumer_info subject=%s error_type=%s call_chain=%s",
+                _safe_log_subject(subject),
+                type(error).__name__,
+                safe_exception_call_chain(error),
+                exc_info=safe_exception_info(error),
+            )
             return configured_interval
 
         config = consumer_info.config
@@ -251,15 +299,24 @@ class Command(BaseCommand):
             for result in drain_results:
                 if isinstance(result, Exception):
                     logger.error(
-                        "NATS listener input drain failed",
-                        exc_info=(type(result), result, result.__traceback__),
+                        "event=nats_listener_drain_failed failed_stage=drain error_type=%s call_chain=%s",
+                        type(result).__name__,
+                        safe_exception_call_chain(result),
+                        exc_info=safe_exception_info(result),
                     )
             await self._message_queue.join()
 
         try:
             await asyncio.wait_for(drain_accepted_messages(), timeout=shutdown_timeout)
-        except asyncio.TimeoutError:
-            logger.error("NATS listener graceful shutdown timed out after %.1fs", shutdown_timeout)
+        except asyncio.TimeoutError as error:
+            logger.error(
+                "event=nats_listener_shutdown_failed failed_stage=shutdown reason=timeout timeout_seconds=%.1f "
+                "error_type=%s call_chain=%s",
+                shutdown_timeout,
+                type(error).__name__,
+                safe_exception_call_chain(error),
+                exc_info=safe_exception_info(error),
+            )
 
         tasks = [*self._fetch_tasks, *self._worker_tasks, *self._progress_tasks]
         for task in tasks:
@@ -313,7 +370,10 @@ class Command(BaseCommand):
             return
 
         if self.js is not None and create_stream:
-            logger.info("event=nats_jetstream_creation_started namespace=%s", namespace)
+            logger.info(
+                "event=nats_jetstream_creation_started namespace=%s",
+                _safe_log_subject(namespace),
+            )
             stream_config.pop("name", None)
             stream_config.pop("subjects", None)
             await self.js.add_stream(
@@ -330,7 +390,7 @@ class Command(BaseCommand):
             func_name = msg.subject
             logger.debug(
                 "event=nats_core_message_received subject=%s payload_bytes=%s",
-                func_name,
+                _safe_log_subject(func_name),
                 len(msg.data),
             )
             try:
@@ -340,7 +400,11 @@ class Command(BaseCommand):
                 )
             except asyncio.TimeoutError:
                 error = _ListenerOverloadedError("NATS listener handler queue is full")
-                logger.warning("NATS handler queue full; rejecting message: %s", func_name)
+                logger.warning(
+                    "event=nats_handler_rejected failed_stage=enqueue subject=%s error_type=%s reason=queue_full",
+                    _safe_log_subject(func_name),
+                    type(error).__name__,
+                )
                 if reply:
                     await self._publish_failure(reply, error)
 
@@ -384,7 +448,7 @@ class Command(BaseCommand):
             if subscription_ready:
                 logger.debug(
                     "event=nats_listener_subscription_ready subject=%s transport=%s",
-                    full_name,
+                    _safe_log_subject(full_name),
                     "jetstream" if data["js"] else "core",
                 )
         subscription_count = core_subscription_count + jetstream_subscription_count

--- a/specs/capabilities/backend-engineering.md
+++ b/specs/capabilities/backend-engineering.md
@@ -58,7 +58,9 @@
 - ✅ **禁原生 SQL**:走 Django ORM(`DB_ENGINE` 多方言,raw SQL 跨库易碎);确需复杂查询用 ORM 表达式。
 - ✅ **图库(CMDB)用参数化查询**,禁拼接 Cypher / 禁 Neo4j 语法(本项目用 FalkorDB)。
 
-## 8. 日志引入
+## 8. 日志契约
+
+### 8.1 logger 来源
 
 - ✅ **`server/apps/<app>/` 内统一从 `apps.core.logger` 引入本 app 的 logger，并别名为 `logger`**:
   ```python
@@ -67,6 +69,26 @@
   现有导出见 `server/apps/core/logger.py`（如 `cmdb_logger`、`opspilot_logger`、`alert_logger`、`monitor_logger`、`node_logger`、`job_logger`、`mlops_logger`、`log_logger`、`system_mgmt_logger`、`console_mgmt_logger`、`operation_analysis_logger`、`nats_logger`、`celery_logger`）。`core` / 跨 app 共享工具可用默认 `from apps.core.logger import logger`。
   - ❌ `from loguru import logger`、直接 `logging.getLogger(...)`、或引入其他 app 的 `*_logger`。
   - ❌ 新增 app logger 时绕过 `apps/core/logger.py` 就地创建。
+
+### 8.2 模板、等级与失败所有权
+
+- ✅ **稳定模板 + 惰性参数**：stdlib logging 使用 `logger.info("event=task_completed task_id=%s", task_id)`；独立算法服务沿用 loguru 的 `{}` 参数风格。禁止用 f-string、字符串拼接、`%` 或 `.format()` 预先把动态值固化进模板。
+- ✅ **等级表达运行语义**：INFO 只记录可独立检索的 accepted、lifecycle、terminal 或有界批次汇总；逐项成功、循环进度、函数开始/结束和内部 read/decode/retry 阶段使用 DEBUG 或删除；可恢复降级、跳过和业务失败使用 WARNING；真正需要运维处理的失败才使用 ERROR。
+- ✅ **一个失败只有一个 traceback 所有者**：由最接近业务语义且拥有 task/run/execution/callback ID 的边界在 `except` 中使用 `logger.exception`；下层继续上抛时不得重复 ERROR，也不得手工调用 `traceback.format_exc()`。上层可记录不带重复堆栈的有界终态汇总。
+- ✅ **失败字段可关联**：失败日志至少包含稳定 event、可用的业务关联 ID、`failed_stage` 和 `error_type`；异步链路分别表达执行结果、持久化结果与投递/ACK 结果，不用单一 `success` 掩盖部分失败。
+
+### 8.3 安全、容量与业务兼容
+
+- ✅ **敏感正文直接省略**：密码、token、cookie、Authorization、credential、私钥、完整 payload/result/响应正文、模板正文和未脱敏 SQL 不进入日志；不得把凭据截短后宣称安全。确需关联时使用非凭据 ID 或项目已有的专用 sanitizer。
+- ✅ **动态字段有界且单行**：用户或外部系统可控的 ID、路径、URL、subject 等只记录排障必需部分，按领域上限截断日志副本并转义 CR/LF；不得为日志修改传给业务、协议或持久化层的原值。
+- ✅ **常驻运行路径不使用 `print`**：Server、Agent 和在线 serving 统一走 logger；明确面向人的 CLI、管理命令、代码生成/诊断脚本和测试工具可以使用 stdout/stderr。
+- ✅ **日志改动不夹带业务契约变化**：默认保持返回值、用户可见文案、异常类型/身份、重试、状态、数据库写入、NATS subject/payload/ACK 和外部 SDK 调用不变；确需改变时必须拆分说明并补兼容与回滚测试。
+
+### 8.4 日志测试契约
+
+- ✅ **测试日志行为而非文案镜像**：稳定模板改动需断言模板与独立参数，并用 `LogRecord.getMessage()` 或等价 formatter 验证最终渲染；异常链需断言语义边界恰好一条 traceback ERROR、`exc_info` 为真实异常且关联字段完整。
+- ✅ **安全断言覆盖完整输出**：使用唯一哨兵值验证 message、参数和带 traceback 的完整格式化结果均不包含凭据、payload、响应正文或其他禁记内容；只断言“截断后看不到完整值”不算通过。
+- ✅ **回归同时锁定业务契约**：日志测试必须同步证明原返回值、用户可见错误、异常类型与对象身份、状态/持久化及协议字段保持不变；不得只验证 mock logger 被调用。
 
 ## 9. 架构卫生
 
@@ -101,7 +123,7 @@
 - [ ] 多步写有 `atomic`,通知在 `on_commit`,RMW 原子
 - [ ] 输入经校验,异常不吞,失败码语义正确(400/403 非 500)
 - [ ] serializer 无 `__all__`,敏感字段 write_only
-- [ ] 日志从 `apps.core.logger` 引入本 app 的 `*_logger as logger`,未用 loguru / 就地 getLogger
+- [ ] 日志符合 §8：来源正确、模板稳定、等级真实、失败单一持有 traceback，关联字段完整且动态值安全有界
 - [ ] 无原生 SQL,图查询参数化
 - [ ] 安全边界变更已盘点存量契约,有迁移与回滚方案
 - [ ] 异步状态有 fencing/幂等,持久化与外部副作用可补偿重试

--- a/specs/capabilities/backend-engineering.md
+++ b/specs/capabilities/backend-engineering.md
@@ -74,7 +74,7 @@
 
 - ✅ **稳定模板 + 惰性参数**：stdlib logging 使用 `logger.info("event=task_completed task_id=%s", task_id)`；独立算法服务沿用 loguru 的 `{}` 参数风格。禁止用 f-string、字符串拼接、`%` 或 `.format()` 预先把动态值固化进模板。
 - ✅ **等级表达运行语义**：INFO 只记录可独立检索的 accepted、lifecycle、terminal 或有界批次汇总；逐项成功、循环进度、函数开始/结束和内部 read/decode/retry 阶段使用 DEBUG 或删除；可恢复降级、跳过和业务失败使用 WARNING；真正需要运维处理的失败才使用 ERROR。
-- ✅ **一个失败只有一个 traceback 所有者**：由最接近业务语义且拥有 task/run/execution/callback ID 的边界在 `except` 中使用 `logger.exception`；下层继续上抛时不得重复 ERROR，也不得手工调用 `traceback.format_exc()`。上层可记录不带重复堆栈的有界终态汇总。
+- ✅ **一个失败只有一个 traceback 所有者**：由最接近业务语义且拥有 task/run/execution/callback ID 的边界在 `except` 中持有真实 traceback；通常使用 `logger.exception`。异常正文可能含 payload、响应或凭据时，必须改用原始 `error.__traceback__` + 脱敏替代异常正文的 `exc_info` / Loguru `opt(exception=...)`，同时记录稳定 `error_type`；Loguru 生产 handler 必须显式 `diagnose=False`，禁止从 traceback 帧展开 locals。仅记录字符串 call-chain 不能替代 traceback。下层继续上抛时不得重复 ERROR，也不得手工调用 `traceback.format_exc()`。上层可记录不带重复堆栈的有界终态汇总。
 - ✅ **失败字段可关联**：失败日志至少包含稳定 event、可用的业务关联 ID、`failed_stage` 和 `error_type`；异步链路分别表达执行结果、持久化结果与投递/ACK 结果，不用单一 `success` 掩盖部分失败。
 
 ### 8.3 安全、容量与业务兼容
@@ -86,8 +86,8 @@
 
 ### 8.4 日志测试契约
 
-- ✅ **测试日志行为而非文案镜像**：稳定模板改动需断言模板与独立参数，并用 `LogRecord.getMessage()` 或等价 formatter 验证最终渲染；异常链需断言语义边界恰好一条 traceback ERROR、`exc_info` 为真实异常且关联字段完整。
-- ✅ **安全断言覆盖完整输出**：使用唯一哨兵值验证 message、参数和带 traceback 的完整格式化结果均不包含凭据、payload、响应正文或其他禁记内容；只断言“截断后看不到完整值”不算通过。
+- ✅ **测试日志行为而非文案镜像**：稳定模板改动需断言模板与独立参数，并用 `LogRecord.getMessage()` 或等价 formatter 验证最终渲染；异常链需断言语义边界恰好一条 traceback ERROR、保留真实 traceback 对象且关联字段完整；异常正文安全时可用原异常，可能敏感时必须使用受控代理异常且不修改原异常。
+- ✅ **安全断言覆盖完整输出**：使用唯一哨兵值验证 message、参数和带 traceback 的完整格式化结果均不包含凭据、payload、响应正文或其他禁记内容；脱敏异常代理还必须证明 `exc_info` / Loguru exception tuple 保留原始 traceback 对象和调用帧、替代正文受控且不修改原异常。Loguru 测试必须直接使用生产 handler，并断言 `diagnose=False`，不得另加测试专用安全 sink 绕过生产配置。只断言 mock 调用或“截断后看不到完整值”不算通过。
 - ✅ **回归同时锁定业务契约**：日志测试必须同步证明原返回值、用户可见错误、异常类型与对象身份、状态/持久化及协议字段保持不变；不得只验证 mock logger 被调用。
 
 ## 9. 架构卫生

--- a/specs/changes/log-diagnosability-round-06/spec.md
+++ b/specs/changes/log-diagnosability-round-06/spec.md
@@ -1,0 +1,63 @@
+# 日志可诊断性第六轮统一治理
+
+关联 Issue：#4963
+
+## 目标
+
+在不改变业务返回、异常传播、协议和持久化语义的前提下，处理已确认的剩余日志噪声、错误 logger 来源、装饰性运行日志、生产 `print` 绕过和低风险敏感片段。
+
+## 共同契约
+
+1. 日志调整默认不改变返回值、异常类型、重试、状态、数据库写入、NATS subject/payload/ACK 和云 SDK 请求。
+2. 一个失败由最接近业务语义且能提供关联 ID 的边界持有 traceback；下层继续传播时不重复 ERROR。
+3. INFO 只表达可独立检索的生命周期、终态或有界汇总，不表达函数内 Loading/Read/Decode 等阶段，也不使用 emoji/分隔线装饰。
+4. DEBUG 可记录有界诊断摘要；不记录 payload、响应正文、凭据、token、cookie、模板正文或未脱敏 SQL。
+5. `server/apps/<app>` 从 `apps.core.logger` 使用对应 app logger；共享 Core 使用默认 logger。`apps/core/logger.py` 自身和按异常模块动态选择 logger 的兼容封装除外。
+6. `print` 只允许明确面向人的 CLI、管理命令、代码生成/诊断脚本和测试工具；常驻 Server/Agent 运行路径必须走统一 logger。
+
+## 模块契约
+
+### S3JSONField
+
+- `to_python(path)` 和 descriptor 读取的返回、缓存、gzip/raw 兼容及失败返回保持不变；
+- 一次成功读取不产生 INFO，只产生一个 `s3_json_load_succeeded` DEBUG；
+- DEBUG 只包含最长 500 字符的对象路径、是否压缩、存储/解码字节数、值类型和条目数；
+- 空对象、坏 JSON、storage 异常继续产生 WARNING/ERROR。
+
+### logger 来源
+
+- 活跃 `server/apps` 生产文件不再就地 `logging.getLogger`；
+- 迁移只改变 logger 路由入口，不改变日志级别、模板、参数和控制流；
+- app 与 logger 映射以 `apps/core/logger.py` 的现有导出为准。
+
+### print 与装饰日志
+
+- NATS listener 不输出完整消息数据，只记录稳定 handler/subject 元数据；
+- Server/Stargazer 常驻运行路径的异常与阶段信息进入统一 logger；
+- 云插件不把完整云响应写 stdout；
+- 离线训练 CLI、显式诊断脚本和管理命令的人类可读 stdout 不纳入生产 logger 迁移。
+
+### 敏感片段
+
+- 微信 token 交换失败只记录稳定事件、HTTP/业务状态和错误类型，不记录完整响应；
+- 补丁执行过期结果保留 task/target/stage 关联，不记录 fencing token；
+- 已经经过 `_mask_*` / `_sanitize_*` 的 NATS 连接错误保持现有诊断信息。
+
+### 规范沉淀
+
+- `specs/capabilities/backend-engineering.md` 长期记录 logger 来源、稳定模板、日志等级、异常所有权、关联字段、安全容量和业务兼容契约；
+- `AGENTS.md` 提供 Agent 执行短清单并指向长期契约，后续修改日志不依赖历史 change spec 才能发现规则。
+
+## 测试契约
+
+- 每类运行时修复至少一个可回退失败的行为测试；
+- logger 来源以导入/日志路由测试或静态精确断言覆盖，不只比较候选总数；
+- 敏感日志用哨兵值证明完整 formatter 输出不包含原值；
+- 长期规范与 Agent 短清单覆盖本轮共同契约，且不存在相互矛盾的等级、安全或 stdout 规则；
+- 最终按模块运行相关回归，并执行全仓重扫记录新基线和剩余候选。
+
+## 排除范围
+
+- 不机械修复全部 L001/P1 历史候选；
+- 不改变云 SDK、NATS、数据库或外部 API 契约；
+- 不将 stdout 禁令扩展到明确 CLI/诊断工具。

--- a/specs/changes/log-diagnosability-round-06/spec.md
+++ b/specs/changes/log-diagnosability-round-06/spec.md
@@ -9,7 +9,7 @@
 ## 共同契约
 
 1. 日志调整默认不改变返回值、异常类型、重试、状态、数据库写入、NATS subject/payload/ACK 和云 SDK 请求。
-2. 一个失败由最接近业务语义且能提供关联 ID 的边界持有 traceback；下层继续传播时不重复 ERROR。
+2. 一个失败由最接近业务语义且能提供关联 ID 的边界持有真实 traceback；下层继续传播时不重复 ERROR。异常正文可能含 payload、响应或凭据时，保留原始 traceback 对象并用受控异常正文替代原正文；Loguru 生产 handler 显式禁用 locals 诊断（`diagnose=False`），字符串帧摘要不能单独替代 traceback。
 3. INFO 只表达可独立检索的生命周期、终态或有界汇总，不表达函数内 Loading/Read/Decode 等阶段，也不使用 emoji/分隔线装饰。
 4. DEBUG 可记录有界诊断摘要；不记录 payload、响应正文、凭据、token、cookie、模板正文或未脱敏 SQL。
 5. `server/apps/<app>` 从 `apps.core.logger` 使用对应 app logger；共享 Core 使用默认 logger。`apps/core/logger.py` 自身和按异常模块动态选择 logger 的兼容封装除外。
@@ -52,7 +52,7 @@
 
 - 每类运行时修复至少一个可回退失败的行为测试；
 - logger 来源以导入/日志路由测试或静态精确断言覆盖，不只比较候选总数；
-- 敏感日志用哨兵值证明完整 formatter 输出不包含原值；
+- 敏感日志用哨兵值证明完整 formatter 输出不包含原值；脱敏异常代理同时证明原始 traceback 对象与调用帧保留、替代正文受控且原异常/业务传播不变；Loguru 直接验证生产 handler 均为 `diagnose=False`；
 - 长期规范与 Agent 短清单覆盖本轮共同契约，且不存在相互矛盾的等级、安全或 stdout 规则；
 - 最终按模块运行相关回归，并执行全仓重扫记录新基线和剩余候选。
 


### PR DESCRIPTION
## 问题

前五轮已经覆盖凭据泄露、采集循环 INFO 和异步失败所有权，但仓库仍同时存在正常路径日志噪声、错误 logger 来源、常驻进程 `print`、装饰性日志和低风险敏感片段。它们共同导致 Server 与 Stargazer 出现故障后难以按稳定事件、级别和关联 ID 检索。

## 根因与方案

本轮在不改变返回值、异常、持久化、NATS 协议和云 SDK 调用的前提下统一处理：

- S3 JSON 正常读取由多条阶段 INFO 收敛为一条有界 DEBUG 终态；
- 78 个 `server/apps` 生产文件迁移到 `apps.core.logger`，并修正 Core 调度日志路由；
- 清理 NATS listener、Stargazer、ManageOne、SSH、CMDB、Alerts 和六类在线算法 serving 的 `print`、装饰符及重复阶段日志；
- 微信 token 交换失败不再记录响应正文，补丁过期结果不再记录 fencing token，云响应和消息 payload 不进入日志；
- 保留面向人的 CLI、训练、生成和诊断 stdout，不将生产日志约束扩大到离线工具。
- 将稳定模板、等级边界、异常所有权、安全容量、stdout 边界和日志测试契约沉淀到长期工程规范与 Agent 执行短清单。

## 调用链

```mermaid
flowchart LR
  Runtime[Server / Stargazer / Serving] --> Boundary[业务与任务边界]
  Boundary --> Logger[统一 logger 与稳定事件]
  Logger --> Summary[有界终态与关联字段]
  Logger -. 异常 .-> Failure[单一 traceback ERROR]
  Cli[离线 CLI / 诊断工具] --> Stdout[人类可读 stdout]
```

## 兼容性与风险

- 不改变 API 返回、异常类型、重试、数据库写入、NATS subject/payload/ACK 或云 SDK 请求；
- 不把不可记录的 token 做截断后继续输出，而是直接省略；
- NATS 只有实际建立订阅时才记录 ready，零活跃订阅改为 WARNING；
- CLI、管理命令和离线训练的 stdout 行为保持；
- PR 以一个干净提交交付，可通过一次 `git revert` 整体回滚。

## 验证

- Server 相关回归：74 passed，覆盖 S3、微信、NATS、CMDB、logger 来源、补丁 fencing 和 Alerts；
- Stargazer、SSH、ManageOne 与采集相关回归：30 passed；
- 在线算法相关回归：30 passed；
- NATS listener：11 passed，覆盖零活跃订阅、正常订阅、enqueue、ACK、失败信封和关停；
- Python 编译、YAML 解析和 `git diff --check` 通过；
- 最终干净提交的新鲜定向验证合计 134 passed。

## 审查结论

- Spec：PASS；
- Standards：PASS；
- Runtime Contract：PASS，包含回退失败证据；
- 最终 diff 与分支历史均只包含运行时治理、测试和长期规范。

Fixes #4963
