### PR TITLE
bugfix: 延迟操作日志权限目标查询

### DIFF
--- a/server/apps/alerts/tests/test_permission_scope.py
+++ b/server/apps/alerts/tests/test_permission_scope.py
@@ -196,16 +196,26 @@ def test_filter_operator_log_no_team_returns_none():
 
 
 @pytest.mark.django_db
-def test_filter_operator_log_scoped_to_alert():
+def test_filter_operator_log_scope_is_lazy_and_keeps_alert_incident_visibility(django_assert_num_queries):
     from apps.alerts.constants.constants import LogTargetType
     from apps.alerts.models.operator_log import OperatorLog
 
     Alert.objects.create(alert_id="A1", level="0", title="t", content="c", fingerprint="fp", team=[1])
+    Incident.objects.create(incident_id="I1", level="0", title="i", fingerprint="ifp", team=["1"])
     OperatorLog.objects.create(action="add", target_type=LogTargetType.ALERT, operator="u", target_id="A1", overview="x")
     OperatorLog.objects.create(action="add", target_type=LogTargetType.ALERT, operator="u", target_id="A-other", overview="x")
+    OperatorLog.objects.create(action="add", target_type=LogTargetType.INCIDENT, operator="u", target_id="I1", overview="x")
+    OperatorLog.objects.create(action="add", target_type=LogTargetType.INCIDENT, operator="u", target_id="I-other", overview="x")
+    OperatorLog.objects.create(action="add", target_type=LogTargetType.SYSTEM, operator="u", target_id="A1", overview="x")
     request = _request(current_team="1", is_superuser=True)
-    result = ps.filter_operator_log_queryset_for_request(OperatorLog.objects.all(), request)
-    assert result.count() == 1
+
+    with django_assert_num_queries(0):
+        result = ps.filter_operator_log_queryset_for_request(OperatorLog.objects.all(), request)
+
+    assert set(result.values_list("target_type", "target_id")) == {
+        (LogTargetType.ALERT, "A1"),
+        (LogTargetType.INCIDENT, "I1"),
+    }
 
 
 @pytest.mark.django_db

--- a/server/apps/alerts/utils/permission_scope.py
+++ b/server/apps/alerts/utils/permission_scope.py
@@ -1,11 +1,11 @@
-from django.db.models import Q
+from django.db.models import Q, Subquery
 from rest_framework.exceptions import PermissionDenied
 
 from apps.alerts.constants.constants import LogTargetType
 from apps.alerts.models.models import Alert, Incident
-from apps.system_mgmt.utils.group_utils import GroupUtils
 from apps.core.utils.team_utils import get_current_team
 from apps.core.utils.viewset_utils import build_json_membership_query
+from apps.system_mgmt.utils.group_utils import GroupUtils
 
 
 def get_current_team_from_request(request, required=False):
@@ -87,9 +87,7 @@ def extract_child_group_ids(group_tree, current_team_id):
 def apply_team_scope_with_group_ids(queryset, group_ids, field_name="team"):
     if not group_ids:
         return queryset.none()
-    return queryset.filter(
-        build_json_membership_query(queryset, field_name, group_ids)
-    ).distinct()
+    return queryset.filter(build_json_membership_query(queryset, field_name, group_ids)).distinct()
 
 
 def apply_team_scope_for_request(queryset, request, field_name="team"):
@@ -107,9 +105,7 @@ def _build_team_query(field_name, group_ids):
 
 
 def _filter_json_membership_fallback(queryset, field_name, expected_values):
-    return queryset.filter(
-        build_json_membership_query(queryset, field_name, expected_values)
-    )
+    return queryset.filter(build_json_membership_query(queryset, field_name, expected_values))
 
 
 def filter_alert_queryset_for_request(queryset, request):
@@ -142,14 +138,10 @@ def filter_operator_log_queryset_for_request(queryset, request):
     if not current_team:
         return queryset.none()
 
-    scoped_alert_ids = list(filter_alert_queryset_for_request(Alert.objects.all(), request).values_list("alert_id", flat=True))
-    scoped_incident_ids = list(filter_incident_queryset_for_request(Incident.objects.all(), request).values_list("incident_id", flat=True))
-    if not scoped_alert_ids and not scoped_incident_ids:
-        return queryset.none()
-
-    query = Q()
-    if scoped_alert_ids:
-        query |= Q(target_type=LogTargetType.ALERT, target_id__in=scoped_alert_ids)
-    if scoped_incident_ids:
-        query |= Q(target_type=LogTargetType.INCIDENT, target_id__in=scoped_incident_ids)
+    scoped_alert_ids = filter_alert_queryset_for_request(Alert.objects.all(), request).order_by().values("alert_id")
+    scoped_incident_ids = filter_incident_queryset_for_request(Incident.objects.all(), request).order_by().values("incident_id")
+    query = Q(target_type=LogTargetType.ALERT, target_id__in=Subquery(scoped_alert_ids)) | Q(
+        target_type=LogTargetType.INCIDENT,
+        target_id__in=Subquery(scoped_incident_ids),
+    )
     return queryset.filter(query).distinct()


### PR DESCRIPTION
## 变更说明

- 将操作日志的 Alert / Incident 可见目标改为惰性数据库子查询，不再提前物化全部 ID。
- 清除子查询默认排序，确保只选择单个业务 ID 字段并保持 SQL 文本稳定。
- 保持用户、当前团队、父子组织、数字/字符串团队及两类目标的可见范围不变。

## 复杂度

- 修复前：构造日志 queryset 即执行 2 条全量查询，传输、Python 内存和 `IN` 参数为 O(A+I)。
- 修复后：构造阶段 0 查询，由数据库在分页查询内完成权限子查询；SQL 文本和 Python 内存不随目标总量展开。

## 验证

- TDD RED：旧实现构造权限 queryset 时实际执行 2 条查询。
- PostgreSQL 精确关联测试：43 passed。
- 覆盖无团队、Alert / Incident 混合、字符串团队 ID、越权目标和真实列表接口。
- Black、isort、flake8、`git diff --check`：通过。
- Standards / Spec / Runtime Contract：均通过，P0/P1/P2 为 0。

## 残余范围

本 PR 是 #4675 的首个安全切片，消除应用层 ID 物化；OperatorLog 组合索引需独立、可回滚 migration，Issue 保持开启继续跟踪。

关联 #4675
