### PR TITLE
bugfix: 修复通知全失败误确认

### DIFF
--- a/server/apps/alerts/service/notify_service.py
+++ b/server/apps/alerts/service/notify_service.py
@@ -33,22 +33,21 @@ class NotifyResultService(object):
         self.notify_action_object = notify_action_object
         self.notify_object = notify_object
 
-    def format_notify_result(self):
-        """
-        格式化通知结果
-        """
+    @classmethod
+    def classify_notify_result(cls, notify_result):
+        """按现有兼容契约分类单个渠道结果。"""
         try:
-            if not isinstance(self.notify_result, dict):
+            if not isinstance(notify_result, dict):
                 return NotifyResultStatus.FAILED
 
-            result = self.notify_result.get("result")
+            result = notify_result.get("result")
             if isinstance(result, bool):
                 return NotifyResultStatus.SUCCESS if result else NotifyResultStatus.FAILED
 
             for code_field in ("errcode", "code"):
-                if code_field not in self.notify_result:
+                if code_field not in notify_result:
                     continue
-                code = self.notify_result[code_field]
+                code = notify_result[code_field]
                 is_success = str(code).strip() == "0"
                 return NotifyResultStatus.SUCCESS if is_success else NotifyResultStatus.FAILED
 
@@ -57,9 +56,15 @@ class NotifyResultService(object):
         except Exception as e:
             logger.warning(
                 "[AlertNotify] NotifyResultService format_notify_result 解析失败, result=%s, error=%s",
-                self.notify_result, e,
+                notify_result, e,
             )
             return NotifyResultStatus.FAILED
+
+    def format_notify_result(self):
+        """
+        格式化通知结果
+        """
+        return self.classify_notify_result(self.notify_result)
 
     def format_failure_reason(self):
         """提取可向前端展示的安全失败原因。"""

--- a/server/apps/alerts/service/outbox.py
+++ b/server/apps/alerts/service/outbox.py
@@ -37,9 +37,22 @@ def _deliver_payload(kind: str, payload: dict, *, delivery_claim=None) -> None:
     if outbox_handlers.deliver(kind, payload, delivery_claim=delivery_claim):
         return
     if kind == "notification":
+        from apps.alerts.constants.constants import NotifyResultStatus
+        from apps.alerts.service.notify_service import NotifyResultService
         from apps.alerts.tasks import sync_notify
 
-        sync_notify(payload.get("params") or [])
+        params = payload.get("params") or []
+        results = sync_notify(params)
+        if (
+            params
+            and isinstance(results, list)
+            and len(results) == len(params)
+            and all(
+                NotifyResultService.classify_notify_result(result) == NotifyResultStatus.FAILED
+                for result in results
+            )
+        ):
+            raise RuntimeError("all notification channels failed")
         return
     if kind == "action":
         from apps.alerts.tasks.action_tasks import process_alert_actions

--- a/server/apps/alerts/tests/test_outbox.py
+++ b/server/apps/alerts/tests/test_outbox.py
@@ -101,6 +101,51 @@ def test_existing_outbox_kinds_keep_their_original_dispatch_contracts():
     assignment.assert_called_once_with(["A1"])
 
 
+@pytest.mark.django_db(transaction=True)
+def test_notification_outbox_retries_when_every_selected_channel_fails():
+    record = AlertOutbox.objects.create(
+        kind="notification",
+        payload={"params": [{"channel_id": 1}, {"channel_id": 2}]},
+        idempotency_key="notification-all-failed",
+    )
+
+    results = [
+        {"result": False, "message": "email unavailable"},
+        {"errcode": 500, "errmsg": "sms unavailable"},
+    ]
+    with mock.patch("apps.alerts.tasks.sync_notify", return_value=results):
+        with pytest.raises(RuntimeError, match="all notification channels failed"):
+            deliver_outbox_record(record.pk)
+
+    record.refresh_from_db()
+    assert record.status == AlertOutbox.Status.PENDING
+    assert record.attempts == 1
+    assert record.delivered_at is None
+    assert record.next_retry_at is not None
+
+
+@pytest.mark.django_db(transaction=True)
+def test_notification_outbox_keeps_partial_success_compatibility_without_retrying_successful_channel():
+    record = AlertOutbox.objects.create(
+        kind="notification",
+        payload={"params": [{"channel_id": 1}, {"channel_id": 2}]},
+        idempotency_key="notification-partial-success",
+    )
+
+    results = [
+        {"result": True},
+        {"code": 500, "message": "sms unavailable"},
+    ]
+    with mock.patch("apps.alerts.tasks.sync_notify", return_value=results) as notify:
+        assert deliver_outbox_record(record.pk) is True
+
+    notify.assert_called_once()
+    record.refresh_from_db()
+    assert record.status == AlertOutbox.Status.DELIVERED
+    assert record.attempts == 1
+    assert record.delivered_at is not None
+
+
 def test_unknown_non_incident_outbox_kind_is_rejected():
     with pytest.raises(ValueError, match="unsupported alert outbox kind"):
         _deliver_payload("unknown", {})


### PR DESCRIPTION
## 变更说明

- 复用现有通知结果兼容规则，统一识别 `result`、`errcode` 与 `code`。
- 当所有已选择通知渠道均明确失败时，让 Alerts Outbox 保持可重试，不再错误标记为 `delivered`。
- 部分成功继续保持现有确认语义，避免重试时重复发送已成功渠道。

## 验证

- `server/apps/alerts/tests/test_outbox.py`
- `server/apps/alerts/tests/test_notify_result_service.py`
- 结果：40 passed
- flake8 与 diff-check 已通过；触及逻辑分支均由关联测试覆盖。

## 兼容与回滚

该首片不修改数据模型、渠道返回格式或部分成功行为。回滚可直接撤销本提交，恢复原有整条确认语义。

残余渠道级状态、外部幂等键和部分成功重试迁移继续由 Issue 分阶段治理，本 PR 不宣称关闭全部范围。

Refs #4490
