### PR TITLE
fix(monitor): 公式区提示实例标签由系统自动补充

### DIFF
--- a/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
+++ b/web/src/app/monitor/(pages)/integration/list/detail/metric/metricModal.tsx
@@ -953,26 +953,31 @@ const MetricModal = forwardRef<ModalRef, ModalProps>(
                 name="query"
                 rules={[{ required: true, message: t('common.required') }]}
                 extra={
-                  <div className="mt-1 flex gap-4">
-                    <Popover
-                      trigger="click"
-                      open={metricPickerOpen}
-                      onOpenChange={handleSelectMetricOpenChange}
-                      content={metricPickerContent}
-                      placement="bottomLeft"
-                    >
-                      <Button type="link" className="h-auto px-0">
-                        {t('monitor.integrations.selectMetric')}
+                  <div className="mt-1 space-y-1">
+                    <p className="m-0 text-xs leading-5 text-[var(--color-text-3)]">
+                      {t('monitor.integrations.formulaLabelsAutoHint')}
+                    </p>
+                    <div className="flex gap-4">
+                      <Popover
+                        trigger="click"
+                        open={metricPickerOpen}
+                        onOpenChange={handleSelectMetricOpenChange}
+                        content={metricPickerContent}
+                        placement="bottomLeft"
+                      >
+                        <Button type="link" className="h-auto px-0">
+                          {t('monitor.integrations.selectMetric')}
+                        </Button>
+                      </Popover>
+                      <Button
+                        type="link"
+                        className="h-auto px-0"
+                        loading={testLoading}
+                        onClick={handleTestMetric}
+                      >
+                        {t('monitor.integrations.testMetric')}
                       </Button>
-                    </Popover>
-                    <Button
-                      type="link"
-                      className="h-auto px-0"
-                      loading={testLoading}
-                      onClick={handleTestMetric}
-                    >
-                      {t('monitor.integrations.testMetric')}
-                    </Button>
+                    </div>
                   </div>
                 }
               >

--- a/web/src/app/monitor/locales/en.json
+++ b/web/src/app/monitor/locales/en.json
@@ -527,6 +527,7 @@
       "dbTypeDes": "The database types required for collection",
       "mappedValue": "Mapped Value",
       "formula": "Formula",
+      "formulaLabelsAutoHint": "Instance match labels are added automatically on save and query. You do not need to write them in the formula.",
       "selectMetric": "Select Metric",
       "testMetric": "Test Metric",
       "dimensionId": "Dimension ID",

--- a/web/src/app/monitor/locales/zh.json
+++ b/web/src/app/monitor/locales/zh.json
@@ -527,6 +527,7 @@
       "dbTypeDes": "采集中所需要的数据库类型",
       "mappedValue": "映射值",
       "formula": "公式",
+      "formulaLabelsAutoHint": "实例匹配标签由系统在保存与查询时自动补充，无需在公式中手写。",
       "selectMetric": "选择指标",
       "testMetric": "测试指标",
       "dimensionId": "维度ID",


### PR DESCRIPTION
## Summary
- 指标公式编辑区增加常驻说明：实例匹配标签由系统在保存与查询时自动补充，无需手写
- 与已合并的隐藏 `__$labels__` / 自动 ensure 行为配套，降低用户对 `{label}` / labels 的疑惑

## Test plan
- [ ] 打开添加/编辑指标弹窗，公式下方可见灰色提示文案
- [ ] 中英文切换文案正确
- [ ] 选择指标 / 测试指标按钮仍可用