### PR TITLE
bugfix: 限制告警通知历史加载

### DIFF
--- a/server/apps/alerts/serializers/alert.py
+++ b/server/apps/alerts/serializers/alert.py
@@ -1,4 +1,6 @@
 # -- coding: utf-8 --
+from django.db.models import Count, F, Q, Window
+from django.db.models.functions import RowNumber
 from django.db.models.query import QuerySet
 from django.utils import timezone
 from rest_framework import serializers
@@ -98,19 +100,44 @@ class AlertModelSerializer(AuthSerializer):
         total_map = {}
         raw_records_map = {}
         usernames = set()
-        notify_results = NotifyResult.objects.filter(
+        notify_result_filter = NotifyResult.objects.filter(
             notify_type="alert",
             notify_object__in=alert_ids,
-        ).order_by("notify_object", "-notify_time", "-id")
+        )
 
-        for notify_result in notify_results:
+        aggregate_rows = notify_result_filter.values("notify_object").annotate(
+            total=Count("id"),
+            success=Count("id", filter=Q(notify_result=NotifyResultStatus.SUCCESS)),
+        )
+        for row in aggregate_rows:
+            notify_object = row["notify_object"]
+            total = row["total"]
+            success = row["success"]
+            total_map[notify_object] = total
+            if success == total:
+                status_map[notify_object] = [True]
+            elif success == 0:
+                status_map[notify_object] = [False]
+            else:
+                status_map[notify_object] = [True, False]
+
+        latest_notify_results = (
+            notify_result_filter.annotate(
+                row_number=Window(
+                    expression=RowNumber(),
+                    partition_by=[F("notify_object")],
+                    order_by=[F("notify_time").desc(), F("id").desc()],
+                )
+            )
+            .filter(row_number__lte=5)
+            .order_by("notify_object", "-notify_time", "-id")
+        )
+
+        for notify_result in latest_notify_results:
             notify_object = notify_result.notify_object
-            status_map.setdefault(notify_object, []).append(notify_result.notify_result == NotifyResultStatus.SUCCESS)
-            total_map[notify_object] = total_map.get(notify_object, 0) + 1
             records = raw_records_map.setdefault(notify_object, [])
-            if len(records) < 5:
-                records.append(notify_result)
-                usernames.update(str(user) for user in (notify_result.notify_people or []))
+            records.append(notify_result)
+            usernames.update(str(user) for user in (notify_result.notify_people or []))
 
         user_map = dict(User.objects.filter(username__in=usernames).values_list("username", "display_name")) if usernames else {}
         records_map = {}

--- a/server/apps/alerts/tests/test_alert_serializer_methods.py
+++ b/server/apps/alerts/tests/test_alert_serializer_methods.py
@@ -36,7 +36,8 @@ def test_set_alert_notify_result_map_aggregates():
     NotifyResult.objects.create(notify_type="alert", notify_object="A1", notify_result=NotifyResultStatus.SUCCESS)
     NotifyResult.objects.create(notify_type="alert", notify_object="A1", notify_result=NotifyResultStatus.FAILED)
     result = AlertModelSerializer.set_alert_notify_result_map([alert])
-    assert result["A1"] == [False, True]
+    serializer = _ser(notify_map=result)
+    assert serializer.get_notify_status(alert) == NotifyResultStatus.PARTIAL_SUCCESS
 
 
 @pytest.mark.django_db
@@ -49,19 +50,17 @@ def test_notification_details_return_total_latest_five_and_recipient_display_nam
     alert = Alert.objects.create(alert_id="A1", level="0", title="t", content="c", fingerprint="fp")
     User.objects.create(username="alice", display_name="Alice Zhang", domain="domain.com")
     now = timezone.now()
-    rows = []
-    for index in range(6):
+    for index in range(100):
         row = NotifyResult.objects.create(
             notify_type="alert",
             notify_object="A1",
             notify_people=["alice", "deleted-user"],
             notify_channel="wechat",
             notify_channel_name="企业微信",
-            notify_result=(NotifyResultStatus.FAILED if index == 5 else NotifyResultStatus.SUCCESS),
-            failure_reason="receiver rejected" if index == 5 else None,
+            notify_result=(NotifyResultStatus.FAILED if index == 99 else NotifyResultStatus.SUCCESS),
+            failure_reason="receiver rejected" if index == 99 else None,
         )
         NotifyResult.objects.filter(pk=row.pk).update(notify_time=now + timedelta(minutes=index))
-        rows.append(row)
 
     serializer = _ser()
     (
@@ -70,7 +69,7 @@ def test_notification_details_return_total_latest_five_and_recipient_display_nam
         serializer.alert_notify_records_map,
     ) = AlertModelSerializer.set_alert_notification_maps([alert])
 
-    assert serializer.get_notify_total(alert) == 6
+    assert serializer.get_notify_total(alert) == 100
     records = serializer.get_notify_records(alert)
     assert len(records) == 5
     assert records[0]["result"] == NotifyResultStatus.FAILED
@@ -100,7 +99,9 @@ def test_notification_detail_maps_use_constant_query_count(django_assert_num_que
             notify_result=NotifyResultStatus.SUCCESS,
         )
 
-    with django_assert_num_queries(2):
+    # 聚合状态/总数、每个告警最近五条、收件人展示名各一条查询，
+    # 查询数量不随告警数或通知历史量增长。
+    with django_assert_num_queries(3):
         maps = AlertModelSerializer.set_alert_notification_maps(alerts)
 
     serializer = _ser()


### PR DESCRIPTION
## 变更说明

- 将告警通知总数和成功状态改为数据库分组聚合，避免在应用进程中保存完整状态数组。
- 使用窗口函数按告警截取最近五条通知详情，继续按 `notify_time`、`id` 倒序展示。
- 保持 `notify_status`、`notify_total`、`notify_records` 的字段和语义不变，并补充 100 条历史与常量查询数回归。

## 复杂度

- 修复前：当前页全部通知历史均传输并实例化，应用层时间和内存为 O(R)。
- 修复后：详情实例化上限为每条告警 5 条，即 O(P×5)；聚合结果不超过 P 条，查询数固定为 3。

## 验证

- TDD RED：旧实现执行 2 条无界查询，不满足拆分聚合与有界详情的 3 查询契约。
- PostgreSQL 精确关联测试：41 passed。
- Black、isort、flake8、`git diff --check`：通过。
- Standards / Spec / Runtime Contract：均通过，P0/P1/P2 为 0。

## 残余范围

本 PR 是 #4673 的首个安全切片，解决应用进程 O(R) 物化；数据库侧组合索引需独立迁移，Issue 保持开启继续跟踪。

关联 #4673
