### PR TITLE
refactor: 提取模型标签字段策略

### DIFF
--- a/server/apps/cmdb/services/model.py
+++ b/server/apps/cmdb/services/model.py
@@ -64,7 +64,6 @@ from apps.cmdb.services.unique_rule import (
 )
 from apps.cmdb.utils.change_record import create_change_record
 from apps.cmdb.validators import IdentifierValidator
-from apps.cmdb.validators.field_validator import normalize_tag_field_option as normalize_tag_field_option_config
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
 from apps.core.services.user_group import UserGroup
@@ -202,35 +201,15 @@ class ModelManage(object):
 
     @staticmethod
     def _is_tag_attr(attr: dict) -> bool:
-        return attr.get("attr_type") == "tag" or attr.get("attr_id") == TAG_ATTR_ID
+        return ModelAttributePolicy._is_tag_attr(attr)
 
     @staticmethod
     def validate_tag_attr_definition(attrs: list[dict], incoming_attr: dict) -> None:
-        attr_type = incoming_attr.get("attr_type")
-        incoming_attr_id = incoming_attr.get("attr_id")
-
-        if attr_type == "tag" and incoming_attr_id != TAG_ATTR_ID:
-            raise BaseAppException("tag 字段 attr_id 必须固定为 tag")
-
-        if incoming_attr_id == TAG_ATTR_ID and attr_type != "tag":
-            raise BaseAppException("attr_id 为 tag 的字段类型必须为 tag")
-
-        if attr_type != "tag":
-            return
-
-        tag_count = sum(1 for attr in attrs if ModelManage._is_tag_attr(attr))
-        if tag_count >= 1:
-            raise BaseAppException("单模型最多允许一个 tag 字段")
+        return ModelAttributePolicy.validate_tag_attr_definition(attrs, incoming_attr)
 
     @staticmethod
     def normalize_tag_field_option(option: dict | list[Any] | None) -> dict:
-        if isinstance(option, list):
-            option = {"mode": TAG_MODE_FREE, "options": option}
-        config = normalize_tag_field_option_config(option)
-        return {
-            "mode": config.mode,
-            "options": [{"key": item.key, "value": item.value} for item in config.options],
-        }
+        return ModelAttributePolicy.normalize_tag_field_option(option)
 
     @staticmethod
     def merge_tag_options_from_values(model_id: str, values: list[str]) -> None:
@@ -1096,7 +1075,8 @@ class ModelManage(object):
 
                 if updated_count > 0:
                     logger.info(
-                        f"[update_enum_instances_display] 枚举选项变更，已更新 {updated_count} 个实例的 {display_field_id} 字段, " f"模型: {model_id}, 字段: {attr_id}"
+                        f"[update_enum_instances_display] 枚举选项变更，已更新 {updated_count} 个实例的 {display_field_id} 字段, "
+                        f"模型: {model_id}, 字段: {attr_id}"
                     )
 
         except Exception as e:
@@ -1181,7 +1161,10 @@ class ModelManage(object):
                     updated_count += len(property_values)
 
                 if updated_count > 0:
-                    logger.info(f"[rebuild_file_instances_display] 已回填 {updated_count} 个实例的 {display_field_id} 字段, " f"模型: {model_id}, 字段: {attr_id}")
+                    logger.info(
+                        f"[rebuild_file_instances_display] 已回填 {updated_count} 个实例的 {display_field_id} 字段, "
+                        f"模型: {model_id}, 字段: {attr_id}"
+                    )
 
         except Exception as e:
             logger.error(
@@ -2145,7 +2128,8 @@ class ModelManage(object):
                     if conflicts:
                         if keep_existing_unique_rules_on_conflict:
                             logger.warning(
-                                "[UniqueRule] 存量实例与待应用规则冲突，保留原唯一规则并继续初始化 " "model_id=%s sheet_name=%s conflict_count=%s reason=%s",
+                                "[UniqueRule] 存量实例与待应用规则冲突，保留原唯一规则并继续初始化 "
+                                "model_id=%s sheet_name=%s conflict_count=%s reason=%s",
                                 model_id,
                                 sheet_name,
                                 len(conflicts),

--- a/server/apps/cmdb/services/model_attribute_policy.py
+++ b/server/apps/cmdb/services/model_attribute_policy.py
@@ -8,12 +8,44 @@ from collections.abc import Callable
 from typing import Any
 
 from apps.cmdb.constants.constants import ENUM_SELECT_MODE_DEFAULT
+from apps.cmdb.constants.field_constraints import TAG_ATTR_ID, TAG_MODE_FREE
+from apps.cmdb.validators.field_validator import normalize_tag_field_option as normalize_tag_field_option_config
 from apps.core.exceptions.base_app_exception import BaseAppException
 from apps.core.logger import cmdb_logger as logger
 
 
 class ModelAttributePolicy:
     """模型字段定义的无状态策略集合。"""
+
+    @staticmethod
+    def _is_tag_attr(attr: dict) -> bool:
+        return attr.get("attr_type") == "tag" or attr.get("attr_id") == TAG_ATTR_ID
+
+    @staticmethod
+    def validate_tag_attr_definition(attrs: list[dict], incoming_attr: dict) -> None:
+        attr_type = incoming_attr.get("attr_type")
+        incoming_attr_id = incoming_attr.get("attr_id")
+
+        if attr_type == "tag" and incoming_attr_id != TAG_ATTR_ID:
+            raise BaseAppException("tag 字段 attr_id 必须固定为 tag")
+        if incoming_attr_id == TAG_ATTR_ID and attr_type != "tag":
+            raise BaseAppException("attr_id 为 tag 的字段类型必须为 tag")
+        if attr_type != "tag":
+            return
+
+        tag_count = sum(1 for attr in attrs if ModelAttributePolicy._is_tag_attr(attr))
+        if tag_count >= 1:
+            raise BaseAppException("单模型最多允许一个 tag 字段")
+
+    @staticmethod
+    def normalize_tag_field_option(option: dict | list[Any] | None) -> dict:
+        if isinstance(option, list):
+            option = {"mode": TAG_MODE_FREE, "options": option}
+        config = normalize_tag_field_option_config(option)
+        return {
+            "mode": config.mode,
+            "options": [{"key": item.key, "value": item.value} for item in config.options],
+        }
 
     @staticmethod
     def _normalize_default_value(raw_value: Any) -> list[str]:
@@ -184,7 +216,6 @@ class ModelAttributePolicy:
             return runtime_options if isinstance(runtime_options, list) else []
         except Exception as e:
             active_logger.warning(
-                f"[EnumPublicBinding] resolve_runtime_enum_options fallback to snapshot, "
-                f"public_library_id={public_library_id}, error={e}"
+                f"[EnumPublicBinding] resolve_runtime_enum_options fallback to snapshot, " f"public_library_id={public_library_id}, error={e}"
             )
             return option if isinstance(option, list) else []

--- a/server/apps/cmdb/tests/test_model_attribute_policy_pure.py
+++ b/server/apps/cmdb/tests/test_model_attribute_policy_pure.py
@@ -24,6 +24,12 @@ ENUM_POLICY_METHODS = (
     "resolve_runtime_enum_options",
 )
 
+TAG_POLICY_METHODS = (
+    "_is_tag_attr",
+    "validate_tag_attr_definition",
+    "normalize_tag_field_option",
+)
+
 
 def test_model_manage_enum_policy_keeps_signatures_and_runtime_behaviour(monkeypatch):
     policy_module = import_module("apps.cmdb.services.model_attribute_policy")
@@ -53,9 +59,7 @@ def test_model_manage_enum_policy_keeps_signatures_and_runtime_behaviour(monkeyp
             {"attr_type": "enum", "enum_select_mode": "single"},
             {"attr_type": "enum", "enum_select_mode": "multiple"},
         )
-    assert ModelManage.resolve_runtime_enum_options(
-        {"attr_type": "enum", "enum_rule_type": "custom", "option": [{"id": "a"}]}
-    ) == [{"id": "a"}]
+    assert ModelManage.resolve_runtime_enum_options({"attr_type": "enum", "enum_rule_type": "custom", "option": [{"id": "a"}]}) == [{"id": "a"}]
 
     monkeypatch.setattr(
         "apps.cmdb.services.public_enum_library.get_library_or_raise",
@@ -79,9 +83,7 @@ def test_model_manage_old_path_monkeypatch_reaches_extracted_execution(monkeypat
         staticmethod(lambda _attr: [{"id": "patched"}]),
     )
 
-    result = ModelManage.sanitize_attr_default_value(
-        {"attr_type": "enum", "default_value": ["ignored"], "enum_select_mode": "single"}
-    )
+    result = ModelManage.sanitize_attr_default_value({"attr_type": "enum", "default_value": ["ignored"], "enum_select_mode": "single"})
 
     assert result["default_value"] == ["patched"]
 
@@ -107,8 +109,7 @@ def test_model_manage_old_logger_patch_keeps_failure_fallback_observable(monkeyp
     assert result == [{"id": "snapshot"}]
     patched_logger.warning.assert_called_once()
     assert patched_logger.warning.call_args.args == (
-        "[EnumPublicBinding] resolve_runtime_enum_options fallback to snapshot, "
-        "public_library_id=missing, error=library unavailable",
+        "[EnumPublicBinding] resolve_runtime_enum_options fallback to snapshot, " "public_library_id=missing, error=library unavailable",
     )
 
 
@@ -145,3 +146,34 @@ def test_extracted_policy_keeps_enum_default_value_behavior():
 
     assert result["default_value"] == ["a"]
     assert attr["default_value"] == ["a", "b", "missing"]
+
+
+def test_model_manage_tag_policy_keeps_signatures_and_runtime_behaviour():
+    for method_name in TAG_POLICY_METHODS:
+        assert signature(getattr(ModelManage, method_name)) == signature(getattr(ModelAttributePolicy, method_name))
+
+    assert ModelAttributePolicy._is_tag_attr({"attr_type": "tag"}) is True
+    assert ModelAttributePolicy._is_tag_attr({"attr_id": "tag"}) is True
+    assert ModelAttributePolicy._is_tag_attr({"attr_type": "str", "attr_id": "name"}) is False
+
+    ModelAttributePolicy.validate_tag_attr_definition([], {"attr_type": "tag", "attr_id": "tag"})
+    with pytest.raises(BaseAppException, match="attr_id 必须固定为 tag"):
+        ModelAttributePolicy.validate_tag_attr_definition([], {"attr_type": "tag", "attr_id": "labels"})
+    with pytest.raises(BaseAppException, match="单模型最多允许一个 tag 字段"):
+        ModelAttributePolicy.validate_tag_attr_definition(
+            [{"attr_type": "tag", "attr_id": "tag"}],
+            {"attr_type": "tag", "attr_id": "tag"},
+        )
+
+    assert ModelAttributePolicy.normalize_tag_field_option([{"key": "env", "value": "prod"}]) == {
+        "mode": "free",
+        "options": [{"key": "env", "value": "prod"}],
+    }
+
+
+def test_model_manage_tag_facade_delegates_to_current_policy(monkeypatch):
+    policy_method = Mock(return_value={"mode": "patched", "options": []})
+    monkeypatch.setattr(ModelAttributePolicy, "normalize_tag_field_option", policy_method)
+
+    assert ModelManage.normalize_tag_field_option([]) == {"mode": "patched", "options": []}
+    policy_method.assert_called_once_with([])


### PR DESCRIPTION
## 问题

`ModelManage` 作为兼容门面仍直接承载 tag 字段身份、定义约束和 option 归一化。无状态字段策略与模型 CRUD、Graph 写和导入编排共置，继续放大公共门面的回归面。

## 根因

tag 字段策略缺少独立边界；但 HTTP、OpenAPI、NATS、内部服务和测试仍依赖 `ModelManage` 方法名，直接迁移调用方会破坏公开接缝。

## 怎么修的

- 将 `_is_tag_attr`、`validate_tag_attr_definition`、`normalize_tag_field_option` 迁入既有 `ModelAttributePolicy`。
- `ModelManage` 保留原静态方法名和签名，并动态委托当前策略实现。
- 不迁移调用方，不修改持久化 option、错误文案、Graph 写、权限或接口响应。

## 调用链

```mermaid
flowchart TD
    subgraph T["现有调用方"]
        T1["HTTP / OpenAPI / NATS\n内部服务与测试"]
    end

    M["ModelManage\n兼容静态门面"]

    subgraph P["字段策略层"]
        P1["ModelAttributePolicy\ntag 身份与定义约束"]
        P2["tag option 归一化"]
    end

    V["FieldValidator\nfree / strict option 契约"]

    T1 --> M --> P1
    M --> P2 --> V
```

## 影响范围

这是 #4842 在 #4841 枚举策略首片之后的第二切片。只调整 CMDB 内部组织；旧入口和 patch 路径保留，无数据迁移、跨模块发布或默认行为变化。

## 验证

- TDD RED：`ModelAttributePolicy` 缺少 tag 策略方法。
- 字段策略、模型服务、tag/enum 校验三个具体文件：58 passed。
- 覆盖签名兼容、动态委托、非法 tag ID、重复 tag、list option 与 free 模式。
- Black、isort、flake8、`git diff --check`：通过。

## 三轨门禁

- Standards：PASS。
- Spec：PASS，只抽取一个无状态职责组并保留兼容门面。
- Runtime Contract：PASS，旧入口与策略层结果一致。
- P0/P1/P2：0/0/0，评分 95/100。

## 后续

Issue 保持开启。下一批继续选择单一职责组，先冻结调用方与旧 patch 接缝，再保留兼容委托迁移。

关联 #4842
