### PR TITLE
fix(apm): 查询地址与监控/日志对齐，读取 VICTORIATRACES_HOST

### DIFF
--- a/server/apps/apm/adapters/victoriatraces.py
+++ b/server/apps/apm/adapters/victoriatraces.py
@@ -157,7 +157,12 @@ class VictoriaTracesTelemetryStore:
         *,
         session: requests.Session | None = None,
     ):
-        self.endpoint = (endpoint or os.getenv("APM_VICTORIATRACES_QUERY_ENDPOINT") or "http://127.0.0.1:10428").rstrip("/")
+        self.endpoint = (
+            endpoint
+            or os.getenv("VICTORIATRACES_HOST")
+            or os.getenv("APM_VICTORIATRACES_QUERY_ENDPOINT")
+            or "http://127.0.0.1:10428"
+        ).rstrip("/")
         self.session = session or requests.Session()
         self.timeout = (3, int(os.getenv("APM_VICTORIATRACES_QUERY_TIMEOUT", "15")))
         self.verify = os.getenv("APM_VICTORIATRACES_VERIFY_TLS", "true").casefold() != "false"

--- a/server/apps/apm/services/health.py
+++ b/server/apps/apm/services/health.py
@@ -265,7 +265,11 @@ class RuntimeDependencyHealthProbe:
 
     def probe(self) -> dict[str, dict[str, object]]:
         checked_at = timezone.now().isoformat()
-        traces_endpoint = os.getenv("APM_VICTORIATRACES_QUERY_ENDPOINT", "http://127.0.0.1:10428")
+        traces_endpoint = (
+            os.getenv("VICTORIATRACES_HOST")
+            or os.getenv("APM_VICTORIATRACES_QUERY_ENDPOINT")
+            or "http://127.0.0.1:10428"
+        )
         trace_user = os.getenv("APM_VICTORIATRACES_USER", "")
         trace_password = os.getenv("APM_VICTORIATRACES_PASSWORD", "")
         result = {

--- a/server/apps/apm/tests/test_victoriatraces_adapter.py
+++ b/server/apps/apm/tests/test_victoriatraces_adapter.py
@@ -208,6 +208,24 @@ def test_transport_failures_are_mapped_to_trace_store_degradation():
         store.get_trace("a" * 32)
 
 
+def test_store_reads_victoria_traces_host(monkeypatch):
+    monkeypatch.delenv("APM_VICTORIATRACES_QUERY_ENDPOINT", raising=False)
+    monkeypatch.setenv("VICTORIATRACES_HOST", "http://victoria-traces:10428")
+
+    store = VictoriaTracesTelemetryStore()
+
+    assert store.endpoint == "http://victoria-traces:10428"
+
+
+def test_store_prefers_victoria_traces_host_over_legacy_query_endpoint(monkeypatch):
+    monkeypatch.setenv("VICTORIATRACES_HOST", "http://victoria-traces:10428")
+    monkeypatch.setenv("APM_VICTORIATRACES_QUERY_ENDPOINT", "http://127.0.0.1:10428")
+
+    store = VictoriaTracesTelemetryStore()
+
+    assert store.endpoint == "http://victoria-traces:10428"
+
+
 def _vector(**values):
     return {
         "status": "success",

--- a/server/envs/.env.example
+++ b/server/envs/.env.example
@@ -38,6 +38,8 @@ VICTORIALOGS_QUERY_LIMIT_MAX=1000
 VICTORIALOGS_FIELD_VALUES_LIMIT_MAX=1000
 VICTORIALOGS_HITS_FIELDS_LIMIT_MAX=100
 
+VICTORIATRACES_HOST=
+
 # webhookd 渲染请求（log/monitor/cmdb K8s 接入，会下发 NATS 凭据）的 TLS 校验：
 # 留空/true=校验系统CA（默认安全）；自签名内网填受信 CA 路径（如 /etc/ssl/webhook-ca.pem）；false=显式关闭（不推荐）
 WEBHOOK_SERVER_SSL_VERIFY=true


### PR DESCRIPTION
生产 compose 只注入 Docker 服务名，避免未配置时默认打 127.0.0.1 导致 VictoriaTraces 查询不可用。