### PR TITLE
feat(监控): 腾讯云 CVM 子对象增加内置 IP 展示列

### DIFF
--- a/agents/stargazer/tasks/collectors/qcloud_collector.py
+++ b/agents/stargazer/tasks/collectors/qcloud_collector.py
@@ -7,9 +7,62 @@ QCloud 监控数据采集器
 """
 import asyncio
 import datetime
-from typing import Dict, Any
+
 from sanic.log import logger
+
 from .base_collector import BaseCollector
+
+QCLOUD_CVM_OBJECT_ID = "qcloud_cvm"
+
+
+def _flatten_ip_values(value):
+    """展开列表/字符串中的 IP，去掉空白和空值。"""
+    if value is None:
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            yield from _flatten_ip_values(item)
+        return
+    ip = str(value).strip()
+    if ip:
+        yield ip
+
+
+def _join_cvm_ips(resource):
+    """优先内网 IP，其次公网 IP；去重并保持原顺序，逗号拼接。"""
+    ips = []
+    seen = set()
+    for value in (resource.get("inner_ip"), resource.get("public_ip")):
+        for ip in _flatten_ip_values(value):
+            if ip not in seen:
+                seen.add(ip)
+                ips.append(ip)
+    return ",".join(ips)
+
+
+def _cvm_resource_ip_map(resources):
+    """qcloud_cvm 的 resource_id → IP；无 IP 的资源不入表。"""
+    mapping = {}
+    for resource in resources or ():
+        resource_id = resource.get("resource_id")
+        ip = _join_cvm_ips(resource)
+        if resource_id and ip:
+            mapping[resource_id] = ip
+    return mapping
+
+
+def _attach_ip_dimension(metrics, ip):
+    """把 resource_ip 写成 convert_to_prometheus 已支持的维度，不改公共转换层。"""
+    ip_dim = ("resource_ip", ip)
+    attached = {}
+    for metric_name, metric_data in (metrics or {}).items():
+        if isinstance(metric_data, list):
+            attached[metric_name] = {(ip_dim,): metric_data}
+        elif isinstance(metric_data, dict):
+            attached[metric_name] = {(ip_dim,) + tuple(dims): values for dims, values in metric_data.items()}
+        else:
+            attached[metric_name] = metric_data
+    return attached
 
 
 class QCloudCollector(BaseCollector):
@@ -66,6 +119,7 @@ class QCloudCollector(BaseCollector):
                 continue
 
             resource_ids = [resource["resource_id"] for resource in resources]
+            ip_by_resource = _cvm_resource_ip_map(resources) if object_id == QCLOUD_CVM_OBJECT_ID else {}
             logger.info(f"[QCloud Collector] Processing '{object_id}': {len(resource_ids)} resources")
 
             try:
@@ -75,7 +129,7 @@ class QCloudCollector(BaseCollector):
                     EndTime=end_time_str,
                     Period=300,
                     Metrics=[],
-                    context={"resources": [{"bk_obj_id": object_id}]}
+                    context={"resources": [{"bk_obj_id": object_id}]},
                 )
 
                 if not data["result"]:
@@ -83,6 +137,9 @@ class QCloudCollector(BaseCollector):
                     continue
 
                 for resource_id, metrics in data["data"].items():
+                    ip = ip_by_resource.get(resource_id)
+                    if ip:
+                        metrics = _attach_ip_dimension(metrics, ip)
                     metric_dict[(resource_id, object_id)] = metrics
 
                 total_resources_processed += len(data["data"])

--- a/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/metrics.json
+++ b/server/apps/monitor/support-files/plugins/Telegraf/http/qcloud/metrics.json
@@ -40,7 +40,7 @@
       "default_metric": "any({resource_type='qcloud_cvm'}) by (instance_id, resource_id)",
       "instance_id_keys": ["instance_id", "resource_id"],
       "supplementary_indicators": ["CPUUsage_gauge", "MemUsage_gauge", "CvmDiskUsage_gauge"],
-      "display_fields": [{"name": "CPU Utilization", "sort_order": 0, "metrics": [{"plugin": "Tencent Cloud", "metric": "CPUUsage_gauge"}]}, {"name": "Memory Utilization", "sort_order": 1, "metrics": [{"plugin": "Tencent Cloud", "metric": "MemUsage_gauge"}]}, {"name": "Disk Utilization", "sort_order": 2, "metrics": [{"plugin": "Tencent Cloud", "metric": "CvmDiskUsage_gauge"}]}],
+      "display_fields": [{"name": "IP 地址", "type": "field", "role": "resource_ip", "variable_id": "vm_ip", "sort_order": 0, "metrics": [{"plugin": "Tencent Cloud", "metric": "CPUUsage_gauge", "field": "resource_ip"}]}, {"name": "CPU Utilization", "sort_order": 1, "metrics": [{"plugin": "Tencent Cloud", "metric": "CPUUsage_gauge"}]}, {"name": "Memory Utilization", "sort_order": 2, "metrics": [{"plugin": "Tencent Cloud", "metric": "MemUsage_gauge"}]}, {"name": "Disk Utilization", "sort_order": 3, "metrics": [{"plugin": "Tencent Cloud", "metric": "CvmDiskUsage_gauge"}]}],
       "metrics": [
         {
           "metric_group": "CPU",


### PR DESCRIPTION
## Summary
- 腾讯云 CVM 子对象增加内置 IP 展示列（`display_fields` `type=field` / `role=resource_ip` / `variable_id=vm_ip`），绑定稳定指标 `CPUUsage_gauge` 的 `resource_ip` label。
- QCloud 采集器仅对 `qcloud_cvm` 从 `inner_ip` 优先、`public_ip` 其次拼接 IP，有真实 IP 才挂维度；空 IP 和非 CVM 对象不写 label。不改 VMware / 其他云对象，无测试文件。

## Test plan
- [ ] 下发腾讯云 CVM 采集后，实例列表「IP 地址」显示内网（多 IP 逗号拼接），无 IP 显示 `--`
- [ ] 告警变量 `${vm_ip}` 可解析
- [ ] `plugin_init` 后未自定义列的 CVM 对象出现该种子列；已 `display_fields_customized` 的对象不被覆盖
- [ ] 非 CVM 对象（如 MySQL）指标无 `resource_ip` label