### PR TITLE
fix(monitor): 树节点 id 比较兼容 string/number，修复策略模板空白

### DIFF
--- a/web/src/app/log/utils/common.tsx
+++ b/web/src/app/log/utils/common.tsx
@@ -141,10 +141,14 @@ export const escapeArrayToJson = (arr: React.Key[]) => {
   return JSON.stringify(arr).replace(/"/g, '\\"');
 };
 
-// 树形组件根据id查其title
-export const findLabelById = (data: TreeItem[], key: string): string | null => {
+// 树形组件根据 id 查 label。key 可能是 number（建树）或 string（Ant Tree / 回调），须归一化比较。
+export const findLabelById = (
+  data: TreeItem[],
+  key: string | number
+): string | null => {
+  const target = String(key);
   for (const node of data) {
-    if (node.key === key) {
+    if (String(node.key) === target) {
       return node.label as string;
     }
     if (node.children) {
@@ -162,9 +166,10 @@ export const findTreeParentKey = (
   targetKey: React.Key
 ): React.Key | null => {
   let parentKey: React.Key | null = null;
+  const target = String(targetKey);
   const loop = (nodes: TreeItem[], parent: React.Key | null) => {
     for (const node of nodes) {
-      if (node.key === targetKey) {
+      if (String(node.key) === target) {
         parentKey = parent;
         return;
       }

--- a/web/src/app/monitor/(pages)/event/strategy/selectAssets.tsx
+++ b/web/src/app/monitor/(pages)/event/strategy/selectAssets.tsx
@@ -59,9 +59,11 @@ const filterTreeData = (treeData: any, searchText: string) => {
     .filter((item: any) => item !== null);
 };
 
-const getLabelByKey = (key: string, treeData: any): string => {
+const getLabelByKey = (key: string | number, treeData: any): string => {
+  const target = String(key);
   for (const node of treeData) {
-    if (node.key === key) {
+    // 组织树 key 为 number，勾选回调/状态里可能是 string，须归一化
+    if (String(node.key) === target) {
       return node.title;
     }
     if (node.children?.length) {

--- a/web/src/app/monitor/utils/common.tsx
+++ b/web/src/app/monitor/utils/common.tsx
@@ -240,10 +240,16 @@ export const calculateMetrics = (
   };
 };
 
-// 树形组件根据id查其title
-export const findLabelById = (data: TreeItem[], key: string): string | null => {
+// 树形组件根据 id 查 label（监控对象 name）。
+// TreeSelector 的 onNodeSelect 会 String(key)，而建树时常用数字 id 作 key，
+// 必须按字符串比较，否则查不到 name，策略模板等列表会整页空白。
+export const findLabelById = (
+  data: TreeItem[],
+  key: string | number
+): string | null => {
+  const target = String(key);
   for (const node of data) {
-    if (node.key === key) {
+    if (String(node.key) === target) {
       return node.label || null;
     }
     if (node.children) {
@@ -452,9 +458,10 @@ export const findTreeParentKey = (
   targetKey: React.Key
 ): React.Key | null => {
   let parentKey: React.Key | null = null;
+  const target = String(targetKey);
   const loop = (nodes: TreeItem[], parent: React.Key | null) => {
     for (const node of nodes) {
-      if (node.key === targetKey) {
+      if (String(node.key) === target) {
         parentKey = parent;
         return;
       }


### PR DESCRIPTION
## Summary
- 修复策略模板页整页空白：`TreeSelector` 将选中 key `String()` 化后，`findLabelById` 仍用严格 `===` 匹配数字树 key，导致 `monitor_object_name` 为空。
- 同步归一化 `findTreeParentKey`（monitor/log）与策略选资产 `getLabelByKey` 的同类比较。

## Test plan
- [ ] 打开 `/monitor/event/template`，切换 TCP/主机等对象，确认模板卡片正常展示（非「暂无策略模板」）
- [ ] 策略列表跳转新建/编辑时 URL 中 `monitorName` 正确
- [ ] 策略选资产 → 组织树勾选后，右侧已选标签显示组织名

## Review notes
- 已检查提交范围：仅 3 个源文件；测试文件与其他 WIP 未纳入
- 本地 eslint 对改动文件无 error；全仓 tsc 既有无关测试错误，改动文件无新增报错