### PR TITLE
test: 冻结图片算法公共预测契约

### DIFF
--- a/algorithms/contracts/image_predict_v1.json
+++ b/algorithms/contracts/image_predict_v1.json
@@ -1,0 +1,211 @@
+{
+  "contract": "image-predict",
+  "version": 1,
+  "request_fields": [
+    "images",
+    "config"
+  ],
+  "images": {
+    "min_items": 1,
+    "max_items": 100
+  },
+  "budget_defaults": {
+    "mode": "observe",
+    "max_image_base64_bytes": 10485760,
+    "max_batch_base64_bytes": 100663296,
+    "max_batch_decoded_bytes": 67108864,
+    "max_batch_pixels": 67108864
+  },
+  "request_cases": [
+    {
+      "name": "plain_base64",
+      "valid": true,
+      "images": [
+        "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg=="
+      ]
+    },
+    {
+      "name": "data_uri",
+      "valid": true,
+      "images": [
+        "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg=="
+      ]
+    },
+    {
+      "name": "empty_batch",
+      "valid": false,
+      "images": []
+    },
+    {
+      "name": "short_image",
+      "valid": false,
+      "images": [
+        "eHg="
+      ]
+    },
+    {
+      "name": "invalid_base64",
+      "valid": false,
+      "images": [
+        "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg=!!"
+      ]
+    },
+    {
+      "name": "data_uri_without_base64_marker",
+      "valid": false,
+      "images": [
+        "data:image/png,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg=="
+      ]
+    }
+  ],
+  "decoder_valid_inputs": [
+    "iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg==",
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAIAAAAmkwkpAAAAE0lEQVR4nGPkUbJggAEmOAsvBwAUxABu6v+piAAAAABJRU5ErkJggg=="
+  ],
+  "decoded_image": {
+    "size": [
+      4,
+      4
+    ],
+    "mode": "RGB"
+  },
+  "error_fields": [
+    "code",
+    "message",
+    "details"
+  ],
+  "error_example": {
+    "code": "E1000",
+    "message": "invalid request",
+    "details": {
+      "stage": "request_validation"
+    }
+  },
+  "response_fields": [
+    "results",
+    "metadata",
+    "success",
+    "error"
+  ],
+  "result_common_fields": [
+    "success",
+    "error",
+    "decode_time_ms"
+  ],
+  "metadata_common_fields": [
+    "model_version",
+    "source",
+    "batch_size",
+    "total_time_ms",
+    "decode_time_ms",
+    "predict_time_ms",
+    "postprocess_time_ms",
+    "avg_time_per_image_ms",
+    "success_count",
+    "failure_count",
+    "success_rate"
+  ],
+  "services": {
+    "image_classification": {
+      "config_defaults": {
+        "top_k": 5
+      },
+      "result_payload_field": "predictions",
+      "metadata_extension_fields": [],
+      "response_example": {
+        "results": [
+          {
+            "predictions": [],
+            "success": false,
+            "error": "decode failed",
+            "decode_time_ms": null
+          },
+          {
+            "predictions": [
+              {
+                "class_id": 1,
+                "class_name": "normal",
+                "confidence": 0.9
+              }
+            ],
+            "success": true,
+            "error": null,
+            "decode_time_ms": 1.25
+          }
+        ],
+        "metadata": {
+          "model_version": "contract-v1",
+          "source": "fixture",
+          "batch_size": 2,
+          "total_time_ms": 3.0,
+          "decode_time_ms": 1.25,
+          "predict_time_ms": 1.5,
+          "postprocess_time_ms": 0.25,
+          "avg_time_per_image_ms": 3.0,
+          "success_count": 1,
+          "failure_count": 1,
+          "success_rate": 0.5
+        },
+        "success": true,
+        "error": null
+      }
+    },
+    "object_detection": {
+      "config_defaults": {
+        "conf_threshold": 0.25,
+        "iou_threshold": 0.45,
+        "max_detections": 300
+      },
+      "result_payload_field": "detections",
+      "metadata_extension_fields": [
+        "total_detections",
+        "avg_detections_per_image"
+      ],
+      "response_example": {
+        "results": [
+          {
+            "detections": [],
+            "success": false,
+            "error": "decode failed",
+            "decode_time_ms": null
+          },
+          {
+            "detections": [
+              {
+                "bbox": {
+                  "x1": 1.0,
+                  "y1": 2.0,
+                  "x2": 3.0,
+                  "y2": 4.0
+                },
+                "class_id": 1,
+                "class_name": "object",
+                "confidence": 0.9
+              }
+            ],
+            "success": true,
+            "error": null,
+            "decode_time_ms": 1.25
+          }
+        ],
+        "metadata": {
+          "model_version": "contract-v1",
+          "source": "fixture",
+          "batch_size": 2,
+          "total_time_ms": 3.0,
+          "decode_time_ms": 1.25,
+          "predict_time_ms": 1.5,
+          "postprocess_time_ms": 0.25,
+          "avg_time_per_image_ms": 3.0,
+          "success_count": 1,
+          "failure_count": 1,
+          "success_rate": 0.5,
+          "total_detections": 1,
+          "avg_detections_per_image": 1.0
+        },
+        "success": true,
+        "error": null
+      }
+    }
+  }
+}

--- a/algorithms/tests/image_predict_contract_runner.py
+++ b/algorithms/tests/image_predict_contract_runner.py
@@ -1,0 +1,98 @@
+"""在单一算法运行时中验证共享图片预测契约。"""
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+from pydantic import ValidationError
+
+ALGORITHMS_DIR = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ALGORITHMS_DIR / "contracts/image_predict_v1.json"
+SERVICES = {
+    "image_classification": "classify_image_classification_server",
+    "object_detection": "classify_object_detection_server",
+}
+
+
+def _load_runtime(service_name):
+    package = SERVICES[service_name]
+    sys.path.insert(0, str(ALGORITHMS_DIR / package))
+    schema = importlib.import_module(f"{package}.serving.schemas.api_schema")
+    service_module = importlib.import_module(f"{package}.serving.service")
+    return schema, service_module.MLService
+
+
+def _validate_request_contract(contract, schema):
+    json_schema = schema.PredictRequest.model_json_schema()
+    assert set(schema.PredictRequest.model_fields) == set(contract["request_fields"])
+    assert json_schema["properties"]["images"]["minItems"] == contract["images"]["min_items"]
+    assert json_schema["properties"]["images"]["maxItems"] == contract["images"]["max_items"]
+
+    for case in contract["request_cases"]:
+        if case["valid"]:
+            assert schema.PredictRequest(images=case["images"]).images == case["images"]
+        else:
+            try:
+                schema.PredictRequest(images=case["images"])
+            except ValidationError:
+                continue
+            raise AssertionError(f"invalid request case accepted: {case['name']}")
+
+
+def _validate_budget_defaults(contract, schema):
+    budget = contract["budget_defaults"]
+    os.environ.pop("MLOPS_PREDICT_IMAGE_BUDGET_MODE", None)
+    assert schema.get_image_budget_mode() == budget["mode"]
+    assert schema.DEFAULT_MAX_IMAGE_BASE64_BYTES == budget["max_image_base64_bytes"]
+    assert schema.DEFAULT_MAX_IMAGE_BATCH_BASE64_BYTES == budget["max_batch_base64_bytes"]
+    assert schema.DEFAULT_MAX_IMAGE_BATCH_BYTES == budget["max_batch_decoded_bytes"]
+    assert schema.DEFAULT_MAX_IMAGE_BATCH_PIXELS == budget["max_batch_pixels"]
+
+
+def _validate_response_contract(contract, service_name, schema):
+    service_contract = contract["services"][service_name]
+    assert set(schema.ErrorDetail.model_fields) == set(contract["error_fields"])
+    error = schema.ErrorDetail.model_validate(contract["error_example"])
+    assert error.model_dump(mode="json") == contract["error_example"]
+    assert set(schema.PredictResponse.model_fields) == set(contract["response_fields"])
+    assert set(schema.ImageResult.model_fields) == set(contract["result_common_fields"]) | {service_contract["result_payload_field"]}
+    assert set(schema.PredictionMetadata.model_fields) == set(contract["metadata_common_fields"]) | set(service_contract["metadata_extension_fields"])
+    assert set(schema.PredictConfig.model_fields) == set(service_contract["config_defaults"])
+    assert {name: field.default for name, field in schema.PredictConfig.model_fields.items()} == service_contract["config_defaults"]
+
+    response = schema.PredictResponse.model_validate(service_contract["response_example"])
+    assert response.model_dump(mode="json") == service_contract["response_example"]
+
+
+def _validate_decoder_contract(contract, service_class):
+    service = object.__new__(service_class.inner)
+    for value in contract["decoder_valid_inputs"]:
+        image = service._decode_base64_image(value)
+        try:
+            assert image.size == tuple(contract["decoded_image"]["size"])
+            assert image.mode == contract["decoded_image"]["mode"]
+        finally:
+            image.close()
+
+
+def main():
+    service_name = sys.argv[1]
+    if service_name not in SERVICES:
+        raise SystemExit(f"unknown service: {service_name}")
+
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert contract["contract"] == "image-predict"
+    assert contract["version"] == 1
+    schema, service_class = _load_runtime(service_name)
+    _validate_budget_defaults(contract, schema)
+    os.environ["MLOPS_PREDICT_IMAGE_BUDGET_MODE"] = "enforce"
+    _validate_request_contract(contract, schema)
+    _validate_response_contract(contract, service_name, schema)
+    _validate_decoder_contract(contract, service_class)
+    print(json.dumps({"contract": contract["contract"], "service": service_name, "version": contract["version"]}))
+
+
+if __name__ == "__main__":
+    main()

--- a/algorithms/tests/test_image_predict_v1_contract.py
+++ b/algorithms/tests/test_image_predict_v1_contract.py
@@ -1,0 +1,29 @@
+"""图片分类与目标检测在独立运行时中验证同一契约（Issue #4012）。"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+RUNNER = Path(__file__).with_name("image_predict_contract_runner.py")
+
+
+@pytest.mark.parametrize("service_name", ["image_classification", "object_detection"])
+def test_image_predict_v1_contract(service_name):
+    result = subprocess.run(
+        [sys.executable, str(RUNNER), service_name],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    report = json.loads(result.stdout.strip().splitlines()[-1])
+    assert report == {
+        "contract": "image-predict",
+        "service": service_name,
+        "version": 1,
+    }


### PR DESCRIPTION
## 问题

图片分类与目标检测分别维护相同的 Base64 解码、图片列表校验和资源预算。任何单边修复都可能让两个服务对同一图片产生不同接受结果；但两个服务的 Top-K 分类结果与 bounding box、阈值、检测统计又是合法领域差异，不能直接合并成一个公共 schema。

## 根因（设计层）

后续公共化缺少一个可执行、可版本化的兼容基线。直接移动生产代码无法判断哪些字段和默认值必须保持一致、哪些扩展必须保留；六个算法服务又拥有独立依赖锁和镜像构建上下文，一次性抽公共包不具备安全回滚边界。

## 怎么修的

1. 新增 `image-predict` v1 fixture，冻结图片分类和目标检测真正共享的请求、错误、资源预算与响应字段。
2. 显式登记两个服务的合法差异：分类 Top-K；目标检测阈值、最大检测数、检测框与统计字段。
3. 用同一 fixture 验证纯 Base64、Data URI、非法输入、默认 observe、四项预算、partial-success 和解码结果。
4. 两个服务会注册同名 Prometheus 指标，因此契约测试按真实部署边界在隔离子进程中分别加载，避免构造生产中不存在的同进程运行形态。

## 影响范围

- 仅新增测试 fixture 与测试执行器，不修改生产代码、API 字段、错误码、默认值、依赖锁、Dockerfile 或镜像。
- 当前独立 Docker context 继续保持，由现有测试证明没有被扩大。
- 本 PR 是 #4012 第一阶段。第二阶段在确认版本化制品和单镜像回滚能力后，再先迁移 image、后迁移 object。
- 第一阶段不需要部署配置；第二阶段若现有 Nexus 已具备新包发布能力，可由开发按普通镜像发布流程完成。

## 调用链

```mermaid
flowchart TD
    subgraph T["契约输入层"]
        T1["image-predict v1 fixture\nalgorithms/contracts"]
    end

    subgraph N["隔离验证层"]
        N1["图片分类独立进程\nPredictRequest / PredictResponse"]
        N2["目标检测独立进程\nPredictRequest / PredictResponse"]
    end

    subgraph C["兼容边界"]
        C1["共享图片输入、预算、错误"]
        C2["Top-K 分类扩展"]
        C3["检测框、阈值、统计扩展"]
    end

    T1 --> N1 --> C1
    T1 --> N2 --> C1
    N1 --> C2
    N2 --> C3
```

## 验证

- 缺少版本化 fixture 时，两个隔离运行时均稳定失败，证明首片契约此前不存在。
- `algorithms/tests/test_image_predict_v1_contract.py` 与 `algorithms/tests/test_docker_build_context.py`：16 passed。
- `classify_image_classification_server/tests/test_issue_3852_image_budget.py`：26 passed。
- `classify_object_detection_server/tests/test_issue_3852_image_budget.py` 与 `test_issue_4619_max_detections.py`：42 passed。
- 合计 84 passed；JSON、Flake8、Python 编译和 diff-check 通过。

## 三轨门禁

- Standards：PASS。变更仅三份测试资产，隔离执行带超时，不污染生产包或构建上下文。
- Spec：PASS。共享边界、默认值、partial-success 与领域扩展均已固化，未越界统一其余算法服务。
- Runtime Contract：PASS。两个真实算法包分别执行同一 fixture，实际运行 Pydantic 与 PIL 解码路径。
- 质量评分：96 / 100，SCORE_PASS。

关联 Issue #4012。
