### PR TITLE
bugfix: 兼容算法预测输入错误状态

### DIFF
--- a/server/apps/mlops/predict_response.py
+++ b/server/apps/mlops/predict_response.py
@@ -1,0 +1,16 @@
+from rest_framework import status
+
+PREDICT_INPUT_ERROR_STATUSES = frozenset(
+    {
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+    }
+)
+
+
+def map_predict_upstream_status(status_code: int) -> int:
+    """保留算法侧已登记的输入错误，其余上游异常继续收敛为 500。"""
+    if status_code in PREDICT_INPUT_ERROR_STATUSES:
+        return status_code
+    return status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/server/apps/mlops/tests/test_object_detection_serving.py
+++ b/server/apps/mlops/tests/test_object_detection_serving.py
@@ -2,8 +2,8 @@ import pytest
 from rest_framework import status
 
 from apps.mlops.models.object_detection import ObjectDetectionTrainJob
-from .conftest import create_object_detection_serving, create_train_job
 
+from .conftest import create_object_detection_serving, create_train_job
 
 pytestmark = [pytest.mark.django_db, pytest.mark.integration]
 
@@ -32,6 +32,8 @@ def test_object_detection_predict_uses_container_info_even_when_serving_status_i
         return "http://fake-service/predict"
 
     class FakeResponse:
+        status_code = status.HTTP_200_OK
+
         def raise_for_status(self):
             return None
 

--- a/server/apps/mlops/tests/test_predict_response_pure.py
+++ b/server/apps/mlops/tests/test_predict_response_pure.py
@@ -1,0 +1,32 @@
+import pytest
+from rest_framework import status
+
+from apps.mlops.predict_response import map_predict_upstream_status
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    "upstream_status",
+    [
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+    ],
+)
+def test_map_predict_upstream_status_preserves_registered_input_errors(upstream_status):
+    assert map_predict_upstream_status(upstream_status) == upstream_status
+
+
+@pytest.mark.parametrize(
+    "upstream_status",
+    [
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_404_NOT_FOUND,
+        status.HTTP_429_TOO_MANY_REQUESTS,
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        status.HTTP_503_SERVICE_UNAVAILABLE,
+    ],
+)
+def test_map_predict_upstream_status_keeps_unregistered_failures_internal(upstream_status):
+    assert map_predict_upstream_status(upstream_status) == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/server/apps/mlops/tests/test_predict_upstream_error_contract.py
+++ b/server/apps/mlops/tests/test_predict_upstream_error_contract.py
@@ -1,0 +1,349 @@
+"""算法预测端点的新旧错误契约兼容测试（Issue #4009）。"""
+
+import pytest
+import requests
+from rest_framework import status
+
+from apps.mlops.models.anomaly_detection import AnomalyDetectionServing, AnomalyDetectionTrainJob
+from apps.mlops.models.classification import ClassificationServing, ClassificationTrainJob
+from apps.mlops.models.image_classification import ImageClassificationServing, ImageClassificationTrainJob
+from apps.mlops.models.log_clustering import LogClusteringServing, LogClusteringTrainJob
+from apps.mlops.models.object_detection import ObjectDetectionTrainJob
+from apps.mlops.models.timeseries_predict import TimeSeriesPredictServing, TimeSeriesPredictTrainJob
+
+from .conftest import create_object_detection_serving, create_train_job
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+CONTAINER_INFO = {"port": 3000, "state": "running", "status": "success"}
+
+
+def _create_serving(serving_model, train_job, team=1):
+    return serving_model.objects.create(
+        name=f"typed-error-contract-{team}",
+        description="",
+        team=[team],
+        train_job=train_job,
+        model_version="latest",
+        status="inactive",
+        container_info=CONTAINER_INFO,
+    )
+
+
+PREDICT_CASES = [
+    pytest.param(
+        "anomaly_detection",
+        "anomaly_detection-Predict",
+        AnomalyDetectionTrainJob,
+        AnomalyDetectionServing,
+        {"data": [{"value": 1}]},
+        status.HTTP_400_BAD_REQUEST,
+        id="anomaly-400",
+    ),
+    pytest.param(
+        "classification",
+        "classification-Predict",
+        ClassificationTrainJob,
+        ClassificationServing,
+        {"texts": ["sample"]},
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        id="text-413",
+    ),
+    pytest.param(
+        "image_classification",
+        "image_classification-Predict",
+        ImageClassificationTrainJob,
+        ImageClassificationServing,
+        {"images": ["base64-image"]},
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        id="image-422",
+    ),
+    pytest.param(
+        "log_clustering",
+        "log_clustering-Predict",
+        LogClusteringTrainJob,
+        LogClusteringServing,
+        {"data": ["log line"]},
+        status.HTTP_400_BAD_REQUEST,
+        id="log-400",
+    ),
+    pytest.param(
+        "timeseries_predict",
+        "timeseries_predict-Predict",
+        TimeSeriesPredictTrainJob,
+        TimeSeriesPredictServing,
+        {"data": [{"timestamp": "2024-01-01T00:00:00Z", "value": 1}], "steps": 1},
+        status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+        id="timeseries-413",
+    ),
+    pytest.param(
+        "object_detection",
+        "object_detection-Predict",
+        ObjectDetectionTrainJob,
+        None,
+        {"images": ["base64-image"]},
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+        id="object-422",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("route", "permission", "train_job_model", "serving_model", "payload", "upstream_status"),
+    PREDICT_CASES,
+)
+def test_predict_preserves_upstream_client_error_status(
+    mlops_api_client,
+    mlops_user,
+    monkeypatch,
+    route,
+    permission,
+    train_job_model,
+    serving_model,
+    payload,
+    upstream_status,
+):
+    """算法侧 400/413/422 是客户端输入错误，Server 不应放大成 500。"""
+    mlops_user.permission["mlops"].add(permission)
+    train_job = create_train_job(train_job_model, team=1)
+    if route == "object_detection":
+        serving = create_object_detection_serving(train_job, team=1, container_info=CONTAINER_INFO)
+    else:
+        serving = _create_serving(serving_model, train_job)
+
+    module_path = f"apps.mlops.views.{route}"
+    monkeypatch.setattr(f"{module_path}.build_predict_url", lambda **_kwargs: "http://fake-predict/predict")
+
+    class FakeResponse:
+        status_code = upstream_status
+        text = '{"detail":[{"type":"request_validation"}]}'
+
+        def json(self):
+            return {"detail": [{"type": "request_validation"}]}
+
+        def raise_for_status(self):
+            raise AssertionError("已识别的客户端输入错误不应进入 HTTPError 分支")
+
+    monkeypatch.setattr(f"{module_path}.requests.post", lambda *_args, **_kwargs: FakeResponse())
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/{route}_servings/{serving.id}/predict/",
+        payload,
+        format="json",
+    )
+
+    assert response.status_code == upstream_status
+    assert "error" in response.data
+
+
+LEGACY_ENVELOPE_CASES = [
+    pytest.param(
+        "anomaly_detection",
+        "anomaly_detection-Predict",
+        AnomalyDetectionTrainJob,
+        AnomalyDetectionServing,
+        {"data": [{"value": 1}]},
+        id="anomaly",
+    ),
+    pytest.param(
+        "classification",
+        "classification-Predict",
+        ClassificationTrainJob,
+        ClassificationServing,
+        {"texts": ["sample"]},
+        id="text",
+    ),
+    pytest.param(
+        "log_clustering",
+        "log_clustering-Predict",
+        LogClusteringTrainJob,
+        LogClusteringServing,
+        {"data": ["log line"]},
+        id="log",
+    ),
+    pytest.param(
+        "timeseries_predict",
+        "timeseries_predict-Predict",
+        TimeSeriesPredictTrainJob,
+        TimeSeriesPredictServing,
+        {"data": [{"timestamp": "2024-01-01T00:00:00Z", "value": 1}], "steps": 1},
+        id="timeseries",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("route", "permission", "train_job_model", "serving_model", "payload"),
+    LEGACY_ENVELOPE_CASES,
+)
+def test_predict_keeps_legacy_error_envelope_contract(
+    mlops_api_client,
+    mlops_user,
+    monkeypatch,
+    route,
+    permission,
+    train_job_model,
+    serving_model,
+    payload,
+):
+    """旧镜像的 200 + error envelope 在迁移窗口内仍按既有 400 解析。"""
+    mlops_user.permission["mlops"].add(permission)
+    train_job = create_train_job(train_job_model, team=1)
+    serving = _create_serving(serving_model, train_job)
+    module_path = f"apps.mlops.views.{route}"
+    monkeypatch.setattr(f"{module_path}.build_predict_url", lambda **_kwargs: "http://fake-predict/predict")
+
+    class FakeResponse:
+        status_code = status.HTTP_200_OK
+
+        def json(self):
+            return {
+                "success": False,
+                "error": {
+                    "code": "INVALID_INPUT",
+                    "message": "legacy validation failed",
+                    "details": {"field": "data"},
+                },
+            }
+
+    monkeypatch.setattr(f"{module_path}.requests.post", lambda *_args, **_kwargs: FakeResponse())
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/{route}_servings/{serving.id}/predict/",
+        payload,
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.data["error_code"] == "INVALID_INPUT"
+    assert response.data["details"] == {"field": "data"}
+
+
+@pytest.mark.parametrize(
+    ("route", "permission", "train_job_model", "serving_model"),
+    [
+        pytest.param(
+            "image_classification",
+            "image_classification-Predict",
+            ImageClassificationTrainJob,
+            ImageClassificationServing,
+            id="image",
+        ),
+        pytest.param(
+            "object_detection",
+            "object_detection-Predict",
+            ObjectDetectionTrainJob,
+            None,
+            id="object",
+        ),
+    ],
+)
+def test_image_predict_keeps_partial_success_contract(
+    mlops_api_client,
+    mlops_user,
+    monkeypatch,
+    route,
+    permission,
+    train_job_model,
+    serving_model,
+):
+    """图片类旧镜像可继续返回单项失败、同批其他项成功的 200 响应。"""
+    mlops_user.permission["mlops"].add(permission)
+    train_job = create_train_job(train_job_model, team=1)
+    if route == "object_detection":
+        serving = create_object_detection_serving(train_job, team=1, container_info=CONTAINER_INFO)
+    else:
+        serving = _create_serving(serving_model, train_job)
+
+    module_path = f"apps.mlops.views.{route}"
+    monkeypatch.setattr(f"{module_path}.build_predict_url", lambda **_kwargs: "http://fake-predict/predict")
+    partial_result = {
+        "success": True,
+        "results": [
+            {"success": False, "error": {"code": "INVALID_IMAGE"}},
+            {"success": True, "prediction": {"label": "normal"}},
+        ],
+    }
+
+    class FakeResponse:
+        status_code = status.HTTP_200_OK
+
+        def json(self):
+            return partial_result
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(f"{module_path}.requests.post", lambda *_args, **_kwargs: FakeResponse())
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/{route}_servings/{serving.id}/predict/",
+        {"images": ["invalid-image", "valid-image"]},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.data == partial_result
+
+
+@pytest.mark.parametrize(
+    ("route", "permission", "train_job_model", "serving_model", "payload"),
+    [
+        pytest.param(
+            "anomaly_detection",
+            "anomaly_detection-Predict",
+            AnomalyDetectionTrainJob,
+            AnomalyDetectionServing,
+            {"data": [{"value": 1}]},
+            id="standard-proxy",
+        ),
+        pytest.param(
+            "object_detection",
+            "object_detection-Predict",
+            ObjectDetectionTrainJob,
+            None,
+            {"images": ["base64-image"]},
+            id="raise-for-status-proxy",
+        ),
+    ],
+)
+def test_predict_keeps_upstream_service_failures_internal(
+    mlops_api_client,
+    mlops_user,
+    monkeypatch,
+    route,
+    permission,
+    train_job_model,
+    serving_model,
+    payload,
+):
+    """算法服务自身失败仍收敛为 500，不能被输入错误映射误放大到客户端。"""
+    mlops_user.permission["mlops"].add(permission)
+    train_job = create_train_job(train_job_model, team=1)
+    if route == "object_detection":
+        serving = create_object_detection_serving(train_job, team=1, container_info=CONTAINER_INFO)
+    else:
+        serving = _create_serving(serving_model, train_job)
+
+    module_path = f"apps.mlops.views.{route}"
+    monkeypatch.setattr(f"{module_path}.build_predict_url", lambda **_kwargs: "http://fake-predict/predict")
+
+    class FakeResponse:
+        status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        text = "serving unavailable"
+
+        def json(self):
+            return {"error": "serving unavailable"}
+
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError("503 Server Error")
+
+    monkeypatch.setattr(f"{module_path}.requests.post", lambda *_args, **_kwargs: FakeResponse())
+
+    response = mlops_api_client.post(
+        f"/api/v1/mlops/{route}_servings/{serving.id}/predict/",
+        payload,
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/server/apps/mlops/views/anomaly_detection.py
+++ b/server/apps/mlops/views/anomaly_detection.py
@@ -28,6 +28,7 @@ from apps.mlops.models.anomaly_detection import (
     AnomalyDetectionTrainData,
     AnomalyDetectionTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.anomaly_detection import (
@@ -1305,7 +1306,7 @@ class AnomalyDetectionServingViewSet(TeamModelViewSet):
                 logger.error(f"{error_msg}, serving_id={serving.id}")
                 return Response(
                     {"error": error_msg, "detail": response.text},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    status=map_predict_upstream_status(response.status_code),
                 )
 
         except requests.exceptions.Timeout:

--- a/server/apps/mlops/views/classification.py
+++ b/server/apps/mlops/views/classification.py
@@ -28,6 +28,7 @@ from apps.mlops.models.classification import (
     ClassificationTrainData,
     ClassificationTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.classification import (
@@ -710,7 +711,7 @@ class ClassificationServingViewSet(TeamModelViewSet):
                 logger.error(f"{error_msg}, serving_id={serving.id}")
                 return Response(
                     {"error": error_msg, "detail": response.text},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    status=map_predict_upstream_status(response.status_code),
                 )
 
         except requests.exceptions.Timeout:

--- a/server/apps/mlops/views/image_classification.py
+++ b/server/apps/mlops/views/image_classification.py
@@ -30,6 +30,7 @@ from apps.mlops.models.image_classification import (
     ImageClassificationTrainData,
     ImageClassificationTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.image_classification import (
@@ -1508,7 +1509,7 @@ class ImageClassificationServingViewSet(TeamModelViewSet):
                 logger.error(f"{error_msg}, serving_id={serving.id}")
                 return Response(
                     {"error": error_msg, "detail": response.text},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    status=map_predict_upstream_status(response.status_code),
                 )
 
         except requests.exceptions.Timeout:

--- a/server/apps/mlops/views/log_clustering.py
+++ b/server/apps/mlops/views/log_clustering.py
@@ -28,6 +28,7 @@ from apps.mlops.models.log_clustering import (
     LogClusteringTrainData,
     LogClusteringTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.log_clustering import (
@@ -1245,7 +1246,7 @@ class LogClusteringServingViewSet(TeamModelViewSet):
                 logger.error(f"{error_msg}, serving_id={serving.id}")
                 return Response(
                     {"error": error_msg, "detail": response.text},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    status=map_predict_upstream_status(response.status_code),
                 )
 
         except requests.exceptions.Timeout:

--- a/server/apps/mlops/views/object_detection.py
+++ b/server/apps/mlops/views/object_detection.py
@@ -30,6 +30,7 @@ from apps.mlops.models.object_detection import (
     ObjectDetectionTrainData,
     ObjectDetectionTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.object_detection import (
@@ -1476,6 +1477,18 @@ class ObjectDetectionServingViewSet(TeamModelViewSet):
 
             # 调用推理服务
             response = requests.post(predict_url, json=payload, timeout=60)
+            mapped_status = map_predict_upstream_status(response.status_code)
+            if mapped_status != status.HTTP_500_INTERNAL_SERVER_ERROR:
+                return Response(
+                    {
+                        "error": mlops_message(
+                            request,
+                            "error.serving_inference_service_error",
+                            detail=response.text,
+                        )
+                    },
+                    status=mapped_status,
+                )
             response.raise_for_status()
 
             result = response.json()

--- a/server/apps/mlops/views/timeseries_predict.py
+++ b/server/apps/mlops/views/timeseries_predict.py
@@ -32,6 +32,7 @@ from apps.mlops.models.timeseries_predict import (
     TimeSeriesPredictTrainData,
     TimeSeriesPredictTrainJob,
 )
+from apps.mlops.predict_response import map_predict_upstream_status
 from apps.mlops.predict_url_builder import build_predict_url
 from apps.mlops.serializers.algorithm_config import AlgorithmConfigListSerializer, AlgorithmConfigSerializer
 from apps.mlops.serializers.timeseries_predict import (
@@ -1797,7 +1798,7 @@ class TimeSeriesPredictServingViewSet(TeamModelViewSet):
                 logger.error(f"{error_msg}, serving_id={serving.id}")
                 return Response(
                     {"error": error_msg, "detail": response.text},
-                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    status=map_predict_upstream_status(response.status_code),
                 )
 
         except requests.exceptions.Timeout:


### PR DESCRIPTION
## 问题

五个算法服务仍使用裸列表或字典参数，并以 `200 + error envelope` 表示输入校验失败；日志聚类已经使用 typed request，会由 BentoML 返回 400/413/422。Server 的六个预测入口此前把所有非 200 响应统一转换为 500，导致算法镜像无法按兼容顺序迁移：客户端输入错误会被误报成服务端故障。

## 根因（设计层）

算法服务已经存在新旧两种失败协议，但 Server 代理层没有显式区分“输入错误”和“算法服务故障”。直接迁移任一算法镜像都会先改变上层可见语义；image 与 object 还需要继续保留逐元素 partial-success，不能机械地一次性翻转全部服务。

## 怎么修的

1. 在 MLOps 中登记算法预测输入错误状态 400、413、422，仅这些状态由 Server 原样保留；未登记的 4xx 与 5xx 继续收敛为 500。
2. 六个预测入口统一使用该映射；object detection 在调用 `raise_for_status()` 前先识别输入错误，避免其落入 HTTPError 分支。
3. 增加六端点契约测试，覆盖新 400/413/422、旧 `200 + error envelope`、图片 partial-success、算法服务 5xx、现有批量上限和 object 成功路径。

## 影响范围

- 仅修改 Server 的 MLOps 预测代理，不修改五个算法服务签名、请求字段、响应字段、依赖锁或镜像配置。
- 旧算法镜像继续使用既有 200 错误包络；新 typed-request 镜像可以逐个灰度。
- image/object 的单项失败、同批其他项成功行为保持不变。
- 不需要部署配置或运维脚本；发布顺序为 Server 首片先上线，再逐个迁移算法镜像。
- 本 PR 是 #4009 的第一片，Issue 保持 OPEN，后续继续迁移 anomaly、timeseries、text、image、object。

## 调用链

```mermaid
flowchart TD
    subgraph T["触发层"]
        T1["MLOps predict API\nserver/apps/mlops/views"]
    end

    subgraph N["算法调用层"]
        N1["requests.post\n算法 Serving /predict"]
        N2["输入错误状态映射\npredict_response.py"]
    end

    subgraph C["兼容与故障层"]
        C1["旧 200 error envelope\n继续解析为 400"]
        C2["新 400/413/422\n保留客户端错误"]
        C3["其他 4xx/5xx\n继续收敛为 500"]
    end

    T1 --> N1 --> N2
    N2 --> C1
    N2 --> C2
    N2 -. "服务故障" .-> C3
```

## 验证

- 修复前，六个真实 DRF 预测入口收到算法侧 400/413/422 时均返回 500，新增契约为 6 failed。
- 修复后，以下具体测试文件合计 31 passed：
  - `apps/mlops/tests/test_predict_response_pure.py`
  - `apps/mlops/tests/test_predict_upstream_error_contract.py`
  - `apps/mlops/tests/test_predict_batch_size_limit.py`
  - `apps/mlops/tests/test_object_detection_serving.py`
- 新增文件 Flake8、Python 编译与 diff-check 通过；触及视图中的既有 Flake8 基线未由本 PR 扩大。

## 三轨门禁

- Standards：PASS。共享映射集中、差异最小，无配置、迁移或无关格式化。
- Spec：PASS。完成用户选择 A 的 Server 双栈首片，旧包络与图片 partial-success 均有兼容证据。
- Runtime Contract：PASS。PostgreSQL + DRF 真实入口覆盖正常、输入错误、旧镜像、partial-success 与服务故障路径。
- 质量评分：95 / 100，SCORE_PASS。

关联 Issue #4009。
