### PR TITLE
fix(log): 修复分析仪表盘明细表时间列显示为空

### DIFF
--- a/web/src/app/log/(pages)/analysis/dashBoard/widgets/comTable.tsx
+++ b/web/src/app/log/(pages)/analysis/dashBoard/widgets/comTable.tsx
@@ -1,6 +1,35 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import CustomTable from '@/components/custom-table';
 import { TableDataItem } from '@/app/log/types';
+import { useLocalizedTime } from '@/hooks/useLocalizedTime';
+
+const TIME_FIELD_KEYS = new Set([
+  '_time',
+  '@timestamp',
+  'timestamp',
+  'last_change_time',
+  'last_time'
+]);
+
+const normalizeTimeColumn = (
+  column: Record<string, unknown>,
+  formatTime: (value: unknown) => string
+) => {
+  const dataIndex = String(column.dataIndex ?? '');
+  const normalizedIndex = dataIndex === '@timestamp' ? '_time' : dataIndex;
+  const isTimeField = TIME_FIELD_KEYS.has(dataIndex);
+
+  if (!isTimeField) {
+    return column;
+  }
+
+  return {
+    ...column,
+    dataIndex: normalizedIndex,
+    key: column.key === dataIndex ? normalizedIndex : column.key,
+    render: column.render ?? ((value: unknown) => formatTime(value))
+  };
+};
 
 interface ComTableProps {
   rawData: any;
@@ -13,9 +42,17 @@ const ComTable: React.FC<ComTableProps> = ({
   loading = false,
   config
 }) => {
+  const { convertToLocalizedTime } = useLocalizedTime();
   const [tableData, setTableData] = useState<TableDataItem[]>([]);
   const [scrollY, setScrollY] = useState<number>(300);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const formatTime = useCallback((value: unknown) => {
+    if (value === null || value === undefined || value === '') {
+      return '--';
+    }
+    return convertToLocalizedTime(String(value), 'YYYY-MM-DD HH:mm:ss');
+  }, [convertToLocalizedTime]);
 
   useEffect(() => {
     if (!loading) {
@@ -51,8 +88,16 @@ const ComTable: React.FC<ComTableProps> = ({
     };
   }, []);
 
-  const columns = config?.showIndex
-    ? [
+  const columns = useMemo(() => {
+    const configuredColumns = (config?.columns || []).map((column: Record<string, unknown>) =>
+      normalizeTimeColumn(column, formatTime)
+    );
+
+    if (!config?.showIndex) {
+      return configuredColumns;
+    }
+
+    return [
       {
         key: '__index__',
         title: '#',
@@ -65,9 +110,9 @@ const ComTable: React.FC<ComTableProps> = ({
           </span>
         )
       },
-      ...(config?.columns || [])
-    ]
-    : config?.columns || [];
+      ...configuredColumns
+    ];
+  }, [config?.columns, config?.showIndex, formatTime]);
 
   return (
     <div ref={containerRef} className="h-full flex">

--- a/web/src/app/log/hooks/analysis/apacheDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/apacheDashboard.tsx
@@ -270,7 +270,7 @@ export const useApacheDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '状态码', dataIndex: 'apache.access.response_code', key: 'apache.access.response_code', width: 90, render: renderStatusTag },
             { title: '方法', dataIndex: 'apache.access.method', key: 'apache.access.method', width: 86 },
             { title: 'URL', dataIndex: 'apache.access.url', key: 'apache.access.url', width: 220 },
@@ -294,7 +294,7 @@ export const useApacheDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '级别', dataIndex: 'apache.error.level', key: 'apache.error.level', width: 90, render: renderWebLevel },
             { title: '客户端', dataIndex: 'apache.error.client', key: 'apache.error.client', width: 120 },
             { title: '消息摘要', dataIndex: 'apache.error.message', key: 'apache.error.message', width: 360 }

--- a/web/src/app/log/hooks/analysis/elasticsearchDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/elasticsearchDashboard.tsx
@@ -315,7 +315,7 @@ export const useElasticsearchDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '节点', dataIndex: 'instance_id', key: 'instance_id', width: 140 },
             { title: '索引', dataIndex: 'elasticsearch.slowlog.index', key: 'elasticsearch.slowlog.index', width: 160 },
             { title: '类型', dataIndex: 'elasticsearch.slowlog.type', key: 'elasticsearch.slowlog.type', width: 90 },
@@ -340,7 +340,7 @@ export const useElasticsearchDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '节点', dataIndex: 'elasticsearch.server.node.name', key: 'elasticsearch.server.node.name', width: 140 },
             { title: '级别', dataIndex: 'elasticsearch.server.level', key: 'elasticsearch.server.level', width: 90, render: renderEsLevel },
             { title: '组件', dataIndex: 'elasticsearch.server.component', key: 'elasticsearch.server.component', width: 120 },

--- a/web/src/app/log/hooks/analysis/fileIntegrityDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/fileIntegrityDashboard.tsx
@@ -249,7 +249,7 @@ export const useFileIntegrityDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 166 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 166 },
             { title: '主机', dataIndex: 'host.name', key: 'host.name', width: 82 },
             { title: '动作', dataIndex: 'file_action', key: 'file_action', width: 88, render: renderActionTag },
             { title: '路径', dataIndex: 'file_path', key: 'file_path', width: 210 },
@@ -277,7 +277,7 @@ export const useFileIntegrityDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 166 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 166 },
             { title: '主机', dataIndex: 'host.name', key: 'host.name', width: 82 },
             { title: '动作', dataIndex: 'file_action', key: 'file_action', width: 88, render: renderActionTag },
             { title: '路径', dataIndex: 'file_path', key: 'file_path', width: 180 },

--- a/web/src/app/log/hooks/analysis/kafkaDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/kafkaDashboard.tsx
@@ -234,7 +234,7 @@ export const useKafkaDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 180 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 180 },
             { title: '实例 / Broker', dataIndex: 'instance_id', key: 'instance_id', width: 170 },
             { title: '级别', dataIndex: 'kafka.log.level', key: 'kafka.log.level', width: 90, render: renderKafkaLevel },
             { title: '组件', dataIndex: 'kafka.log.component', key: 'kafka.log.component', width: 140 },
@@ -259,7 +259,7 @@ export const useKafkaDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 180 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 180 },
             { title: '实例 / Broker', dataIndex: 'instance_id', key: 'instance_id', width: 170 },
             { title: '级别', dataIndex: 'kafka.log.level', key: 'kafka.log.level', width: 90, render: renderKafkaLevel },
             { title: '组件', dataIndex: 'kafka.log.component', key: 'kafka.log.component', width: 140 },

--- a/web/src/app/log/hooks/analysis/mongodbDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/mongodbDashboard.tsx
@@ -270,7 +270,7 @@ export const useMongodbDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 168 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 168 },
             { title: '实例', dataIndex: 'instance_id', key: 'instance_id', width: 160 },
             { title: '级别', dataIndex: 'mongodb.log.severity', key: 'mongodb.log.severity', width: 90, render: renderMongoSeverity },
             { title: '组件', dataIndex: 'mongodb.log.component', key: 'mongodb.log.component', width: 140 },
@@ -295,7 +295,7 @@ export const useMongodbDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 168 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 168 },
             { title: '实例', dataIndex: 'instance_id', key: 'instance_id', width: 160 },
             { title: '级别', dataIndex: 'mongodb.log.severity', key: 'mongodb.log.severity', width: 90, render: renderMongoSeverity },
             { title: '组件', dataIndex: 'mongodb.log.component', key: 'mongodb.log.component', width: 140 },

--- a/web/src/app/log/hooks/analysis/nginxDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/nginxDashboard.tsx
@@ -270,7 +270,7 @@ export const useNginxDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '状态码', dataIndex: 'nginx.access.response_code', key: 'nginx.access.response_code', width: 90, render: renderStatusTag },
             { title: '方法', dataIndex: 'nginx.access.method', key: 'nginx.access.method', width: 86 },
             { title: 'URL', dataIndex: 'nginx.access.url', key: 'nginx.access.url', width: 220 },
@@ -294,7 +294,7 @@ export const useNginxDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '级别', dataIndex: 'nginx.error.level', key: 'nginx.error.level', width: 90, render: renderWebLevel },
             { title: '连接 ID', dataIndex: 'nginx.error.connection_id', key: 'nginx.error.connection_id', width: 110 },
             { title: '消息摘要', dataIndex: 'nginx.error.message', key: 'nginx.error.message', width: 360 }

--- a/web/src/app/log/hooks/analysis/postgresqlDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/postgresqlDashboard.tsx
@@ -227,7 +227,7 @@ export const usePostgresqlDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 156 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 156 },
             { title: '数据库', dataIndex: 'postgresql.log.database', key: 'postgresql.log.database', width: 110 },
             { title: '用户', dataIndex: 'postgresql.log.user', key: 'postgresql.log.user', width: 110 },
             { title: '耗时', dataIndex: 'postgresql.log.duration', key: 'postgresql.log.duration', width: 90 },
@@ -251,7 +251,7 @@ export const usePostgresqlDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 156 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 156 },
             { title: '数据库', dataIndex: 'postgresql.log.database', key: 'postgresql.log.database', width: 110 },
             { title: '用户', dataIndex: 'postgresql.log.user', key: 'postgresql.log.user', width: 110 },
             { title: '级别', dataIndex: 'postgresql.log.level', key: 'postgresql.log.level', width: 92, render: renderPgLevel },

--- a/web/src/app/log/hooks/analysis/rabbitmqDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/rabbitmqDashboard.tsx
@@ -284,7 +284,7 @@ export const useRabbitmqDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 176 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 176 },
             { title: '级别', dataIndex: 'rabbitmq.log.level', key: 'rabbitmq.log.level', width: 84, render: renderRabbitLevel },
             { title: 'PID', dataIndex: 'rabbitmq.log.pid', key: 'rabbitmq.log.pid', width: 86 },
             { title: '关键词分类', dataIndex: 'keyword_type', key: 'keyword_type', width: 108, render: renderRabbitKeyword },
@@ -309,7 +309,7 @@ export const useRabbitmqDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 176 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 176 },
             { title: '级别', dataIndex: 'rabbitmq.log.level', key: 'rabbitmq.log.level', width: 84, render: renderRabbitLevel },
             { title: 'PID', dataIndex: 'rabbitmq.log.pid', key: 'rabbitmq.log.pid', width: 86 },
             { title: '关键词分类', dataIndex: 'keyword_type', key: 'keyword_type', width: 108, render: renderRabbitKeyword },

--- a/web/src/app/log/hooks/analysis/syslogDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/syslogDashboard.tsx
@@ -271,7 +271,7 @@ export const useSyslogDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '主机', dataIndex: 'hostname', key: 'hostname', width: 140 },
             { title: '应用', dataIndex: 'appname', key: 'appname', width: 120 },
             { title: 'Facility', dataIndex: 'facility', key: 'facility', width: 90 },
@@ -298,7 +298,7 @@ export const useSyslogDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 160 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 160 },
             { title: '主机', dataIndex: 'hostname', key: 'hostname', width: 140 },
             { title: '应用', dataIndex: 'appname', key: 'appname', width: 120 },
             { title: 'Facility', dataIndex: 'facility', key: 'facility', width: 90 },

--- a/web/src/app/log/hooks/analysis/windowsEventDashboard.tsx
+++ b/web/src/app/log/hooks/analysis/windowsEventDashboard.tsx
@@ -248,7 +248,7 @@ export const useWindowsEventDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 176 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 176 },
             { title: '主机', dataIndex: 'winlog.computer_name', key: 'winlog.computer_name', width: 120 },
             { title: '用户', dataIndex: 'winlog.user.name', key: 'winlog.user.name', width: 92 },
             { title: '事件 ID', dataIndex: 'winlog.event_id', key: 'winlog.event_id', width: 80 },
@@ -274,7 +274,7 @@ export const useWindowsEventDashboard = () => {
           dataSource: 1,
           showIndex: false,
           columns: [
-            { title: '时间', dataIndex: '@timestamp', key: '@timestamp', width: 176 },
+            { title: '时间', dataIndex: '_time', key: '_time', width: 176 },
             { title: '主机', dataIndex: 'winlog.computer_name', key: 'winlog.computer_name', width: 120 },
             { title: '通道', dataIndex: 'winlog.channel', key: 'winlog.channel', width: 90 },
             { title: '级别', dataIndex: 'log.level', key: 'log.level', width: 80, render: renderEventLevel },


### PR DESCRIPTION
## Summary

- 修复 10 个日志分析仪表盘（Syslog/Kafka/MongoDB/Nginx/Apache 等）明细表时间列恒显示 `--` 的问题
- 根因：timestamp 契约上线后 VictoriaLogs 以 `_time` 返回服务端接收时间，但前端仍绑定 `@timestamp`
- 在共享 `ComTable` 中统一将时间字段映射为 `_time` 并用 `useLocalizedTime` 格式化；各仪表盘配置同步对齐

## 与 p398_575 的关系

- 仅改 UI 展示字段，不改后端 Vector 归一化或 `collect_timestamp` 语义
- 「时间」列展示 `_time`（服务端接收时间），符合 timestamp 契约

## Test plan

- [x] `pnpm type-check`（改动文件）
- [x] `eslint` 受影响 11 个文件
- [ ] Syslog 分析仪表盘「最近高危日志」「最近 Syslog 明细」时间列有值
- [ ] 抽查 Kafka / Nginx 等仪表盘明细表时间列