### PR TITLE
refactor: 抽取监控 NATS 查询契约接缝

### DIFF
--- a/server/apps/monitor/nats/monitor.py
+++ b/server/apps/monitor/nats/monitor.py
@@ -1,5 +1,4 @@
 import time
-from datetime import datetime
 from types import SimpleNamespace
 from typing import Optional
 
@@ -53,6 +52,15 @@ from apps.monitor.services.host_dashboard import (
 from apps.monitor.services.host_resource_top import HostResourceTopService, validate_metric_type
 from apps.monitor.services.interface_metrics_query import InterfaceMetricsQueryError, normalize_instance_ids, query_interface_metric_items
 from apps.monitor.services.metrics import Metrics
+from apps.monitor.services.nats_query_contract import build_vm_query_failure_result as _build_vm_query_failure_result
+from apps.monitor.services.nats_query_contract import normalize_bool
+from apps.monitor.services.nats_query_contract import normalize_dimensions as _normalize_dimensions
+from apps.monitor.services.nats_query_contract import normalize_filter_values as _normalize_filter_values
+from apps.monitor.services.nats_query_contract import normalize_monitor_query_data as _normalize_monitor_query_data
+from apps.monitor.services.nats_query_contract import normalize_positive_int as _normalize_positive_int
+from apps.monitor.services.nats_query_contract import normalize_step as _normalize_step
+from apps.monitor.services.nats_query_contract import normalize_time_value as _normalize_time_value
+from apps.monitor.services.nats_query_contract import paginate_items as _paginate_items
 from apps.monitor.services.network_device_resource_top import NetworkDeviceResourceTopService
 from apps.monitor.services.network_device_resource_top import validate_metric_type as validate_network_metric_type
 from apps.monitor.utils.dimension import parse_instance_id
@@ -62,105 +70,7 @@ from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
 from apps.monitor.utils.vm_query_batch import run_unique_vm_queries
 from apps.rpc.system_mgmt import SystemMgmt
 
-
-def _normalize_monitor_query_data(query_data: dict) -> dict:
-    normalized = dict(query_data or {})
-    if "monitor_obj_id" not in normalized and "monitor_object_id" in normalized:
-        normalized["monitor_obj_id"] = normalized["monitor_object_id"]
-    if "start" not in normalized and "start_time" in normalized:
-        normalized["start"] = normalized["start_time"]
-    if "end" not in normalized and "end_time" in normalized:
-        normalized["end"] = normalized["end_time"]
-    return normalized
-
-
-def _normalize_positive_int(value, field_name: str, default=None):
-    if value in (None, ""):
-        return default
-    try:
-        normalized = int(value)
-    except (TypeError, ValueError):
-        raise ValueError(f"{field_name} 必须是整数")
-    if normalized < 1:
-        raise ValueError(f"{field_name} 必须大于等于 1")
-    return normalized
-
-
-def _normalize_bool(value, field_name: str):
-    if isinstance(value, bool):
-        return value
-    if value in (None, ""):
-        return False
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in {"true", "1", "yes"}:
-            return True
-        if normalized in {"false", "0", "no"}:
-            return False
-    raise ValueError(f"{field_name} 必须是布尔值")
-
-
-def _normalize_time_value(value, field_name: str):
-    if value in (None, ""):
-        raise ValueError(f"{field_name} 不能为空")
-    if isinstance(value, (int, float)):
-        return datetime.fromtimestamp(value)
-    if isinstance(value, str):
-        value = value.strip()
-        if value.isdigit():
-            return datetime.fromtimestamp(int(value))
-        try:
-            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
-        except ValueError as exc:
-            raise ValueError(f"{field_name} 时间格式错误，应为 YYYY-MM-DD HH:MM:SS 或时间戳") from exc
-    raise ValueError(f"{field_name} 时间格式错误")
-
-
-def _normalize_filter_values(value, field_name: str):
-    if value in (None, ""):
-        return []
-    if isinstance(value, list):
-        return [str(item) for item in value if item not in (None, "")]
-    if isinstance(value, str):
-        return [item.strip() for item in value.split(",") if item.strip()]
-    raise ValueError(f"{field_name} 必须是字符串或列表")
-
-
-def _build_vm_query_failure_result(resp: dict, default_message: str):
-    error_message = resp.get("error") or resp.get("message") or default_message
-    error_type = resp.get("errorType")
-    if error_type:
-        error_message = f"{error_type}: {error_message}"
-    return {"result": False, "data": [], "message": error_message}
-
-
-def _normalize_step(step):
-    if step in (None, ""):
-        return "5m"
-    Metrics.parse_step_to_seconds(step)
-    return step
-
-
-def _normalize_dimensions(metric, dimensions):
-    if dimensions in (None, ""):
-        return {}
-    if not isinstance(dimensions, dict):
-        raise ValueError("dimensions 必须是字典")
-
-    allowed_dimensions = set(metric.instance_id_keys or [])
-    for item in metric.dimensions or []:
-        if isinstance(item, dict):
-            name = item.get("name")
-            if name:
-                allowed_dimensions.add(name)
-        elif item:
-            allowed_dimensions.add(item)
-
-    invalid_keys = [key for key in dimensions.keys() if key not in allowed_dimensions]
-    if invalid_keys:
-        raise ValueError(f"dimensions 包含未定义维度: {', '.join(invalid_keys)}")
-
-    return {str(key): str(value) for key, value in dimensions.items() if value is not None}
+_normalize_bool = normalize_bool
 
 
 def _serialize_metric_plugin(metric: Metric) -> Optional[dict]:
@@ -175,18 +85,6 @@ def _serialize_metric_plugin(metric: Metric) -> Optional[dict]:
         "template_type": plugin.template_type,
         "collector": plugin.collector,
         "collect_type": plugin.collect_type,
-    }
-
-
-def _paginate_items(items: list, page, page_size):
-    total_count = len(items)
-    start = (page - 1) * page_size
-    end = start + page_size
-    return {
-        "count": total_count,
-        "page": page,
-        "page_size": page_size,
-        "items": items[start:end],
     }
 
 

--- a/server/apps/monitor/services/nats_query_contract.py
+++ b/server/apps/monitor/services/nats_query_contract.py
@@ -1,0 +1,117 @@
+"""监控 NATS 查询输入与响应的无副作用兼容接缝。"""
+
+from datetime import datetime
+
+from apps.monitor.services.metrics import Metrics
+
+
+def normalize_monitor_query_data(query_data: dict) -> dict:
+    normalized = dict(query_data or {})
+    if "monitor_obj_id" not in normalized and "monitor_object_id" in normalized:
+        normalized["monitor_obj_id"] = normalized["monitor_object_id"]
+    if "start" not in normalized and "start_time" in normalized:
+        normalized["start"] = normalized["start_time"]
+    if "end" not in normalized and "end_time" in normalized:
+        normalized["end"] = normalized["end_time"]
+    return normalized
+
+
+def normalize_positive_int(value, field_name: str, default=None):
+    if value in (None, ""):
+        return default
+    try:
+        normalized = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"{field_name} 必须是整数")
+    if normalized < 1:
+        raise ValueError(f"{field_name} 必须大于等于 1")
+    return normalized
+
+
+def normalize_bool(value, field_name: str):
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+    raise ValueError(f"{field_name} 必须是布尔值")
+
+
+def normalize_time_value(value, field_name: str):
+    if value in (None, ""):
+        raise ValueError(f"{field_name} 不能为空")
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value)
+    if isinstance(value, str):
+        value = value.strip()
+        if value.isdigit():
+            return datetime.fromtimestamp(int(value))
+        try:
+            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+        except ValueError as exc:
+            raise ValueError(f"{field_name} 时间格式错误，应为 YYYY-MM-DD HH:MM:SS 或时间戳") from exc
+    raise ValueError(f"{field_name} 时间格式错误")
+
+
+def normalize_filter_values(value, field_name: str):
+    if value in (None, ""):
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if item not in (None, "")]
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    raise ValueError(f"{field_name} 必须是字符串或列表")
+
+
+def build_vm_query_failure_result(resp: dict, default_message: str):
+    error_message = resp.get("error") or resp.get("message") or default_message
+    error_type = resp.get("errorType")
+    if error_type:
+        error_message = f"{error_type}: {error_message}"
+    return {"result": False, "data": [], "message": error_message}
+
+
+def normalize_step(step):
+    if step in (None, ""):
+        return "5m"
+    Metrics.parse_step_to_seconds(step)
+    return step
+
+
+def normalize_dimensions(metric, dimensions):
+    if dimensions in (None, ""):
+        return {}
+    if not isinstance(dimensions, dict):
+        raise ValueError("dimensions 必须是字典")
+
+    allowed_dimensions = set(metric.instance_id_keys or [])
+    for item in metric.dimensions or []:
+        if isinstance(item, dict):
+            name = item.get("name")
+            if name:
+                allowed_dimensions.add(name)
+        elif item:
+            allowed_dimensions.add(item)
+
+    invalid_keys = [key for key in dimensions if key not in allowed_dimensions]
+    if invalid_keys:
+        raise ValueError(f"dimensions 包含未定义维度: {', '.join(invalid_keys)}")
+
+    return {str(key): str(value) for key, value in dimensions.items() if value is not None}
+
+
+def paginate_items(items: list, page, page_size):
+    total_count = len(items)
+    start = (page - 1) * page_size
+    end = start + page_size
+    return {
+        "count": total_count,
+        "page": page,
+        "page_size": page_size,
+        "items": items[start:end],
+    }

--- a/server/apps/monitor/tests/test_nats_query_contract_service.py
+++ b/server/apps/monitor/tests/test_nats_query_contract_service.py
@@ -1,0 +1,55 @@
+"""监控 NATS 查询接缝拆分契约。"""
+
+import importlib
+
+from nats_client.registry import default_registry
+
+
+def test_query_contract_service_has_no_registration_side_effects():
+    before = set(default_registry.registry)
+
+    service = importlib.import_module("apps.monitor.services.nats_query_contract")
+    importlib.reload(service)
+
+    assert set(default_registry.registry) == before
+
+
+def test_legacy_monitor_module_reexports_query_contract_helpers():
+    from apps.monitor.nats import monitor
+    from apps.monitor.services import nats_query_contract
+
+    assert monitor._normalize_monitor_query_data({"monitor_object_id": 1}) == nats_query_contract.normalize_monitor_query_data(
+        {"monitor_object_id": 1}
+    )
+    assert monitor._normalize_positive_int("2", "page") == nats_query_contract.normalize_positive_int("2", "page")
+    assert monitor._normalize_bool("true", "enabled") == nats_query_contract.normalize_bool("true", "enabled")
+    assert monitor._normalize_filter_values("a,b", "filters") == nats_query_contract.normalize_filter_values("a,b", "filters")
+    assert monitor._build_vm_query_failure_result({}, "failed") == nats_query_contract.build_vm_query_failure_result({}, "failed")
+    assert monitor._paginate_items([1, 2], 1, 1) == nats_query_contract.paginate_items([1, 2], 1, 1)
+
+
+def test_query_contract_service_preserves_representative_behavior():
+    from apps.monitor.services import nats_query_contract as service
+
+    assert service.normalize_monitor_query_data({"monitor_object_id": 7, "start_time": 10, "end_time": 20}) == {
+        "monitor_object_id": 7,
+        "monitor_obj_id": 7,
+        "start_time": 10,
+        "start": 10,
+        "end_time": 20,
+        "end": 20,
+    }
+    assert service.normalize_positive_int("3", "page") == 3
+    assert service.normalize_bool("yes", "enabled") is True
+    assert service.normalize_filter_values("a, b", "filters") == ["a", "b"]
+    assert service.build_vm_query_failure_result({"error": "invalid", "errorType": "bad_data"}, "query failed") == {
+        "result": False,
+        "data": [],
+        "message": "bad_data: invalid",
+    }
+    assert service.paginate_items([1, 2, 3], 2, 2) == {
+        "count": 3,
+        "page": 2,
+        "page_size": 2,
+        "items": [3],
+    }


### PR DESCRIPTION
## 问题

监控 NATS 门面同时承载注册、身份权限、查询输入归一化和业务 handler。查询契约 helper 与注册模块绑定，使后续按能力组拆分难以验证“服务组件无注册副作用”和旧 patch 路径兼容。

## 根因

查询输入与响应的纯契约没有独立 service seam，只能通过导入 1900 余行的 NATS 门面复用；任何搬移都可能无意改变启动 registry 或旧模块测试接缝。

## 怎么修的

- 新增无注册副作用的 `nats_query_contract` service，承载查询别名、整数/布尔/时间/筛选值、step、维度、分页和 VM 失败响应归一化。
- 旧 `apps.monitor.nats.monitor._...` 名称继续兼容导出，handler 调用点和测试 patch 路径无需迁移。
- 不移动 handler、不改 subject、参数、响应、身份或权限逻辑。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["26 个既有 NATS subject\nmonitor.py"]
    end

    subgraph C["兼容门面"]
        C1["旧 _normalize_* 名称\nmonitor.py"]
    end

    subgraph S["无副作用服务层"]
        S1["nats_query_contract\n输入与响应归一化"]
    end

    subgraph D["业务依赖"]
        D1["Metrics step 校验"]
        D2["VictoriaMetrics / ORM handler"]
    end

    T1 --> C1 --> S1
    S1 --> D1
    C1 --> D2
```

## 影响范围

这是 #4824 阶段 2 的首个接缝切片。真实 registry 仍为 26 个 handler，旧模块兼容名称和全部运行语义不变；没有数据库迁移，也不触及 Web、RPC 或运营分析公开契约。

## 验证

- TDD RED：新 service 不存在，独立导入契约失败。
- 新 service 重载前后 registry 不变，旧/新接缝代表性结果一致。
- 新接缝、旧 helper、完整 handler/registry 三个具体文件：117 passed。
- Black、isort、flake8、`git diff --check`：通过。

## 三轨门禁

- Standards：PASS。
- Spec：PASS，本切片只建立查询服务接缝，不提前迁移 handler。
- Runtime Contract：PASS，26 个 subject、权限与失败响应完整回归。
- P0/P1/P2：0/0/0，评分 96/100。

## 后续

Issue 保持开启。下一切片应基于该 service seam 按单一能力组迁移 handler，并继续保留旧模块兼容导出与组级回滚。

关联 #4824
