### PR TITLE
bugfix: 绑定 Host Remote 回调执行身份

### DIFF
--- a/agents/stargazer/HOST_REMOTE_CALLBACK_DESIGN.md
+++ b/agents/stargazer/HOST_REMOTE_CALLBACK_DESIGN.md
@@ -5,28 +5,55 @@ Host 监控与配置采集共用 `CollectionRuntime`。目标通过 TCP 预检�
 
 ```text
 HTTP X-Task-ID
-  -> CollectionRuntime / RunLease(fence)
+  -> CollectionRuntime / RunLease(fence + attempt_id + owner)
   -> TargetCollection(host + credential)
-  -> HostCollector.submit_collection(callback identity)
-  -> Redis callback context
+  -> HostCollector.submit_collection(v2 callback.context + one-time token)
+  -> Redis callback context + latest-run tombstone + current-generation pointer
   -> NATS callback
-  -> validate parent task + target + fence
+  -> validate token + task + target + fence + attempt + owner + caller
   -> Sanic local callback task
   -> publish metrics / retry state
 ```
 
-每个目标的 callback task ID 由父任务、插件、目标和 fencing token 确定性摘要得到，因此一个
-多目标运行不会互相覆盖 callback 上下文。Redis 上下文保存：
+启用 v2 后，每个目标的 callback task ID 由父任务、插件、目标、fencing token 和真实 `attempt_id`
+确定性摘要得到，因此一个多目标运行或新一轮租约不会互相覆盖 callback 上下文。Redis 上下文
+通过 Lua 在仍持有当前 run 的前提下，同时写入有界 TTL 的 parent-task generation 指针并原子保留
+首次 callback context；同 task 重投复用原 token，身份冲突时在提交 Executor 前失败关闭。薄 run
+租约可在返回 `Deferred` 后删除，generation 指针继续覆盖 callback 生命周期；每次 run acquire 还会
+在同一 Lua 中推进有界保留的 latest-run tombstone，因此新 attempt 即使在创建首个 callback context
+前结束，旧回调也不会重新变为有效。上下文保存：
 
 - callback task ID 与父 `collection_task_id`；
-- 目标、插件、owner 和 fencing token；
+- v2 协议版本与 token 摘要；token 由独立环境密钥和不可变执行身份确定性 HMAC 派生，不写 Redis；
+- 目标、插件、owner、fencing token、真实 `attempt_id` 和 Executor caller；
 - Remote 原始结果、执行/发布状态、重试次数和截止时间；
 - 发布所需的非秘密参数。
 
-回调必须同时匹配父任务 ID、目标和 fencing token，校验失败时不会登记 payload 或启动处理。
+回调必须同时匹配一次性 token、父任务 ID、目标、fencing token、`attempt_id`、owner 和 caller；
+随后通过单个 Lua 快照读取 generation、latest-run tombstone 与 active run：run 已因同一 Deferred
+完成而删除时仍核对 latest-run；若 run 存在则三者都必须与回调的 fence、attempt、owner 一致。
+callback payload 的首次落库会在另一个 Lua 中再次原子核对这三层身份，关闭“校验返回后新 run
+acquire”的竞态。任一校验失败时不会登记 payload、清 running 标记或启动处理。Executor 只在
+加密的 `callback_secret` 中持久化 token，查询态、JetStream 重试消息与 DLQ 使用遮蔽值；Redis
+始终只保存 token 摘要，首次合法 callback 落库时也会从 raw payload 中剥离 token。
+
+提交被明确拒绝时不立即删除共享 callback context：并发重投可能已经被 Executor 接受，删除会让
+合法回调永久失去凭据。该短期状态继续受默认 1 小时 TTL 和 300 秒 pre-accept sweeper 约束，
+不会无限保留。
 重复或待重试处理由进程内有名 Task 登记表去重；callback sweeper 在 Sanic 运行期扫描 Redis
 短期状态并重新触发发布。该 Task 登记表只管理生命周期，不是持久队列。
 
 Pod 退出时 callback Task 会被取消，Redis 上下文保留到 TTL；NATS 重投或 sweeper 可在新 Pod
 继续处理。发布成功后删除上下文。Redis 或 NATS 故障不会通过延长启动等待、无限重试或恢复
 ARQ Worker 来掩盖。
+
+滚动升级期间 `HOST_REMOTE_CALLBACK_V2_ENABLED` 默认关闭，继续签发旧 `remote-` 任务；先滚动升级
+Executor 并确认旧版本、旧 context 与 callback retry 清零，再配置至少 32 字符的独立
+`HOST_REMOTE_CALLBACK_TOKEN_SECRET` 并启用 v2。新 handler 仅对旧前缀、无 v2 标记且未超过
+context TTL/deadline 的在途记录保留兼容。`HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS` 默认等于
+context TTL，可在排空后设为 0。回滚前先关闭 v2 新签发，并排空 v2 context、执行任务与 Executor
+retry；若不能排空，必须保留能处理 v2 的 Stargazer handler，不能直接回退到 fixed-base handler。
+
+当前 v2 token 能阻断只知道或猜到 task ID 的盲伪造，但不是最终 NATS 信任根。默认管理员仍可
+订阅任务请求并观察 token；完整关闭该风险仍需为 Stargazer/Executor 建立独立服务身份与最小
+subject ACL，或采用预置独立私钥的 Executor 签名。该治理完成前 Issue #4280 保持开放。

--- a/agents/stargazer/README.md
+++ b/agents/stargazer/README.md
@@ -194,9 +194,23 @@ rg 'task_id=<task-id>|target=<ip>' logs/snmp_facts.log
 ## Host Remote
 
 Host Remote 提交返回 `Deferred`。每个目标使用独立 callback ID；可信上下文包含父任务 ID、
-目标、owner 和 fencing token。回调必须同时匹配父任务、目标和 fencing，处理任务直接注册在
-Sanic 本地生命周期中，不再进入 ARQ。Redis 中的 callback 上下文继续提供重复回调和发布重试
-所需的短期状态。
+目标、owner、fencing token、真实 `attempt_id`、Executor caller 和一次性 v2 token。回调先匹配
+完整身份，再用单个 Lua 快照核对 Redis generation、latest-run tombstone 与可选 active run 的
+fence、attempt 和 owner；该指针在 run 返回 `Deferred` 并完成薄租约后继续存在，latest-run 又在
+每次 acquire 时原子推进，因此新 run 即使在创建首个 context 前结束也会让旧 generation 失败关闭。
+首次保存 callback payload 时会再次原子核对三层身份，并移除 raw payload 中已消费的 token。
+token 由独立环境密钥和不可变执行身份确定性 HMAC 派生，Redis 只存摘要。失败时不会 claim、
+清 running 或启动处理。创建 callback context 的 Lua 同时核验当前 run 并保留首次身份，让同 task 重投幂等；失败
+重投不删除共享 context，而由 1 小时 TTL / 300 秒 pre-accept sweeper 有界收敛。处理任务直接注册
+在 Sanic 本地生命周期中，不再进入 ARQ。
+
+滚动升级时 `HOST_REMOTE_CALLBACK_V2_ENABLED` 默认关闭；先升级并排空旧 Executor/context/retry，
+再设置至少 32 字符的 `HOST_REMOTE_CALLBACK_TOKEN_SECRET` 并启用。旧 `remote-` callback 仅在
+context TTL/deadline 内兼容，排空后可把 `HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS` 设为 0。
+回滚前先关闭 v2 新签发并排空 v2 context、执行任务及 Executor retry；无法排空时保留 v2 handler。
+
+该 token 只阻断无法读取任务请求的盲伪造；共享 NATS 管理员仍能观察 token。最终信任根需用
+独立服务身份和最小 subject ACL，或 Executor 独立签名完成，相关治理完成前 Issue #4280 保持开放。
 
 ## 网络拓扑发现契约
 

--- a/agents/stargazer/core/collection/host_remote/adapter.py
+++ b/agents/stargazer/core/collection/host_remote/adapter.py
@@ -48,32 +48,57 @@ async def submit_host_remote_collection(
         fence=context.fence,
         attempt_id=context.attempt_id,
     )
-    callback_task_id = "remote-" + result_id[:24]
     callback_params["collection_result_id"] = result_id
     callback_subject = callback_state.get_host_remote_callback_subject()
-    callback_payload = {
-        "task_id": callback_task_id,
-        "collection_task_id": context.task_id,
-        "collection_fence": context.fence,
-        "collection_target": target,
-        "collection_plugin_ref": context.plugin_ref,
-        "collection_owner": context.owner_id,
-        "collection_attempt": context.fence,
-        "collection_caller": callback_caller,
-    }
-    await callback_state.store_host_remote_callback_context(
-        callback_task_id,
-        callback_params,
-        {
-            "owner_id": context.owner_id,
+    v2_enabled = callback_state.is_host_remote_callback_v2_enabled()
+    callback_task_id = ("remote-v2-" if v2_enabled else "remote-") + result_id[:24]
+    if v2_enabled:
+        _, trusted_identity = callback_state.issue_host_remote_callback_identity(
+            fence=context.fence,
+            target=target,
+            collection_task_id=context.task_id,
+            plugin_ref=context.plugin_ref,
+            owner_id=context.owner_id,
+            attempt=context.attempt_id,
+            caller=callback_caller,
+        )
+    else:
+        trusted_identity = {
             "fence": context.fence,
-            "plugin_ref": context.plugin_ref,
             "target": target,
             "collection_task_id": context.task_id,
-            "attempt": context.fence,
+            "plugin_ref": context.plugin_ref,
+            "owner_id": context.owner_id,
+            "attempt": context.attempt_id,
             "caller": callback_caller,
-        },
+        }
+    stored_context = await callback_state.store_host_remote_callback_context(
+        callback_task_id,
+        callback_params,
+        trusted_identity,
     )
+    persisted_identity = (stored_context or {}).get("ctx") or trusted_identity
+    binding_fields = [
+        "fence",
+        "target",
+        "collection_task_id",
+        "plugin_ref",
+        "owner_id",
+        "attempt",
+        "caller",
+    ]
+    if v2_enabled:
+        binding_fields.insert(0, "protocol_version")
+    if any(
+        persisted_identity.get(key) != trusted_identity.get(key)
+        for key in binding_fields
+    ):
+        raise RuntimeError("Host Remote stored identity conflict")
+    callback_payload = {}
+    if v2_enabled:
+        callback_payload["context"] = (
+            callback_state.restore_host_remote_callback_identity(persisted_identity)
+        )
     accepted = await HostCollector(params).submit_collection(
         callback_task_id,
         callback_subject,
@@ -81,7 +106,14 @@ async def submit_host_remote_collection(
     )
     accepted_result = accepted.get("result") or {}
     if accepted.get("success") is False or accepted_result.get("accepted") is False:
-        await callback_state.clear_host_remote_callback_context(callback_task_id)
+        callback_state.log_host_remote_event(
+            "submit_rejected_context_retained",
+            callback_task_id,
+            level="warning",
+            execution="waiting_callback",
+            failed_stage="executor_submit",
+            error_type="executor_rejected",
+        )
         return CollectOutcome(
             status=CollectOutcomeStatus.FAILED,
             error_code="remote_submission_failed",

--- a/agents/stargazer/core/collection/host_remote/callback.py
+++ b/agents/stargazer/core/collection/host_remote/callback.py
@@ -1,13 +1,17 @@
+import base64
+import hashlib
+import hmac
 import json
 import os
 import time
 import uuid
 from typing import Any, Dict, List
 
-from core.logger import logger
 from core.infra.redis_client import get_redis_client
+from core.logger import logger
 
 HOST_REMOTE_CALLBACK_HANDLER = "host_remote.callback"
+HOST_REMOTE_CALLBACK_PROTOCOL_VERSION = "host_remote.v2"
 HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS = int(
     os.getenv("HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS", "3600")
 )
@@ -23,9 +27,149 @@ HOST_REMOTE_PROCESSING_STALE_SECONDS = int(
 HOST_REMOTE_SWEEP_INTERVAL_SECONDS = int(
     os.getenv("HOST_REMOTE_SWEEP_INTERVAL_SECONDS", "30")
 )
+HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS = int(
+    os.getenv(
+        "HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS",
+        str(HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS),
+    )
+)
 _HOST_REMOTE_CALLBACK_CONTEXT_KEY_PREFIX = "host_remote:callback_context"
+_HOST_REMOTE_CALLBACK_GENERATION_KEY_PREFIX = "host_remote:current_generation"
 _host_remote_callback_pool = None
 _HOST_REMOTE_PROCESSING_CLAIM_PREFIX = "host_remote:processing_claim"
+
+_STORE_CALLBACK_CONTEXT_LUA = """
+local run_key = KEYS[1]
+local generation_key = KEYS[2]
+local context_key = KEYS[3]
+local expected_owner = ARGV[1]
+local expected_fence = tostring(ARGV[2])
+local expected_attempt = ARGV[3]
+local generation_json = ARGV[4]
+local context_json = ARGV[5]
+local ttl_seconds = tonumber(ARGV[6])
+
+if redis.call('HGET', run_key, 'owner_id') ~= expected_owner then
+    return {0, ''}
+end
+if redis.call('HGET', run_key, 'fence') ~= expected_fence then
+    return {0, ''}
+end
+if redis.call('HGET', run_key, 'attempt_id') ~= expected_attempt then
+    return {0, ''}
+end
+
+redis.call('SET', generation_key, generation_json, 'EX', ttl_seconds)
+local existing_context = redis.call('GET', context_key)
+if existing_context then
+    return {2, existing_context}
+end
+redis.call('SET', context_key, context_json, 'EX', ttl_seconds)
+return {1, context_json}
+"""
+_READ_CALLBACK_GENERATION_LUA = """
+local generation_json = redis.call('GET', KEYS[1]) or ''
+local run_exists = redis.call('EXISTS', KEYS[2])
+local latest_fence = redis.call('HGET', KEYS[3], 'fence') or ''
+local latest_attempt = redis.call('HGET', KEYS[3], 'attempt_id') or ''
+local latest_owner = redis.call('HGET', KEYS[3], 'owner_id') or ''
+if run_exists == 0 then
+    return {
+        generation_json, '', '', '', 0,
+        latest_fence, latest_attempt, latest_owner
+    }
+end
+return {
+    generation_json,
+    redis.call('HGET', KEYS[2], 'fence') or '',
+    redis.call('HGET', KEYS[2], 'attempt_id') or '',
+    redis.call('HGET', KEYS[2], 'owner_id') or '',
+    1,
+    latest_fence,
+    latest_attempt,
+    latest_owner
+}
+"""
+_RECORD_CALLBACK_PAYLOAD_LUA = """
+local context_json = redis.call('GET', KEYS[1])
+if not context_json then
+    return {0, ''}
+end
+
+local expected_owner = ARGV[1]
+local expected_fence = tostring(ARGV[2])
+local expected_attempt = ARGV[3]
+local generation_json = redis.call('GET', KEYS[2])
+if not generation_json then
+    return {1, ''}
+end
+local generation = cjson.decode(generation_json)
+if tostring(generation['fence'] or '') ~= expected_fence
+    or tostring(generation['attempt'] or '') ~= expected_attempt
+    or tostring(generation['owner_id'] or '') ~= expected_owner then
+    return {1, ''}
+end
+
+if tostring(redis.call('HGET', KEYS[4], 'fence') or '') ~= expected_fence
+    or tostring(redis.call('HGET', KEYS[4], 'attempt_id') or '') ~= expected_attempt
+    or tostring(redis.call('HGET', KEYS[4], 'owner_id') or '') ~= expected_owner then
+    return {2, ''}
+end
+
+if redis.call('EXISTS', KEYS[3]) == 1 then
+    if tostring(redis.call('HGET', KEYS[3], 'fence') or '') ~= expected_fence
+        or tostring(redis.call('HGET', KEYS[3], 'attempt_id') or '') ~= expected_attempt
+        or tostring(redis.call('HGET', KEYS[3], 'owner_id') or '') ~= expected_owner then
+        return {3, ''}
+    end
+end
+
+local context = cjson.decode(context_json)
+if not context['status']
+    or context['status']['execution'] ~= 'waiting_callback'
+    or (context['raw_callback'] and context['raw_callback'] ~= cjson.null) then
+    return {4, context_json}
+end
+
+local now_ms = tonumber(ARGV[5])
+context['raw_callback'] = cjson.decode(ARGV[4])
+context['callback_received_at'] = now_ms
+context['updated_at'] = now_ms
+context['last_error'] = cjson.null
+context['status']['execution'] = 'execution_finished'
+if context['ctx'] then
+    context['ctx']['token'] = nil
+end
+local updated_json = cjson.encode(context)
+local ttl_seconds = redis.call('TTL', KEYS[1])
+if ttl_seconds <= 0 then
+    ttl_seconds = tonumber(ARGV[6])
+end
+redis.call('SET', KEYS[1], updated_json, 'EX', ttl_seconds)
+return {5, updated_json}
+"""
+_MARK_SUBMIT_ACCEPTED_LUA = """
+local context_json = redis.call('GET', KEYS[1])
+if not context_json then
+    return {0, ''}
+end
+local context = cjson.decode(context_json)
+if not context['status']
+    or context['status']['execution'] ~= 'waiting_callback'
+    or (context['raw_callback'] and context['raw_callback'] ~= cjson.null) then
+    return {2, context_json}
+end
+context['callback_deadline_at'] = tonumber(ARGV[1])
+context['updated_at'] = tonumber(ARGV[2])
+context['last_error'] = cjson.null
+local updated_json = cjson.encode(context)
+local ttl_seconds = redis.call('TTL', KEYS[1])
+if ttl_seconds <= 0 then
+    ttl_seconds = tonumber(ARGV[3])
+end
+redis.call('SET', KEYS[1], updated_json, 'EX', ttl_seconds)
+return {1, updated_json}
+"""
 
 _RELEASE_PROCESSING_CLAIM_LUA = """
 if redis.call('GET', KEYS[1]) == ARGV[1] then
@@ -46,7 +190,9 @@ def get_stargazer_service_name(instance_id: str | None = None) -> str:
 
 
 def get_host_remote_callback_subject(service_name: str | None = None) -> str:
-    return f"{service_name or get_stargazer_service_name()}.{HOST_REMOTE_CALLBACK_HANDLER}"
+    return (
+        f"{service_name or get_stargazer_service_name()}.{HOST_REMOTE_CALLBACK_HANDLER}"
+    )
 
 
 def get_host_remote_callback_queue(service_name: str | None = None) -> str:
@@ -60,35 +206,160 @@ def _normalize_task_id(task_id) -> str:
     return normalized_task_id
 
 
-def validate_host_remote_callback_identity(payload: dict, callback_context: dict) -> None:
+def _hash_callback_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def is_host_remote_callback_v2_enabled() -> bool:
+    return str(
+        os.getenv("HOST_REMOTE_CALLBACK_V2_ENABLED", "false")
+    ).strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _derive_host_remote_callback_token(identity: dict) -> str:
+    secret = str(os.getenv("HOST_REMOTE_CALLBACK_TOKEN_SECRET") or "")
+    if len(secret) < 32:
+        raise RuntimeError(
+            "HOST_REMOTE_CALLBACK_TOKEN_SECRET must contain at least 32 characters"
+        )
+    canonical = json.dumps(
+        identity,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    digest = hmac.new(secret.encode("utf-8"), canonical, hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def restore_host_remote_callback_identity(trusted_identity: dict) -> dict:
+    binding_fields = (
+        "protocol_version",
+        "fence",
+        "target",
+        "collection_task_id",
+        "plugin_ref",
+        "owner_id",
+        "attempt",
+        "caller",
+    )
+    identity = {key: trusted_identity[key] for key in binding_fields}
+    identity["token"] = _derive_host_remote_callback_token(identity)
+    if not hmac.compare_digest(
+        _hash_callback_token(identity["token"]),
+        str(trusted_identity.get("token_hash") or ""),
+    ):
+        raise RuntimeError("Host Remote stored identity token digest mismatch")
+    return identity
+
+
+def _is_legacy_host_remote_callback_context(
+    payload: dict, callback_context: dict
+) -> bool:
+    task_id = str(
+        (payload or {}).get("task_id") or (callback_context or {}).get("task_id") or ""
+    ).strip()
     trusted = (callback_context or {}).get("ctx") or {}
+    return (
+        task_id.startswith("remote-")
+        and not task_id.startswith("remote-v2-")
+        and not trusted.get("protocol_version")
+        and not trusted.get("token_hash")
+    )
+
+
+def _validate_legacy_host_remote_callback_context(callback_context: dict) -> None:
+    created_at = int((callback_context or {}).get("created_at") or 0)
+    max_age_ms = max(0, HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS) * 1000
+    if not created_at or not max_age_ms or _now_ms() - created_at > max_age_ms:
+        raise RuntimeError("Host Remote legacy compatibility window expired")
+    status = (callback_context or {}).get("status") or {}
+    if status.get("execution") != "waiting_callback":
+        raise RuntimeError("Host Remote callback is duplicate or out of order")
+    if (callback_context or {}).get("raw_callback") is not None:
+        raise RuntimeError("Host Remote callback is duplicate or out of order")
+    deadline = int((callback_context or {}).get("callback_deadline_at") or 0)
+    if deadline and deadline <= _now_ms():
+        raise RuntimeError("Host Remote callback is expired")
+
+
+def issue_host_remote_callback_identity(
+    *,
+    fence: int,
+    target: str,
+    collection_task_id: str,
+    plugin_ref: str,
+    owner_id: str,
+    attempt: str,
+    caller: str,
+) -> tuple[dict, dict]:
+    identity = {
+        "protocol_version": HOST_REMOTE_CALLBACK_PROTOCOL_VERSION,
+        "fence": fence,
+        "target": target,
+        "collection_task_id": collection_task_id,
+        "plugin_ref": plugin_ref,
+        "owner_id": owner_id,
+        "attempt": attempt,
+        "caller": caller,
+    }
+    token = _derive_host_remote_callback_token(identity)
+    identity["token"] = token
+    trusted = dict(identity)
+    trusted.pop("token")
+    trusted["token_hash"] = _hash_callback_token(token)
+    return identity, trusted
+
+
+def validate_host_remote_callback_identity(
+    payload: dict, callback_context: dict
+) -> None:
+    if _is_legacy_host_remote_callback_context(payload, callback_context):
+        _validate_legacy_host_remote_callback_context(callback_context)
+        log_host_remote_event(
+            "legacy_callback_accepted",
+            (callback_context or {}).get("task_id"),
+            level="warning",
+            execution="waiting_callback",
+        )
+        return
+    trusted = (callback_context or {}).get("ctx") or {}
+    identity = (payload or {}).get("callback_context")
+    if not isinstance(identity, dict):
+        raise RuntimeError("Host Remote callback identity context is missing")
+    if identity.get("protocol_version") != HOST_REMOTE_CALLBACK_PROTOCOL_VERSION:
+        raise RuntimeError("Host Remote callback protocol version mismatch")
+    token = identity.get("token")
+    expected_token_hash = str(trusted.get("token_hash") or "")
+    if (
+        not isinstance(token, str)
+        or not token
+        or not expected_token_hash
+        or not hmac.compare_digest(_hash_callback_token(token), expected_token_hash)
+    ):
+        raise RuntimeError("Host Remote callback token mismatch")
     expected_fence = int(trusted.get("fence") or 0)
-    actual_fence = int((payload or {}).get("collection_fence") or 0)
+    actual_fence = int(identity.get("fence") or 0)
     if not expected_fence or actual_fence != expected_fence:
         raise RuntimeError("Host Remote callback fencing token mismatch")
-    if str((payload or {}).get("collection_target") or "") != str(
-        trusted.get("target") or ""
-    ):
+    if str(identity.get("target") or "") != str(trusted.get("target") or ""):
         raise RuntimeError("Host Remote callback target mismatch")
-    if str((payload or {}).get("collection_task_id") or "") != str(
+    if str(identity.get("collection_task_id") or "") != str(
         trusted.get("collection_task_id") or ""
     ):
         raise RuntimeError("Host Remote callback collection task mismatch")
-    if str((payload or {}).get("collection_plugin_ref") or "") != str(
-        trusted.get("plugin_ref") or ""
-    ):
+    if str(identity.get("plugin_ref") or "") != str(trusted.get("plugin_ref") or ""):
         raise RuntimeError("Host Remote callback plugin mismatch")
-    if str((payload or {}).get("collection_owner") or "") != str(
-        trusted.get("owner_id") or ""
-    ):
+    if str(identity.get("owner_id") or "") != str(trusted.get("owner_id") or ""):
         raise RuntimeError("Host Remote callback owner mismatch")
-    if int((payload or {}).get("collection_attempt") or 0) != int(
-        trusted.get("attempt") or 0
-    ):
+    if str(identity.get("attempt") or "") != str(trusted.get("attempt") or ""):
         raise RuntimeError("Host Remote callback attempt mismatch")
-    if str((payload or {}).get("collection_caller") or "") != str(
-        trusted.get("caller") or ""
-    ):
+    if str(identity.get("caller") or "") != str(trusted.get("caller") or ""):
         raise RuntimeError("Host Remote callback caller mismatch")
     status = (callback_context or {}).get("status") or {}
     if status.get("execution") != "waiting_callback":
@@ -104,24 +375,85 @@ async def ensure_host_remote_callback_fence_is_current(
     callback_context: dict,
 ) -> None:
     """拒绝 Pod 接管后由旧 fencing token 返回的迟到回调。"""
+    if _is_legacy_host_remote_callback_context({}, callback_context):
+        _validate_legacy_host_remote_callback_context(callback_context)
+        return
     trusted = (callback_context or {}).get("ctx") or {}
     task_id = str(trusted.get("collection_task_id") or "").strip()
     expected_fence = int(trusted.get("fence") or 0)
-    if not task_id or not expected_fence:
+    expected_attempt = str(trusted.get("attempt") or "").strip()
+    expected_owner = str(trusted.get("owner_id") or "").strip()
+    if not task_id or not expected_fence or not expected_attempt or not expected_owner:
         raise RuntimeError("Host Remote callback context identity is incomplete")
     redis_pool = await _get_host_remote_callback_pool()
-    prefix = os.getenv("COLLECTION_REDIS_PREFIX", "stargazer:collection:v1")
-    current_fence = await redis_pool.hget(
-        f"{prefix.rstrip(':')}:run:{task_id}", "fence"
+    (
+        raw_generation,
+        active_fence,
+        active_attempt,
+        active_owner,
+        run_exists,
+        latest_fence,
+        latest_attempt,
+        latest_owner,
+    ) = await redis_pool.eval(
+        _READ_CALLBACK_GENERATION_LUA,
+        3,
+        _build_callback_generation_key(task_id),
+        _build_collection_run_key(task_id),
+        _build_collection_fence_key(task_id),
     )
-    if isinstance(current_fence, (bytes, bytearray)):
-        current_fence = current_fence.decode()
+    if not raw_generation:
+        raise RuntimeError("Host Remote callback generation is stale")
+    generation = json.loads(_decode_redis_text(raw_generation))
+    current_fence = str(generation.get("fence") or "")
+    current_attempt = str(generation.get("attempt") or "")
+    current_owner = str(generation.get("owner_id") or "")
     if str(current_fence or "") != str(expected_fence):
         raise RuntimeError("Host Remote callback fencing token is stale")
+    if current_attempt != expected_attempt:
+        raise RuntimeError("Host Remote callback attempt is stale")
+    if current_owner != expected_owner:
+        raise RuntimeError("Host Remote callback owner is stale")
+    if _decode_redis_text(latest_fence) != str(expected_fence):
+        raise RuntimeError("Host Remote callback latest fencing token is stale")
+    if _decode_redis_text(latest_attempt) != expected_attempt:
+        raise RuntimeError("Host Remote callback latest attempt is stale")
+    if _decode_redis_text(latest_owner) != expected_owner:
+        raise RuntimeError("Host Remote callback latest owner is stale")
+    if int(run_exists):
+        if _decode_redis_text(active_fence) != str(expected_fence):
+            raise RuntimeError("Host Remote callback active fencing token is stale")
+        if _decode_redis_text(active_attempt) != expected_attempt:
+            raise RuntimeError("Host Remote callback active attempt is stale")
+        if _decode_redis_text(active_owner) != expected_owner:
+            raise RuntimeError("Host Remote callback active owner is stale")
+
+
+def _decode_redis_text(value) -> str:
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    return str(value or "")
 
 
 def _build_callback_context_key(task_id) -> str:
     return f"{_HOST_REMOTE_CALLBACK_CONTEXT_KEY_PREFIX}:{_normalize_task_id(task_id)}"
+
+
+def _build_callback_generation_key(collection_task_id) -> str:
+    return (
+        f"{_HOST_REMOTE_CALLBACK_GENERATION_KEY_PREFIX}:"
+        f"{_normalize_task_id(collection_task_id)}"
+    )
+
+
+def _build_collection_run_key(collection_task_id) -> str:
+    prefix = os.getenv("COLLECTION_REDIS_PREFIX", "stargazer:collection:v1")
+    return f"{prefix.rstrip(':')}:run:{_normalize_task_id(collection_task_id)}"
+
+
+def _build_collection_fence_key(collection_task_id) -> str:
+    prefix = os.getenv("COLLECTION_REDIS_PREFIX", "stargazer:collection:v1")
+    return f"{prefix.rstrip(':')}:fence:{_normalize_task_id(collection_task_id)}"
 
 
 def get_task_running_key(task_id) -> str:
@@ -140,9 +472,7 @@ async def claim_host_remote_processing(task_id: str) -> str:
     return token if claimed else ""
 
 
-async def release_host_remote_processing_claim(
-    task_id: str, token: str
-) -> bool:
+async def release_host_remote_processing_claim(task_id: str, token: str) -> bool:
     if not token:
         return False
     redis_pool = await _get_host_remote_callback_pool()
@@ -233,16 +563,20 @@ def get_host_remote_processing_job_id(task_id) -> str:
     return f"process_host_remote_callback:{_normalize_task_id(task_id)}"
 
 
-def log_host_remote_event(event: str, task_id, level: str = "info", **fields: Any) -> None:
+def log_host_remote_event(
+    event: str, task_id, level: str = "info", **fields: Any
+) -> None:
     normalized_task_id = str(task_id or "").strip()
     rendered_fields = ", ".join(
         f"{key}={value}" for key, value in fields.items() if value is not None
     )
-    message = f"[Host Remote] event={event}, task_id={normalized_task_id}"
+    message = "[Host Remote] event=%s, task_id=%s"
+    arguments = [event, normalized_task_id]
     if rendered_fields:
-        message = f"{message}, {rendered_fields}"
+        message = f"{message}, %s"
+        arguments.append(rendered_fields)
     log_method = getattr(logger, level, logger.info)
-    log_method(message)
+    log_method(message, *arguments)
 
 
 def _normalize_callback_context(task_id, callback_context) -> dict:
@@ -273,12 +607,18 @@ def _normalize_callback_context(task_id, callback_context) -> dict:
     callback_context.setdefault("next_retry_at", None)
     callback_context.setdefault("published_at", None)
     callback_context.setdefault("last_error", None)
-    callback_context.setdefault("created_at", callback_context.get("created_at") or now_ms)
+    callback_context.setdefault(
+        "created_at", callback_context.get("created_at") or now_ms
+    )
     callback_context["updated_at"] = now_ms
     return callback_context
 
 
-async def _save_host_remote_callback_context(task_id, callback_context, ttl_seconds=None):
+async def _save_host_remote_callback_context(
+    task_id,
+    callback_context,
+    ttl_seconds=None,
+):
     redis_pool = await _get_host_remote_callback_pool()
     normalized_context = _normalize_callback_context(task_id, callback_context)
     await redis_pool.set(
@@ -298,7 +638,9 @@ async def _get_host_remote_callback_pool():
     return _host_remote_callback_pool
 
 
-async def store_host_remote_callback_context(task_id, params, ctx=None, ttl_seconds=None):
+async def store_host_remote_callback_context(
+    task_id, params, ctx=None, ttl_seconds=None
+):
     created_at = _now_ms()
     callback_context = {
         "task_id": _normalize_task_id(task_id),
@@ -320,28 +662,78 @@ async def store_host_remote_callback_context(task_id, params, ctx=None, ttl_seco
         "published_at": None,
         "last_error": None,
     }
-    await _save_host_remote_callback_context(task_id, callback_context, ttl_seconds)
+    trusted = callback_context["ctx"]
+    collection_task_id = str(trusted.get("collection_task_id") or "").strip()
+    owner_id = str(trusted.get("owner_id") or "").strip()
+    fence = int(trusted.get("fence") or 0)
+    attempt = str(trusted.get("attempt") or "").strip()
+    if not collection_task_id or not owner_id or not fence or not attempt:
+        raise RuntimeError("Host Remote callback context identity is incomplete")
+    ttl = ttl_seconds or HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS
+    generation_json = json.dumps(
+        {"fence": fence, "attempt": attempt, "owner_id": owner_id},
+        separators=(",", ":"),
+    )
+    context_json = json.dumps(callback_context)
+    redis_pool = await _get_host_remote_callback_pool()
+    status, stored_context_json = await redis_pool.eval(
+        _STORE_CALLBACK_CONTEXT_LUA,
+        3,
+        _build_collection_run_key(collection_task_id),
+        _build_callback_generation_key(collection_task_id),
+        _build_callback_context_key(task_id),
+        owner_id,
+        fence,
+        attempt,
+        generation_json,
+        context_json,
+        ttl,
+    )
+    if int(status) == 0:
+        raise RuntimeError("Host Remote callback generation is stale")
+    stored_context = _normalize_callback_context(
+        task_id,
+        json.loads(_decode_redis_text(stored_context_json)),
+    )
     log_host_remote_event(
         "context_stored",
         task_id,
         execution="waiting_callback",
         delivery="not_ready",
     )
+    return stored_context
 
 
 async def mark_host_remote_submit_accepted(task_id):
-    deadline_at = _now_ms() + HOST_REMOTE_CALLBACK_DEADLINE_SECONDS * 1000
-    updated_context = await update_host_remote_callback_context(
-        task_id,
-        callback_deadline_at=deadline_at,
-        last_error=None,
+    now_ms = _now_ms()
+    deadline_at = now_ms + HOST_REMOTE_CALLBACK_DEADLINE_SECONDS * 1000
+    redis_pool = await _get_host_remote_callback_pool()
+    status, stored_context_json = await redis_pool.eval(
+        _MARK_SUBMIT_ACCEPTED_LUA,
+        1,
+        _build_callback_context_key(task_id),
+        deadline_at,
+        now_ms,
+        HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS,
     )
+    status = int(status)
+    if status == 0:
+        raise RuntimeError("Host Remote callback context disappeared before submit ack")
+    updated_context = _normalize_callback_context(
+        task_id,
+        json.loads(_decode_redis_text(stored_context_json)),
+    )
+    event = "callback_deadline_started"
+    fields = {"callback_deadline_at": deadline_at}
+    if status == 2:
+        event = "submit_ack_after_callback"
+        fields = {}
     log_host_remote_event(
-        "callback_deadline_started",
+        event,
         task_id,
         execution=(updated_context or {}).get("status", {}).get("execution"),
         delivery=(updated_context or {}).get("status", {}).get("delivery"),
-        callback_deadline_at=deadline_at,
+        **fields,
     )
     return updated_context
 
@@ -380,21 +772,64 @@ async def record_host_remote_callback_payload(task_id, payload):
     if callback_context is None:
         return None
 
-    if callback_context.get("raw_callback") is not None:
+    if _is_legacy_host_remote_callback_context(payload, callback_context):
+        _validate_legacy_host_remote_callback_context(callback_context)
+        return await update_host_remote_callback_context(
+            task_id,
+            raw_callback=payload,
+            callback_received_at=_now_ms(),
+            last_error=None,
+            status={"execution": "execution_finished"},
+        )
+
+    trusted = (callback_context or {}).get("ctx") or {}
+    collection_task_id = str(trusted.get("collection_task_id") or "").strip()
+    owner_id = str(trusted.get("owner_id") or "").strip()
+    fence = int(trusted.get("fence") or 0)
+    attempt = str(trusted.get("attempt") or "").strip()
+    if not collection_task_id or not owner_id or not fence or not attempt:
+        raise RuntimeError("Host Remote callback context identity is incomplete")
+    redacted_payload = dict(payload or {})
+    identity = redacted_payload.get("callback_context")
+    if isinstance(identity, dict):
+        redacted_payload["callback_context"] = {
+            key: value for key, value in identity.items() if key != "token"
+        }
+    redis_pool = await _get_host_remote_callback_pool()
+    status, stored_context_json = await redis_pool.eval(
+        _RECORD_CALLBACK_PAYLOAD_LUA,
+        4,
+        _build_callback_context_key(task_id),
+        _build_callback_generation_key(collection_task_id),
+        _build_collection_run_key(collection_task_id),
+        _build_collection_fence_key(collection_task_id),
+        owner_id,
+        fence,
+        attempt,
+        json.dumps(redacted_payload),
+        _now_ms(),
+        HOST_REMOTE_CALLBACK_CONTEXT_TTL_SECONDS,
+    )
+    status = int(status)
+    if status == 0:
+        raise RuntimeError("Host Remote callback context disappeared before record")
+    if status == 1:
+        raise RuntimeError("Host Remote callback generation is stale")
+    if status == 2:
+        raise RuntimeError("Host Remote callback latest generation is stale")
+    if status == 3:
+        raise RuntimeError("Host Remote callback active generation is stale")
+    if status == 4:
         log_host_remote_event(
             "callback_duplicate",
             task_id,
             execution=(callback_context.get("status") or {}).get("execution"),
             delivery=(callback_context.get("status") or {}).get("delivery"),
         )
-        return callback_context
-
-    updated_context = await update_host_remote_callback_context(
+        raise RuntimeError("Host Remote callback is duplicate or out of order")
+    updated_context = _normalize_callback_context(
         task_id,
-        raw_callback=payload,
-        callback_received_at=_now_ms(),
-        last_error=None,
-        status={"execution": "execution_finished"},
+        json.loads(_decode_redis_text(stored_context_json)),
     )
     log_host_remote_event("callback_received", task_id, execution="execution_finished")
     return updated_context
@@ -404,7 +839,8 @@ async def mark_host_remote_processing_enqueued(task_id, processing_job_id=None):
     updated_context = await update_host_remote_callback_context(
         task_id,
         process_enqueued_at=_now_ms(),
-        processing_job_id=processing_job_id or get_host_remote_processing_job_id(task_id),
+        processing_job_id=processing_job_id
+        or get_host_remote_processing_job_id(task_id),
         status={"delivery": "processing"},
     )
     log_host_remote_event(
@@ -523,7 +959,11 @@ async def list_host_remote_callback_contexts() -> List[Dict[str, Any]]:
     raw_keys = await redis_pool.keys(f"{_HOST_REMOTE_CALLBACK_CONTEXT_KEY_PREFIX}:*")
     callback_contexts = []
     for raw_key in raw_keys:
-        key = raw_key.decode() if isinstance(raw_key, (bytes, bytearray)) else str(raw_key)
+        key = (
+            raw_key.decode()
+            if isinstance(raw_key, (bytes, bytearray))
+            else str(raw_key)
+        )
         task_id = key.rsplit(":", 1)[-1]
         callback_context = await load_host_remote_callback_context(task_id)
         if callback_context is not None:

--- a/agents/stargazer/core/collection/redis_state.py
+++ b/agents/stargazer/core/collection/redis_state.py
@@ -7,23 +7,24 @@ import json
 import time
 import uuid
 
+from core.collection.credential_policy import CredentialFailure, CredentialScope
 from core.collection.runtime import (
-    LeaseAcquisition,
     LeaseAcquireStatus,
+    LeaseAcquisition,
     RunLease,
     RunStatus,
 )
-from core.collection.credential_policy import CredentialFailure, CredentialScope
-
 
 _ACQUIRE_RUN_LUA = """
 -- 薄租约：执行中则 duplicate_active；否则取得租约。不做 digest 冲突、不做 fencing 接管续跑。
 local run_key = KEYS[1]
+local generation_key = KEYS[2]
 local request_digest = ARGV[1]
 local owner_id = ARGV[2]
 local ttl_ms = tonumber(ARGV[3])
 local now_ms = tonumber(ARGV[4])
 local attempt_id = ARGV[5]
+local generation_retention_ms = tonumber(ARGV[6])
 
 local existing_owner = redis.call('HGET', run_key, 'owner_id') or ''
 local existing_expires = tonumber(redis.call('HGET', run_key, 'expires_at_ms') or '0')
@@ -48,6 +49,14 @@ redis.call(
 )
 redis.call('HDEL', run_key, 'summary')
 redis.call('PEXPIRE', run_key, ttl_ms * 2)
+redis.call(
+    'HSET',
+    generation_key,
+    'owner_id', owner_id,
+    'fence', 1,
+    'attempt_id', attempt_id
+)
+redis.call('PEXPIRE', generation_key, generation_retention_ms)
 return {'acquired', owner_id, 1, expires_at_ms, '', attempt_id}
 """
 
@@ -130,13 +139,15 @@ class RedisRunStateStore:
         ttl_ms = max(1, int(ttl_seconds * 1000))
         raw = await self._redis.eval(
             _ACQUIRE_RUN_LUA,
-            1,
+            2,
             self._run_key(task_id),
+            self._fence_key(task_id),
             request_digest,
             owner_id,
             ttl_ms,
             now_ms,
             uuid.uuid4().hex,
+            self._fence_retention_ms,
         )
         status_value, lease_owner, fence, expires_at_ms, summary_value, attempt_id = raw
         status = LeaseAcquireStatus(self._text(status_value))
@@ -171,9 +182,7 @@ class RedisRunStateStore:
         )
         return bool(result)
 
-    async def heartbeat(
-        self, lease: RunLease, *, ttl_seconds: float
-    ) -> bool:
+    async def heartbeat(self, lease: RunLease, *, ttl_seconds: float) -> bool:
         ttl_ms = max(1, int(ttl_seconds * 1000))
         result = await self._redis.eval(
             _HEARTBEAT_RUN_LUA,
@@ -231,8 +240,7 @@ class RedisCredentialStateStore:
         keys = [self._success_key(scope)]
         normalized_ids = [str(item or "") for item in credential_ids]
         keys.extend(
-            self._failure_key(scope, credential_id)
-            for credential_id in normalized_ids
+            self._failure_key(scope, credential_id) for credential_id in normalized_ids
         )
         values = await self._redis.mget(keys)
         success_id = self._text(values[0] if values else None)
@@ -242,9 +250,7 @@ class RedisCredentialStateStore:
             failures[credential_id] = self._parse_failure(raw)
         return success_id, failures
 
-    async def set_success(
-        self, scope: CredentialScope, credential_id: str
-    ) -> None:
+    async def set_success(self, scope: CredentialScope, credential_id: str) -> None:
         await self._redis.set(
             self._success_key(scope),
             credential_id,
@@ -290,9 +296,7 @@ class RedisCredentialStateStore:
             ex=self._failure_ttl_seconds,
         )
 
-    async def clear_failure(
-        self, scope: CredentialScope, credential_id: str
-    ) -> None:
+    async def clear_failure(self, scope: CredentialScope, credential_id: str) -> None:
         await self._redis.delete(self._failure_key(scope, credential_id))
 
     async def clear_scope_failures(self, scope: CredentialScope) -> None:
@@ -312,12 +316,8 @@ class RedisCredentialStateStore:
     def _success_key(self, scope: CredentialScope) -> str:
         return f"{self._key_prefix}:scope:{self._scope_digest(scope)}:success"
 
-    def _failure_key(
-        self, scope: CredentialScope, credential_id: str
-    ) -> str:
-        credential_digest = hashlib.sha256(
-            credential_id.encode("utf-8")
-        ).hexdigest()
+    def _failure_key(self, scope: CredentialScope, credential_id: str) -> str:
+        credential_digest = hashlib.sha256(credential_id.encode("utf-8")).hexdigest()
         return (
             f"{self._key_prefix}:scope:{self._scope_digest(scope)}:"
             f"credential:{credential_digest}:failure"

--- a/agents/stargazer/service/nats_server.py
+++ b/agents/stargazer/service/nats_server.py
@@ -129,6 +129,8 @@ async def handle_host_remote_callback(data: dict) -> dict:
             task_id,
             payload,
         )
+        if callback_context is None:
+            raise RuntimeError("Host Remote callback context disappeared before record")
         await _clear_host_remote_running_flag_best_effort(task_id)
         task_info = await schedule_host_remote_processing(
             task_id, claim_token=claim_token

--- a/agents/stargazer/tests/test_host_remote_stateless.py
+++ b/agents/stargazer/tests/test_host_remote_stateless.py
@@ -1,12 +1,43 @@
-import pytest
+import hashlib
+import importlib
+import json
+import sys
+from unittest.mock import AsyncMock, Mock
 
 import core.collection.host_remote.callback as callback_state
+import pytest
+from core.collection.contracts import CollectOutcomeStatus, TargetCollectionContext
 from core.collection.plugins import MonitorCollectionPlugin
-from core.collection.contracts import (
-    CollectOutcomeStatus,
-    TargetCollectionContext,
-)
 from tasks.collectors.host_collector import HostCollector
+
+
+@pytest.fixture(autouse=True)
+def host_remote_v2_settings(monkeypatch):
+    monkeypatch.setenv("HOST_REMOTE_CALLBACK_V2_ENABLED", "true")
+    monkeypatch.setenv(
+        "HOST_REMOTE_CALLBACK_TOKEN_SECRET",
+        "issue-4280-test-token-secret-with-32-bytes",
+    )
+
+
+def _generation_snapshot(generation=None, active_run=None, latest_generation=None):
+    generation_json = json.dumps(generation) if generation else ""
+    latest_generation = latest_generation or active_run or generation or {}
+    active_values = ["", "", "", 0]
+    if active_run:
+        active_values = [
+            str(active_run["fence"]),
+            active_run["attempt"],
+            active_run["owner_id"],
+            1,
+        ]
+    return [
+        generation_json,
+        *active_values,
+        str(latest_generation.get("fence") or ""),
+        latest_generation.get("attempt") or "",
+        latest_generation.get("owner_id") or "",
+    ]
 
 
 @pytest.mark.asyncio
@@ -34,6 +65,7 @@ async def test_host_remote_uses_unique_fenced_callback_id_per_target(monkeypatch
         fence=6,
         params={"monitor_type": "host", "ansible_node_id": "node-a"},
         owner_id="pod-a",
+        attempt_id="attempt-a",
     )
 
     first = await plugin.collect(
@@ -45,65 +77,856 @@ async def test_host_remote_uses_unique_fenced_callback_id_per_target(monkeypatch
 
     assert first.status == second.status == CollectOutcomeStatus.DEFERRED
     assert stored[0][0] != stored[1][0]
-    assert stored[0][2] == {
+    assert stored[0][0].startswith("remote-v2-")
+    trusted_identity = stored[0][2]
+    callback_identity = submitted[0][2]["context"]
+    assert trusted_identity == {
+        "protocol_version": "host_remote.v2",
+        "token_hash": hashlib.sha256(
+            callback_identity["token"].encode("utf-8")
+        ).hexdigest(),
         "owner_id": "pod-a",
         "fence": 6,
         "plugin_ref": "host.monitor",
         "target": "10.10.24.1",
         "collection_task_id": "monitor-host-run",
-            "attempt": 6,
-            "caller": "node-a",
-        }
+        "attempt": "attempt-a",
+        "caller": "node-a",
+    }
     assert stored[0][1]["host"] == "10.10.24.1"
     assert "credential_id" not in stored[0][1]
     assert "password" not in stored[0][1]
     assert stored[0][1]["callback_timestamp"] > 0
-    assert submitted[0][2]["collection_fence"] == 6
-    assert submitted[0][2]["collection_task_id"] == "monitor-host-run"
-    assert submitted[0][2]["collection_plugin_ref"] == "host.monitor"
-    assert submitted[0][2]["collection_owner"] == "pod-a"
-    assert submitted[0][2]["collection_attempt"] == 6
+    assert callback_identity["fence"] == 6
+    assert callback_identity["collection_task_id"] == "monitor-host-run"
+    assert callback_identity["plugin_ref"] == "host.monitor"
+    assert callback_identity["owner_id"] == "pod-a"
+    assert callback_identity["attempt"] == "attempt-a"
+
+
+@pytest.mark.asyncio
+async def test_host_remote_issues_one_time_identity_in_forwarded_context(monkeypatch):
+    stored = []
+    submitted = []
+
+    async def store(task_id, params, ctx):
+        stored.append((task_id, params, ctx))
+
+    async def accepted(task_id):
+        return None
+
+    async def submit(self, task_id, subject, payload):
+        submitted.append((task_id, subject, payload))
+        return {"success": True, "result": {"accepted": True}}
+
+    monkeypatch.setattr(callback_state, "store_host_remote_callback_context", store)
+    monkeypatch.setattr(callback_state, "mark_host_remote_submit_accepted", accepted)
+    monkeypatch.setattr(HostCollector, "submit_collection", submit)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    result = await MonitorCollectionPlugin().collect(
+        "10.10.24.1", {"credential_id": "credential-1"}, context
+    )
+
+    assert result.status == CollectOutcomeStatus.DEFERRED
+    callback_identity = submitted[0][2]["context"]
+    assert callback_identity == {
+        "protocol_version": "host_remote.v2",
+        "token": callback_identity["token"],
+        "fence": 6,
+        "target": "10.10.24.1",
+        "collection_task_id": "monitor-host-run",
+        "plugin_ref": "host.monitor",
+        "owner_id": "pod-a",
+        "attempt": "attempt-a",
+        "caller": "node-a",
+    }
+    assert len(callback_identity["token"]) >= 32
+    assert (
+        stored[0][2]["token_hash"]
+        == hashlib.sha256(callback_identity["token"].encode("utf-8")).hexdigest()
+    )
+    assert "token" not in stored[0][2]
+
+
+@pytest.mark.asyncio
+async def test_host_remote_duplicate_submission_reuses_stored_identity(monkeypatch):
+    submitted = []
+
+    async def store(task_id, params, ctx):
+        return {"ctx": dict(ctx)}
+
+    async def accepted(task_id):
+        return None
+
+    async def submit(self, task_id, subject, payload):
+        submitted.append((task_id, subject, payload))
+        return {"success": True, "result": {"accepted": True, "duplicate": True}}
+
+    monkeypatch.setattr(callback_state, "store_host_remote_callback_context", store)
+    monkeypatch.setattr(callback_state, "mark_host_remote_submit_accepted", accepted)
+    monkeypatch.setattr(HostCollector, "submit_collection", submit)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    first = await MonitorCollectionPlugin().collect(
+        "10.10.24.1", {"credential_id": "credential-1"}, context
+    )
+    second = await MonitorCollectionPlugin().collect(
+        "10.10.24.1", {"credential_id": "credential-1"}, context
+    )
+
+    assert first.status == second.status == CollectOutcomeStatus.DEFERRED
+    assert submitted[0][2]["context"]["token"] == submitted[1][2]["context"]["token"]
+
+
+@pytest.mark.asyncio
+async def test_v2_can_be_disabled_until_old_executors_are_drained(monkeypatch):
+    submitted = []
+
+    async def store(task_id, params, ctx):
+        return {"ctx": dict(ctx)}
+
+    async def accepted(task_id):
+        return None
+
+    async def submit(self, task_id, subject, payload):
+        submitted.append((task_id, subject, payload))
+        return {"success": True, "result": {"accepted": True}}
+
+    monkeypatch.setenv("HOST_REMOTE_CALLBACK_V2_ENABLED", "false")
+    monkeypatch.setattr(callback_state, "store_host_remote_callback_context", store)
+    monkeypatch.setattr(callback_state, "mark_host_remote_submit_accepted", accepted)
+    monkeypatch.setattr(HostCollector, "submit_collection", submit)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    result = await MonitorCollectionPlugin().collect(
+        "10.10.24.1", {"credential_id": "credential-1"}, context
+    )
+
+    assert result.status == CollectOutcomeStatus.DEFERRED
+    assert submitted[0][0].startswith("remote-")
+    assert not submitted[0][0].startswith("remote-v2-")
+    assert "context" not in submitted[0][2]
+
+
+@pytest.mark.asyncio
+async def test_v2_fails_closed_without_independent_token_secret(monkeypatch):
+    submitted = AsyncMock()
+    monkeypatch.delenv("HOST_REMOTE_CALLBACK_TOKEN_SECRET", raising=False)
+    monkeypatch.setattr(HostCollector, "submit_collection", submitted)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    with pytest.raises(RuntimeError, match="must contain at least 32 characters"):
+        await MonitorCollectionPlugin().collect(
+            "10.10.24.1", {"credential_id": "credential-1"}, context
+        )
+
+    submitted.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_host_remote_failed_retry_keeps_shared_callback_context(monkeypatch):
+    cleared = AsyncMock()
+    logged = []
+
+    async def store(task_id, params, ctx):
+        return {"ctx": ctx}
+
+    async def submit(self, task_id, subject, payload):
+        return {"success": False, "result": {"accepted": False}}
+
+    monkeypatch.setattr(callback_state, "store_host_remote_callback_context", store)
+    monkeypatch.setattr(callback_state, "clear_host_remote_callback_context", cleared)
+    monkeypatch.setattr(
+        callback_state,
+        "log_host_remote_event",
+        lambda event, task_id, **fields: logged.append((event, task_id, fields)),
+    )
+    monkeypatch.setattr(HostCollector, "submit_collection", submit)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    result = await MonitorCollectionPlugin().collect(
+        "10.10.24.1", {"credential_id": "credential-1"}, context
+    )
+
+    assert result.status == CollectOutcomeStatus.FAILED
+    cleared.assert_not_awaited()
+    assert len(logged) == 1
+    event, task_id, fields = logged[0]
+    assert event == "submit_rejected_context_retained"
+    assert task_id.startswith("remote-v2-")
+    assert fields == {
+        "level": "warning",
+        "execution": "waiting_callback",
+        "failed_stage": "executor_submit",
+        "error_type": "executor_rejected",
+    }
+    assert "token" not in str(logged)
+
+
+def test_host_remote_event_uses_lazy_stable_template_without_secret(monkeypatch):
+    info = Mock()
+    monkeypatch.setattr(callback_state.logger, "info", info)
+
+    callback_state.log_host_remote_event(
+        "submit_rejected_context_retained",
+        "remote-v2-id",
+        failed_stage="executor_submit",
+        error_type="executor_rejected",
+    )
+
+    template, *arguments = info.call_args.args
+    assert template == "[Host Remote] event=%s, task_id=%s, %s"
+    assert arguments == [
+        "submit_rejected_context_retained",
+        "remote-v2-id",
+        "failed_stage=executor_submit, error_type=executor_rejected",
+    ]
+    rendered = template % tuple(arguments)
+    assert rendered == (
+        "[Host Remote] event=submit_rejected_context_retained, "
+        "task_id=remote-v2-id, failed_stage=executor_submit, "
+        "error_type=executor_rejected"
+    )
+    assert "token" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_host_remote_rejects_conflicting_stored_identity(monkeypatch):
+    submitted = []
+
+    async def store(task_id, params, ctx):
+        persisted = dict(ctx)
+        persisted["target"] = "10.10.24.99"
+        return {"ctx": persisted}
+
+    async def submit(self, task_id, subject, payload):
+        submitted.append((task_id, subject, payload))
+        return {"success": True, "result": {"accepted": True}}
+
+    async def accepted(task_id):
+        return None
+
+    monkeypatch.setattr(callback_state, "store_host_remote_callback_context", store)
+    monkeypatch.setattr(callback_state, "mark_host_remote_submit_accepted", accepted)
+    monkeypatch.setattr(HostCollector, "submit_collection", submit)
+    context = TargetCollectionContext(
+        task_id="monitor-host-run",
+        plugin_ref="host.monitor",
+        fence=6,
+        params={"monitor_type": "host", "ansible_node_id": "node-a"},
+        owner_id="pod-a",
+        attempt_id="attempt-a",
+    )
+
+    with pytest.raises(RuntimeError, match="stored identity conflict"):
+        await MonitorCollectionPlugin().collect(
+            "10.10.24.1", {"credential_id": "credential-1"}, context
+        )
+
+    assert submitted == []
+
+
+@pytest.mark.asyncio
+async def test_store_host_remote_context_keeps_first_identity_atomically(monkeypatch):
+    class Redis:
+        def __init__(self):
+            self.values = {}
+            self.run = {
+                "owner_id": "pod-a",
+                "fence": "8",
+                "attempt_id": "attempt-a",
+            }
+
+        async def eval(self, script, key_count, *args):
+            assert key_count == 3
+            (
+                run_key,
+                generation_key,
+                context_key,
+                owner_id,
+                fence,
+                attempt_id,
+                generation_json,
+                context_json,
+                ttl_seconds,
+            ) = args
+            assert run_key.endswith(":run:parent-task")
+            assert ttl_seconds > 0
+            if self.run != {
+                "owner_id": owner_id,
+                "fence": str(fence),
+                "attempt_id": attempt_id,
+            }:
+                return [0, ""]
+            self.values[generation_key] = generation_json
+            if context_key in self.values:
+                return [2, self.values[context_key]]
+            self.values[context_key] = context_json
+            return [1, context_json]
+
+        async def get(self, key):
+            return self.values.get(key)
+
+    redis = Redis()
+
+    async def get_pool():
+        return redis
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+    first = await callback_state.store_host_remote_callback_context(
+        "remote-v2-id",
+        {"monitor_type": "host"},
+        {
+            "protocol_version": "host_remote.v2",
+            "token": "first-token",
+            "collection_task_id": "parent-task",
+            "owner_id": "pod-a",
+            "fence": 8,
+            "attempt": "attempt-a",
+        },
+    )
+    second = await callback_state.store_host_remote_callback_context(
+        "remote-v2-id",
+        {"monitor_type": "host"},
+        {
+            "protocol_version": "host_remote.v2",
+            "token": "second-token",
+            "collection_task_id": "parent-task",
+            "owner_id": "pod-a",
+            "fence": 8,
+            "attempt": "attempt-a",
+        },
+    )
+
+    assert first["ctx"]["token"] == "first-token"
+    assert second["ctx"]["token"] == "first-token"
+
+
+@pytest.mark.asyncio
+async def test_store_host_remote_context_rejects_stale_parent_generation(monkeypatch):
+    class Redis:
+        async def eval(self, script, key_count, *args):
+            return [0, ""]
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="generation is stale"):
+        await callback_state.store_host_remote_callback_context(
+            "remote-v2-id",
+            {"monitor_type": "host"},
+            {
+                "protocol_version": "host_remote.v2",
+                "token": "stale-token",
+                "collection_task_id": "parent-task",
+                "owner_id": "pod-a",
+                "fence": 8,
+                "attempt": "attempt-a",
+            },
+        )
+
+
+def test_host_remote_callback_accepts_current_nested_identity():
+    token = "current-one-time-token"
+    callback_context = {
+        "ctx": {
+            "token_hash": hashlib.sha256(token.encode("utf-8")).hexdigest(),
+            "fence": 8,
+            "target": "10.10.24.1",
+            "collection_task_id": "monitor-host-run",
+            "plugin_ref": "host.monitor",
+            "owner_id": "pod-a",
+            "attempt": "attempt-a",
+            "caller": "executor-region-a",
+        },
+        "raw_callback": None,
+        "status": {"execution": "waiting_callback"},
+    }
+    identity = {
+        "protocol_version": "host_remote.v2",
+        "token": token,
+        "fence": 8,
+        "target": "10.10.24.1",
+        "collection_task_id": "monitor-host-run",
+        "plugin_ref": "host.monitor",
+        "owner_id": "pod-a",
+        "attempt": "attempt-a",
+        "caller": "executor-region-a",
+    }
+
+    callback_state.validate_host_remote_callback_identity(
+        {"task_id": "remote-id", "callback_context": identity},
+        callback_context,
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_inflight_callback_remains_accepted_within_bounded_ttl(
+    monkeypatch,
+):
+    now_ms = 1_800_000
+    monkeypatch.setattr(callback_state, "_now_ms", lambda: now_ms)
+    callback_context = {
+        "task_id": "remote-legacy-id",
+        "ctx": {
+            "fence": 8,
+            "attempt": 8,
+            "owner_id": "pod-a",
+            "collection_task_id": "monitor-host-run",
+        },
+        "status": {"execution": "waiting_callback"},
+        "raw_callback": None,
+        "created_at": now_ms - 30_000,
+        "callback_deadline_at": now_ms + 30_000,
+    }
+    payload = {"task_id": "remote-legacy-id", "result": {"cpu": 1}}
+
+    callback_state.validate_host_remote_callback_identity(
+        payload,
+        callback_context,
+    )
+    await callback_state.ensure_host_remote_callback_fence_is_current(callback_context)
+
+
+def test_expired_legacy_inflight_callback_is_rejected(monkeypatch):
+    now_ms = 7_200_000
+    monkeypatch.setattr(callback_state, "_now_ms", lambda: now_ms)
+    callback_context = {
+        "task_id": "remote-legacy-id",
+        "ctx": {
+            "fence": 8,
+            "attempt": 8,
+            "owner_id": "pod-a",
+            "collection_task_id": "monitor-host-run",
+        },
+        "status": {"execution": "waiting_callback"},
+        "raw_callback": None,
+        "created_at": now_ms - 3_700_000,
+        "callback_deadline_at": now_ms + 30_000,
+    }
+
+    with pytest.raises(RuntimeError, match="legacy compatibility window expired"):
+        callback_state.validate_host_remote_callback_identity(
+            {"task_id": "remote-legacy-id", "result": {"cpu": 1}},
+            callback_context,
+        )
+
+
+def test_host_remote_callback_rejects_forged_token_before_scheduling():
+    callback_context = {
+        "ctx": {
+            "token_hash": hashlib.sha256(b"current-token").hexdigest(),
+            "fence": 8,
+            "target": "10.10.24.1",
+            "collection_task_id": "monitor-host-run",
+            "plugin_ref": "host.monitor",
+            "owner_id": "pod-a",
+            "attempt": "attempt-a",
+            "caller": "executor-region-a",
+        },
+        "raw_callback": None,
+        "status": {"execution": "waiting_callback"},
+    }
+
+    with pytest.raises(RuntimeError, match="callback token mismatch"):
+        callback_state.validate_host_remote_callback_identity(
+            {
+                "task_id": "remote-id",
+                "callback_context": {
+                    "protocol_version": "host_remote.v2",
+                    "token": "forged-token",
+                    "fence": 8,
+                    "target": "10.10.24.1",
+                    "collection_task_id": "monitor-host-run",
+                    "plugin_ref": "host.monitor",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                    "caller": "executor-region-a",
+                },
+            },
+            callback_context,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "invalid_value", "error_match"),
+    [
+        ("protocol_version", "host_remote.v1", "protocol version mismatch"),
+        ("token", "forged-token", "token mismatch"),
+        ("fence", 9, "fencing token mismatch"),
+        ("target", "10.10.24.2", "target mismatch"),
+        ("collection_task_id", "other-run", "collection task mismatch"),
+        ("plugin_ref", "host.other", "plugin mismatch"),
+        ("owner_id", "pod-b", "owner mismatch"),
+        ("attempt", "attempt-b", "attempt mismatch"),
+        ("caller", "executor-region-b", "caller mismatch"),
+        ("_deadline", 1, "callback is expired"),
+        ("_status", "execution_finished", "duplicate or out of order"),
+        ("_raw", {"result": "first"}, "duplicate or out of order"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_host_remote_handler_rejects_invalid_identity_without_side_effects(
+    monkeypatch,
+    field,
+    invalid_value,
+    error_match,
+):
+    import core.infra.nats as nats_module
+
+    def register_handler(*args, **kwargs):
+        return lambda handler: handler
+
+    monkeypatch.setattr(nats_module, "register_handler", register_handler)
+    monkeypatch.delitem(sys.modules, "service.nats_server", raising=False)
+    nats_server = importlib.import_module("service.nats_server")
+    callback_context = {
+        "ctx": {
+            "token_hash": hashlib.sha256(b"current-token").hexdigest(),
+            "fence": 8,
+            "target": "10.10.24.1",
+            "collection_task_id": "monitor-host-run",
+            "plugin_ref": "host.monitor",
+            "owner_id": "pod-a",
+            "attempt": "attempt-a",
+            "caller": "executor-region-a",
+        },
+        "raw_callback": None,
+        "status": {"execution": "waiting_callback"},
+    }
+    load_context = AsyncMock(return_value=callback_context)
+    ensure_current = AsyncMock()
+    claim_processing = AsyncMock(return_value="claim-token")
+    record_payload = AsyncMock()
+    clear_running = AsyncMock()
+    schedule_processing = AsyncMock()
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "load_host_remote_callback_context",
+        load_context,
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "ensure_host_remote_callback_fence_is_current",
+        ensure_current,
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "claim_host_remote_processing",
+        claim_processing,
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "record_host_remote_callback_payload",
+        record_payload,
+    )
+    monkeypatch.setattr(
+        nats_server,
+        "_clear_host_remote_running_flag_best_effort",
+        clear_running,
+    )
+    monkeypatch.setattr(
+        nats_server,
+        "schedule_host_remote_processing",
+        schedule_processing,
+    )
+
+    callback_identity = {
+        "protocol_version": "host_remote.v2",
+        "token": "current-token",
+        "fence": 8,
+        "target": "10.10.24.1",
+        "collection_task_id": "monitor-host-run",
+        "plugin_ref": "host.monitor",
+        "owner_id": "pod-a",
+        "attempt": "attempt-a",
+        "caller": "executor-region-a",
+    }
+    if field == "_deadline":
+        callback_context["callback_deadline_at"] = invalid_value
+    elif field == "_status":
+        callback_context["status"]["execution"] = invalid_value
+    elif field == "_raw":
+        callback_context["raw_callback"] = invalid_value
+    else:
+        callback_identity[field] = invalid_value
+    with pytest.raises(RuntimeError, match=error_match):
+        await nats_server.handle_host_remote_callback(
+            {
+                "args": [
+                    {
+                        "task_id": "remote-v2-id",
+                        "callback_context": callback_identity,
+                    }
+                ],
+                "kwargs": {},
+            }
+        )
+
+    ensure_current.assert_not_awaited()
+    claim_processing.assert_not_awaited()
+    record_payload.assert_not_awaited()
+    clear_running.assert_not_awaited()
+    schedule_processing.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_host_remote_handler_stops_when_atomic_record_loses_context(
+    monkeypatch,
+):
+    import core.infra.nats as nats_module
+
+    monkeypatch.setattr(
+        nats_module,
+        "register_handler",
+        lambda *args, **kwargs: lambda handler: handler,
+    )
+    monkeypatch.delitem(sys.modules, "service.nats_server", raising=False)
+    nats_server = importlib.import_module("service.nats_server")
+    callback_context = {
+        "ctx": {},
+        "params": {"monitor_type": "host"},
+        "status": {"execution": "waiting_callback"},
+        "raw_callback": None,
+    }
+    release_claim = AsyncMock(return_value=True)
+    clear_running = AsyncMock()
+    schedule_processing = AsyncMock()
+    mark_enqueued = AsyncMock()
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "load_host_remote_callback_context",
+        AsyncMock(return_value=callback_context),
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "validate_host_remote_callback_identity",
+        lambda payload, context: None,
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "ensure_host_remote_callback_fence_is_current",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "claim_host_remote_processing",
+        AsyncMock(return_value="claim-token"),
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "record_host_remote_callback_payload",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "release_host_remote_processing_claim",
+        release_claim,
+    )
+    monkeypatch.setattr(
+        nats_server,
+        "_clear_host_remote_running_flag_best_effort",
+        clear_running,
+    )
+    monkeypatch.setattr(
+        nats_server,
+        "schedule_host_remote_processing",
+        schedule_processing,
+    )
+    monkeypatch.setattr(
+        nats_server.host_remote_callback,
+        "mark_host_remote_processing_enqueued",
+        mark_enqueued,
+    )
+
+    with pytest.raises(RuntimeError, match="context disappeared"):
+        await nats_server.handle_host_remote_callback(
+            {"args": [{"task_id": "remote-v2-id"}], "kwargs": {}}
+        )
+
+    release_claim.assert_awaited_once_with("remote-v2-id", "claim-token")
+    clear_running.assert_not_awaited()
+    schedule_processing.assert_not_awaited()
+    mark_enqueued.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_atomic_record_rejects_duplicate_status(monkeypatch):
+    callback_context = {
+        "ctx": {
+            "collection_task_id": "monitor-host-run",
+            "owner_id": "pod-a",
+            "fence": 1,
+            "attempt": "attempt-a",
+        },
+        "status": {"execution": "execution_finished"},
+        "raw_callback": {"result": "first"},
+    }
+
+    class Redis:
+        async def eval(self, *args):
+            return [4, json.dumps(callback_context)]
+
+    monkeypatch.setattr(
+        callback_state,
+        "load_host_remote_callback_context",
+        AsyncMock(return_value=callback_context),
+    )
+    monkeypatch.setattr(
+        callback_state,
+        "_get_host_remote_callback_pool",
+        AsyncMock(return_value=Redis()),
+    )
+
+    with pytest.raises(RuntimeError, match="duplicate or out of order"):
+        await callback_state.record_host_remote_callback_payload(
+            "remote-v2-id",
+            {"task_id": "remote-v2-id", "callback_context": {}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_submit_accepted_does_not_overwrite_completed_callback(monkeypatch):
+    logged = []
+    completed = {
+        "task_id": "remote-v2-id",
+        "ctx": {"token_hash": "digest"},
+        "status": {"execution": "execution_finished", "delivery": "not_ready"},
+        "raw_callback": {"result": {"cpu": 1}},
+    }
+    stale_waiting = {
+        **completed,
+        "ctx": {"token": "plaintext", "token_hash": "digest"},
+        "status": {"execution": "waiting_callback", "delivery": "not_ready"},
+        "raw_callback": None,
+    }
+
+    class Redis:
+        async def eval(self, *args):
+            return [2, json.dumps(completed)]
+
+        async def set(self, *args, **kwargs):
+            return True
+
+    monkeypatch.setattr(
+        callback_state,
+        "load_host_remote_callback_context",
+        AsyncMock(return_value=stale_waiting),
+    )
+    monkeypatch.setattr(
+        callback_state,
+        "_get_host_remote_callback_pool",
+        AsyncMock(return_value=Redis()),
+    )
+    monkeypatch.setattr(
+        callback_state,
+        "log_host_remote_event",
+        lambda event, task_id, **fields: logged.append((event, task_id, fields)),
+    )
+
+    stored = await callback_state.mark_host_remote_submit_accepted("remote-v2-id")
+
+    assert stored["status"]["execution"] == "execution_finished"
+    assert stored["raw_callback"] == {"result": {"cpu": 1}}
+    assert "token" not in stored["ctx"]
+    assert logged == [
+        (
+            "submit_ack_after_callback",
+            "remote-v2-id",
+            {"execution": "execution_finished", "delivery": "not_ready"},
+        )
+    ]
 
 
 def test_host_remote_callback_rejects_wrong_fence_before_scheduling():
+    token = "current-token"
     callback_context = {
-            "ctx": {
-                "fence": 8,
-                "target": "10.10.24.1",
-                "collection_task_id": "monitor-host-run",
-                "plugin_ref": "host.monitor",
-                "owner_id": "pod-a",
-                "attempt": 8,
-            },
-            "params": {"monitor_type": "host"},
-            "raw_callback": None,
-            "status": {"execution": "waiting_callback"},
-        }
+        "ctx": {
+            "protocol_version": "host_remote.v2",
+            "token_hash": hashlib.sha256(token.encode("utf-8")).hexdigest(),
+            "fence": 8,
+            "target": "10.10.24.1",
+            "collection_task_id": "monitor-host-run",
+            "plugin_ref": "host.monitor",
+            "owner_id": "pod-a",
+            "attempt": "attempt-a",
+            "caller": "executor-region-a",
+        },
+        "params": {"monitor_type": "host"},
+        "raw_callback": None,
+        "status": {"execution": "waiting_callback"},
+    }
 
     with pytest.raises(RuntimeError, match="fencing token mismatch"):
         callback_state.validate_host_remote_callback_identity(
             {
                 "task_id": "remote-id",
-                "collection_fence": 7,
-                "collection_target": "10.10.24.1",
-                "collection_task_id": "monitor-host-run",
-                "collection_plugin_ref": "host.monitor",
-                "collection_owner": "pod-a",
-                "collection_attempt": 8,
+                "callback_context": {
+                    "protocol_version": "host_remote.v2",
+                    "token": token,
+                    "fence": 7,
+                    "target": "10.10.24.1",
+                    "collection_task_id": "monitor-host-run",
+                    "plugin_ref": "host.monitor",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                    "caller": "executor-region-a",
+                },
             },
             callback_context,
         )
 
 
 def test_host_remote_callback_rejects_untrusted_responder_caller():
+    token = "current-token"
     callback_context = {
         "ctx": {
+            "protocol_version": "host_remote.v2",
+            "token_hash": hashlib.sha256(token.encode("utf-8")).hexdigest(),
             "fence": 8,
             "target": "10.10.24.1",
             "collection_task_id": "monitor-host-run",
             "plugin_ref": "host.monitor",
             "owner_id": "pod-a",
-            "attempt": 8,
+            "attempt": "attempt-a",
             "caller": "executor-region-a",
         },
         "raw_callback": None,
@@ -113,13 +936,17 @@ def test_host_remote_callback_rejects_untrusted_responder_caller():
     with pytest.raises(RuntimeError, match="caller mismatch"):
         callback_state.validate_host_remote_callback_identity(
             {
-                "collection_fence": 8,
-                "collection_target": "10.10.24.1",
-                "collection_task_id": "monitor-host-run",
-                "collection_plugin_ref": "host.monitor",
-                "collection_owner": "pod-a",
-                "collection_attempt": 8,
-                "collection_caller": "executor-region-b",
+                "callback_context": {
+                    "protocol_version": "host_remote.v2",
+                    "token": token,
+                    "fence": 8,
+                    "target": "10.10.24.1",
+                    "collection_task_id": "monitor-host-run",
+                    "plugin_ref": "host.monitor",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                    "caller": "executor-region-b",
+                },
             },
             callback_context,
         )
@@ -130,17 +957,20 @@ async def test_host_remote_callback_rejects_fence_replaced_by_takeover(
     monkeypatch,
 ):
     class Redis:
-        async def hget(self, key, field):
-            assert key.endswith(":run:monitor-host-run")
-            assert field == "fence"
-            return "9"
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            assert key_count == 3
+            assert generation_key.endswith(":current_generation:monitor-host-run")
+            assert fence_key.endswith(":fence:monitor-host-run")
+            return _generation_snapshot(
+                {"fence": 9, "attempt": "attempt-a", "owner_id": "pod-a"}
+            )
 
     async def get_pool():
         return Redis()
 
     monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
 
-    with pytest.raises(RuntimeError, match="token is stale"):
+    with pytest.raises(RuntimeError, match="fencing token is stale"):
         await callback_state.ensure_host_remote_callback_fence_is_current(
             {
                 "ctx": {
@@ -149,7 +979,186 @@ async def test_host_remote_callback_rejects_fence_replaced_by_takeover(
                     "collection_task_id": "monitor-host-run",
                     "plugin_ref": "host.monitor",
                     "owner_id": "pod-a",
-                    "attempt": 8,
+                    "attempt": "attempt-a",
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_host_remote_callback_rejects_replaced_attempt_with_same_fence(
+    monkeypatch,
+):
+    class Redis:
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            return _generation_snapshot(
+                {"fence": 8, "attempt": "attempt-b", "owner_id": "pod-a"}
+            )
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="attempt is stale"):
+        await callback_state.ensure_host_remote_callback_fence_is_current(
+            {
+                "ctx": {
+                    "fence": 8,
+                    "collection_task_id": "monitor-host-run",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_host_remote_callback_rejects_replaced_owner(monkeypatch):
+    class Redis:
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            return _generation_snapshot(
+                {"fence": 8, "attempt": "attempt-a", "owner_id": "pod-b"}
+            )
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="owner is stale"):
+        await callback_state.ensure_host_remote_callback_fence_is_current(
+            {
+                "ctx": {
+                    "fence": 8,
+                    "collection_task_id": "monitor-host-run",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_host_remote_callback_accepts_generation_after_run_key_finished(
+    monkeypatch,
+):
+    class Redis:
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            assert key_count == 3
+            return _generation_snapshot(
+                {"fence": 8, "attempt": "attempt-a", "owner_id": "pod-a"}
+            )
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    await callback_state.ensure_host_remote_callback_fence_is_current(
+        {
+            "ctx": {
+                "fence": 8,
+                "collection_task_id": "monitor-host-run",
+                "owner_id": "pod-a",
+                "attempt": "attempt-a",
+            }
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_old_callback_rejected_after_new_run_acquired_before_context_store(
+    monkeypatch,
+):
+    class Redis:
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            return _generation_snapshot(
+                {"fence": 1, "attempt": "attempt-a", "owner_id": "pod-a"},
+                {"fence": 1, "attempt": "attempt-b", "owner_id": "pod-b"},
+            )
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="attempt is stale|owner is stale"):
+        await callback_state.ensure_host_remote_callback_fence_is_current(
+            {
+                "ctx": {
+                    "fence": 1,
+                    "collection_task_id": "monitor-host-run",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_old_callback_rejected_after_new_run_finished_before_context_store(
+    monkeypatch,
+):
+    class Redis:
+        async def eval(self, script, key_count, *keys):
+            generation = {
+                "fence": 8,
+                "attempt": "attempt-a",
+                "owner_id": "pod-a",
+            }
+            if key_count == 2:
+                return _generation_snapshot(generation)
+            assert key_count == 3
+            assert keys[2].endswith(":fence:monitor-host-run")
+            return [
+                json.dumps(generation),
+                "",
+                "",
+                "",
+                0,
+                "8",
+                "attempt-b",
+                "pod-b",
+            ]
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="latest attempt is stale"):
+        await callback_state.ensure_host_remote_callback_fence_is_current(
+            {
+                "ctx": {
+                    "fence": 8,
+                    "collection_task_id": "monitor-host-run",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
+                }
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_host_remote_callback_rejects_expired_generation_pointer(monkeypatch):
+    class Redis:
+        async def eval(self, script, key_count, generation_key, run_key, fence_key):
+            return _generation_snapshot()
+
+    async def get_pool():
+        return Redis()
+
+    monkeypatch.setattr(callback_state, "_get_host_remote_callback_pool", get_pool)
+
+    with pytest.raises(RuntimeError, match="generation is stale"):
+        await callback_state.ensure_host_remote_callback_fence_is_current(
+            {
+                "ctx": {
+                    "fence": 8,
+                    "collection_task_id": "monitor-host-run",
+                    "owner_id": "pod-a",
+                    "attempt": "attempt-a",
                 }
             }
         )
@@ -189,9 +1198,7 @@ async def test_host_remote_processing_claim_is_cross_pod_atomic(monkeypatch):
     assert not await callback_state.release_host_remote_processing_claim(
         "remote-id", "wrong-token"
     )
-    assert await callback_state.release_host_remote_processing_claim(
-        "remote-id", first
-    )
+    assert await callback_state.release_host_remote_processing_claim("remote-id", first)
     assert await callback_state.claim_host_remote_processing("remote-id")
 
 

--- a/agents/stargazer/tests/test_redis_collection_state.py
+++ b/agents/stargazer/tests/test_redis_collection_state.py
@@ -9,21 +9,9 @@ from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from redis import Redis
-from redis.asyncio import Redis as AsyncRedis
-from redis.exceptions import ConnectionError as RedisConnectionError
-from redis.exceptions import ResponseError
-
-from core.collection.runtime import LeaseAcquireStatus, RunLease, RunStatus
-from core.collection.runtime import CollectionRequest
 from core.collection.application import (
     CollectionApplication,
     CollectionApplicationSettings,
-)
-from core.collection.credential_policy import CredentialPolicy
-from core.collection.redis_state import (
-    RedisCredentialStateStore,
-    RedisRunStateStore,
 )
 from core.collection.contracts import (
     CollectOutcome,
@@ -31,7 +19,23 @@ from core.collection.contracts import (
     PreflightResult,
     PreflightStatus,
 )
+from core.collection.credential_policy import CredentialPolicy
+from core.collection.host_remote import callback as callback_state
+from core.collection.redis_state import (
+    RedisCredentialStateStore,
+    RedisRunStateStore,
+)
+from core.collection.runtime import (
+    CollectionRequest,
+    LeaseAcquireStatus,
+    RunLease,
+    RunStatus,
+)
 from core.infra.credential_state_cache import CredentialStateCache
+from redis import Redis
+from redis.asyncio import Redis as AsyncRedis
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
 
 
 def _stop_redis(process):
@@ -128,6 +132,141 @@ async def test_two_pods_atomically_share_one_run_lease(redis_client):
     assert duplicate.lease.fence == first.lease.fence == 1
     assert duplicate.lease.attempt_id == first.lease.attempt_id
     assert first.lease.attempt_id
+
+
+@pytest.mark.asyncio
+async def test_run_acquire_persists_latest_generation_tombstone(redis_client):
+    run_store = RedisRunStateStore(redis_client, key_prefix="test:generation")
+
+    acquisition = await run_store.acquire(
+        task_id="collect-generation",
+        request_digest="digest-a",
+        owner_id="pod-a",
+        ttl_seconds=60,
+    )
+
+    assert acquisition.lease is not None
+    latest_generation = await redis_client.hgetall(
+        run_store._fence_key("collect-generation")
+    )
+    assert latest_generation == {
+        "owner_id": acquisition.lease.owner_id,
+        "fence": str(acquisition.lease.fence),
+        "attempt_id": acquisition.lease.attempt_id,
+    }
+    assert await redis_client.pttl(run_store._fence_key("collect-generation")) > 0
+
+
+@pytest.mark.asyncio
+async def test_callback_record_rechecks_latest_finished_generation_atomically(
+    redis_client,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "HOST_REMOTE_CALLBACK_TOKEN_SECRET",
+        "issue-4280-test-token-secret-with-32-bytes",
+    )
+    monkeypatch.setattr(callback_state, "_host_remote_callback_pool", redis_client)
+    run_store = RedisRunStateStore(redis_client)
+    first = await run_store.acquire(
+        task_id="callback-generation",
+        request_digest="digest-a",
+        owner_id="pod-a",
+        ttl_seconds=60,
+    )
+    assert first.lease is not None
+    callback_identity, trusted_identity = (
+        callback_state.issue_host_remote_callback_identity(
+            fence=first.lease.fence,
+            target="10.0.0.1",
+            collection_task_id=first.lease.task_id,
+            plugin_ref="host.monitor",
+            owner_id=first.lease.owner_id,
+            attempt=first.lease.attempt_id,
+            caller="executor-a",
+        )
+    )
+    callback_task_id = "remote-v2-generation-race"
+    await callback_state.store_host_remote_callback_context(
+        callback_task_id,
+        {"host": "10.0.0.1"},
+        trusted_identity,
+        ttl_seconds=60,
+    )
+    assert await run_store.finish(first.lease, RunStatus.COMPLETED)
+    second = await run_store.acquire(
+        task_id="callback-generation",
+        request_digest="digest-b",
+        owner_id="pod-b",
+        ttl_seconds=60,
+    )
+    assert second.lease is not None
+    assert await run_store.finish(second.lease, RunStatus.FAILED)
+
+    with pytest.raises(RuntimeError, match="latest generation is stale"):
+        await callback_state.record_host_remote_callback_payload(
+            callback_task_id,
+            {
+                "task_id": callback_task_id,
+                "callback_context": callback_identity,
+                "result": {"cpu": 1},
+            },
+        )
+
+    stored = await callback_state.load_host_remote_callback_context(callback_task_id)
+    assert stored["raw_callback"] is None
+
+
+@pytest.mark.asyncio
+async def test_callback_record_removes_consumed_token_from_redis(
+    redis_client,
+    monkeypatch,
+):
+    monkeypatch.setenv(
+        "HOST_REMOTE_CALLBACK_TOKEN_SECRET",
+        "issue-4280-test-token-secret-with-32-bytes",
+    )
+    monkeypatch.setattr(callback_state, "_host_remote_callback_pool", redis_client)
+    run_store = RedisRunStateStore(redis_client)
+    acquisition = await run_store.acquire(
+        task_id="callback-token-redaction",
+        request_digest="digest",
+        owner_id="pod-a",
+        ttl_seconds=60,
+    )
+    assert acquisition.lease is not None
+    callback_identity, trusted_identity = (
+        callback_state.issue_host_remote_callback_identity(
+            fence=acquisition.lease.fence,
+            target="10.0.0.1",
+            collection_task_id=acquisition.lease.task_id,
+            plugin_ref="host.monitor",
+            owner_id=acquisition.lease.owner_id,
+            attempt=acquisition.lease.attempt_id,
+            caller="executor-a",
+        )
+    )
+    callback_task_id = "remote-v2-token-redaction"
+    await callback_state.store_host_remote_callback_context(
+        callback_task_id,
+        {"host": "10.0.0.1"},
+        trusted_identity,
+        ttl_seconds=60,
+    )
+    assert await run_store.finish(acquisition.lease, RunStatus.COMPLETED)
+
+    stored = await callback_state.record_host_remote_callback_payload(
+        callback_task_id,
+        {
+            "task_id": callback_task_id,
+            "callback_context": callback_identity,
+            "result": {"cpu": 1},
+        },
+    )
+
+    assert "token" not in stored["ctx"]
+    assert "token" not in stored["raw_callback"]["callback_context"]
+    assert stored["ctx"]["token_hash"] == trusted_identity["token_hash"]
 
 
 @pytest.mark.asyncio
@@ -276,9 +415,7 @@ async def test_concurrent_result_events_commit_before_cursor_can_advance(
         )
         if not raw_page:
             break
-        page = [
-            CredentialStateCache._decode_event_member(item) for item in raw_page
-        ]
+        page = [CredentialStateCache._decode_event_member(item) for item in raw_page]
         observed_ids.extend(event["event_id"] for event in page)
         legacy_cursor = page[-1]["finished_at"]
 
@@ -326,11 +463,7 @@ async def test_rollback_cursor_keeps_old_writer_events_reachable(
     )
     await redis_client.zadd(
         CredentialStateCache._event_stream_key(),
-        {
-            old_writer_event: CredentialStateCache._event_score(
-                old_writer_finished_at
-            )
-        },
+        {old_writer_event: CredentialStateCache._event_score(old_writer_finished_at)},
     )
 
     assert CredentialStateCache._event_score(legacy_cursor) < (
@@ -414,9 +547,7 @@ async def test_credential_affinity_and_cooldown_are_shared_without_storing_secre
         "10.10.24.1",
         request.credentials[1],
     )
-    eligible = await second_policy.eligible_credentials(
-        request, "10.10.24.1"
-    )
+    eligible = await second_policy.eligible_credentials(request, "10.10.24.1")
 
     assert [item["credential_id"] for item in eligible] == [
         "credential-2",


### PR DESCRIPTION
## 问题

Host Remote 回调原先只用 `task_id` 查找等待中的 Redis context。同一 NATS 域内能够发布消息的主体一旦获知任务 ID，就可能抢先写入伪造结果；真实 Executor 回调随后会被 first-write-wins 语义忽略。

## 根因

任务提交与结果回调之间没有可验证的执行身份契约：callback 配置没有把真实运行代次、owner、目标和一次性能力绑定到 Executor 已支持的 `callback.context`；Redis 的运行租约结束后也没有持久的最新代次栅栏，校验与结果落库之间缺少原子线性化点。

## 怎么修的

- 新增 `host_remote.v2` callback context，绑定 token、fence、目标、父任务、插件、owner、真实 attempt 和 Executor caller。
- token 由独立环境密钥与不可变执行身份确定性 HMAC 派生，Redis 只保存摘要；Executor 继续复用既有加密 callback secret 持久化与原样回显契约。
- 每次 run acquire 在 Redis Lua 中推进 latest-run tombstone；callback generation、active run、submit ACK 和首次 payload 都通过 Lua 条件更新，任何新代次都会使旧回调失败关闭。
- 只有首次 payload 明确 committed 后才清理 running 并启动处理；context 消失、重复、过期或身份错误均释放 claim 且不产生清理/入队副作用。

## 影响范围与迁移

- 改动限于 Stargazer Host Remote 提交、回调状态与相关文档；Ansible Executor 的公开 payload 与持久化接口不变。
- `HOST_REMOTE_CALLBACK_V2_ENABLED` 默认关闭，先升级并排空旧 Executor、旧 context 和 callback retry，再配置至少 32 字符的 `HOST_REMOTE_CALLBACK_TOKEN_SECRET` 并启用。
- 旧 `remote-` 在途任务仅在既有 context TTL/deadline 内兼容；排空后可把 `HOST_REMOTE_CALLBACK_LEGACY_MAX_AGE_SECONDS` 设为 `0`。
- 回滚前先停止新 v2 签发并排空 v2 context、执行任务及 Executor retry；不能排空时保留 v2 handler。
- 本片阻断无法读取任务请求的盲伪造；共享 NATS 管理员可观察任务面的最终信任根仍需后续最小 ACL/独立服务身份治理。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["submit_host_remote_collection\nadapter.py"]
    end

    subgraph R["Redis 身份层"]
        R1["run acquire\nlatest-run tombstone"]
        R2["callback context\ntoken hash + generation"]
    end

    subgraph E["执行与回调层"]
        E1["Ansible Executor\ncallback.context 加密回显"]
        E2["handle_host_remote_callback\nnats_server.py"]
    end

    subgraph C["原子提交层"]
        C1["generation/latest/active 校验"]
        C2["首次 payload committed"]
        C3["清 running 并调度处理"]
    end

    T1 --> R1 --> R2 --> E1 --> E2 --> C1 --> C2 --> C3
    C1 -. "失配/过期/重复" .-> X["释放 claim，零副作用"]
```

## 验证

- `agents/stargazer/tests/test_host_remote_stateless.py` + `agents/stargazer/tests/test_redis_collection_state.py`：54 passed。
- `agents/ansible-executor/tests/test_nats_service.py` + `agents/ansible-executor/tests/test_task_store.py`：58 passed。
- Redis 7.2：submit ACK CAS、首次 payload 原子提交、重复拒绝、takeover 栅栏及 token hash-only 生命周期通过。
- 差异覆盖率：88%。
- 定向 Black、isort、flake8、compileall 与 diff-check：通过。

## 三轨门禁

- Standards：PASS（98）
- Spec：PASS（99）
- Runtime Contract：PASS（98）
- G6：98/100

关联 Issue #4280。
