### PR TITLE
bugfix: 限制 TrainData 列表内联资源

### DIFF
--- a/server/apps/mlops/serializers/anomaly_detection.py
+++ b/server/apps/mlops/serializers/anomaly_detection.py
@@ -1,9 +1,22 @@
 from types import SimpleNamespace
 
-from apps.core.utils.serializers import AuthSerializer
-from apps.mlops.models.anomaly_detection import *
-from apps.mlops.utils.i18n import serializer_message
 from rest_framework import serializers
+
+from apps.core.utils.serializers import AuthSerializer
+from apps.mlops.models.anomaly_detection import (
+    AnomalyDetectionDataset,
+    AnomalyDetectionDatasetRelease,
+    AnomalyDetectionServing,
+    AnomalyDetectionTrainData,
+    AnomalyDetectionTrainJob,
+)
+from apps.mlops.serializers.train_data_inline import (
+    BoundedInlineTrainDataListSerializer,
+    InlineTrainDataLimitExceeded,
+    consume_inline_records,
+    inline_csv_read_options,
+    open_inline_train_data,
+)
 from apps.mlops.utils.group_scope import (
     assert_dataset_version_scope,
     assert_parent_team_matches,
@@ -11,6 +24,7 @@ from apps.mlops.utils.group_scope import (
     get_current_team,
     validate_requested_teams,
 )
+from apps.mlops.utils.i18n import serializer_message
 
 
 class AnomalyDetectionDatasetSerializer(AuthSerializer):
@@ -32,6 +46,7 @@ class AnomalyDetectionTrainDataSerializer(AuthSerializer):
     class Meta:
         model = AnomalyDetectionTrainData
         fields = "__all__"  # 允许新增时包含所有字段
+        list_serializer_class = BoundedInlineTrainDataListSerializer
         extra_kwargs = {
             "name": {"required": False},
             "train_data": {"required": False},
@@ -62,7 +77,9 @@ class AnomalyDetectionTrainDataSerializer(AuthSerializer):
             required_columns = ["timestamp", "value", "label"]
             missing = set(required_columns) - set(df.columns)
             if missing:
-                raise serializers.ValidationError(serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing)))
+                raise serializers.ValidationError(
+                    serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing))
+                )
 
             # 检查数据类型
             if df["value"].isnull().any():
@@ -88,8 +105,9 @@ class AnomalyDetectionTrainDataSerializer(AuthSerializer):
         自定义返回数据，根据 include_train_data 参数动态控制 train_data 字段
         当 include_train_data=true 时，后端直接读取 CSV 并解析为结构化数据返回
         """
-        from apps.core.logger import mlops_logger as logger
         import pandas as pd
+
+        from apps.core.logger import mlops_logger as logger
 
         representation = super().to_representation(instance)
 
@@ -97,7 +115,18 @@ class AnomalyDetectionTrainDataSerializer(AuthSerializer):
         if self.include_train_data and instance.train_data:
             try:
                 # 读取 CSV 文件
-                df = pd.read_csv(instance.train_data.open("rb"))
+                train_data_stream = open_inline_train_data(instance.train_data, self)
+                csv_options, csv_cells = inline_csv_read_options(self, train_data_stream)
+                df = pd.read_csv(
+                    train_data_stream,
+                    **csv_options,
+                )
+                consume_inline_records(
+                    self,
+                    len(df),
+                    csv_columns=len(df.columns),
+                    csv_cells=csv_cells,
+                )
 
                 # 🔥 处理 timestamp 字段：转换为 Unix 时间戳（秒）
                 if "timestamp" in df.columns:
@@ -118,6 +147,8 @@ class AnomalyDetectionTrainDataSerializer(AuthSerializer):
                 representation["train_data"] = data_list
                 logger.info(f"Successfully loaded train_data for instance {instance.id}: {len(data_list)} rows")
 
+            except InlineTrainDataLimitExceeded:
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to read train_data for instance {instance.id}: {e}",
@@ -180,7 +211,9 @@ class AnomalyDetectionDatasetReleaseSerializer(AuthSerializer):
             allow_failed_retry = bool(train_file_id and val_file_id and test_file_id) and existing and existing.status == "failed"
 
             if existing and not allow_failed_retry:
-                raise serializers.ValidationError({"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)})
+                raise serializers.ValidationError(
+                    {"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)}
+                )
 
         return attrs
 
@@ -188,8 +221,6 @@ class AnomalyDetectionDatasetReleaseSerializer(AuthSerializer):
         """
         自定义创建方法，支持从文件ID创建数据集发布版本
         """
-        from apps.core.logger import mlops_logger as logger
-
         # 提取文件ID
         train_file_id = validated_data.pop("train_file_id", None)
         val_file_id = validated_data.pop("val_file_id", None)
@@ -233,7 +264,9 @@ class AnomalyDetectionDatasetReleaseSerializer(AuthSerializer):
                     release.save(update_fields=["status", "file_size", "metadata"])
                 else:
                     logger.info(f"数据集版本已存在 - Dataset: {dataset.id}, Version: {version}, Status: {existing.status}")
-                    raise serializers.ValidationError(serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version))
+                    raise serializers.ValidationError(
+                        serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version)
+                    )
             else:
                 # 创建 pending 状态的发布记录
                 validated_data["status"] = "pending"

--- a/server/apps/mlops/serializers/classification.py
+++ b/server/apps/mlops/serializers/classification.py
@@ -1,9 +1,22 @@
 from types import SimpleNamespace
 
-from apps.core.utils.serializers import AuthSerializer
-from apps.mlops.models.classification import *
-from apps.mlops.utils.i18n import serializer_message
 from rest_framework import serializers
+
+from apps.core.utils.serializers import AuthSerializer
+from apps.mlops.models.classification import (
+    ClassificationDataset,
+    ClassificationDatasetRelease,
+    ClassificationServing,
+    ClassificationTrainData,
+    ClassificationTrainJob,
+)
+from apps.mlops.serializers.train_data_inline import (
+    BoundedInlineTrainDataListSerializer,
+    InlineTrainDataLimitExceeded,
+    consume_inline_records,
+    inline_csv_read_options,
+    open_inline_train_data,
+)
 from apps.mlops.utils.group_scope import (
     assert_dataset_version_scope,
     assert_parent_team_matches,
@@ -11,6 +24,7 @@ from apps.mlops.utils.group_scope import (
     get_current_team,
     validate_requested_teams,
 )
+from apps.mlops.utils.i18n import serializer_message
 
 
 class ClassificationDatasetSerializer(AuthSerializer):
@@ -65,6 +79,7 @@ class ClassificationTrainDataSerializer(AuthSerializer):
     class Meta:
         model = ClassificationTrainData
         fields = "__all__"
+        list_serializer_class = BoundedInlineTrainDataListSerializer
         extra_kwargs = {
             "name": {"required": False},
             "train_data": {"required": False},
@@ -95,7 +110,9 @@ class ClassificationTrainDataSerializer(AuthSerializer):
             required_columns = ["text", "label"]
             missing = set(required_columns) - set(df.columns)
             if missing:
-                raise serializers.ValidationError(serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing)))
+                raise serializers.ValidationError(
+                    serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing))
+                )
 
             # 检查数据类型
             if df["text"].isnull().any():
@@ -121,8 +138,9 @@ class ClassificationTrainDataSerializer(AuthSerializer):
         自定义返回数据，根据 include_train_data 参数动态控制 train_data 字段
         当 include_train_data=true 时，后端直接读取 CSV 并解析为结构化数据返回
         """
-        from apps.core.logger import mlops_logger as logger
         import pandas as pd
+
+        from apps.core.logger import mlops_logger as logger
 
         representation = super().to_representation(instance)
 
@@ -130,7 +148,18 @@ class ClassificationTrainDataSerializer(AuthSerializer):
         if self.include_train_data and instance.train_data:
             try:
                 # 读取 CSV 文件
-                df = pd.read_csv(instance.train_data.open("rb"))
+                train_data_stream = open_inline_train_data(instance.train_data, self)
+                csv_options, csv_cells = inline_csv_read_options(self, train_data_stream)
+                df = pd.read_csv(
+                    train_data_stream,
+                    **csv_options,
+                )
+                consume_inline_records(
+                    self,
+                    len(df),
+                    csv_columns=len(df.columns),
+                    csv_cells=csv_cells,
+                )
 
                 # 转换为字典列表并添加索引
                 data_list = df.to_dict("records")
@@ -140,6 +169,8 @@ class ClassificationTrainDataSerializer(AuthSerializer):
                 representation["train_data"] = data_list
                 logger.info(f"Successfully loaded train_data for instance {instance.id}: {len(data_list)} rows")
 
+            except InlineTrainDataLimitExceeded:
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to read train_data for instance {instance.id}: {e}",
@@ -230,7 +261,9 @@ class ClassificationDatasetReleaseSerializer(AuthSerializer):
             allow_failed_retry = bool(train_file_id and val_file_id and test_file_id) and existing and existing.status == "failed"
 
             if existing and not allow_failed_retry:
-                raise serializers.ValidationError({"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)})
+                raise serializers.ValidationError(
+                    {"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)}
+                )
 
         return attrs
 
@@ -238,8 +271,6 @@ class ClassificationDatasetReleaseSerializer(AuthSerializer):
         """
         自定义创建方法，支持从文件ID创建数据集发布版本
         """
-        from apps.core.logger import mlops_logger as logger
-
         # 提取文件ID
         train_file_id = validated_data.pop("train_file_id", None)
         val_file_id = validated_data.pop("val_file_id", None)
@@ -258,8 +289,9 @@ class ClassificationDatasetReleaseSerializer(AuthSerializer):
 
         创建 pending 状态的记录，触发 Celery 任务进行异步处理
         """
-        from apps.core.logger import mlops_logger as logger
         from rest_framework import serializers
+
+        from apps.core.logger import mlops_logger as logger
 
         dataset = validated_data.get("dataset")
         version = validated_data.get("version")
@@ -284,7 +316,9 @@ class ClassificationDatasetReleaseSerializer(AuthSerializer):
                     release.save(update_fields=["status", "file_size", "metadata"])
                 else:
                     logger.info(f"数据集版本已存在 - Dataset: {dataset.id}, Version: {version}, Status: {existing.status}")
-                    raise serializers.ValidationError(serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version))
+                    raise serializers.ValidationError(
+                        serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version)
+                    )
             else:
                 # 创建 pending 状态的发布记录
                 validated_data["status"] = "pending"

--- a/server/apps/mlops/serializers/log_clustering.py
+++ b/server/apps/mlops/serializers/log_clustering.py
@@ -1,10 +1,22 @@
+from io import StringIO
 from types import SimpleNamespace
 
 from rest_framework import serializers
 
 from apps.core.utils.serializers import AuthSerializer
-from apps.mlops.models.log_clustering import *
-from apps.mlops.utils.i18n import serializer_message
+from apps.mlops.models.log_clustering import (
+    LogClusteringDataset,
+    LogClusteringDatasetRelease,
+    LogClusteringServing,
+    LogClusteringTrainData,
+    LogClusteringTrainJob,
+)
+from apps.mlops.serializers.train_data_inline import (
+    BoundedInlineTrainDataListSerializer,
+    InlineTrainDataLimitExceeded,
+    consume_inline_records,
+    read_inline_train_data,
+)
 from apps.mlops.utils.group_scope import (
     assert_dataset_version_scope,
     assert_parent_team_matches,
@@ -12,6 +24,7 @@ from apps.mlops.utils.group_scope import (
     get_current_team,
     validate_requested_teams,
 )
+from apps.mlops.utils.i18n import serializer_message
 
 
 class LogClusteringDatasetSerializer(AuthSerializer):
@@ -35,6 +48,7 @@ class LogClusteringTrainDataSerializer(AuthSerializer):
     class Meta:
         model = LogClusteringTrainData
         fields = "__all__"
+        list_serializer_class = BoundedInlineTrainDataListSerializer
         extra_kwargs = {
             "name": {"required": False},
             "train_data": {"required": False},
@@ -67,13 +81,17 @@ class LogClusteringTrainDataSerializer(AuthSerializer):
         if self.include_train_data and instance.train_data:
             try:
                 # 读取文本文件内容，每行一条日志
-                file_content = instance.train_data.read().decode("utf-8")
+                file_content = read_inline_train_data(instance.train_data, self).decode("utf-8")
+                record_count = sum(1 for line in StringIO(file_content) if line.strip())
+                consume_inline_records(self, record_count)
                 lines = file_content.strip().split("\n")
                 data_list = [{"log": line} for line in lines if line.strip()]
 
                 representation["train_data"] = data_list
                 logger.info(f"Successfully loaded train_data for instance {instance.id}: {len(data_list)} logs")
 
+            except InlineTrainDataLimitExceeded:
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to read train_data for instance {instance.id}: {e}",
@@ -141,7 +159,9 @@ class LogClusteringDatasetReleaseSerializer(AuthSerializer):
             allow_failed_retry = bool(train_file_id and val_file_id and test_file_id) and existing and existing.status == "failed"
 
             if existing and not allow_failed_retry:
-                raise serializers.ValidationError({"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)})
+                raise serializers.ValidationError(
+                    {"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)}
+                )
 
         return attrs
 
@@ -149,8 +169,6 @@ class LogClusteringDatasetReleaseSerializer(AuthSerializer):
         """
         自定义创建方法，支持从文件ID创建数据集发布版本
         """
-        from apps.core.logger import mlops_logger as logger
-
         # 提取文件ID
         train_file_id = validated_data.pop("train_file_id", None)
         val_file_id = validated_data.pop("val_file_id", None)
@@ -194,7 +212,9 @@ class LogClusteringDatasetReleaseSerializer(AuthSerializer):
                     release.save(update_fields=["status", "file_size", "metadata"])
                 else:
                     logger.info(f"数据集版本已存在 - Dataset: {dataset.id}, Version: {version}, Status: {existing.status}")
-                    raise serializers.ValidationError(serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version))
+                    raise serializers.ValidationError(
+                        serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version)
+                    )
             else:
                 # 创建 pending 状态的发布记录
                 validated_data["status"] = "pending"

--- a/server/apps/mlops/serializers/timeseries_predict.py
+++ b/server/apps/mlops/serializers/timeseries_predict.py
@@ -2,10 +2,22 @@ from types import SimpleNamespace
 
 from rest_framework import serializers
 
-from apps.core.utils.serializers import AuthSerializer
-from apps.mlops.models.timeseries_predict import *
-from apps.mlops.utils.i18n import serializer_message
 from apps.core.logger import mlops_logger as logger
+from apps.core.utils.serializers import AuthSerializer
+from apps.mlops.models.timeseries_predict import (
+    TimeSeriesPredictDataset,
+    TimeSeriesPredictDatasetRelease,
+    TimeSeriesPredictServing,
+    TimeSeriesPredictTrainData,
+    TimeSeriesPredictTrainJob,
+)
+from apps.mlops.serializers.train_data_inline import (
+    BoundedInlineTrainDataListSerializer,
+    InlineTrainDataLimitExceeded,
+    consume_inline_records,
+    inline_csv_read_options,
+    open_inline_train_data,
+)
 from apps.mlops.utils.group_scope import (
     assert_dataset_version_scope,
     assert_parent_team_matches,
@@ -13,6 +25,7 @@ from apps.mlops.utils.group_scope import (
     get_current_team,
     validate_requested_teams,
 )
+from apps.mlops.utils.i18n import serializer_message
 
 
 class TimeSeriesPredictDatasetSerializer(AuthSerializer):
@@ -76,6 +89,7 @@ class TimeSeriesPredictTrainDataSerializer(AuthSerializer):
     class Meta:
         model = TimeSeriesPredictTrainData
         fields = "__all__"
+        list_serializer_class = BoundedInlineTrainDataListSerializer
 
     def __init__(self, *args, **kwargs):
         """
@@ -101,7 +115,9 @@ class TimeSeriesPredictTrainDataSerializer(AuthSerializer):
             required_columns = ["timestamp", "value"]
             missing = set(required_columns) - set(df.columns)
             if missing:
-                raise serializers.ValidationError(serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing)))
+                raise serializers.ValidationError(
+                    serializer_message(self, "error.training_data_required_columns_missing", columns=", ".join(missing))
+                )
 
             # 检查数据类型
             if df["value"].isnull().any():
@@ -124,8 +140,9 @@ class TimeSeriesPredictTrainDataSerializer(AuthSerializer):
         自定义返回数据，根据 include_train_data 参数动态控制 train_data 字段
         当 include_train_data=true 时，后端直接读取 CSV 并解析为结构化数据返回
         """
-        from apps.core.logger import mlops_logger as logger
         import pandas as pd
+
+        from apps.core.logger import mlops_logger as logger
 
         representation = super().to_representation(instance)
 
@@ -133,7 +150,18 @@ class TimeSeriesPredictTrainDataSerializer(AuthSerializer):
         if self.include_train_data and instance.train_data:
             try:
                 # 读取 CSV 文件
-                df = pd.read_csv(instance.train_data.open("rb"))
+                train_data_stream = open_inline_train_data(instance.train_data, self)
+                csv_options, csv_cells = inline_csv_read_options(self, train_data_stream)
+                df = pd.read_csv(
+                    train_data_stream,
+                    **csv_options,
+                )
+                consume_inline_records(
+                    self,
+                    len(df),
+                    csv_columns=len(df.columns),
+                    csv_cells=csv_cells,
+                )
 
                 # 🔥 处理 timestamp 字段：转换为 Unix 时间戳（秒）
                 if "timestamp" in df.columns:
@@ -154,6 +182,8 @@ class TimeSeriesPredictTrainDataSerializer(AuthSerializer):
                 representation["train_data"] = data_list
                 logger.info(f"Successfully loaded train_data for instance {instance.id}: {len(data_list)} rows")
 
+            except InlineTrainDataLimitExceeded:
+                raise
             except Exception as e:
                 logger.error(
                     f"Failed to read train_data for instance {instance.id}: {e}",
@@ -251,7 +281,9 @@ class TimeSeriesPredictDatasetReleaseSerializer(AuthSerializer):
             allow_failed_retry = bool(train_file_id and val_file_id and test_file_id) and existing and existing.status == "failed"
 
             if existing and not allow_failed_retry:
-                raise serializers.ValidationError({"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)})
+                raise serializers.ValidationError(
+                    {"version": serializer_message(self, "error.dataset_release_version_exists", dataset_name=dataset.name, version=version)}
+                )
 
         return attrs
 
@@ -300,7 +332,9 @@ class TimeSeriesPredictDatasetReleaseSerializer(AuthSerializer):
                     release.save(update_fields=["status", "file_size", "metadata"])
                 else:
                     logger.info(f"数据集版本已存在 - Dataset: {dataset.id}, Version: {version}, Status: {existing.status}")
-                    raise serializers.ValidationError(serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version))
+                    raise serializers.ValidationError(
+                        serializer_message(self, "error.dataset_release_version_unavailable", dataset_name=dataset.name, version=version)
+                    )
             else:
                 # 创建 pending 状态的发布记录
                 validated_data["status"] = "pending"

--- a/server/apps/mlops/serializers/train_data_inline.py
+++ b/server/apps/mlops/serializers/train_data_inline.py
@@ -1,0 +1,263 @@
+"""CSV/TXT TrainData 列表内联读取的统一资源边界。"""
+
+import os
+from io import BytesIO
+
+from rest_framework import serializers
+
+MAX_INLINE_LIST_ITEMS = 20
+MAX_INLINE_FILE_BYTES = 4 * 1024 * 1024
+MAX_INLINE_TOTAL_BYTES = 8 * 1024 * 1024
+MAX_INLINE_RECORDS = 50_000
+MAX_INLINE_CSV_COLUMNS = 256
+MAX_INLINE_CSV_CELLS = 500_000
+
+
+def _configured_limit(name, hard_limit):
+    """读取只能下调的资源额度，非法配置回退到安全硬上限。"""
+    try:
+        value = int(os.getenv(name, str(hard_limit)))
+    except (TypeError, ValueError):
+        return hard_limit
+    if value <= 0:
+        return hard_limit
+    return min(value, hard_limit)
+
+
+class InlineTrainDataLimitExceeded(serializers.ValidationError):
+    """列表内联读取超过稳定资源契约。"""
+
+    def __init__(self, reason, limit):
+        super().__init__(
+            {
+                "error": "inline_train_data_limit_exceeded",
+                "reason": reason,
+                "limit": limit,
+            },
+            code="inline_train_data_limit_exceeded",
+        )
+
+
+class _InlineTrainDataBudget:
+    def __init__(self):
+        self.max_list_items = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_LIST_ITEMS",
+            MAX_INLINE_LIST_ITEMS,
+        )
+        self.max_file_bytes = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES",
+            MAX_INLINE_FILE_BYTES,
+        )
+        self.max_total_bytes = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_TOTAL_BYTES",
+            MAX_INLINE_TOTAL_BYTES,
+        )
+        self.max_records = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_RECORDS",
+            MAX_INLINE_RECORDS,
+        )
+        self.max_csv_columns = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS",
+            MAX_INLINE_CSV_COLUMNS,
+        )
+        self.max_csv_cells = _configured_limit(
+            "MLOPS_INLINE_TRAIN_DATA_MAX_CSV_CELLS",
+            MAX_INLINE_CSV_CELLS,
+        )
+        self.used_bytes = 0
+        self.used_records = 0
+        self.used_csv_cells = 0
+        self.used_files = 0
+
+    def read(self, field_file):
+        if self.used_files >= self.max_list_items:
+            raise InlineTrainDataLimitExceeded("list_items", self.max_list_items)
+        self.used_files += 1
+        remaining_total_bytes = self.max_total_bytes - self.used_bytes
+        read_limit = min(self.max_file_bytes, remaining_total_bytes)
+        with field_file.storage.open(field_file.name, "rb") as stream:
+            content = _read_until_eof_or_limit(
+                stream,
+                read_limit + 1,
+                on_chunk=self._consume_transferred_bytes,
+            )
+        if len(content) > read_limit:
+            if self.max_file_bytes <= remaining_total_bytes:
+                raise InlineTrainDataLimitExceeded(
+                    "file_bytes",
+                    self.max_file_bytes,
+                )
+            raise InlineTrainDataLimitExceeded("total_bytes", self.max_total_bytes)
+        return content
+
+    def _consume_transferred_bytes(self, count):
+        self.used_bytes += count
+
+    @property
+    def remaining_records(self):
+        return self.max_records - self.used_records
+
+    @property
+    def remaining_csv_cells(self):
+        return self.max_csv_cells - self.used_csv_cells
+
+    def consume_records(self, count, csv_columns=None, csv_cells=None):
+        if csv_columns is not None and csv_columns > self.max_csv_columns:
+            raise InlineTrainDataLimitExceeded("csv_columns", self.max_csv_columns)
+        if count > self.remaining_records:
+            raise InlineTrainDataLimitExceeded("records", self.max_records)
+        output_cells = count * csv_columns if csv_columns is not None else 0
+        charged_csv_cells = max(csv_cells or 0, output_cells)
+        if charged_csv_cells > self.remaining_csv_cells:
+            raise InlineTrainDataLimitExceeded("csv_cells", self.max_csv_cells)
+        self.used_records += count
+        self.used_csv_cells += charged_csv_cells
+
+
+def _read_until_eof_or_limit(stream, limit, on_chunk=None):
+    content = bytearray()
+    remaining = limit
+    while remaining > 0:
+        chunk = stream.read(remaining)
+        if not chunk:
+            break
+        if on_chunk is not None:
+            on_chunk(len(chunk))
+        content.extend(chunk)
+        remaining -= len(chunk)
+    return bytes(content)
+
+
+def _scan_csv_shape(stream):
+    stream.seek(0)
+    content = stream.getbuffer()
+    stream.seek(0)
+    if not content:
+        return 1, 1, 0, 0
+
+    index = 0
+    if len(content) >= 3 and tuple(content[:3]) == (0xEF, 0xBB, 0xBF):
+        index = 3
+    header_columns = None
+    max_fields = 1
+    data_records = 0
+    data_fields = 0
+    fields = 1
+    in_quotes = False
+    at_field_start = True
+    record_nonblank = False
+
+    def finish_record():
+        nonlocal header_columns, max_fields, data_records, data_fields
+        if not record_nonblank:
+            return
+        if header_columns is None:
+            header_columns = fields
+        else:
+            data_records += 1
+            data_fields += fields
+        max_fields = max(max_fields, fields)
+
+    while index < len(content):
+        value = content[index]
+        if in_quotes and value == ord('"'):
+            if index + 1 < len(content) and content[index + 1] == ord('"'):
+                index += 1
+            else:
+                in_quotes = False
+        elif at_field_start and value == ord('"'):
+            in_quotes = True
+            at_field_start = False
+            record_nonblank = True
+        elif value == ord(",") and not in_quotes:
+            fields += 1
+            at_field_start = True
+            record_nonblank = True
+        elif value in (ord("\r"), ord("\n")) and not in_quotes:
+            finish_record()
+            fields = 1
+            at_field_start = True
+            record_nonblank = False
+            if value == ord("\r") and index + 1 < len(content) and content[index + 1] == ord("\n"):
+                index += 1
+        else:
+            at_field_start = False
+            if value not in (ord(" "), ord("\t")):
+                record_nonblank = True
+        index += 1
+    finish_record()
+    if header_columns is None:
+        return 1, 1, 0, 0
+    return header_columns, max_fields, data_records, data_fields
+
+
+def _prepare_collection(data):
+    if hasattr(data, "filter") and hasattr(data, "exclude"):
+        file_count = data.filter(train_data__isnull=False).exclude(train_data="").count()
+        return data, file_count
+    if not hasattr(data, "__len__"):
+        data = list(data)
+    return data, sum(bool(getattr(item, "train_data", None)) for item in data)
+
+
+class BoundedInlineTrainDataListSerializer(serializers.ListSerializer):
+    """仅为显式请求内联文件的列表设置固定最坏成本。"""
+
+    def to_representation(self, data):
+        if not self.child.include_train_data:
+            return super().to_representation(data)
+
+        data, file_count = _prepare_collection(data)
+        budget = _InlineTrainDataBudget()
+        if file_count > budget.max_list_items:
+            raise InlineTrainDataLimitExceeded("list_items", budget.max_list_items)
+
+        self.child._inline_train_data_budget = budget
+        try:
+            return super().to_representation(data)
+        finally:
+            del self.child._inline_train_data_budget
+
+
+def open_inline_train_data(field_file, serializer):
+    """列表走有界内存流；详情保持既有直读行为。"""
+    budget = getattr(serializer, "_inline_train_data_budget", None)
+    if budget is None:
+        return field_file.open("rb")
+    return BytesIO(budget.read(field_file))
+
+
+def read_inline_train_data(field_file, serializer):
+    """列表走有界字节读取；详情保持既有 FieldFile.read 行为。"""
+    budget = getattr(serializer, "_inline_train_data_budget", None)
+    if budget is None:
+        return field_file.read()
+    return budget.read(field_file)
+
+
+def inline_csv_read_options(serializer, stream):
+    """列表只让 Pandas 物化剩余额度加一行，以便可靠检测超限。"""
+    budget = getattr(serializer, "_inline_train_data_budget", None)
+    if budget is None:
+        return {}, None
+    csv_columns, max_fields, data_records, data_fields = _scan_csv_shape(stream)
+    if csv_columns > budget.max_csv_columns or max_fields > budget.max_csv_columns:
+        raise InlineTrainDataLimitExceeded("csv_columns", budget.max_csv_columns)
+    if data_records > budget.remaining_records:
+        raise InlineTrainDataLimitExceeded("records", budget.max_records)
+    parser_cells = max(data_fields, data_records * csv_columns)
+    if parser_cells > budget.remaining_csv_cells:
+        raise InlineTrainDataLimitExceeded("csv_cells", budget.max_csv_cells)
+    rows_by_cells = budget.remaining_csv_cells // csv_columns
+    return {"nrows": min(budget.remaining_records, rows_by_cells) + 1}, parser_cells
+
+
+def consume_inline_records(serializer, count, csv_columns=None, csv_cells=None):
+    """在构造 Python records 前占用请求级对象额度。"""
+    budget = getattr(serializer, "_inline_train_data_budget", None)
+    if budget is not None:
+        budget.consume_records(
+            count,
+            csv_columns=csv_columns,
+            csv_cells=csv_cells,
+        )

--- a/server/apps/mlops/tests/_issue_4248_inline_helpers.py
+++ b/server/apps/mlops/tests/_issue_4248_inline_helpers.py
@@ -1,0 +1,102 @@
+"""Issue #4248：TrainData 列表内联读取资源边界回归。"""
+
+import importlib
+from io import BytesIO
+from types import SimpleNamespace
+
+SERIALIZER_CASES = (
+    ("log_clustering", "LogClustering", b"first log\nsecond log\n"),
+    ("classification", "Classification", b"text,label\nhealthy,ok\n"),
+    (
+        "anomaly_detection",
+        "AnomalyDetection",
+        b"timestamp,value\n2026-01-01T00:00:00Z,10\n",
+    ),
+    (
+        "timeseries_predict",
+        "TimeSeriesPredict",
+        b"timestamp,value\n2026-01-01T00:00:00Z,10\n",
+    ),
+)
+
+RECORD_LIMIT_CASES = (
+    ("log_clustering", "LogClustering", b"first log\nsecond log\n"),
+    (
+        "classification",
+        "Classification",
+        b"text,label\nhealthy,ok\nunhealthy,bad\n",
+    ),
+    (
+        "anomaly_detection",
+        "AnomalyDetection",
+        b"timestamp,value\n2026-01-01T00:00:00Z,10\n2026-01-02T00:00:00Z,20\n",
+    ),
+    (
+        "timeseries_predict",
+        "TimeSeriesPredict",
+        b"timestamp,value\n2026-01-01T00:00:00Z,10\n2026-01-02T00:00:00Z,20\n",
+    ),
+)
+
+CSV_SERIALIZER_CASES = (
+    ("classification", "Classification"),
+    ("anomaly_detection", "AnomalyDetection"),
+    ("timeseries_predict", "TimeSeriesPredict"),
+)
+
+HTTP_TRAIN_DATA_CASES = (
+    ("anomaly_detection", "AnomalyDetection", "anomaly_detection_train_data"),
+    ("classification", "Classification", "classification_train_data"),
+    ("log_clustering", "LogClustering", "log_clustering_train_data"),
+    ("timeseries_predict", "TimeSeriesPredict", "timeseries_predict_train_data"),
+)
+
+
+def _request(mlops_user, *, include_train_data=True):
+    return SimpleNamespace(
+        user=mlops_user,
+        COOKIES={"current_team": "1"},
+        query_params={"include_train_data": "true" if include_train_data else "false"},
+        build_absolute_uri=lambda url: (url if url.startswith(("http://", "https://")) else f"http://testserver{url}"),
+    )
+
+
+def _fixed_base_content(seed):
+    return seed * max(1, 32 * 1024 // len(seed))
+
+
+def _classes(suffix, basename):
+    serializer_module = importlib.import_module(f"apps.mlops.serializers.{suffix}")
+    model_module = importlib.import_module(f"apps.mlops.models.{suffix}")
+    return (
+        getattr(serializer_module, f"{basename}TrainDataSerializer"),
+        getattr(model_module, f"{basename}Dataset"),
+        getattr(model_module, f"{basename}TrainData"),
+    )
+
+
+def _instances(suffix, basename, count):
+    serializer_class, Dataset, TrainData = _classes(suffix, basename)
+    dataset = Dataset(id=1, name="dataset", team=[1])
+    instances = [
+        TrainData(
+            id=index + 1,
+            name=f"train-{index}",
+            dataset=dataset,
+            train_data=f"fixtures/{index}.data",
+            metadata={},
+        )
+        for index in range(count)
+    ]
+    return serializer_class, instances
+
+
+def _install_file_reader(monkeypatch, instances, content, stream_factory=BytesIO):
+    reads = []
+
+    def open_file(name, *_args, **_kwargs):
+        reads.append(name)
+        return stream_factory(content)
+
+    monkeypatch.setattr(instances[0].train_data.storage, "open", open_file)
+    return reads

--- a/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_csv.py
+++ b/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_csv.py
@@ -1,0 +1,257 @@
+"""Issue #4248 CSV 形状、解析与对象放大契约。"""
+
+import pytest
+from rest_framework import serializers
+
+from apps.mlops.tests._issue_4248_inline_helpers import CSV_SERIALIZER_CASES, _install_file_reader, _instances, _request
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+@pytest.mark.parametrize(("suffix", "basename"), CSV_SERIALIZER_CASES)
+def test_inline_csv_rejects_wide_header_before_pandas_expansion(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"first,second,third\n1,2,3\n",
+    )
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["reason"] == "csv_columns"
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        b'first"alias,second,third\n1,2,3\n',
+        b"\n \t\nfirst,second,third\n",
+    ),
+)
+def test_inline_csv_column_scan_matches_pandas_header_selection(
+    monkeypatch,
+    mlops_user,
+    content,
+):
+    import pandas as pd
+
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(monkeypatch, instances, content)
+    pandas_calls = []
+
+    def unexpected_pandas_call(*_args, **_kwargs):
+        pandas_calls.append(True)
+        raise AssertionError("超宽 CSV 必须在 Pandas 前拒绝")
+
+    monkeypatch.setattr(pd, "read_csv", unexpected_pandas_call)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["reason"] == "csv_columns"
+    assert pandas_calls == []
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(
+    "content",
+    (
+        b"first,second\n1,2,3\n",
+        b'first,second\n"1,2",3,4\n',
+    ),
+)
+def test_inline_csv_rejects_wide_data_row_before_pandas_expansion(
+    monkeypatch,
+    mlops_user,
+    content,
+):
+    import pandas as pd
+
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        content,
+    )
+    pandas_calls = []
+
+    def unexpected_pandas_call(*_args, **_kwargs):
+        pandas_calls.append(True)
+        raise AssertionError("超宽数据行必须在 Pandas 前拒绝")
+
+    monkeypatch.setattr(pd, "read_csv", unexpected_pandas_call)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["reason"] == "csv_columns"
+    assert pandas_calls == []
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_csv_small_ragged_row_keeps_pandas_contract(
+    monkeypatch,
+    mlops_user,
+):
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nleft,middle,right\n",
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data[0]["train_data"][0]["text"] == "middle"
+    assert data[0]["train_data"][0]["label"] == "right"
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_csv_quoted_newline_and_escaped_quote_keep_record_shape(
+    monkeypatch,
+    mlops_user,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b'first,second\n"line one\nline two","quoted ""value"""\n',
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data[0]["train_data"][0]["first"] == "line one\nline two"
+    assert data[0]["train_data"][0]["second"] == 'quoted "value"'
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_csv_quoted_header_delimiter_keeps_two_columns(
+    monkeypatch,
+    mlops_user,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b'"first,alias",second\nhealthy,ok\n',
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert list(data[0]["train_data"][0]) == ["first,alias", "second", "index"]
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_csv_utf8_bom_keeps_quoted_header_contract(
+    monkeypatch,
+    mlops_user,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "2")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b'\xef\xbb\xbf"first,alias",second\nhealthy,ok\n',
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert list(data[0]["train_data"][0]) == ["first,alias", "second", "index"]
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(("suffix", "basename"), CSV_SERIALIZER_CASES)
+def test_inline_csv_rejects_total_cells_before_records_conversion(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", "10")
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_CELLS", "2")
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"first,second\n1,2\n3,4\n",
+    )
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["reason"] == "csv_cells"
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(("suffix", "basename"), CSV_SERIALIZER_CASES)
+@pytest.mark.parametrize(
+    "content",
+    (
+        b"",
+        b'first,second\n1,"unterminated\n',
+    ),
+)
+def test_inline_csv_parse_failures_keep_item_level_error_contract(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data[0]["train_data"] == []
+    assert "error" in data[0]
+    assert reads == ["fixtures/0.data"]

--- a/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_pure.py
+++ b/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_pure.py
@@ -1,0 +1,102 @@
+"""Issue #4248 纯预算与内存边界契约。"""
+
+import tracemalloc
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("name", "hard_limit"),
+    (
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_LIST_ITEMS", 20),
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES", 4 * 1024 * 1024),
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_TOTAL_BYTES", 8 * 1024 * 1024),
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_RECORDS", 50_000),
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_COLUMNS", 256),
+        ("MLOPS_INLINE_TRAIN_DATA_MAX_CSV_CELLS", 500_000),
+    ),
+)
+@pytest.mark.parametrize("configured", ("equal", "above", "zero", "negative", "invalid"))
+def test_inline_limit_configuration_cannot_disable_hard_boundary(
+    monkeypatch,
+    name,
+    hard_limit,
+    configured,
+):
+    from apps.mlops.serializers.train_data_inline import _configured_limit
+
+    values = {
+        "equal": str(hard_limit),
+        "above": str(hard_limit + 1),
+        "zero": "0",
+        "negative": "-1",
+        "invalid": "invalid",
+    }
+    monkeypatch.setenv(name, values[configured])
+
+    assert _configured_limit(name, hard_limit) == hard_limit
+
+
+def test_one_byte_remote_short_reads_keep_near_limit_memory_bounded():
+    from apps.mlops.serializers.train_data_inline import _read_until_eof_or_limit
+
+    content = b"abc" * (256 * 1024 // 3)
+
+    class OneByteStream(BytesIO):
+        def read(self, _size=-1):
+            return super().read(1)
+
+    tracemalloc.start()
+    result = _read_until_eof_or_limit(OneByteStream(content), len(content))
+    _, peak_bytes = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert result == content
+    assert peak_bytes < len(content) * 4
+
+
+def test_transferred_bytes_remain_charged_after_midstream_error(monkeypatch):
+    from apps.mlops.serializers.train_data_inline import InlineTrainDataLimitExceeded, _InlineTrainDataBudget
+
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES", "16")
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_TOTAL_BYTES", "20")
+    transferred = []
+
+    class FaultAfterChunk:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self, _size=-1):
+            if not transferred:
+                transferred.append(12)
+                return b"x" * 12
+            raise OSError("stream interrupted")
+
+    class TrackingStream(BytesIO):
+        def read(self, size=-1):
+            chunk = super().read(size)
+            transferred.append(len(chunk))
+            return chunk
+
+    class Storage:
+        def open(self, name, _mode):
+            if name == "first":
+                return FaultAfterChunk()
+            return TrackingStream(b"y" * 20)
+
+    storage = Storage()
+    budget = _InlineTrainDataBudget()
+    with pytest.raises(OSError, match="stream interrupted"):
+        budget.read(SimpleNamespace(storage=storage, name="first"))
+
+    assert budget.used_bytes == 12
+    with pytest.raises(InlineTrainDataLimitExceeded) as exc:
+        budget.read(SimpleNamespace(storage=storage, name="second"))
+
+    assert exc.value.detail["reason"] == "total_bytes"
+    assert sum(transferred) == 21

--- a/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_service.py
+++ b/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_service.py
@@ -1,0 +1,332 @@
+"""Issue #4248 serializer 与 storage 资源契约。"""
+
+from io import BytesIO
+
+import pytest
+from rest_framework import serializers
+
+from apps.mlops.tests._issue_4248_inline_helpers import (
+    RECORD_LIMIT_CASES,
+    SERIALIZER_CASES,
+    _fixed_base_content,
+    _install_file_reader,
+    _instances,
+    _request,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+@pytest.mark.parametrize(("suffix", "basename", "seed"), SERIALIZER_CASES)
+@pytest.mark.parametrize("record_count", (1, 10, 100))
+def test_fixed_base_1_10_100_growth_is_bounded(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    seed,
+    record_count,
+):
+    serializer_class, instances = _instances(suffix, basename, record_count)
+    content = _fixed_base_content(seed)
+    reads = _install_file_reader(monkeypatch, instances, content)
+    serializer = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    )
+
+    if record_count == 100:
+        with pytest.raises(serializers.ValidationError) as exc:
+            serializer.data
+        assert exc.value.detail["reason"] == "list_items"
+        assert reads == []
+    else:
+        assert len(serializer.data) == record_count
+        assert len(reads) == record_count
+        assert len(reads) * len(content) == record_count * len(content)
+
+
+@pytest.mark.parametrize(("suffix", "basename", "content"), SERIALIZER_CASES)
+def test_inline_list_over_item_limit_is_rejected_before_remote_reads(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    serializer_class, instances = _instances(suffix, basename, 100)
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["error"] == "inline_train_data_limit_exceeded"
+    assert exc.value.detail["reason"] == "list_items"
+    assert reads == []
+
+
+def test_inline_list_rechecks_item_limit_after_queryset_count(
+    monkeypatch,
+    mlops_user,
+):
+    serializer_class, instances = _instances("classification", "Classification", 21)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nhealthy,ok\n",
+    )
+
+    class GrowingQuerySet:
+        def filter(self, **_kwargs):
+            return self
+
+        def exclude(self, **_kwargs):
+            return self
+
+        def count(self):
+            return 20
+
+        def __iter__(self):
+            return iter(instances)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            GrowingQuerySet(),
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["reason"] == "list_items"
+    assert len(reads) == 20
+
+
+@pytest.mark.parametrize(("suffix", "basename", "content"), SERIALIZER_CASES)
+def test_inline_list_over_file_limit_has_stable_error(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES", "16")
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["error"] == "inline_train_data_limit_exceeded"
+    assert exc.value.detail["reason"] == "file_bytes"
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_list_over_total_limit_stops_at_bounded_prefix(
+    monkeypatch,
+    mlops_user,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES", "64")
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_TOTAL_BYTES", "32")
+    serializer_class, instances = _instances("classification", "Classification", 2)
+    content = b"text,label\nhealthy,ok\n"
+    reads = []
+    transferred = []
+
+    class TrackingStream(BytesIO):
+        def read(self, size=-1):
+            chunk = super().read(size)
+            transferred.append(len(chunk))
+            return chunk
+
+    def open_file(name, *_args, **_kwargs):
+        reads.append(name)
+        return TrackingStream(content)
+
+    monkeypatch.setattr(instances[0].train_data.storage, "open", open_file)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["error"] == "inline_train_data_limit_exceeded"
+    assert exc.value.detail["reason"] == "total_bytes"
+    assert reads == ["fixtures/0.data", "fixtures/1.data"]
+    assert sum(transferred) == 33
+
+
+@pytest.mark.parametrize(("suffix", "basename", "content"), RECORD_LIMIT_CASES)
+def test_inline_list_record_limit_bounds_parser_object_expansion(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_RECORDS", "1")
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    with pytest.raises(serializers.ValidationError) as exc:
+        serializer_class(
+            instances,
+            many=True,
+            context={"request": _request(mlops_user)},
+        ).data
+
+    assert exc.value.detail["error"] == "inline_train_data_limit_exceeded"
+    assert exc.value.detail["reason"] == "records"
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(("suffix", "basename", "content"), SERIALIZER_CASES)
+def test_inline_list_reads_short_remote_chunks_until_eof(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    class ShortReadStream(BytesIO):
+        def read(self, size=-1):
+            return super().read(min(size, 3))
+
+    serializer_class, instances = _instances(suffix, basename, 1)
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        content,
+        stream_factory=ShortReadStream,
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert len(data[0]["train_data"]) >= 1
+    assert "error" not in data[0]
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_txt_invalid_utf8_keeps_item_level_error_contract(
+    monkeypatch,
+    mlops_user,
+):
+    serializer_class, instances = _instances("log_clustering", "LogClustering", 1)
+    reads = _install_file_reader(monkeypatch, instances, b"\xff")
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data[0]["train_data"] == []
+    assert "error" in data[0]
+    assert reads == ["fixtures/0.data"]
+
+
+def test_inline_storage_missing_does_not_block_following_item(
+    monkeypatch,
+    mlops_user,
+):
+    serializer_class, instances = _instances("classification", "Classification", 2)
+    reads = []
+
+    def open_file(name, *_args, **_kwargs):
+        reads.append(name)
+        if name == "fixtures/0.data":
+            raise FileNotFoundError(name)
+        return BytesIO(b"text,label\nhealthy,ok\n")
+
+    monkeypatch.setattr(instances[0].train_data.storage, "open", open_file)
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data[0]["train_data"] == []
+    assert "error" in data[0]
+    assert data[1]["train_data"][0]["text"] == "healthy"
+    assert reads == ["fixtures/0.data", "fixtures/1.data"]
+
+
+def test_normal_inline_list_preserves_order_and_duplicate_instances(
+    monkeypatch,
+    mlops_user,
+):
+    serializer_class, instances = _instances("classification", "Classification", 2)
+    instances = [instances[1], instances[0], instances[1]]
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nhealthy,ok\n",
+    )
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert [item["id"] for item in data] == [2, 1, 2]
+    assert reads == ["fixtures/1.data", "fixtures/0.data", "fixtures/1.data"]
+    assert [item["train_data"][0]["text"] for item in data] == [
+        "healthy",
+        "healthy",
+        "healthy",
+    ]
+
+
+def test_detail_inline_read_keeps_existing_unbounded_behavior(
+    monkeypatch,
+    mlops_user,
+):
+    monkeypatch.setenv("MLOPS_INLINE_TRAIN_DATA_MAX_FILE_BYTES", "16")
+    serializer_class, instances = _instances("classification", "Classification", 1)
+    content = b"text,label\nhealthy,ok\n"
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    data = serializer_class(
+        instances[0],
+        context={"request": _request(mlops_user)},
+    ).data
+
+    assert data["train_data"][0]["text"] == "healthy"
+    assert reads == ["fixtures/0.data"]
+
+
+@pytest.mark.parametrize(("suffix", "basename", "content"), SERIALIZER_CASES)
+def test_list_without_inline_data_keeps_zero_remote_reads(
+    monkeypatch,
+    mlops_user,
+    suffix,
+    basename,
+    content,
+):
+    serializer_class, instances = _instances(suffix, basename, 100)
+    reads = _install_file_reader(monkeypatch, instances, content)
+
+    data = serializer_class(
+        instances,
+        many=True,
+        context={"request": _request(mlops_user, include_train_data=False)},
+    ).data
+
+    assert len(data) == 100
+    assert reads == []
+    assert all("train_data" not in item for item in data)

--- a/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_views.py
+++ b/server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_views.py
@@ -1,0 +1,205 @@
+"""Issue #4248 四类 HTTP 列表契约。"""
+
+import pytest
+
+from apps.mlops.tests._issue_4248_inline_helpers import HTTP_TRAIN_DATA_CASES, _classes, _install_file_reader
+
+pytestmark = [pytest.mark.integration, pytest.mark.django_db]
+
+
+@pytest.mark.parametrize("page_size", (None, "0", "-1"))
+def test_http_list_rejects_unpaginated_inline_expansion_before_storage(
+    monkeypatch,
+    mlops_api_client,
+    page_size,
+):
+    from apps.mlops.models.classification import ClassificationDataset, ClassificationTrainData
+
+    dataset = ClassificationDataset.objects.create(
+        name="dataset",
+        description="",
+        team=[1],
+    )
+    instances = ClassificationTrainData.objects.bulk_create(
+        [
+            ClassificationTrainData(
+                name=f"train-{index}",
+                dataset=dataset,
+                train_data=f"fixtures/{index}.csv",
+            )
+            for index in range(21)
+        ]
+    )
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nhealthy,ok\n",
+    )
+    query = {"include_train_data": "true"}
+    if page_size is not None:
+        query["page_size"] = page_size
+
+    response = mlops_api_client.get(
+        "/api/v1/mlops/classification_train_data/",
+        query,
+    )
+
+    assert response.status_code == 400
+    assert response.data["error"] == "inline_train_data_limit_exceeded"
+    assert response.data["reason"] == "list_items"
+    assert reads == []
+
+
+def test_http_list_budget_counts_only_current_team_records(
+    monkeypatch,
+    mlops_api_client,
+):
+    from apps.mlops.models.classification import ClassificationDataset, ClassificationTrainData
+
+    visible_dataset = ClassificationDataset.objects.create(
+        name="visible",
+        description="",
+        team=[1],
+    )
+    hidden_dataset = ClassificationDataset.objects.create(
+        name="hidden",
+        description="",
+        team=[2],
+    )
+    visible = ClassificationTrainData.objects.create(
+        name="visible",
+        dataset=visible_dataset,
+        train_data="fixtures/visible.csv",
+    )
+    hidden = ClassificationTrainData.objects.bulk_create(
+        [
+            ClassificationTrainData(
+                name=f"hidden-{index}",
+                dataset=hidden_dataset,
+                train_data=f"fixtures/hidden-{index}.csv",
+            )
+            for index in range(100)
+        ]
+    )
+    reads = _install_file_reader(
+        monkeypatch,
+        [visible, *hidden],
+        b"text,label\nhealthy,ok\n",
+    )
+
+    response = mlops_api_client.get(
+        "/api/v1/mlops/classification_train_data/",
+        {"include_train_data": "true", "page_size": "-1"},
+    )
+
+    assert response.status_code == 200
+    assert [item["id"] for item in response.data] == [visible.id]
+    assert reads == ["fixtures/visible.csv"]
+
+
+@pytest.mark.parametrize(("suffix", "basename", "endpoint"), HTTP_TRAIN_DATA_CASES)
+def test_all_http_train_data_lists_share_stable_limit_error(
+    monkeypatch,
+    mlops_api_client,
+    suffix,
+    basename,
+    endpoint,
+):
+    _, Dataset, TrainData = _classes(suffix, basename)
+    dataset = Dataset.objects.create(name="dataset", description="", team=[1])
+    instances = TrainData.objects.bulk_create(
+        [
+            TrainData(
+                name=f"train-{index}",
+                dataset=dataset,
+                train_data=f"fixtures/{index}.data",
+            )
+            for index in range(21)
+        ]
+    )
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nhealthy,ok\n",
+    )
+
+    response = mlops_api_client.get(
+        f"/api/v1/mlops/{endpoint}/",
+        {"include_train_data": "true", "page_size": "-1"},
+    )
+
+    assert response.status_code == 400
+    assert response.data["error"] == "inline_train_data_limit_exceeded"
+    assert response.data["reason"] == "list_items"
+    assert reads == []
+
+
+def test_http_inline_list_keeps_normal_paginated_response_contract(
+    monkeypatch,
+    mlops_api_client,
+):
+    from apps.mlops.models.classification import ClassificationDataset, ClassificationTrainData
+
+    dataset = ClassificationDataset.objects.create(
+        name="dataset",
+        description="",
+        team=[1],
+    )
+    instances = ClassificationTrainData.objects.bulk_create(
+        [
+            ClassificationTrainData(
+                name=f"train-{index}",
+                dataset=dataset,
+                train_data=f"fixtures/{index}.csv",
+            )
+            for index in range(21)
+        ]
+    )
+    reads = _install_file_reader(
+        monkeypatch,
+        instances,
+        b"text,label\nhealthy,ok\n",
+    )
+
+    response = mlops_api_client.get(
+        "/api/v1/mlops/classification_train_data/",
+        {"include_train_data": "true", "page": "1", "page_size": "10"},
+    )
+
+    assert response.status_code == 200
+    assert response.data["count"] == 21
+    assert len(response.data["items"]) == 10
+    assert len(reads) == 10
+
+
+def test_http_inline_list_denies_without_view_permission_before_storage(
+    monkeypatch,
+    mlops_api_client,
+    mlops_user,
+):
+    from apps.mlops.models.classification import ClassificationDataset, ClassificationTrainData
+
+    dataset = ClassificationDataset.objects.create(
+        name="dataset",
+        description="",
+        team=[1],
+    )
+    instance = ClassificationTrainData.objects.create(
+        name="train",
+        dataset=dataset,
+        train_data="fixtures/train.csv",
+    )
+    reads = _install_file_reader(
+        monkeypatch,
+        [instance],
+        b"text,label\nhealthy,ok\n",
+    )
+    mlops_user.permission = {"mlops": set()}
+
+    response = mlops_api_client.get(
+        "/api/v1/mlops/classification_train_data/",
+        {"include_train_data": "true", "page_size": "-1"},
+    )
+
+    assert response.status_code == 403
+    assert reads == []


### PR DESCRIPTION
## 问题

四类 CSV/TXT TrainData 的列表与详情共用 serializer。列表请求显式携带 `include_train_data=true` 时，序列化阶段会逐项打开对象存储文件；共享分页器又允许分页参数缺省、`0`、`-1` 返回完整查询集，导致单次请求的远程读取次数、解析量和响应内存随历史文件总量无界增长。

## 根因

远程文件读取与 Pandas/Python 对象物化发生在单条 `to_representation` 内，原先没有请求级资源上下文。列表层既无法在首次读取前判断整体规模，也无法约束跨文件累计字节、records、CSV 列和 cells，存储短读或中途异常还会让事后计量失真。

## 怎么修的

- 为四类 TrainData 配置统一的有界 ListSerializer；只在列表显式内联时启用，详情保持原行为。
- 在团队过滤和分页之后预检有效文件数，并在每次实际读取前再次消费额度，关闭查询计数与迭代之间的并发增长窗口。
- 通过独立 `storage.open` 流循环处理短读，并在每个 chunk 到达时即时计费；中途异常不退还已传输字节。
- 在 Pandas 前扫描全部 CSV 逻辑 records，处理 BOM、空行、quoted newline 和 escaped quote；限制最大字段数、records 与实际 parser cells，解析后再以 DataFrame 实际行列二次校验。
- 超限统一返回 HTTP 400：`error=inline_train_data_limit_exceeded`，并携带稳定的 `reason` 与 `limit`。

默认硬边界如下，环境变量只能下调，不能放宽或关闭：列表文件 20、单文件 4 MiB、请求累计 8 MiB、records 50,000、CSV fields 256、CSV cells 500,000。

## 影响范围

- 默认不传 `include_train_data` 的列表仍不读取对象文件。
- 正常分页、详情内联、团队过滤、排序、重复实例、缺失文件、CSV 解析异常、TXT 非法 UTF-8 及逐项错误响应保持原契约。
- 小规模 ragged CSV 保留既有 Pandas 解析语义；只有超过硬资源边界的请求由原成功改为稳定 400。
- 未修改共享分页器、数据库模型、权限规则或对象存储数据，无迁移；回滚为删除本提交。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["TrainData ViewSet.list\nserver/apps/mlops/views"]
    end

    Q["团队过滤 + 分页\nQuerySet / page"]

    subgraph N["有界处理层"]
        N1["BoundedInlineTrainDataListSerializer\ntrain_data_inline.py"]
        N2["storage.open + chunk 计费\n文件数 / bytes"]
        N3["CSV/TXT shape + parser\nrecords / fields / cells"]
    end

    E["稳定 400\nerror / reason / limit"]

    T1 --> Q --> N1 --> N2 --> N3
    N1 -. "条数超限" .-> E
    N2 -. "字节超限" .-> E
    N3 -. "对象形状超限" .-> E
```

## 验证

- `server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_service.py`
- `server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_csv.py`
- `server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_views.py`
- `server/apps/mlops/tests/test_issue_4248_inline_train_data_limits_pure.py`
- 定向结果：100 passed；共享资源边界覆盖率 97%。
- 固定输入对比：四类在 N=100 时由修复前各 100 次文件读取，变为修复后预检阶段 0 次读取；N=1/10 的正常规模结果保持。
- isort、Black、flake8 与 diff-check 均通过。

## 三轨门禁

- Standards：pass，99/100。
- Spec：pass，98/100。
- Runtime Contract：pass，97/100。四类 HTTP、权限、分页、短读、中断、异常与兼容路径已验证；真实 MinIO 网络实现未接入本地验证，存储边界通过生产 `storage.open` 配合受控流覆盖。

关联 Issue #4248。
