### PR TITLE
feat(监控): K8s Node/Pod 列表增加内置 IP 展示列

### DIFF
--- a/agents/webhookd/bk-lite-metric-collector.yaml
+++ b/agents/webhookd/bk-lite-metric-collector.yaml
@@ -687,7 +687,8 @@ data:
         # 监控链路只按 instance_id/node/pod/namespace/container/phase/reason/
         # condition/status/resource 及工作负载名聚合，其余维度未被任何查询消费，
         # 抓取时丢弃以削减传输与存储
-        - regex: uid|unit|created_by_kind|created_by_name|host_ip|pod_ip|host_network|priority_class|internal_ip|os_image|kernel_version|kubelet_version|container_runtime_version|kubeproxy_version|pod_cidr|system_uuid|provider_id
+        # pod_ip/internal_ip 保留供 Pod/Node 列表 IP 展示列读取；host_ip 为 Pod 宿主机 IP，仍丢弃
+        - regex: uid|unit|created_by_kind|created_by_name|host_ip|host_network|priority_class|os_image|kernel_version|kubelet_version|container_runtime_version|kubeproxy_version|pod_cidr|system_uuid|provider_id
           action: labeldrop
 
 ---

--- a/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
+++ b/deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml
@@ -704,7 +704,8 @@ data:
         # 监控链路只按 instance_id/node/pod/namespace/container/phase/reason/
         # condition/status/resource 及工作负载名聚合，其余维度未被任何查询消费，
         # 抓取时丢弃以削减传输与存储
-        - regex: uid|unit|created_by_kind|created_by_name|host_ip|pod_ip|host_network|priority_class|internal_ip|os_image|kernel_version|kubelet_version|container_runtime_version|kubeproxy_version|pod_cidr|system_uuid|provider_id
+        # pod_ip/internal_ip 保留供 Pod/Node 列表 IP 展示列读取；host_ip 为 Pod 宿主机 IP，仍丢弃
+        - regex: uid|unit|created_by_kind|created_by_name|host_ip|host_network|priority_class|os_image|kernel_version|kubelet_version|container_runtime_version|kubeproxy_version|pod_cidr|system_uuid|provider_id
           action: labeldrop
 
 ---

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/en.yaml
@@ -42,6 +42,9 @@ monitor_object_metric:
       name: Disk Utilization
       desc: Overall disk utilization of the Kubernetes cluster.
   Pod:
+    pod_info:
+      name: Pod Info
+      desc: Pod metadata from kube_pod_info, used as the carrier metric for the IP display column.
     pod_status_phase:
       name: Pod Phase
       desc: Current lifecycle phase of the Pod.
@@ -67,6 +70,9 @@ monitor_object_metric:
       name: Network Outbound Traffic
       desc: Outbound network traffic rate sent by the Pod.
   Node:
+    node_info:
+      name: Node Info
+      desc: Node metadata from kube_node_info, used as the carrier metric for the IP display column.
     node_status_condition:
       name: Node Status
       desc: Current operational condition of the node.

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml
@@ -40,6 +40,9 @@ monitor_object_metric:
       name: 磁盘使用率
       desc: Kubernetes 集群的整体磁盘使用率。
   Pod:
+    pod_info:
+      name: Pod 信息
+      desc: 来自 kube_pod_info 的 Pod 元数据，用作 IP 展示列的载体指标。
     pod_status_phase:
       name: Pod 阶段
       desc: Pod 当前的生命周期阶段。
@@ -65,6 +68,9 @@ monitor_object_metric:
       name: 网络出流量
       desc: Pod 发送的出向网络流量速率。
   Node:
+    node_info:
+      name: 节点信息
+      desc: 来自 kube_node_info 的节点元数据，用作 IP 展示列的载体指标。
     node_status_condition:
       name: 节点状态
       desc: 节点当前的运行状态。

--- a/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
+++ b/server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json
@@ -73,8 +73,19 @@
       "default_metric": "prometheus_remote_write_kube_pod_info",
       "instance_id_keys": ["instance_id", "pod"],
       "supplementary_indicators": ["pod_status_phase", "pod_cpu_utilization", "pod_memory_utilization"],
-      "display_fields": [{"name": "Pod Status", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "pod_status_phase"}]}, {"name": "CPU Utilization", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "pod_cpu_utilization"}]}, {"name": "Memory Utilization", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "pod_memory_utilization"}]}],
+      "display_fields": [{"name": "IP 地址", "type": "field", "role": "resource_ip", "variable_id": "vm_ip", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "pod_info", "field": "pod_ip"}]}, {"name": "Pod Status", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "pod_status_phase"}]}, {"name": "CPU Utilization", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "pod_cpu_utilization"}]}, {"name": "Memory Utilization", "sort_order": 3, "metrics": [{"plugin": "K8S", "metric": "pod_memory_utilization"}]}],
       "metrics": [
+        {
+          "metric_group": "Status",
+          "name": "pod_info",
+          "display_name": "Pod Info",
+          "instance_id_keys": ["instance_id", "pod"],
+          "data_type": "Number",
+          "unit": "counts",
+          "dimensions": [],
+          "description": "Pod metadata from kube_pod_info, used as the carrier metric for the IP display column.",
+          "query": "prometheus_remote_write_kube_pod_info{instance_type=\"k8s\",__$labels__}"
+        },
         {
           "metric_group": "Status",
           "name": "pod_status_phase",
@@ -174,8 +185,19 @@
       "default_metric": "prometheus_remote_write_kube_node_info",
       "instance_id_keys": ["instance_id", "node"],
       "supplementary_indicators": ["node_status_condition", "node_cpu_utilization", "node_memory_utilization", "node_disk_usage_rate"],
-      "display_fields": [{"name": "Node Status", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "node_status_condition"}]}, {"name": "CPU Utilization", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "node_cpu_utilization"}]}, {"name": "Memory Usage", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "node_memory_utilization"}]}, {"name": "Disk Usage", "sort_order": 3, "metrics": [{"plugin": "K8S", "metric": "node_disk_usage_rate"}]}],
+      "display_fields": [{"name": "IP 地址", "type": "field", "role": "resource_ip", "variable_id": "vm_ip", "sort_order": 0, "metrics": [{"plugin": "K8S", "metric": "node_info", "field": "internal_ip"}]}, {"name": "Node Status", "sort_order": 1, "metrics": [{"plugin": "K8S", "metric": "node_status_condition"}]}, {"name": "CPU Utilization", "sort_order": 2, "metrics": [{"plugin": "K8S", "metric": "node_cpu_utilization"}]}, {"name": "Memory Usage", "sort_order": 3, "metrics": [{"plugin": "K8S", "metric": "node_memory_utilization"}]}, {"name": "Disk Usage", "sort_order": 4, "metrics": [{"plugin": "K8S", "metric": "node_disk_usage_rate"}]}],
       "metrics": [
+        {
+          "metric_group": "Status",
+          "name": "node_info",
+          "display_name": "Node Info",
+          "instance_id_keys": ["instance_id", "node"],
+          "data_type": "Number",
+          "unit": "counts",
+          "dimensions": [],
+          "description": "Node metadata from kube_node_info, used as the carrier metric for the IP display column.",
+          "query": "prometheus_remote_write_kube_node_info{instance_type=\"k8s\",__$labels__}"
+        },
         {
           "metric_group": "Status",
           "name": "node_status_condition",


### PR DESCRIPTION
## Summary

K8s 监控对象 Node、Pod 的列表此前无法直接看到 IP，需要翻查字段或标签。本次为该两类子对象增加内置 IP 展示列，参考云平台子对象 IP（如腾讯云 CVM `resource_ip`）的方式：

- 采集链路：**保留** kube-state-metrics 原生上报的 `pod_ip` / `internal_ip` label（此前被 `labeldrop` 丢弃），`host_ip`（Pod 宿主机 IP）仍丢弃
- 插件配置：K8S 插件为 Pod / Node 各自新增载体指标 `pod_info` / `node_info`，并在 `display_fields` 声明 `type=field`、`role=resource_ip` 的「IP 地址」列
  - Pod → `pod_info.pod_ip`
  - Node → `node_info.internal_ip`

## 效果

- Node / Pod 列表可**直接看到 IP**，不再需要翻其它字段或标签
- IP 列位于实例名之后、上报时间之前，与基础对象 `asset.ip` 摘要列位置一致
- 无 IP 的实例（如 Pending Pod）展示为 `--`
- 支持按 IP 筛选 / 枚举

## 关键约定（与 readme §6.6 一致）

- 使用 KSM 原生 label 名，不统一改写为 `resource_ip`
- 告警变量 `variable_id` 用 `vm_ip`，不使用保留字 `resource_ip`
- IP 不写入 `dimensions`，不作为告警分组维度

## 涉及文件

- `agents/webhookd/bk-lite-metric-collector.yaml`（labeldrop 保留 `pod_ip`/`internal_ip`）
- `deploy/dist/bk-lite-kubernetes-collector/bk-lite-metric-collector.yaml`（同上，与 webhookd 同步）
- `server/apps/monitor/support-files/plugins/unknown/k8s/k8s/metrics.json`（新增载体指标 + IP 展示列）
- `server/apps/monitor/support-files/plugins/unknown/k8s/k8s/language/zh-Hans.yaml`、`en.yaml`（载体指标文案）

## 部署说明

1. 重新 apply 采集模板并滚动 vmagent，使新 scrape 的 series 带上 IP label
2. 执行 `python manage.py plugin_init` 同步 DB 种子到 `MonitorObject.display_fields`（用户已自定义展示列的对象不受影响）

## 测试

- 已验证 `metrics.json` 结构与 IP 列配置、两份采集模板 labeldrop 保持一致
- 契约测试新增 `test_vmagent_ksm_labeldrop_preserves_ip_labels`（未随本 PR 提交）