### PR TITLE
fix(web): 隔离 Storybook 正式认证流程

### DIFF
--- a/web/.storybook/main.ts
+++ b/web/.storybook/main.ts
@@ -27,6 +27,17 @@ const toAliasArray = (aliases: unknown) => {
   return Object.entries(aliases).map(([name, alias]) => ({ name, alias }));
 };
 
+const storybookExactMockPlugin = {
+  apply(compiler: any) {
+    compiler.hooks.normalModuleFactory.tap('StorybookExactMockPlugin', (normalModuleFactory: any) => {
+      normalModuleFactory.hooks.beforeResolve.tap('StorybookExactMockPlugin', (resolveData: any) => {
+        const mock = mockAliases.find(({ name }) => name === resolveData?.request);
+        if (mock) resolveData.request = mock.alias;
+      });
+    });
+  },
+};
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [],
@@ -36,6 +47,7 @@ const config: StorybookConfig = {
   },
   staticDirs: ['../public'],
   webpackFinal: async (config) => {
+    config.plugins = [...(config.plugins || []), storybookExactMockPlugin];
     if (config.resolve) {
       config.resolve.alias = [
         ...mockAliases,

--- a/web/.storybook/preview.tsx
+++ b/web/.storybook/preview.tsx
@@ -12,7 +12,7 @@ import { ThemeBootstrap, ThemeProvider } from '@/theme';
 import { ClientProvider } from '@/context/client';
 import { PermissionsProvider } from '@/context/permissions';
 import { UserInfoProvider } from '@/context/userInfo';
-import AuthProvider from '@/context/auth';
+import AuthProvider from './mocks/auth';
 import { installMonitorDashboardRequestInterceptor } from './mocks/monitor-dashboard-request';
 
 installMonitorDashboardRequestInterceptor();

--- a/web/package.json
+++ b/web/package.json
@@ -96,6 +96,7 @@
     "test:opspilot-download-url-security": "pnpm exec tsx scripts/opspilot-download-url-security-test.ts",
     "test:opspilot-tour": "playwright test --config=playwright.opspilot-tour.config.ts",
     "test:opspilot-planned-execution-step": "pnpm exec tsx scripts/opspilot-planned-execution-step-test.ts",
+    "test:storybook-auth-isolation": "pnpm exec tsx scripts/storybook-auth-isolation-test.ts",
     "gen:capability-matrix": "pnpm exec tsx scripts/generate-capability-matrix.ts",
     "test:monitor-template-bulk": "pnpm exec tsx scripts/monitor-template-bulk-logic-test.ts",
     "test:related-alerts": "pnpm exec tsx scripts/related-alerts-validation.ts",

--- a/web/scripts/storybook-auth-isolation-test.ts
+++ b/web/scripts/storybook-auth-isolation-test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const previewSource = readFileSync('.storybook/preview.tsx', 'utf8');
+const mainSource = readFileSync('.storybook/main.ts', 'utf8');
+
+assert.match(
+  previewSource,
+  /import AuthProvider from ['"]\.\/mocks\/auth['"];?/,
+  'Storybook must mount its mock AuthProvider directly so production session recovery cannot run',
+);
+assert.doesNotMatch(
+  previewSource,
+  /import AuthProvider from ['"]@\/context\/auth['"];?/,
+  'Storybook preview must not rely on webpack aliases to isolate the root AuthProvider',
+);
+assert.ok(
+  mainSource.includes("name: '@/context/auth'") && mainSource.includes('onlyModule: true'),
+  'Storybook stories must resolve application auth hooks through the exact mock alias',
+);
+assert.ok(
+  mainSource.includes('StorybookExactMockPlugin') && mainSource.includes('normalModuleFactory'),
+  'Storybook must replace mock imports before Next.js tsconfig path resolution can bypass webpack aliases',
+);
+
+console.log('storybook auth isolation contract ok');


### PR DESCRIPTION
## 变更说明

- Storybook 根装饰器直接使用 mock `AuthProvider`，避免运行正式会话恢复流程。
- 在模块解析前精确替换 Storybook mock，防止 Next.js tsconfig 路径插件绕过 webpack alias。
- 新增 Storybook 认证隔离回归测试和对应测试脚本。

## 验证

- `pnpm test:storybook-auth-isolation`：通过
- `pnpm exec eslint --no-ignore .storybook/main.ts .storybook/preview.tsx scripts/storybook-auth-isolation-test.ts`：通过
- `pnpm type-check`：通过
- Storybook 浏览器冒烟验证：`single-value-sizing-regression` 正常渲染，未请求 `/api/auth/recovery-check`，未访问 `/auth/signin`，未出现登录弹窗

## 已知基线问题

- `pnpm lint` 仍被上游 `master` 现有的 23 个无关错误阻断，触及文件的定向 ESLint 已通过。
