### PR TITLE
bugfix: Fix cross team template misplacement and duplicate name issue…

### DIFF
--- a/server/apps/core/tests/test_viewset_permission_include_children.py
+++ b/server/apps/core/tests/test_viewset_permission_include_children.py
@@ -62,3 +62,21 @@ def test_include_children_allows_when_instance_granted(monkeypatch):
     allowed = _Fun().get_has_permission(_user(), _instance(), current_team=10, include_children=True)
 
     assert allowed is True  # 显式实例授权 → 放行
+
+
+def test_instance_rule_cannot_cross_current_team_scope(monkeypatch):
+    """用户同时属于多个组织时，实例规则也不能绕过当前组织边界。"""
+    user = SimpleNamespace(
+        group_list=[{"id": 10}, {"id": 12}],
+        group_tree=[],
+    )
+    instance = SimpleNamespace(id=999, team=[12])
+    monkeypatch.setattr(
+        viewset_utils,
+        "get_permission_rules",
+        lambda *a, **k: {"team": [], "instance": [{"id": 999, "permission": ["View", "Operate"]}]},
+    )
+
+    allowed = _Fun().get_has_permission(user, instance, current_team=10)
+
+    assert allowed is False

--- a/server/apps/core/tests/utils/test_viewset_utils_more.py
+++ b/server/apps/core/tests/utils/test_viewset_utils_more.py
@@ -1,4 +1,5 @@
 import pydantic.root_model  # noqa
+
 """apps/core/utils/viewset_utils.py 补充覆盖（baseline 未触达的方法）。
 
 聚焦：
@@ -238,6 +239,32 @@ class TestGetQuerysetByPermission:
         assert g2.id not in ids
 
     @pytest.mark.django_db
+    def test_instance_rule_cannot_expand_current_team_scope(self):
+        from apps.system_mgmt.models import Group
+
+        current_team = Group.objects.create(name="current-scope", parent_id=0)
+        foreign_team = Group.objects.create(name="foreign-scope", parent_id=0)
+        vs = _auth_vs(app_name="system_mgmt", permission_key="instance", org_field="id")
+        user = SimpleNamespace(
+            is_superuser=False,
+            group_list=[{"id": current_team.id}, {"id": foreign_team.id}],
+            group_tree=[],
+        )
+        req = SimpleNamespace(user=user, COOKIES={"include_children": "0"})
+        rules = {
+            "instance": [{"id": foreign_team.id, "permission": ["View"]}],
+            "team": [current_team.id],
+        }
+        with (
+            patch.object(AuthViewSet, "ORGANIZATION_FIELD", "id"),
+            patch("apps.core.utils.viewset_utils.get_current_team", return_value=str(current_team.id)),
+            patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules),
+        ):
+            queryset = vs.get_queryset_by_permission(req, Group.objects.all())
+
+        assert set(queryset.values_list("id", flat=True)) == {current_team.id}
+
+    @pytest.mark.django_db
     def test_empty_rules_returns_id_zero_filter(self):
         from apps.system_mgmt.models import Group
 
@@ -268,9 +295,7 @@ class TestFilterByGroup:
         user = SimpleNamespace(is_superuser=True, group_list=[], group_tree=[])
         req = SimpleNamespace(user=user, COOKIES={"include_children": "0"})
         with patch("apps.core.utils.viewset_utils.get_current_team", return_value="5"):
-            current_team, include_children, org_field, query = AuthViewSet.filter_by_group(
-                Group.objects.all(), req, user
-            )
+            current_team, include_children, org_field, query = AuthViewSet.filter_by_group(Group.objects.all(), req, user)
         assert current_team == 5
         assert include_children is False
 
@@ -295,9 +320,7 @@ class TestFilterByGroup:
         )
         req = SimpleNamespace(user=user, COOKIES={"include_children": "1"})
         with patch("apps.core.utils.viewset_utils.get_current_team", return_value="1"):
-            current_team, include_children, org_field, query = AuthViewSet.filter_by_group(
-                Group.objects.all(), req, user
-            )
+            current_team, include_children, org_field, query = AuthViewSet.filter_by_group(Group.objects.all(), req, user)
         assert include_children is True
         # org_field "team" 不在 Group 字段中 -> query 为空 Q（走 else 分支也可），仅断言不抛异常
         assert current_team == 1

--- a/server/apps/core/utils/viewset_utils.py
+++ b/server/apps/core/utils/viewset_utils.py
@@ -9,7 +9,6 @@ from apps.core.logger import logger
 from apps.core.utils.loader import LanguageLoader
 from apps.core.utils.permission_utils import delete_instance_rules, get_permission_rules
 from apps.core.utils.team_utils import get_current_team
-from apps.core.utils.user_group import normalize_user_group_ids
 from apps.system_mgmt.models import Group
 
 
@@ -80,12 +79,16 @@ class GenericViewSetFun(object):
 
     def get_has_permission(self, user, instance, current_team, is_list=False, is_check=False, include_children=False):
         """获取规则实例ID"""
-        user_groups = normalize_user_group_ids(getattr(user, "group_list", []))
+        try:
+            normalized_current_team = int(current_team)
+        except (TypeError, ValueError):
+            normalized_current_team = current_team
+        scoped_groups = {normalized_current_team}
         if include_children:
             group_tree = getattr(user, "group_tree", [])
             child_groups = self.extract_child_group_ids(group_tree, current_team)
             if child_groups:
-                user_groups = child_groups
+                scoped_groups = set(child_groups)
         org_field = getattr(self, "ORGANIZATION_FIELD", "team")
         if is_list:
             instance_id = list(instance.values_list("id", flat=True))
@@ -93,12 +96,12 @@ class GenericViewSetFun(object):
                 if hasattr(i, org_field):
                     # 判断两个集合是否有交集
                     org_value = getattr(i, org_field)
-                    if not set(org_value).intersection(set(user_groups)):
+                    if not set(org_value).intersection(scoped_groups):
                         return False
         else:
             if hasattr(instance, org_field):
                 org_value = getattr(instance, org_field)
-                if not set(org_value).intersection(set(user_groups)):
+                if not set(org_value).intersection(scoped_groups):
                     return False
             instance_id = [instance.id]
         try:
@@ -112,7 +115,7 @@ class GenericViewSetFun(object):
                 # "对象属于当前组织树即放行"，造成子组织任务越权（issue #3037）。
                 # current_team 自身已授权的情况已由上方 current_team in permission_rules["team"] 覆盖。
                 allowed_teams = {i for i in permission_rules.get("team", [])}
-                if allowed_teams & set(user_groups):
+                if allowed_teams & scoped_groups:
                     return True
 
             operate = "View" if is_check else "Operate"
@@ -172,11 +175,15 @@ class GenericViewSetFun(object):
             permission_data = get_permission_rules(user, current_team, app_name, permission_key, include_children)
             instance_ids = [i["id"] for i in permission_data.get("instance", [])]
             team = permission_data.get("team", [])
+            permission_query = Q()
             if instance_ids:
-                query |= Q(id__in=instance_ids)
-            query |= build_json_membership_query(queryset, org_field, team)
+                permission_query |= Q(id__in=instance_ids)
+            permission_query |= build_json_membership_query(queryset, org_field, team)
             if not instance_ids and not team:
                 return queryset.filter(id=0)
+            # 实例级规则只在当前组织范围内生效。团队移除后即使远程规则清理
+            # 暂时失败，旧规则也不能绕过本地组织边界重新暴露实例。
+            query &= permission_query
         return queryset.filter(query)
 
     @classmethod
@@ -518,8 +525,10 @@ class AuthViewSet(MaintainerViewSet):
         return normalized
 
     def retrieve(self, request, *args, **kwargs):
-        serializer = self.get_detail(request, *args, **kwargs)
-        return Response(serializer.data)
+        detail = self.get_detail(request, *args, **kwargs)
+        if isinstance(detail, (JsonResponse, Response)):
+            return detail
+        return Response(detail.data)
 
     def get_detail(self, request, *args, **kwargs):
         """获取详情"""
@@ -589,9 +598,7 @@ class AuthViewSet(MaintainerViewSet):
         if hasattr(self, "permission_key"):
             include_children = request.COOKIES.get("include_children", "0") == "1"
             if not self.get_has_permission(user, instance, current_team, include_children=include_children):
-                message = (
-                    self.loader.get("error.no_permission_update") if self.loader else "User does not have permission to update this instance"
-                )
+                message = self.loader.get("error.no_permission_update") if self.loader else "User does not have permission to update this instance"
                 return self.value_error(message)
         if org_field in data:
             org_values = self._normalize_org_values(data, org_field)

--- a/server/apps/job_mgmt/tests/test_script_views.py
+++ b/server/apps/job_mgmt/tests/test_script_views.py
@@ -1,5 +1,7 @@
 """脚本库视图测试（CRUD + 高危命令拦截 + 批量删除）"""
 
+from unittest.mock import patch
+
 import pytest
 
 from apps.job_mgmt.constants import DangerousLevel
@@ -28,6 +30,42 @@ class TestScriptCrud:
         resp = su_client.get(f"{URL}{s.id}/")
         assert resp.status_code == 200
         assert resp.data["name"] == "s1"
+
+    def test_normal_user_list_does_not_include_instance_rule_from_other_current_team(self, api_client, authenticated_user):
+        current = Script.objects.create(name="巡检模板", content="echo current", script_type="shell", team=[1])
+        foreign = Script.objects.create(name="巡检模板", content="echo foreign", script_type="shell", team=[2])
+        authenticated_user.is_superuser = False
+        authenticated_user.group_list = [{"id": 1, "name": "Current"}, {"id": 2, "name": "Foreign"}]
+        authenticated_user.permission = {"job": {"script_library-View"}}
+        api_client.cookies["current_team"] = "1"
+        rules = {
+            "team": [1],
+            "instance": [{"id": foreign.id, "permission": ["View"]}],
+        }
+
+        with patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules):
+            response = api_client.get(URL)
+
+        assert response.status_code == 200
+        assert [item["id"] for item in response.data] == [current.id]
+
+    def test_normal_user_foreign_instance_rule_returns_permission_error_on_retrieve(self, api_client, authenticated_user):
+        foreign = Script.objects.create(name="外部模板", content="echo foreign", script_type="shell", team=[2])
+        authenticated_user.is_superuser = False
+        authenticated_user.group_list = [{"id": 1, "name": "Current"}, {"id": 2, "name": "Foreign"}]
+        authenticated_user.permission = {"job": {"script_library-View"}}
+        api_client.cookies["current_team"] = "1"
+        rules = {
+            "team": [],
+            "instance": [{"id": foreign.id, "permission": ["View"]}],
+        }
+
+        with patch("apps.core.utils.viewset_utils.get_permission_rules", return_value=rules):
+            response = api_client.get(f"{URL}{foreign.id}/")
+
+        assert response.status_code == 200
+        assert response.json()["result"] is False
+        assert "id" not in response.json()
 
     def test_update_script(self, su_client):
         s = Script.objects.create(name="s1", content="echo", script_type="shell", team=[1])


### PR DESCRIPTION
…s caused by out of bounds filtering of general organizational permissions, and complete regression testing of lists and details.