### PR TITLE
feat(monitor): 告警详情支持按权限跳转策略编辑

### DIFF
--- a/server/apps/monitor/views/monitor_alert.py
+++ b/server/apps/monitor/views/monitor_alert.py
@@ -116,6 +116,48 @@ class AlertPermissionMixin:
         accessible_policy_ids = self._get_all_accessible_policy_ids(request)
         return alert_obj.policy_id in accessible_policy_ids
 
+    def _build_policy_permission_map(self, request, policies):
+        """为告警列表补充每条策略的实例权限，供前端编辑按钮门控。"""
+        if not policies:
+            return {}
+
+        if request.user.is_superuser:
+            return {
+                policy.id: PermissionConstants.DEFAULT_PERMISSION for policy in policies
+            }
+
+        scope = self._get_data_scope(request)
+        permissions_result = get_permissions_rules(
+            request.user,
+            scope.current_team,
+            "monitor",
+            PermissionConstants.POLICY_MODULE,
+            include_children=scope.include_children,
+        )
+        if not isinstance(permissions_result, dict):
+            return {}
+
+        policy_permissions = permissions_result.get("data", {})
+        cur_team = permissions_result.get("team", [])
+        if not isinstance(policy_permissions, dict) or not isinstance(cur_team, list):
+            return {}
+
+        permission_map = {}
+        for policy_obj in policies:
+            monitor_object_id = str(policy_obj.monitor_object_id)
+            teams = {
+                org.organization for org in policy_obj.policyorganization_set.all()
+            }
+            permissions = get_instance_permissions(
+                monitor_object_id,
+                policy_obj.id,
+                teams,
+                policy_permissions,
+                cur_team,
+            )
+            permission_map[policy_obj.id] = permissions
+        return permission_map
+
 
 class MonitorAlertViewSet(
     AlertPermissionMixin,
@@ -187,18 +229,16 @@ class MonitorAlertViewSet(
 
         # 将策略和实例数据映射到字典中
         policy_dict = {policy.id: policy for policy in policies}
-
-        # # 如果有权限规则，则添加到数据中
-        # inst_permission_map = {i["id"]: i["permission"] for i in permission.get("instance", [])}
+        policy_permission_map = self._build_policy_permission_map(request, policies)
 
         # 补充策略和实例到每个 alert 中
 
         for alert in results:
-            # # 补充权限信息
-            # if alert["policy_id"] in inst_permission_map:
-            #     alert["permission"] = inst_permission_map[alert["policy_id"]]
-            # else:
-            #     alert["permission"] = DEFAULT_PERMISSION
+            policy_id = alert["policy_id"]
+            if policy_id in policy_permission_map:
+                alert["policy_permission"] = policy_permission_map[policy_id]
+            elif policy_id:
+                alert["policy_permission"] = PermissionConstants.DEFAULT_PERMISSION
 
             # 补充instance_id_values
 

--- a/web/src/app/monitor/(pages)/event/alert/information.tsx
+++ b/web/src/app/monitor/(pages)/event/alert/information.tsx
@@ -17,6 +17,7 @@ import { OBJECT_DEFAULT_ICON, LEVEL_MAP } from '@/app/monitor/constants';
 import Permission from '@/components/permission';
 import { formatUserDisplayName } from '@/utils/userDisplay';
 import { getPolicySecondaryContext } from '@/app/monitor/utils/policyDisplayName';
+import { buildMonitorStrategyDetailUrl } from '@/app/monitor/utils/policyRouteUtils';
 import { buildAlertDimensionDisplayItems } from './alertDimensionUtils';
 
 interface InformationProps extends TableDataItem {
@@ -64,6 +65,20 @@ const Information: React.FC<InformationProps> = ({
     };
     const queryString = new URLSearchParams(params).toString();
     const url = `/monitor/view/detail?${queryString}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const openPolicyEdit = (row: TableDataItem) => {
+    const monitorItem = objects.find(
+      (item: ObjectItem) => item.id === row.policy?.monitor_object
+    );
+    if (!row.policy?.id || !row.policy?.monitor_object) return;
+    const url = buildMonitorStrategyDetailUrl('edit', {
+      monitorObjId: row.policy.monitor_object,
+      monitorName: monitorItem?.name || monitorItem?.display_name || '',
+      id: row.policy.id,
+      name: row.policy.name || ''
+    });
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
@@ -188,12 +203,29 @@ const Information: React.FC<InformationProps> = ({
               monitor_object_display_name: monitorObj?.display_name || monitorObj?.name
             });
             return (
-              <div>
-                <div>{formData.policy?.name || '--'}</div>
-                {secondary ? (
-                  <div className="mt-0.5 text-[12px] leading-4 text-[var(--color-text-3)]">
-                    {secondary}
-                  </div>
+              <div className="flex justify-between items-start gap-2">
+                <div className="min-w-0 flex-1">
+                  <div>{formData.policy?.name || '--'}</div>
+                  {secondary ? (
+                    <div className="mt-0.5 text-[12px] leading-4 text-[var(--color-text-3)]">
+                      {secondary}
+                    </div>
+                  ) : null}
+                </div>
+                {formData.policy?.id ? (
+                  <Permission
+                    requiredPermissions={['Edit']}
+                    permissionPath="/monitor/event/strategy"
+                    instPermissions={formData.policy_permission ?? []}
+                  >
+                    <Button
+                      type="link"
+                      className="shrink-0 ml-2 p-0 h-auto"
+                      onClick={() => openPolicyEdit(formData)}
+                    >
+                      {t('common.edit')}
+                    </Button>
+                  </Permission>
                 ) : null}
               </div>
             );

--- a/web/src/app/monitor/(pages)/event/strategy/page.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/page.tsx
@@ -20,6 +20,7 @@ import CustomTable from '@/components/custom-table';
 import SelectAssets from './selectAssets';
 import UserAvatar from '@/components/user-avatar';
 import { findLabelById } from '@/app/monitor/utils/common';
+import { buildMonitorStrategyDetailUrl } from '@/app/monitor/utils/policyRouteUtils';
 import { useLocalizedTime } from '@/hooks/useLocalizedTime';
 import { PlusOutlined } from '@ant-design/icons';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -381,15 +382,14 @@ const Strategy: React.FC = () => {
   const linkToStrategyDetail = (type: string, row = { id: '', name: '' }) => {
     const monitorObjId = objectId as string;
     const monitorName = findLabelById(treeData, monitorObjId) as string;
-    const params = new URLSearchParams({
-      monitorObjId,
-      monitorName,
-      type,
-      id: row.id,
-      name: row.name
-    });
-    const targetUrl = `/monitor/event/strategy/detail?${params.toString()}`;
-    router.push(targetUrl);
+    router.push(
+      buildMonitorStrategyDetailUrl(type, {
+        monitorObjId,
+        monitorName,
+        id: row.id,
+        name: row.name
+      })
+    );
   };
 
   return (

--- a/web/src/app/monitor/utils/policyRouteUtils.ts
+++ b/web/src/app/monitor/utils/policyRouteUtils.ts
@@ -1,0 +1,26 @@
+export type MonitorStrategyDetailType = 'edit' | 'add' | 'builtIn';
+
+export interface MonitorStrategyDetailParams {
+  id?: string | number;
+  name?: string;
+  monitorObjId: string | number;
+  monitorName: string;
+}
+
+export function buildMonitorStrategyDetailUrl(
+  type: MonitorStrategyDetailType | string,
+  params: MonitorStrategyDetailParams
+): string {
+  const searchParams = new URLSearchParams({
+    monitorObjId: String(params.monitorObjId),
+    monitorName: params.monitorName,
+    type
+  });
+  if (params.id !== undefined && params.id !== '') {
+    searchParams.set('id', String(params.id));
+  }
+  if (params.name) {
+    searchParams.set('name', params.name);
+  }
+  return `/monitor/event/strategy/detail?${searchParams.toString()}`;
+}


### PR DESCRIPTION
## Summary
- 告警详情「策略名称」旁增加编辑按钮，有权限时新开 Tab 进入策略编辑页
- 告警列表接口补充 `policy_permission`，与策略列表的 Edit + Operate 双门控对齐
- 抽取 `buildMonitorStrategyDetailUrl` 供告警详情与策略列表复用
- 修复：`policy_permission` 缺失时不再回退为默认 Operate，避免误放行

## Test plan
- [ ] admin：打开告警详情 → 编辑可点 → 新 Tab 进入正确策略编辑页
- [ ] demo（仅 View）：同一告警详情 → 编辑灰显，悬停「无权限」
- [ ] 策略列表新建/编辑跳转仍正常
- [ ] 告警列表、关闭告警等既有能力无回归