### PR TITLE
bugfix: 拆分云区域公开配置读取

### DIFF
--- a/server/apps/apm/services/integration_configuration.py
+++ b/server/apps/apm/services/integration_configuration.py
@@ -402,7 +402,7 @@ class DjangoIntegrationConfigurationService:
 
         def _node_server_url() -> object:
             if "value" not in env_config_cache:
-                env_config = node_mgmt.get_cloud_region_envconfig(cloud_region_id)
+                env_config = node_mgmt.get_cloud_region_public_config(cloud_region_id)
                 env_config_cache["value"] = env_config if isinstance(env_config, dict) else {}
             return env_config_cache["value"].get("NODE_SERVER_URL")
 

--- a/server/apps/apm/tests/test_api_permissions.py
+++ b/server/apps/apm/tests/test_api_permissions.py
@@ -25,7 +25,7 @@ def _integration_region(monkeypatch):
     region = Mock()
     region.cloud_region_list.return_value = [{"id": 7, "name": "华东一区"}]
     region.get_cloud_region_proxy_address.return_value = "apm-east.example.com"
-    region.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
+    region.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
     monkeypatch.setattr("apps.apm.views.control_plane.NodeMgmt", lambda: region)
     return region
 
@@ -142,7 +142,7 @@ def test_integration_config_is_stateless_and_maps_standard_resource_attributes(a
     region = Mock()
     region.cloud_region_list.return_value = [{"id": 7, "name": "华东一区"}]
     region.get_cloud_region_proxy_address.return_value = "apm-east.example.com"
-    region.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
+    region.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
 
     with pytest.MonkeyPatch.context() as monkeypatch:
         monkeypatch.setattr("apps.apm.views.control_plane.NodeMgmt", lambda: region)
@@ -175,7 +175,7 @@ def test_integration_config_is_stateless_and_maps_standard_resource_attributes(a
     assert "http://10.10.10.1:8011/api/v1/apm/open_api/probe/download/opentelemetry-python-wheels.tar.gz" in response.data["code"]
     assert "pypi.org" not in response.data["code"]
     region.get_cloud_region_proxy_address.assert_called_once_with(7)
-    region.get_cloud_region_envconfig.assert_called_once_with(7)
+    region.get_cloud_region_public_config.assert_called_once_with(7)
     assert ApmApplication.objects.filter(is_builtin=False).count() == 1
 
 
@@ -337,7 +337,7 @@ def test_integration_config_falls_back_to_trusted_node_server_url_without_node_o
     region = Mock()
     region.cloud_region_list.return_value = [{"id": 7, "name": "直连区域"}]
     region.get_cloud_region_proxy_address.return_value = ""
-    region.get_cloud_region_envconfig.return_value = {
+    region.get_cloud_region_public_config.return_value = {
         "NODE_SERVER_URL": "http://10.10.10.1:8011",
     }
 
@@ -361,13 +361,13 @@ def test_integration_config_falls_back_to_trusted_node_server_url_without_node_o
     assert response.data["http_endpoint"] == "http://10.10.10.1:4318/v1/traces"
     assert response.data["environment"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://10.10.10.1:4318"
     region.get_cloud_region_proxy_address.assert_called_once_with(7)
-    region.get_cloud_region_envconfig.assert_called_once_with(7)
+    region.get_cloud_region_public_config.assert_called_once_with(7)
 
 
 def test_integration_config_java_snippet_uses_the_system_probe_download_address(apm_api_client, monkeypatch):
     create_application("shop", (10,))
     region = _integration_region(monkeypatch)
-    region.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
+    region.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
 
     response = apm_api_client.post(
         "/api/v1/apm/integration-config/",
@@ -386,7 +386,7 @@ def test_integration_config_java_snippet_uses_the_system_probe_download_address(
     assert response.status_code == 200
     assert "http://10.10.10.1:8011/api/v1/apm/open_api/probe/download/opentelemetry-javaagent.jar" in response.data["code"]
     assert "github.com" not in response.data["code"]
-    region.get_cloud_region_envconfig.assert_called_once_with(7)
+    region.get_cloud_region_public_config.assert_called_once_with(7)
 
 
 @pytest.mark.parametrize(
@@ -429,7 +429,7 @@ def test_integration_config_snippets_use_system_probe_download_addresses(
 def test_integration_config_java_snippet_reports_missing_probe_download_address(apm_api_client, monkeypatch):
     create_application("shop", (10,))
     region = _integration_region(monkeypatch)
-    region.get_cloud_region_envconfig.return_value = {}
+    region.get_cloud_region_public_config.return_value = {}
 
     response = apm_api_client.post(
         "/api/v1/apm/integration-config/",

--- a/server/apps/apm/tests/test_ingest_snippets.py
+++ b/server/apps/apm/tests/test_ingest_snippets.py
@@ -281,7 +281,7 @@ def test_resolve_region_builds_the_probe_download_url_from_node_server_url(langu
     node_mgmt = Mock()
     node_mgmt.cloud_region_list.return_value = [{"id": 7, "name": "华东一区"}]
     node_mgmt.get_cloud_region_proxy_address.return_value = "apm-east.example.com"
-    node_mgmt.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
+    node_mgmt.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "http://10.10.10.1:8011"}
 
     endpoints = DjangoIntegrationConfigurationService().resolve_region(
         node_mgmt,
@@ -293,7 +293,7 @@ def test_resolve_region_builds_the_probe_download_url_from_node_server_url(langu
 
     assert endpoints.http_endpoint == "http://apm-east.example.com:4318"
     assert endpoints.probe_download_url == f"http://10.10.10.1:8011/api/v1/apm/open_api/probe/download/{artifact_name}"
-    node_mgmt.get_cloud_region_envconfig.assert_called_once_with(7)
+    node_mgmt.get_cloud_region_public_config.assert_called_once_with(7)
 
 
 def test_resolve_region_skips_env_config_when_probe_download_is_not_needed():
@@ -304,7 +304,7 @@ def test_resolve_region_skips_env_config_when_probe_download_is_not_needed():
     endpoints = DjangoIntegrationConfigurationService().resolve_region(node_mgmt, 7, organization_ids=[10])
 
     assert endpoints.probe_download_url == ""
-    node_mgmt.get_cloud_region_envconfig.assert_not_called()
+    node_mgmt.get_cloud_region_public_config.assert_not_called()
 
 
 @pytest.mark.parametrize("env_config", [{}, {"NODE_SERVER_URL": "ftp://10.10.10.1:8011"}, "not-a-dict"])
@@ -312,7 +312,7 @@ def test_resolve_region_fails_closed_when_the_probe_download_address_is_unavaila
     node_mgmt = Mock()
     node_mgmt.cloud_region_list.return_value = [{"id": 7, "name": "华东一区"}]
     node_mgmt.get_cloud_region_proxy_address.return_value = "apm-east.example.com"
-    node_mgmt.get_cloud_region_envconfig.return_value = env_config
+    node_mgmt.get_cloud_region_public_config.return_value = env_config
 
     with pytest.raises(CloudRegionConfigurationError) as exc_info:
         DjangoIntegrationConfigurationService().resolve_region(

--- a/server/apps/cmdb/services/k8s_setup.py
+++ b/server/apps/cmdb/services/k8s_setup.py
@@ -45,7 +45,7 @@ class K8sSetupService:
         from apps.rpc.node_mgmt import NodeMgmt
 
         node_mgmt_rpc = NodeMgmt()
-        env_vars = node_mgmt_rpc.get_cloud_region_envconfig(cloud_region_id)
+        env_vars = node_mgmt_rpc.get_cloud_region_public_config(cloud_region_id)
 
         server_url = env_vars.get("NODE_SERVER_URL")
         if not server_url:

--- a/server/apps/cmdb/tests/test_slice_collect_tool_data_cleanup_k8s.py
+++ b/server/apps/cmdb/tests/test_slice_collect_tool_data_cleanup_k8s.py
@@ -579,7 +579,7 @@ class TestK8sSetupService:
 
     def test_generate_install_command_builds_curl(self, mocker):
         fake_node = mocker.Mock()
-        fake_node.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "http://srv:8000/"}
+        fake_node.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "http://srv:8000/"}
         mocker.patch("apps.rpc.node_mgmt.NodeMgmt", return_value=fake_node)
         mocker.patch.object(k8s_mod.InfraService, "generate_install_token", return_value="TKN")
 
@@ -591,7 +591,7 @@ class TestK8sSetupService:
 
     def test_generate_install_command_missing_server_url(self, mocker):
         fake_node = mocker.Mock()
-        fake_node.get_cloud_region_envconfig.return_value = {}
+        fake_node.get_cloud_region_public_config.return_value = {}
         mocker.patch("apps.rpc.node_mgmt.NodeMgmt", return_value=fake_node)
         with pytest.raises(BaseAppException):
             K8sSetupService.generate_install_command("c1", 3)

--- a/server/apps/log/services/cloud_region_receiver.py
+++ b/server/apps/log/services/cloud_region_receiver.py
@@ -26,7 +26,7 @@ class CloudRegionReceiverService:
             if not isinstance(node_data, dict) or not node_data.get("nodes"):
                 return ""
 
-        env_config = node_mgmt.get_cloud_region_envconfig(cloud_region_id)
+        env_config = node_mgmt.get_cloud_region_public_config(cloud_region_id)
         if not isinstance(env_config, dict):
             return ""
 

--- a/server/apps/log/services/k8s_collect.py
+++ b/server/apps/log/services/k8s_collect.py
@@ -340,6 +340,13 @@ class K8sLogCollectService:
 
         return env_vars
 
+    @staticmethod
+    def get_cloud_region_public_config(cloud_region_id: str) -> dict:
+        env_vars = NodeMgmt().get_cloud_region_public_config(cloud_region_id)
+        if not env_vars.get("NODE_SERVER_URL"):
+            raise BaseAppException(f"Missing NODE_SERVER_URL in cloud region {cloud_region_id}")
+        return env_vars
+
     @classmethod
     def generate_install_command(
         cls,
@@ -350,7 +357,7 @@ class K8sLogCollectService:
         instance = cls.get_k8s_instance(instance_id)
         cls.load_setting_render_options(instance.id)
 
-        env_vars = cls.get_cloud_region_envconfig(cloud_region_id)
+        env_vars = cls.get_cloud_region_public_config(cloud_region_id)
         server_url = env_vars.get("NODE_SERVER_URL")
         token = cls.generate_install_token(instance.id, str(cloud_region_id), image_registry_prefix)
         api_url = f"{server_url.rstrip('/')}/api/v1/log/open_api/k8s/render/"

--- a/server/apps/log/tests/test_cloud_region_receiver.py
+++ b/server/apps/log/tests/test_cloud_region_receiver.py
@@ -9,7 +9,7 @@ def _node_mgmt(proxy_address="", env_config=None):
     client = Mock()
     client.get_cloud_region_proxy_address.return_value = proxy_address
     client.node_list.return_value = {"nodes": [{"id": "node-1"}]}
-    client.get_cloud_region_envconfig.return_value = env_config
+    client.get_cloud_region_public_config.return_value = env_config
     return client
 
 
@@ -23,7 +23,7 @@ def test_resolve_prefers_explicit_proxy_address():
 
     assert result == "proxy.example.com"
     client.get_cloud_region_proxy_address.assert_called_once_with(42, [1])
-    client.get_cloud_region_envconfig.assert_not_called()
+    client.get_cloud_region_public_config.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -56,7 +56,7 @@ def test_resolve_does_not_fall_back_when_cloud_region_is_not_accessible():
     result = CloudRegionReceiverService.resolve(client, 42, [1])
 
     assert result == ""
-    client.get_cloud_region_envconfig.assert_not_called()
+    client.get_cloud_region_public_config.assert_not_called()
 
 
 def test_resolve_returns_empty_for_user_without_organizations():

--- a/server/apps/log/tests/test_k8s_collect_pure.py
+++ b/server/apps/log/tests/test_k8s_collect_pure.py
@@ -132,7 +132,11 @@ def test_get_cloud_region_envconfig_missing_vars(mocker):
 def test_generate_install_command_builds_curl(mocker):
     inst = mocker.MagicMock(id="inst-1")
     mocker.patch("apps.log.services.k8s_collect.CollectInstance.objects.filter").return_value.first.return_value = inst
-    mocker.patch.object(K8s, "get_cloud_region_envconfig", return_value=dict(_FULL_ENV))
+    mocker.patch.object(
+        K8s,
+        "get_cloud_region_public_config",
+        return_value={"NODE_SERVER_URL": _FULL_ENV["NODE_SERVER_URL"]},
+    )
     mocker.patch.object(K8s, "generate_install_token", return_value="tok-123")
     cmd = K8s.generate_install_command("inst-1", "cr1", "harbor.internal/bklite")
     assert "curl -sSLk -X POST" in cmd

--- a/server/apps/log/tests/test_node_proxy_address.py
+++ b/server/apps/log/tests/test_node_proxy_address.py
@@ -53,7 +53,7 @@ def test_cloud_region_proxy_address_endpoint_falls_back_to_node_server_url(authe
     mocked_rpc = Mock()
     mocked_rpc.get_cloud_region_proxy_address.return_value = ""
     mocked_rpc.node_list.return_value = {"nodes": [{"id": "node-1"}]}
-    mocked_rpc.get_cloud_region_envconfig.return_value = {
+    mocked_rpc.get_cloud_region_public_config.return_value = {
         "NODE_SERVER_URL": "https://logs.example.com:8011/api/v1",
     }
     mocker.patch("apps.log.views.node.NodeMgmt", return_value=mocked_rpc)

--- a/server/apps/monitor/services/flow_access_guide.py
+++ b/server/apps/monitor/services/flow_access_guide.py
@@ -26,7 +26,7 @@ class FlowAccessGuideService:
 
     @classmethod
     def _get_listener_host(cls, cloud_region_id):
-        env_config = NodeMgmt().get_cloud_region_envconfig(cloud_region_id)
+        env_config = NodeMgmt().get_cloud_region_public_config(cloud_region_id)
         if not isinstance(env_config, dict):
             raise BaseAppException("获取云区域环境变量失败")
 

--- a/server/apps/monitor/services/k3s_onboarding.py
+++ b/server/apps/monitor/services/k3s_onboarding.py
@@ -171,7 +171,7 @@ class K3SOnboardingService:
     @classmethod
     def generate_install_commands(cls, *, instance_id, cloud_region_id):
         instance = cls._get_cluster_instance(instance_id)
-        env = NodeMgmt().get_cloud_region_envconfig(cloud_region_id)
+        env = NodeMgmt().get_cloud_region_public_config(cloud_region_id)
         server_url = env.get("NODE_SERVER_URL")
         if not server_url:
             raise BaseAppException(

--- a/server/apps/monitor/services/manual_collect.py
+++ b/server/apps/monitor/services/manual_collect.py
@@ -123,7 +123,7 @@ class ManualCollectService:
         from apps.rpc.node_mgmt import NodeMgmt
 
         node_mgmt_rpc = NodeMgmt()
-        env_vars = node_mgmt_rpc.get_cloud_region_envconfig(cloud_region_id)
+        env_vars = node_mgmt_rpc.get_cloud_region_public_config(cloud_region_id)
 
         # 从云区域环境变量中获取服务器地址
         server_url = env_vars.get("NODE_SERVER_URL")

--- a/server/apps/monitor/services/template_access_guide.py
+++ b/server/apps/monitor/services/template_access_guide.py
@@ -28,7 +28,7 @@ class TemplateAccessGuideService:
 
     @staticmethod
     def get_telegraf_listener_endpoint(cloud_region_id: int) -> str:
-        env_config = NodeMgmt().get_cloud_region_envconfig(cloud_region_id)
+        env_config = NodeMgmt().get_cloud_region_public_config(cloud_region_id)
         if not isinstance(env_config, dict):
             raise BaseAppException("获取云区域环境变量失败")
 

--- a/server/apps/monitor/tests/test_flow_access_guide_service.py
+++ b/server/apps/monitor/tests/test_flow_access_guide_service.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.unit
 def _patch_nodemgmt(env_config):
     return patch(
         "apps.monitor.services.flow_access_guide.NodeMgmt",
-        return_value=type("M", (), {"get_cloud_region_envconfig": lambda self, _id: env_config})(),
+        return_value=type("M", (), {"get_cloud_region_public_config": lambda self, _id: env_config})(),
     )
 
 

--- a/server/apps/monitor/tests/test_infra_image_registry_views.py
+++ b/server/apps/monitor/tests/test_infra_image_registry_views.py
@@ -55,7 +55,7 @@ def test_monitor_install_command_binds_registry_to_generated_token(monkeypatch):
         generate_token,
     )
     node_mgmt = Mock()
-    node_mgmt.return_value.get_cloud_region_envconfig.return_value = {
+    node_mgmt.return_value.get_cloud_region_public_config.return_value = {
         "NODE_SERVER_URL": "https://node.internal/base",
     }
     monkeypatch.setattr("apps.rpc.node_mgmt.NodeMgmt", node_mgmt)

--- a/server/apps/monitor/tests/test_k3s_onboarding_service.py
+++ b/server/apps/monitor/tests/test_k3s_onboarding_service.py
@@ -76,7 +76,7 @@ def test_generate_commands_are_bounded_and_match_private_ca_install_convention(
     )
     mocker.patch(
         "apps.monitor.services.k3s_onboarding.NodeMgmt"
-    ).return_value.get_cloud_region_envconfig.return_value = {
+    ).return_value.get_cloud_region_public_config.return_value = {
         "NODE_SERVER_URL": "https://bk-lite.example/base",
     }
 

--- a/server/apps/monitor/tests/test_plugin_view.py
+++ b/server/apps/monitor/tests/test_plugin_view.py
@@ -298,7 +298,7 @@ class TestGetAccessGuide:
             display_name="API2",
         )
         plugin.monitor_object.add(obj)
-        mocker.patch("apps.monitor.services.template_access_guide.NodeMgmt").return_value.get_cloud_region_envconfig.return_value = {
+        mocker.patch("apps.monitor.services.template_access_guide.NodeMgmt").return_value.get_cloud_region_public_config.return_value = {
             "NODE_SERVER_URL": "https://node.example.com:8080"
         }
         resp = api_client.get(f"{BASE}/api/monitor_plugin/{plugin.id}/access_guide/?organization_id=1&cloud_region_id=2")

--- a/server/apps/monitor/tests/test_tasks_and_misc_services.py
+++ b/server/apps/monitor/tests/test_tasks_and_misc_services.py
@@ -134,19 +134,19 @@ class TestTemplateAccessGuide:
 
     def test_telegraf_endpoint_builds_url(self, mocker):
         node = mocker.patch("apps.monitor.services.template_access_guide.NodeMgmt")
-        node.return_value.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "https://node.example.com:8080/foo"}
+        node.return_value.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "https://node.example.com:8080/foo"}
         url = TemplateAccessGuideService.get_telegraf_listener_endpoint(1)
         assert url == "https://node.example.com:8080/telegraf/api"
 
     def test_telegraf_endpoint_missing_url_raises(self, mocker):
         node = mocker.patch("apps.monitor.services.template_access_guide.NodeMgmt")
-        node.return_value.get_cloud_region_envconfig.return_value = {}
+        node.return_value.get_cloud_region_public_config.return_value = {}
         with pytest.raises(BaseAppException):
             TemplateAccessGuideService.get_telegraf_listener_endpoint(1)
 
     def test_telegraf_endpoint_bad_url_raises(self, mocker):
         node = mocker.patch("apps.monitor.services.template_access_guide.NodeMgmt")
-        node.return_value.get_cloud_region_envconfig.return_value = {"NODE_SERVER_URL": "not-a-url"}
+        node.return_value.get_cloud_region_public_config.return_value = {"NODE_SERVER_URL": "not-a-url"}
         with pytest.raises(BaseAppException):
             TemplateAccessGuideService.get_telegraf_listener_endpoint(1)
 

--- a/server/apps/node_mgmt/nats/node.py
+++ b/server/apps/node_mgmt/nats/node.py
@@ -41,6 +41,7 @@ LEGACY_NODE_LIST_CALLSITES = frozenset(
         "stargazer.node_info",
     }
 )
+PUBLIC_CLOUD_REGION_CONFIG_KEYS = (NodeConstants.SERVER_URL_KEY,)
 _observed_legacy_node_list_callsites: set[str] = set()
 _legacy_node_list_observation_lock = threading.Lock()
 
@@ -765,6 +766,15 @@ def get_cloud_region_envconfig(cloud_region_id: str):
             variables[obj.key] = obj.value
 
     return variables
+
+
+@nats_client.register
+def get_cloud_region_public_config(cloud_region_id: str):
+    """只返回允许跨业务模块读取的非敏感云区域配置。"""
+    return RegionService.get_cloud_region_envconfig(
+        cloud_region_id,
+        keys=PUBLIC_CLOUD_REGION_CONFIG_KEYS,
+    )
 
 
 @nats_client.register

--- a/server/apps/node_mgmt/tests/test_cloud_region_public_config.py
+++ b/server/apps/node_mgmt/tests/test_cloud_region_public_config.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+
+from apps.core.utils.crypto.aes_crypto import AESCryptor
+from apps.node_mgmt.models import CloudRegion, SidecarEnv
+from apps.node_mgmt.nats import node as node_nats
+
+pytestmark = [pytest.mark.django_db, pytest.mark.integration]
+
+
+def test_public_config_only_returns_node_server_url():
+    region = CloudRegion.objects.create(name="public-config-region")
+    SidecarEnv.objects.create(
+        cloud_region=region,
+        key="NODE_SERVER_URL",
+        value="https://node.example.com",
+        type="text",
+    )
+    SidecarEnv.objects.create(
+        cloud_region=region,
+        key="NATS_PASSWORD",
+        value=AESCryptor().encode("region-secret"),
+        type="secret",
+    )
+
+    result = node_nats.get_cloud_region_public_config(str(region.id))
+
+    assert result == {"NODE_SERVER_URL": "https://node.example.com"}
+    assert node_nats.get_cloud_region_envconfig(str(region.id)) == {
+        "NODE_SERVER_URL": "https://node.example.com",
+        "NATS_PASSWORD": "region-secret",
+    }
+
+
+PUBLIC_CALLERS = {
+    "apm/services/integration_configuration.py": (1, 0),
+    "cmdb/services/k8s_setup.py": (1, 0),
+    "log/services/cloud_region_receiver.py": (1, 0),
+    "monitor/services/flow_access_guide.py": (1, 0),
+    "monitor/services/manual_collect.py": (1, 0),
+    "monitor/services/template_access_guide.py": (1, 0),
+}
+MIXED_CALLERS = {
+    "log/services/k8s_collect.py": (2, 2),
+    "monitor/services/k3s_onboarding.py": (1, 1),
+}
+SENSITIVE_RENDERERS = {
+    "cmdb/services/infra.py": (0, 1),
+    "monitor/services/infra.py": (0, 1),
+}
+REGISTERED_CONFIG_CALLERS = PUBLIC_CALLERS | MIXED_CALLERS | SENSITIVE_RENDERERS
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_counts"),
+    sorted(REGISTERED_CONFIG_CALLERS.items()),
+)
+def test_cloud_region_config_callsites_are_split_by_purpose(relative_path, expected_counts):
+    apps_dir = Path(__file__).resolve().parents[2]
+    source = (apps_dir / relative_path).read_text(encoding="utf-8")
+
+    assert (
+        source.count(".get_cloud_region_public_config("),
+        source.count(".get_cloud_region_envconfig("),
+    ) == expected_counts
+
+
+def test_no_unregistered_business_caller_reads_full_cloud_region_config():
+    apps_dir = Path(__file__).resolve().parents[2]
+    full_config_callers = set()
+    for app_name in ("apm", "cmdb", "log", "monitor"):
+        for source_file in (apps_dir / app_name).rglob("*.py"):
+            if "tests" in source_file.parts:
+                continue
+            source = source_file.read_text(encoding="utf-8")
+            if ".get_cloud_region_envconfig(" in source:
+                full_config_callers.add(source_file.relative_to(apps_dir).as_posix())
+
+    assert full_config_callers == set(MIXED_CALLERS | SENSITIVE_RENDERERS)

--- a/server/apps/rpc/node_mgmt.py
+++ b/server/apps/rpc/node_mgmt.py
@@ -222,6 +222,10 @@ class NodeMgmt(object):
         return_data = self.client.run("get_cloud_region_envconfig", cloud_region_id)
         return return_data
 
+    def get_cloud_region_public_config(self, cloud_region_id):
+        """获取允许跨业务模块读取的非敏感云区域配置。"""
+        return self.client.run("get_cloud_region_public_config", cloud_region_id)
+
     def install_collector(self, collector_package: int, nodes: list[str]):
         """通过 NATS 触发采集器安装"""
         return self.client.run(

--- a/server/apps/rpc/tests/test_node_mgmt_forwarding.py
+++ b/server/apps/rpc/tests/test_node_mgmt_forwarding.py
@@ -165,6 +165,11 @@ def test_get_cloud_region_envconfig_转发(node):
     assert _last(node.client) == ("get_cloud_region_envconfig", (5,), {})
 
 
+def test_get_cloud_region_public_config_转发(node):
+    node.get_cloud_region_public_config(5)
+    assert _last(node.client) == ("get_cloud_region_public_config", (5,), {})
+
+
 def test_install_collector_组装字典(node):
     node.install_collector(3, ["n1", "n2"])
     assert _last(node.client) == ("install_collector", ({"collector_package": 3, "nodes": ["n1", "n2"]},), {})


### PR DESCRIPTION
## 问题

APM、CMDB、Log、Monitor 的多条用户入口只需要云区域 `NODE_SERVER_URL`，却统一调用 `get_cloud_region_envconfig(region_id)`。该 RPC 会解密并返回区域全部变量，包括 NATS 用户名和密码，使地址查询拥有了不必要的 Secret 读取能力。

## 根因（设计层）

云区域配置 RPC 只表达“查询哪个区域”，没有表达用途和允许字段。直接给旧接口增加组织必传参数会破坏新接入、尚无节点关系的区域；保留可选参数又无法关闭过宽返回。真正需要凭据的安装渲染与只需要公开地址的接入指引被混在了同一契约中。

## 怎么修的

1. 新增只允许返回 `NODE_SERVER_URL` 的公开配置 RPC，字段集合由 NodeMgmt 服务端固定，调用方不能申请额外字段。
2. 将 APM、CMDB、Log、Monitor 中 8 条地址用途链路迁移到公开接口。
3. 旧全量接口暂时只保留给 4 条已有短期 token 边界的安装渲染路径，避免首片破坏现有安装功能。
4. 增加调用面防回退契约：四个业务模块出现新的全量配置调用时测试立即失败；剩余敏感调用名单固定为第二阶段迁移对象。

## 影响范围

- 公开接口只改变内部 RPC 方法，不改变 HTTP 请求字段、响应字段、安装 token 或渲染结果。
- `NODE_SERVER_URL` 缺失和格式非法的既有错误语义保持。
- 旧全量接口仍可返回完整配置，四条敏感 render 保持兼容。
- 不新增环境变量、Secret、数据库迁移或运维脚本；部署配置介入为否。
- 本 PR 是 #4073 第一片，Issue 保持 OPEN；第二阶段将把剩余 render 与调用方、用途、区域和短期 token 绑定后下线旧接口。

## 调用链

```mermaid
flowchart TD
    subgraph T["业务入口"]
        T1["APM / CMDB / Log / Monitor\n地址与安装命令入口"]
        T2["短期 token render\n四条敏感渲染路径"]
    end

    subgraph N["NodeMgmt RPC"]
        N1["get_cloud_region_public_config\n固定 NODE_SERVER_URL"]
        N2["legacy envconfig\n全量解密配置"]
    end

    subgraph C["配置存储"]
        C1["SidecarEnv\n按服务端允许字段读取"]
    end

    T1 --> N1 --> C1
    T2 -. "第二阶段待迁移" .-> N2 --> C1
```

## 验证

- 修复前，公开 RPC 不存在且 8 条地址链路均使用全量接口，新增契约为 10 failed。
- `apps/node_mgmt/tests/test_cloud_region_public_config.py` 与 `apps/rpc/tests/test_node_mgmt_forwarding.py`：41 passed。
- Log 相关三个具体测试文件：35 passed。
- Monitor 相关五个具体测试文件：57 passed。
- CMDB/APM 相关四个具体测试文件：163 passed。
- 合计 296 passed；新增文件 Flake8、Python 编译和 diff-check 通过。

## 三轨门禁

- Standards：PASS。最小字段由服务端固定，迁移改动机械且有调用面登记，无原生 SQL、配置或无关格式化。
- Spec：PASS。完成用户选择 A 的公开地址首片，同时保留 token-render 兼容和明确第二阶段边界。
- Runtime Contract：PASS。PostgreSQL、真实 NodeMgmt handler/RPC、DRF 及四个业务模块调用链均通过。
- 质量评分：93 / 100，SCORE_PASS。

关联 Issue #4073。
