### PR TITLE
optimization: 限定告警升级到期扫描

### DIFF
--- a/server/apps/alerts/migrations/0024_alertescalationtask_next_escalation_at.py
+++ b/server/apps/alerts/migrations/0024_alertescalationtask_next_escalation_at.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("alerts", "0023_k8sinstalltoken"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="alertescalationtask",
+            name="next_escalation_at",
+            field=models.DateTimeField(
+                blank=True,
+                db_index=True,
+                help_text="下次升级检查时间；空值为待回填旧记录",
+                null=True,
+            ),
+        ),
+    ]

--- a/server/apps/alerts/models/alert_operator.py
+++ b/server/apps/alerts/models/alert_operator.py
@@ -119,6 +119,12 @@ class AlertEscalationTask(models.Model):
     layers = JSONField(default=list, help_text="升级链层级快照")
     current_layer_index = models.IntegerField(default=0, help_text="当前层级索引")
     layer_started_at = models.DateTimeField(help_text="本层开始时间")
+    next_escalation_at = models.DateTimeField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="下次升级检查时间；空值为待回填旧记录",
+    )
 
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/server/apps/alerts/service/escalation_service.py
+++ b/server/apps/alerts/service/escalation_service.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 from django.db import connection, transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from apps.alerts.common.notification_target import (
@@ -21,6 +22,11 @@ VALID_MODES = ("append", "replace")
 
 class EscalationService:
     EXPIRED_DAYS = 30
+    SCAN_BATCH_SIZE = 200
+
+    @staticmethod
+    def _next_escalation_at(layers, layer_index, started_at):
+        return started_at + timedelta(minutes=layers[layer_index]["wait_minutes"])
 
     @staticmethod
     def parse_escalation_config(config: Optional[dict]) -> Optional[dict]:
@@ -194,6 +200,7 @@ class EscalationService:
                 "layers": effective,
                 "current_layer_index": 0,
                 "layer_started_at": now,
+                "next_escalation_at": cls._next_escalation_at(effective, 0, now),
             },
         )
         cls._union_into_operator(alert, effective[0]["personnel"])
@@ -206,7 +213,7 @@ class EscalationService:
         """认领/解决/关闭后停止升级。"""
         updated = AlertEscalationTask.objects.filter(
             alert=alert, is_active=True
-        ).update(is_active=False, updated_at=timezone.now())
+        ).update(is_active=False, next_escalation_at=None, updated_at=timezone.now())
         return updated > 0
 
     @classmethod
@@ -294,11 +301,12 @@ class EscalationService:
         now = timezone.now()
         task.current_layer_index = next_index
         task.layer_started_at = now
+        task.next_escalation_at = cls._next_escalation_at(task.layers, next_index, now)
         # 升级是时间驱动：本层等待时长已过即推进，无论通知是否成功投递
         # （spec §3.2/§3.5：提醒因屏蔽/投递失败被跳过时升级时钟照常推进）。
         # 因此此处先持久化层级推进、再发通知；通知的同步构建部分仍在扫描的
         # transaction.atomic() 内，构建异常会连同推进一起回滚。
-        task.save(update_fields=["current_layer_index", "layer_started_at", "updated_at"])
+        task.save(update_fields=["current_layer_index", "layer_started_at", "next_escalation_at", "updated_at"])
 
         roster = cls.resolve_roster(task.layers, next_index, task.mode)
         cls._union_into_operator(alert, next_personnel)
@@ -320,10 +328,12 @@ class EscalationService:
         processed = 0
         escalated = 0
         try:
+            now = timezone.now()
             ids = list(
-                AlertEscalationTask.objects.filter(is_active=True).values_list(
-                    "alert_id", flat=True
-                )
+                AlertEscalationTask.objects.filter(is_active=True)
+                .filter(Q(next_escalation_at__lte=now) | Q(next_escalation_at__isnull=True))
+                .order_by("next_escalation_at", "alert_id")
+                .values_list("alert_id", flat=True)[: cls.SCAN_BATCH_SIZE]
             )
             select_for_update_kwargs = {}
             if connection.features.has_select_for_update_skip_locked:
@@ -346,19 +356,24 @@ class EscalationService:
 
                         if task.alert.status != AlertStatus.PENDING:
                             task.is_active = False
-                            task.save(update_fields=["is_active", "updated_at"])
+                            task.next_escalation_at = None
+                            task.save(update_fields=["is_active", "next_escalation_at", "updated_at"])
                             continue
 
-                        deadline = task.layer_started_at + timedelta(
-                            minutes=task.layers[task.current_layer_index]["wait_minutes"]
+                        deadline = task.next_escalation_at or cls._next_escalation_at(
+                            task.layers, task.current_layer_index, task.layer_started_at
                         )
-                        if timezone.now() < deadline:
+                        if now < deadline:
+                            if task.next_escalation_at is None:
+                                task.next_escalation_at = deadline
+                                task.save(update_fields=["next_escalation_at", "updated_at"])
                             continue
 
                         is_last = task.current_layer_index >= len(task.layers) - 1
                         if is_last:
                             task.is_active = False
-                            task.save(update_fields=["is_active", "updated_at"])
+                            task.next_escalation_at = None
+                            task.save(update_fields=["is_active", "next_escalation_at", "updated_at"])
                             logger.info("告警已达最后一层，不再升级: alert_id=%s", task.alert.alert_id)
                             continue
 

--- a/server/apps/alerts/tests/test_escalation_service.py
+++ b/server/apps/alerts/tests/test_escalation_service.py
@@ -235,6 +235,45 @@ def test_scan_filters_future_tasks_before_opening_per_task_transactions(mock_sen
 
 @pytest.mark.django_db
 @mock.patch("apps.alerts.service.escalation_service.EscalationService._send_escalation_notification")
+def test_scan_backfills_legacy_future_deadline_without_escalating(mock_send):
+    alert = _make_alert(status="pending")
+    assignment = _make_assignment(escalation=_chain())
+    task = _due_task(alert, assignment, index=0, minutes_ago=0)
+    expected_deadline = task.next_escalation_at
+    AlertEscalationTask.objects.filter(pk=task.pk).update(next_escalation_at=None)
+
+    result = ES.check_and_process_escalations()
+
+    task.refresh_from_db()
+    assert result == {"processed": 1, "escalated": 0}
+    assert task.next_escalation_at == expected_deadline
+    assert task.current_layer_index == 0
+    mock_send.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("apps.alerts.service.escalation_service.EscalationService._send_escalation_notification")
+def test_scan_processes_at_most_one_configured_batch(mock_send, monkeypatch):
+    monkeypatch.setattr(ES, "SCAN_BATCH_SIZE", 2)
+    assignment = _make_assignment(escalation=_chain())
+    tasks = []
+    for index in range(3):
+        alert = _make_alert(alert_id=f"due-{index}", status="pending")
+        tasks.append(_due_task(alert, assignment, index=0, minutes_ago=15))
+
+    result = ES.check_and_process_escalations()
+
+    assert result == {"processed": 2, "escalated": 2}
+    assert list(
+        AlertEscalationTask.objects.filter(pk__in=[task.pk for task in tasks])
+        .order_by("alert_id")
+        .values_list("current_layer_index", flat=True)
+    ) == [1, 1, 0]
+    assert mock_send.call_count == 2
+
+
+@pytest.mark.django_db
+@mock.patch("apps.alerts.service.escalation_service.EscalationService._send_escalation_notification")
 def test_scan_last_layer_deactivates_no_more_escalation(mock_send):
     alert = _make_alert(status="pending")
     assignment = _make_assignment(escalation=_chain())

--- a/server/apps/alerts/tests/test_escalation_service.py
+++ b/server/apps/alerts/tests/test_escalation_service.py
@@ -187,6 +187,7 @@ def _due_task(alert, assignment, index=0, minutes_ago=15):
     task = ES.create_escalation_task(alert, assignment)
     task.current_layer_index = index
     task.layer_started_at = timezone.now() - timedelta(minutes=minutes_ago)
+    task.next_escalation_at = ES._next_escalation_at(task.layers, index, task.layer_started_at)
     task.save()
     return task
 
@@ -215,6 +216,20 @@ def test_scan_not_due_does_nothing(mock_send):
     _due_task(alert, assignment, index=0, minutes_ago=3)
     ES.check_and_process_escalations()
     assert AlertEscalationTask.objects.get(alert=alert).current_layer_index == 0
+    mock_send.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch("apps.alerts.service.escalation_service.EscalationService._send_escalation_notification")
+def test_scan_filters_future_tasks_before_opening_per_task_transactions(mock_send):
+    assignment = _make_assignment(escalation=_chain())
+    for index in range(10):
+        alert = _make_alert(alert_id=f"future-{index}", status="pending")
+        _due_task(alert, assignment, index=0, minutes_ago=0)
+
+    result = ES.check_and_process_escalations()
+
+    assert result == {"processed": 0, "escalated": 0}
     mock_send.assert_not_called()
 
 


### PR DESCRIPTION
## 变更说明

- 为升级任务增加可索引的 nullable `next_escalation_at`。
- 创建、重置、推进和停用时同步维护下一次到期时间。
- 分钟扫描只获取已到期任务和待回填旧记录，并限制每轮最多 200 条；PostgreSQL 支持时继续使用 `skip_locked`。
- 旧记录首次进入有界兜底时计算并回填 deadline，不改变原升级语义。

## 复杂度变化

- 原实现：每轮枚举全部活跃任务并逐条事务查询，`1 + N` 查询/锁检查。
- 新实现：数据库先按索引筛选到期/legacy 候选，应用只处理 `D + L`，且 `D + L <= 200`。

## 验证

- `server/apps/alerts/tests/test_escalation_service.py`
- PostgreSQL `--create-db`：29 passed
- diff-check：通过

已有测试文件存在两处 fixed-base flake8 历史问题；新增代码未引入新的静态错误。迁移已在重建测试库中执行。

Refs #4672
