### PR TITLE
bugfix: 下推告警来源分布聚合

### DIFF
--- a/server/apps/alerts/nats/nats.py
+++ b/server/apps/alerts/nats/nats.py
@@ -25,11 +25,7 @@ from apps.alerts.models.alert_source import AlertSource
 from apps.alerts.models.models import Alert, Event, Incident, Level
 from apps.alerts.utils.permission_scope import apply_team_scope_with_group_ids
 from apps.core.logger import alert_logger as logger
-from apps.core.utils.internal_event_auth import (
-    TRUSTED_INTERNAL_EVENT_CALLERS,
-    legacy_internal_event_auth_allowed,
-    verify_internal_event,
-)
+from apps.core.utils.internal_event_auth import TRUSTED_INTERNAL_EVENT_CALLERS, legacy_internal_event_auth_allowed, verify_internal_event
 from apps.core.utils.permission_utils import get_permission_rules
 from apps.core.utils.time_util import parse_rfc3339_range_utc, parse_rfc3339_utc
 from apps.core.utils.trend_granularity import resolve_trend_group_by_from_range
@@ -450,12 +446,15 @@ def get_alert_source_distribution(*args, **kwargs) -> Dict[str, Any]:
 
     counts = {}
     unknown_count = 0
-    for source_name in queryset.values_list("source_name", flat=True):
+    source_counts = queryset.order_by().values("source_name").annotate(count=Count("id", distinct=True))
+    for item in source_counts:
+        source_name = item["source_name"]
+        count = item["count"]
         name = source_name.strip() if isinstance(source_name, str) and source_name.strip() else None
         if name is None:
-            unknown_count += 1
+            unknown_count += count
             continue
-        counts[name] = counts.get(name, 0) + 1
+        counts[name] = counts.get(name, 0) + count
 
     ordered = sorted(counts.items(), key=lambda item: (-item[1], item[0]))
     data = [{"name": name, "value": value} for name, value in ordered]

--- a/server/apps/alerts/tests/test_nats_handlers.py
+++ b/server/apps/alerts/tests/test_nats_handlers.py
@@ -6,6 +6,8 @@
 import datetime
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from apps.alerts.constants.constants import AlertStatus, LevelType
@@ -920,15 +922,29 @@ def test_get_alert_source_distribution_returns_full_distribution_and_unknown():
             source_name="zabbix" if index < 3 else (None if index == 11 else f"source-{index}"),
             team=[1],
         )
-    result = N.get_alert_source_distribution(user_info={"team": 1, "is_superuser": True})
+    for index, source_name in enumerate([" zabbix ", "", "   "], start=12):
+        Alert.objects.create(
+            alert_id=f"DIST-{index}",
+            level="0",
+            title="t",
+            content="c",
+            fingerprint=f"dist-{index}",
+            source_name=source_name,
+            team=[1],
+        )
+
+    with CaptureQueriesContext(connection) as queries:
+        result = N.get_alert_source_distribution(user_info={"team": 1, "is_superuser": True})
 
     assert result["result"] is True
     assert result["data"] == [
-        {"name": "zabbix", "value": 3},
+        {"name": "zabbix", "value": 4},
         {"name": "source-10", "value": 1},
         *[{"name": f"source-{index}", "value": 1} for index in range(3, 10)],
-        {"name": "未知来源", "value": 1},
+        {"name": "未知来源", "value": 3},
     ]
+    assert len(queries) == 1
+    assert "GROUP BY" in queries[0]["sql"].upper()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## 变更说明

- 将告警来源分布的计数下推到数据库，授权范围和 NATS RPC 契约保持不变。
- 清除 queryset 默认排序后按 `source_name` 分组，避免排序字段扩大分组结果。
- 在小量分组结果上继续合并 `NULL`、空串、纯空白及 trim 后同名来源，并保持原有排序。

## 复杂度

- 修复前：数据库向应用传输 A 条历史告警，Python 时间和内存均为 O(A)。
- 修复后：数据库完成精确聚合，应用仅处理来源分组 O(S)，查询数保持 1。

## 验证

- TDD RED：旧 SQL 无 `GROUP BY`，会返回全部历史行。
- PostgreSQL 精确关联测试：113 passed。
- 覆盖普通来源、空值、空串、纯空白、trim 后同名、计数和排序契约。
- Black、isort、flake8、`git diff --check`：通过。
- Standards / Spec / Runtime Contract：均通过，P0/P1/P2 为 0。

Closes #4674
