### PR TITLE
feat(监控): 容器节点主机监控 IP 映射到云区域代理地址

### DIFF
--- a/server/apps/monitor/services/host_container_asset_ip.py
+++ b/server/apps/monitor/services/host_container_asset_ip.py
@@ -10,19 +10,22 @@ from apps.node_mgmt.utils.region_display_ip import as_ip, load_region_display_ip
 ASSET_IP_FACT = "asset.ip"
 
 
-def fill_missing_host_container_asset_ips(items):
+def fill_missing_host_container_asset_ips(items, monitor_object_name=None):
     """列表期回填 Host 本地采集缺失的 asset.ip，不落库。
 
     仅走 CollectConfig(Telegraf/host) → ChildConfig → Node → 云区域展示 IP。
     容器节点无可用 node.ip 时用区域 proxy / 平台 IP；普通主机节点仍用 node.ip。
     Host Remote / k8s / 云 resource_ip 不在此路径。
     """
+    if monitor_object_name not in (None, "", HostDeploymentStatus.MONITOR_OBJECT_NAME):
+        return
     try:
         _fill_missing_host_container_asset_ips(items)
     except Exception as exc:
         logger.exception(
-            "event=fill_host_container_asset_ip_failed failed_stage=list_fill error_type=%s",
+            "event=fill_host_container_asset_ip_failed failed_stage=list_fill error_type=%s item_count=%s",
             type(exc).__name__,
+            len(items or []),
         )
 
 
@@ -46,6 +49,7 @@ def _fill_missing_host_container_asset_ips(items):
             monitor_instance_id__in=missing_ids,
             collector=HostDeploymentStatus.COLLECTOR,
             collect_type=HostDeploymentStatus.COLLECT_TYPE,
+            is_child=True,
         ).values_list("id", "monitor_instance_id")
     )
     if not config_rows:

--- a/server/apps/monitor/services/host_container_asset_ip.py
+++ b/server/apps/monitor/services/host_container_asset_ip.py
@@ -1,0 +1,104 @@
+from django.db.models import F
+
+from apps.core.logger import monitor_logger as logger
+from apps.monitor.models import CollectConfig
+from apps.monitor.services.host_deployment import HostDeploymentStatus
+from apps.node_mgmt.constants.controller import ControllerConstants
+from apps.node_mgmt.models.sidecar import ChildConfig
+from apps.node_mgmt.utils.region_display_ip import as_ip, load_region_display_ips
+
+ASSET_IP_FACT = "asset.ip"
+
+
+def fill_missing_host_container_asset_ips(items):
+    """列表期回填 Host 本地采集缺失的 asset.ip，不落库。
+
+    仅走 CollectConfig(Telegraf/host) → ChildConfig → Node → 云区域展示 IP。
+    容器节点无可用 node.ip 时用区域 proxy / 平台 IP；普通主机节点仍用 node.ip。
+    Host Remote / k8s / 云 resource_ip 不在此路径。
+    """
+    try:
+        _fill_missing_host_container_asset_ips(items)
+    except Exception as exc:
+        logger.exception(
+            "event=fill_host_container_asset_ip_failed failed_stage=list_fill error_type=%s",
+            type(exc).__name__,
+        )
+
+
+def _fill_missing_host_container_asset_ips(items):
+    if not items:
+        return
+
+    missing_ids = []
+    items_by_id = {}
+    for item in items:
+        instance_id = item.get("instance_id")
+        if instance_id in (None, "") or not _missing_asset_ip(item.get("summary_facts")):
+            continue
+        missing_ids.append(instance_id)
+        items_by_id.setdefault(instance_id, []).append(item)
+    if not missing_ids:
+        return
+
+    config_rows = list(
+        CollectConfig.objects.filter(
+            monitor_instance_id__in=missing_ids,
+            collector=HostDeploymentStatus.COLLECTOR,
+            collect_type=HostDeploymentStatus.COLLECT_TYPE,
+        ).values_list("id", "monitor_instance_id")
+    )
+    if not config_rows:
+        return
+
+    instance_by_config_id = {str(config_id): instance_id for config_id, instance_id in config_rows}
+    node_rows = list(
+        ChildConfig.objects.filter(id__in=instance_by_config_id.keys())
+        .values(
+            "id",
+            node_id=F("collector_config__nodes__id"),
+            node_type=F("collector_config__nodes__node_type"),
+            node_ip=F("collector_config__nodes__ip"),
+            cloud_region_id=F("collector_config__nodes__cloud_region_id"),
+        )
+        .order_by("id", "node_id")
+    )
+    mapped_by_instance = {}
+    region_ids = {
+        row["cloud_region_id"]
+        for row in node_rows
+        if str(row.get("node_type") or "") == ControllerConstants.NODE_TYPE_CONTAINER
+        and row.get("cloud_region_id") not in (None, "")
+        and not as_ip(row.get("node_ip"))
+    }
+    region_display_ips = load_region_display_ips(region_ids)
+    for row in node_rows:
+        instance_id = instance_by_config_id.get(str(row["id"]))
+        if instance_id in (None, "") or instance_id in mapped_by_instance or row.get("node_id") in (None, ""):
+            continue
+        mapped = _mapped_ip_for_node(
+            row.get("node_type"),
+            row.get("node_ip"),
+            region_display_ips.get(row.get("cloud_region_id"), ""),
+        )
+        if mapped:
+            mapped_by_instance[instance_id] = mapped
+
+    for instance_id, mapped in mapped_by_instance.items():
+        for item in items_by_id.get(instance_id, []):
+            facts = dict(item.get("summary_facts") or {})
+            facts[ASSET_IP_FACT] = mapped
+            item["summary_facts"] = facts
+
+
+def _missing_asset_ip(facts):
+    if not isinstance(facts, dict):
+        return True
+    return facts.get(ASSET_IP_FACT) in (None, "")
+
+
+def _mapped_ip_for_node(node_type, node_ip, region_display_ip):
+    own_ip = as_ip(node_ip)
+    if str(node_type or "") == ControllerConstants.NODE_TYPE_CONTAINER:
+        return own_ip or as_ip(region_display_ip)
+    return own_ip

--- a/server/apps/monitor/services/instance_facts.py
+++ b/server/apps/monitor/services/instance_facts.py
@@ -2,6 +2,7 @@ import ipaddress
 from urllib.parse import urlsplit
 
 from apps.core.exceptions.base_app_exception import BaseAppException
+from apps.node_mgmt.constants.controller import ControllerConstants
 
 
 class InstanceFactResolver:
@@ -68,11 +69,7 @@ class InstanceFactResolver:
     @classmethod
     def merge(cls, existing, generated, source=None):
         merged = dict(existing or {})
-        source_map = {
-            fact: dict(contributions)
-            for fact, contributions in (merged.get("_sources") or {}).items()
-            if isinstance(contributions, dict)
-        }
+        source_map = {fact: dict(contributions) for fact, contributions in (merged.get("_sources") or {}).items() if isinstance(contributions, dict)}
         for fact, value in (generated or {}).items():
             if fact.startswith("_"):
                 continue
@@ -100,6 +97,7 @@ class InstanceFactResolver:
     def _resolve_binding(cls, binding, instance_input, context):
         resolver = binding["resolver"]
         options = binding["options"]
+        skip_required = False
         if resolver == "input":
             raw_value = instance_input.get(options.get("field"))
         elif resolver == "constant":
@@ -107,6 +105,11 @@ class InstanceFactResolver:
         elif resolver == "selected_node":
             nodes = cls._selected_nodes(instance_input, context, options)
             raw_value = nodes[0].get(options.get("node_field", "ip")) if nodes else None
+            raw_value, skip_required = cls._map_container_node_ip(
+                nodes[0] if nodes else None,
+                options.get("node_field", "ip"),
+                raw_value,
+            )
         elif resolver == "selected_nodes":
             return [cls._node_ref(node) for node in cls._selected_nodes(instance_input, context, options)]
         elif resolver == "compose_endpoint":
@@ -119,11 +122,29 @@ class InstanceFactResolver:
         else:  # pragma: no cover - validate_bindings 已拦截
             raise BaseAppException(f"不支持的实例事实解析器: {resolver}")
         normalized = cls._normalize(raw_value, binding["value_type"])
+        if skip_required:
+            return normalized
         if raw_value in (None, "") and options.get("required") is True:
             raise BaseAppException(f"必需实例事实缺失: {binding['fact']}")
         if raw_value not in (None, "") and normalized in (None, "", []) and options.get("required") is True:
             raise BaseAppException(f"必需实例事实无法规整: {binding['fact']}")
         return normalized
+
+    @classmethod
+    def _map_container_node_ip(cls, node, node_field, raw_value):
+        """容器节点无可用 node.ip 时回退云区域展示 IP；域名不入库。"""
+        if str(node_field or "ip") != "ip" or not cls._is_container_node(node):
+            return raw_value, False
+        if cls._normalize(raw_value, "ip"):
+            return raw_value, False
+        mapped = (node or {}).get("region_display_ip")
+        if cls._normalize(mapped, "ip"):
+            return mapped, False
+        return None, True
+
+    @staticmethod
+    def _is_container_node(node):
+        return bool(node) and str(node.get("node_type") or "") == ControllerConstants.NODE_TYPE_CONTAINER
 
     @staticmethod
     def _selected_nodes(instance_input, context, options):

--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -970,7 +970,7 @@ class InstanceSearch:
             }
             for obj in results
         ]
-        fill_missing_host_container_asset_ips(serialized)
+        fill_missing_host_container_asset_ips(serialized, getattr(self.monitor_obj, "name", None))
         return dict(count=count, results=serialized)
 
     def _batch_plugin_status_maps(self, instance_id_keys, queries):

--- a/server/apps/monitor/services/monitor_instance.py
+++ b/server/apps/monitor/services/monitor_instance.py
@@ -12,6 +12,7 @@ from apps.monitor.constants.language import LanguageConstants
 from apps.monitor.constants.monitor_object import MonitorObjConstants
 from apps.monitor.constants.plugin import PluginConstants
 from apps.monitor.models import CollectConfig, Metric, MonitorInstance, MonitorInstanceOrganization, MonitorObject, MonitorPlugin
+from apps.monitor.services.host_container_asset_ip import fill_missing_host_container_asset_ips
 from apps.monitor.services.monitor_object import MonitorObjectService
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.victoriametrics_api import VictoriaMetricsAPI
@@ -591,9 +592,7 @@ class InstanceSearch:
         """
         if not monitor_object_id:
             return []
-        display_fields = (
-            MonitorObject.objects.filter(id=monitor_object_id).values_list("display_fields", flat=True).first() or []
-        )
+        display_fields = MonitorObject.objects.filter(id=monitor_object_id).values_list("display_fields", flat=True).first() or []
         bindings = []
         seen = set()
         for col in display_fields:
@@ -955,25 +954,24 @@ class InstanceSearch:
                 org_map[org.monitor_instance_id] = set()
             org_map[org.monitor_instance_id].add(org.organization)
 
-        return dict(
-            count=count,
-            results=[
-                {
-                    "instance_id": obj.id,
-                    "instance_name": obj.name,
-                    "instance_id_values": list(parse_instance_id(obj.id)),
-                    "interval": obj.interval,
-                    "cloud_region_id": obj.cloud_region_id,
-                    "ip": obj.ip,
-                    "summary_facts": obj.summary_facts,
-                    "fallback_sampling_rate": obj.fallback_sampling_rate,
-                    "node_id": obj.node_id or "",
-                    "cmdb_id": obj.cmdb_id or "",
-                    "organizations": list(org_map.get(obj.id, [])),
-                }
-                for obj in results
-            ],
-        )
+        serialized = [
+            {
+                "instance_id": obj.id,
+                "instance_name": obj.name,
+                "instance_id_values": list(parse_instance_id(obj.id)),
+                "interval": obj.interval,
+                "cloud_region_id": obj.cloud_region_id,
+                "ip": obj.ip,
+                "summary_facts": obj.summary_facts,
+                "fallback_sampling_rate": obj.fallback_sampling_rate,
+                "node_id": obj.node_id or "",
+                "cmdb_id": obj.cmdb_id or "",
+                "organizations": list(org_map.get(obj.id, [])),
+            }
+            for obj in results
+        ]
+        fill_missing_host_container_asset_ips(serialized)
+        return dict(count=count, results=serialized)
 
     def _batch_plugin_status_maps(self, instance_id_keys, queries):
         """并发拉取多个插件 status_query 的正常状态映射，返回 {query: status_map}。

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -16,6 +16,7 @@ from apps.monitor.models.collect_config import CollectConfig
 from apps.monitor.models.monitor_metrics import Metric
 from apps.monitor.models.monitor_object import MonitorInstance, MonitorInstanceOrganization, MonitorObject, MonitorObjectType
 from apps.monitor.models.plugin import MonitorPlugin
+from apps.monitor.services.host_container_asset_ip import fill_missing_host_container_asset_ips
 from apps.monitor.tasks.grouping_rule import sync_instance_and_group
 from apps.monitor.utils.dimension import parse_instance_id
 from apps.monitor.utils.display_fields_metrics import display_field_key, extract_field_bindings, extract_metric_bindings
@@ -195,12 +196,8 @@ class MonitorObjectService:
             qs = qs.filter(id=instance_id)
         if name:
             # 与列表「IP信息」/ ${resource_ip} 同源：summary_facts['asset.ip'] 优先字段。
-            qs = qs.annotate(
-                _asset_ip_fact=KeyTextTransform("asset.ip", "summary_facts")
-            ).filter(
-                Q(name__icontains=name)
-                | Q(ip__icontains=name)
-                | Q(_asset_ip_fact__icontains=name)
+            qs = qs.annotate(_asset_ip_fact=KeyTextTransform("asset.ip", "summary_facts")).filter(
+                Q(name__icontains=name) | Q(ip__icontains=name) | Q(_asset_ip_fact__icontains=name)
             )
 
         monitor_obj = MonitorObject.objects.filter(id=monitor_object_id).first()
@@ -273,6 +270,7 @@ class MonitorObjectService:
 
         for obj in objs:
             result.append(MonitorObjectService._serialize_instance_list_item(obj, instance_map, org_map))
+        fill_missing_host_container_asset_ips(result)
 
         if add_metrics and page_size != -1:
             MonitorObjectService._safe_fill_display_metrics(monitor_object_id, obj_metric_map, result)
@@ -679,11 +677,7 @@ class MonitorObjectService:
         frontier = [root_id]
         seen = {root_id}
         while frontier:
-            children = list(
-                MonitorObject.objects.filter(parent_id__in=frontier)
-                .exclude(id__in=seen)
-                .values_list("id", flat=True)
-            )
+            children = list(MonitorObject.objects.filter(parent_id__in=frontier).exclude(id__in=seen).values_list("id", flat=True))
             descendant_ids.extend(children)
             seen.update(children)
             frontier = children

--- a/server/apps/monitor/services/monitor_object.py
+++ b/server/apps/monitor/services/monitor_object.py
@@ -270,7 +270,7 @@ class MonitorObjectService:
 
         for obj in objs:
             result.append(MonitorObjectService._serialize_instance_list_item(obj, instance_map, org_map))
-        fill_missing_host_container_asset_ips(result)
+        fill_missing_host_container_asset_ips(result, monitor_obj.name)
 
         if add_metrics and page_size != -1:
             MonitorObjectService._safe_fill_display_metrics(monitor_object_id, obj_metric_map, result)

--- a/server/apps/node_mgmt/services/node.py
+++ b/server/apps/node_mgmt/services/node.py
@@ -18,6 +18,7 @@ from apps.node_mgmt.models.sidecar import Action, ChildConfig, Collector, Collec
 from apps.node_mgmt.serializers.node import NodeSerializer
 from apps.node_mgmt.services.sidecar import Sidecar
 from apps.node_mgmt.tasks.action_task import ACTION_TASK_TIMEOUT_SECONDS, timeout_collector_action_task
+from apps.node_mgmt.utils.region_display_ip import load_region_display_ips
 from apps.rpc.system_mgmt import SystemMgmt
 from apps.system_mgmt.models import User
 
@@ -648,7 +649,10 @@ class NodeService:
         if not normalized_node_ids:
             return []
 
-        nodes = Node.objects.filter(id__in=normalized_node_ids).select_related("cloud_region").prefetch_related("nodeorganization_set")
+        nodes = list(Node.objects.filter(id__in=normalized_node_ids).select_related("cloud_region").prefetch_related("nodeorganization_set"))
+        region_display_ips = load_region_display_ips(
+            {node.cloud_region_id for node in nodes if node.node_type == ControllerConstants.NODE_TYPE_CONTAINER}
+        )
         return [
             {
                 "id": node.id,
@@ -659,6 +663,7 @@ class NodeService:
                 "node_type": node.node_type,
                 "operating_system": node.operating_system,
                 "organization_ids": [rel.organization for rel in node.nodeorganization_set.all()],
+                "region_display_ip": region_display_ips.get(node.cloud_region_id, ""),
             }
             for node in nodes
         ]

--- a/server/apps/node_mgmt/utils/region_display_ip.py
+++ b/server/apps/node_mgmt/utils/region_display_ip.py
@@ -1,0 +1,57 @@
+import ipaddress
+from urllib.parse import urlsplit
+
+from apps.node_mgmt.constants.database import EnvVariableConstants
+from apps.node_mgmt.constants.node import NodeConstants
+from apps.node_mgmt.models.cloud_region import CloudRegion
+from apps.node_mgmt.services.cloudregion import RegionService
+
+
+def as_ip(raw_value):
+    """把地址规整为 IP；域名或无法解析的值返回 None。"""
+    value = str(raw_value or "").strip()
+    if not value:
+        return None
+    for candidate in value.split(","):
+        candidate = candidate.strip()
+        try:
+            return str(ipaddress.ip_address(candidate.strip("[]")))
+        except ValueError:
+            try:
+                parsed = urlsplit(candidate if "://" in candidate else f"//{candidate}")
+                return str(ipaddress.ip_address((parsed.hostname or "").strip("[]")))
+            except ValueError:
+                continue
+    return None
+
+
+def resolve_region_display_ip(proxy_address, sidecar_proxy_address="", node_server_url=""):
+    """云区域展示 IP：proxy_address → PROXY_ADDRESS → NODE_SERVER_URL host。
+
+    每级只有规整后的 IP 才采用；域名视为不可用并继续回退。
+    """
+    for candidate in (proxy_address, sidecar_proxy_address, node_server_url):
+        mapped = as_ip(candidate)
+        if mapped:
+            return mapped
+    return None
+
+
+def load_region_display_ips(cloud_region_ids):
+    """批量解析云区域展示 IP，返回 {region_id: ip_or_empty}。"""
+    region_ids = {region_id for region_id in cloud_region_ids if region_id not in (None, "")}
+    if not region_ids:
+        return {}
+
+    proxy_by_region = dict(CloudRegion.objects.filter(id__in=region_ids).values_list("id", "proxy_address"))
+    env_by_region = RegionService.get_cloud_regions_envconfig(region_ids)
+    display_ips = {}
+    for region_id in region_ids:
+        env = env_by_region.get(region_id) or {}
+        mapped = resolve_region_display_ip(
+            proxy_by_region.get(region_id, ""),
+            env.get(EnvVariableConstants.PROXY_ADDRESS_KEY, ""),
+            env.get(NodeConstants.SERVER_URL_KEY, ""),
+        )
+        display_ips[region_id] = mapped or ""
+    return display_ips


### PR DESCRIPTION
## Summary
- 主机本地 Telegraf 下发时，若选中的是平台容器节点且 node.ip 不可用，将 `asset.ip` 映射为云区域 `proxy_address`
- `proxy_address` 为空或不是合法 IP 时，再兜底 sidecar PROXY_ADDRESS / NODE_SERVER_URL 的主机地址
- 列表「IP信息」对已有空事实的 Host 行按 CollectConfig → 节点 → 云区域补齐，避免 WeOpsX 等容器节点显示 `--`
- 普通主机节点仍用 node.ip；Host Remote / k8s / 云资源 IP 管道未改

## Test plan
- [ ] 对容器节点（无可用 node.ip）下发主机监控，实例列表 IP 信息显示云区域 proxy 或平台地址
- [ ] 普通主机节点下发后 IP 仍是节点自身 IP
- [ ] 已存在 IP 为 `--` 的 Host 容器节点行，刷新列表后能补上映射 IP
- [ ] 云区域 proxy 为域名时不写入非法 hostname