### PR TITLE
fix(monitor): SNMPv3 密码改 sidecar env 下发，并统一接入 Select 宽度

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_arris/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/bdcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_bdcom/bdcom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_casa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_casa/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_cdata/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_cdata/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_fiberhome_olt/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_fiberhome_olt/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_harmonic/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_harmonic/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_icotera/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_icotera/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_nateks/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_packetfront/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_packetfront/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_rad/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_rad/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_raisecom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_topvision/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_topvision/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_utstarcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_utstarcom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_vsolution/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_vsolution/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_zhone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/access_zhone/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_avocent/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_avocent/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_lantronix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_lantronix/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/opengear.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_opengear/opengear.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_perle/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_perle/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_raritan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_raritan/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_wti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/console_server_wti/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/amaranten.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_amaranten/amaranten.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_barracuda/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_barracuda/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/blockbit.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/blockbit.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/bluedon.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_bluedon/bluedon.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/checkpoint.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_checkpoint/checkpoint.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/clavister.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_clavister/clavister.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/dptech.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_dptech/dptech.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/forcepoint.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_forcepoint/forcepoint.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/fortinet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_fortinet/fortinet.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/genua.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_genua/genua.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/hillstone.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_hillstone/hillstone.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/huawei_usg.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_huawei/huawei_usg.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/kerio.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_kerio/kerio.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/neteye.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_neteye/neteye.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/opnsense.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_opnsense/opnsense.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/paloalto.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_paloalto/paloalto.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/pfsense.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pfsense/pfsense.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/pulsesecure.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_pulsesecure/pulsesecure.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/sangfor.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sangfor/sangfor.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/screenos.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_screenos/screenos.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/secworld.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_secworld/secworld.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/sonicwall.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sonicwall/sonicwall.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/sophos.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_sophos/sophos.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/stormshield.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_stormshield/stormshield.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/watchguard.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_watchguard/watchguard.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/westone.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_westone/westone.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/zorp.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_zorp/zorp.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/hardware_server.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/hardware_server/hardware_server.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/a10.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_a10/a10.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/alteon.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_alteon/alteon.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/f5.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_f5/f5.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/fortiadc.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_fortiadc/fortiadc.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/kemp.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_kemp/kemp.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/netscaler.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_netscaler/netscaler.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_relianoid/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_relianoid/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/superiority.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/loadbalance_superiority/superiority.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/accedian.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_accedian/accedian.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_allot/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_allot/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_apc/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_apc/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_asentria/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_asentria/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_bluecat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_bluecat/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_deva/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_deva/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_eaton/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_eaton/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_efficientip/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_efficientip/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endace/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endace/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endrun/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_endrun/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_enlogic/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_enlogic/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_geist/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_geist/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/gigamon.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gigamon/gigamon.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gude/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_gude/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/infoblox.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_infoblox/infoblox.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_liebert/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_liebert/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_meinberg/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_meinberg/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nomadix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nomadix/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_nti/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_panduit/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_panduit/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_rittal/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_rittal/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_servertech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_servertech/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_socomec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_socomec/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_spectracom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_spectracom/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_tripplite/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_tripplite/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/network_service_zdns/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/adtran.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_adtran/adtran.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/aethra.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_aethra/aethra.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/avaya.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avaya/avaya.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/avici.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_avici/avici.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_benu/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/bintec.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_bintec/bintec.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/cradlepoint.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_cradlepoint/cradlepoint.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/digi.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_digi/digi.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/draytek.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_draytek/draytek.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/harbour.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_harbour/harbour.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/huawei_ar.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_huawei_ar/huawei_ar.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/juniper_mx.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_juniper_mx/juniper_mx.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_lancom/lancom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_mikrotik/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_milesight/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/multitech.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_multitech/multitech.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/nec.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_nec/nec.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/netmodule.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_netmodule/netmodule.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/oneaccess.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_oneaccess/oneaccess.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/sierrawireless.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_sierrawireless/sierrawireless.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/teldat.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teldat/teldat.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/teltonika.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_teltonika/teltonika.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/unisphere.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_unisphere/unisphere.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_velocloud/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_velocloud/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/versa.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_versa/versa.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/viprinet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_viprinet/viprinet.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/vyatta.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_vyatta/vyatta.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/yamaha.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_yamaha/yamaha.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/3com.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_3com/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/advantech.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_advantech/advantech.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/alaxala.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alaxala/alaxala.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/alcatel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alcatel/alcatel.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/alliedtelesis.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_alliedtelesis/alliedtelesis.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/allnet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_allnet/allnet.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_antaira/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_antaira/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_apresia/apresia.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/arista.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_arista/arista.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/aruba.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_aruba/aruba.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_asterfusion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_asterfusion/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_atop/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_atop/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_bdcom/bdcom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/brocade.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_brocade/brocade.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/cisco.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cisco/cisco.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_comtrol/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_comtrol/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/cumulus.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_cumulus/cumulus.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/datacom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_datacom/datacom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/dcn.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dcn/dcn.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/dellforce.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellforce/dellforce.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/dellos10.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dellos10/dellos10.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/dlink.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_dlink/dlink.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_edgecore/edgecore.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/eltex.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_eltex/eltex.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_enterasys/enterasys.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/etherwan.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_etherwan/etherwan.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/extreme.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_extreme/extreme.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/fiberhome.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fiberhome/fiberhome.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/fortiswitch.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fortiswitch/fortiswitch.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/fs.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_fs/fs.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/futurematrix.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_futurematrix/futurematrix.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_garretcom/garretcom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_h3c/h3c.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hirschmann/hirschmann.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/hphpn.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_hphpn/hphpn.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/huawei.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_huawei/huawei.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_inhand/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_inhand/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/intelbras.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_intelbras/intelbras.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ipinfusion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ipinfusion/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/juniper.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_juniper/juniper.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/korenix.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_korenix/korenix.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_kyland/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_kyland/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lantech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lantech/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/lenovocnos.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_lenovocnos/lenovocnos.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_maipu/maipu.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/mellanox.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mellanox/mellanox.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_microsens/microsens.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/mikrotik.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_mikrotik/mikrotik.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/moxa.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_moxa/moxa.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_murrelektronik/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_murrelektronik/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/netgear.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netgear/netgear.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/netonix.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_netonix/netonix.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/nexans.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nexans/nexans.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_nokia/nokia.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/omniswitch.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omniswitch/omniswitch.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omnitron/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_omnitron/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/parks.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_parks/parks.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/phoenixcontact.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_phoenixcontact/phoenixcontact.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/pica8.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pica8/pica8.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_planet/planet.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/pluribus.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_pluribus/pluribus.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/qtech.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_qtech/qtech.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/redlion.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_redlion/redlion.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_rubytech/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_rubytech/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruggedcom/ruggedcom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/ruijie.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ruijie/ruijie.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/scalance.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_scalance/scalance.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/sixnet.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_sixnet/sixnet.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/snr.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_snr/snr.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/tplink.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tplink/tplink.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/transition.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_transition/transition.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_tsntec/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/ubiquiti.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquiti/ubiquiti.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquoss/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_ubiquoss/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_wago/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_wago/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/waystream.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_waystream/waystream.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_weidmuller/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_weidmuller/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_westermo/westermo.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_witek/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_womaster/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_womaster/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_xikestor/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_xikestor/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/yamaha.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_yamaha/yamaha.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/zte.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zte/zte.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/zyxel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/switch_zyxel/zyxel.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_alcoma/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_alcoma/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_bridgewave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_bridgewave/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/ciena.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ciena/ciena.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_dragonwave/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ekinops/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ekinops/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ericsson/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ericsson/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_exalt/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_exalt/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_fibrolan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_fibrolan/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_hubersuhner/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ifotec/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_ifotec/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_infinera/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_infinera/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_marconi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_marconi/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_mrv/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_mrv/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_packetlight/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_packetlight/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_pandacom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_pandacom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_redline/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_redline/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_saftehnika/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_saftehnika/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_siae/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_sycamore/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_sycamore/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_tachyon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_tachyon/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_viavi/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_viavi/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/transmission_xkl/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_acmepacket/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_acmepacket/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_addpac/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_addpac/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/audiocodes.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_audiocodes/audiocodes.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_innovaphone/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_innovaphone/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_mitel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_mitel/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_patton/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_patton/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_polycom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_polycom/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_ribbon/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_ribbon/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_sangoma/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_sangoma/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_yeastar/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_yeastar/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/voice_gateway_zenitel/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_acksys/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_acksys/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/aerohive.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_aerohive/aerohive.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_airspan/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_airspan/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/albentia.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_albentia/albentia.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/ascom.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_ascom/ascom.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/cambium.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_cambium/cambium.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/engenius.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_engenius/engenius.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/grandstream.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_grandstream/grandstream.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_prosoft/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_prosoft/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
@@ -222,10 +222,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.auth_password",
-        "to_api": {}
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
       },
-      "label_en": "Auth Password"
+      "label_en": "Auth Password",
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -290,10 +290,10 @@
         ]
       },
       "transform_on_edit": {
-        "origin_path": "child.content.config.priv_password",
-        "to_api": {}
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
       },
-      "label_en": "Privacy Password"
+      "label_en": "Privacy Password",
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/UI.json
@@ -191,7 +191,7 @@
       "label_en": "Auth Protocol"
     },
     {
-      "name": "auth_password",
+      "name": "ENV_AUTH_PASSWORD",
       "label": "认证密码",
       "type": "password",
       "required": false,
@@ -262,7 +262,7 @@
       "label_en": "Privacy Protocol"
     },
     {
-      "name": "priv_password",
+      "name": "ENV_PRIV_PASSWORD",
       "label": "加密密码",
       "type": "password",
       "required": false,

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/proxim.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_proxim/proxim.child.toml.j2
@@ -13,9 +13,9 @@
     sec_name = "{{ sec_name }}"
     sec_level = "{{ sec_level }}"
     auth_protocol = "{{ auth_protocol }}"
-    auth_password = "{{ auth_password }}"
+    auth_password = "${AUTH_PASSWORD__{{ config_id }}}"
     priv_protocol = "{{ priv_protocol }}"
-    priv_password = "{{ priv_password }}"
+    priv_password = "${PRIV_PASSWORD__{{ config_id }}}"
     {% else %}
     {% endif %}
     [inputs.snmp.tags]

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/wireless_xirrus/UI.json
@@ -150,7 +150,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.AUTH_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "priv_protocol",
@@ -201,7 +205,11 @@
             }
           ]
         ]
-      }
+      },
+      "transform_on_edit": {
+        "origin_path": "child.env_config.PRIV_PASSWORD__{{config_id}}"
+      },
+      "encrypted": true
     },
     {
       "name": "timeout",

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -41,9 +41,13 @@ const mutexValuesEqual = (left: any, right: any) => {
 
 export const useConfigRenderer = () => {
   const { t } = useTranslation();
-  // Select 的 antd 样式默认 width:100%，仅靠 Tailwind 类会被覆盖；与 Input 对齐用同一数值。
+  // 接入表单控件统一宽度（COMPONENT_GOVERNANCE §4）：单点常量 + style，勿再散落 w-[300px]。
+  // Select 的 antd 默认 width:100% 也会盖掉 Tailwind class，必须走 style。
   const FORM_WIDGET_WIDTH = 300;
-  const FORM_WIDGET_WIDTH_CLASS = 'w-[300px]';
+  const formWidgetWidthStyle = (style?: React.CSSProperties) => ({
+    ...(style && typeof style === 'object' ? style : {}),
+    width: FORM_WIDGET_WIDTH,
+  });
   const fieldGuideTitle = t('monitor.integrations.fieldGuideTip');
 
   const renderFormField = (fieldConfig: any, mode?: string) => {
@@ -292,7 +296,8 @@ export const useConfigRenderer = () => {
               {...widget_props}
               disabled={Boolean(locked || widget_props.disabled)}
               placeholder={widget_props.placeholder || label}
-              className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px]`}
+              className="mr-[10px]"
+              style={formWidgetWidthStyle(widget_props.style)}
             />
           );
 
@@ -303,17 +308,19 @@ export const useConfigRenderer = () => {
               clickToEdit={mode === 'edit' && editable !== false}
               trimOuterWhitespace
               placeholder={widget_props.placeholder || label}
-              className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px]`}
+              className="mr-[10px]"
+              style={formWidgetWidthStyle(widget_props.style)}
             />
           );
 
         case 'inputNumber': {
-          const { addonAfter, ...restProps } = widget_props;
+          const { addonAfter, style: widgetStyle, ...restProps } = widget_props;
           return (
             <InputNumber
               {...restProps}
               placeholder={widget_props.placeholder || label}
-              className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px] align-middle`}
+              className="mr-[10px] align-middle"
+              style={formWidgetWidthStyle(widgetStyle)}
               min={widget_props.min || 1}
               precision={
                 widget_props.precision !== undefined
@@ -347,11 +354,8 @@ export const useConfigRenderer = () => {
               }
               showSearch
               optionFilterProp="label"
-              className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px]`}
-              style={{
-                ...(widgetStyle && typeof widgetStyle === 'object' ? widgetStyle : {}),
-                width: FORM_WIDGET_WIDTH,
-              }}
+              className="mr-[10px]"
+              style={formWidgetWidthStyle(widgetStyle)}
             >
               {options.map((option: any) => (
                 <Select.Option key={option.value} value={option.value} label={option.label}>
@@ -367,7 +371,7 @@ export const useConfigRenderer = () => {
             <Input.TextArea
               {...widget_props}
               placeholder={widget_props.placeholder || label}
-              className={FORM_WIDGET_WIDTH_CLASS}
+              style={formWidgetWidthStyle(widget_props.style)}
               autoSize={{ minRows: 3, maxRows: 6 }}
             />
           );
@@ -438,7 +442,11 @@ export const useConfigRenderer = () => {
 
         default:
           return (
-            <Input placeholder={label} className={FORM_WIDGET_WIDTH_CLASS} />
+            <Input
+              placeholder={label}
+              className="mr-[10px]"
+              style={formWidgetWidthStyle()}
+            />
           );
       }
     };

--- a/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
+++ b/web/src/app/monitor/hooks/integration/useConfigRenderer.tsx
@@ -41,6 +41,8 @@ const mutexValuesEqual = (left: any, right: any) => {
 
 export const useConfigRenderer = () => {
   const { t } = useTranslation();
+  // Select 的 antd 样式默认 width:100%，仅靠 Tailwind 类会被覆盖；与 Input 对齐用同一数值。
+  const FORM_WIDGET_WIDTH = 300;
   const FORM_WIDGET_WIDTH_CLASS = 'w-[300px]';
   const fieldGuideTitle = t('monitor.integrations.fieldGuideTip');
 
@@ -326,9 +328,10 @@ export const useConfigRenderer = () => {
         case 'select': {
           const allowCustomTags =
             name === 'iftype_exclude' || name === 'iftype_include';
+          const { style: widgetStyle, ...restSelectProps } = widget_props;
           return (
             <Select
-              {...widget_props}
+              {...restSelectProps}
               mode={allowCustomTags ? 'tags' : widget_props.mode}
               tokenSeparators={
                 allowCustomTags
@@ -345,6 +348,10 @@ export const useConfigRenderer = () => {
               showSearch
               optionFilterProp="label"
               className={`${FORM_WIDGET_WIDTH_CLASS} mr-[10px]`}
+              style={{
+                ...(widgetStyle && typeof widgetStyle === 'object' ? widgetStyle : {}),
+                width: FORM_WIDGET_WIDTH,
+              }}
             >
               {options.map((option: any) => (
                 <Select.Option key={option.value} value={option.value} label={option.label}>


### PR DESCRIPTION
## Summary
- 将剩余 SNMP 插件的 SNMPv3 `auth_password`/`priv_password` 从 Jinja 明文内联改为 `${AUTH/PRIV_PASSWORD__{{ config_id }}}` + UI `ENV_*` 字段，经 sidecar `env_config` 下发
- 补齐全部 SNMP `ENV_*` 密码字段的 `transform_on_edit.origin_path`（`child.env_config.*`）与 `encrypted: true`，避免编辑改密写错路径
- 接入表单控件统一 `FORM_WIDGET_WIDTH=300` 的 style 契约，修复「版本」等 Select 被 antd 默认拉满宽的问题

## Test plan
- [ ] `plugin_init` 后新建 SNMPv3 实例，节点配置中 `auth_password`/`priv_password` 为 `${…}` 占位，密码仅出现在 env
- [ ] 编辑已有 SNMPv3 实例并修改认证/加密密码后重新下发，采集仍正常
- [ ] 打开接入配置页，「版本」Select 与「团体名」Input 同宽（300px）
- [ ] SNMPv2c community 行为未变（本次未改 community）