### PR TITLE
bugfix: 隔离 Ansible 实时日志发布背压

### DIFF
--- a/agents/ansible-executor/service/ansible_runner.py
+++ b/agents/ansible-executor/service/ansible_runner.py
@@ -24,6 +24,11 @@ from service.runtime import current_entrypoint_command
 
 BASE_TASK_DIR = Path(os.getenv("ANSIBLE_WORK_DIR", "/tmp/ansible-executor"))
 DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024
+DEFAULT_STREAM_QUEUE_SIZE = 256
+DEFAULT_STREAM_BATCH_SIZE = 16
+DEFAULT_STREAM_FLUSH_TIMEOUT = 1.0
+DEFAULT_STREAM_MAX_LINE_BYTES = 16 * 1024
+STREAM_LINE_CHUNK_MARKER = "...[实时日志超长行分段]"
 PLAYBOOK_ARCHIVE_MAX_SIZE_BYTES = 20 * 1024 * 1024
 PLAYBOOK_ARCHIVE_MAX_MEMBERS = 2000
 PLAYBOOK_ARCHIVE_MAX_MEMBER_SIZE_BYTES = 5 * 1024 * 1024
@@ -683,9 +688,7 @@ def _build_host_credentials_inventory(workspace: Path, host_credentials: list[di
     legacy_password_ssh_host_count = 0
     known_hosts_file = os.getenv(_SSH_KNOWN_HOSTS_FILE_ENV, "").strip()
     if known_hosts_file and any(
-        item.get("password")
-        and str(item.get("connection", "")).strip().lower() == "ssh"
-        and not _get_explicit_ssh_common_args(item)
+        item.get("password") and str(item.get("connection", "")).strip().lower() == "ssh" and not _get_explicit_ssh_common_args(item)
         for item in host_credentials
     ):
         _validate_known_hosts_file(known_hosts_file)
@@ -1059,8 +1062,12 @@ class LineEventStreamer:
     replacement and have their trailing ``\\r``/``\\n`` stripped.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, max_line_bytes: int = DEFAULT_STREAM_MAX_LINE_BYTES) -> None:
+        if max_line_bytes <= 0:
+            raise ValueError("max_line_bytes must be positive")
         self._buffer = bytearray()
+        self._max_line_bytes = max_line_bytes
+        self.chunked_lines = 0
 
     def feed(self, chunk: bytes) -> list[str]:
         if not chunk:
@@ -1069,6 +1076,13 @@ class LineEventStreamer:
         lines: list[str] = []
         while True:
             idx = self._buffer.find(b"\n")
+            if idx > self._max_line_bytes or (idx == -1 and len(self._buffer) > self._max_line_bytes):
+                chunk_size = self._utf8_safe_chunk_size()
+                raw_line = bytes(self._buffer[:chunk_size])
+                del self._buffer[:chunk_size]
+                lines.append(f"{self._decode_line(raw_line)}{STREAM_LINE_CHUNK_MARKER}")
+                self.chunked_lines += 1
+                continue
             if idx == -1:
                 break
             raw_line = bytes(self._buffer[:idx])
@@ -1087,28 +1101,205 @@ class LineEventStreamer:
     def _decode_line(raw_line: bytes) -> str:
         return raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
 
+    def _utf8_safe_chunk_size(self) -> int:
+        """避免把有效 UTF-8 多字节字符切在实时日志分段边界。"""
+        candidate = bytes(self._buffer[: self._max_line_bytes])
+        try:
+            candidate.decode("utf-8")
+        except UnicodeDecodeError as error:
+            if error.reason == "unexpected end of data" and error.start > 0:
+                return error.start
+        return self._max_line_bytes
+
 
 StreamPublish = Callable[[str, bytes], Awaitable[None]]
 
 
-def build_stream_log_payload(execution_id: str, line: str) -> bytes:
+def build_stream_log_payload(
+    execution_id: str,
+    line: str,
+    *,
+    event_type: str | None = None,
+    dropped_lines: int = 0,
+) -> bytes:
     payload = {
         "execution_id": execution_id,
         "stream": "stdout",
         "line": line,
         "timestamp": datetime.now(UTC).isoformat(),
     }
+    if event_type:
+        payload["type"] = event_type
+    if dropped_lines:
+        payload["dropped_lines"] = dropped_lines
     return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+
+
+class BufferedStreamPublisher:
+    """有界、顺序、best-effort 的实时日志发布器。"""
+
+    _STOP = object()
+
+    def __init__(
+        self,
+        publish: StreamPublish,
+        subject: str,
+        execution_id: str,
+        *,
+        queue_size: int,
+        batch_size: int,
+    ) -> None:
+        if queue_size <= 0 or batch_size <= 0:
+            raise ValueError("stream queue_size and batch_size must be positive")
+        self._publish = publish
+        self._subject = subject
+        self._execution_id = execution_id
+        self._queue: asyncio.Queue[str | object] = asyncio.Queue(maxsize=queue_size)
+        self._batch_size = min(batch_size, queue_size)
+        self._worker: asyncio.Task | None = None
+        self._closing = False
+        self._pending_gap = 0
+        self._inflight_lines = 0
+        self.lines_dropped = 0
+        self.publish_failures = 0
+        self.flush_timed_out = False
+
+    def start(self) -> None:
+        if self._worker is None:
+            self._worker = asyncio.create_task(self._run())
+
+    def offer(self, line: str) -> None:
+        if self._closing:
+            self._record_dropped(1)
+            return
+        self.start()
+        try:
+            self._queue.put_nowait(line)
+        except asyncio.QueueFull:
+            self._record_dropped(1)
+
+    def _record_dropped(self, count: int) -> None:
+        self.lines_dropped += count
+        self._pending_gap += count
+
+    async def _publish_lines(self, lines: list[str]) -> None:
+        try:
+            await self._publish(
+                self._subject,
+                build_stream_log_payload(self._execution_id, "\n".join(lines)),
+            )
+        except Exception as publish_err:  # noqa: BLE001 - streaming is best-effort
+            self.publish_failures += 1
+            self._record_dropped(len(lines))
+            logger.warning("stream log publish failed: %s", publish_err)
+
+    async def _publish_gap(self) -> None:
+        if not self._pending_gap:
+            return
+        dropped_lines = self._pending_gap
+        self._pending_gap = 0
+        line = f"[实时日志缺口] 省略 {dropped_lines} 行；请以任务终态输出为准（终态可能截断）"
+        try:
+            await self._publish(
+                self._subject,
+                build_stream_log_payload(
+                    self._execution_id,
+                    line,
+                    event_type="gap",
+                    dropped_lines=dropped_lines,
+                ),
+            )
+        except Exception as publish_err:  # noqa: BLE001 - streaming is best-effort
+            self.publish_failures += 1
+            self._pending_gap += dropped_lines
+            logger.warning("stream log gap publish failed: %s", publish_err)
+
+    async def _run(self) -> None:
+        stop_after_batch = False
+        while not stop_after_batch:
+            item = await self._queue.get()
+            if item is self._STOP:
+                break
+
+            lines = [item]
+            while len(lines) < self._batch_size:
+                try:
+                    item = self._queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+                if item is self._STOP:
+                    stop_after_batch = True
+                    break
+                lines.append(item)
+
+            self._inflight_lines = len(lines)
+            await self._publish_lines(lines)
+            self._inflight_lines = 0
+            await self._publish_gap()
+
+        await self._publish_gap()
+
+    def _discard_queued_lines(self) -> int:
+        discarded = 0
+        while True:
+            try:
+                item = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            if item is not self._STOP:
+                discarded += 1
+        return discarded
+
+    async def close(self, timeout: float) -> dict[str, Any]:
+        if self._worker is None:
+            return self.metadata()
+        if self._closing:
+            return self.metadata()
+        self._closing = True
+
+        async def _finish() -> None:
+            await self._queue.put(self._STOP)
+            await self._worker
+
+        try:
+            await asyncio.wait_for(_finish(), timeout=max(timeout, 0.001))
+        except asyncio.TimeoutError:
+            self.flush_timed_out = True
+            self._record_dropped(self._discard_queued_lines() + self._inflight_lines)
+            self._inflight_lines = 0
+            self._worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._worker
+            logger.warning(
+                "stream log tail flush timed out: execution_id=%s dropped=%s",
+                self._execution_id,
+                self.lines_dropped,
+            )
+        except Exception as publish_err:  # noqa: BLE001 - streaming is best-effort
+            self.publish_failures += 1
+            logger.warning("stream log worker failed: %s", publish_err)
+        return self.metadata()
+
+    def metadata(self) -> dict[str, Any]:
+        return {
+            "stream_lines_dropped": self.lines_dropped,
+            "stream_publish_failures": self.publish_failures,
+            "stream_flush_timed_out": self.flush_timed_out,
+        }
 
 
 async def run_command(
     cmd: list[str],
-    timeout: int,
+    timeout: int | float,
     max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
     *,
     stream_publish: StreamPublish | None = None,
     stream_log_topic: str | None = None,
     execution_id: str | None = None,
+    stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
+    stream_batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    stream_flush_timeout: float = DEFAULT_STREAM_FLUSH_TIMEOUT,
+    stream_max_line_bytes: int = DEFAULT_STREAM_MAX_LINE_BYTES,
 ) -> tuple[int, str, dict[str, Any]]:
     process_kwargs: dict[str, Any] = {}
     if os.name == "posix":
@@ -1121,15 +1312,34 @@ async def run_command(
     )
 
     streaming_enabled = bool(stream_publish and stream_log_topic and execution_id)
-    streamer = LineEventStreamer() if streaming_enabled else None
+    streamer = LineEventStreamer(max_line_bytes=stream_max_line_bytes) if streaming_enabled else None
+    stream_publisher = (
+        BufferedStreamPublisher(
+            stream_publish,
+            stream_log_topic,
+            execution_id,
+            queue_size=stream_queue_size,
+            batch_size=stream_batch_size,
+        )
+        if streaming_enabled
+        else None
+    )
+    if stream_publisher is not None:
+        stream_publisher.start()
 
-    async def _publish_line(line: str) -> None:
-        # Streaming is best-effort: a publish failure must never break the run.
-        try:
-            data = build_stream_log_payload(execution_id, line)
-            await stream_publish(stream_log_topic, data)
-        except Exception as publish_err:  # noqa: BLE001 - intentionally swallowed
-            logger.warning("stream log publish failed: %s", publish_err)
+    async def _terminate_process() -> None:
+        if proc.returncode is not None:
+            return
+        if os.name == "posix":
+            with contextlib.suppress(ProcessLookupError):
+                os.killpg(proc.pid, signal.SIGKILL)
+        else:
+            proc.kill()
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        if proc.returncode is None:
+            proc.kill()
+            await proc.wait()
 
     async def _collect_output() -> tuple[bytes, dict[str, Any]]:
         assert proc.stdout is not None
@@ -1153,44 +1363,56 @@ async def run_command(
                 truncated = True
             if streamer is not None:
                 for line in streamer.feed(chunk):
-                    await _publish_line(line)
+                    stream_publisher.offer(line)
 
         if streamer is not None:
             trailing = streamer.flush()
             if trailing is not None:
-                await _publish_line(trailing)
+                stream_publisher.offer(trailing)
 
         return b"".join(chunks), {
             "truncated": truncated,
             "output_bytes_total": total_bytes,
             "output_bytes_retained": retained_bytes,
             "output_max_bytes": max_output_bytes,
+            "stream_line_chunks": streamer.chunked_lines if streamer is not None else 0,
         }
 
+    timed_out = False
+    output_meta = {
+        "truncated": False,
+        "output_bytes_total": 0,
+        "output_bytes_retained": 0,
+        "output_max_bytes": max_output_bytes,
+        "stream_line_chunks": 0,
+    }
     try:
         stdout, output_meta = await asyncio.wait_for(_collect_output(), timeout=timeout)
         await asyncio.wait_for(proc.wait(), timeout=5)
+    except asyncio.CancelledError:
+        await asyncio.shield(_terminate_process())
+        raise
     except asyncio.TimeoutError:
-        if os.name == "posix":
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(proc.pid, signal.SIGKILL)
-        else:
-            proc.kill()
-        with contextlib.suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(proc.wait(), timeout=5)
-        if proc.returncode is None:
-            proc.kill()
-            await proc.wait()
+        await _terminate_process()
         logger.error("command timed out: %s", " ".join(shlex.quote(part) for part in cmd))
+        timed_out = True
+        stdout = b""
+        output_meta = {
+            "truncated": False,
+            "output_bytes_total": 0,
+            "output_bytes_retained": 0,
+            "output_max_bytes": max_output_bytes,
+            "stream_line_chunks": streamer.chunked_lines if streamer is not None else 0,
+        }
+    finally:
+        if stream_publisher is not None:
+            output_meta.update(await stream_publisher.close(stream_flush_timeout))
+
+    if timed_out:
         return (
             124,
             "command timed out",
-            {
-                "truncated": False,
-                "output_bytes_total": 0,
-                "output_bytes_retained": 0,
-                "output_max_bytes": max_output_bytes,
-            },
+            output_meta,
         )
     output, decode_strategy = decode_command_output(stdout)
     exit_code = proc.returncode or 0

--- a/agents/ansible-executor/service/nats_service.py
+++ b/agents/ansible-executor/service/nats_service.py
@@ -198,6 +198,10 @@ class AnsibleNATSService(NATSTopologyMixin, CallbackDeliveryMixin):
             "output_bytes_total": int(output_meta.get("output_bytes_total", len(output.encode("utf-8")))),
             "output_bytes_retained": int(output_meta.get("output_bytes_retained", len(output.encode("utf-8")))),
             "output_max_bytes": int(output_meta.get("output_max_bytes", 0)),
+            "stream_lines_dropped": int(output_meta.get("stream_lines_dropped", 0)),
+            "stream_publish_failures": int(output_meta.get("stream_publish_failures", 0)),
+            "stream_flush_timed_out": bool(output_meta.get("stream_flush_timed_out", False)),
+            "stream_line_chunks": int(output_meta.get("stream_line_chunks", 0)),
         }
 
         return {

--- a/agents/ansible-executor/service/remote_shell_stream.py
+++ b/agents/ansible-executor/service/remote_shell_stream.py
@@ -14,10 +14,14 @@ from typing import Any
 
 from core.config import logger
 from service.ansible_runner import (
+    DEFAULT_STREAM_BATCH_SIZE,
+    DEFAULT_STREAM_FLUSH_TIMEOUT,
+    DEFAULT_STREAM_MAX_LINE_BYTES,
+    DEFAULT_STREAM_QUEUE_SIZE,
     DEFAULT_MAX_OUTPUT_BYTES,
+    BufferedStreamPublisher,
     LineEventStreamer,
     StreamPublish,
-    build_stream_log_payload,
     parse_ansible_output_per_host,
     run_command,
 )
@@ -192,6 +196,10 @@ async def run_remote_shell_stream(
     poll_interval: float = 1.0,
     command_runner: CommandRunner = run_command,
     sleep: Sleep = asyncio.sleep,
+    stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
+    stream_batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    stream_flush_timeout: float = DEFAULT_STREAM_FLUSH_TIMEOUT,
+    stream_max_line_bytes: int = DEFAULT_STREAM_MAX_LINE_BYTES,
 ) -> tuple[int, str, dict[str, Any]]:
     """后台执行 Linux 远端脚本，并通过短 Ansible 轮询实时发布新增日志行。"""
     start_args, poll_args, stop_args, remote_dir = _build_remote_commands(
@@ -206,12 +214,18 @@ async def run_remote_shell_stream(
     states: dict[str, _HostState] = {}
     retained_bytes = 0
     truncated = False
+    stream_publisher = BufferedStreamPublisher(
+        stream_publish,
+        stream_log_topic,
+        execution_id,
+        queue_size=stream_queue_size,
+        batch_size=stream_batch_size,
+    )
+    stream_publisher.start()
+    stream_meta: dict[str, Any] = {}
 
     async def publish_line(line: str) -> None:
-        try:
-            await stream_publish(stream_log_topic, build_stream_log_payload(execution_id, line))
-        except Exception as error:  # noqa: BLE001 - 流式日志是 best effort，不影响任务结果
-            logger.warning("remote stream log publish failed: %s", error)
+        stream_publisher.offer(line)
 
     async def append_chunk(state: _HostState, chunk: bytes) -> None:
         nonlocal retained_bytes, truncated
@@ -232,13 +246,14 @@ async def run_remote_shell_stream(
         start_results = parse_ansible_output_per_host(start_output)
         for result in start_results:
             host = str(result.get("host", ""))
-            state = _HostState(host=host)
+            state = _HostState(host=host, streamer=LineEventStreamer(max_line_bytes=stream_max_line_bytes))
             if result.get("status") != "success" or _STARTED_MARKER not in str(result.get("stdout", "")):
                 state.running = False
                 state.exit_code = int(result.get("exit_code") or 1)
                 await append_chunk(state, str(result.get("stderr") or result.get("stdout") or "start failed").encode("utf-8"))
             states[host] = state
         if not states:
+            stream_meta = await stream_publisher.close(stream_flush_timeout)
             return (
                 start_code or 1,
                 start_output,
@@ -247,6 +262,8 @@ async def run_remote_shell_stream(
                     "output_bytes_total": len(start_output.encode("utf-8")),
                     "output_bytes_retained": len(start_output.encode("utf-8")),
                     "output_max_bytes": max_output_bytes,
+                    "stream_line_chunks": 0,
+                    **stream_meta,
                 },
             )
 
@@ -290,6 +307,7 @@ async def run_remote_shell_stream(
     finally:
         with contextlib.suppress(Exception):
             await command_runner(stop_command, min(timeout, 30))
+        stream_meta = await stream_publisher.close(stream_flush_timeout)
         logger.info("remote stream workspace cleaned: %s", remote_dir)
 
     output_parts: list[str] = []
@@ -310,5 +328,7 @@ async def run_remote_shell_stream(
             "output_bytes_total": total_bytes,
             "output_bytes_retained": retained_bytes,
             "output_max_bytes": max_output_bytes,
+            "stream_line_chunks": sum(state.streamer.chunked_lines for state in states.values()),
+            **stream_meta,
         },
     )

--- a/agents/ansible-executor/service/winrm_stream.py
+++ b/agents/ansible-executor/service/winrm_stream.py
@@ -9,8 +9,17 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from core.config import logger
-from service.ansible_runner import DEFAULT_MAX_OUTPUT_BYTES, LineEventStreamer, StreamPublish, build_stream_log_payload, decode_command_output
+from service.ansible_runner import (
+    DEFAULT_MAX_OUTPUT_BYTES,
+    DEFAULT_STREAM_BATCH_SIZE,
+    DEFAULT_STREAM_FLUSH_TIMEOUT,
+    DEFAULT_STREAM_MAX_LINE_BYTES,
+    DEFAULT_STREAM_QUEUE_SIZE,
+    BufferedStreamPublisher,
+    LineEventStreamer,
+    StreamPublish,
+    decode_command_output,
+)
 from winrm.exceptions import WinRMOperationTimeoutError
 from winrm.protocol import Protocol
 
@@ -155,6 +164,10 @@ async def run_winrm_stream(
     execution_id: str,
     max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES,
     protocol_factory: ProtocolFactory = _build_protocol,
+    stream_queue_size: int = DEFAULT_STREAM_QUEUE_SIZE,
+    stream_batch_size: int = DEFAULT_STREAM_BATCH_SIZE,
+    stream_flush_timeout: float = DEFAULT_STREAM_FLUSH_TIMEOUT,
+    stream_max_line_bytes: int = DEFAULT_STREAM_MAX_LINE_BYTES,
 ) -> tuple[int, str, dict[str, Any]]:
     """为每个 Windows 目标建立一个 WinRM shell，在同一会话中持续接收输出。"""
     if not host_credentials:
@@ -162,18 +175,29 @@ async def run_winrm_stream(
     command, arguments = _build_command(script_content, script_type)
     loop = asyncio.get_running_loop()
     queue: asyncio.Queue[_ThreadEvent] = asyncio.Queue(maxsize=max(4, len(host_credentials) * 2))
-    states = [_HostState(host=str(item.get("host") or "")) for item in host_credentials]
+    states = [
+        _HostState(
+            host=str(item.get("host") or ""),
+            streamer=LineEventStreamer(max_line_bytes=stream_max_line_bytes),
+        )
+        for item in host_credentials
+    ]
     retained_bytes = 0
     truncated = False
+    stream_publisher = BufferedStreamPublisher(
+        stream_publish,
+        stream_log_topic,
+        execution_id,
+        queue_size=stream_queue_size,
+        batch_size=stream_batch_size,
+    )
+    stream_publisher.start()
 
     def emit(event: _ThreadEvent) -> None:
         asyncio.run_coroutine_threadsafe(queue.put(event), loop).result()
 
     async def publish_line(line: str) -> None:
-        try:
-            await stream_publish(stream_log_topic, build_stream_log_payload(execution_id, line))
-        except Exception as error:  # noqa: BLE001 - 日志发布是 best effort
-            logger.warning("WinRM stream log publish failed: %s", error)
+        stream_publisher.offer(line)
 
     workers = [
         asyncio.create_task(
@@ -191,30 +215,34 @@ async def run_winrm_stream(
         for index, credential in enumerate(host_credentials)
     ]
     completed = 0
-    while completed < len(states):
-        event = await queue.get()
-        state = states[event.index]
-        if event.kind == "done":
-            state.exit_code = event.exit_code
-            trailing = state.streamer.flush()
-            if trailing is not None:
-                await publish_line(trailing)
-            completed += 1
-            continue
+    stream_meta: dict[str, Any] = {}
+    try:
+        while completed < len(states):
+            event = await queue.get()
+            state = states[event.index]
+            if event.kind == "done":
+                state.exit_code = event.exit_code
+                trailing = state.streamer.flush()
+                if trailing is not None:
+                    await publish_line(trailing)
+                completed += 1
+                continue
 
-        state.total_bytes += len(event.chunk)
-        remaining = max_output_bytes - retained_bytes
-        kept = b""
-        if remaining > 0:
-            kept = event.chunk[:remaining]
-            state.retained.extend(kept)
-            retained_bytes += len(kept)
-        if len(event.chunk) > max(remaining, 0):
-            truncated = True
-        for line in state.streamer.feed(kept):
-            await publish_line(line)
+            state.total_bytes += len(event.chunk)
+            remaining = max_output_bytes - retained_bytes
+            kept = b""
+            if remaining > 0:
+                kept = event.chunk[:remaining]
+                state.retained.extend(kept)
+                retained_bytes += len(kept)
+            if len(event.chunk) > max(remaining, 0):
+                truncated = True
+            for line in state.streamer.feed(event.chunk):
+                await publish_line(line)
 
-    await asyncio.gather(*workers)
+        await asyncio.gather(*workers)
+    finally:
+        stream_meta = await stream_publisher.close(stream_flush_timeout)
     output_parts = []
     for state in states:
         raw_status = "CHANGED" if state.exit_code == 0 else "FAILED"
@@ -231,5 +259,7 @@ async def run_winrm_stream(
             "output_bytes_total": total_bytes,
             "output_bytes_retained": retained_bytes,
             "output_max_bytes": max_output_bytes,
+            "stream_line_chunks": sum(state.streamer.chunked_lines for state in states),
+            **stream_meta,
         },
     )

--- a/agents/ansible-executor/tests/test_nats_service.py
+++ b/agents/ansible-executor/tests/test_nats_service.py
@@ -866,6 +866,10 @@ def test_build_task_result_keeps_structured_results_when_output_is_truncated(mon
             "output_bytes_total": 1024,
             "output_bytes_retained": 32,
             "output_max_bytes": 32,
+            "stream_lines_dropped": 17,
+            "stream_publish_failures": 2,
+            "stream_flush_timed_out": True,
+            "stream_line_chunks": 3,
         },
         "",
     )
@@ -876,6 +880,10 @@ def test_build_task_result_keeps_structured_results_when_output_is_truncated(mon
     assert result["result_summary"]["output_bytes_total"] == 1024
     assert result["result_summary"]["output_bytes_retained"] == 32
     assert result["result_summary"]["output_max_bytes"] == 32
+    assert result["result_summary"]["stream_lines_dropped"] == 17
+    assert result["result_summary"]["stream_publish_failures"] == 2
+    assert result["result_summary"]["stream_flush_timed_out"] is True
+    assert result["result_summary"]["stream_line_chunks"] == 3
 
 
 class RecordingNATSClient(DummyNATSClient):

--- a/agents/ansible-executor/tests/test_remote_shell_stream.py
+++ b/agents/ansible-executor/tests/test_remote_shell_stream.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import subprocess
@@ -18,7 +19,7 @@ def _poll_body(chunk: bytes, status: str) -> str:
 
 
 @pytest.mark.asyncio
-async def test_remote_shell_stream_publishes_each_poll_before_command_finishes():
+async def test_remote_shell_stream_decouples_polling_and_batches_in_order():
     events: list[str] = []
     responses = iter(
         [
@@ -58,15 +59,49 @@ async def test_remote_shell_stream_publishes_each_poll_before_command_finishes()
     assert code == 0
     assert "first\nsecond" in output
     assert output_meta["truncated"] is False
-    assert events == [
-        "command-returned",
-        "command-returned",
-        "publish:job.stream.23.ansible:first",
-        "sleep",
-        "command-returned",
-        "publish:job.stream.23.ansible:second",
-        "command-returned",
-    ]
+    assert events.count("command-returned") == 4
+    assert events.index("sleep") < next(index for index, event in enumerate(events) if event.startswith("publish:"))
+    published = [event.rsplit(":", 1)[-1] for event in events if event.startswith("publish:")]
+    assert "\n".join(published).splitlines() == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_remote_shell_stream_slow_publisher_does_not_consume_command_budget():
+    lines = "".join(f"line{i}\n" for i in range(100)).encode()
+    responses = iter(
+        [
+            (0, _ansible_result("192.0.2.10", "__BKLITE_STREAM_STARTED__"), {}),
+            (0, _ansible_result("192.0.2.10", _poll_body(lines, "0")), {}),
+            (0, _ansible_result("192.0.2.10", "cleaned"), {}),
+        ]
+    )
+
+    async def command_runner(_command, _timeout, **_kwargs):
+        return next(responses)
+
+    async def slow_publisher(_subject, _payload):
+        await asyncio.sleep(0.05)
+
+    started = time.monotonic()
+    code, output, meta = await run_remote_shell_stream(
+        ["ansible", "all", "-i", "inventory", "-m", "shell", "-a", "ignored"],
+        script_content="echo ignored",
+        shell_executable="/bin/bash",
+        timeout=1,
+        stream_publish=slow_publisher,
+        stream_log_topic="job.stream.25.ansible",
+        execution_id="25",
+        poll_interval=0,
+        command_runner=command_runner,
+        stream_queue_size=4,
+        stream_batch_size=2,
+        stream_flush_timeout=0.05,
+    )
+
+    assert code == 0
+    assert "line99" in output
+    assert time.monotonic() - started < 0.5
+    assert meta["stream_lines_dropped"] > 0
 
 
 @pytest.mark.asyncio

--- a/agents/ansible-executor/tests/test_stream_log.py
+++ b/agents/ansible-executor/tests/test_stream_log.py
@@ -1,7 +1,10 @@
+import asyncio
 import json
 import sys
+import time
 
 import pytest
+from service import ansible_runner as runner_module
 from service.ansible_runner import LineEventStreamer, run_command
 
 # ---------------------------------------------------------------------------
@@ -65,18 +68,43 @@ def test_line_streamer_decodes_utf8_with_replacement():
     assert lines == ["中文行"]
 
 
+def test_line_streamer_chunks_oversized_line_with_visible_marker():
+    streamer = LineEventStreamer(max_line_bytes=4)
+
+    lines = _drain(streamer, [b"abcdefghij\n"])
+
+    assert lines == [
+        "abcd...[实时日志超长行分段]",
+        "efgh...[实时日志超长行分段]",
+        "ij",
+    ]
+    assert streamer.chunked_lines == 2
+
+
+def test_line_streamer_does_not_split_valid_utf8_character():
+    streamer = LineEventStreamer(max_line_bytes=4)
+
+    lines = _drain(streamer, ["中文中文\n".encode("utf-8")])
+
+    assert "�" not in "".join(lines)
+    assert "".join(line.replace("...[实时日志超长行分段]", "") for line in lines) == "中文中文"
+
+
 # ---------------------------------------------------------------------------
 # Integration tests: run_command streams stdout line-by-line via callback.
 # ---------------------------------------------------------------------------
 
 
 class FakePublisher:
-    def __init__(self, fail: bool = False):
+    def __init__(self, fail: bool = False, delay: float = 0):
         self.calls: list[tuple[str, bytes]] = []
         self.fail = fail
+        self.delay = delay
 
     async def publish(self, subject: str, data: bytes) -> None:
         self.calls.append((subject, data))
+        if self.delay:
+            await asyncio.sleep(self.delay)
         if self.fail:
             raise RuntimeError("nats down")
 
@@ -101,7 +129,7 @@ async def test_run_command_streams_each_line():
     assert "line0" in output and "line2" in output
 
     events = publisher.decoded()
-    assert [e["line"] for e in events] == ["line0", "line1", "line2"]
+    assert "\n".join(e["line"] for e in events).splitlines() == ["line0", "line1", "line2"]
     # Topic correct on every publish.
     assert all(subject == "bk.ans_exec.stream.exec-1" for subject, _ in publisher.calls)
     # Flat JSON contract.
@@ -144,7 +172,7 @@ async def test_run_command_no_streaming_without_publisher():
 async def test_run_command_swallows_publish_errors():
     publisher = FakePublisher(fail=True)
     # Even though every publish raises, the command must complete and return output.
-    code, output, _ = await run_command(
+    code, output, meta = await run_command(
         [sys.executable, "-c", "print('still works')"],
         timeout=10,
         stream_publish=publisher.publish,
@@ -155,3 +183,145 @@ async def test_run_command_swallows_publish_errors():
     assert output.strip() == "still works"
     # Publish was attempted (and raised) at least once.
     assert len(publisher.calls) >= 1
+    assert meta["stream_lines_dropped"] >= 1
+    assert meta["stream_publish_failures"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_slow_publisher_does_not_consume_command_timeout():
+    publisher = FakePublisher(delay=0.05)
+    script = "for i in range(100): print('line%d' % i)"
+
+    started = time.monotonic()
+    code, output, meta = await run_command(
+        [sys.executable, "-c", script],
+        timeout=0.2,
+        stream_publish=publisher.publish,
+        stream_log_topic="bk.stream",
+        execution_id="exec-slow",
+        stream_queue_size=4,
+        stream_batch_size=2,
+        stream_flush_timeout=0.05,
+    )
+    elapsed = time.monotonic() - started
+
+    assert code == 0
+    assert "line99" in output
+    assert elapsed < 0.5
+    assert meta["stream_lines_dropped"] > 0
+    assert meta["stream_flush_timed_out"] is True
+
+
+@pytest.mark.asyncio
+async def test_stream_queue_batches_lines_in_order():
+    publisher = FakePublisher()
+    script = "for i in range(100): print('line%d' % i)"
+
+    code, output, meta = await run_command(
+        [sys.executable, "-c", script],
+        timeout=2,
+        stream_publish=publisher.publish,
+        stream_log_topic="bk.stream",
+        execution_id="exec-batch",
+        stream_queue_size=128,
+        stream_batch_size=20,
+        stream_flush_timeout=1,
+    )
+
+    assert code == 0
+    assert "line99" in output
+    events = [event for event in publisher.decoded() if event.get("type") != "gap"]
+    assert "\n".join(event["line"] for event in events).splitlines() == [f"line{i}" for i in range(100)]
+    assert len(events) <= 5
+    assert meta["stream_lines_dropped"] == 0
+    assert meta["stream_flush_timed_out"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_queue_saturation_emits_visible_gap_event():
+    release = asyncio.Event()
+    publishing = asyncio.Event()
+    calls = []
+
+    async def gated_publish(subject, data):
+        calls.append((subject, data))
+        if len(calls) == 1:
+            publishing.set()
+            await release.wait()
+
+    task = asyncio.create_task(
+        run_command(
+            [sys.executable, "-c", "for i in range(50): print('line%d' % i)"],
+            timeout=1,
+            stream_publish=gated_publish,
+            stream_log_topic="bk.stream",
+            execution_id="exec-gap",
+            stream_queue_size=2,
+            stream_batch_size=1,
+            stream_flush_timeout=1,
+        )
+    )
+    await asyncio.wait_for(publishing.wait(), timeout=1)
+    await asyncio.sleep(0.05)
+    release.set()
+    code, output, meta = await task
+
+    assert code == 0
+    assert "line49" in output
+    events = [json.loads(data.decode("utf-8")) for _, data in calls]
+    gap_events = [event for event in events if event.get("type") == "gap"]
+    assert gap_events
+    assert gap_events[0]["dropped_lines"] == meta["stream_lines_dropped"]
+    assert "实时日志缺口" in gap_events[0]["line"]
+    assert meta["stream_lines_dropped"] > 0
+
+
+@pytest.mark.asyncio
+async def test_run_command_cancellation_terminates_subprocess(monkeypatch):
+    read_started = asyncio.Event()
+    never_finishes = asyncio.Event()
+    killed = []
+
+    class BlockingStdout:
+        async def read(self, _size):
+            read_started.set()
+            await never_finishes.wait()
+
+    class FakeProcess:
+        stdout = BlockingStdout()
+        pid = 4242
+        returncode = None
+
+        def kill(self):
+            killed.append("kill")
+            self.returncode = -9
+
+        async def wait(self):
+            self.returncode = -9
+            return self.returncode
+
+    process = FakeProcess()
+
+    async def fake_create_subprocess_exec(*_args, **_kwargs):
+        return process
+
+    monkeypatch.setattr(runner_module.asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr(runner_module.os, "killpg", lambda pid, sig: killed.append((pid, sig)))
+
+    task = asyncio.create_task(
+        run_command(
+            ["fake-command"],
+            timeout=10,
+            stream_publish=FakePublisher().publish,
+            stream_log_topic="bk.stream",
+            execution_id="exec-cancel",
+        )
+    )
+    await asyncio.wait_for(read_started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert killed
+    assert process.returncode == -9

--- a/agents/ansible-executor/tests/test_winrm_stream.py
+++ b/agents/ansible-executor/tests/test_winrm_stream.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import time
 
 import pytest
 from service.winrm_stream import _build_command, _build_protocol, run_winrm_stream
@@ -104,7 +106,36 @@ async def test_winrm_stream_bounds_retained_and_streamed_partial_line():
     assert code == 0
     assert "xxxxxxxxxx" in output
     assert "x" * 11 not in output
-    assert lines == ["xxxxxxxxxx"]
+    assert lines == ["x" * 20]
     assert meta["truncated"] is True
     assert meta["output_bytes_total"] == 20
     assert meta["output_bytes_retained"] == 10
+
+
+@pytest.mark.asyncio
+async def test_winrm_stream_slow_publisher_does_not_block_output_receive():
+    protocol = _Protocol()
+    protocol.responses = iter([("".join(f"line{i}\n" for i in range(100)).encode(), b"", 0, True)])
+
+    async def slow_publisher(_subject, _payload):
+        await asyncio.sleep(0.05)
+
+    started = time.monotonic()
+    code, output, meta = await run_winrm_stream(
+        [{"host": "10.10.90.120"}],
+        script_content="Write-Output ignored",
+        script_type="powershell",
+        timeout=1,
+        stream_publish=slow_publisher,
+        stream_log_topic="job.stream.33.ansible",
+        execution_id="33",
+        stream_queue_size=4,
+        stream_batch_size=2,
+        stream_flush_timeout=0.05,
+        protocol_factory=lambda credential: protocol,
+    )
+
+    assert code == 0
+    assert "line99" in output
+    assert time.monotonic() - started < 0.5
+    assert meta["stream_lines_dropped"] > 0

--- a/server/apps/job_mgmt/tests/test_execution_stream_service_async.py
+++ b/server/apps/job_mgmt/tests/test_execution_stream_service_async.py
@@ -13,11 +13,12 @@ pytestmark = pytest.mark.unit
 def _collect(async_gen):
     async def _run():
         return [chunk async for chunk in async_gen]
+
     return asyncio.run(_run())
 
 
 def _payloads(chunks):
-    return [json.loads(c[len("data: "):].strip()) for c in chunks if c.startswith("data: ") and "[DONE]" not in c]
+    return [json.loads(c[len("data: ") :].strip()) for c in chunks if c.startswith("data: ") and "[DONE]" not in c]
 
 
 def test_publish_done_sentinel_publishes_expected_payload():
@@ -49,12 +50,14 @@ async def _fake_source(items):
 
 
 def test_stream_events_replays_then_live_then_stops_on_all_done():
-    source = _fake_source([
-        {"target_key": "a", "stream": "stdout", "line": "hist-1"},
-        {"target_key": "a", "stream": "stdout", "line": "live-1"},
-        {"target_key": "a", "type": svc.DONE_TYPE, "status": "success"},
-        {"target_key": "a", "stream": "stdout", "line": "SHOULD-NOT-APPEAR"},
-    ])
+    source = _fake_source(
+        [
+            {"target_key": "a", "stream": "stdout", "line": "hist-1"},
+            {"target_key": "a", "stream": "stdout", "line": "live-1"},
+            {"target_key": "a", "type": svc.DONE_TYPE, "status": "success"},
+            {"target_key": "a", "stream": "stdout", "line": "SHOULD-NOT-APPEAR"},
+        ]
+    )
     gen = svc.stream_execution_events(1, ["a"], message_source=source)
     chunks = _collect(gen)
 
@@ -83,6 +86,21 @@ def test_stream_events_handles_source_error_gracefully():
     payloads = _payloads(chunks)
     assert any(p.get("type") == "error" for p in payloads)
     assert chunks[-1] == "data: [DONE]\n\n"
+
+
+def test_stream_events_preserves_visible_gap_payload():
+    gap = {
+        "target_key": "a",
+        "stream": "stdout",
+        "line": "[实时日志缺口] 省略 12 行",
+        "type": "gap",
+        "dropped_lines": 12,
+    }
+    source = _fake_source([gap, {"target_key": "a", "type": svc.DONE_TYPE, "status": "success"}])
+
+    chunks = _collect(svc.stream_execution_events(1, ["a"], message_source=source))
+
+    assert gap in _payloads(chunks)
 
 
 def test_stream_events_uses_default_source_when_none(monkeypatch):

--- a/web/package.json
+++ b/web/package.json
@@ -107,6 +107,7 @@
     "test:cmdb-attr-type-i18n": "pnpm exec tsx scripts/cmdb-attr-type-i18n-test.ts",
     "test:operation-log-detail": "pnpm exec tsx scripts/operation-log-detail-test.ts",
     "test:proxy-request-timeout": "pnpm exec tsx scripts/proxy-request-timeout-test.ts",
+    "test:job-execution-stream-gap": "pnpm exec tsx scripts/job-execution-stream-gap-test.ts",
     "test:session-expiry-trigger": "pnpm exec tsx scripts/session-expiry-trigger-test.ts && pnpm exec vitest run src/context/__tests__/authColdStart.test.tsx",
     "test:cmdb-relationships-imports": "node scripts/cmdb-relationships-imports-test.mjs",
     "test:cmdb-ipam-grid-height": "node scripts/cmdb-ipam-grid-height-test.mjs",

--- a/web/scripts/job-execution-stream-gap-test.ts
+++ b/web/scripts/job-execution-stream-gap-test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+
+import { applyExecutionStreamEvent } from '../src/app/job/hooks/executionStreamState';
+
+const gapLine =
+  '[实时日志缺口] 省略 12 行；请以任务终态输出为准（终态可能截断）';
+const withGap = applyExecutionStreamEvent(
+  {},
+  {
+    target_key: 'ansible',
+    stream: 'stdout',
+    type: 'gap',
+    line: gapLine,
+    dropped_lines: 12,
+  }
+);
+
+assert.equal(withGap.ansible.stdout, `${gapLine}\n`);
+assert.equal(withGap.ansible.done, false);
+
+const completed = applyExecutionStreamEvent(withGap, {
+  target_key: 'ansible',
+  type: 'done',
+  status: 'success',
+});
+
+assert.equal(completed.ansible.stdout, `${gapLine}\n`);
+assert.equal(completed.ansible.done, true);
+assert.equal(completed.ansible.status, 'success');
+
+console.log('job execution stream gap contract passed');

--- a/web/src/app/job/hooks/executionStreamState.ts
+++ b/web/src/app/job/hooks/executionStreamState.ts
@@ -1,0 +1,54 @@
+export interface TargetLiveOutput {
+  stdout: string;
+  stderr: string;
+  status?: string;
+  done: boolean;
+}
+
+export type LiveOutputMap = Record<string, TargetLiveOutput>;
+
+export interface StreamEventPayload {
+  execution_id?: string;
+  target_key?: string;
+  stream?: 'stdout' | 'stderr';
+  line?: string;
+  type?: string;
+  status?: string;
+  message?: string;
+  dropped_lines?: number;
+}
+
+const MAX_CHARS_PER_TARGET = 500_000;
+
+function appendCapped(prev: string, chunk: string): string {
+  const next = prev + chunk;
+  if (next.length <= MAX_CHARS_PER_TARGET) return next;
+  return next.slice(next.length - MAX_CHARS_PER_TARGET);
+}
+
+export function applyExecutionStreamEvent(
+  prev: LiveOutputMap,
+  payload: StreamEventPayload
+): LiveOutputMap {
+  const targetKey = payload.target_key;
+  if (!targetKey) return prev;
+
+  const cur: TargetLiveOutput = prev[targetKey] || {
+    stdout: '',
+    stderr: '',
+    done: false,
+  };
+  const next: TargetLiveOutput = { ...cur };
+  if (payload.type === 'done') {
+    next.done = true;
+    if (payload.status) next.status = payload.status;
+  } else if (payload.line != null) {
+    const chunk = payload.line + '\n';
+    if (payload.stream === 'stderr') {
+      next.stderr = appendCapped(cur.stderr, chunk);
+    } else {
+      next.stdout = appendCapped(cur.stdout, chunk);
+    }
+  }
+  return { ...prev, [targetKey]: next };
+}

--- a/web/src/app/job/hooks/useExecutionStream.ts
+++ b/web/src/app/job/hooks/useExecutionStream.ts
@@ -2,28 +2,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-/**
- * 单个目标的实时输出累积结果。
- * key 为后端 target_key（node_id 或 target_id 字符串）。
- */
-export interface TargetLiveOutput {
-  stdout: string;
-  stderr: string;
-  status?: string;
-  done: boolean;
-}
-
-export type LiveOutputMap = Record<string, TargetLiveOutput>;
-
-interface StreamEventPayload {
-  execution_id?: string;
-  target_key?: string;
-  stream?: 'stdout' | 'stderr';
-  line?: string;
-  type?: string; // 'done' | 'error' | 'history' | undefined(实时行)
-  status?: string;
-  message?: string;
-}
+import {
+  applyExecutionStreamEvent,
+  type LiveOutputMap,
+  type StreamEventPayload,
+} from './executionStreamState';
 
 interface UseExecutionStreamArgs {
   executionId: number | null;
@@ -31,15 +14,6 @@ interface UseExecutionStreamArgs {
   token: string | null;
   /** 所有目标都收到 done（或流自然结束）时回调，用于拉取权威最终结果。 */
   onAllDone?: () => void;
-}
-
-// 单个目标输出上限，防止超长脚本把内存撑爆（保留尾部）。
-const MAX_CHARS_PER_TARGET = 500_000;
-
-function appendCapped(prev: string, chunk: string): string {
-  const next = prev + chunk;
-  if (next.length <= MAX_CHARS_PER_TARGET) return next;
-  return next.slice(next.length - MAX_CHARS_PER_TARGET);
 }
 
 /**
@@ -64,24 +38,7 @@ export function useExecutionStream({
   onAllDoneRef.current = onAllDone;
 
   const applyEvent = useCallback((payload: StreamEventPayload) => {
-    const targetKey = payload.target_key;
-    if (!targetKey) return;
-    setLiveOutput((prev) => {
-      const cur: TargetLiveOutput = prev[targetKey] || { stdout: '', stderr: '', done: false };
-      const next: TargetLiveOutput = { ...cur };
-      if (payload.type === 'done') {
-        next.done = true;
-        if (payload.status) next.status = payload.status;
-      } else if (payload.line != null) {
-        const chunk = payload.line + '\n';
-        if (payload.stream === 'stderr') {
-          next.stderr = appendCapped(cur.stderr, chunk);
-        } else {
-          next.stdout = appendCapped(cur.stdout, chunk);
-        }
-      }
-      return { ...prev, [targetKey]: next };
-    });
+    setLiveOutput((prev) => applyExecutionStreamEvent(prev, payload));
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 背景

Issue #4282 发现 Ansible Executor 在读取命令输出时逐行等待 NATS 发布。只要消息发布延迟升高，远端命令的 stdout 消费就会被阻塞，最终可能把正常运行误判为超时。

本 PR 按已确认的方案 A 落地首个安全切片：将命令执行和实时日志发布解耦，并在容量不足时显式暴露日志缺口。该方案不需要部署配置、脚本、密钥或存储卷调整。

## 根因

- stdout/stderr 消费循环与远端 NATS 发布处于同一等待链路。
- 发布延迟会直接占用命令超时预算。
- 旧实现没有有界背压、尾部刷新预算或可见的日志丢弃事件。

## 变更

- 新增有界 `BufferedStreamPublisher`，默认队列 256、批量 16、尾部刷新预算 1 秒。
- stdout/stderr 生产侧仅做非阻塞入队，NATS 发布延迟不再拖慢命令读取。
- 队列饱和或发布失败时累计丢弃数，并发送可见 `gap` 事件；前端显示“实时日志缺口”，不会把缺失内容伪装成完整日志。
- 最终任务结果保留完整受控输出，并携带丢弃数、发布失败数、尾部超时和长行切分统计，可用于故障恢复和审计。
- 单行超过 16 KiB 时按 UTF-8 安全边界切分，避免单条消息无界增长。
- 将同一机制接入 Ansible、Remote Shell 和 WinRM 的生产执行路径；取消任务时仍会终止子进程。
- Server 保持透传 gap 载荷；Web reducer 显示缺口，同时保持既有完成状态语义。

```mermaid
flowchart LR
    A[Job] --> B[Ansible Executor]
    B --> C[stdout/stderr drain]
    C --> D[有界队列]
    D --> E[批量 Publisher]
    E --> F[NATS]
    F --> G[Server SSE]
    G --> H[Web 日志视图]
    D -. 饱和或发布失败 .-> I[可见 gap 事件]
    C --> J[最终任务结果]
```

## 兼容性与回滚

- 保留现有 NATS subject 和核心 `line` 字段；新增 gap 字段对旧消费者向后兼容。
- 不内联新的部署配置，默认值由代码管理，不需要运维介入。
- 回滚可直接回退本提交，不涉及数据迁移。
- 本 PR 不自动关闭 #4282；后续仍可独立评估其他执行器或更细粒度的观测切片。

## 验证

- Agent 全量定向目录：`126 passed`
- Server SSE 精确文件：`7 passed`
- Web gap 运行时契约：通过
- TypeScript 严格类型检查：通过
- 合计：`134 passed`
- 10,000 行、单次发布延迟 5 ms 的基准：命令约 125 ms 完成；最终输出包含末行；18 次发布；产生 1 个可见 gap；尾部刷新未超时。
- Standards / Spec / Runtime Contract：全部 PASS，综合 95/100。

关联：#4282
