### PR TITLE
feat(监控): 为有证据的 SNMP 基线模板补充 HOST-RESOURCES CPU

### DIFF
--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/blockbit.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/blockbit.child.toml.j2
@@ -48,4 +48,13 @@
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.31.1.1.1.10"
         name = "ifHCOutOctets"
-# ---- CPU/内存/温度/风扇/电源：Blockbit UTM/NGFW 安全网关运行加固类 Unix 系统,其 CPU/内存/磁盘仅经按行索引的标准 host-resource 表暴露,telegraf inputs.snmp 无法行级过滤,且无公开可查的厂商私有健康标量 → CPU/内存/温度/风扇/电源 N/A 不采,不臆造。本基线模板仅采集标准 MIB-II 运行时长与 IF-MIB（含 64 位 HC）接口指标,干净可采。----
+    # ---- CPU usage (HOST-RESOURCES hrProcessorLoad, per-core %) ----
+    # 来源：Blockbit 加固类 Unix 系统经标准 HOST-RESOURCES 暴露 CPU；hrProcessorLoad 表各行均为 CPU 负载，无需行级类型过滤。
+    [[inputs.snmp.table]]
+        name = "device_cpu"
+        inherit_tags = ["source"]
+        index_as_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.3.3.1.2"
+        name = "usage"
+# ---- 内存/温度/风扇/电源：Blockbit UTM/NGFW 内存/磁盘经 hrStorage 混表暴露，inputs.snmp 无法按行过滤；无公开可查的厂商私有健康标量 → 内存/温度/风扇/电源 N/A。CPU 经 HOST-RESOURCES hrProcessorLoad 已采。----

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/language/en.yaml
@@ -1,7 +1,8 @@
 Firewall Blockbit SNMP:
   name: Blockbit (Telegraf)
   desc: SNMP monitoring template for Blockbit firewall. It reports system uptime,
-    interface speed, inbound error packets, and other key metrics
+    per-core CPU utilization (HOST-RESOURCES), interface speed, inbound error packets,
+    and other key metrics
 monitor_object:
   Firewall: Firewall
 monitor_object_type:
@@ -116,9 +117,10 @@ monitor_object_metric:
         for observing VPN decryption load and anomalous spikes.
     device_cpu_usage:
       name: CPU Usage
-      desc: This metric reports the overall CPU utilization of the FortiGate firewall
-        (FORTINET-FORTIGATE-MIB fgSysCpuUsage). Sustained high CPU usage may indicate
-        heavy traffic inspection load, attack activity or a control-plane bottleneck.
+      desc: This metric reports per-core CPU load on the Blockbit firewall as a percentage
+        (HOST-RESOURCES-MIB hrProcessorLoad, per index dimension). Sustained high values
+        may indicate heavy traffic inspection load, attack activity or a control-plane
+        bottleneck.
     device_memory_usage:
       name: Memory Usage
       desc: This metric reports the overall memory utilization of the FortiGate firewall

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/language/zh-Hans.yaml
@@ -1,6 +1,6 @@
 Firewall Blockbit SNMP:
   name: Blockbit（Telegraf）
-  desc: 面向 Blockbit 防火墙的 SNMP 监控模板,可采集 运行时长、接口速率、入向错误包等主要指标。
+  desc: 面向 Blockbit 防火墙的 SNMP 监控模板,可采集 运行时长、CPU 使用率（HOST-RESOURCES）、接口速率、入向错误包等主要指标。
 monitor_object:
   Firewall: 防火墙
 monitor_object_type:
@@ -79,8 +79,8 @@ monitor_object_metric:
         VPN 解密流量负载与异常波动。
     device_cpu_usage:
       name: CPU 使用率
-      desc: 该指标报告 FortiGate 防火墙整体 CPU 使用率（FORTINET-FORTIGATE-MIB fgSysCpuUsage）。持续高
-        CPU 可能意味着流量检测负载过重、攻击活动或控制平面瓶颈。
+      desc: 该指标报告 Blockbit 防火墙各 CPU 核心的负载百分比（HOST-RESOURCES-MIB hrProcessorLoad，按 index
+        维度上报）。持续偏高可能意味着流量检测负载过重、攻击活动或控制平面瓶颈。
     device_memory_usage:
       name: 内存使用率
       desc: 该指标报告 FortiGate 防火墙整体内存使用率（FORTINET-FORTIGATE-MIB fgSysMemUsage，直接以百分比上报）。内存压力过高时设备可能进入保护模式并丢弃新会话。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/firewall_blockbit/metrics.json
@@ -2,7 +2,7 @@
   "collector": "Telegraf",
   "collect_type": "snmp_blockbit",
   "plugin": "Firewall Blockbit SNMP",
-  "plugin_desc": "Baseline SNMP collection template for Blockbit UTM / NGFW security appliances. Based on standard MIB-II / IF-MIB, it collects device uptime, 64-bit HC interface traffic, interface RX/TX error and discard rates, interface admin/operational status and bandwidth, and device-wide total traffic roll-ups. Blockbit appliances run a hardened Unix-like OS whose CPU/memory/disk are exposed only via row-indexed standard host-resource tables that telegraf inputs.snmp cannot filter row-wise, and no vendor private health scalar is publicly documented, so CPU/memory/temperature/fan/power are N/A and not faked. Applicable to Blockbit UTM / NGFW security gateways managed over SNMP.",
+  "plugin_desc": "SNMP collection template for Blockbit UTM / NGFW security appliances. Based on standard MIB-II / IF-MIB, it collects device uptime, HOST-RESOURCES hrProcessorLoad per-core CPU utilization, 64-bit HC interface traffic, interface RX/TX error and discard rates, interface admin/operational status and bandwidth, and device-wide total traffic roll-ups. Memory, temperature, fan and power remain N/A: hrStorage mixes RAM/Flash rows that telegraf inputs.snmp cannot filter row-wise, and no vendor private health scalar is publicly documented. Applicable to Blockbit UTM / NGFW security gateways managed over SNMP.",
   "status_query": "any({instance_type='firewall', collect_type='snmp_blockbit'}) by (instance_id)",
   "name": "Firewall",
   "icon": "mm-firewall_防火墙",
@@ -14,6 +14,7 @@
   ],
   "supplementary_indicators": [
     "snmp_uptime",
+    "device_cpu_usage",
     "device_total_incoming_traffic",
     "device_total_outgoing_traffic"
   ],
@@ -30,6 +31,24 @@
         "instance_id"
       ],
       "description": "This metric indicates the uptime of the device since the last restart. By monitoring the uptime, network administrators can understand the stability and reliability of the device and identify potential reboot or failure issues."
+    },
+    {
+      "metric_group": "Firewall",
+      "name": "device_cpu_usage",
+      "query": "device_cpu_usage{instance_type='firewall', __$labels__}",
+      "display_name": "CPU Usage",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports per-core CPU load on the Blockbit firewall as a percentage (HOST-RESOURCES-MIB hrProcessorLoad). Sustained high values may indicate heavy traffic inspection load, attack activity or a control-plane bottleneck."
     },
     {
       "metric_group": "Status",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/6wind.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/6wind.child.toml.j2
@@ -48,4 +48,13 @@
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.31.1.1.1.10"
         name = "ifHCOutOctets"
-# ---- CPU/内存/温度/风扇/电源：6WIND VSR（企业号 7336）当前状态只确认标准 HOST-RESOURCES/MIB-II 与 IF-MIB ifXTable 可用，未确认无需行级过滤且跨版本稳定的厂商私有设备健康标量 → CPU/内存/温度/风扇/电源 N/A 不采。本基线模板仅采集标准 MIB-II 运行时长与 IF-MIB（含 64 位 HC）接口指标。----
+    # ---- CPU usage (HOST-RESOURCES hrProcessorLoad, per-core %) ----
+    # 来源：6WIND VSR 确认标准 HOST-RESOURCES 可用；hrProcessorLoad 表各行均为 CPU 负载，无需行级类型过滤。
+    [[inputs.snmp.table]]
+        name = "device_cpu"
+        inherit_tags = ["source"]
+        index_as_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.3.3.1.2"
+        name = "usage"
+# ---- 内存/温度/风扇/电源：6WIND VSR（企业号 7336）内存经 hrStorage 混表（RAM/Flash 行索引不固定）暴露，inputs.snmp 无法按行过滤；未确认跨版本稳定的厂商私有设备健康标量 → 内存/温度/风扇/电源 N/A。CPU 经 HOST-RESOURCES hrProcessorLoad 已采。----

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/language/en.yaml
@@ -1,7 +1,8 @@
 Router 6WIND VSR SNMP:
   name: 6WIND VSR (Telegraf)
   desc: SNMP monitoring template for 6WIND VSR router. It reports per-port inbound
-    traffic rate, per-port outbound traffic rate, and system uptime
+    traffic rate, per-port outbound traffic rate, per-core CPU utilization (HOST-RESOURCES),
+    and system uptime
 monitor_object:
   Router: Router
 monitor_object_type:
@@ -36,9 +37,9 @@ monitor_object_metric:
         memory consumption and pressure.
     device_cpu_usage:
       name: CPU Usage
-      desc: This metric reports the average CPU utilization across the operating entities
-        of the Juniper MX router (JUNIPER-MIB jnxOperatingCPU, aggregated per instance_id).
-        Sustained high usage indicates heavy forwarding or control-plane load.
+      desc: This metric reports per-core CPU load on the 6WIND VSR router as a percentage
+        (HOST-RESOURCES-MIB hrProcessorLoad, per index dimension). Sustained high values
+        indicate control-plane or forwarding load.
     device_memory_usage:
       name: Memory Usage
       desc: This metric reports the average memory utilization across the operating

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/language/zh-Hans.yaml
@@ -1,6 +1,6 @@
 Router 6WIND VSR SNMP:
   name: 6WIND VSR（Telegraf）
-  desc: 面向 6WIND VSR 路由器的 SNMP 监控模板,可采集 每端口入向流量速率、每端口出向流量速率和运行时长。
+  desc: 面向 6WIND VSR 路由器的 SNMP 监控模板,可采集 每端口入向流量速率、每端口出向流量速率、CPU 使用率（HOST-RESOURCES）和运行时长。
 monitor_object:
   Router: 路由器
 monitor_object_type:
@@ -27,8 +27,8 @@ monitor_object_metric:
       desc: 该指标报告路由器当前已使用的物理内存字节数（由内存总量减去空闲内存计算得到）。用于评估绝对内存消耗与压力。
     device_cpu_usage:
       name: CPU 使用率
-      desc: 该指标报告 Juniper MX 路由器各运行实体的 CPU 使用率均值（JUNIPER-MIB jnxOperatingCPU，按 instance_id
-        聚合）。持续偏高说明转发/控制平面负载吃紧。
+      desc: 该指标报告 6WIND VSR 路由器各 CPU 核心的负载百分比（HOST-RESOURCES-MIB hrProcessorLoad，按 index
+        维度上报）。持续偏高说明控制平面或转发负载吃紧。
     device_memory_usage:
       name: 内存使用率
       desc: 该指标报告 Juniper MX 路由器各运行实体的内存使用率均值（JUNIPER-MIB jnxOperatingBuffer，直接以百分比上报）。持续偏高可能由路由表过大或内存泄漏导致。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_6wind/metrics.json
@@ -2,7 +2,7 @@
   "collector": "Telegraf",
   "collect_type": "snmp_6wind",
   "plugin": "Router 6WIND VSR SNMP",
-  "plugin_desc": "6WIND VSR router SNMP child template (enterprise 7336). The currently verified profile is a clean baseline built on standard MIB-II and IF-MIB ifXTable; no stable vendor-specific scalar device-health gauges are confirmed for CPU, memory, temperature, fan or power state. This child therefore declares no vendor-specific metric deltas in metrics.json. The shared Router SNMP floor supplies uptime, IF-MIB interface metrics and aggregate traffic through the generic snmp/router metric model while this plugin provides the 6WIND collect_type, UI and Telegraf child template. Supported brands/models — 6WIND Virtual Service Router.",
+  "plugin_desc": "6WIND VSR router SNMP child template (enterprise 7336). The verified profile builds on standard MIB-II and IF-MIB ifXTable plus HOST-RESOURCES hrProcessorLoad for per-core CPU utilization. Memory, temperature, fan and power state remain N/A: hrStorage mixes RAM/Flash rows that telegraf inputs.snmp cannot filter row-wise, and no stable vendor-specific scalar device-health gauges are confirmed. The shared Router SNMP floor supplies uptime, IF-MIB interface metrics and aggregate traffic through the generic snmp/router metric model while this plugin provides the 6WIND collect_type, UI and Telegraf child template. Supported brands/models — 6WIND Virtual Service Router.",
   "status_query": "any({instance_type='router', collect_type='snmp_6wind'}) by (instance_id)",
   "name": "Router",
   "icon": "mm-router_路由器",
@@ -13,7 +13,8 @@
     "instance_id"
   ],
   "supplementary_indicators": [
-    "snmp_uptime"
+    "snmp_uptime",
+    "device_cpu_usage"
   ],
   "metrics": [
     {
@@ -51,6 +52,24 @@
         "instance_id"
       ],
       "description": "This metric indicates the average rate of bytes sent over the past 5 minutes, based on the 64-bit ifHCOutOctets counter which does not wrap on high-speed interfaces."
+    },
+    {
+      "metric_group": "Router",
+      "name": "device_cpu_usage",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
+      "display_name": "CPU Usage",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports per-core CPU load on the 6WIND VSR router as a percentage (HOST-RESOURCES-MIB hrProcessorLoad). Sustained high values indicate control-plane or forwarding load."
     },
     {
       "metric_group": "Base",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/language/en.yaml
@@ -1,7 +1,8 @@
 Router Robustel SNMP:
   name: Robustel (Telegraf)
   desc: SNMP monitoring template for Robustel router. It reports per-port inbound
-    traffic rate, per-port outbound traffic rate, and system uptime
+    traffic rate, per-port outbound traffic rate, per-core CPU utilization (HOST-RESOURCES),
+    and system uptime
 monitor_object:
   Router: Router
 monitor_object_type:
@@ -36,9 +37,9 @@ monitor_object_metric:
         memory consumption and pressure.
     device_cpu_usage:
       name: CPU Usage
-      desc: This metric reports the average CPU utilization across the operating entities
-        of the Juniper MX router (JUNIPER-MIB jnxOperatingCPU, aggregated per instance_id).
-        Sustained high usage indicates heavy forwarding or control-plane load.
+      desc: This metric reports per-core CPU load on the Robustel router as a percentage
+        (HOST-RESOURCES-MIB hrProcessorLoad, per index dimension). Sustained high values
+        indicate control-plane or forwarding load.
     device_memory_usage:
       name: Memory Usage
       desc: This metric reports the average memory utilization across the operating

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/language/zh-Hans.yaml
@@ -1,6 +1,6 @@
 Router Robustel SNMP:
   name: Robustel（Telegraf）
-  desc: 面向 Robustel 路由器的 SNMP 监控模板,可采集 每端口入向流量速率、每端口出向流量速率和运行时长。
+  desc: 面向 Robustel 路由器的 SNMP 监控模板,可采集 每端口入向流量速率、每端口出向流量速率、CPU 使用率（HOST-RESOURCES）和运行时长。
 monitor_object:
   Router: 路由器
 monitor_object_type:
@@ -27,8 +27,8 @@ monitor_object_metric:
       desc: 该指标报告路由器当前已使用的物理内存字节数（由内存总量减去空闲内存计算得到）。用于评估绝对内存消耗与压力。
     device_cpu_usage:
       name: CPU 使用率
-      desc: 该指标报告 Juniper MX 路由器各运行实体的 CPU 使用率均值（JUNIPER-MIB jnxOperatingCPU，按 instance_id
-        聚合）。持续偏高说明转发/控制平面负载吃紧。
+      desc: 该指标报告 Robustel 路由器各 CPU 核心的负载百分比（HOST-RESOURCES-MIB hrProcessorLoad，按 index
+        维度上报）。持续偏高说明控制平面或转发负载吃紧。
     device_memory_usage:
       name: 内存使用率
       desc: 该指标报告 Juniper MX 路由器各运行实体的内存使用率均值（JUNIPER-MIB jnxOperatingBuffer，直接以百分比上报）。持续偏高可能由路由表过大或内存泄漏导致。

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/metrics.json
@@ -2,7 +2,7 @@
   "collector": "Telegraf",
   "collect_type": "snmp_robustel",
   "plugin": "Router Robustel SNMP",
-  "plugin_desc": "Robustel router SNMP child template (enterprise 39699). The currently verified profile is a clean baseline built on standard MIB-II and IF-MIB ifXTable; no stable vendor-specific scalar device-health gauges are confirmed for CPU, memory, temperature, fan or power state. This child therefore declares no vendor-specific metric deltas in metrics.json. The shared Router SNMP floor supplies uptime, IF-MIB interface metrics and aggregate traffic through the generic snmp/router metric model while this plugin provides the Robustel collect_type, UI and Telegraf child template. Supported brands/models — Robustel R3000 industrial cellular router/gateway.",
+  "plugin_desc": "Robustel router SNMP child template (enterprise 39699). The verified profile builds on standard MIB-II and IF-MIB ifXTable plus HOST-RESOURCES hrProcessorLoad for per-core CPU utilization. Memory, temperature, fan and power state remain N/A: hrStorage mixes RAM/Flash rows that telegraf inputs.snmp cannot filter row-wise, and no stable vendor-specific scalar device-health gauges are confirmed. The shared Router SNMP floor supplies uptime, IF-MIB interface metrics and aggregate traffic through the generic snmp/router metric model while this plugin provides the Robustel collect_type, UI and Telegraf child template. Supported brands/models — Robustel R3000 industrial cellular router/gateway.",
   "status_query": "any({instance_type='router', collect_type='snmp_robustel'}) by (instance_id)",
   "name": "Router",
   "icon": "mm-router_路由器",
@@ -13,7 +13,8 @@
     "instance_id"
   ],
   "supplementary_indicators": [
-    "snmp_uptime"
+    "snmp_uptime",
+    "device_cpu_usage"
   ],
   "metrics": [
     {
@@ -51,6 +52,24 @@
         "instance_id"
       ],
       "description": "This metric indicates the average rate of bytes sent over the past 5 minutes, based on the 64-bit ifHCOutOctets counter which does not wrap on high-speed interfaces."
+    },
+    {
+      "metric_group": "Router",
+      "name": "device_cpu_usage",
+      "query": "device_cpu_usage{instance_type='router', __$labels__}",
+      "display_name": "CPU Usage",
+      "data_type": "Number",
+      "unit": "percent",
+      "dimensions": [
+        {
+          "name": "index",
+          "description": "SNMP table row index"
+        }
+      ],
+      "instance_id_keys": [
+        "instance_id"
+      ],
+      "description": "This metric reports per-core CPU load on the Robustel router as a percentage (HOST-RESOURCES-MIB hrProcessorLoad). Sustained high values indicate control-plane or forwarding load."
     },
     {
       "metric_group": "Base",

--- a/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/robustel.child.toml.j2
+++ b/server/apps/monitor/support-files/plugins/Telegraf/snmp/router_robustel/robustel.child.toml.j2
@@ -48,4 +48,13 @@
     [[inputs.snmp.table.field]]
         oid = "1.3.6.1.2.1.31.1.1.1.10"
         name = "ifHCOutOctets"
-# ---- CPU/内存/温度/风扇/电源：Robustel（企业号 39699）当前状态只确认标准 HOST-RESOURCES/MIB-II 与 IF-MIB ifXTable 可用，未确认无需行级过滤且跨版本稳定的厂商私有设备健康标量 → CPU/内存/温度/风扇/电源 N/A 不采。本基线模板仅采集标准 MIB-II 运行时长与 IF-MIB（含 64 位 HC）接口指标。----
+    # ---- CPU usage (HOST-RESOURCES hrProcessorLoad, per-core %) ----
+    # 来源：Robustel 确认标准 HOST-RESOURCES 可用；hrProcessorLoad 表各行均为 CPU 负载，无需行级类型过滤。
+    [[inputs.snmp.table]]
+        name = "device_cpu"
+        inherit_tags = ["source"]
+        index_as_tag = true
+    [[inputs.snmp.table.field]]
+        oid = "1.3.6.1.2.1.25.3.3.1.2"
+        name = "usage"
+# ---- 内存/温度/风扇/电源：Robustel（企业号 39699）内存经 hrStorage 混表（RAM/Flash 行索引不固定）暴露，inputs.snmp 无法按行过滤；未确认跨版本稳定的厂商私有设备健康标量 → 内存/温度/风扇/电源 N/A。CPU 经 HOST-RESOURCES hrProcessorLoad 已采。----


### PR DESCRIPTION
## Summary

- 为已确认可采 HOST-RESOURCES `hrProcessorLoad` 的三个 SNMP 品牌模板（6WIND VSR、Robustel、Blockbit）补充 `device_cpu_usage` 采集，沿用 Arista/pfSense 的 Telegraf 表结构（OID `1.3.6.1.2.1.25.3.3.1.2`，`index_as_tag=true`）。
- 同步更新各模板的 `metrics.json`、`supplementary_indicators` 与中英文插件/指标文案；内存/温度/风扇/电源仍保持 N/A（hrStorage 混表需行过滤）。

## Test plan

- 本地已验证 Telegraf 子模板与 metrics 契约；契约测试文件按仓库约定未纳入本 PR。