### PR TITLE
bugfix: 保留删除失败的 PDF 清理索引

### DIFF
--- a/server/apps/operation_analysis/services/pdf_artifact_cleanup_service.py
+++ b/server/apps/operation_analysis/services/pdf_artifact_cleanup_service.py
@@ -13,15 +13,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
-from apps.core.logger import operation_analysis_logger as logger
-from apps.operation_analysis.models.subscription_models import (
-    DashboardReportExecution,
-    DashboardReportPdfArtifact,
-)
-from apps.operation_analysis.services.report_render_service import (
-    DashboardReportRenderService,
-)
 from django.utils import timezone
+
+from apps.core.logger import operation_analysis_logger as logger
+from apps.operation_analysis.models.subscription_models import DashboardReportExecution, DashboardReportPdfArtifact
+from apps.operation_analysis.services.report_render_service import DashboardReportRenderService
 
 DEFAULT_ARTIFACT_CLEANUP_BATCH_SIZE = 200
 
@@ -83,8 +79,7 @@ class PdfArtifactCleanupService:
             except Exception:
                 errors += 1
                 logger.exception(
-                    "PDF artifact cleanup failed: artifact_id=%s "
-                    "execution_id=%s",
+                    "PDF artifact cleanup failed: artifact_id=%s " "execution_id=%s",
                     artifact.id,
                     artifact.execution_id,
                 )
@@ -97,8 +92,7 @@ class PdfArtifactCleanupService:
         )
         if stats.scanned:
             logger.info(
-                "PdfArtifactCleanup finished: scanned=%s deleted=%s "
-                "file_missing=%s errors=%s",
+                "PdfArtifactCleanup finished: scanned=%s deleted=%s " "file_missing=%s errors=%s",
                 stats.scanned,
                 stats.deleted,
                 stats.file_missing,
@@ -108,7 +102,7 @@ class PdfArtifactCleanupService:
 
     @classmethod
     def _cleanup_one(cls, artifact: DashboardReportPdfArtifact) -> str:
-        """删文件（缺文件幂等）后删 DB 行。返回 deleted | file_missing。"""
+        """删文件（缺文件幂等）后删 DB 行；删除异常向上抛出并保留索引。"""
         root = DashboardReportRenderService._artifact_root()
         path = (root / artifact.storage_reference).resolve()
         file_was_missing = False
@@ -121,24 +115,16 @@ class PdfArtifactCleanupService:
             )
         else:
             try:
-                if path.is_file():
-                    path.unlink()
-                else:
-                    file_was_missing = True
-                # 尽量去掉空的 execution-{id}/ 目录
-                parent = path.parent
-                if parent != root and parent.is_dir():
-                    try:
-                        parent.rmdir()
-                    except OSError:
-                        pass
-            except Exception:
-                logger.warning(
-                    "删除 PDF 文件失败（继续删 DB 行）: artifact_id=%s path=%s",
-                    artifact.id,
-                    path,
-                    exc_info=True,
-                )
+                path.unlink()
+            except FileNotFoundError:
+                file_was_missing = True
+            # 尽量去掉空的 execution-{id}/ 目录
+            parent = path.parent
+            if parent != root and parent.is_dir():
+                try:
+                    parent.rmdir()
+                except OSError:
+                    pass
 
         artifact.delete()
         return "file_missing" if file_was_missing else "deleted"

--- a/server/apps/operation_analysis/tests/test_dashboard_report_cleanup_l5.py
+++ b/server/apps/operation_analysis/tests/test_dashboard_report_cleanup_l5.py
@@ -7,16 +7,9 @@ import pytest
 from django.utils import timezone
 
 from apps.operation_analysis.models.models import Dashboard, Directory
-from apps.operation_analysis.models.subscription_models import (
-    DashboardReportExecution,
-    DashboardReportPdfArtifact,
-    DashboardReportSubscription,
-)
-from apps.operation_analysis.services.pdf_artifact_cleanup_service import (
-    PdfArtifactCleanupService,
-)
+from apps.operation_analysis.models.subscription_models import DashboardReportExecution, DashboardReportPdfArtifact, DashboardReportSubscription
+from apps.operation_analysis.services.pdf_artifact_cleanup_service import PdfArtifactCleanupService
 from apps.system_mgmt.models import Channel
-
 
 pytestmark = pytest.mark.django_db
 
@@ -82,9 +75,7 @@ def _make_artifact(
     )
 
 
-def test_expired_succeeded_artifact_is_deleted(
-    subscription, tmp_path, monkeypatch
-):
+def test_expired_succeeded_artifact_is_deleted(subscription, tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
     now = timezone.now()
     execution = _make_execution(
@@ -128,9 +119,7 @@ def test_unexpired_artifact_is_kept(subscription, tmp_path, monkeypatch):
     assert (tmp_path / artifact.storage_reference).is_file()
 
 
-def test_running_expired_artifact_is_not_deleted(
-    subscription, tmp_path, monkeypatch
-):
+def test_running_expired_artifact_is_not_deleted(subscription, tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
     now = timezone.now()
     execution = _make_execution(
@@ -149,9 +138,7 @@ def test_running_expired_artifact_is_not_deleted(
     assert (tmp_path / artifact.storage_reference).is_file()
 
 
-def test_pending_expired_artifact_is_not_deleted(
-    subscription, tmp_path, monkeypatch
-):
+def test_pending_expired_artifact_is_not_deleted(subscription, tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
     now = timezone.now()
     execution = _make_execution(
@@ -169,9 +156,7 @@ def test_pending_expired_artifact_is_not_deleted(
     assert DashboardReportPdfArtifact.objects.filter(pk=artifact.pk).exists()
 
 
-def test_cleanup_is_idempotent_when_repeated(
-    subscription, tmp_path, monkeypatch
-):
+def test_cleanup_is_idempotent_when_repeated(subscription, tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
     now = timezone.now()
     execution = _make_execution(
@@ -193,9 +178,7 @@ def test_cleanup_is_idempotent_when_repeated(
     assert DashboardReportPdfArtifact.objects.count() == 0
 
 
-def test_missing_file_cleanup_is_idempotent(
-    subscription, tmp_path, monkeypatch
-):
+def test_missing_file_cleanup_is_idempotent(subscription, tmp_path, monkeypatch):
     monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
     now = timezone.now()
     execution = _make_execution(
@@ -220,13 +203,47 @@ def test_missing_file_cleanup_is_idempotent(
     assert again.scanned == 0
 
 
+def test_unlink_failure_keeps_artifact_for_next_cleanup_retry(subscription, tmp_path, monkeypatch):
+    monkeypatch.setenv("DASHBOARD_REPORT_ARTIFACT_ROOT", str(tmp_path))
+    now = timezone.now()
+    execution = _make_execution(
+        subscription,
+        status=DashboardReportExecution.Status.SUCCEEDED,
+        finished_at=now - timedelta(hours=1),
+    )
+    artifact = _make_artifact(
+        execution,
+        expires_at=now - timedelta(minutes=1),
+        root=tmp_path,
+    )
+    path = tmp_path / artifact.storage_reference
+    real_unlink = Path.unlink
+    failed_once = False
+
+    def flaky_unlink(target, *args, **kwargs):
+        nonlocal failed_once
+        if target == path and not failed_once:
+            failed_once = True
+            raise PermissionError("artifact mount is temporarily read-only")
+        return real_unlink(target, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+    first = PdfArtifactCleanupService.cleanup(now=now)
+    assert first.deleted == 0
+    assert first.errors == 1
+    assert DashboardReportPdfArtifact.objects.filter(pk=artifact.pk).exists()
+    assert path.is_file()
+
+    second = PdfArtifactCleanupService.cleanup(now=now)
+    assert second.deleted == 1
+    assert second.errors == 0
+    assert not DashboardReportPdfArtifact.objects.filter(pk=artifact.pk).exists()
+    assert not path.exists()
+
+
 def test_beat_registers_pdf_artifact_cleanup_task():
     from apps.operation_analysis.config import CELERY_BEAT_SCHEDULE
 
-    entry = CELERY_BEAT_SCHEDULE[
-        "cleanup_expired_dashboard_report_pdf_artifacts"
-    ]
-    assert (
-        entry["task"]
-        == "operation_analysis.cleanup_expired_dashboard_report_pdf_artifacts"
-    )
+    entry = CELERY_BEAT_SCHEDULE["cleanup_expired_dashboard_report_pdf_artifacts"]
+    assert entry["task"] == "operation_analysis.cleanup_expired_dashboard_report_pdf_artifacts"


### PR DESCRIPTION
## 问题

周期清理依赖数据库 artifact 行保存重试意图；磁盘删除失败时继续删除该行，会让残留 PDF 永久失去索引，并把失败伪报为成功。

## 根因

文件删除与元数据删除被实现为无条件前进的 best-effort 流程，没有把“文件已删除或确认不存在”作为消费清理索引的前置条件。

## 怎么修的

- 直接执行 `unlink`，避免文件状态探测把权限异常误判为文件不存在。
- `FileNotFoundError` 继续按幂等缺失处理；其他异常向批次隔离层传播，在删除 DB 行前停止。
- 批次将失败计入 `errors`，保留 artifact 供下一轮重试；故障恢复后沿原路径成功收敛。

## 调用链

```mermaid
flowchart TD
    subgraph T["调度层"]
        T1["Celery 每 15 分钟\ncleanup_expired_dashboard_report_pdf_artifacts"]
    end

    subgraph C["清理层"]
        C1["PdfArtifactCleanupService.cleanup"]
        C2["_cleanup_one\n直接 unlink"]
    end

    subgraph S["持久化与重试"]
        S1["文件删除成功或不存在\n删除 artifact 行"]
        S2["删除异常\n保留 artifact 并 errors+1"]
        S3["下一轮故障恢复\n再次清理"]
    end

    T1 --> C1 --> C2 --> S1
    C2 -. "存储异常" .-> S2
    S2 -. "周期重试" .-> S3 --> C2
```

## 影响范围

仅修改运营分析 PDF artifact 的内部失败路径；任务名、批次上限、保留期、终态过滤和过期下载拒绝均不变。不存在 server/agents/web 协议变化或数据迁移。

## 验证

- TDD RED：首次 `PermissionError` 在旧实现得到 deleted=1/errors=0，且 DB 行被删除。
- 修复后：首次得到 deleted=0/errors=1，文件与 DB 行均保留；第二轮恢复后成功删除。
- 清理与 Execution 保留两个具体测试文件：18 passed。
- Black、isort、flake8、`git diff --check`：通过。

## 三轨门禁

- Standards：PASS。
- Spec：PASS。
- Runtime Contract：PASS，覆盖成功、缺失、异常、恢复重试、终态保护和批次统计。
- P0/P1/P2：0/0/0，评分 98/100。

Closes #4678
